### PR TITLE
[vipersync] deflake TestWatchConfig

### DIFF
--- a/go/viperutil/internal/sync/sync_test.go
+++ b/go/viperutil/internal/sync/sync_test.go
@@ -77,9 +77,8 @@ func TestWatchConfig(t *testing.T) {
 		return writeConfig(tmp, a, b)
 	}
 
-	tmp, err := os.CreateTemp(".", "TestWatchConfig_*.json")
+	tmp, err := os.CreateTemp(t.TempDir(), "TestWatchConfig_*.json")
 	require.NoError(t, err)
-	t.Cleanup(func() { os.Remove(tmp.Name()) })
 
 	require.NoError(t, writeRandomConfig(tmp))
 

--- a/go/viperutil/internal/sync/sync_test.go
+++ b/go/viperutil/internal/sync/sync_test.go
@@ -36,19 +36,16 @@ import (
 )
 
 func TestWatchConfig(t *testing.T) {
-	t.Skip("flaky test (@ajm188): https://github.com/vitessio/vitess/issues/13498")
 	type config struct {
 		A, B int
 	}
 
-	tmp, err := os.CreateTemp(".", "TestWatchConfig_*.json")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.Remove(tmp.Name()) })
+	writeConfig := func(tmp *os.File, a, b int) error {
+		stat, err := os.Stat(tmp.Name())
+		if err != nil {
+			return err
+		}
 
-	stat, err := os.Stat(tmp.Name())
-	require.NoError(t, err)
-
-	writeConfig := func(a, b int) error {
 		data, err := json.Marshal(&config{A: a, B: b})
 		if err != nil {
 			return err
@@ -75,19 +72,23 @@ func TestWatchConfig(t *testing.T) {
 
 		return nil
 	}
-	writeRandomConfig := func() error {
+	writeRandomConfig := func(tmp *os.File) error {
 		a, b := rand.Intn(100), rand.Intn(100)
-		return writeConfig(a, b)
+		return writeConfig(tmp, a, b)
 	}
 
-	require.NoError(t, writeRandomConfig())
+	tmp, err := os.CreateTemp(".", "TestWatchConfig_*.json")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(tmp.Name()) })
+
+	require.NoError(t, writeRandomConfig(tmp))
 
 	v := viper.New()
 	v.SetConfigFile(tmp.Name())
 	require.NoError(t, v.ReadInConfig())
 
 	wCh, rCh := make(chan struct{}), make(chan struct{})
-	v.OnConfigChange(func(in fsnotify.Event) {
+	v.OnConfigChange(func(event fsnotify.Event) {
 		select {
 		case <-rCh:
 			return
@@ -103,7 +104,7 @@ func TestWatchConfig(t *testing.T) {
 	// Make sure that basic, unsynchronized WatchConfig is set up before
 	// beginning the actual test.
 	a, b := v.GetInt("a"), v.GetInt("b")
-	require.NoError(t, writeConfig(a+1, b+1))
+	require.NoError(t, writeConfig(tmp, a+1, b+1))
 	<-wCh // wait for the update to finish
 
 	require.Equal(t, a+1, v.GetInt("a"))
@@ -163,7 +164,7 @@ func TestWatchConfig(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		require.NoError(t, writeRandomConfig())
+		require.NoError(t, writeRandomConfig(tmp))
 		time.Sleep(writeJitter())
 	}
 


### PR DESCRIPTION
## Description

Turns out this is very tricky to repro locally, so I temporarily rewrote the test to do the following:

```go
func TestWatchConfig(t *testing.T) {
	t.Parallel()

	type config struct {
		A, B int
	}

	writeConfig := func(tmp *os.File, a, b int) error {
		stat, err := os.Stat(tmp.Name())
		if err != nil {
			return err
		}

		data, err := json.Marshal(&config{A: a, B: b})
		if err != nil {
			return err
		}

		err = os.WriteFile(tmp.Name(), data, stat.Mode())
		if err != nil {
			return err
		}

		data, err = os.ReadFile(tmp.Name())
		if err != nil {
			return err
		}

		var cfg config
		if err := json.Unmarshal(data, &cfg); err != nil {
			return err
		}

		if cfg.A != a || cfg.B != b {
			return fmt.Errorf("config did not persist; want %+v got %+v", config{A: a, B: b}, cfg)
		}

		return nil
	}
	writeRandomConfig := func(tmp *os.File) error {
		a, b := rand.Intn(100), rand.Intn(100)
		return writeConfig(tmp, a, b)
	}

	for i := 0; i < 10; i++ {
		t.Run("", func(t *testing.T) {
			t.Parallel()

			tmp, err := os.CreateTemp(".", "TestWatchConfig_*.json")
			require.NoError(t, err)
			t.Cleanup(func() { os.Remove(tmp.Name()) })

			require.NoError(t, writeRandomConfig(tmp))

			v := viper.New()
			v.SetConfigFile(tmp.Name())
			require.NoError(t, v.ReadInConfig())

			wCh, rCh := make(chan struct{}), make(chan struct{})
			v.OnConfigChange(func(event fsnotify.Event) {
				select {
				case <-rCh:
					return
				default:
				}

				wCh <- struct{}{}
				// block forever to prevent this viper instance from double-updating.
				<-rCh
			})
			v.WatchConfig()

			// Make sure that basic, unsynchronized WatchConfig is set up before
			// beginning the actual test.
			a, b := v.GetInt("a"), v.GetInt("b")
			require.NoError(t, writeConfig(tmp, a+1, b+1))
			<-wCh // wait for the update to finish

			require.Equal(t, a+1, v.GetInt("a"))
			require.Equal(t, b+1, v.GetInt("b"))

			rCh <- struct{}{}
		})
	}

	return
}
```

From there I was able to reproduce the failure locally with `go test -failfast -count=1000 -run TestWatchConfig ./go/viperutil/internal/sync`

I then changed the following line:

```diff
-			tmp, err := os.CreateTemp(".", "TestWatchConfig_*.json")
+			tmp, err := os.CreateTemp(t.TempDir(), "TestWatchConfig_*.json")
```

and the failures vanished. (incidentally, since `go test` manages cleanup of the test's tempdir, we don't need to manually remove the file during a `Cleanup` func anymore)

My working theory is this is happening because `inotify` watches the directory of the file you tell it to watch, and this causes a watch to run at O(N) of the number of files in that directory. For us, this is the vitess checkout dir and combined with the tighter constraints of the runners vs a dedicated laptop doing nothing but running this test, causes the failures to happen pretty much only in CI.

## Related Issue(s)

Fixes #13498 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
