### PR TITLE
vtgate tablet gateway buffering: don't shutdown if not initialized

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -201,7 +201,9 @@ func (gw *TabletGateway) WaitForTablets(tabletTypesToWait []topodatapb.TabletTyp
 // Close shuts down underlying connections.
 // This function hides the inner implementation.
 func (gw *TabletGateway) Close(_ context.Context) error {
-	gw.buffer.Shutdown()
+	if gw.buffer != nil {
+		gw.buffer.Shutdown()
+	}
 	return gw.hc.Close()
 }
 


### PR DESCRIPTION
## Description
In https://github.com/vitessio/vitess/pull/13507 we stopped creating the buffer objects if buffering was disabled. However buffer shutdown was still being called on vtgate shutdown causing this panic
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1011a77a8]

goroutine 1310 [running]:
vitess.io/vitess/go/vt/vtgate/buffer.(*Buffer).shutdown(0x0)
	vitess.io/vitess/go/vt/vtgate/buffer/buffer.go:239 +0x28
vitess.io/vitess/go/vt/vtgate/buffer.(*Buffer).Shutdown(0x0?)
	vitess.io/vitess/go/vt/vtgate/buffer/buffer.go:234 +0x20
vitess.io/vitess/go/vt/vtgate.(*TabletGateway).Close(0x140000b4ee0, {0x101eba500?, 0x1400069a300?})
	vitess.io/vitess/go/vt/vtgate/tabletgateway.go:204 +0x28
main.main.func2()
	vitess.io/vitess/go/cmd/vtgate/vtgate.go:166 +0x38
vitess.io/vitess/go/event.(*Hooks).Fire.func1(0x140002dc280?)
	vitess.io/vitess/go/event/hooks.go:49 +0x2c
created by vitess.io/vitess/go/event.(*Hooks).Fire
	vitess.io/vitess/go/event/hooks.go:48 +0xe4
```

## Related Issue(s)

https://github.com/vitessio/vitess/pull/13507
https://github.com/vitessio/vitess/issues/13464

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
