### PR TITLE
Fix `BackupShard` to get its options from its own flags

### DIFF
--- a/go/cmd/vtctldclient/command/backups.go
+++ b/go/cmd/vtctldclient/command/backups.go
@@ -136,10 +136,10 @@ func commandBackupShard(cmd *cobra.Command, args []string) error {
 	stream, err := client.BackupShard(commandCtx, &vtctldatapb.BackupShardRequest{
 		Keyspace:           keyspace,
 		Shard:              shard,
-		AllowPrimary:       backupOptions.AllowPrimary,
-		Concurrency:        backupOptions.Concurrency,
+		AllowPrimary:       backupShardOptions.AllowPrimary,
+		Concurrency:        backupShardOptions.Concurrency,
 		IncrementalFromPos: backupShardOptions.IncrementalFromPos,
-		UpgradeSafe:        backupOptions.UpgradeSafe,
+		UpgradeSafe:        backupShardOptions.UpgradeSafe,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Presumably a copy-paste error that got missed, it was previously reading all its options (except `--incremental-from-pos`) from the flags defined on the `Backup` command, which effectively meant it accepted those flags on the
command line but disregarded their actual values.

Yikes!

## Related Issue(s)

Fixes #13812 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
