### PR TITLE
ignore all error for views in engine reload

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,7 +30,6 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/concurrency"
-	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	"vitess.io/vitess/go/vt/sidecardb"
 
@@ -500,17 +498,8 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 		tableType := row[1].String()
 		table, err := LoadTable(conn, se.cp.DBName(), tableName, tableType, row[3].ToString())
 		if err != nil {
-			isView := strings.Contains(tableType, tmutils.TableView)
-			var emptyColumnsError *mysqlctl.EmptyColumnsErr
-			if errors.As(err, &emptyColumnsError) && isView {
-				log.Warningf("Failed reading schema for the table: %s, error: %v", tableName, err)
-				continue
-			}
-			sqlErr, isSQLErr := mysql.NewSQLErrorFromError(err).(*mysql.SQLError)
-			if isSQLErr && sqlErr != nil && sqlErr.Number() == mysql.ERNoSuchUser && isView {
-				// A VIEW that has an invalid DEFINER, leading to:
-				// ERROR 1449 (HY000): The user specified as a definer (...) does not exist
-				log.Warningf("Failed reading schema for the table: %s, error: %v", tableName, err)
+			if isView := strings.Contains(tableType, tmutils.TableView); isView {
+				log.Warningf("Failed reading schema for the view: %s, error: %v", tableName, err)
 				continue
 			}
 			// Non recoverable error:

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -457,12 +457,12 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 
 	logs := tl.GetAllLogs()
 	logOutput := strings.Join(logs, ":::")
-	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the table: test_view")
+	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the view: test_view")
 	assert.Contains(t, logOutput, "The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")
 }
 
-// TestOpenFailedDueToEmptyColumnInView tests that schema engine load should not fail instead should log the failures for empty columns in view
-func TestOpenFailedDueToEmptyColumnInView(t *testing.T) {
+// TestOpenNoErrorDueToInvalidViews tests that schema engine load does not fail instead should log the failures for the views
+func TestOpenNoErrorDueToInvalidViews(t *testing.T) {
 	tl := syslogger.NewTestLogger()
 	defer tl.Close()
 	db := fakesqldb.New(t)
@@ -471,13 +471,18 @@ func TestOpenFailedDueToEmptyColumnInView(t *testing.T) {
 	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,
 		Rows: [][]sqltypes.Value{
-			mysql.BaseShowTablesRow("test_view", true, "VIEW"),
+			mysql.BaseShowTablesRow("foo_view", true, "VIEW"),
+			mysql.BaseShowTablesRow("bar_view", true, "VIEW"),
 		},
 	})
 
 	// adding column query for table_view
-	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "test_view"),
+	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "foo_view"),
 		&sqltypes.Result{})
+	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "bar_view"),
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("column_name", "varchar"), "col1", "col2"))
+	// rejecting the impossible query
+	db.AddRejectedQuery("SELECT `col1`, `col2` FROM `fakesqldb`.`bar_view` WHERE 1 != 1", mysql.NewSQLError(mysql.ERWrongFieldWithGroup, mysql.SSClientError, "random error for table bar_view"))
 
 	AddFakeInnoDBReadRowsResult(db, 0)
 	se := newEngine(10, 1*time.Second, 1*time.Second, 0, db)
@@ -486,8 +491,10 @@ func TestOpenFailedDueToEmptyColumnInView(t *testing.T) {
 
 	logs := tl.GetAllLogs()
 	logOutput := strings.Join(logs, ":::")
-	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the table: test_view")
-	assert.Contains(t, logOutput, "unable to get columns for table fakesqldb.test_view")
+	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the view: foo_view")
+	assert.Contains(t, logOutput, "unable to get columns for table fakesqldb.foo_view")
+	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the view: bar_view")
+	assert.Contains(t, logOutput, "random error for table bar_view")
 }
 
 func TestExportVars(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR ignores all the view related error on vttablet engine reload method. 
The current implementation only ignores a few errors on views during reload, which is insufficient to continue smoothly.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/13422

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
