### PR TITLE
[vtctldclient] flags need to be defined to be deprecated

### DIFF
--- a/go/cmd/vtctldclient/command/schema.go
+++ b/go/cmd/vtctldclient/command/schema.go
@@ -285,7 +285,9 @@ func commandReloadSchemaShard(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
+	ApplySchema.Flags().Bool("allow-long-unavailability", false, "Deprecated and has no effect.")
 	ApplySchema.Flags().MarkDeprecated("--allow-long-unavailability", "")
+	ApplySchema.Flags().Bool("skip-preflight", false, "Deprecated and has no effect.")
 	ApplySchema.Flags().MarkDeprecated("--skip-preflight", "Deprecated. Assumed to be always 'true'")
 	ApplySchema.Flags().StringVar(&applySchemaOptions.DDLStrategy, "ddl-strategy", string(schema.DDLStrategyDirect), "Online DDL strategy, compatible with @@ddl_strategy session variable (examples: 'gh-ost', 'pt-osc', 'gh-ost --max-load=Threads_running=100'.")
 	ApplySchema.Flags().StringSliceVar(&applySchemaOptions.UUIDList, "uuid", nil, "Optional, comma-delimited, repeatable, explicit UUIDs for migration. If given, must match number of DDL changes.")


### PR DESCRIPTION


## Description

#10717 and #10716 removed the actual definitions when deprecating the flags, which causes cobra to completely error if they are provided, rather than provide a deprecation warning.

Examples:

```
$ vtctldclient ApplySchema --allow-long-unavailability
E0801 14:22:20.991123   23903 main.go:56] unknown flag: --allow-long-unavailability
$ vtctldclient ApplySchema --skip-preflight
E0801 14:22:48.317692   24011 main.go:56] unknown flag: --skip-preflight
```

## Related Issue(s)

https://github.com/vitessio/vitess/issues/6926

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
