### PR TITLE
icuregex: Lazy load ICU data into memory

### DIFF
--- a/go/mysql/icuregex/internal/icudata/embed.go
+++ b/go/mysql/icuregex/internal/icudata/embed.go
@@ -80,17 +80,17 @@ var Nfkc []byte
 // case folding.
 // This is used for property checks of characters about composition.
 //
-//go:embed nfkc_cf.nrm
-var NfkcCf []byte
+//Unused: go:embed nfkc_cf.nrm
+//var NfkcCf []byte
 
 // BrkChar is used for matching against character break
 // characters in regular expressions.
 //
-//go:embed char.brk
-var BrkChar []byte
+//Unused: go:embed char.brk
+//var BrkChar []byte
 
 // BrkWord is used for matching against word break
 // characters in regular expressions.
 //
-//go:embed word.brk
-var BrkWord []byte
+//Unused: go:embed word.brk
+///var BrkWord []byte

--- a/go/mysql/icuregex/internal/ubidi/loader.go
+++ b/go/mysql/icuregex/internal/ubidi/loader.go
@@ -1,0 +1,125 @@
+/*
+© 2016 and later: Unicode, Inc. and others.
+Copyright (C) 2004-2015, International Business Machines Corporation and others.
+Copyright 2023 The Vitess Authors.
+
+This file contains code derived from the Unicode Project's ICU library.
+License & terms of use for the original code: http://www.unicode.org/copyright.html
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ubidi
+
+import (
+	"errors"
+	"sync"
+
+	"vitess.io/vitess/go/mysql/icuregex/internal/icudata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/udata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/utrie"
+)
+
+var ubidiOnce sync.Once
+var ubidi struct {
+	indexes []int32
+	trie    *utrie.UTrie2
+	mirrors []uint32
+	jg      []uint8
+	jg2     []uint8
+}
+
+func indexes() []int32 {
+	loadUBidi()
+	return ubidi.indexes
+}
+
+func trie() *utrie.UTrie2 {
+	loadUBidi()
+	return ubidi.trie
+}
+
+func mirrors() []uint32 {
+	loadUBidi()
+	return ubidi.mirrors
+}
+
+func jg() []uint8 {
+	loadUBidi()
+	return ubidi.jg
+}
+
+func jg2() []uint8 {
+	loadUBidi()
+	return ubidi.jg2
+}
+
+func loadUBidi() {
+	ubidiOnce.Do(func() {
+		b := udata.NewBytes(icudata.UBidi)
+		if err := readData(b); err != nil {
+			panic(err)
+		}
+	})
+}
+
+func readData(bytes *udata.Bytes) error {
+	err := bytes.ReadHeader(func(info *udata.DataInfo) bool {
+		return info.DataFormat[0] == 0x42 &&
+			info.DataFormat[1] == 0x69 &&
+			info.DataFormat[2] == 0x44 &&
+			info.DataFormat[3] == 0x69 &&
+			info.FormatVersion[0] == 2
+	})
+	if err != nil {
+		return err
+	}
+
+	count := int32(bytes.Uint32())
+	if count < ixTop {
+		return errors.New("indexes[0] too small in ucase.icu")
+	}
+
+	ubidi.indexes = make([]int32, count)
+	ubidi.indexes[0] = count
+
+	for i := int32(1); i < count; i++ {
+		ubidi.indexes[i] = int32(bytes.Uint32())
+	}
+
+	ubidi.trie, err = utrie.UTrie2FromBytes(bytes)
+	if err != nil {
+		return err
+	}
+
+	expectedTrieLength := ubidi.indexes[ixTrieSize]
+	trieLength := ubidi.trie.SerializedLength()
+
+	if trieLength > expectedTrieLength {
+		return errors.New("ucase.icu: not enough bytes for the trie")
+	}
+
+	bytes.Skip(expectedTrieLength - trieLength)
+
+	if n := ubidi.indexes[ixMirrorLength]; n > 0 {
+		ubidi.mirrors = bytes.Uint32Slice(n)
+	}
+	if n := ubidi.indexes[ixJgLimit] - ubidi.indexes[ixJgStart]; n > 0 {
+		ubidi.jg = bytes.Uint8Slice(n)
+	}
+	if n := ubidi.indexes[ixJgLimit2] - ubidi.indexes[ixJgStart2]; n > 0 {
+		ubidi.jg2 = bytes.Uint8Slice(n)
+	}
+
+	return nil
+}

--- a/go/mysql/icuregex/internal/ucase/fold.go
+++ b/go/mysql/icuregex/internal/ucase/fold.go
@@ -83,7 +83,7 @@ func FoldRunes(str []rune) []rune {
   - U+0130 has no simple case folding (simple-case-folds to itself).
 */
 func Fold(c rune) rune {
-	props := ucase.trie.Get16(c)
+	props := trie().Get16(c)
 	if !hasException(props) {
 		if isUpperOrTitle(props) {
 			c += getDelta(props)
@@ -130,7 +130,7 @@ func Fold(c rune) rune {
 
 func FullFolding(c rune) (rune, []uint16) {
 	result := c
-	props := ucase.trie.Get16(c)
+	props := trie().Get16(c)
 
 	if !hasException(props) {
 		if isUpperOrTitle(props) {
@@ -222,7 +222,7 @@ func getDelta(props uint16) rune {
 }
 
 func getExceptions(props uint16) []uint16 {
-	return ucase.exceptions[props>>4:]
+	return exceptions()[props>>4:]
 }
 
 func hasSlot(flags uint16, idx int32) bool {

--- a/go/mysql/icuregex/internal/ucase/loader.go
+++ b/go/mysql/icuregex/internal/ucase/loader.go
@@ -1,0 +1,110 @@
+/*
+© 2016 and later: Unicode, Inc. and others.
+Copyright (C) 2004-2015, International Business Machines Corporation and others.
+Copyright 2023 The Vitess Authors.
+
+This file contains code derived from the Unicode Project's ICU library.
+License & terms of use for the original code: http://www.unicode.org/copyright.html
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ucase
+
+import (
+	"errors"
+	"sync"
+
+	"vitess.io/vitess/go/mysql/icuregex/internal/icudata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/udata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/utrie"
+)
+
+var ucaseOnce sync.Once
+var ucase struct {
+	trie       *utrie.UTrie2
+	exceptions []uint16
+	unfold     []uint16
+}
+
+func trie() *utrie.UTrie2 {
+	loadUCase()
+	return ucase.trie
+}
+
+func exceptions() []uint16 {
+	loadUCase()
+	return ucase.exceptions
+}
+
+func unfold() []uint16 {
+	loadUCase()
+	return ucase.unfold
+}
+
+func loadUCase() {
+	ucaseOnce.Do(func() {
+		b := udata.NewBytes(icudata.UCase)
+		if err := readData(b); err != nil {
+			panic(err)
+		}
+	})
+}
+
+func readData(bytes *udata.Bytes) error {
+	err := bytes.ReadHeader(func(info *udata.DataInfo) bool {
+		return info.DataFormat[0] == 0x63 &&
+			info.DataFormat[1] == 0x41 &&
+			info.DataFormat[2] == 0x53 &&
+			info.DataFormat[3] == 0x45 &&
+			info.FormatVersion[0] == 4
+	})
+	if err != nil {
+		return err
+	}
+
+	count := int32(bytes.Uint32())
+	if count < ixTop {
+		return errors.New("indexes[0] too small in ucase.icu")
+	}
+
+	indexes := make([]int32, count)
+	indexes[0] = count
+
+	for i := int32(1); i < count; i++ {
+		indexes[i] = int32(bytes.Uint32())
+	}
+
+	ucase.trie, err = utrie.UTrie2FromBytes(bytes)
+	if err != nil {
+		return err
+	}
+
+	expectedTrieLength := indexes[ixTrieSize]
+	trieLength := ucase.trie.SerializedLength()
+
+	if trieLength > expectedTrieLength {
+		return errors.New("ucase.icu: not enough bytes for the trie")
+	}
+
+	bytes.Skip(expectedTrieLength - trieLength)
+
+	if n := indexes[ixExcLength]; n > 0 {
+		ucase.exceptions = bytes.Uint16Slice(n)
+	}
+	if n := indexes[ixUnfoldLength]; n > 0 {
+		ucase.unfold = bytes.Uint16Slice(n)
+	}
+
+	return nil
+}

--- a/go/mysql/icuregex/internal/uchar/loader.go
+++ b/go/mysql/icuregex/internal/uchar/loader.go
@@ -1,0 +1,139 @@
+/*
+© 2016 and later: Unicode, Inc. and others.
+Copyright (C) 2004-2015, International Business Machines Corporation and others.
+Copyright 2023 The Vitess Authors.
+
+This file contains code derived from the Unicode Project's ICU library.
+License & terms of use for the original code: http://www.unicode.org/copyright.html
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uchar
+
+import (
+	"errors"
+	"sync"
+
+	"vitess.io/vitess/go/mysql/icuregex/internal/icudata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/udata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/utrie"
+)
+
+var upropsOnce sync.Once
+var uprops struct {
+	trie             *utrie.UTrie2
+	trie2            *utrie.UTrie2
+	vectorsColumns   int32
+	vectors          []uint32
+	scriptExtensions []uint16
+}
+
+func trie() *utrie.UTrie2 {
+	loadUProps()
+	return uprops.trie
+}
+
+func trie2() *utrie.UTrie2 {
+	loadUProps()
+	return uprops.trie2
+}
+
+func vectorsColumns() int32 {
+	loadUProps()
+	return uprops.vectorsColumns
+}
+
+func vectors() []uint32 {
+	loadUProps()
+	return uprops.vectors
+}
+
+func scriptExtensions() []uint16 {
+	loadUProps()
+	return uprops.scriptExtensions
+}
+
+func loadUProps() {
+	upropsOnce.Do(func() {
+		b := udata.NewBytes(icudata.UProps)
+		if err := readData(b); err != nil {
+			panic(err)
+		}
+	})
+}
+
+func readData(bytes *udata.Bytes) error {
+	err := bytes.ReadHeader(func(info *udata.DataInfo) bool {
+		return info.DataFormat[0] == 0x55 &&
+			info.DataFormat[1] == 0x50 &&
+			info.DataFormat[2] == 0x72 &&
+			info.DataFormat[3] == 0x6f &&
+			info.FormatVersion[0] == 7
+	})
+	if err != nil {
+		return err
+	}
+
+	propertyOffset := bytes.Int32()
+	/* exceptionOffset = */ bytes.Int32()
+	/* caseOffset = */ bytes.Int32()
+	additionalOffset := bytes.Int32()
+	additionalVectorsOffset := bytes.Int32()
+	uprops.vectorsColumns = bytes.Int32()
+	scriptExtensionsOffset := bytes.Int32()
+	reservedOffset7 := bytes.Int32()
+	/* reservedOffset8 = */ bytes.Int32()
+	/* dataTopOffset = */ bytes.Int32()
+	_ = bytes.Int32()
+	_ = bytes.Int32()
+	bytes.Skip((16 - 12) << 2)
+
+	uprops.trie, err = utrie.UTrie2FromBytes(bytes)
+	if err != nil {
+		return err
+	}
+
+	expectedTrieLength := (propertyOffset - 16) * 4
+	trieLength := uprops.trie.SerializedLength()
+
+	if trieLength > expectedTrieLength {
+		return errors.New("ucase.icu: not enough bytes for the trie")
+	}
+
+	bytes.Skip(expectedTrieLength - trieLength)
+	bytes.Skip((additionalOffset - propertyOffset) * 4)
+
+	if uprops.vectorsColumns > 0 {
+		uprops.trie2, err = utrie.UTrie2FromBytes(bytes)
+		if err != nil {
+			return err
+		}
+
+		expectedTrieLength = (additionalVectorsOffset - additionalOffset) * 4
+		trieLength = uprops.trie2.SerializedLength()
+
+		if trieLength > expectedTrieLength {
+			return errors.New("ucase.icu: not enough bytes for the trie")
+		}
+
+		bytes.Skip(expectedTrieLength - trieLength)
+		uprops.vectors = bytes.Uint32Slice(scriptExtensionsOffset - additionalVectorsOffset)
+	}
+
+	if n := (reservedOffset7 - scriptExtensionsOffset) * 2; n > 0 {
+		uprops.scriptExtensions = bytes.Uint16Slice(n)
+	}
+
+	return nil
+}

--- a/go/mysql/icuregex/internal/unames/loader.go
+++ b/go/mysql/icuregex/internal/unames/loader.go
@@ -1,0 +1,90 @@
+/*
+© 2016 and later: Unicode, Inc. and others.
+Copyright (C) 2004-2015, International Business Machines Corporation and others.
+Copyright 2023 The Vitess Authors.
+
+This file contains code derived from the Unicode Project's ICU library.
+License & terms of use for the original code: http://www.unicode.org/copyright.html
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unames
+
+import (
+	"sync"
+
+	"vitess.io/vitess/go/mysql/icuregex/internal/icudata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/udata"
+)
+
+var charNamesOnce sync.Once
+var charNames *unames
+
+type unames struct {
+	tokens       []uint16
+	tokenStrings []uint8
+	groups       []uint16
+	groupNames   []uint8
+	algNames     []algorithmicRange
+}
+
+func loadCharNames() {
+	charNamesOnce.Do(func() {
+		b := udata.NewBytes(icudata.UNames)
+		if err := b.ReadHeader(func(info *udata.DataInfo) bool {
+			return info.Size >= 20 &&
+				info.IsBigEndian == 0 &&
+				info.CharsetFamily == 0 &&
+				info.DataFormat[0] == 0x75 && /* dataFormat="unam" */
+				info.DataFormat[1] == 0x6e &&
+				info.DataFormat[2] == 0x61 &&
+				info.DataFormat[3] == 0x6d &&
+				info.FormatVersion[0] == 1
+		}); err != nil {
+			panic(err)
+		}
+
+		tokenStringOffset := int32(b.Uint32() - 16)
+		groupsOffset := int32(b.Uint32() - 16)
+		groupStringOffset := int32(b.Uint32() - 16)
+		algNamesOffset := int32(b.Uint32() - 16)
+		charNames = &unames{
+			tokens:       b.Uint16Slice(tokenStringOffset / 2),
+			tokenStrings: b.Uint8Slice(groupsOffset - tokenStringOffset),
+			groups:       b.Uint16Slice((groupStringOffset - groupsOffset) / 2),
+			groupNames:   b.Uint8Slice(algNamesOffset - groupStringOffset),
+		}
+
+		algCount := b.Uint32()
+		charNames.algNames = make([]algorithmicRange, 0, algCount)
+
+		for i := uint32(0); i < algCount; i++ {
+			ar := algorithmicRange{
+				start:   b.Uint32(),
+				end:     b.Uint32(),
+				typ:     b.Uint8(),
+				variant: b.Uint8(),
+			}
+			size := b.Uint16()
+			switch ar.typ {
+			case 0:
+				ar.s = b.Uint8Slice(int32(size) - 12)
+			case 1:
+				ar.factors = b.Uint16Slice(int32(ar.variant))
+				ar.s = b.Uint8Slice(int32(size) - 12 - int32(ar.variant)*2)
+			}
+			charNames.algNames = append(charNames.algNames, ar)
+		}
+	})
+}

--- a/go/mysql/icuregex/internal/unames/unames.go
+++ b/go/mysql/icuregex/internal/unames/unames.go
@@ -25,72 +25,7 @@ import (
 	"bytes"
 	"strconv"
 	"strings"
-	"sync"
-
-	"vitess.io/vitess/go/mysql/icuregex/internal/icudata"
-	"vitess.io/vitess/go/mysql/icuregex/internal/udata"
 )
-
-var charNamesOnce sync.Once
-var charNames *unames
-
-type unames struct {
-	tokens       []uint16
-	tokenStrings []uint8
-	groups       []uint16
-	groupNames   []uint8
-	algNames     []algorithmicRange
-}
-
-func loadCharNames() {
-	charNamesOnce.Do(func() {
-		b := udata.NewBytes(icudata.UNames)
-		if err := b.ReadHeader(func(info *udata.DataInfo) bool {
-			return info.Size >= 20 &&
-				info.IsBigEndian == 0 &&
-				info.CharsetFamily == 0 &&
-				info.DataFormat[0] == 0x75 && /* dataFormat="unam" */
-				info.DataFormat[1] == 0x6e &&
-				info.DataFormat[2] == 0x61 &&
-				info.DataFormat[3] == 0x6d &&
-				info.FormatVersion[0] == 1
-		}); err != nil {
-			panic(err)
-		}
-
-		tokenStringOffset := int32(b.Uint32() - 16)
-		groupsOffset := int32(b.Uint32() - 16)
-		groupStringOffset := int32(b.Uint32() - 16)
-		algNamesOffset := int32(b.Uint32() - 16)
-		charNames = &unames{
-			tokens:       b.Uint16Slice(tokenStringOffset / 2),
-			tokenStrings: b.Uint8Slice(groupsOffset - tokenStringOffset),
-			groups:       b.Uint16Slice((groupStringOffset - groupsOffset) / 2),
-			groupNames:   b.Uint8Slice(algNamesOffset - groupStringOffset),
-		}
-
-		algCount := b.Uint32()
-		charNames.algNames = make([]algorithmicRange, 0, algCount)
-
-		for i := uint32(0); i < algCount; i++ {
-			ar := algorithmicRange{
-				start:   b.Uint32(),
-				end:     b.Uint32(),
-				typ:     b.Uint8(),
-				variant: b.Uint8(),
-			}
-			size := b.Uint16()
-			switch ar.typ {
-			case 0:
-				ar.s = b.Uint8Slice(int32(size) - 12)
-			case 1:
-				ar.factors = b.Uint16Slice(int32(ar.variant))
-				ar.s = b.Uint8Slice(int32(size) - 12 - int32(ar.variant)*2)
-			}
-			charNames.algNames = append(charNames.algNames, ar)
-		}
-	})
-}
 
 func (names *unames) getGroupName(group []uint16) []uint8 {
 	return names.groupNames[names.getGroupOffset(group):]

--- a/go/mysql/icuregex/internal/uprops/loader.go
+++ b/go/mysql/icuregex/internal/uprops/loader.go
@@ -1,0 +1,93 @@
+/*
+© 2016 and later: Unicode, Inc. and others.
+Copyright (C) 2004-2015, International Business Machines Corporation and others.
+Copyright 2023 The Vitess Authors.
+
+This file contains code derived from the Unicode Project's ICU library.
+License & terms of use for the original code: http://www.unicode.org/copyright.html
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uprops
+
+import (
+	"fmt"
+	"sync"
+
+	"vitess.io/vitess/go/mysql/icuregex/internal/icudata"
+	"vitess.io/vitess/go/mysql/icuregex/internal/udata"
+)
+
+var pnamesOnce sync.Once
+var pnames struct {
+	valueMaps []uint32
+	byteTrie  []uint8
+}
+
+func valueMaps() []uint32 {
+	loadPNames()
+	return pnames.valueMaps
+}
+
+func byteTrie() []uint8 {
+	loadPNames()
+	return pnames.byteTrie
+}
+
+func loadPNames() {
+	pnamesOnce.Do(func() {
+		b := udata.NewBytes(icudata.PNames)
+		if err := readData(b); err != nil {
+			panic(err)
+		}
+	})
+}
+
+func readData(bytes *udata.Bytes) error {
+	err := bytes.ReadHeader(func(info *udata.DataInfo) bool {
+		return info.DataFormat[0] == 0x70 &&
+			info.DataFormat[1] == 0x6e &&
+			info.DataFormat[2] == 0x61 &&
+			info.DataFormat[3] == 0x6d &&
+			info.FormatVersion[0] == 2
+	})
+	if err != nil {
+		return err
+	}
+
+	count := bytes.Int32() / 4
+	if count < 8 {
+		return fmt.Errorf("indexes[0] too small in ucase.icu")
+	}
+
+	indexes := make([]int32, count)
+	indexes[0] = count * 4
+
+	for i := int32(1); i < count; i++ {
+		indexes[i] = bytes.Int32()
+	}
+
+	offset := indexes[ixValueMapsOffset]
+	nextOffset := indexes[ixByteTriesOffset]
+	numInts := (nextOffset - offset) / 4
+
+	pnames.valueMaps = bytes.Uint32Slice(numInts)
+
+	offset = nextOffset
+	nextOffset = indexes[ixNameGroupsOffset]
+	numBytes := nextOffset - offset
+
+	pnames.byteTrie = bytes.Uint8Slice(numBytes)
+	return nil
+}


### PR DESCRIPTION
This avoids loading the ICU data into memory for parts of Vitess that never end up using it, like `vtorc` or `vttablet`.

## Related Issue(s)

Fixes #13639 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required