### PR TITLE
Unset the PREFIX environment variable when building VTAdmin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ endif
 		    -o ${VTROOTBIN} ./go/...
 ifndef NOVTADMINBUILD
 	echo "Building VTAdmin Web, disable VTAdmin build by setting 'NOVTADMINBUILD'"
-	./web/vtadmin/build.sh
+	PREFIX="" ./web/vtadmin/build.sh
 endif
 
 # cross-build can be used to cross-compile Vitess client binaries

--- a/web/vtadmin/build.sh
+++ b/web/vtadmin/build.sh
@@ -48,6 +48,8 @@ nvm install "$NODE_VERSION" || fail "Could not install and use nvm $NODE_VERSION
 
 npm --prefix "$web_dir" --silent install
 
+export PATH=$PATH:$web_dir/node_modules/.bin/
+
 VITE_VTADMIN_API_ADDRESS="http://${hostname}:${vtadmin_api_port}" \
   VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
   npm run --prefix "$web_dir" build


### PR DESCRIPTION
## Description

This PR unsets the `PREFIX` environment variable when building VTAdmin. It fixes https://github.com/vitessio/vitess/issues/13532
## Related Issue(s)

https://github.com/vitessio/vitess/issues/13532

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
