### PR TITLE
go/vt/vitessdriver: implement driver.{Connector,DriverContext}

### DIFF
--- a/go/vt/vitessdriver/convert.go
+++ b/go/vt/vitessdriver/convert.go
@@ -109,12 +109,16 @@ func (cv *converter) bindVarsFromNamedValues(args []driver.NamedValue) (map[stri
 	return bindVars, nil
 }
 
-func newConverter(cfg *Configuration) (c *converter, err error) {
-	c = &converter{
-		location: time.UTC,
+func newConverter(cfg *Configuration) (*converter, error) {
+	c := &converter{location: time.UTC}
+	if cfg.DefaultLocation == "" {
+		return c, nil
 	}
-	if cfg.DefaultLocation != "" {
-		c.location, err = time.LoadLocation(cfg.DefaultLocation)
+
+	loc, err := time.LoadLocation(cfg.DefaultLocation)
+	if err != nil {
+		return nil, err
 	}
-	return
+	c.location = loc
+	return c, nil
 }

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -33,8 +33,7 @@ import (
 )
 
 // fakeVTGateService has the server side of this fake
-type fakeVTGateService struct {
-}
+type fakeVTGateService struct{}
 
 // queryExecute contains all the fields we use to test Execute
 type queryExecute struct {
@@ -280,6 +279,20 @@ var execMap = map[string]struct {
 		result: &sqltypes.Result{},
 		session: &vtgatepb.Session{
 			TargetString: "@primary",
+		},
+	},
+	"use @rdonly": {
+		execQuery: &queryExecute{
+			SQL: "use @rdonly",
+			Session: &vtgatepb.Session{
+				TargetString: "@primary",
+				Autocommit:   true,
+			},
+		},
+		result: &sqltypes.Result{},
+		session: &vtgatepb.Session{
+			TargetString: "@rdonly",
+			SessionUUID:  "1111",
 		},
 	},
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Implements various new optional interfaces for the vtgate `database/sql` driver so that we can efficiently create connections using a shared config/converter, and can safely pull individual connections from the pool while assuring that there is no shared state pollution for concurrently opened connections.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #13703

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

n/a