### PR TITLE
[release-15.0] fix: error.as method usage to send pointer to the reference type expected (#13496)

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -384,7 +384,7 @@ func (se *Engine) reload(ctx context.Context) error {
 		table, err := LoadTable(conn, se.cp.DBName(), tableName, row[3].ToString())
 		if err != nil {
 			isView := strings.Contains(tableType, tmutils.TableView)
-			var emptyColumnsError mysqlctl.EmptyColumnsErr
+			var emptyColumnsError *mysqlctl.EmptyColumnsErr
 			if errors.As(err, &emptyColumnsError) && isView {
 				log.Warningf("Failed reading schema for the table: %s, error: %v", tableName, err)
 				continue


### PR DESCRIPTION
## Description

This is a backport of #13496 
