### PR TITLE
Fix flaky vtgate test TestInconsistentStateDetectedBuffering

### DIFF
--- a/go/vt/vtgate/tabletgateway_flaky_test.go
+++ b/go/vt/vtgate/tabletgateway_flaky_test.go
@@ -318,7 +318,11 @@ func TestInconsistentStateDetectedBuffering(t *testing.T) {
 	case <-queryChan:
 		require.Nil(t, res)
 		require.Error(t, err)
-		require.Equal(t, "target: ks1.-80.primary: inconsistent state detected, primary is serving but initially found no available tablet", err.Error())
+		// depending on whether the health check ticks before or after the buffering code, we might get different errors
+		if !(err.Error() == "target: ks1.-80.primary: inconsistent state detected, primary is serving but initially found no available tablet" ||
+			err.Error() == "target: ks1.-80.primary: no healthy tablet available for 'keyspace:\"ks1\" shard:\"-80\" tablet_type:PRIMARY'") {
+			t.Fatalf("wrong error returned: %v", err)
+		}
 	case <-time.After(15 * time.Second):
 		t.Fatalf("timed out waiting for query to execute")
 	}


### PR DESCRIPTION
## Description

Due to valid races the test can get one of two error messages. Only one was expected earlier causing flakiness

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

