### PR TITLE
Remove explicit usage of etcd v2 (api and storage)

### DIFF
--- a/changelog/18.0/18.0.0/summary.md
+++ b/changelog/18.0/18.0.0/summary.md
@@ -4,6 +4,7 @@
 
 - **[Major Changes](#major-changes)**
   - **[Breaking Changes](#breaking-changes)**
+    - [Local examples now use etcd v3 storage and API](#local-examples-etcd-v3)
   - **[New command line flags and behavior](#new-flag)**
     - [VTOrc flag `--allow-emergency-reparent`](#new-flag-toggle-ers)
     - [ERS sub flag `--wait-for-all-tablets`](#new-ers-subflag)
@@ -25,6 +26,14 @@
 ## <a id="major-changes"/>Major Changes
 
 ### <a id="breaking-changes"/>Breaking Changes
+
+#### <a id="local-examples-etcd-v3"/>Local examples now use etcd v3 storage and API
+In previous releases the [local examples](https://github.com/vitessio/vitess/tree/main/examples/local) were
+explicitly using etcd v2 storage (`etcd --enable-v2=true`) and API (`ETCDCTL_API=2`) mode. We have now
+removed this legacy etcd usage and instead use the new (default) etcd v3 storage and API. Please see
+[PR #13791](https://github.com/vitessio/vitess/pull/13791) for additional info. If you are using the local
+examples in any sort of long-term non-testing capacity, then you will need to explicitly use the v2 storage
+and API mode or [migrate your existing data from v2 to v3](https://etcd.io/docs/v3.5/tutorials/how-to-migrate/).
 
 ### <a id="new-flag"/>New command line flags and behavior
 

--- a/examples/common/scripts/etcd-up.sh
+++ b/examples/common/scripts/etcd-up.sh
@@ -19,21 +19,14 @@
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
 cell=${CELL:-'test'}
-export ETCDCTL_API=2
 
 # Check that etcd is not already running
 curl "http://${ETCD_SERVER}" > /dev/null 2>&1 && fail "etcd is already running. Exiting."
 
-etcd --enable-v2=true --data-dir "${VTDATAROOT}/etcd/"  --listen-client-urls "http://${ETCD_SERVER}" --advertise-client-urls "http://${ETCD_SERVER}" > "${VTDATAROOT}"/tmp/etcd.out 2>&1 &
+etcd --data-dir "${VTDATAROOT}/etcd/"  --listen-client-urls "http://${ETCD_SERVER}" --advertise-client-urls "http://${ETCD_SERVER}" > "${VTDATAROOT}"/tmp/etcd.out 2>&1 &
 PID=$!
 echo $PID > "${VTDATAROOT}/tmp/etcd.pid"
 sleep 5
-
-echo "add /vitess/global"
-etcdctl --endpoints "http://${ETCD_SERVER}" mkdir /vitess/global &
-
-echo "add /vitess/$cell"
-etcdctl --endpoints "http://${ETCD_SERVER}" mkdir /vitess/$cell &
 
 # And also add the CellInfo description for the cell.
 # If the node already exists, it's fine, means we used existing data.

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -113,6 +113,14 @@ func (topo *TopoProcess) SetupEtcd() (err error) {
 	timeout := time.Now().Add(60 * time.Second)
 	for time.Now().Before(timeout) {
 		if topo.IsHealthy() {
+			cli, cerr := clientv3.New(clientv3.Config{
+				Endpoints:   []string{net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port))},
+				DialTimeout: 5 * time.Second,
+			})
+			if cerr != nil {
+				return err
+			}
+			topo.Client = cli
 			return
 		}
 		select {
@@ -236,14 +244,6 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 	timeout := time.Now().Add(60 * time.Second)
 	for time.Now().Before(timeout) {
 		if topo.IsHealthy() {
-			cli, cerr := clientv3.New(clientv3.Config{
-				Endpoints:   []string{net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port))},
-				DialTimeout: 5 * time.Second,
-			})
-			if cerr != nil {
-				return err
-			}
-			topo.Client = cli
 			return
 		}
 		select {

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -57,10 +57,6 @@ func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) 
 	case "consul":
 		return topo.SetupConsul(cluster)
 	default:
-		// We still rely on the etcd v2 API for things like mkdir.
-		// If this ENV var is not set then some tests may fail with etcd 3.4+
-		// where the v2 API is disabled by default in both the client and server.
-		os.Setenv("ETCDCTL_API", "2")
 		return topo.SetupEtcd()
 	}
 }
@@ -77,7 +73,6 @@ func (topo *TopoProcess) SetupEtcd() (err error) {
 		"--initial-advertise-peer-urls", topo.PeerURL,
 		"--listen-peer-urls", topo.PeerURL,
 		"--initial-cluster", fmt.Sprintf("%s=%s", topo.Name, topo.PeerURL),
-		"--enable-v2=true",
 	)
 
 	err = createDirectory(topo.DataDirectory, 0700)

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -368,7 +368,7 @@ func TopoProcessInstance(port int, peerPort int, hostname string, flavor string,
 	topo.ListenClientURL = fmt.Sprintf("http://%s:%d", topo.Host, topo.Port)
 	topo.DataDirectory = path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("%s_%d", "topo", port))
 	topo.LogDirectory = path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("%s_%d", "topo", port), "logs")
-	topo.VerifyURL = fmt.Sprintf("http://%s:%d/v3/kv", topo.Host, topo.Port)
+	topo.VerifyURL = fmt.Sprintf("http://%s:%d/health", topo.Host, topo.Port)
 	topo.PeerURL = fmt.Sprintf("http://%s:%d", hostname, peerPort)
 	return topo
 }


### PR DESCRIPTION
## Description

Etcd v3.0 — released _7 years ago_ — had major rewrites of the API and storage layer (data model): https://www.infoworld.com/article/3090223/coreos-ramps-up-container-scaling-with-etcd-30.html 

In order to ease the transition, they supported using 3.x in v2 mode via:
  - The etcd `--enable-v2=true` flag
  - The `ETCDCTL_API=2` env variable

We've been using these in Vitess to support explicit v2 API usage such as `mkdir` (which is gone, and generally unnecessary because you don't need to create empty prefix keys). This was explicitly needed as starting in 3.4 `--enable-v2` defaulted to false: https://etcd.io/docs/v3.4/upgrades/upgrade_3_4/

The problem with using etcd in v2 mode, however, is that by default reads from replicas/followers are not consistent — i.e. you can get stale reads by default. With v3, however, you get linearizable reads by default: https://etcd.io/docs/v3.5/learning/api_guarantees/#isolation-level-and-consistency-of-replicas

We believe that we've recently seen the v2 storage behavior impact test flakiness. See: https://github.com/vitessio/vitess/pull/13788

And given that etcd v4.0 is on the horizon and v2 is going away, it's past time for us to move away from it. From [the 3.5 changelog](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md):
- etcd --experimental-enable-v2v3 flag remains experimental and to be deprecated.
  - v2 storage emulation feature will be deprecated in the next release.
  - etcd 3.5 is the last version that supports V2 API. Flags --enable-v2 and --experimental-enable-v2v3 are now deprecated and will be removed in etcd v3.6 release.
- v4.0 will configure etcd --enable-v2=true --enable-v2v3=/aaa to enable v2 API server that is backed by v3 storage.

> **Note**
> 1. The only explicit usage of v2 today was in the endtoend tests and the local examples
> 2. We're already explicitly using the v3 client API throughout vitess: https://github.com/search?q=repo%3Avitessio%2Fvitess%20clientv3&type=code
> 3. The Vitess Operator is already explicitly using v3: https://github.com/planetscale/vitess-operator/blob/main/pkg/operator/etcd/pod.go#L144-L147

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were updated
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
