### PR TITLE
docker/bootstrap: remove --no-cache flag

### DIFF
--- a/docker/bootstrap/build.sh
+++ b/docker/bootstrap/build.sh
@@ -60,5 +60,10 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -f "docker/bootstrap/Dockerfile.$flavor" ]; then
-    docker build --no-cache -f docker/bootstrap/Dockerfile.$flavor -t $image --build-arg bootstrap_version=$version --build-arg image=$base_image .
+    docker build \
+      -f docker/bootstrap/Dockerfile.$flavor \
+      -t $image \
+      --build-arg bootstrap_version=$version \
+      --build-arg image=$base_image \
+      .
 fi


### PR DESCRIPTION
## Description

It seems like this was added back in 2015 when vitess used to use raw
go get commands to build the image, the reasoning behind it was to ensure
that the image has the most recent dependencies. This is no longer needed
because in the dockerfile we correctly add go.* dep manifests and call go mod download.

## Related Issue(s)

PR where this was added:
https://github.com/vitessio/vitess/pull/665

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required


