### PR TITLE
[release-17.0] fix: error.as method usage to send pointer to the reference type expected (#13496)

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -504,7 +504,7 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 		table, err := LoadTable(conn, se.cp.DBName(), tableName, tableType, row[3].ToString())
 		if err != nil {
 			isView := strings.Contains(tableType, tmutils.TableView)
-			var emptyColumnsError mysqlctl.EmptyColumnsErr
+			var emptyColumnsError *mysqlctl.EmptyColumnsErr
 			if errors.As(err, &emptyColumnsError) && isView {
 				log.Warningf("Failed reading schema for the table: %s, error: %v", tableName, err)
 				continue

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -461,6 +461,35 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	assert.Contains(t, logOutput, "The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")
 }
 
+// TestOpenFailedDueToEmptyColumnInView tests that schema engine load should not fail instead should log the failures for empty columns in view
+func TestOpenFailedDueToEmptyColumnInView(t *testing.T) {
+	tl := syslogger.NewTestLogger()
+	defer tl.Close()
+	db := fakesqldb.New(t)
+	defer db.Close()
+	schematest.AddDefaultQueries(db)
+	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
+		Fields: mysql.BaseShowTablesFields,
+		Rows: [][]sqltypes.Value{
+			mysql.BaseShowTablesRow("test_view", true, "VIEW"),
+		},
+	})
+
+	// adding column query for table_view
+	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "test_view"),
+		&sqltypes.Result{})
+
+	AddFakeInnoDBReadRowsResult(db, 0)
+	se := newEngine(10, 1*time.Second, 1*time.Second, 0, db)
+	err := se.Open()
+	require.NoError(t, err)
+
+	logs := tl.GetAllLogs()
+	logOutput := strings.Join(logs, ":::")
+	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the table: test_view")
+	assert.Contains(t, logOutput, "unable to get columns for table fakesqldb.test_view")
+}
+
 func TestExportVars(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()


### PR DESCRIPTION
## Description

This is a backport of #13496 
