### PR TITLE
Fix bug in `fileNameFromPosition` test helper

### DIFF
--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -567,7 +567,7 @@ func fileNameFromPosition(pos string) string {
 
 func TestFileNameFromPosition(t *testing.T) {
 	assert.Equal(t, "", fileNameFromPosition("shouldfail"))
-	assert.Equal(t, "filename", fileNameFromPosition("filename:123456789"))
+	assert.Equal(t, "FilePos/vt-0000000101-bin.000001", fileNameFromPosition("FilePos/vt-0000000101-bin.000001:123456789"))
 }
 
 // rowNumberFromPosition gets the row number from the position

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -557,7 +558,16 @@ func waitForFilePosition(t *testing.T, clusterInstance *cluster.LocalProcessClus
 
 // fileNameFromPosition gets the file name from the position
 func fileNameFromPosition(pos string) string {
-	return pos[0 : len(pos)-4]
+	s := strings.SplitN(pos, ":", 2)
+	if len(s) != 2 {
+		return ""
+	}
+	return s[0]
+}
+
+func TestFileNameFromPosition(t *testing.T) {
+	assert.Equal(t, "", fileNameFromPosition("shouldfail"))
+	assert.Equal(t, "filename", fileNameFromPosition("filename:123456789"))
 }
 
 // rowNumberFromPosition gets the row number from the position


### PR DESCRIPTION
## Description

This PR fixes a bug that causes `fileNameFromPosition` (a test helper-`func` from `go/test/endtoend/reparent/plannedreparent`) to fail to parse a filename when the position text is too long

This is causing `plannedreparent` tests to be flaky on faster, dedicated CI runners we're using because they generate more binlog positions than this test is expecting

Here is a Go Playground reproducing the problem with the old, brittle logic: https://go.dev/play/p/ck5jEMcZu_V

Thanks to @deepthi for helping me find this problem in the Vitess Slack 🙇 

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13779

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
