### PR TITLE
Add Foreign key Cascade engine primitive

### DIFF
--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -73,6 +73,26 @@ func (cached *CheckCol) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(8))
 	return size
 }
+func (cached *Child) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(64)
+	}
+	// field BVName string
+	size += hack.RuntimeAllocSize(int64(len(cached.BVName)))
+	// field Cols []int
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Cols)) * int64(8))
+	}
+	// field P vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.P.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	return size
+}
 
 //go:nocheckptr
 func (cached *Concatenate) CachedSize(alloc bool) int64 {
@@ -223,6 +243,31 @@ func (cached *ExecStmt) CachedSize(alloc bool) int64 {
 	}
 	// field Input vitess.io/vitess/go/vt/vtgate/engine.Primitive
 	if cc, ok := cached.Input.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	return size
+}
+func (cached *FK_Cascade) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(64)
+	}
+	// field Input vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.Input.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	// field Child []vitess.io/vitess/go/vt/vtgate/engine.Child
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Child)) * int64(56))
+		for _, elem := range cached.Child {
+			size += elem.CachedSize(false)
+		}
+	}
+	// field Parent vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.Parent.(cachedObject); ok {
 		size += cc.CachedSize(true)
 	}
 	return size

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -73,26 +73,6 @@ func (cached *CheckCol) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(8))
 	return size
 }
-func (cached *Child) CachedSize(alloc bool) int64 {
-	if cached == nil {
-		return int64(0)
-	}
-	size := int64(0)
-	if alloc {
-		size += int64(64)
-	}
-	// field BVName string
-	size += hack.RuntimeAllocSize(int64(len(cached.BVName)))
-	// field Cols []int
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Cols)) * int64(8))
-	}
-	// field P vitess.io/vitess/go/vt/vtgate/engine.Primitive
-	if cc, ok := cached.P.(cachedObject); ok {
-		size += cc.CachedSize(true)
-	}
-	return size
-}
 
 //go:nocheckptr
 func (cached *Concatenate) CachedSize(alloc bool) int64 {
@@ -247,31 +227,6 @@ func (cached *ExecStmt) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
-func (cached *FK_Cascade) CachedSize(alloc bool) int64 {
-	if cached == nil {
-		return int64(0)
-	}
-	size := int64(0)
-	if alloc {
-		size += int64(64)
-	}
-	// field Input vitess.io/vitess/go/vt/vtgate/engine.Primitive
-	if cc, ok := cached.Input.(cachedObject); ok {
-		size += cc.CachedSize(true)
-	}
-	// field Child []vitess.io/vitess/go/vt/vtgate/engine.Child
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Child)) * int64(56))
-		for _, elem := range cached.Child {
-			size += elem.CachedSize(false)
-		}
-	}
-	// field Parent vitess.io/vitess/go/vt/vtgate/engine.Primitive
-	if cc, ok := cached.Parent.(cachedObject); ok {
-		size += cc.CachedSize(true)
-	}
-	return size
-}
 func (cached *Filter) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -290,6 +245,51 @@ func (cached *Filter) CachedSize(alloc bool) int64 {
 	}
 	// field Input vitess.io/vitess/go/vt/vtgate/engine.Primitive
 	if cc, ok := cached.Input.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	return size
+}
+func (cached *FkCascade) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(64)
+	}
+	// field Selection vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.Selection.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	// field Children []vitess.io/vitess/go/vt/vtgate/engine.FkChild
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Children)) * int64(56))
+		for _, elem := range cached.Children {
+			size += elem.CachedSize(false)
+		}
+	}
+	// field Parent vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.Parent.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	return size
+}
+func (cached *FkChild) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(64)
+	}
+	// field BVName string
+	size += hack.RuntimeAllocSize(int64(len(cached.BVName)))
+	// field Cols []int
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Cols)) * int64(8))
+	}
+	// field Exec vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.Exec.(cachedObject); ok {
 		size += cc.CachedSize(true)
 	}
 	return size

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -25,6 +25,8 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
+// FkChild contains the Child Primitive to be executed collecting the values from the Selection Primitive using the column indexes.
+// BVName is used to pass the value as bind variable to the Child Primitive.
 type FkChild struct {
 	BVName string
 	Cols   []int // indexes
@@ -34,9 +36,12 @@ type FkChild struct {
 // FkCascade is a primitive that implements foreign key cascading using Selection as values required to execute the FkChild Primitives.
 // On success, it executes the Parent Primitive.
 type FkCascade struct {
+	// Selection is the Primitive that is used to find the rows that are going to be modified in the child tables.
 	Selection Primitive
-	Children  []FkChild
-	Parent    Primitive
+	// Children is a list of child foreign key Primitives that are executed using rows from the Selection Primitive.
+	Children []FkChild
+	// Parent is the Primitive that is executed after the children are modified.
+	Parent Primitive
 
 	txNeeded
 }

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -25,58 +25,64 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
-type Child struct {
+type FkChild struct {
 	BVName string
 	Cols   []int // indexes
-	P      Primitive
+	Exec   Primitive
 }
 
-// FK_Cascade is a primitive that implements foreign key cascading using Input as values required to execute the Child Primitive.
+// FkCascade is a primitive that implements foreign key cascading using Selection as values required to execute the FkChild Primitives.
 // On success, it executes the Parent Primitive.
-type FK_Cascade struct {
-	Input  Primitive
-	Child  []Child
-	Parent Primitive
+type FkCascade struct {
+	Selection Primitive
+	Children  []FkChild
+	Parent    Primitive
 
 	txNeeded
 }
 
 // RouteType implements the Primitive interface.
-func (fkc *FK_Cascade) RouteType() string {
-	return "FK_CASCADE"
+func (fkc *FkCascade) RouteType() string {
+	return "FkCascade"
 }
 
 // GetKeyspaceName implements the Primitive interface.
-func (fkc *FK_Cascade) GetKeyspaceName() string {
+func (fkc *FkCascade) GetKeyspaceName() string {
 	return fkc.Parent.GetKeyspaceName()
 }
 
 // GetTableName implements the Primitive interface.
-func (fkc *FK_Cascade) GetTableName() string {
+func (fkc *FkCascade) GetTableName() string {
 	return fkc.Parent.GetTableName()
 }
 
 // GetFields implements the Primitive interface.
-func (fkc *FK_Cascade) GetFields(_ context.Context, _ VCursor, _ map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (fkc *FkCascade) GetFields(_ context.Context, _ VCursor, _ map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] GetFields should not be called")
 }
 
 // TryExecute implements the Primitive interface.
-func (fkc *FK_Cascade) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	inputRes, err := vcursor.ExecutePrimitive(ctx, fkc.Input, bindVars, wantfields)
+func (fkc *FkCascade) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	// Execute the Selection primitive to find the rows that are going to modified.
+	// This will be used to find the rows that need modification on the children.
+	selectionRes, err := vcursor.ExecutePrimitive(ctx, fkc.Selection, bindVars, wantfields)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(inputRes.Rows) == 0 {
+	// If no rows are to be modified, there is nothing to do.
+	if len(selectionRes.Rows) == 0 {
 		return &sqltypes.Result{}, nil
 	}
 
-	for _, child := range fkc.Child {
+	for _, child := range fkc.Children {
+		// We create a bindVariable for each Child
+		// that stores the tuple of columns involved in the fk constraint.
 		bv := &querypb.BindVariable{
 			Type: querypb.Type_TUPLE,
 		}
-		for _, row := range inputRes.Rows {
+		for _, row := range selectionRes.Rows {
+			// Create a tuple from each Row.
 			tuple := &querypb.Value{
 				Type: querypb.Type_TUPLE,
 			}
@@ -86,37 +92,89 @@ func (fkc *FK_Cascade) TryExecute(ctx context.Context, vcursor VCursor, bindVars
 			}
 			bv.Values = append(bv.Values, tuple)
 		}
+		// Execute the child primitive, and bail out incase of failure.
+		// Since this Primitive is always executed in a transaction, the changes should
+		// be rolled back incase of an error.
 		bindVars[child.BVName] = bv
-		_, err = vcursor.ExecutePrimitive(ctx, child.P, bindVars, wantfields)
+		_, err = vcursor.ExecutePrimitive(ctx, child.Exec, bindVars, wantfields)
 		if err != nil {
 			return nil, err
 		}
 		delete(bindVars, child.BVName)
 	}
 
+	// All the children are modified successfully, we can now execute the Parent Primitive.
 	return vcursor.ExecutePrimitive(ctx, fkc.Parent, bindVars, wantfields)
 }
 
 // TryStreamExecute implements the Primitive interface.
-func (fkc *FK_Cascade) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
-	// TODO implement me
-	panic("implement me")
+func (fkc *FkCascade) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	// We create a bindVariable for each Child
+	// that stores the tuple of columns involved in the fk constraint.
+	var bindVariables []*querypb.BindVariable
+	for range fkc.Children {
+		bindVariables = append(bindVariables, &querypb.BindVariable{
+			Type: querypb.Type_TUPLE,
+		})
+	}
+
+	// Execute the Selection primitive to find the rows that are going to modified.
+	// This will be used to find the rows that need modification on the children.
+	err := vcursor.StreamExecutePrimitive(ctx, fkc.Selection, bindVars, wantfields, func(result *sqltypes.Result) error {
+		if len(result.Rows) == 0 {
+			return nil
+		}
+		for idx, child := range fkc.Children {
+			for _, row := range result.Rows {
+				// Create a tuple from each Row.
+				tuple := &querypb.Value{
+					Type: querypb.Type_TUPLE,
+				}
+				for _, colIdx := range child.Cols {
+					tuple.Values = append(tuple.Values,
+						sqltypes.ValueToProto(row[colIdx]))
+				}
+				bindVariables[idx].Values = append(bindVariables[idx].Values, tuple)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Execute the child primitive, and bail out incase of failure.
+	// Since this Primitive is always executed in a transaction, the changes should
+	// be rolled back incase of an error.
+	for idx, child := range fkc.Children {
+		bindVars[child.BVName] = bindVariables[idx]
+		err = vcursor.StreamExecutePrimitive(ctx, child.Exec, bindVars, wantfields, func(result *sqltypes.Result) error {
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		delete(bindVars, child.BVName)
+	}
+
+	// All the children are modified successfully, we can now execute the Parent Primitive.
+	return vcursor.StreamExecutePrimitive(ctx, fkc.Parent, bindVars, wantfields, callback)
 }
 
 // Inputs implements the Primitive interface.
-func (fkc *FK_Cascade) Inputs() []Primitive {
-	inputs := []Primitive{fkc.Input}
-	for _, child := range fkc.Child {
-		inputs = append(inputs, child.P)
+func (fkc *FkCascade) Inputs() []Primitive {
+	inputs := []Primitive{fkc.Selection}
+	for _, child := range fkc.Children {
+		inputs = append(inputs, child.Exec)
 	}
 	inputs = append(inputs, fkc.Parent)
 	return inputs
 }
 
-func (fkc *FK_Cascade) description() PrimitiveDescription {
+func (fkc *FkCascade) description() PrimitiveDescription {
 	return PrimitiveDescription{
 		OperatorType: fkc.RouteType(),
 	}
 }
 
-var _ Primitive = (*FK_Cascade)(nil)
+var _ Primitive = (*FkCascade)(nil)

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+type Child struct {
+	BVName string
+	Cols   []int // indexes
+	P      Primitive
+}
+
+// delete from child where (a, b) in ::__vals
+// delete from child where (a, b) in (:t1, :t2)
+
+// "__vals" : tuple (
+
+type FK_Cascade struct {
+	// select a, b, c, d from parent where a = 1
+	Input Primitive
+
+	Child []Child
+
+	Parent Primitive
+
+	txNeeded
+}
+
+func (fkc *FK_Cascade) RouteType() string {
+	return "FK_CASCADE"
+}
+
+func (fkc *FK_Cascade) GetKeyspaceName() string {
+	return fkc.Parent.GetKeyspaceName()
+}
+
+func (fkc *FK_Cascade) GetTableName() string {
+	return fkc.Parent.GetTableName()
+}
+
+func (fkc *FK_Cascade) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] GetFields should not be called")
+}
+
+func (fkc *FK_Cascade) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	inputRes, err := vcursor.ExecutePrimitive(ctx, fkc.Input, bindVars, wantfields)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(inputRes.Rows) == 0 {
+		return &sqltypes.Result{}, nil
+	}
+
+	for _, child := range fkc.Child {
+		bv := &querypb.BindVariable{
+			Type: querypb.Type_TUPLE,
+		}
+		for _, row := range inputRes.Rows {
+			tuple := &querypb.Value{
+				Type: querypb.Type_TUPLE,
+			}
+			for _, colIdx := range child.Cols {
+				tuple.Values = append(tuple.Values,
+					sqltypes.ValueToProto(row[colIdx]))
+			}
+			bv.Values = append(bv.Values, tuple)
+		}
+		bindVars[child.BVName] = bv
+		_, err = vcursor.ExecutePrimitive(ctx, child.P, bindVars, wantfields)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return vcursor.ExecutePrimitive(ctx, fkc.Parent, bindVars, wantfields)
+}
+
+func (fkc *FK_Cascade) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (fkc *FK_Cascade) Inputs() []Primitive {
+	inputs := []Primitive{fkc.Input}
+	for _, child := range fkc.Child {
+		inputs = append(inputs, child.P)
+	}
+	inputs = append(inputs, fkc.Parent)
+	return inputs
+}
+
+func (fkc *FK_Cascade) description() PrimitiveDescription {
+	return PrimitiveDescription{
+		OperatorType: fkc.RouteType(),
+	}
+}
+
+var _ Primitive = (*FK_Cascade)(nil)

--- a/go/vt/vtgate/engine/fk_cascade_test.go
+++ b/go/vt/vtgate/engine/fk_cascade_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+func TestDeleteCascade(t *testing.T) {
+	fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "1|a", "2|b")
+
+	inputP := &fakePrimitive{results: []*sqltypes.Result{fakeRes}}
+	childP := &fakePrimitive{results: []*sqltypes.Result{fakeRes}}
+	parentP := &fakePrimitive{results: []*sqltypes.Result{fakeRes}}
+	fkc := &FK_Cascade{
+		Input:  inputP,
+		Child:  []Child{{BVName: "__vals", Cols: []int{0, 1}, P: childP}},
+		Parent: parentP,
+	}
+
+	vc := &loggingVCursor{}
+	_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{`Execute  true`}, inputP.log)
+	assert.Equal(t, []string{`Execute __vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}} true`}, childP.log)
+	assert.Equal(t, []string{`Execute  true`}, parentP.log)
+}

--- a/go/vt/vtgate/engine/fk_cascade_test.go
+++ b/go/vt/vtgate/engine/fk_cascade_test.go
@@ -20,29 +20,57 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 func TestDeleteCascade(t *testing.T) {
 	fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "1|a", "2|b")
 
-	inputP := &fakePrimitive{results: []*sqltypes.Result{fakeRes}}
-	childP := &fakePrimitive{results: []*sqltypes.Result{fakeRes}}
-	parentP := &fakePrimitive{results: []*sqltypes.Result{fakeRes}}
+	inputP := &Route{
+		Query: "select cola, colb from parent where foo = 48",
+		RoutingParameters: &RoutingParameters{
+			Opcode:   Unsharded,
+			Keyspace: &vindexes.Keyspace{Name: "ks"},
+		},
+	}
+	childP := &Delete{
+		DML: &DML{
+			Query: "delete from child where (cola, colb) in ::__vals",
+			RoutingParameters: &RoutingParameters{
+				Opcode:   Unsharded,
+				Keyspace: &vindexes.Keyspace{Name: "ks"},
+			},
+		},
+	}
+	parentP := &Delete{
+		DML: &DML{
+			Query: "delete from parent where foo = 48",
+			RoutingParameters: &RoutingParameters{
+				Opcode:   Unsharded,
+				Keyspace: &vindexes.Keyspace{Name: "ks"},
+			},
+		},
+	}
 	fkc := &FK_Cascade{
 		Input:  inputP,
 		Child:  []Child{{BVName: "__vals", Cols: []int{0, 1}, P: childP}},
 		Parent: parentP,
 	}
 
-	vc := &loggingVCursor{}
+	vc := newDMLTestVCursor("0")
+	vc.results = []*sqltypes.Result{fakeRes}
 	_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{`Execute  true`}, inputP.log)
-	assert.Equal(t, []string{`Execute __vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}} true`}, childP.log)
-	assert.Equal(t, []string{`Execute  true`}, parentP.log)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ks.0: select cola, colb from parent where foo = 48 {} false false`,
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ks.0: delete from child where (cola, colb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} true true`,
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ks.0: delete from parent where foo = 48 {} true true`,
+	})
 }

--- a/go/vt/vtgate/engine/fk_cascade_test.go
+++ b/go/vt/vtgate/engine/fk_cascade_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
+// TestDeleteCascade tests that FK_Cascade executes the child and parent primitives for a delete cascade.
 func TestDeleteCascade(t *testing.T) {
 	fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "1|a", "2|b")
 
@@ -39,7 +40,7 @@ func TestDeleteCascade(t *testing.T) {
 	}
 	childP := &Delete{
 		DML: &DML{
-			Query: "delete from child where (cola, colb) in ::__vals",
+			Query: "delete from child where (ca, cb) in ::__vals",
 			RoutingParameters: &RoutingParameters{
 				Opcode:   Unsharded,
 				Keyspace: &vindexes.Keyspace{Name: "ks"},
@@ -69,8 +70,57 @@ func TestDeleteCascade(t *testing.T) {
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
 		`ExecuteMultiShard ks.0: select cola, colb from parent where foo = 48 {} false false`,
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: delete from child where (cola, colb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} true true`,
+		`ExecuteMultiShard ks.0: delete from child where (ca, cb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} true true`,
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
 		`ExecuteMultiShard ks.0: delete from parent where foo = 48 {} true true`,
+	})
+}
+
+// TestUpdateCascade tests that FK_Cascade executes the child and parent primitives for an update cascade.
+func TestUpdateCascade(t *testing.T) {
+	fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "1|a", "2|b")
+
+	inputP := &Route{
+		Query: "select cola, colb from parent where foo = 48",
+		RoutingParameters: &RoutingParameters{
+			Opcode:   Unsharded,
+			Keyspace: &vindexes.Keyspace{Name: "ks"},
+		},
+	}
+	childP := &Update{
+		DML: &DML{
+			Query: "update child set ca = :vtg1 where (ca, cb) in ::__vals",
+			RoutingParameters: &RoutingParameters{
+				Opcode:   Unsharded,
+				Keyspace: &vindexes.Keyspace{Name: "ks"},
+			},
+		},
+	}
+	parentP := &Update{
+		DML: &DML{
+			Query: "update parent set cola = 1 where foo = 48",
+			RoutingParameters: &RoutingParameters{
+				Opcode:   Unsharded,
+				Keyspace: &vindexes.Keyspace{Name: "ks"},
+			},
+		},
+	}
+	fkc := &FK_Cascade{
+		Input:  inputP,
+		Child:  []Child{{BVName: "__vals", Cols: []int{0, 1}, P: childP}},
+		Parent: parentP,
+	}
+
+	vc := newDMLTestVCursor("0")
+	vc.results = []*sqltypes.Result{fakeRes}
+	_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ks.0: select cola, colb from parent where foo = 48 {} false false`,
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ks.0: update child set ca = :vtg1 where (ca, cb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} true true`,
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ks.0: update parent set cola = 1 where foo = 48 {} true true`,
 	})
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR adds an engine primitive that can execute a foreign key cascade.
The planner support to support this use case is still not done.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #12967 

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
