### PR TITLE
Move examples tests to GitHub larger runners

### DIFF
--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -4,11 +4,10 @@ permissions: read-all
 jobs:
 
   build:
-    name: Local example using ${{ matrix.topo }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Local example using ${{ matrix.topo }} on ubuntu-22.04
+    runs-on: gh-runner-examples-32cores-1
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         topo: [consul,etcd,k8s]
 
     steps:

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: Local example using ${{ matrix.topo }} on ubuntu-22.04
-    runs-on: gh-runner-examples-32cores-1
+    runs-on: gh-runner-examples-4cores-1
     strategy:
       matrix:
         topo: [consul,etcd,k8s]

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: Region Sharding example using ${{ matrix.topo }} on ubuntu-22.04
-    runs-on: gh-runner-examples-32cores-1
+    runs-on: gh-runner-examples-4cores-1
     strategy:
       matrix:
         topo: [etcd]

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -4,11 +4,10 @@ permissions: read-all
 jobs:
 
   build:
-    name: Region Sharding example using ${{ matrix.topo }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Region Sharding example using ${{ matrix.topo }} on ubuntu-22.04
+    runs-on: gh-runner-examples-32cores-1
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         topo: [etcd]
 
     steps:


### PR DESCRIPTION
## Description
This PR moves the examples workflow (local and region) from standard runners to larger runners. The dedicated runner is named `gh-runner-examples-4cores-1` (4-cores · 16 GB RAM), this runners can scale up to 50 concurrent jobs at the same time.

For reference, in a previous PR #13835, the local example workflow on etcd [was taking 19 mins](https://github.com/vitessio/vitess/actions/runs/5956621174/job/16157756716?pr=13835), and it is now taking [10 mins](https://github.com/vitessio/vitess/actions/runs/5957255578/job/16159614564?pr=13844)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
