### PR TITLE
[viper WatchConfig] platform-specific write to ensure callback fires exactly once

### DIFF
--- a/go/viperutil/internal/sync/sync_darwin_test.go
+++ b/go/viperutil/internal/sync/sync_darwin_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync_test
+
+import "os"
+
+func atomicWrite(path string, data []byte) error {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, stat.Mode())
+}

--- a/go/viperutil/internal/sync/sync_darwin_test.go
+++ b/go/viperutil/internal/sync/sync_darwin_test.go
@@ -18,6 +18,12 @@ package sync_test
 
 import "os"
 
+// atomicWrite overwrites a file in such a way as to produce exactly one
+// filesystem event of the type CREATE or WRITE (which are tracked by viper)
+// without producing any REMOVE events.
+//
+// At time of writing, this produces the following on darwin:
+// CHMOD => WRITE => CHMOD.
 func atomicWrite(path string, data []byte) error {
 	stat, err := os.Stat(path)
 	if err != nil {

--- a/go/viperutil/internal/sync/sync_linux_test.go
+++ b/go/viperutil/internal/sync/sync_linux_test.go
@@ -18,6 +18,12 @@ package sync_test
 
 import "os"
 
+// atomicWrite overwrites a file in such a way as to produce exactly one
+// filesystem event of the type CREATE or WRITE (which are tracked by viper)
+// without producing any REMOVE events.
+//
+// At time of writing, this produces the following on x86_64 linux:
+// CREATE.
 func atomicWrite(path string, data []byte) error {
 	stat, err := os.Stat(path)
 	if err != nil {

--- a/go/viperutil/internal/sync/sync_linux_test.go
+++ b/go/viperutil/internal/sync/sync_linux_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync_test
+
+import "os"
+
+func atomicWrite(path string, data []byte) error {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, stat.Mode()); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp, path)
+}

--- a/go/viperutil/internal/sync/sync_test.go
+++ b/go/viperutil/internal/sync/sync_test.go
@@ -45,6 +45,11 @@ func TestWatchConfig(t *testing.T) {
 			return err
 		}
 
+		// In order to guarantee viper's watcher detects exactly one config
+		// change, we perform a write specific to the platform we're executing
+		// on.
+		//
+		// Consequently, this test only supports linux and macos for now.
 		return atomicWrite(tmp.Name(), data)
 	}
 	writeRandomConfig := func(tmp *os.File) error {

--- a/go/viperutil/internal/sync/sync_test.go
+++ b/go/viperutil/internal/sync/sync_test.go
@@ -19,15 +19,11 @@ package sync_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"math"
 	"math/rand"
 	"os"
 	"sync"
 	"testing"
 	"time"
-
-	"vitess.io/vitess/go/vt/log"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
@@ -44,36 +40,12 @@ func TestWatchConfig(t *testing.T) {
 	}
 
 	writeConfig := func(tmp *os.File, a, b int) error {
-		stat, err := os.Stat(tmp.Name())
-		if err != nil {
-			return err
-		}
-
 		data, err := json.Marshal(&config{A: a, B: b})
 		if err != nil {
 			return err
 		}
 
-		err = os.WriteFile(tmp.Name(), data, stat.Mode())
-		if err != nil {
-			return err
-		}
-
-		data, err = os.ReadFile(tmp.Name())
-		if err != nil {
-			return err
-		}
-
-		var cfg config
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return err
-		}
-
-		if cfg.A != a || cfg.B != b {
-			return fmt.Errorf("config did not persist; want %+v got %+v", config{A: a, B: b}, cfg)
-		}
-
-		return nil
+		return atomicWrite(tmp.Name(), data)
 	}
 	writeRandomConfig := func(tmp *os.File) error {
 		a, b := rand.Intn(100), rand.Intn(100)
@@ -109,19 +81,8 @@ func TestWatchConfig(t *testing.T) {
 	require.NoError(t, writeConfig(tmp, a+1, b+1))
 	<-wCh // wait for the update to finish
 
-	// temporary hack to fix flakiness where we seem to miss one update.
-	const permittedVariance = 1
-	closeEnoughTo := func(want, got int) bool {
-		if math.Abs(float64(want-got)) <= permittedVariance {
-			return true
-		}
-		log.Infof("TestWatchConfig: count not close enough: want %d, got %d, permitted variance %d",
-			want, got, permittedVariance)
-		return false
-	}
-
-	require.True(t, closeEnoughTo(a+1, v.GetInt("a")))
-	require.True(t, closeEnoughTo(b+1, v.GetInt("b")))
+	require.Equal(t, a+1, v.GetInt("a"))
+	require.Equal(t, b+1, v.GetInt("b"))
 
 	rCh <- struct{}{}
 


### PR DESCRIPTION
## Description

It turns out that when you call `os.WriteFile`, it does two things:

```go
f, err := OpenFile(name, O_WRONLY|O_CREATE|O_TRUNC, perm)

f.Write(...)
```

On certain platforms (linux), opening with `O_TRUNC` counts as a WRITE event (since the file _is_ being "written" to blank), which causes fsnotify, and therefor viper to detect a config change, and attempt to reload the config, which results in us failing to parse an empty file as JSON. The second WRITE then fires, and the new config is loaded correctly, but if the main test goroutine resumes before this happens, it will make assertions based on the old config, hence the flakiness.

Therefore, we need to make sure we get exactly _one_ WRITE (or CREATE) event to make the test deterministic, without producing any REMOVE events. How we do this depends on the platform the test runs on, outlined in the following table:

| method | darwin | linux |
| --------| -------| ------|
| tempfile + `os.Rename` | REMOVE => CREATE | CREATE |
| `os.WriteFile` | CHMOD => WRITE => CHMOD | WRITE => WRITE |

## Related Issue(s)

Fixes #13498 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
