### PR TITLE
Fix for "text type with an unknown/unsupported collation cannot be hashed" error

### DIFF
--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -291,6 +291,14 @@ func (st *SemTable) AddExprs(tbl *sqlparser.AliasedTableExpr, cols sqlparser.Sel
 
 // TypeForExpr returns the type of expressions in the query
 func (st *SemTable) TypeForExpr(e sqlparser.Expr) (sqltypes.Type, collations.ID, bool) {
+	// We add a lot of WeightString() expressions to queries at late stages of the planning,
+	// which means that they don't have any type information. We can safely assume that they
+	// are VarBinary, since that's the only type that WeightString() can return.
+	_, isWS := e.(*sqlparser.WeightStringFuncExpr)
+	if isWS {
+		return sqltypes.VarBinary, collations.CollationBinaryID, true
+	}
+
 	if typ, found := st.ExprTypes[e]; found {
 		return typ.Type, typ.Collation, true
 	}

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -291,6 +291,10 @@ func (st *SemTable) AddExprs(tbl *sqlparser.AliasedTableExpr, cols sqlparser.Sel
 
 // TypeForExpr returns the type of expressions in the query
 func (st *SemTable) TypeForExpr(e sqlparser.Expr) (sqltypes.Type, collations.ID, bool) {
+	if typ, found := st.ExprTypes[e]; found {
+		return typ.Type, typ.Collation, true
+	}
+
 	// We add a lot of WeightString() expressions to queries at late stages of the planning,
 	// which means that they don't have any type information. We can safely assume that they
 	// are VarBinary, since that's the only type that WeightString() can return.
@@ -299,9 +303,6 @@ func (st *SemTable) TypeForExpr(e sqlparser.Expr) (sqltypes.Type, collations.ID,
 		return sqltypes.VarBinary, collations.CollationBinaryID, true
 	}
 
-	if typ, found := st.ExprTypes[e]; found {
-		return typ.Type, typ.Collation, true
-	}
 	return sqltypes.Unknown, collations.Unknown, false
 }
 


### PR DESCRIPTION
## Description
The vtgate planner and runtime was tripping up itself, trying to hash a weightstring value but getting the typing wrong, which lead to this error being produced. 

As of the merging of #13450, we started using the hashing distinct a lot more than before, and these errors have started popping up.

I recommend we backport this fix - we used this hashing distinct in earlier releases, just not as much as today, so this bug is probably there in earlier releases as well. That combined with it being a pretty small and safe fix makes me say backport.

## Related Issue(s)
Fixes #13764

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
