### PR TITLE
Flakes: Synchronize access to logErrStacks in vterrors

### DIFF
--- a/go/vt/vterrors/errors_test.go
+++ b/go/vt/vterrors/errors_test.go
@@ -257,8 +257,8 @@ func TestStackFormat(t *testing.T) {
 	assertContains(t, got, "middle", false)
 	assertContains(t, got, "outer", false)
 
-	logErrStacks = true
-	defer func() { logErrStacks = false }()
+	setLogErrStacks(true)
+	defer func() { setLogErrStacks(false) }()
 	got = fmt.Sprintf("%v", err)
 	assertContains(t, got, "innerMost", true)
 	assertContains(t, got, "middle", true)
@@ -340,9 +340,9 @@ func TestWrapping(t *testing.T) {
 	err3 := Wrapf(err2, "baz")
 	errorWithoutStack := fmt.Sprintf("%v", err3)
 
-	logErrStacks = true
+	setLogErrStacks(true)
 	errorWithStack := fmt.Sprintf("%v", err3)
-	logErrStacks = false
+	setLogErrStacks(false)
 
 	assertEquals(t, err3.Error(), "baz: bar: foo")
 	assertContains(t, errorWithoutStack, "foo", true)


### PR DESCRIPTION

## Description

Race conditions around access to the `vterrors`.`logErrStacks` variable have been causing different tests to fail with errors like:

While this fix is not addressing the location where the backed flag is actually getting evaluated on load, most likely, there are no competing goroutines. So this should fix a significant number of such flakes.

```
WARNING: DATA RACE

Write at 0x0000042aba01 by goroutine 36851:
  github.com/spf13/pflag.newBoolValue()
      /home/runner/go/pkg/mod/github.com/spf13/pflag@v1.0.5/bool.go:16 +0x70
  github.com/spf13/pflag.(*FlagSet).BoolVarP()
      /home/runner/go/pkg/mod/github.com/spf13/pflag@v1.0.5/bool.go:55 +0x80
  github.com/spf13/pflag.(*FlagSet).BoolVar()
      /home/runner/go/pkg/mod/github.com/spf13/pflag@v1.0.5/bool.go:50 +0x57
  vitess.io/vitess/go/vt/vterrors.RegisterFlags()
      /home/runner/work/vitess/vitess/go/vt/vterrors/vterrors.go:107 +0x25
  vitess.io/vitess/go/vt/servenv.GetFlagSetFor()
      /home/runner/work/vitess/vitess/go/vt/servenv/servenv.go:370 +0x183
  vitess.io/vitess/go/vt/servenv.ParseFlagsForTests()
      /home/runner/work/vitess/vitess/go/vt/servenv/servenv.go:358 +0x3a
  vitess.io/vitess/go/vt/vttablet/tabletconntest.SetProtocol()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletconntest/tabletconntest.go:1052 +0x1c4
  vitess.io/vitess/go/vt/wrangler.newTestShardMigrater()
      /home/runner/work/vitess/vitess/go/vt/wrangler/traffic_switcher_env_test.go:577 +0x12ae
  vitess.io/vitess/go/vt/wrangler.TestReshardV2()
      /home/runner/work/vitess/vitess/go/vt/wrangler/workflow_test.go:568 +0x55e
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1629 +0x4

Previous read at 0x0000042aba01 by goroutine 36844:

  vitess.io/vitess/go/vt/vterrors.(*wrapping).Format()
      /home/runner/work/vitess/vitess/go/vt/vterrors/vterrors.go:281 +0x284
  fmt.(*pp).handleMethods()
      /opt/hostedtoolcache/go/1.20.5/x64/src/fmt/print.go:640 +0x1f8
  fmt.(*pp).printArg()
      /opt/hostedtoolcache/go/1.20.5/x64/src/fmt/print.go:756 +0xce4
  fmt.(*pp).doPrintf()
      /opt/hostedtoolcache/go/1.20.5/x64/src/fmt/print.go:1077 +0x599
  fmt.Sprintf()
      /opt/hostedtoolcache/go/1.20.5/x64/src/fmt/print.go:239 +0x67
  vitess.io/vitess/go/mysql/sqlerror.NewSQLError()
      /home/runner/work/vitess/vitess/go/mysql/sqlerror/sql_error.go:50 +0x134
  vitess.io/vitess/go/mysql.(*Conn).clientHandshake()
      /home/runner/work/vitess/vitess/go/mysql/client.go:211 +0xae
  vitess.io/vitess/go/mysql.Connect.func1()
      /home/runner/work/vitess/vitess/go/mysql/client.go:119 +0x8c7

```
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required


