### PR TITLE
Flakes: skip flaky check that ETA for a VReplication VDiff2 Progress command is in the future.

### DIFF
--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -111,12 +111,20 @@ func waitForVDiff2ToComplete(t *testing.T, ksWorkflow, cells, uuid string, compl
 				// The timestamp format allows us to compare them lexicographically.
 				// We don't test that the ETA always increases as it can decrease based on how
 				// quickly we're doing work.
-				if info.Progress.ETA != "" {
-					// If we're operating at the second boundary then the ETA can be up
-					// to 1 second in the past due to using second based precision.
-					loc, _ := time.LoadLocation("UTC")
-					require.GreaterOrEqual(t, info.Progress.ETA, time.Now().Add(-time.Second).In(loc).Format(vdiff2.TimestampFormat))
-				}
+
+				// Commenting out this check for now as it is quite flaky in Github CI: we sometimes get a difference of
+				// more than 1s between the ETA and the current time, empirically seen 2s when it has failed,
+				// but presumably it can be higher. Keeping the code here for now in case we want to re-enable it.
+
+				/*
+					if info.Progress.ETA != "" {
+						// If we're operating at the second boundary then the ETA can be up
+						// to 1 second in the past due to using second based precision.
+						loc, _ := time.LoadLocation("UTC")
+						require.GreaterOrEqual(t, info.Progress.ETA, time.Now().Add(-time.Second).In(loc).Format(vdiff2.TimestampFormat))
+					}
+				*/
+
 				if !first {
 					require.GreaterOrEqual(t, info.Progress.Percentage, previousProgress.Percentage)
 				}


### PR DESCRIPTION
## Description

During a VDiff2 in vreplication e2e tests there is a check that the ETA for a VDiff2 Progress command is in the future. We have added a jitter of 1 second to account for time precision. However we sometimes get a difference of more than 1s between the ETA and the current time, empirically seen 2s when it has failed, but presumably it can be higher. Commenting that check to reduce the flakes (but keeping the code here for now in case we want to fix and re-enable it).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
