### PR TITLE
v17: Fix backup_pitr flakiness

### DIFF
--- a/go/test/endtoend/backup/pitr/backup_mysqlctld_pitr_test.go
+++ b/go/test/endtoend/backup/pitr/backup_mysqlctld_pitr_test.go
@@ -34,10 +34,10 @@ import (
 func waitForReplica(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	pMsgs := backup.ReadRowsFromPrimary(t)
 	for {
-		rMsgs := backup.ReadRowsFromReplica(t)
-		if len(pMsgs) == len(rMsgs) {
+		primaryPos := backup.GetPrimaryPosition(t)
+		replicaPos := backup.GetReplicaPosition(t)
+		if replicaPos == primaryPos {
 			// success
 			return
 		}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1093,9 +1093,17 @@ func vtctlBackupReplicaNoDestroyNoWrites(t *testing.T, tabletType string) (backu
 	return backups, destroy
 }
 
-func GetReplicaPosition(t *testing.T) string {
-	pos, _ := cluster.GetPrimaryPosition(t, *replica1, hostname)
+func GetTabletPosition(t *testing.T, tablet *cluster.Vttablet) string {
+	pos, _ := cluster.GetPrimaryPosition(t, *tablet, hostname)
 	return pos
+}
+
+func GetReplicaPosition(t *testing.T) string {
+	return GetTabletPosition(t, replica1)
+}
+
+func GetPrimaryPosition(t *testing.T) string {
+	return GetTabletPosition(t, primary)
 }
 
 func GetReplicaGtidPurged(t *testing.T) string {


### PR DESCRIPTION

## Description

A `v17` specific variation of https://github.com/vitessio/vitess/pull/13761. https://github.com/vitessio/vitess/pull/13761 can't be backported because the structure of backup/pitr endtoend tests has changed too much.

Keeping this PR in `Draft` so I can manually run `backup_pitr` multiple times to confirm the flakiness is solved.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/13761

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
