### PR TITLE
vtgate: fix race condition iterating tables and views from schema tracker

### DIFF
--- a/go/vt/vtgate/schema/tracker.go
+++ b/go/vt/vtgate/schema/tracker.go
@@ -221,7 +221,12 @@ func (t *Tracker) Tables(ks string) map[string]*vindexes.TableInfo {
 		return map[string]*vindexes.TableInfo{} // we know nothing about this KS, so that is the info we can give out
 	}
 
-	return m
+	dup := make(map[string]*vindexes.TableInfo, len(m))
+	for k, v := range m {
+		dup[k] = v
+	}
+
+	return dup
 }
 
 // Views returns all known views in the keyspace with their definition.
@@ -232,7 +237,18 @@ func (t *Tracker) Views(ks string) map[string]sqlparser.SelectStatement {
 	if t.views == nil {
 		return nil
 	}
-	return t.views.m[ks]
+
+	m := t.views.m[ks]
+	if m == nil {
+		return nil
+	}
+
+	dup := make(map[string]sqlparser.SelectStatement, len(m))
+	for k, v := range m {
+		dup[k] = v
+	}
+
+	return dup
 }
 
 func (t *Tracker) updateSchema(th *discovery.TabletHealth) bool {

--- a/go/vt/vtgate/schema/tracker.go
+++ b/go/vt/vtgate/schema/tracker.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/exp/maps"
+
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -221,12 +223,7 @@ func (t *Tracker) Tables(ks string) map[string]*vindexes.TableInfo {
 		return map[string]*vindexes.TableInfo{} // we know nothing about this KS, so that is the info we can give out
 	}
 
-	dup := make(map[string]*vindexes.TableInfo, len(m))
-	for k, v := range m {
-		dup[k] = v
-	}
-
-	return dup
+	return maps.Clone(m)
 }
 
 // Views returns all known views in the keyspace with their definition.
@@ -239,16 +236,7 @@ func (t *Tracker) Views(ks string) map[string]sqlparser.SelectStatement {
 	}
 
 	m := t.views.m[ks]
-	if m == nil {
-		return nil
-	}
-
-	dup := make(map[string]sqlparser.SelectStatement, len(m))
-	for k, v := range m {
-		dup[k] = v
-	}
-
-	return dup
+	return maps.Clone(m)
 }
 
 func (t *Tracker) updateSchema(th *discovery.TabletHealth) bool {


### PR DESCRIPTION
## Description

Fixes a race condition between vtgate schema tracker and vschema manager which results in a panic when vschema manager attempts to iterate the map provided by the schema tracker. Updates the schema tracker to return a shallow copy of tables and views.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/13672

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

n/a