### PR TITLE
Skip VTAdmin build in Docker tests

### DIFF
--- a/test.go
+++ b/test.go
@@ -202,7 +202,7 @@ func (t *Test) run(dir, dataDir string) ([]byte, error) {
 			// If there is no cache, we have to call 'make build' before each test.
 			args = []string{t.flavor, t.bootstrapVersion, "make build && " + testArgs}
 			if !*buildVTAdmin {
-				args[2] = "NOVTADMINBUILD=1 " + args[2]
+				args[len(args)-1] = "NOVTADMINBUILD=1 " + args[len(args)-1]
 			}
 		}
 

--- a/test.go
+++ b/test.go
@@ -201,6 +201,9 @@ func (t *Test) run(dir, dataDir string) ([]byte, error) {
 		} else {
 			// If there is no cache, we have to call 'make build' before each test.
 			args = []string{t.flavor, t.bootstrapVersion, "make build && " + testArgs}
+			if !*buildVTAdmin {
+				args[2] = "NOVTADMINBUILD=1 " + args[2]
+			}
 		}
 
 		cmd = exec.Command(path.Join(dir, "docker/test/run.sh"), args...)


### PR DESCRIPTION
## Description

This PR skips the build of VTAdmin in Docker tests initiated by `test.go`.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/13837
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
