### PR TITLE
Deflake tests that use tabletconntest.SetProtocol()

### DIFF
--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -351,6 +351,17 @@ func ParseFlags(cmd string) {
 	logutil.PurgeLogs()
 }
 
+// ParseFlagsForUnitTests initializes flags but skips the filesystem args
+// and go flag related work.
+// Note: this should NOT be used outside of unit tests.
+func ParseFlagsForUnitTests(cmd string) {
+	fs := GetFlagSetFor(cmd)
+	pflag.CommandLine = fs
+	pflag.Parse()
+	viperutil.BindFlags(fs)
+	loadViper(cmd)
+}
+
 // GetFlagSetFor returns the flag set for a given command.
 // This has to exported for the Vitess-operator to use
 func GetFlagSetFor(cmd string) *pflag.FlagSet {

--- a/go/vt/vttablet/tabletconntest/tabletconntest.go
+++ b/go/vt/vttablet/tabletconntest/tabletconntest.go
@@ -1049,7 +1049,7 @@ func SetProtocol(name string, protocol string) {
 
 		tabletconn.RegisterFlags(fs)
 	})
-	servenv.ParseFlags(name)
+	servenv.ParseFlagsForUnitTests(name)
 
 	if err := pflag.Set(tabletProtocolFlagName, protocol); err != nil {
 		msg := "failed to set flag %q to %q: %v"


### PR DESCRIPTION
## Description
Extracting @mattlord's fix: https://github.com/vitessio/vitess/pull/13656/commits/22e21d07cd783aed27245a668beba74a136c0cc0

Fix unit test race failures like:

```
==================
2023-08-08T18:34:30.0020698Z WARNING: DATA RACE
2023-08-08T18:34:30.0021046Z Read at 0x00c00007c198 by goroutine 10120:
2023-08-08T18:34:30.0021398Z   flag.(*FlagSet).Parsed()
2023-08-08T18:34:30.0021955Z       /opt/hostedtoolcache/go/1.20.5/x64/src/flag/flag.go:1132 +0x184
2023-08-08T18:34:30.0022344Z   flag.Parsed()
2023-08-08T18:34:30.0022876Z       /opt/hostedtoolcache/go/1.20.5/x64/src/flag/flag.go:1144 +0x15b
2023-08-08T18:34:30.0023334Z   github.com/golang/glog.(*loggingT).output()
2023-08-08T18:34:30.0023943Z       /home/runner/go/pkg/mod/github.com/golang/glog@v1.0.0/glog.go:679 +0x1ca
2023-08-08T18:34:30.0024424Z   github.com/golang/glog.(*loggingT).printDepth()
2023-08-08T18:34:30.0025002Z       /home/runner/go/pkg/mod/github.com/golang/glog@v1.0.0/glog.go:646 +0x1fa
2023-08-08T18:34:30.0025445Z   github.com/golang/glog.WarningDepth()
2023-08-08T18:34:30.0026031Z       /home/runner/go/pkg/mod/github.com/golang/glog@v1.0.0/glog.go:1085 +0x56
2023-08-08T18:34:30.0026520Z   vitess.io/vitess/go/vt/grpcclient.(*glogger).Warningln()
2023-08-08T18:34:30.0027106Z       /home/runner/work/vitess/vitess/go/vt/grpcclient/glogger.go:51 +0xe1
2023-08-08T18:34:30.0027625Z   google.golang.org/grpc/internal/grpclog.WarningDepth()
2023-08-08T18:34:30.0028496Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/internal/grpclog/grpclog.go:46 +0xb9
2023-08-08T18:34:30.0029077Z   google.golang.org/grpc/grpclog.(*componentData).WarningDepth()
2023-08-08T18:34:30.0029892Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/grpclog/component.go:41 +0x164
2023-08-08T18:34:30.0030420Z   google.golang.org/grpc/internal/channelz.AddTraceEvent()
2023-08-08T18:34:30.0031299Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/internal/channelz/funcs.go:342 +0x2f8
2023-08-08T18:34:30.0031842Z   google.golang.org/grpc/internal/channelz.Warningf()
2023-08-08T18:34:30.0032668Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/internal/channelz/logging.go:59 +0xd3
2023-08-08T18:34:30.0033216Z   google.golang.org/grpc.(*addrConn).createTransport()
2023-08-08T18:34:30.0033988Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/clientconn.go:1292 +0x7c5
2023-08-08T18:34:30.0034500Z   google.golang.org/grpc.(*addrConn).tryAllAddrs()
2023-08-08T18:34:30.0035255Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/clientconn.go:1233 +0x5b7
2023-08-08T18:34:30.0035775Z   google.golang.org/grpc.(*addrConn).resetTransport()
2023-08-08T18:34:30.0036519Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/clientconn.go:1168 +0x217
2023-08-08T18:34:30.0037017Z   google.golang.org/grpc.(*addrConn).connect()
2023-08-08T18:34:30.0037918Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/clientconn.go:819 +0x258
2023-08-08T18:34:30.0038472Z   google.golang.org/grpc.(*acBalancerWrapper).Connect.func2()
2023-08-08T18:34:30.0039296Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/balancer_conn_wrappers.go:413 +0x39
2023-08-08T18:34:30.0039641Z 
2023-08-08T18:34:30.0039875Z Previous write at 0x00c00007c198 by goroutine 10109:
2023-08-08T18:34:30.0040174Z   flag.(*FlagSet).Parse()
2023-08-08T18:34:30.0040709Z       /opt/hostedtoolcache/go/1.20.5/x64/src/flag/flag.go:1105 +0x48
2023-08-08T18:34:30.0041077Z   flag.Parse()
2023-08-08T18:34:30.0041575Z       /opt/hostedtoolcache/go/1.20.5/x64/src/flag/flag.go:1139 +0x12e
2023-08-08T18:34:30.0042035Z   vitess.io/vitess/go/internal/flag.TrickGlog()
2023-08-08T18:34:30.0042625Z       /home/runner/work/vitess/vitess/go/internal/flag/flag.go:102 +0xb0
2023-08-08T18:34:30.0043077Z   vitess.io/vitess/go/internal/flag.Parse()
2023-08-08T18:34:30.0043743Z       /home/runner/work/vitess/vitess/go/internal/flag/flag.go:65 +0x1f1
2023-08-08T18:34:30.0044205Z   vitess.io/vitess/go/vt/servenv.ParseFlags()
2023-08-08T18:34:30.0044793Z       /home/runner/work/vitess/vitess/go/vt/servenv/servenv.go:336 +0x65
2023-08-08T18:34:30.0045360Z   vitess.io/vitess/go/vt/vttablet/tabletconntest.SetProtocol()
2023-08-08T18:34:30.0046068Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletconntest/tabletconntest.go:1052 +0x1c4
2023-08-08T18:34:30.0046621Z   vitess.io/vitess/go/vt/wrangler.newTestShardMigrater()
2023-08-08T18:34:30.0047293Z       /home/runner/work/vitess/vitess/go/vt/wrangler/traffic_switcher_env_test.go:498 +0x12ae
2023-08-08T18:34:30.0047863Z   vitess.io/vitess/go/vt/wrangler.TestStreamMigrateStillCopying()
2023-08-08T18:34:30.0048551Z       /home/runner/work/vitess/vitess/go/vt/wrangler/stream_migrater_test.go:1187 +0x179
2023-08-08T18:34:30.0048967Z   testing.tRunner()
2023-08-08T18:34:30.0049529Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1576 +0x216
2023-08-08T18:34:30.0049940Z   testing.(*T).Run.func1()
2023-08-08T18:34:30.0050474Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1629 +0x47
2023-08-08T18:34:30.0050760Z 
2023-08-08T18:34:30.0050972Z Goroutine 10120 (running) created at:
2023-08-08T18:34:30.0051361Z   google.golang.org/grpc.(*acBalancerWrapper).Connect()
2023-08-08T18:34:30.0052191Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/balancer_conn_wrappers.go:413 +0x116
2023-08-08T18:34:30.0052774Z   google.golang.org/grpc.(*pickfirstBalancer).UpdateClientConnState()
2023-08-08T18:34:30.0053575Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/pickfirst.go:108 +0x6e1
2023-08-08T18:34:30.0054200Z   google.golang.org/grpc/internal/balancer/gracefulswitch.(*Balancer).UpdateClientConnState()
2023-08-08T18:34:30.0055196Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/internal/balancer/gracefulswitch/gracefulswitch.go:164 +0x10d
2023-08-08T18:34:30.0055858Z   google.golang.org/grpc.(*ccBalancerWrapper).handleClientConnStateChange()
2023-08-08T18:34:30.0056707Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/balancer_conn_wrappers.go:192 +0x2b6
2023-08-08T18:34:30.0057256Z   google.golang.org/grpc.(*ccBalancerWrapper).watcher()
2023-08-08T18:34:30.0058081Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/balancer_conn_wrappers.go:123 +0x419
2023-08-08T18:34:30.0058620Z   google.golang.org/grpc.newCCBalancerWrapper.func1()
2023-08-08T18:34:30.0059555Z       /home/runner/go/pkg/mod/google.golang.org/grpc@v1.55.0-dev/balancer_conn_wrappers.go:76 +0x39
2023-08-08T18:34:30.0059887Z 
2023-08-08T18:34:30.0060093Z Goroutine 10109 (running) created at:
2023-08-08T18:34:30.0060381Z   testing.(*T).Run()
2023-08-08T18:34:30.0060927Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1629 +0x805
2023-08-08T18:34:30.0061343Z   testing.runTests.func1()
2023-08-08T18:34:30.0062077Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:2036 +0x8d
2023-08-08T18:34:30.0062492Z   testing.tRunner()
2023-08-08T18:34:30.0063049Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1576 +0x216
2023-08-08T18:34:30.0063484Z   testing.runTests()
2023-08-08T18:34:30.0064035Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:2034 +0x87c
2023-08-08T18:34:30.0064425Z   testing.(*M).Run()
2023-08-08T18:34:30.0064947Z       /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1906 +0xb44
2023-08-08T18:34:30.0065371Z   vitess.io/vitess/go/vt/wrangler.TestMain()
2023-08-08T18:34:30.0065992Z       /home/runner/work/vitess/vitess/go/vt/wrangler/materializer_env_test.go:60 +0x33
2023-08-08T18:34:30.0066389Z   main.main()
2023-08-08T18:34:30.0066778Z       _testmain.go:301 +0x324
2023-08-08T18:34:30.0067098Z ==================
```

## Related Issue(s)


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
