### PR TITLE
docker: run apt-get upgrade in bootstrap/common

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,7 +1,8 @@
 FROM --platform=linux/amd64 golang:1.20.5-buster
 
 # Install Vitess build dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     # TODO(mberlin): Group these to make it easier to understand which library actually requires them.
     ant \
     chromium \


### PR DESCRIPTION
This runs `apt-get upgrade` as part of the dockerfile build process for the bootstrap container. The purpose of this change is to help ensure OS packages within the container image are up-to-date.
