### PR TITLE
Vtgate: pass 'SHOW VITESS_MIGRATIONS' to tablet's query executor

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2569,8 +2569,8 @@ func TestExecutorShowVitessMigrations(t *testing.T) {
 	ctx := context.Background()
 	_, err := executor.Execute(ctx, nil, "", session, showQuery, nil)
 	require.NoError(t, err)
-	assert.Contains(t, sbc1.StringQueries(), "SELECT * FROM _vt.schema_migrations")
-	assert.Contains(t, sbc2.StringQueries(), "SELECT * FROM _vt.schema_migrations")
+	assert.Contains(t, sbc1.StringQueries(), "show vitess_migrations")
+	assert.Contains(t, sbc2.StringQueries(), "show vitess_migrations")
 }
 
 func TestExecutorDescHash(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/testdata/show_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/show_cases.json
@@ -535,7 +535,7 @@
           "Sharded": true
         },
         "TargetDestination": "AllShards()",
-        "Query": "SELECT * FROM _vt.schema_migrations where migration_uuid LIKE '%format' OR migration_context LIKE '%format' OR migration_status LIKE '%format'"
+        "Query": "show vitess_migrations from `user` like '%format'"
       }
     }
   },
@@ -552,7 +552,7 @@
           "Sharded": true
         },
         "TargetDestination": "AllShards()",
-        "Query": "SELECT * FROM _vt.schema_migrations where id = 5"
+        "Query": "show vitess_migrations from `user` where id = 5"
       }
     }
   },


### PR DESCRIPTION
## Description

This PR follows up on https://github.com/vitessio/vitess/pull/12688. In https://github.com/vitessio/vitess/pull/12688 (release in `v17`) we made `vttablet` support `SHOW VITESS_MIGRATIONS` query in Query Executor. Now, in `v18`, we make `vtgate` direct `SHOW VITESS_MIGRATIONS` queries to the tablet's query service rather than construct a `SELECT` query.

Testing: `endtoend/onlineddl` already relies heavily on `SHOW VITESS_MIGRATIONS` in vtgate. This PR adds no tests -- all the existing `endtoend` tests will use the new logic and are expected to pass seamlessly.
Updated unit test files.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/13706
https://github.com/vitessio/vitess/pull/12688
 
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
