### PR TITLE
planbuilder enhancement: turn outer joins into inner joins in more situations

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/null_sensitive_test.go
+++ b/go/vt/vtgate/planbuilder/operators/null_sensitive_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotTrueWhenRootIsNULL(t *testing.T) {
+	// This test checks whether the function NotTrueWhenRootIsNULL
+	// returns true when the expression is not true when the root is NULL. The name kind of gives it away.
+
+	testcases := []struct {
+		expr     string
+		expected bool
+	}{
+		// The following expressions are guaranteed to return false or NULL if the root is NULL.
+		{expr: "root", expected: true},
+		{expr: "root + 1", expected: true},
+		{expr: "root = 42", expected: true},
+		{expr: "root is true", expected: true},
+		{expr: "root is false", expected: true},
+		{expr: "root is not null", expected: true},
+		{expr: "root between 100 and 200", expected: true},
+		{expr: "root = 42 and somethingElse", expected: true},
+
+		// The following expressions can return true even if the root is NULL
+		{expr: "root is null"},
+		{expr: "root is not false"},
+		{expr: "root is not true"},
+		{expr: "coalesce(root, 1)"},
+		{expr: "root <=> 42"}}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.expr, func(t *testing.T) {
+			expr, err := sqlparser.ParseExpr(testcase.expr)
+			require.NoError(t, err)
+			res := notTrueWhenRootIsNULL(expr, func(node *sqlparser.ColName) bool {
+				return node.Name.EqualString("root")
+			})
+			require.Equal(t, testcase.expected, res)
+		})
+	}
+}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -3888,42 +3888,35 @@
       "QueryType": "SELECT",
       "Original": "select user.id from user left join user_extra on user.col = user_extra.col where user_extra.col between 10 and 20",
       "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "user_extra.col between 10 and 20",
-        "ResultColumns": 1,
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "JoinVars": {
+          "user_col": 1
+        },
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "LeftJoin",
-            "JoinColumnIndexes": "L:0,R:0",
-            "JoinVars": {
-              "user_col": 1
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
             },
-            "TableName": "`user`_user_extra",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.id, `user`.col from `user`",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col",
-                "Table": "user_extra"
-              }
-            ]
+            "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
+            "Query": "select `user`.id, `user`.col from `user`",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from user_extra where 1 != 1",
+            "Query": "select 1 from user_extra where user_extra.col between 10 and 20 and user_extra.col = :user_col",
+            "Table": "user_extra"
           }
         ]
       },


### PR DESCRIPTION
## Description
Small enhancement in how well the planner recognises when it's possible to reformulate a join from an outer join into an inner join.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
