### PR TITLE
Throttler: reintroduce deprecated flags so that deprecation actually works

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -77,22 +77,14 @@ func init() {
 	servenv.OnParseFor("vttablet", registerThrottlerFlags)
 }
 
-var (
-	deprecatedThrottlerConfigViaTopo    = false // unused. Remove in v19
-	deprecatedThrottleThreshold         time.Duration
-	deprecatedThrottleMetricQuery       string
-	deprecatedThrottleMetricThreshold   float64
-	deprecatedThrottlerCheckAsCheckSelf bool
-)
-
 func registerThrottlerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&throttleTabletTypes, "throttle_tablet_types", throttleTabletTypes, "Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' aways implicitly included")
 
-	fs.DurationVar(&deprecatedThrottleThreshold, "throttle_threshold", deprecatedThrottleThreshold, "Replication lag threshold for default lag throttling")
-	fs.StringVar(&deprecatedThrottleMetricQuery, "throttle_metrics_query", deprecatedThrottleMetricQuery, "Override default heartbeat/lag metric. Use either `SELECT` (must return single row, single value) or `SHOW GLOBAL ... LIKE ...` queries. Set -throttle_metrics_threshold respectively.")
-	fs.Float64Var(&deprecatedThrottleMetricThreshold, "throttle_metrics_threshold", deprecatedThrottleMetricThreshold, "Override default throttle threshold, respective to --throttle_metrics_query")
-	fs.BoolVar(&deprecatedThrottlerCheckAsCheckSelf, "throttle_check_as_check_self", deprecatedThrottlerCheckAsCheckSelf, "Should throttler/check return a throttler/check-self result (changes throttler behavior for writes)")
-	fs.BoolVar(&deprecatedThrottlerConfigViaTopo, "throttler-config-via-topo", deprecatedThrottlerConfigViaTopo, "Deprecated, will be removed in v19. Assumed to be 'true'")
+	fs.Duration("throttle_threshold", 0, "Replication lag threshold for default lag throttling")
+	fs.String("throttle_metrics_query", "", "Override default heartbeat/lag metric. Use either `SELECT` (must return single row, single value) or `SHOW GLOBAL ... LIKE ...` queries. Set -throttle_metrics_threshold respectively.")
+	fs.Float64("throttle_metrics_threshold", 0, "Override default throttle threshold, respective to --throttle_metrics_query")
+	fs.Bool("throttle_check_as_check_self", false, "Should throttler/check return a throttler/check-self result (changes throttler behavior for writes)")
+	fs.Bool("throttler-config-via-topo", false, "Deprecated, will be removed in v19. Assumed to be 'true'")
 
 	fs.MarkDeprecated("throttle_threshold", "Replication lag threshold for default lag throttling")
 	fs.MarkDeprecated("throttle_metrics_query", "Override default heartbeat/lag metric. Use either `SELECT` (must return single row, single value) or `SHOW GLOBAL ... LIKE ...` queries. Set -throttle_metrics_threshold respectively.")

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -77,8 +77,22 @@ func init() {
 	servenv.OnParseFor("vttablet", registerThrottlerFlags)
 }
 
+var (
+	deprecatedThrottlerConfigViaTopo    = false // unused. Remove in v19
+	deprecatedThrottleThreshold         time.Duration
+	deprecatedThrottleMetricQuery       string
+	deprecatedThrottleMetricThreshold   float64
+	deprecatedThrottlerCheckAsCheckSelf bool
+)
+
 func registerThrottlerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&throttleTabletTypes, "throttle_tablet_types", throttleTabletTypes, "Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' aways implicitly included")
+
+	fs.DurationVar(&deprecatedThrottleThreshold, "throttle_threshold", deprecatedThrottleThreshold, "Replication lag threshold for default lag throttling")
+	fs.StringVar(&deprecatedThrottleMetricQuery, "throttle_metrics_query", deprecatedThrottleMetricQuery, "Override default heartbeat/lag metric. Use either `SELECT` (must return single row, single value) or `SHOW GLOBAL ... LIKE ...` queries. Set -throttle_metrics_threshold respectively.")
+	fs.Float64Var(&deprecatedThrottleMetricThreshold, "throttle_metrics_threshold", deprecatedThrottleMetricThreshold, "Override default throttle threshold, respective to --throttle_metrics_query")
+	fs.BoolVar(&deprecatedThrottlerCheckAsCheckSelf, "throttle_check_as_check_self", deprecatedThrottlerCheckAsCheckSelf, "Should throttler/check return a throttler/check-self result (changes throttler behavior for writes)")
+	fs.BoolVar(&deprecatedThrottlerConfigViaTopo, "throttler-config-via-topo", deprecatedThrottlerConfigViaTopo, "Deprecated, will be removed in v19. Assumed to be 'true'")
 
 	fs.MarkDeprecated("throttle_threshold", "Replication lag threshold for default lag throttling")
 	fs.MarkDeprecated("throttle_metrics_query", "Override default heartbeat/lag metric. Use either `SELECT` (must return single row, single value) or `SHOW GLOBAL ... LIKE ...` queries. Set -throttle_metrics_threshold respectively.")


### PR DESCRIPTION

## Description

Followup and fix to https://github.com/vitessio/vitess/pull/13246

Per https://github.com/vitessio/vitess/pull/13246#issuecomment-1646614732, the deprecation was done incorrectly, and eventually unnecessarily led to https://github.com/vitessio/vitess/pull/13516

This PR re-introduces the flags so that they are deprecated correctly.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/13246

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
