### PR TITLE
check keyspace snapshot time if none specified for backup restores

### DIFF
--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -51,17 +51,21 @@ func VerifyQueriesUsingVtgate(t *testing.T, session *vtgateconn.VTGateSession, q
 }
 
 // RestoreTablet performs a PITR restore.
-func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tablet *cluster.Vttablet, restoreKSName string, shardName string, keyspaceName string, commonTabletArg []string) {
+func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tablet *cluster.Vttablet, restoreKSName string, shardName string, keyspaceName string, commonTabletArg []string, restoreTime time.Time) {
 	tablet.ValidateTabletRestart(t)
 	replicaTabletArgs := commonTabletArg
 
 	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("GetKeyspace", restoreKSName)
 
+	if restoreTime.IsZero() {
+		restoreTime = time.Now().UTC()
+	}
+
 	if err != nil {
 		tm := time.Now().UTC()
 		_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace", "--",
 			"--keyspace_type=SNAPSHOT", "--base_keyspace="+keyspaceName,
-			"--snapshot_time", tm.Format(time.RFC3339), restoreKSName)
+			"--snapshot_time", restoreTime.Format(time.RFC3339), restoreKSName)
 		require.Nil(t, err)
 	}
 

--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -62,7 +62,6 @@ func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tabl
 	}
 
 	if err != nil {
-		tm := time.Now().UTC()
 		_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace", "--",
 			"--keyspace_type=SNAPSHOT", "--base_keyspace="+keyspaceName,
 			"--snapshot_time", restoreTime.Format(time.RFC3339), restoreKSName)

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -185,34 +185,36 @@ func TestMainImpl(m *testing.M) {
 }
 
 // TestRecoveryImpl does following
-// - create a shard with primary and replica1 only
-// - run InitShardPrimary
-// - insert some data
-// - take a backup
-// - insert more data on the primary
-// - take another backup
-// - create a recovery keyspace after first backup
-// - bring up tablet_replica2 in the new keyspace
-// - check that new tablet does not have data created after backup1
-// - create second recovery keyspace after second backup
-// - bring up tablet_replica3 in second keyspace
-// - check that new tablet has data created after backup1 but not data created after backup2
-// - check that vtgate queries work correctly
+// 1. create a shard with primary and replica1 only
+// 	- run InitShardPrimary
+// 	- insert some data
+// 2. take a backup
+// 3.create a recovery keyspace after first backup
+// 	- bring up tablet_replica2 in the new keyspace
+// 	- check that new tablet has data from backup1
+// 4. insert more data on the primary
+// 5. take another backup
+// 6. create a recovery keyspace after second backup
+// 	- bring up tablet_replica3 in the new keyspace
+// 	- check that new tablet has data from backup2
+// 7. insert more data on the primary
+// 8. take another backup
+// 9. create a recovery keyspace after second backup again
+// 	- bring up tablet_replica4 in the new keyspace
+// 	- check that new tablet has data from backup2 but not backup3
+// 10. check that vtgate queries work correctly
 func TestRecoveryImpl(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	defer tabletsTeardown()
 	verifyInitialReplication(t)
 
+	// take first backup of value = test1
 	err := localCluster.VtctlclientProcess.ExecuteCommand("Backup", replica1.Alias)
 	assert.NoError(t, err)
 
 	backups := listBackups(t)
 	require.Equal(t, len(backups), 1)
 	assert.Contains(t, backups[0], replica1.Alias)
-
-	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test2')", keyspaceName, true)
-	assert.NoError(t, err)
-	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 2)
 
 	err = localCluster.VtctlclientProcess.ApplyVSchema(keyspaceName, vSchema)
 	assert.NoError(t, err)
@@ -221,15 +223,14 @@ func TestRecoveryImpl(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, output, "vt_insert_test")
 
-	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS1, "0", keyspaceName, commonTabletArg)
+	// restore with latest backup
+	restoreTime := time.Now().UTC()
+	recovery.RestoreTablet(t, localCluster, replica2, recoveryKS1, "0", keyspaceName, commonTabletArg, restoreTime)
 
 	output, err = localCluster.VtctlclientProcess.ExecuteCommandWithOutput("GetSrvVSchema", cell)
 	assert.NoError(t, err)
 	assert.Contains(t, output, keyspaceName)
 	assert.Contains(t, output, recoveryKS1)
-
-	err = localCluster.VtctlclientProcess.ExecuteCommand("GetSrvKeyspace", cell, keyspaceName)
-	assert.NoError(t, err)
 
 	output, err = localCluster.VtctlclientProcess.ExecuteCommandWithOutput("GetVSchema", recoveryKS1)
 	assert.NoError(t, err)
@@ -237,48 +238,43 @@ func TestRecoveryImpl(t *testing.T) {
 
 	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 1)
 
+	// verify that restored replica has value = test1
+	qr, err := replica2.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "test1", qr.Rows[0][0].ToString())
+
+	// insert new row on primary
+	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test2')", keyspaceName, true)
+	assert.NoError(t, err)
+	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 2)
+
 	// update the original row in primary
 	_, err = primary.VttabletProcess.QueryTablet("update vt_insert_test set msg = 'msgx1' where id = 1", keyspaceName, true)
 	assert.NoError(t, err)
 
 	// verify that primary has new value
-	qr, err := primary.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
+	qr, err = primary.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
 	assert.NoError(t, err)
 	assert.Equal(t, "msgx1", qr.Rows[0][0].ToString())
 
-	// verify that restored replica has old value
-	qr, err = replica2.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
-	assert.NoError(t, err)
-	assert.Equal(t, "test1", qr.Rows[0][0].ToString())
-
+	// take second backup of value = msgx1
 	err = localCluster.VtctlclientProcess.ExecuteCommand("Backup", replica1.Alias)
 	assert.NoError(t, err)
 
-	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test3')", keyspaceName, true)
-	assert.NoError(t, err)
-	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 3)
-
-	recovery.RestoreTablet(t, localCluster, replica3, recoveryKS2, "0", keyspaceName, commonTabletArg)
+	// restore to first backup
+	recovery.RestoreTablet(t, localCluster, replica3, recoveryKS2, "0", keyspaceName, commonTabletArg, restoreTime)
 
 	output, err = localCluster.VtctlclientProcess.ExecuteCommandWithOutput("GetVSchema", recoveryKS2)
 	assert.NoError(t, err)
 	assert.Contains(t, output, "vt_insert_test")
 
-	cluster.VerifyRowsInTablet(t, replica3, keyspaceName, 2)
+	// only one row from first backup
+	cluster.VerifyRowsInTablet(t, replica3, keyspaceName, 1)
 
-	// update the original row in primary
-	_, err = primary.VttabletProcess.QueryTablet("update vt_insert_test set msg = 'msgx2' where id = 1", keyspaceName, true)
-	assert.NoError(t, err)
-
-	// verify that primary has new value
-	qr, err = primary.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
-	assert.NoError(t, err)
-	assert.Equal(t, "msgx2", qr.Rows[0][0].ToString())
-
-	// verify that restored replica has old value
+	//verify that restored replica has value = test1
 	qr, err = replica3.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "msgx1", qr.Rows[0][0].ToString())
+	assert.Equal(t, "test1", qr.Rows[0][0].ToString())
 
 	vtgateInstance := localCluster.NewVtgateInstance()
 	vtgateInstance.TabletTypesToWait = "REPLICA"
@@ -299,19 +295,19 @@ func TestRecoveryImpl(t *testing.T) {
 	session := vtgateConn.Session("@replica", nil)
 
 	// check that vtgate doesn't route queries to new tablet
-	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(3)")
-	recovery.VerifyQueriesUsingVtgate(t, session, "select msg from vt_insert_test where id = 1", `VARCHAR("msgx2")`)
+	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(2)")
+	recovery.VerifyQueriesUsingVtgate(t, session, "select msg from vt_insert_test where id = 1", `VARCHAR("msgx1")`)
 	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select count(*) from %s.vt_insert_test", recoveryKS1), "INT64(1)")
 	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select msg from %s.vt_insert_test where id = 1", recoveryKS1), `VARCHAR("test1")`)
-	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select count(*) from %s.vt_insert_test", recoveryKS2), "INT64(2)")
-	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select msg from %s.vt_insert_test where id = 1", recoveryKS2), `VARCHAR("msgx1")`)
+	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select count(*) from %s.vt_insert_test", recoveryKS2), "INT64(1)")
+	recovery.VerifyQueriesUsingVtgate(t, session, fmt.Sprintf("select msg from %s.vt_insert_test where id = 1", recoveryKS2), `VARCHAR("test1")`)
 
 	// check that new keyspace is accessible with 'use ks'
 	cluster.ExecuteQueriesUsingVtgate(t, session, "use "+recoveryKS1+"@replica")
 	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(1)")
 
 	cluster.ExecuteQueriesUsingVtgate(t, session, "use "+recoveryKS2+"@replica")
-	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(2)")
+	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(1)")
 
 	// check that new tablet is accessible with use `ks:shard`
 	cluster.ExecuteQueriesUsingVtgate(t, session, "use `"+recoveryKS1+":0@replica`")

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -200,6 +200,7 @@ func TestMainImpl(m *testing.M) {
 // 6. create a recovery keyspace after second backup
 //   - bring up tablet_replica3 in the new keyspace
 //   - check that new tablet has data from backup2
+//
 // 7. check that vtgate queries work correctly
 func TestRecoveryImpl(t *testing.T) {
 	defer cluster.PanicHandler(t)

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -318,7 +318,7 @@ func TestRecoveryImpl(t *testing.T) {
 	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(1)")
 
 	cluster.ExecuteQueriesUsingVtgate(t, session, "use `"+recoveryKS2+":0@replica`")
-	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(2)")
+	recovery.VerifyQueriesUsingVtgate(t, session, "select count(*) from vt_insert_test", "INT64(1)")
 }
 
 // verifyInitialReplication will create schema in primary, insert some data to primary and verify the same data in replica.

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -186,22 +186,26 @@ func TestMainImpl(m *testing.M) {
 
 // TestRecoveryImpl does following
 // 1. create a shard with primary and replica1 only
-// 	- run InitShardPrimary
-// 	- insert some data
+//   - run InitShardPrimary
+//   - insert some data
+//
 // 2. take a backup
 // 3.create a recovery keyspace after first backup
-// 	- bring up tablet_replica2 in the new keyspace
-// 	- check that new tablet has data from backup1
+//   - bring up tablet_replica2 in the new keyspace
+//   - check that new tablet has data from backup1
+//
 // 4. insert more data on the primary
 // 5. take another backup
 // 6. create a recovery keyspace after second backup
-// 	- bring up tablet_replica3 in the new keyspace
-// 	- check that new tablet has data from backup2
+//   - bring up tablet_replica3 in the new keyspace
+//   - check that new tablet has data from backup2
+//
 // 7. insert more data on the primary
 // 8. take another backup
 // 9. create a recovery keyspace after second backup again
-// 	- bring up tablet_replica4 in the new keyspace
-// 	- check that new tablet has data from backup2 but not backup3
+//   - bring up tablet_replica4 in the new keyspace
+//   - check that new tablet has data from backup2 but not backup3
+//
 // 10. check that vtgate queries work correctly
 func TestRecoveryImpl(t *testing.T) {
 	defer cluster.PanicHandler(t)

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -195,18 +195,12 @@ func TestMainImpl(m *testing.M) {
 //   - check that new tablet has data from backup1
 //
 // 4. insert more data on the primary
+//
 // 5. take another backup
 // 6. create a recovery keyspace after second backup
 //   - bring up tablet_replica3 in the new keyspace
 //   - check that new tablet has data from backup2
-//
-// 7. insert more data on the primary
-// 8. take another backup
-// 9. create a recovery keyspace after second backup again
-//   - bring up tablet_replica4 in the new keyspace
-//   - check that new tablet has data from backup2 but not backup3
-//
-// 10. check that vtgate queries work correctly
+// 7. check that vtgate queries work correctly
 func TestRecoveryImpl(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	defer tabletsTeardown()

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -185,6 +185,11 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		log.Infof("Using base_keyspace %v to restore keyspace %v using a backup time of %v", keyspace, tablet.Keyspace, logutil.ProtoToTime(request.BackupTime))
 	}
 
+	startTime := logutil.ProtoToTime(request.BackupTime)
+	if startTime.IsZero() {
+		startTime = logutil.ProtoToTime(keyspaceInfo.SnapshotTime)
+	}
+
 	params := mysqlctl.RestoreParams{
 		Cnf:                 tm.Cnf,
 		Mysqld:              tm.MysqlDaemon,
@@ -195,7 +200,7 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		DbName:              topoproto.TabletDbName(tablet),
 		Keyspace:            keyspace,
 		Shard:               tablet.Shard,
-		StartTime:           logutil.ProtoToTime(request.BackupTime),
+		StartTime:           startTime,
 		DryRun:              request.DryRun,
 		Stats:               backupstats.RestoreStats(),
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Tablets coming up in SNAPSHOT keyspaces always use the latest backup regardless of the snapshot timestamp specified during keyspace creation. We expect that the latest backup on or before the snapshot time gets used. Reproduced in the issue linked below. 

Discussion here: https://vitess.slack.com/archives/C0PQY0PTK/p1683010265492109

## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/13556

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

**Testing:** 

1. `make build` & `cd examples/local`
2. `./101_initial_cluster`
3. From `GetTablets` pick a replica
4. `vtctldclient --server localhost:15999 Backup zone1-0000000100`
5. 
```
vtctldclient --server localhost:15999 CreateKeyspace --type=SNAPSHOT --base-keyspace=commerce --snapshot-timestamp=2023-07-19T18:24:00Z pitrexample                                                                          
Successfully created keyspace pitrexample. Result:
{
  "name": "pitrexample",
  "keyspace": {
    "served_froms": [],
    "keyspace_type": 1,
    "base_keyspace": "commerce",
    "snapshot_time": {
      "seconds": "1689791040",
      "nanoseconds": 0
    },
    "durability_policy": "none",
    "throttler_config": null,
    "sidecar_db_name": "_vt"
  }
}
```
6. Create another backup for a later timestamp `vtctldclient --server localhost:15999 Backup zone1-0000000101`
7. 
```
ls vtdataroot/backups/commerce/0                                                                                                                                                                                           
2023-07-19.182309.zone1-0000000101 2023-07-19.182505.zone1-0000000101
```
8. update `vttablet-up.sh` to have `--init_db_name_override vt_commerce`
9. Run `CELL=zone1 TABLET_UID=300 ../common/scripts/mysqlctl-up.sh`
10. Run `CELL-zone1 KEYSPACE=pitrexample TABLET_UID=300 ../common/scripts/vttablet-up.sh`
11. Navigate to `localhost:15300/debug/vars` and check `RestoredBackupTime`
![image](https://github.com/vitessio/vitess/assets/15112506/3a0d8905-df79-4cf7-b602-9522800714c4)

Verified that the backup used is not latest and corresponds with the snapshot time specified.

Updated recovery endtoend tests to check for the custom restore time case.

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
