### PR TITLE
mycnf: Switch to using the default MySQL 8.0 auth

### DIFF
--- a/config/mycnf/mysql80.cnf
+++ b/config/mycnf/mysql80.cnf
@@ -12,7 +12,7 @@ binlog_expire_logs_seconds = 259200
 mysqlx = 0
 
 # 8.0 changes the default auth-plugin to caching_sha2_password
-default_authentication_plugin = mysql_native_password
+default_authentication_plugin = caching_sha2_password
 
 # Semi-sync replication is required for automated unplanned failover
 # (when the primary goes away). Here we just load the plugin so it's


### PR DESCRIPTION
We should use the new default for the backend MySQL. Also with MySQL 8.0.34 this will start throwing deprecation warnings.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required