### PR TITLE
Foreign Keys: `DELETE` planning

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -53,3 +53,32 @@ func TestInsertions(t *testing.T) {
 	_, err = utils.ExecAllowError(t, conn, `insert into multicol_tbl2(cola, colb, colc, msg) values (103, 'c', 'd', 'msg2')`)
 	require.ErrorContains(t, err, "Cannot add or update a child row: a foreign key constraint fails")
 }
+
+// TestDeletions tests that deletions work as expected when foreign key management is enabled in Vitess.
+func TestDeletions(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	// insert some data.
+	utils.Exec(t, conn, `insert into t1(id, col) values (100, 123),(10, 12),(1, 13),(1000, 1234)`)
+	utils.Exec(t, conn, `insert into t2(id, col) values (100, 125), (1, 132)`)
+	utils.Exec(t, conn, `insert into t4(id, col) values (1, 321)`)
+	utils.Exec(t, conn, `insert into multicol_tbl1(cola, colb, colc, msg) values (100, 'a', 'b', 'msg'), (101, 'c', 'd', 'msg2')`)
+	utils.Exec(t, conn, `insert into multicol_tbl2(cola, colb, colc, msg) values (100, 'a', 'b', 'msg3')`)
+
+	// child foreign key is shard scoped. Query will fail at mysql due to On Delete Restrict.
+	_, err := utils.ExecAllowError(t, conn, `delete from t2 where col = 132`)
+	require.ErrorContains(t, err, "Cannot delete or update a parent row: a foreign key constraint fails")
+
+	// child row does not exist so query will succeed.
+	qr := utils.Exec(t, conn, `delete from t2 where col = 125`)
+	require.EqualValues(t, 1, qr.RowsAffected)
+
+	// table's child foreign key has cross shard fk, so query will fail at vtgate.
+	_, err = utils.ExecAllowError(t, conn, `delete from t1 where id = 42`)
+	require.ErrorContains(t, err, "VT12002: unsupported: foreign keys management at vitess (errno 1235) (sqlstate 42000)")
+
+	// child foreign key is cascade, so query will fail at vtgate.
+	_, err = utils.ExecAllowError(t, conn, `delete from multicol_tbl1 where cola = 100`)
+	require.ErrorContains(t, err, "VT12002: unsupported: foreign keys management at vitess (errno 1235) (sqlstate 42000)")
+}

--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -34,17 +34,21 @@ func TestInsertions(t *testing.T) {
 
 	// Verify that inserting data into a table that has shard scoped foreign keys works.
 	utils.Exec(t, conn, `insert into t2(id, col) values (100, 125), (1, 132)`)
+
 	// Verify that insertion fails if the data doesn't follow the fk constraint.
 	_, err := utils.ExecAllowError(t, conn, `insert into t2(id, col) values (1310, 125)`)
 	require.ErrorContains(t, err, "Cannot add or update a child row: a foreign key constraint fails")
+
 	// Verify that insertion fails if the table has cross-shard foreign keys (even if the data follows the constraints).
 	_, err = utils.ExecAllowError(t, conn, `insert into t3(id, col) values (100, 100)`)
 	require.ErrorContains(t, err, "VT12002: unsupported: cross-shard foreign keys")
 
 	// insert some data in a table with multicol vindex.
 	utils.Exec(t, conn, `insert into multicol_tbl1(cola, colb, colc, msg) values (100, 'a', 'b', 'msg'), (101, 'c', 'd', 'msg2')`)
+
 	// Verify that inserting data into a table that has shard scoped multi-column foreign keys works.
 	utils.Exec(t, conn, `insert into multicol_tbl2(cola, colb, colc, msg) values (100, 'a', 'b', 'msg3')`)
+
 	// Verify that insertion fails if the data doesn't follow the fk constraint.
 	_, err = utils.ExecAllowError(t, conn, `insert into multicol_tbl2(cola, colb, colc, msg) values (103, 'c', 'd', 'msg2')`)
 	require.ErrorContains(t, err, "Cannot add or update a child row: a foreign key constraint fails")

--- a/go/test/endtoend/vtgate/foreignkey/main_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/main_test.go
@@ -90,10 +90,16 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 	require.NoError(t, err)
 
 	deleteAll := func() {
+		_ = utils.Exec(t, conn, "use `ks/-80`")
 		tables := []string{"t3", "t2", "t1", "multicol_tbl2", "multicol_tbl1"}
 		for _, table := range tables {
 			_ = utils.Exec(t, conn, "delete from "+table)
 		}
+		_ = utils.Exec(t, conn, "use `ks/80-`")
+		for _, table := range tables {
+			_ = utils.Exec(t, conn, "delete from "+table)
+		}
+		_ = utils.Exec(t, conn, "use `ks`")
 	}
 
 	deleteAll()

--- a/go/test/endtoend/vtgate/foreignkey/main_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/main_test.go
@@ -91,7 +91,7 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 
 	deleteAll := func() {
 		_ = utils.Exec(t, conn, "use `ks/-80`")
-		tables := []string{"t3", "t2", "t1", "multicol_tbl2", "multicol_tbl1"}
+		tables := []string{"t4", "t3", "t2", "t1", "multicol_tbl2", "multicol_tbl1"}
 		for _, table := range tables {
 			_ = utils.Exec(t, conn, "delete from "+table)
 		}

--- a/go/test/endtoend/vtgate/foreignkey/sharded_schema.sql
+++ b/go/test/endtoend/vtgate/foreignkey/sharded_schema.sql
@@ -10,7 +10,7 @@ create table t2
     id    bigint,
     col   bigint,
     primary key (id),
-    foreign key (id) references t1 (id)
+    foreign key (id) references t1 (id) on delete restrict
 ) Engine = InnoDB;
 
 create table t3
@@ -18,7 +18,7 @@ create table t3
     id    bigint,
     col   bigint,
     primary key (id),
-    foreign key (col) references t1 (id)
+    foreign key (col) references t1 (id) on delete restrict
 ) Engine = InnoDB;
 
 create table multicol_tbl1
@@ -37,5 +37,13 @@ create table multicol_tbl2
     colc varchar(50),
     msg  varchar(50),
     primary key (cola, colb, colc),
-    foreign key (cola, colb, colc) references multicol_tbl1 (cola, colb, colc)
+    foreign key (cola, colb, colc) references multicol_tbl1 (cola, colb, colc) on delete cascade
+) Engine = InnoDB;
+
+create table t4
+(
+    id    bigint,
+    col   bigint,
+    primary key (id),
+    foreign key (id) references t2 (id) on delete restrict
 ) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/foreignkey/sharded_vschema.json
+++ b/go/test/endtoend/vtgate/foreignkey/sharded_vschema.json
@@ -39,6 +39,14 @@
         }
       ]
     },
+    "t4": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
     "multicol_tbl1": {
       "column_vindexes": [
         {

--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -81,6 +81,7 @@ var (
 
 	VT12001 = errorWithoutState("VT12001", vtrpcpb.Code_UNIMPLEMENTED, "unsupported: %s", "This statement is unsupported by Vitess. Please rewrite your query to use supported syntax.")
 	VT12002 = errorWithoutState("VT12002", vtrpcpb.Code_UNIMPLEMENTED, "unsupported: cross-shard foreign keys", "Vitess does not support cross shard foreign keys.")
+	VT12003 = errorWithoutState("VT12002", vtrpcpb.Code_UNIMPLEMENTED, "unsupported: foreign keys management at vitess", "Vitess does not support managing foreign keys tables.")
 
 	// VT13001 General Error
 	VT13001 = errorWithoutState("VT13001", vtrpcpb.Code_INTERNAL, "[BUG] %s", "This error should not happen and is a bug. Please file an issue on GitHub: https://github.com/vitessio/vitess/issues/new/choose.")
@@ -145,6 +146,7 @@ var (
 		VT10001,
 		VT12001,
 		VT12002,
+		VT12003,
 		VT13001,
 		VT13002,
 		VT14001,

--- a/go/vt/vtgate/planbuilder/operators/ast2op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast2op.go
@@ -191,6 +191,17 @@ func createOperatorFromDelete(ctx *plancontext.PlanningContext, deleteStmt *sqlp
 		Routing: routing,
 	}
 
+	ksMode, err := ctx.VSchema.ForeignKeyMode(vindexTable.Keyspace.Name)
+	if err != nil {
+		return nil, err
+	}
+	if ksMode == vschemapb.Keyspace_FK_MANAGED {
+		childFks := vindexTable.ChildFKsNeedsHandling()
+		if len(childFks) > 0 {
+			return nil, vterrors.VT12003()
+		}
+	}
+
 	if !vindexTable.Keyspace.Sharded {
 		return route, nil
 	}

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -53,5 +53,42 @@
         "user_fk_allow.multicol_tbl2"
       ]
     }
+  },
+  {
+    "comment": "Delete in a table with cross-shard foreign keys disallowed",
+    "query": "delete from tbl1",
+    "plan": "VT12002: unsupported: foreign keys management at vitess"
+  },
+  {
+    "comment": "Delete in a table with shard-scoped foreign keys is allowed",
+    "query": "delete from tbl7",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from tbl7",
+      "Instructions": {
+        "OperatorType": "Delete",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user_fk_allow",
+          "Sharded": true
+        },
+        "TargetTabletType": "PRIMARY",
+        "Query": "delete from tbl7",
+        "Table": "tbl7"
+      },
+      "TablesUsed": [
+        "user_fk_allow.tbl7"
+      ]
+    }
+  },
+  {
+    "comment": "Delete in a table with shard-scoped multiple column foreign key with cascade not allowed",
+    "query": "delete from multicol_tbl1 where cola = 1 and  colb = 2 and colc = 3",
+    "plan": "VT12002: unsupported: foreign keys management at vitess"
+  },
+  {
+    "comment": "Delete in a table with shard-scoped foreign keys with cascade disallowed",
+    "query": "delete from tbl5",
+    "plan": "VT12002: unsupported: foreign keys management at vitess"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -608,8 +608,7 @@
       "foreignKeyMode": "FK_MANAGED",
       "vindexes": {
         "hash_vin": {
-          "type": "hash_test",
-          "owner": "user"
+          "type": "hash_test"
         },
         "multicolIdx": {
           "type": "multiCol_test"
@@ -660,6 +659,38 @@
           "column_vindexes": [
             {
               "column": "col3",
+              "name": "hash_vin"
+            }
+          ]
+        },
+        "tbl4": {
+          "column_vindexes": [
+            {
+              "column": "col4",
+              "name": "hash_vin"
+            }
+          ]
+        },
+        "tbl5": {
+          "column_vindexes": [
+            {
+              "column": "col5",
+              "name": "hash_vin"
+            }
+          ]
+        },
+        "tbl6": {
+          "column_vindexes": [
+            {
+              "column": "col6",
+              "name": "hash_vin"
+            }
+          ]
+        },
+        "tbl7": {
+          "column_vindexes": [
+            {
+              "column": "col7",
               "name": "hash_vin"
             }
           ]

--- a/go/vt/vtgate/vindexes/foreign_keys.go
+++ b/go/vt/vtgate/vindexes/foreign_keys.go
@@ -146,6 +146,7 @@ func (t *Table) ChildFKsNeedsHandling() (fks []ChildFKInfo) {
 		switch fk.OnDelete {
 		case sqlparser.Cascade, sqlparser.SetNull, sqlparser.SetDefault:
 			fks = append(fks, fk)
+			continue
 		}
 		// sqlparser.Restrict, sqlparser.NoAction, sqlparser.DefaultAction
 		// all the actions means the same thing i.e. Restrict
@@ -159,6 +160,10 @@ func (t *Table) ChildFKsNeedsHandling() (fks []ChildFKInfo) {
 }
 
 func isShardScoped(pTable *Table, cTable *Table, pCols sqlparser.Columns, cCols sqlparser.Columns) bool {
+	if !pTable.Keyspace.Sharded {
+		return true
+	}
+
 	pPrimaryVdx := pTable.ColumnVindexes[0]
 	cPrimaryVdx := cTable.ColumnVindexes[0]
 

--- a/go/vt/vtgate/vindexes/foreign_keys.go
+++ b/go/vt/vtgate/vindexes/foreign_keys.go
@@ -125,42 +125,74 @@ func (t *Table) CrossShardParentFKs() (crossShardFKs []ParentFKInfo) {
 			continue
 		}
 
-		// If the primary vindexes don't match between the parent and child table,
-		// we cannot infer that the fk constraint in shard scoped.
-		primaryVindex := t.ColumnVindexes[0]
-		if fk.Table.ColumnVindexes[0].Vindex != primaryVindex.Vindex {
+		if !isShardScoped(fk.Table, t, fk.ParentColumns, fk.ChildColumns) {
 			crossShardFKs = append(crossShardFKs, fk)
-			continue
-		}
-
-		childFkContatined, childFkIndexes := fk.ChildColumns.Indexes(primaryVindex.Columns)
-		if !childFkContatined {
-			// PrimaryVindex is not part of the foreign key constraint on the children side.
-			// So it is a cross-shard foreign key.
-			crossShardFKs = append(crossShardFKs, fk)
-			continue
-		}
-
-		// We need to run the same check for the parent columns.
-		parentFkContatined, parentFkIndexes := fk.ParentColumns.Indexes(fk.Table.ColumnVindexes[0].Columns)
-		if !parentFkContatined {
-			crossShardFKs = append(crossShardFKs, fk)
-			continue
-		}
-
-		// Both the child and parent table contain the foreign key and that the vindexes are the same,
-		// now we need to make sure, that the indexes of both match.
-		// For example, consider the following tables,
-		//	t1 (primary vindex (x,y))
-		//	t2 (primary vindex (a,b))
-		//	If we have a foreign key constraint from t1(x,y) to t2(b,a), then they are not shard scoped.
-		//	Let's say in t1, (1,3) will be in -80 and (3,1) will be in 80-, then in t2 (1,3) will end up in 80-.
-		for i := range parentFkIndexes {
-			if parentFkIndexes[i] != childFkIndexes[i] {
-				crossShardFKs = append(crossShardFKs, fk)
-				break
-			}
 		}
 	}
 	return
+}
+
+// ChildFKsNeedsHandling retuns the child foreign keys that needs to be handled by the vtgate.
+// This can be either the foreign key is not shard scoped or the child tables needs cascading.
+func (t *Table) ChildFKsNeedsHandling() (fks []ChildFKInfo) {
+	for _, fk := range t.ChildForeignKeys {
+		if fk.OnDelete == sqlparser.NoAction {
+			continue
+		}
+		// If the keyspaces are different, then the fk definition
+		// is going to go across shards.
+		if fk.Table.Keyspace.Name != t.Keyspace.Name {
+			fks = append(fks, fk)
+			continue
+		}
+		// If the action is not Restrict, then it needs a cascade.
+		if fk.OnDelete != sqlparser.Restrict {
+			fks = append(fks, fk)
+			continue
+		}
+
+		// Check if the fk restrict is shard scoped.
+		if !isShardScoped(t, fk.Table, fk.ParentColumns, fk.ChildColumns) {
+			fks = append(fks, fk)
+		}
+	}
+	return
+}
+
+func isShardScoped(pTable *Table, cTable *Table, pCols sqlparser.Columns, cCols sqlparser.Columns) bool {
+	pPrimaryVdx := pTable.ColumnVindexes[0]
+	cPrimaryVdx := cTable.ColumnVindexes[0]
+
+	// If the primary vindexes don't match between the parent and child table,
+	// we cannot infer that the fk constraint in shard scoped.
+	if cPrimaryVdx.Vindex != pPrimaryVdx.Vindex {
+		return false
+	}
+
+	childFkContatined, childFkIndexes := cCols.Indexes(cPrimaryVdx.Columns)
+	if !childFkContatined {
+		// PrimaryVindex is not part of the foreign key constraint on the children side.
+		// So it is a cross-shard foreign key.
+		return false
+	}
+
+	// We need to run the same check for the parent columns.
+	parentFkContatined, parentFkIndexes := pCols.Indexes(pPrimaryVdx.Columns)
+	if !parentFkContatined {
+		return false
+	}
+
+	// Both the child and parent table contain the foreign key and that the vindexes are the same,
+	// now we need to make sure, that the indexes of both match.
+	// For example, consider the following tables,
+	//	t1 (primary vindex (x,y))
+	//	t2 (primary vindex (a,b))
+	//	If we have a foreign key constraint from t1(x,y) to t2(b,a), then they are not shard scoped.
+	//	Let's say in t1, (1,3) will be in -80 and (3,1) will be in 80-, then in t2 (1,3) will end up in 80-.
+	for i := range parentFkIndexes {
+		if parentFkIndexes[i] != childFkIndexes[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds detection of child foreign keys that need handling at VTGate for an update or delete query.
This is currently used in delete planning to send delete queries with foreign keys to unsharded or shard scope for restrict cases and fails for all cascade cases.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/12967

## Checklist

-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI

