### PR TITLE
Throttler: verify deprecated flags are still allowed

### DIFF
--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -156,6 +156,13 @@ func TestMain(m *testing.M) {
 			"--migration_check_interval", "5s",
 			"--queryserver-config-schema-change-signal-interval", "0.1",
 			"--watch_replication_stream",
+			// The next flags are deprecated, and we incldue them to verify that they are nonetheless still allowed.
+			// These should be included in v18, and removed in v19.
+			"--throttle_threshold", "1m",
+			"--throttle_metrics_query", "select 1 from dual",
+			"--throttle_metrics_threshold", "1.5",
+			"--throttle_check_as_check_self", "false",
+			"--throttler-config-via-topo", "true",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl_strategy", "online",

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -157,6 +157,7 @@ func TestMain(m *testing.M) {
 			"--queryserver-config-schema-change-signal-interval", "0.1",
 			"--watch_replication_stream",
 			// The next flags are deprecated, and we incldue them to verify that they are nonetheless still allowed.
+			// The values are irrelevant. Just the fact that the flags are allowed in what's important.
 			// These should be included in v18, and removed in v19.
 			"--throttle_threshold", "1m",
 			"--throttle_metrics_query", "select 1 from dual",

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -162,8 +162,8 @@ func TestMain(m *testing.M) {
 			"--throttle_threshold", "1m",
 			"--throttle_metrics_query", "select 1 from dual",
 			"--throttle_metrics_threshold", "1.5",
-			"--throttle_check_as_check_self", "false",
-			"--throttler-config-via-topo", "true",
+			"--throttle_check_as_check_self=false",
+			"--throttler-config-via-topo=true",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl_strategy", "online",


### PR DESCRIPTION
## Description

Followup to https://github.com/vitessio/vitess/pull/13597#issuecomment-1650628533: picked some random test (`onlineddl_revert`) to re-introduce the deprecated throttler flags, just for the sake of verifying they are still accepted, even though their values are ignored in `v18`.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/13246

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
