### PR TITLE
fastparse: Fix bug in overflow detection

### DIFF
--- a/go/mysql/fastparse/fastparse.go
+++ b/go/mysql/fastparse/fastparse.go
@@ -65,6 +65,18 @@ next:
 			break next
 		}
 
+		var cutoff uint64
+		switch base {
+		case 10:
+			cutoff = math.MaxUint64/10 + 1
+		case 16:
+			cutoff = math.MaxUint64/16 + 1
+		default:
+			cutoff = math.MaxUint64/uint64(base) + 1
+		}
+		if d >= cutoff {
+			return math.MaxUint64, fmt.Errorf("cannot parse uint64 from %q: %w", s, ErrOverflow)
+		}
 		v := d*uint64(base) + uint64(b)
 		if v < d {
 			return math.MaxUint64, fmt.Errorf("cannot parse uint64 from %q: %w", s, ErrOverflow)
@@ -137,6 +149,22 @@ next:
 
 		if b >= byte(base) {
 			break next
+		}
+
+		var cutoff uint64
+		switch base {
+		case 10:
+			cutoff = math.MaxInt64/10 + 1
+		case 16:
+			cutoff = math.MaxInt64/16 + 1
+		default:
+			cutoff = math.MaxInt64/uint64(base) + 1
+		}
+		if d >= cutoff {
+			if minus {
+				return math.MinInt64, fmt.Errorf("cannot parse int64 from %q: %w", s, ErrOverflow)
+			}
+			return math.MaxInt64, fmt.Errorf("cannot parse int64 from %q: %w", s, ErrOverflow)
 		}
 
 		v := d*uint64(base) + uint64(b)

--- a/go/mysql/fastparse/fastparse_test.go
+++ b/go/mysql/fastparse/fastparse_test.go
@@ -162,6 +162,12 @@ func TestParseInt64(t *testing.T) {
 			err:      `cannot parse int64 from "18446744073709551616": overflow`,
 		},
 		{
+			input:    "31415926535897932384",
+			base:     10,
+			expected: 9223372036854775807,
+			err:      `cannot parse int64 from "31415926535897932384": overflow`,
+		},
+		{
 			input:    "1.1",
 			base:     10,
 			expected: 1,
@@ -296,6 +302,12 @@ func TestParseUint64(t *testing.T) {
 			base:     10,
 			expected: 18446744073709551615,
 			err:      `cannot parse uint64 from "18446744073709551616": overflow`,
+		},
+		{
+			input:    "31415926535897932384",
+			base:     10,
+			expected: 18446744073709551615,
+			err:      `cannot parse uint64 from "31415926535897932384": overflow`,
 		},
 		{
 			input:    "1.1",


### PR DESCRIPTION
When we have an overflow here, we didn't always correctly detect this when we parse a value.

The switch trick here makes the compiler see the very common case of base 10 (which we use most of the time by far) and turn the computation into a constant value.

## Related Issue(s)

Fixes #13701

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required