### PR TITLE
Migrates most workflows to 4 and 16 cores Large GitHub-Hosted-Runners

### DIFF
--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (12)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (13)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (15)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (18)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (21)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (22)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_backup_pitr.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (backup_pitr)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_backup_pitr_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (backup_pitr) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (backup_pitr_xtrabackup)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup_mysql57.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (backup_pitr_xtrabackup) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql80)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql_server_vault)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_consul)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_topo)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (topo_connection_cache)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_across_db_versions)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate_vdiff2_convert_tz)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate_vdiff2_convert_tz)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: gh-hosted-runners-16cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_partial_movetables_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_partial_movetables_basic.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_partial_movetables_basic)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_partial_movetables_sequences.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_partial_movetables_sequences.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_partial_movetables_sequences)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_failover)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_false)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_stoponreshard_true)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream_with_keyspaces_to_watch)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtbackup.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtbackup)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtctlbackup_sharded_clustertest_heavy)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_general_heavy)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_godriver)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_partial_keyspace)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_queries)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema_tracker)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_consul)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_etcd)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex_heavy)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtorc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vttablet_prscomplex)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery) mysql57
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: Docker Test Cluster 10
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: Docker Test Cluster 25
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: End-to-End Test (Race)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: End-to-End Test
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -4,11 +4,10 @@ permissions: read-all
 jobs:
 
   build:
-    name: Local example using ${{ matrix.topo }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Local example using ${{ matrix.topo }} on ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         topo: [consul,etcd,k8s]
 
     steps:

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -4,11 +4,10 @@ permissions: read-all
 jobs:
 
   build:
-    name: Region Sharding example using ${{ matrix.topo }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Region Sharding example using ${{ matrix.topo }} on ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         topo: [etcd]
 
     steps:

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -10,7 +10,7 @@ jobs:
 
   build:
     name: Unit Test (Race)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: gh-hosted-runners-16cores-1
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -10,7 +10,7 @@ jobs:
 
   build:
     name: Unit Test (Race)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (mysql57)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (mysql80)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - E2E
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_previous_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Backups - E2E - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     if: always() && needs.get_next_release.result == 'success'
     name: Run Upgrade Downgrade Test - Backups - E2E - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -13,7 +13,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Backups - Manual
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -13,7 +13,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Previous Release - Backups - Manual - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Queries)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Queries) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Queries) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Query Serving (Schema)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Query Serving (Schema) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Query Serving (Schema) Next Release
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_next_release:
     if: always()
     name: Get Latest Release - Reparent New VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_next_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -16,7 +16,7 @@ jobs:
   get_previous_release:
     if: always()
     name: Get Previous Release - Reparent Old VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -36,7 +36,7 @@ jobs:
   upgrade_downgrade_test:
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-16cores-1
     needs:
       - get_previous_release
 

--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
     steps:
       - name: Skip CI
         run: |

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
     steps:
       - name: Skip CI
         run: |

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -145,6 +145,8 @@ var (
 		"onlineddl_vrepl_stress",
 		"onlineddl_vrepl_stress_suite",
 		"onlineddl_vrepl_suite",
+		"vreplication_basic",
+		"vreplication_migrate_vdiff2_convert_tz",
 	}
 )
 

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -140,6 +140,12 @@ var (
 		"vtgate_topo_consul",
 		"tabletmanager_consul",
 	}
+	clusterRequiring16CoresMachines = []string{
+		"onlineddl_vrepl",
+		"onlineddl_vrepl_stress",
+		"onlineddl_vrepl_stress_suite",
+		"onlineddl_vrepl_suite",
+	}
 )
 
 type unitTest struct {
@@ -154,6 +160,7 @@ type clusterTest struct {
 	LimitResourceUsage                 bool
 	EnableBinlogTransactionCompression bool
 	PartialKeyspace                    bool
+	Cores16                            bool
 }
 
 type selfHostedTest struct {
@@ -330,6 +337,13 @@ func generateClusterWorkflows(list []string, tpl string) {
 			test := &clusterTest{
 				Name:  fmt.Sprintf("Cluster (%s)", cluster),
 				Shard: cluster,
+			}
+			cores16Clusters := canonnizeList(clusterRequiring16CoresMachines)
+			for _, cores16Cluster := range cores16Clusters {
+				if cores16Cluster == cluster {
+					test.Cores16 = true
+					break
+				}
 			}
 			makeToolClusters := canonnizeList(clustersRequiringMakeTools)
 			for _, makeToolCluster := range makeToolClusters {

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-22.04
+    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}gh-hosted-runners-4cores-1{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-22.04
+    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}gh-hosted-runners-4cores-1{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-22.04
+    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}gh-hosted-runners-4cores-1{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: {{.Name}}
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Skip CI


### PR DESCRIPTION
## Description

This PR migrates almost all workflows to dedicated larger GitHub-Hosted-Runners. We have two configurations for our large runners: 4-cores and 16-cores. Long running and complex workflows (such as upgrade/downgrade, onlineDDL Vrepl, examples) have been moved to the 16-cores config. All other unit and E2E tests have been moved the the 4-cores configuration.

Each configuration can scale up to 250 machine at the same time.

The only remaining workflows on the Standard runners are static checks, workflows executing on `main` or with a specific trigger (release, CRON, etc).

New E2E workflows can be moved to the 16-cores runners by modifying the `ci_workflow_gen.go` file and adding the cluster name to the `clusterRequiring16CoresMachines` slice.
 
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
