### PR TITLE
Fix a couple of logs in VTOrc

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -1118,7 +1118,9 @@ func ForgetLongUnseenInstances() error {
 		log.Error(err)
 		return err
 	}
-	_ = AuditOperation("forget-unseen", "", fmt.Sprintf("Forgotten instances: %d", rows))
+	if rows > 0 {
+		_ = AuditOperation("forget-unseen", "", fmt.Sprintf("Forgotten instances: %d", rows))
+	}
 	return err
 }
 

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -388,6 +388,7 @@ func getCheckAndRecoverFunctionCode(analysisCode inst.AnalysisCode, tabletAlias 
 	case inst.DeadPrimary, inst.DeadPrimaryAndSomeReplicas:
 		// If ERS is disabled, we have no way of repairing the cluster.
 		if !config.ERSEnabled() {
+			log.Infof("VTOrc not configured to run ERS, skipping recovering %v", analysisCode)
 			return noRecoveryFunc
 		}
 		if isInEmergencyOperationGracefulPeriod(tabletAlias) {
@@ -397,6 +398,7 @@ func getCheckAndRecoverFunctionCode(analysisCode inst.AnalysisCode, tabletAlias 
 	case inst.PrimaryTabletDeleted:
 		// If ERS is disabled, we have no way of repairing the cluster.
 		if !config.ERSEnabled() {
+			log.Infof("VTOrc not configured to run ERS, skipping recovering %v", analysisCode)
 			return noRecoveryFunc
 		}
 		if isInEmergencyOperationGracefulPeriod(tabletAlias) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes a couple of logs in VTOrc - 
1. When VTOrc is configured to not run ERS, we see the following log come up `executeCheckAndRecoverFunction: ignoring analysisEntry that has no action plan: DeadPrimary`, but this doesn't say exactly why VTOrc is unable to fix `DeadPrimary`. A new log line has been added to this end, so that looking at the logs it is clear that VTOrc is not fixing the cluster because it is configured to not run ERS.
2. `auditType:forget-unseen alias: keyspace: shard: message:Forgotten instances: 0` gets printed on a timer and this provides no information at all. The code has been changed to only print this log line when an instance is actually forgotten.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
