### PR TITLE
Address vttablet memory usage with backups to Azure Blob Service

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -3,8 +3,9 @@ Usage of vtbackup:
       --alsologtostderr                                             log to standard error as well as files
       --azblob_backup_account_key_file string                       Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
       --azblob_backup_account_name string                           Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used.
+      --azblob_backup_buffer_size int                               The memory buffer size to use in bytes, per file or stripe, when streaming to Azure Blob Service. (default 104857600)
       --azblob_backup_container_name string                         Azure Blob Container Name.
-      --azblob_backup_parallelism int                               Azure Blob operation parallelism (requires extra memory when increased). (default 1)
+      --azblob_backup_parallelism int                               Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob_backup_buffer_size). (default 1)
       --azblob_backup_storage_root string                           Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup_engine_implementation string                         Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
       --backup_storage_block_size int                               if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -3,8 +3,9 @@ Usage of vtctld:
       --alsologtostderr                                                  log to standard error as well as files
       --azblob_backup_account_key_file string                            Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
       --azblob_backup_account_name string                                Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used.
+      --azblob_backup_buffer_size int                                    The memory buffer size to use in bytes, per file or stripe, when streaming to Azure Blob Service. (default 104857600)
       --azblob_backup_container_name string                              Azure Blob Container Name.
-      --azblob_backup_parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased). (default 1)
+      --azblob_backup_parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob_backup_buffer_size). (default 1)
       --azblob_backup_storage_root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup_engine_implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
       --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -4,8 +4,9 @@ Usage of vttablet:
       --app_pool_size int                                                Size of the connection pool for app connections (default 40)
       --azblob_backup_account_key_file string                            Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
       --azblob_backup_account_name string                                Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used.
+      --azblob_backup_buffer_size int                                    The memory buffer size to use in bytes, per file or stripe, when streaming to Azure Blob Service. (default 104857600)
       --azblob_backup_container_name string                              Azure Blob Container Name.
-      --azblob_backup_parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased). (default 1)
+      --azblob_backup_parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob_backup_buffer_size). (default 1)
       --azblob_backup_storage_root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup_engine_implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
       --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -73,6 +73,14 @@ var (
 		},
 	)
 
+	azBlobBufferSize = viperutil.Configure(
+		configKey("buffer_size"),
+		viperutil.Options[int]{
+			Default:  100 << (10 * 2), // 100 MiB
+			FlagName: "azblob_buffer_size",
+		},
+	)
+
 	azBlobParallelism = viperutil.Configure(
 		configKey("parallelism"),
 		viperutil.Options[int]{
@@ -91,7 +99,8 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.String("azblob_backup_account_key_file", accountKeyFile.Default(), "Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).")
 	fs.String("azblob_backup_container_name", containerName.Default(), "Azure Blob Container Name.")
 	fs.String("azblob_backup_storage_root", storageRoot.Default(), "Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').")
-	fs.Int("azblob_backup_parallelism", azBlobParallelism.Default(), "Azure Blob operation parallelism (requires extra memory when increased).")
+	fs.Int("azblob_backup_buffer_size", azBlobBufferSize.Default(), "The memory buffer size to use in bytes, per file or stripe, when streaming to Azure Blob Service.")
+	fs.Int("azblob_backup_parallelism", azBlobParallelism.Default(), "Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob_backup_buffer_size).")
 
 	viperutil.BindFlags(fs, accountName, accountKeyFile, containerName, storageRoot, azBlobParallelism)
 }
@@ -248,7 +257,7 @@ func (bh *AZBlobBackupHandle) AddFile(ctx context.Context, filename string, file
 	go func() {
 		defer bh.waitGroup.Done()
 		_, err := azblob.UploadStreamToBlockBlob(bh.ctx, reader, blockBlobURL, azblob.UploadStreamToBlockBlobOptions{
-			BufferSize: azblob.BlockBlobMaxStageBlockBytes,
+			BufferSize: azBlobBufferSize.Get(),
 			MaxBuffers: azBlobParallelism.Get(),
 		})
 		if err != nil {


### PR DESCRIPTION
## Description

We do this by adding a new flag that defaults to the buffer size that was previously used in Vitess prior to 16.0.

In [16.0 we upgraded our internal go dependencies]( https://github.com/vitessio/vitess/commit/c67c79097baf05a5112e2d64c63b4d46cccba3a5) and in doing so we upgraded the version of [azure-storage-blob-go library](https://github.com/Azure/azure-storage-blob-go/tree/0.15) we use from v0.10.0 to v0.15.0.

And [in v0.11.0 the library increased the size of the `BlockBlobMaxStageBlockBytes` const from 100MiB to 4GiB](https://github.com/Azure/azure-storage-blob-go/commit/9e15f04c6946bd987ea313f434a2cdc0b1c0f609). We used that in setting the size of the (static) buffer to use when streaming a file to the Azure Blob service indirectly here: https://github.com/vitessio/vitess/blob/2b285f775229609d25f9b39b856ff1397c0dd10d/go/vt/mysqlctl/azblobbackupstorage/azblob.go#L250-L253

Those values then get used in the library here:
https://github.com/Azure/azure-storage-blob-go/blob/ac3d8bf5f055cc1e18bd79f1fb1492ac7b5013c3/azblob/highlevel.go#L390-L394

The result of this external change is that `vttablet` memory usage when performing a backup to Azure Blob Service went up _**40x**_ and will be a multiple of 4GiB depending on the number of files, or stripes with `xtrabackup` (`--xtrabackup_stripes`), and parallelism configured (`--azblob_backup_parallelism`). Memory usage at this level is problematic and likely to cause OOMs and other issues (note that this is _resident memory_ too).

> **Note**
> This was first [reported in the Vitess Slack](https://vitess.slack.com/archives/C0PQY0PTK/p1691483609385139) and there are some additional details there.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13771

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation: https://github.com/vitessio/website/pull/1560