### PR TITLE
Flaky tests: Fix wrangler tests

### DIFF
--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -155,6 +155,10 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 	if useShardAsSource {
 		source = "ks/-80"
 	}
+
+	// PrimaryAlias in the shard record is updated asynchronously, so we should wait for it to succeed.
+	waitForShardPrimary(t, wr, destinationPrimary.Tablet)
+
 	if err := vp.Run([]string{"CopySchemaShard", "--include-views", source, "ks/-40"}); err != nil {
 		t.Fatalf("CopySchemaShard failed: %v", err)
 	}

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -550,6 +550,9 @@ func TestRPCTabletExternallyReparentedDemotesPrimaryToConfiguredTabletType(t *te
 		}
 	}
 
+	// PrimaryAlias in the shard record is updated asynchronously, so we should wait for it to succeed.
+	waitForShardPrimary(t, wr, newPrimary.Tablet)
+
 	shardInfo, err := ts.GetShard(context.Background(), newPrimary.Tablet.Keyspace, newPrimary.Tablet.Shard)
 	assert.NoError(t, err)
 

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -878,26 +878,6 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	assert.True(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly")
 }
 
-// waitForTabletType waits for the given tablet type to be reached.
-func waitForTabletType(t *testing.T, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, tabletType topodatapb.TabletType) {
-	timeout := time.After(15 * time.Second)
-	for {
-		tablet, err := wr.TopoServer().GetTablet(context.Background(), tabletAlias)
-		require.NoError(t, err)
-		if tablet.Type == tabletType {
-			return
-		}
-
-		select {
-		case <-timeout:
-			t.Fatalf("%s didn't reach the tablet type %v", topoproto.TabletAliasString(tabletAlias), tabletType.String())
-			return
-		default:
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
-}
-
 // TestPlannedReparentShardSamePrimary tests PRS with oldPrimary works correctly
 // Simulate failure of previous PRS and oldPrimary is ReadOnly
 // Verify that primary correctly gets set to ReadWrite

--- a/go/vt/wrangler/testlib/utils.go
+++ b/go/vt/wrangler/testlib/utils.go
@@ -1,0 +1,57 @@
+package testlib
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/wrangler"
+)
+
+// waitForTabletType waits for the given tablet type to be reached.
+func waitForTabletType(t *testing.T, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, tabletType topodatapb.TabletType) {
+	timeout := time.After(15 * time.Second)
+	for {
+		tablet, err := wr.TopoServer().GetTablet(context.Background(), tabletAlias)
+		require.NoError(t, err)
+		if tablet.Type == tabletType {
+			return
+		}
+
+		select {
+		case <-timeout:
+			t.Fatalf("%s didn't reach the tablet type %v", topoproto.TabletAliasString(tabletAlias), tabletType.String())
+			return
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// waitForShardPrimary waits for the shard record to be upto date such that it has the given primary.
+func waitForShardPrimary(t *testing.T, wr *wrangler.Wrangler, primaryTablet *topodatapb.Tablet) {
+	timeout := time.After(15 * time.Second)
+	for {
+		si, err := wr.TopoServer().GetShard(context.Background(), primaryTablet.Keyspace, primaryTablet.Shard)
+		require.NoError(t, err)
+		if topoproto.TabletAliasEqual(si.PrimaryAlias, primaryTablet.Alias) {
+			return
+		}
+
+		select {
+		case <-timeout:
+			t.Fatalf("%s/%s didn't see the tablet %v become the primary, instead it is %v",
+				primaryTablet.Keyspace, primaryTablet.Shard,
+				topoproto.TabletAliasString(primaryTablet.Alias),
+				topoproto.TabletAliasString(si.PrimaryAlias),
+			)
+			return
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

This PR fixes the tests in `wrangler/testlib` directory. The tests fixed in this PR are `TestCopySchemaShard_UseTabletAsSource`, `TestCopySchemaShard_UseShardAsSource` and `TestRPCTabletExternallyReparentedDemotesPrimaryToConfiguredTabletType`.

All of these tests were relying on the shard record to be up-to-date and have the `PrimaryAlias` field populated. However, this information is updated by the primary tablet asynchronously and sometimes causes the tests to fail.

This PR adds a waiting logic to these tests to wait upto 15 seconds for the `PrimaryAlias` to be updated before running a operation/test dependent on it. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
