### PR TITLE
Flakes: Delete VTDATAROOT files in reparent test teardown within CI

### DIFF
--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -77,7 +77,11 @@ func SetupRangeBasedCluster(ctx context.Context, t *testing.T) *cluster.LocalPro
 
 // TeardownCluster is used to teardown the reparent cluster
 func TeardownCluster(clusterInstance *cluster.LocalProcessCluster) {
+	usedRoot := clusterInstance.CurrentVTDATAROOT
 	clusterInstance.Teardown()
+	if err := os.RemoveAll(usedRoot); err != nil {
+		log.Errorf("Failed to remove previously used VTDATAROOT (%s): %v", usedRoot, err)
+	}
 }
 
 func setupCluster(ctx context.Context, t *testing.T, shardName string, cells []string, numTablets []int, durability string) *cluster.LocalProcessCluster {


### PR DESCRIPTION
## Description

The reparent upgrade/downgrade workflows have been repeatedly failing in Actions due to running out of disk space. For example:
```
Error: -15T21:51:23.558594Z 1 [ERROR] [MY-012144] [InnoDB] posix_fallocate(): Failed to preallocate data for file mysql.ibd, desired size 1048576 bytes. Operating system error number 28. Check that the disk is not full or a disk quota exceeded. Make sure the file system supports this function. Refer to your operating system documentation for operating system error code information.
Warning: 5T21:51:23.558689Z 1 [Warning] [MY-012638] [InnoDB] Retry attempts for writing partial data failed.
Error: -15T21:51:23.558704Z 1 [ERROR] [MY-012639] [InnoDB] Write to file mysql.ibd failed at offset 8388608, 1048576 bytes should have been written, only 0 were written. Operating system error number 28. Check that your OS and file system support files of this size. Check also that the disk is not full or a disk quota exceeded.
Error: -15T21:51:23.558715Z 1 [ERROR] [MY-012640] [InnoDB] Error number 28 means 'No space left on device'
Warning: 5T21:51:23.558726Z 1 [Warning] [MY-012145] [InnoDB] Error while writing 1048576 zeroes to mysql.ibd starting at offset 8388608
```

It always seems to be the the ERS test that fails.

You can see the failures here as examples:
  - https://github.com/vitessio/vitess/actions/runs/5864448319/job/15921614804?pr=13737
  - https://github.com/vitessio/vitess/actions/runs/5864448314/job/15916299766?pr=13737

These were failing consistently every time on the 2 PRs that I currently have open.

Runs of the same workflows on the PR can be seen here — they each passed _5 times in a row_, followed by 2 more in a row after the second commit (where we limit the behavior to the CI):
  - https://github.com/vitessio/vitess/actions/runs/5872297633/job/15923592558?pr=13793
  - https://github.com/vitessio/vitess/actions/runs/5872297593/job/15923592445?pr=13793
  - https://github.com/vitessio/vitess/actions/runs/5873366370?pr=13793
  - https://github.com/vitessio/vitess/actions/runs/5873366411?pr=13793

> **Note**
> We only delete the used `VTDATAROOT` *if* we detect that we are running in the CI. This allows for local test debugging as needed.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required