### PR TITLE
Use NodeJS v18 in VTAdmin Dockerfile

### DIFF
--- a/docker/k8s/vtadmin/Dockerfile
+++ b/docker/k8s/vtadmin/Dockerfile
@@ -17,7 +17,7 @@ ARG DEBIAN_VER=bullseye-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM node:16-${DEBIAN_VER} as node
+FROM node:18-${DEBIAN_VER} as node
 
 # Prepare directory structure.
 RUN mkdir -p /vt/web


### PR DESCRIPTION
## Description

This PR uses NodeJS version 18 in the vtadmin Dockerfile.

The build has been validated on DockerHub after creating a test auto-build target against the `enable-vtadmin-docker-build` branch.

![image](https://github.com/vitessio/vitess/assets/35779988/dffe6c36-7543-45a7-ad90-cd1861009ac7)


## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/13752 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
