### PR TITLE
Move upgrade downgrade tests to GitHub larger runners

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - E2E
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_previous_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - E2E
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_previous_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - E2E
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_previous_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Backups - E2E - Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_next_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E - Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Backups - E2E - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_next_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Backups - E2E - Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_next_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E - Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - Manual
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - Manual
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - Manual
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Previous Release - Backups - Manual - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Previous Release - Backups - Manual - Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Previous Release - Backups - Manual - Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Queries)
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Queries)
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Queries)
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Queries) Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries) Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Queries) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Queries) Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries) Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Schema)
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Schema)
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Schema)
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Schema) Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema) Next Release
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Schema) Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema) Next Release
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Schema) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New Vtctl
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New Vtctl
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New VTTablet
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New VTTablet
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old Vtctl
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old Vtctl
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old VTTablet
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
-    runs-on: gh-runner-upgrade-downgrade-32cores-1
+    runs-on: gh-runner-upgrade-downgrade-64cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-runner-upgrade-downgrade-32cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old VTTablet
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
-    runs-on: gh-runner-upgrade-downgrade-64cores-1
+    runs-on: gh-runner-upgrade-downgrade-16cores-1
     needs:
       - get_previous_release
 


### PR DESCRIPTION
## Description

This PR moves the upgrade/downgrade tests to GitHub Larger runners. The dedicated runner name is `gh-runner-upgrade-downgrade-16cores-1` and has 16-cores. The machine can scale up to 100 times, supporting 100 concurrent workflows.

When comparing an upgrade downgrade test (`Run Upgrade Downgrade Test - Query Serving (Schema)`) ran on PR #13835 (https://github.com/vitessio/vitess/actions/runs/5956621188/job/16157782259?pr=13835) and the same workflow but ran with the larger runners (https://github.com/vitessio/vitess/actions/runs/5957296442/job/16159769723) we can see we saved about 50% of the time needed to run the workflow.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
