### PR TITLE
[OnlineDDL] add label so break works as intended

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -372,6 +372,8 @@ func checkTablesCount(t *testing.T, tablet *cluster.Vttablet, showTableName stri
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	rowcount := 0
+
+loop:
 	for {
 		queryResult, err := tablet.VttabletProcess.QueryTablet(query, keyspaceName, true)
 		require.Nil(t, err)
@@ -383,9 +385,10 @@ func checkTablesCount(t *testing.T, tablet *cluster.Vttablet, showTableName stri
 		select {
 		case <-time.After(time.Second):
 		case <-ctx.Done():
-			break
+			break loop
 		}
 	}
+
 	assert.Equal(t, expectCount, rowcount)
 }
 

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -373,7 +373,6 @@ func checkTablesCount(t *testing.T, tablet *cluster.Vttablet, showTableName stri
 	defer cancel()
 	rowcount := 0
 
-loop:
 	for {
 		queryResult, err := tablet.VttabletProcess.QueryTablet(query, keyspaceName, true)
 		require.Nil(t, err)
@@ -384,9 +383,12 @@ loop:
 
 		select {
 		case <-time.After(time.Second):
+			continue // Keep looping
 		case <-ctx.Done():
-			break loop
+			// Break below to the assertion
 		}
+
+		break
 	}
 
 	assert.Equal(t, expectCount, rowcount)


### PR DESCRIPTION
## Description

Previously `break` was operating on the `select`, which means there was no functional difference between the two select cases.

## Related Issue(s)

#6926 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
