### PR TITLE
Flakes: remove non-determinism from vtctldclient MoveTables unit test

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -57,13 +57,6 @@ const (
 	getAutoIncrementStep     = "select @@session.auto_increment_increment"
 	setSessionTZ             = "set @@session.time_zone = '+00:00'"
 	setNames                 = "set names 'binary'"
-	setSQLMode               = "set @@session.sql_mode = CONCAT(@@session.sql_mode, ',NO_AUTO_VALUE_ON_ZERO')"
-	setPermissiveSQLMode     = "SET @@session.sql_mode='NO_AUTO_VALUE_ON_ZERO'"
-	setStrictSQLMode         = "SET @@session.sql_mode='ONLY_FULL_GROUP_BY,NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
-	getSQLMode               = "SELECT @@session.sql_mode AS sql_mode"
-	getFKChecks              = "select @@foreign_key_checks"
-	enableFKChecks           = "set foreign_key_checks=1"
-	sqlMode                  = "ONLY_FULL_GROUP_BY,NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 	getBinlogRowImage        = "select @@binlog_row_image"
 	insertStreamsCreatedLog  = "insert into _vt.vreplication_log(vrepl_id, type, state, message) values(1, 'Stream Created', '', '%s'"
 	getVReplicationRecord    = "select * from _vt.vreplication where id = 1"
@@ -323,11 +316,6 @@ func TestMoveTables(t *testing.T) {
 		ftc.vrdbClient.ExpectRequest(`update _vt.vreplication set message='Picked source tablet: cell:\"zone1\" uid:200' where id=1`, &sqltypes.Result{}, nil)
 		ftc.vrdbClient.ExpectRequest(setSessionTZ, &sqltypes.Result{}, nil)
 		ftc.vrdbClient.ExpectRequest(setNames, &sqltypes.Result{}, nil)
-		ftc.vrdbClient.ExpectRequest(setSQLMode, &sqltypes.Result{}, nil)
-		ftc.vrdbClient.ExpectRequest(getSQLMode, sqltypes.MakeTestResult(
-			sqltypes.MakeTestFields("sql_mode", "varchar"),
-			sqlMode,
-		), nil)
 		ftc.vrdbClient.ExpectRequest(getWorkflowState, sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(
 				"pos|stop_pos|max_tps|max_replication_lag|state|workflow_type|workflow|workflow_sub_type|defer_secondary_keys",
@@ -338,14 +326,6 @@ func TestMoveTables(t *testing.T) {
 		ftc.vrdbClient.ExpectRequest(getNumCopyStateTable, sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(
 				"count(distinct table_name)",
-				"int64",
-			),
-			"1",
-		), nil)
-		ftc.vrdbClient.ExpectRequest(setPermissiveSQLMode, &sqltypes.Result{}, nil)
-		ftc.vrdbClient.ExpectRequest(getFKChecks, sqltypes.MakeTestResult(
-			sqltypes.MakeTestFields(
-				"@@foreign_key_checks",
 				"int64",
 			),
 			"1",
@@ -371,8 +351,6 @@ func TestMoveTables(t *testing.T) {
 			),
 			"FULL",
 		), nil)
-		ftc.vrdbClient.ExpectRequest(enableFKChecks, &sqltypes.Result{}, nil)
-		ftc.vrdbClient.ExpectRequest(setStrictSQLMode, &sqltypes.Result{}, nil)
 
 		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(insertStreamsCreatedLog, bls), &sqltypes.Result{}, nil)
 		tenv.tmc.setVReplicationExecResults(ftc.tablet, fmt.Sprintf(getWorkflow, targetKs, wf),


### PR DESCRIPTION
## Description

This fixes a timing issue that could result in the tabletmanager's `TestMoveTables` unit test causing it to fail like this with one or more of the `set foreign_key_checks` or `set @@session.sql_mode` queries coming in an unexpected order:
```
2023-08-10T15:09:33.7869997Z     vdbclient.go:90: DBClient query: set foreign_key_checks=1
2023-08-10T15:09:33.7870724Z     vdbclient.go:90: DBClientMock: query: set foreign_key_checks=1, want select pos, stop_pos, max_tps, max_replication_lag, state, workflow_type, workflow, workflow_sub_type, defer_secondary_keys from _vt.vreplication where id=1
2023-08-10T15:09:33.7871753Z     vdbclient.go:90: DBClient query: SET @@session.sql_mode='ONLY_FULL_GROUP_BY,NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
2023-08-10T15:09:33.7873368Z     vdbclient.go:90: DBClientMock: query: SET @@session.sql_mode='ONLY_FULL_GROUP_BY,NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION', want select pos, stop_pos, max_tps, max_replication_lag, state, workflow_type, workflow, workflow_sub_type, defer_secondary_keys from _vt.vreplication where id=1
```

For both of those `SET` statements we're changing the value _back_ to the original one. And we do that in the flow of work, but ALSO in a defer as a protective measure. The values seen and set are also dependent on the session (default) values, which can change. So we need to make these deterministic in the tests. That's what this PR does.

> **Note**
> In order to verify the fix, I ran the unit57 workflow 20 times in a row on this PR and there was not a single failure: https://github.com/vitessio/vitess/actions/runs/5823478965?pr=13765

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
