### PR TITLE
Flaky tests: Fix race in memory topo

### DIFF
--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -153,8 +153,12 @@ func (mp *cLeaderParticipation) WaitForNewLeader(ctx context.Context) (<-chan st
 	}
 
 	notifications := make(chan string, 8)
+
+	nextWatchIndexMu.Lock()
 	watchIndex := nextWatchIndex
 	nextWatchIndex++
+	nextWatchIndexMu.Unlock()
+
 	n.watches[watchIndex] = watch{lock: notifications}
 
 	if n.lock != nil {

--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -153,13 +153,7 @@ func (mp *cLeaderParticipation) WaitForNewLeader(ctx context.Context) (<-chan st
 	}
 
 	notifications := make(chan string, 8)
-
-	nextWatchIndexMu.Lock()
-	watchIndex := nextWatchIndex
-	nextWatchIndex++
-	nextWatchIndexMu.Unlock()
-
-	n.watches[watchIndex] = watch{lock: notifications}
+	watchIndex := n.addWatch(watch{lock: notifications})
 
 	if n.lock != nil {
 		notifications <- n.lockContents

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -49,11 +49,6 @@ const (
 	UnreachableServerAddr = "unreachable"
 )
 
-var (
-	nextWatchIndex   = 0
-	nextWatchIndexMu sync.Mutex
-)
-
 // Factory is a memory-based implementation of topo.Factory.  It
 // takes a file-system like approach, with directories at each level
 // being an actual directory node. This is meant to be closer to
@@ -205,6 +200,20 @@ func (n *node) propagateRecursiveWatch(ev *topo.WatchDataRecursive) {
 			}
 		}
 	}
+}
+
+var (
+	nextWatchIndex   = 0
+	nextWatchIndexMu sync.Mutex
+)
+
+func (n *node) addWatch(w watch) int {
+	nextWatchIndexMu.Lock()
+	defer nextWatchIndexMu.Unlock()
+	watchIndex := nextWatchIndex
+	nextWatchIndex++
+	n.watches[watchIndex] = w
+	return watchIndex
 }
 
 // PropagateWatchError propagates the given error to all watches on this node

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -50,7 +50,8 @@ const (
 )
 
 var (
-	nextWatchIndex = 0
+	nextWatchIndex   = 0
+	nextWatchIndexMu sync.Mutex
 )
 
 // Factory is a memory-based implementation of topo.Factory.  It

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -50,13 +50,7 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 	}
 
 	notifications := make(chan *topo.WatchData, 100)
-
-	nextWatchIndexMu.Lock()
-	watchIndex := nextWatchIndex
-	nextWatchIndex++
-	nextWatchIndexMu.Unlock()
-
-	n.watches[watchIndex] = watch{contents: notifications}
+	watchIndex := n.addWatch(watch{contents: notifications})
 
 	go func() {
 		<-ctx.Done()
@@ -109,13 +103,7 @@ func (c *Conn) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.Watc
 	})
 
 	notifications := make(chan *topo.WatchDataRecursive, 100)
-
-	nextWatchIndexMu.Lock()
-	watchIndex := nextWatchIndex
-	nextWatchIndex++
-	nextWatchIndexMu.Unlock()
-
-	n.watches[watchIndex] = watch{recursive: notifications}
+	watchIndex := n.addWatch(watch{recursive: notifications})
 
 	go func() {
 		defer close(notifications)

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -50,8 +50,12 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 	}
 
 	notifications := make(chan *topo.WatchData, 100)
+
+	nextWatchIndexMu.Lock()
 	watchIndex := nextWatchIndex
 	nextWatchIndex++
+	nextWatchIndexMu.Unlock()
+
 	n.watches[watchIndex] = watch{contents: notifications}
 
 	go func() {
@@ -105,8 +109,12 @@ func (c *Conn) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.Watc
 	})
 
 	notifications := make(chan *topo.WatchDataRecursive, 100)
+
+	nextWatchIndexMu.Lock()
 	watchIndex := nextWatchIndex
 	nextWatchIndex++
+	nextWatchIndexMu.Unlock()
+
 	n.watches[watchIndex] = watch{recursive: notifications}
 
 	go func() {


### PR DESCRIPTION
## Description

Fixing flaky test found in one of the unit test CI workflow runs.

```
2023-07-19T20:55:15.3945216Z W0719 20:53:54.030022   38113 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/home/runner/work/vitess/vitess/go/vt/wrangler]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
2023-07-19T20:55:15.3948265Z W0719 20:53:54.033199   38113 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/home/runner/work/vitess/vitess/go/vt/wrangler]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
2023-07-19T20:55:15.3950092Z E0719 20:53:54.200947   38113 materializer.go:1112] Error getting DDLs of source tables: source shard must have a primary for copying schema: 0
2023-07-19T20:55:15.3950945Z ==================
2023-07-19T20:55:15.3951230Z WARNING: DATA RACE
2023-07-19T20:55:15.3951565Z Read at 0x000003f7ca60 by goroutine 862:
2023-07-19T20:55:15.3952012Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Watch()
2023-07-19T20:55:15.3952716Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/watch.go:53 +0x37a
2023-07-19T20:55:15.3953199Z   vitess.io/vitess/go/vt/topo.(*StatsConn).Watch()
2023-07-19T20:55:15.3953815Z       /home/runner/work/vitess/vitess/go/vt/topo/stats_conn.go:184 +0x204
2023-07-19T20:55:15.3954302Z   vitess.io/vitess/go/vt/topo.(*Server).WatchShard()
2023-07-19T20:55:15.3955399Z       /home/runner/work/vitess/vitess/go/vt/topo/shard.go:689 +0x1b6
2023-07-19T20:55:15.3955970Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*shardWatcher).start()
2023-07-19T20:55:15.3956961Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_watcher.go:39 +0x1a9
2023-07-19T20:55:15.3957592Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).shardSyncLoop()
2023-07-19T20:55:15.3958610Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_sync.go:145 +0x867
2023-07-19T20:55:15.3959260Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).startShardSync.func2()
2023-07-19T20:55:15.3960017Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_sync.go:270 +0x71
2023-07-19T20:55:15.3960308Z 
2023-07-19T20:55:15.3960517Z Previous write at 0x000003f7ca60 by goroutine 890:
2023-07-19T20:55:15.3960983Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Watch()
2023-07-19T20:55:15.3961637Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/watch.go:54 +0x3aa
2023-07-19T20:55:15.3962110Z   vitess.io/vitess/go/vt/topo.(*StatsConn).Watch()
2023-07-19T20:55:15.3970449Z       /home/runner/work/vitess/vitess/go/vt/topo/stats_conn.go:184 +0x204
2023-07-19T20:55:15.3971022Z   vitess.io/vitess/go/vt/topo.(*Server).WatchShard()
2023-07-19T20:55:15.3971637Z       /home/runner/work/vitess/vitess/go/vt/topo/shard.go:689 +0x1b6
2023-07-19T20:55:15.3973333Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*shardWatcher).start()
2023-07-19T20:55:15.3974093Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_watcher.go:39 +0x1a9
2023-07-19T20:55:15.3974685Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).shardSyncLoop()
2023-07-19T20:55:15.3975447Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_sync.go:145 +0x867
2023-07-19T20:55:15.3976072Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).startShardSync.func2()
2023-07-19T20:55:15.3976831Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_sync.go:270 +0x71
2023-07-19T20:55:15.3977121Z 
2023-07-19T20:55:15.3977284Z Goroutine 862 (running) created at:
2023-07-19T20:55:15.3977805Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).startShardSync()
2023-07-19T20:55:15.3978552Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_sync.go:270 +0x3b1
2023-07-19T20:55:15.3979115Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).Start()
2023-07-19T20:55:15.3979844Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/tm_init.go:393 +0xd1b
2023-07-19T20:55:15.3980398Z   vitess.io/vitess/go/vt/wrangler.(*fakeTablet).StartActionLoop()
2023-07-19T20:55:15.3981365Z       /home/runner/work/vitess/vitess/go/vt/wrangler/fake_tablet_test.go:188 +0xb2c
2023-07-19T20:55:15.3981915Z   vitess.io/vitess/go/vt/wrangler.(*testMigraterEnv).startTablets()
2023-07-19T20:55:15.3982637Z       /home/runner/work/vitess/vitess/go/vt/wrangler/traffic_switcher_env_test.go:557 +0x228
2023-07-19T20:55:15.3983166Z   vitess.io/vitess/go/vt/wrangler.newTestShardMigrater()
2023-07-19T20:55:15.3983888Z       /home/runner/work/vitess/vitess/go/vt/wrangler/traffic_switcher_env_test.go:494 +0x1eb9
2023-07-19T20:55:15.3984559Z   vitess.io/vitess/go/vt/wrangler.TestValidateSchemaKeyspace()
2023-07-19T20:55:15.3985331Z       /home/runner/work/vitess/vitess/go/vt/wrangler/schema_test.go:89 +0x267
2023-07-19T20:55:15.3985731Z   testing.tRunner()
2023-07-19T20:55:15.3986310Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1576 +0x216
2023-07-19T20:55:15.3986701Z   testing.(*T).Run.func1()
2023-07-19T20:55:15.3987276Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1629 +0x47
2023-07-19T20:55:15.3987537Z 
2023-07-19T20:55:15.3987707Z Goroutine 890 (running) created at:
2023-07-19T20:55:15.3988227Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).startShardSync()
2023-07-19T20:55:15.3988971Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/shard_sync.go:270 +0x3b1
2023-07-19T20:55:15.3989546Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).Start()
2023-07-19T20:55:15.3990249Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/tm_init.go:393 +0xd1b
2023-07-19T20:55:15.3990806Z   vitess.io/vitess/go/vt/wrangler.(*fakeTablet).StartActionLoop()
2023-07-19T20:55:15.3991486Z       /home/runner/work/vitess/vitess/go/vt/wrangler/fake_tablet_test.go:188 +0xb2c
2023-07-19T20:55:15.3992030Z   vitess.io/vitess/go/vt/wrangler.(*testMigraterEnv).startTablets()
2023-07-19T20:55:15.3992762Z       /home/runner/work/vitess/vitess/go/vt/wrangler/traffic_switcher_env_test.go:557 +0x228
2023-07-19T20:55:15.3993312Z   vitess.io/vitess/go/vt/wrangler.newTestShardMigrater()
2023-07-19T20:55:15.3994325Z       /home/runner/work/vitess/vitess/go/vt/wrangler/traffic_switcher_env_test.go:494 +0x1eb9
2023-07-19T20:55:15.3995093Z   vitess.io/vitess/go/vt/wrangler.TestValidateSchemaKeyspace()
2023-07-19T20:55:15.3996520Z       /home/runner/work/vitess/vitess/go/vt/wrangler/schema_test.go:90 +0x2a9
2023-07-19T20:55:15.3997228Z   testing.tRunner()
2023-07-19T20:55:15.3998529Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1576 +0x216
2023-07-19T20:55:15.3999858Z   testing.(*T).Run.func1()
2023-07-19T20:55:15.4000467Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1629 +0x47
2023-07-19T20:55:15.4000848Z ==================
2023-07-19T20:55:15.4001750Z ks/c0- has tables that are not in the vschema: [not_in_vschema]
2023-07-19T20:55:15.4002315Z ks/80-c0 has tables that are not in the vschema: [not_in_vschema]
2023-07-19T20:55:15.4003096Z ks/-80 has tables that are not in the vschema: [not_in_vschema]
2023-07-19T20:55:15.4003646Z ks/-40 has tables that are not in the vschema: [not_in_vschema]
2023-07-19T20:55:15.4004661Z ks/40-80 has tables that are not in the vschema: [not_in_vschema]
2023-07-19T20:55:15.4005190Z ks/80- has tables that are not in the vschema: [not_in_vschema]
2023-07-19T20:55:15.4005709Z --- FAIL: TestValidateSchemaKeyspace (0.15s)
2023-07-19T20:55:15.4006831Z     testing.go:1446: race detected during execution of test
```
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
