### PR TITLE
Fix dependencies in docker build script

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -84,6 +84,7 @@ mysql57)
     ;;
 mysql80)
     mysql8_version=8.0.30
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-common_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-common_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb
@@ -93,6 +94,7 @@ mysql80)
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-server_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-server_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-server_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-server_${mysql8_version}-1debian10_amd64.deb
     PACKAGES=(
+        /tmp/mysql-common_${mysql8_version}-1debian10_amd64.deb
         /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
         /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
         /tmp/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb


### PR DESCRIPTION
## Description

The Vitess lite builds were failing within the [`install_dependencies.sh`](https://github.com/vitessio/vitess/blob/main/docker/lite/install_dependencies.sh) script:
```
#11 39.01 The following packages have unmet dependencies:
#11 39.06  libmysqlclient21 : Depends: mysql-common (>= 8.0.30-1debian10) but it is not going to be installed
#11 39.06  mysql-community-client : Depends: mysql-common (>= 8.0.30-1debian10) but it is not going to be installed
#11 39.06  mysql-community-server : Depends: mysql-common (>= 8.0.30-1debian10) but it is not going to be installed
#11 39.06  percona-xtrabackup-80 : Depends: libdbd-mysql-perl but it is not going to be installed
#11 39.07 E: Unable to correct problems, you have held broken packages.
```

You can see recent build failures here: https://hub.docker.com/repository/registry-1.docker.io/vitess/lite/builds

And if you look at the on-merge docker build actions near the bottom of any recent PRs (click on the red X and scroll down): https://github.com/vitessio/vitess/commits/main

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required