### PR TITLE
Manual cherry-pick of 13339

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -28,8 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/log"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
@@ -448,7 +446,7 @@ func primaryBackup(t *testing.T) {
 	// Restore the older/first backup -- using the timestamp we saved -- on the original primary tablet (primary)
 	err = localCluster.VtctlclientProcess.ExecuteCommand("RestoreFromBackup", "--", "--backup_timestamp", firstBackupTimestamp, primary.Alias)
 	require.Nil(t, err)
-
+	verifyRestorePositionAndTimeStats(t, primary.VttabletProcess.GetVars())
 	// Re-init the shard -- making the original primary tablet (primary) primary again -- for subsequent tests
 	err = localCluster.VtctlclientProcess.InitShardPrimary(keyspaceName, shardName, cell, primary.TabletUID)
 	require.Nil(t, err)
@@ -1052,13 +1050,13 @@ func TestReplicaRestoreToPos(t *testing.T, restoreToPos mysql.Position, expectEr
 }
 
 func verifyRestorePositionAndTimeStats(t *testing.T, vars map[string]any) {
-	log.Infof("vars %v", vars)
-	backupPosition := vars["RestorePosition"].(string)
-	backupTime := vars["RestoredBackupTime"].(string)
 	require.Contains(t, vars, "RestoredBackupTime")
-	require.Contains(t, vars, "RestorePosition")
-	require.NotEqual(t, "", backupPosition)
+	backupTime := vars["RestoredBackupTime"].(string)
 	require.NotEqual(t, "", backupTime)
+
+	require.Contains(t, vars, "RestorePosition")
+	backupPosition := vars["RestorePosition"].(string)
+	require.NotEqual(t, "", backupPosition)
 	rp, err := mysql.DecodePosition(backupPosition)
 	require.NoError(t, err)
 	require.False(t, rp.IsZero())

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -887,7 +887,6 @@ func verifyRestoreTablet(t *testing.T, tablet *cluster.Vttablet, status string) 
 	} else if tablet.Type == "rdonly" {
 		verifySemiSyncStatus(t, tablet, "OFF")
 	}
-	verifyRestorePositionAndTimeStats(t, primary.VttabletProcess.GetVars())
 }
 
 func verifySemiSyncStatus(t *testing.T, vttablet *cluster.Vttablet, expectedStatus string) {

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -55,12 +55,12 @@ var (
 	restoreConcurrency     = 4
 	waitForBackupInterval  time.Duration
 
-	statsRestoreBackupTime     *stats.String
+	statsRestoredBackupTime    *stats.String
 	statsRestoreBackupPosition *stats.String
 )
 
 func init() {
-	statsRestoreBackupTime = stats.NewString("RestoreBackupTime")
+	statsRestoredBackupTime = stats.NewString("RestoredBackupTime")
 	statsRestoreBackupPosition = stats.NewString("RestorePosition")
 }
 
@@ -237,7 +237,7 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		backupManifest, err = mysqlctl.Restore(ctx, params)
 		if backupManifest != nil {
 			statsRestoreBackupPosition.Set(mysql.EncodePosition(backupManifest.Position))
-			statsRestoreBackupTime.Set(backupManifest.BackupTime)
+			statsRestoredBackupTime.Set(backupManifest.BackupTime)
 		}
 
 		params.Logger.Infof("Restore: got a restore manifest: %v, err=%v, waitForBackupInterval=%v", backupManifest, err, waitForBackupInterval)

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"time"
 
+	"vitess.io/vitess/go/stats"
+
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/mysql"
@@ -52,7 +54,15 @@ var (
 	restoreFromBackupTsStr string
 	restoreConcurrency     = 4
 	waitForBackupInterval  time.Duration
+
+	statsRestoreBackupTime     *stats.String
+	statsRestoreBackupPosition *stats.String
 )
+
+func init() {
+	statsRestoreBackupTime = stats.NewString("RestoreBackupTime")
+	statsRestoreBackupPosition = stats.NewString("RestorePosition")
+}
 
 func registerRestoreFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&restoreFromBackup, "restore_from_backup", restoreFromBackup, "(init restore parameter) will check BackupStorage for a recent backup at startup and start there")
@@ -225,6 +235,11 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 	var backupManifest *mysqlctl.BackupManifest
 	for {
 		backupManifest, err = mysqlctl.Restore(ctx, params)
+		if backupManifest != nil {
+			statsRestoreBackupPosition.Set(mysql.EncodePosition(backupManifest.Position))
+			statsRestoreBackupTime.Set(backupManifest.BackupTime)
+		}
+
 		params.Logger.Infof("Restore: got a restore manifest: %v, err=%v, waitForBackupInterval=%v", backupManifest, err, waitForBackupInterval)
 		if waitForBackupInterval == 0 {
 			break


### PR DESCRIPTION
## Description

Manually recreated the changes from #13339 to 16.0, rather than doing a complex merge.

FIXME: the changes are currently not tested, because I am not sure where should we invoke `verifyRestorePositionAndTimeStats()`. The test case in `main` where I was doing this is not present in `release-16.0`

## Related Issue(s)

#13339 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
