### PR TITLE
Run auto golang upgrade only on vitessio/vitess

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -9,6 +9,7 @@ permissions: read-all
 
 jobs:
   update_golang_version:
+    if: github.repository == 'vitessio/vitess'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Description

This PR modifies the auto-golang-upgrade workflow to only run on the `vitessio/vitess` repository.
