### PR TITLE
v16 backport: Fix closed channel panic in Online DDL cutover

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -921,6 +921,7 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream) er
 
 		e.updateMigrationStage(ctx, onlineDDL.UUID, "renaming tables")
 		go func() {
+			defer close(renameCompleteChan)
 			_, err := renameConn.Exec(ctx, renameQuery.Query, 1, false)
 			renameCompleteChan <- err
 		}()


### PR DESCRIPTION
## Manual backport of https://github.com/vitessio/vitess/pull/13729

For some reason the backport bot did not run.

This backport is not strictly required, since the bug does not happen in `v16` - the channel wasn't being closed in this version. However, we do the backport so as to close the channel appropriately and release resources.

## Description

Closing a channel should be owned by the writer to the channel. This PR fixes a closed channel panic, described in https://github.com/vitessio/vitess/issues/13728.

Related discussion in `golang` google group: https://groups.google.com/g/golang-nuts/c/_Q6FCjWIr18/m/Wb_NlyusRL8J?pli=1
## Related Issue(s)

https://github.com/vitessio/vitess/issues/13728

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
