### PR TITLE
fix docgen for subcommands

### DIFF
--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -46,11 +46,14 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+
+	"vitess.io/vitess/go/vt/log"
 )
 
 // GenerateMarkdownTree generates a markdown doctree for the root cobra.Command
@@ -79,7 +82,87 @@ func GenerateMarkdownTree(cmd *cobra.Command, dir string) error {
 		return fmt.Errorf("failed to index doc (generated at %s) into proper position (%s): %w", rootDocPath, indexDocPath, err)
 	}
 
+	if err := restructure(dir, dir, cmd.Name(), cmd.Commands()); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+/*
+_index.md (aka vtctldclient.md)
+vtctldclient_AddCellInfo.md
+vtctldclient_movetables.md
+vtctldclient_movetables_show.md
+
+becomes
+
+_index.md
+vtctldclient_AddCellInfo.md
+vtctldclient_movetables/
+	_index.md
+	vtctldclient_movetables_show.md
+*/
+
+func restructure(rootDir string, dir string, name string, commands []*cobra.Command) error {
+	for _, cmd := range commands {
+		fullCmdFilename := strings.Join([]string{name, cmd.Name()}, "_")
+
+		children := cmd.Commands()
+
+		switch {
+		case len(children) > 0:
+			// Command (top-level or not) with children.
+			// 1. Set up a directory for its children.
+			// 2. Move its doc into that dir as "_index.md"
+			// 3. Restructure its children.
+			cmdDir := filepath.Join(dir, fullCmdFilename)
+			if err := os.MkdirAll(cmdDir, 0755); err != nil {
+				return fmt.Errorf("failed to create subdir for %s: %w", fullCmdFilename, err)
+			}
+
+			if err := os.Rename(filepath.Join(rootDir, fullCmdFilename+".md"), filepath.Join(cmdDir, "_index.md")); err != nil {
+				return fmt.Errorf("failed to move index doc for command %s with children: %w", fullCmdFilename, err)
+			}
+
+			if err := restructure(rootDir, cmdDir, fullCmdFilename, children); err != nil {
+				return fmt.Errorf("failed to restructure child commands for %s: %w", fullCmdFilename, err)
+			}
+		case rootDir != dir:
+			// Sub-command without children.
+			// 1. Move its doc into the directory for its parent, name unchanged.
+			if cmd.Name() == "help" {
+				// all commands with children have their own "help" subcommand,
+				// which we do not generate docs for
+				continue
+			}
+
+			oldName := filepath.Join(rootDir, fullCmdFilename+".md")
+			newName := filepath.Join(dir, fullCmdFilename+".md")
+
+			if err := os.Rename(oldName, newName); err != nil {
+				return fmt.Errorf("failed to move child command %s to its parent's dir: %w", fullCmdFilename, err)
+			}
+
+			sed := newParentLinkSedCommand(name, newName)
+			if out, err := sed.CombinedOutput(); err != nil {
+				return fmt.Errorf("failed to rewrite links to parent command in child %s: %w (extra: %s)", newName, err, out)
+			}
+
+			if err := os.Remove(newName + ".bak"); err != nil {
+				log.Warningf("failed to remove backup file for %s, use caution when staging files for commit: %w", newName+".bak", err)
+			}
+		default:
+			// Top-level command without children. Nothing to restructure.
+			continue
+		}
+	}
+
+	return nil
+}
+
+func newParentLinkSedCommand(parent string, file string) *exec.Cmd {
+	return exec.Command("sed", "-i.bak", "-e", fmt.Sprintf("s:(./%s/):(../):", parent), file)
 }
 
 func recursivelyDisableAutoGenTags(root *cobra.Command) {
@@ -106,16 +189,19 @@ func frontmatterFilePrepender(filename string) string {
 		cmdName = root
 	}
 
+	cmdName = strings.ReplaceAll(cmdName, "_", " ")
+
 	return fmt.Sprintf(frontmatter, cmdName, root)
 }
 
 func linkHandler(filename string) string {
-	name := filepath.Base(filename)
-	base := strings.TrimSuffix(name, filepath.Ext(name))
+	base := filepath.Base(filename)
+	name := strings.TrimSuffix(base, filepath.Ext(base))
 
-	if _, _, ok := strings.Cut(base, "_"); !ok {
+	_, _, ok := strings.Cut(name, "_")
+	if !ok {
 		return "../"
 	}
 
-	return fmt.Sprintf("./%s/", strings.ToLower(base))
+	return fmt.Sprintf("./%s/", strings.ToLower(name))
 }

--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -52,8 +52,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-
-	"vitess.io/vitess/go/vt/log"
 )
 
 // GenerateMarkdownTree generates a markdown doctree for the root cobra.Command
@@ -148,10 +146,6 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 			if out, err := sed.CombinedOutput(); err != nil {
 				return fmt.Errorf("failed to rewrite links to parent command in child %s: %w (extra: %s)", newName, err, out)
 			}
-
-			if err := os.Remove(newName + ".bak"); err != nil {
-				log.Warningf("failed to remove backup file for %s, use caution when staging files for commit: %w", newName+".bak", err)
-			}
 		default:
 			// Top-level command without children. Nothing to restructure.
 			continue
@@ -162,7 +156,7 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 }
 
 func newParentLinkSedCommand(parent string, file string) *exec.Cmd {
-	return exec.Command("sed", "-i.bak", "-e", fmt.Sprintf("s:(./%s/):(../):", parent), file)
+	return exec.Command("sed", "-i ''", "-e", fmt.Sprintf("s:(./%s/):(../):", parent), file)
 }
 
 func recursivelyDisableAutoGenTags(root *cobra.Command) {


### PR DESCRIPTION
## Description

In #13015, @mattlord found two issues with the docgen tool.

1. The titles were wrong. This was an easy fix to the frontmatter.
2. The links between parent and child command pages were wrong. This was ... a whole thing, mostly due to the problem that the `linkHandler` function has no context (i.e. you know only what page you are generating a link _to_, not what you are linking to that page _from_). So, two changes here:
    a. restructure the child command files so they sit below their parent rather than having everything in a single top-level file structure
    b. run a `sed` on each child page to rewrite the incorrect link to its parent to simply go to `../`.

I ran this on top of Matt's PR and clicking around worked. I can push those changes directly to his website branch as proof, or he can pull this to double-verify; I am happy to do whatever is most preferred.

## Related Issue(s)

#13015

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
