### PR TITLE
Go 1.21 cleanups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/xlab/treeprint v1.2.0
 	go.uber.org/goleak v1.1.11
-	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090
 	golang.org/x/sync v0.1.0
 	modernc.org/sqlite v1.20.3
 )

--- a/go.sum
+++ b/go.sum
@@ -679,8 +679,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230725093048-515e97ebf090 h1:Di6/M8l0O2lCLc6VVRWhgCiApHV8MnQurBnFSHsQtNY=
-golang.org/x/exp v0.0.0-20230725093048-515e97ebf090/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go/cache/ristretto/bloom/bbloom.go
+++ b/go/cache/ristretto/bloom/bbloom.go
@@ -132,9 +132,7 @@ func (bl *Bloom) Size(sz uint64) {
 
 // Clear resets the Bloom filter.
 func (bl *Bloom) Clear() {
-	for i := range bl.bitset {
-		bl.bitset[i] = 0
-	}
+	clear(bl.bitset)
 }
 
 // Set sets the bit[idx] of bitset.

--- a/go/cache/ristretto/sketch.go
+++ b/go/cache/ristretto/sketch.go
@@ -128,9 +128,7 @@ func (r cmRow) reset() {
 
 func (r cmRow) clear() {
 	// Zero each counter.
-	for i := range r {
-		r[i] = 0
-	}
+	clear(r)
 }
 
 func (r cmRow) string() string {

--- a/go/maps2/maps.go
+++ b/go/maps2/maps.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maps2
+
+// Keys returns the keys of the map m.
+// The keys will be in an indeterminate order.
+func Keys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+// Values returns the values of the map m.
+// The values will be in an indeterminate order.
+func Values[M ~map[K]V, K comparable, V any](m M) []V {
+	r := make([]V, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
+}

--- a/go/mysql/auth_server_static_flaky_test.go
+++ b/go/mysql/auth_server_static_flaky_test.go
@@ -126,9 +126,7 @@ func TestStaticConfigHUP(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	// delete registered Auth server
-	for auth := range authServers {
-		delete(authServers, auth)
-	}
+	clear(authServers)
 }
 
 func TestStaticConfigHUPWithRotation(t *testing.T) {

--- a/go/mysql/collations/8bit.go
+++ b/go/mysql/collations/8bit.go
@@ -78,7 +78,7 @@ func (c *Collation_8bit_bin) WeightString(dst, src []byte, numCodepoints int) []
 	case PadToMax:
 		padToMax = true
 	default:
-		copyCodepoints = minInt(copyCodepoints, numCodepoints)
+		copyCodepoints = min(copyCodepoints, numCodepoints)
 	}
 
 	dst = append(dst, src[:copyCodepoints]...)
@@ -92,7 +92,7 @@ func (c *Collation_8bit_bin) Hash(hasher *vthash.Hasher, src []byte, numCodepoin
 		return
 	}
 
-	tocopy := minInt(len(src), numCodepoints)
+	tocopy := min(len(src), numCodepoints)
 	hasher.Write(src[:tocopy])
 
 	numCodepoints -= tocopy
@@ -153,7 +153,7 @@ func (c *Collation_8bit_simple_ci) IsBinary() bool {
 
 func (c *Collation_8bit_simple_ci) Collate(left, right []byte, rightIsPrefix bool) int {
 	sortOrder := c.sort
-	cmpLen := minInt(len(left), len(right))
+	cmpLen := min(len(left), len(right))
 
 	for i := 0; i < cmpLen; i++ {
 		sortL, sortR := sortOrder[left[i]], sortOrder[right[i]]
@@ -178,7 +178,7 @@ func (c *Collation_8bit_simple_ci) WeightString(dst, src []byte, numCodepoints i
 	case PadToMax:
 		padToMax = true
 	default:
-		copyCodepoints = minInt(copyCodepoints, numCodepoints)
+		copyCodepoints = min(copyCodepoints, numCodepoints)
 	}
 
 	for _, ch := range src[:copyCodepoints] {
@@ -192,7 +192,7 @@ func (c *Collation_8bit_simple_ci) Hash(hasher *vthash.Hasher, src []byte, numCo
 
 	var tocopy = len(src)
 	if numCodepoints > 0 {
-		tocopy = minInt(tocopy, numCodepoints)
+		tocopy = min(tocopy, numCodepoints)
 	}
 
 	hasher.Write64(uint64(c.id))
@@ -280,7 +280,7 @@ func (c *Collation_binary) WeightString(dst, src []byte, numCodepoints int) []by
 	case PadToMax:
 		padToMax = true
 	default:
-		copyCodepoints = minInt(copyCodepoints, numCodepoints)
+		copyCodepoints = min(copyCodepoints, numCodepoints)
 	}
 
 	dst = append(dst, src[:copyCodepoints]...)

--- a/go/mysql/collations/collation.go
+++ b/go/mysql/collations/collation.go
@@ -173,10 +173,3 @@ type WildcardPattern interface {
 type Charset = charset.Charset
 
 const PadToMax = math.MaxInt32
-
-func minInt(i1, i2 int) int {
-	if i1 < i2 {
-		return i1
-	}
-	return i2
-}

--- a/go/mysql/collations/multibyte.go
+++ b/go/mysql/collations/multibyte.go
@@ -51,7 +51,7 @@ func (c *Collation_multibyte) Collate(left, right []byte, isPrefix bool) int {
 		return collationBinary(left, right, isPrefix)
 	}
 
-	cmpLen := minInt(len(left), len(right))
+	cmpLen := min(len(left), len(right))
 	cs := c.charset
 	sortOrder := c.sort
 	for i := 0; i < cmpLen; i++ {
@@ -62,7 +62,7 @@ func (c *Collation_multibyte) Collate(left, right []byte, isPrefix bool) int {
 			}
 			_, widthL := cs.DecodeRune(left[i:])
 			_, widthR := cs.DecodeRune(right[i:])
-			switch minInt(widthL, widthR) {
+			switch min(widthL, widthR) {
 			case 4:
 				i++
 				if left[i] != right[i] {

--- a/go/mysql/collations/uca_test.go
+++ b/go/mysql/collations/uca_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/mysql/collations/charset"
 	"vitess.io/vitess/go/vt/vthash"

--- a/go/mysql/collations/unicode.go
+++ b/go/mysql/collations/unicode.go
@@ -352,7 +352,7 @@ func (c *Collation_unicode_bin) Wildcard(pat []byte, matchOne rune, matchMany ru
 }
 
 func collationBinary(left, right []byte, rightPrefix bool) int {
-	minLen := minInt(len(left), len(right))
+	minLen := min(len(left), len(right))
 	if diff := bytes.Compare(left[:minLen], right[:minLen]); diff != 0 {
 		return diff
 	}

--- a/go/mysql/decimal/decimal.go
+++ b/go/mysql/decimal/decimal.go
@@ -693,13 +693,6 @@ func RescalePair(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
 	return d1, d2.rescale(baseScale)
 }
 
-func min(x, y int32) int32 {
-	if x >= y {
-		return y
-	}
-	return x
-}
-
 // largestForm returns the largest decimal that can be represented
 // with the given amount of integral and fractional digits
 // Example:

--- a/go/mysql/icuregex/compiler.go
+++ b/go/mysql/icuregex/compiler.go
@@ -23,10 +23,9 @@ package icuregex
 
 import (
 	"math"
+	"slices"
 	"strings"
 	"unicode/utf8"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/mysql/icuregex/internal/pattern"
 	"vitess.io/vitess/go/mysql/icuregex/internal/ucase"

--- a/go/mysql/icuregex/internal/uchar/constants.go
+++ b/go/mysql/icuregex/internal/uchar/constants.go
@@ -21,9 +21,7 @@ limitations under the License.
 
 package uchar
 
-import "golang.org/x/exp/constraints"
-
-func uMask[T constraints.Integer](x T) uint32 {
+func Mask[T ~int | ~int8](x T) uint32 {
 	return 1 << x
 }
 
@@ -110,68 +108,68 @@ const (
 )
 
 var (
-	GcCnMask = uMask(GeneralOtherTypes)
+	GcCnMask = Mask(GeneralOtherTypes)
 
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcLuMask = uMask(UppercaseLetter)
+	GcLuMask = Mask(UppercaseLetter)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcLlMask = uMask(LowercaseLetter)
+	GcLlMask = Mask(LowercaseLetter)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcLtMask = uMask(TitlecaseLetter)
+	GcLtMask = Mask(TitlecaseLetter)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcLmMask = uMask(ModifierLetter)
+	GcLmMask = Mask(ModifierLetter)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcLoMask = uMask(OtherLetter)
+	GcLoMask = Mask(OtherLetter)
 
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcMnMask = uMask(NonSpacingMask)
+	GcMnMask = Mask(NonSpacingMask)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcMeMask = uMask(EnclosingMark)
+	GcMeMask = Mask(EnclosingMark)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcMcMask = uMask(CombiningSpacingMask)
+	GcMcMask = Mask(CombiningSpacingMask)
 
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcNdMask = uMask(DecimalDigitNumber)
+	GcNdMask = Mask(DecimalDigitNumber)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcNlMask = uMask(LetterNumber)
+	GcNlMask = Mask(LetterNumber)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcNoMask = uMask(OtherNumber)
+	GcNoMask = Mask(OtherNumber)
 
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcZsMask = uMask(SpaceSeparator)
+	GcZsMask = Mask(SpaceSeparator)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcZlMask = uMask(LineSeparator)
+	GcZlMask = Mask(LineSeparator)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcZpMask = uMask(ParagraphSeparator)
+	GcZpMask = Mask(ParagraphSeparator)
 
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcCcMask = uMask(ControlChar)
+	GcCcMask = Mask(ControlChar)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcCfMask = uMask(FormatChar)
+	GcCfMask = Mask(FormatChar)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcCoMask = uMask(PrivateUseChar)
+	GcCoMask = Mask(PrivateUseChar)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcCsMask = uMask(Surrogate)
+	GcCsMask = Mask(Surrogate)
 
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcPdMask = uMask(DashPunctuation)
+	GcPdMask = Mask(DashPunctuation)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcPsMask = uMask(StartPunctuation)
+	GcPsMask = Mask(StartPunctuation)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcPeMask = uMask(EndPunctuation)
+	GcPeMask = Mask(EndPunctuation)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcPcMask = uMask(ConnectorPunctuation)
+	GcPcMask = Mask(ConnectorPunctuation)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcPoMask = uMask(OtherPunctuation)
+	GcPoMask = Mask(OtherPunctuation)
 
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcSmMask = uMask(MathSymbol)
+	GcSmMask = Mask(MathSymbol)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcScMask = uMask(CurrencySymbol)
+	GcScMask = Mask(CurrencySymbol)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcSkMask = uMask(ModifierSymbol)
+	GcSkMask = Mask(ModifierSymbol)
 	/** Mask constant for a UCharCategory. @stable ICU 2.1 */
-	GcSoMask = uMask(OtherSymbol)
+	GcSoMask = Mask(OtherSymbol)
 
 	/** Mask constant for multiple UCharCategory bits (L Letters). @stable ICU 2.1 */
 	GcLMask = (GcLuMask | GcLlMask | GcLtMask | GcLmMask | GcLoMask)

--- a/go/mysql/icuregex/internal/uchar/uchar.go
+++ b/go/mysql/icuregex/internal/uchar/uchar.go
@@ -156,7 +156,7 @@ func IsGraphPOSIX(c rune) bool {
 	props := trie().Get16(c)
 	/* \p{space}\p{gc=Control} == \p{gc=Z}\p{Control} */
 	/* comparing ==0 returns FALSE for the categories mentioned */
-	return uMask(getCategory(props))&(GcCcMask|GcCsMask|GcCnMask|GcZMask) == 0
+	return Mask(getCategory(props))&(GcCcMask|GcCsMask|GcCnMask|GcZMask) == 0
 }
 
 func IsXDigit(c rune) bool {

--- a/go/mysql/icuregex/internal/uprops/properties.go
+++ b/go/mysql/icuregex/internal/uprops/properties.go
@@ -172,7 +172,7 @@ func ApplyIntPropertyValue(u *uset.UnicodeSet, prop Property, value int32) error
 			return err
 		}
 		u.ApplyFilter(inclusions, func(ch rune) bool {
-			return (uMask(uchar.CharType(ch)) & uint32(value)) != 0
+			return (uchar.Mask(uchar.CharType(ch)) & uint32(value)) != 0
 		})
 	case prop == UCharScriptExtensions:
 		inclusions, err := getInclusionsForProperty(prop)

--- a/go/mysql/icuregex/internal/uprops/uprops.go
+++ b/go/mysql/icuregex/internal/uprops/uprops.go
@@ -188,7 +188,7 @@ func getIntPropertyValue(c rune, which Property) int32 {
 		iprop := intProps[which-UCharIntStart]
 		return iprop.getValue(iprop, c, which)
 	} else if which == UCharGeneralCategoryMask {
-		return int32(uMask(uchar.CharType(c)))
+		return int32(uchar.Mask(uchar.CharType(c)))
 	}
 	return 0 // undefined
 }

--- a/go/mysql/icuregex/internal/uprops/uprops_binary.go
+++ b/go/mysql/icuregex/internal/uprops/uprops_binary.go
@@ -22,8 +22,7 @@ limitations under the License.
 package uprops
 
 import (
-	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"vitess.io/vitess/go/mysql/icuregex/internal/normalizer"
 	"vitess.io/vitess/go/mysql/icuregex/internal/ubidi"
@@ -35,10 +34,6 @@ type binaryProperty struct {
 	column   propertySource
 	mask     uint32
 	contains func(prop *binaryProperty, c rune, which Property) bool
-}
-
-func uMask[T constraints.Integer](x T) uint32 {
-	return 1 << x
 }
 
 func defaultContains(prop *binaryProperty, c rune, _ Property) bool {
@@ -56,50 +51,50 @@ var binProps = [uCharBinaryLimit]*binaryProperty{
 	 *
 	 * See also https://unicode-org.github.io/icu/userguide/strings/properties.html
 	 */
-	{1, uMask(pAlphabetic), defaultContains},
-	{1, uMask(pASCIIHexDigit), defaultContains},
+	{1, uchar.Mask(pAlphabetic), defaultContains},
+	{1, uchar.Mask(pASCIIHexDigit), defaultContains},
 	{srcBidi, 0, isBidiControl},
 	{srcBidi, 0, isMirrored},
-	{1, uMask(pDash), defaultContains},
-	{1, uMask(pDefaultIgnorableCodePoint), defaultContains},
-	{1, uMask(pDeprecated), defaultContains},
-	{1, uMask(pDiacritic), defaultContains},
-	{1, uMask(pExtender), defaultContains},
+	{1, uchar.Mask(pDash), defaultContains},
+	{1, uchar.Mask(pDefaultIgnorableCodePoint), defaultContains},
+	{1, uchar.Mask(pDeprecated), defaultContains},
+	{1, uchar.Mask(pDiacritic), defaultContains},
+	{1, uchar.Mask(pExtender), defaultContains},
 	{srcNfc, 0, hasFullCompositionExclusion},
-	{1, uMask(pGraphemeBase), defaultContains},
-	{1, uMask(pGraphemeExtend), defaultContains},
-	{1, uMask(pGraphemeLink), defaultContains},
-	{1, uMask(pHexDigit), defaultContains},
-	{1, uMask(pHyphen), defaultContains},
-	{1, uMask(pIDContinue), defaultContains},
-	{1, uMask(pIDStart), defaultContains},
-	{1, uMask(pIdeographic), defaultContains},
-	{1, uMask(pIdsBinaryOperator), defaultContains},
-	{1, uMask(pIdsTrinaryOperator), defaultContains},
+	{1, uchar.Mask(pGraphemeBase), defaultContains},
+	{1, uchar.Mask(pGraphemeExtend), defaultContains},
+	{1, uchar.Mask(pGraphemeLink), defaultContains},
+	{1, uchar.Mask(pHexDigit), defaultContains},
+	{1, uchar.Mask(pHyphen), defaultContains},
+	{1, uchar.Mask(pIDContinue), defaultContains},
+	{1, uchar.Mask(pIDStart), defaultContains},
+	{1, uchar.Mask(pIdeographic), defaultContains},
+	{1, uchar.Mask(pIdsBinaryOperator), defaultContains},
+	{1, uchar.Mask(pIdsTrinaryOperator), defaultContains},
 	{srcBidi, 0, isJoinControl},
-	{1, uMask(pLogicalOrderException), defaultContains},
+	{1, uchar.Mask(pLogicalOrderException), defaultContains},
 	{srcCase, 0, caseBinaryPropertyContains}, // UCHAR_LOWERCASE
-	{1, uMask(pMath), defaultContains},
-	{1, uMask(pNoncharacterCodePoint), defaultContains},
-	{1, uMask(pQuotationMark), defaultContains},
-	{1, uMask(pRadical), defaultContains},
+	{1, uchar.Mask(pMath), defaultContains},
+	{1, uchar.Mask(pNoncharacterCodePoint), defaultContains},
+	{1, uchar.Mask(pQuotationMark), defaultContains},
+	{1, uchar.Mask(pRadical), defaultContains},
 	{srcCase, 0, caseBinaryPropertyContains}, // UCHAR_SOFT_DOTTED
-	{1, uMask(pTerminalPunctuation), defaultContains},
-	{1, uMask(pUnifiedIdeograph), defaultContains},
+	{1, uchar.Mask(pTerminalPunctuation), defaultContains},
+	{1, uchar.Mask(pUnifiedIdeograph), defaultContains},
 	{srcCase, 0, caseBinaryPropertyContains}, // UCHAR_UPPERCASE
-	{1, uMask(pWhiteSpace), defaultContains},
-	{1, uMask(pXidContinue), defaultContains},
-	{1, uMask(pXidStart), defaultContains},
+	{1, uchar.Mask(pWhiteSpace), defaultContains},
+	{1, uchar.Mask(pXidContinue), defaultContains},
+	{1, uchar.Mask(pXidStart), defaultContains},
 	{srcCase, 0, caseBinaryPropertyContains}, // UCHAR_CASE_SENSITIVE
-	{1, uMask(pSTerm), defaultContains},
-	{1, uMask(pVariationSelector), defaultContains},
+	{1, uchar.Mask(pSTerm), defaultContains},
+	{1, uchar.Mask(pVariationSelector), defaultContains},
 	{srcNfc, 0, isNormInert},  // UCHAR_NFD_INERT
 	{srcNfkc, 0, isNormInert}, // UCHAR_NFKD_INERT
 	{srcNfc, 0, isNormInert},  // UCHAR_NFC_INERT
 	{srcNfkc, 0, isNormInert}, // UCHAR_NFKC_INERT
 	{srcNfcCanonIter, 0, nil}, // Segment_Starter is currently unsupported
-	{1, uMask(pPatternSyntax), defaultContains},
-	{1, uMask(pPatternWhiteSpace), defaultContains},
+	{1, uchar.Mask(pPatternSyntax), defaultContains},
+	{1, uchar.Mask(pPatternWhiteSpace), defaultContains},
 	{srcCharAndPropsvec, 0, isPOSIXAlnum},
 	{srcChar, 0, isPOSIXBlank},
 	{srcChar, 0, isPOSIXGraph},
@@ -113,14 +108,14 @@ var binProps = [uCharBinaryLimit]*binaryProperty{
 	{srcCaseAndNorm, 0, changesWhenCasefolded},
 	{srcCase, 0, caseBinaryPropertyContains}, // UCHAR_CHANGES_WHEN_CASEMAPPED
 	{srcNfkcCf, 0, nil},                      // Changes_When_NFKC_Casefolded is currently unsupported
-	{2, uMask(p2Emoji), defaultContains},
-	{2, uMask(p2EmojiPresentation), defaultContains},
-	{2, uMask(p2EmojiModifier), defaultContains},
-	{2, uMask(p2EmojiModifierBase), defaultContains},
-	{2, uMask(p2EmojiComponent), defaultContains},
+	{2, uchar.Mask(p2Emoji), defaultContains},
+	{2, uchar.Mask(p2EmojiPresentation), defaultContains},
+	{2, uchar.Mask(p2EmojiModifier), defaultContains},
+	{2, uchar.Mask(p2EmojiModifierBase), defaultContains},
+	{2, uchar.Mask(p2EmojiComponent), defaultContains},
 	{2, 0, isRegionalIndicator},
-	{1, uMask(pPrependedConcatenationMark), defaultContains},
-	{2, uMask(p2ExtendedPictographic), defaultContains},
+	{1, uchar.Mask(pPrependedConcatenationMark), defaultContains},
+	{2, uchar.Mask(p2ExtendedPictographic), defaultContains},
 }
 
 func isBidiControl(_ *binaryProperty, c rune, _ Property) bool {
@@ -165,7 +160,7 @@ func isPOSIXBlank(_ *binaryProperty, c rune, _ Property) bool {
 }
 
 func isPOSIXAlnum(_ *binaryProperty, c rune, _ Property) bool {
-	return (uchar.GetUnicodeProperties(c, 1)&uMask(pAlphabetic)) != 0 || uchar.IsDigit(c)
+	return (uchar.GetUnicodeProperties(c, 1)&uchar.Mask(pAlphabetic)) != 0 || uchar.IsDigit(c)
 }
 
 func isJoinControl(_ *binaryProperty, c rune, _ Property) bool {

--- a/go/mysql/icuregex/internal/uset/unicode_set.go
+++ b/go/mysql/icuregex/internal/uset/unicode_set.go
@@ -23,8 +23,7 @@ package uset
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // HIGH_VALUE > all valid values. 110000 for codepoints

--- a/go/mysql/icuregex/internal/uset/unicode_set.go
+++ b/go/mysql/icuregex/internal/uset/unicode_set.go
@@ -200,13 +200,6 @@ loopEnd:
 	u.list, u.buffer = u.buffer[:k], u.list
 }
 
-func max(a, b rune) rune {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func pinCodePoint(c *rune) rune {
 	if *c < unicodeSetLow {
 		*c = unicodeSetLow

--- a/go/mysql/icuregex/internal/utrie/utrie2.go
+++ b/go/mysql/icuregex/internal/utrie/utrie2.go
@@ -86,13 +86,6 @@ func enumSameValue(value uint32) uint32 {
 	return value
 }
 
-func min(a, b rune) rune {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (t *UTrie2) enumEitherTrie(start, limit rune, enumValue EnumValue, enumRange EnumRange) {
 	if enumRange == nil {
 		return

--- a/go/mysql/icuregex/ops.go
+++ b/go/mysql/icuregex/ops.go
@@ -22,7 +22,7 @@ limitations under the License.
 package icuregex
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"vitess.io/vitess/go/mysql/icuregex/internal/ucase"
 	"vitess.io/vitess/go/mysql/icuregex/internal/utf16"

--- a/go/mysql/json/helpers.go
+++ b/go/mysql/json/helpers.go
@@ -112,13 +112,6 @@ func NewFromSQL(v sqltypes.Value) (*Value, error) {
 }
 
 func (v *Value) Depth() int {
-	max := func(a, b int) int {
-		if a > b {
-			return a
-		}
-		return b
-	}
-
 	var depth int
 	switch v.t {
 	case TypeObject:

--- a/go/mysql/json/json_path_test.go
+++ b/go/mysql/json/json_path_test.go
@@ -17,9 +17,8 @@ limitations under the License.
 package json
 
 import (
+	"slices"
 	"testing"
-
-	"golang.org/x/exp/slices"
 )
 
 func TestParseJSONPath(t *testing.T) {

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -21,12 +21,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 	"unicode/utf16"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/mysql/fastparse"
 

--- a/go/mysql/json/update.go
+++ b/go/mysql/json/update.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 package json
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // Del deletes the entry with the given key from o.
 func (o *Object) Del(key string) {

--- a/go/mysql/replication/mysql56_gtid_set.go
+++ b/go/mysql/replication/mysql56_gtid_set.go
@@ -19,10 +19,9 @@ package replication
 import (
 	"bytes"
 	"encoding/binary"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/stats/counter_test.go
+++ b/go/stats/counter_test.go
@@ -26,7 +26,7 @@ import (
 func TestCounter(t *testing.T) {
 	var gotname string
 	var gotv *Counter
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*Counter)
@@ -54,7 +54,7 @@ func TestCounter(t *testing.T) {
 func TestGaugeFunc(t *testing.T) {
 	var gotname string
 	var gotv *GaugeFunc
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*GaugeFunc)
@@ -77,7 +77,7 @@ func TestGaugeFunc(t *testing.T) {
 func TestGaugeFloat64(t *testing.T) {
 	var gotname string
 	var gotv *GaugeFloat64
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*GaugeFloat64)

--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -70,9 +70,7 @@ func (c *counters) ZeroAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for k := range c.counts {
-		c.counts[k] = 0
-	}
+	clear(c.counts)
 }
 
 // Counts returns a copy of the Counters' map.

--- a/go/stats/counters_test.go
+++ b/go/stats/counters_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestCounters(t *testing.T) {
-	clear()
+	clearStats()
 	c := NewCountersWithSingleLabel("counter1", "help", "label")
 	c.Add("c1", 1)
 	c.Add("c2", 1)
@@ -49,7 +49,7 @@ func TestCounters(t *testing.T) {
 }
 
 func TestCountersTags(t *testing.T) {
-	clear()
+	clearStats()
 	c := NewCountersWithSingleLabel("counterTag1", "help", "label")
 	want := map[string]int64{}
 	got := c.Counts()
@@ -66,7 +66,7 @@ func TestCountersTags(t *testing.T) {
 }
 
 func TestMultiCounters(t *testing.T) {
-	clear()
+	clearStats()
 	c := NewCountersWithMultiLabels("mapCounter1", "help", []string{"aaa", "bbb"})
 	c.Add([]string{"c1a", "c1b"}, 1)
 	c.Add([]string{"c2a", "c2b"}, 1)
@@ -95,7 +95,7 @@ func TestMultiCounters(t *testing.T) {
 }
 
 func TestMultiCountersDot(t *testing.T) {
-	clear()
+	clearStats()
 	c := NewCountersWithMultiLabels("mapCounter2", "help", []string{"aaa", "bbb"})
 	c.Add([]string{"c1.a", "c1b"}, 1)
 	c.Add([]string{"c2a", "c2.b"}, 1)
@@ -121,7 +121,7 @@ func TestMultiCountersDot(t *testing.T) {
 func TestCountersHook(t *testing.T) {
 	var gotname string
 	var gotv *CountersWithSingleLabel
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*CountersWithSingleLabel)
@@ -139,7 +139,7 @@ func TestCountersHook(t *testing.T) {
 var benchCounter = NewCountersWithSingleLabel("bench", "help", "label")
 
 func BenchmarkCounters(b *testing.B) {
-	clear()
+	clearStats()
 	benchCounter.Add("c1", 1)
 	b.ResetTimer()
 
@@ -153,7 +153,7 @@ func BenchmarkCounters(b *testing.B) {
 var benchMultiCounter = NewCountersWithMultiLabels("benchMulti", "help", []string{"call", "keyspace", "dbtype"})
 
 func BenchmarkMultiCounters(b *testing.B) {
-	clear()
+	clearStats()
 	key := []string{"execute-key-ranges", "keyspacename", "replica"}
 	benchMultiCounter.Add(key, 1)
 	b.ResetTimer()
@@ -169,7 +169,7 @@ func BenchmarkCountersTailLatency(b *testing.B) {
 	// For this one, ignore the time reported by 'go test'.
 	// The 99th Percentile log line is all that matters.
 	// (Cmd: go test -bench=BenchmarkCountersTailLatency -benchtime=30s -cpu=10)
-	clear()
+	clearStats()
 	benchCounter.Add("c1", 1)
 	c := make(chan time.Duration, 100)
 	done := make(chan struct{})
@@ -208,7 +208,7 @@ func BenchmarkCountersTailLatency(b *testing.B) {
 }
 
 func TestCountersFuncWithMultiLabels(t *testing.T) {
-	clear()
+	clearStats()
 	f := NewCountersFuncWithMultiLabels("TestCountersFuncWithMultiLabels", "help", []string{"label1"}, func() map[string]int64 {
 		return map[string]int64{
 			"c1": 1,
@@ -226,7 +226,7 @@ func TestCountersFuncWithMultiLabels(t *testing.T) {
 func TestCountersFuncWithMultiLabels_Hook(t *testing.T) {
 	var gotname string
 	var gotv *CountersFuncWithMultiLabels
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*CountersFuncWithMultiLabels)
@@ -244,13 +244,13 @@ func TestCountersFuncWithMultiLabels_Hook(t *testing.T) {
 }
 
 func TestCountersCombineDimension(t *testing.T) {
-	clear()
+	clearStats()
 	// Empty labels shouldn't be combined.
 	c0 := NewCountersWithSingleLabel("counter_combine_dim0", "help", "")
 	c0.Add("c1", 1)
 	assert.Equal(t, `{"c1": 1}`, c0.String())
 
-	clear()
+	clearStats()
 	combineDimensions = "a,c"
 
 	c1 := NewCountersWithSingleLabel("counter_combine_dim1", "help", "label")

--- a/go/stats/duration_test.go
+++ b/go/stats/duration_test.go
@@ -25,7 +25,7 @@ import (
 func TestCounterDuration(t *testing.T) {
 	var gotname string
 	var gotv *CounterDuration
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*CounterDuration)
@@ -52,7 +52,7 @@ func TestCounterDuration(t *testing.T) {
 func TestCounterDurationFunc(t *testing.T) {
 	var gotname string
 	var gotv *CounterDurationFunc
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*CounterDurationFunc)
@@ -75,7 +75,7 @@ func TestCounterDurationFunc(t *testing.T) {
 func TestGaugeDuration(t *testing.T) {
 	var gotname string
 	var gotv *GaugeDuration
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*GaugeDuration)
@@ -103,7 +103,7 @@ func TestGaugeDuration(t *testing.T) {
 func TestGaugeDurationFunc(t *testing.T) {
 	var gotname string
 	var gotv *GaugeDurationFunc
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*GaugeDurationFunc)

--- a/go/stats/export_test.go
+++ b/go/stats/export_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func clear() {
+func clearStats() {
 	defaultVarGroup.vars = make(map[string]expvar.Var)
 	defaultVarGroup.newVarHook = nil
 	combineDimensions = ""
@@ -34,7 +34,7 @@ func clear() {
 }
 
 func TestNoHook(t *testing.T) {
-	clear()
+	clearStats()
 	v := NewCounter("plainint", "help")
 	v.Add(1)
 	if v.String() != "1" {
@@ -45,7 +45,7 @@ func TestNoHook(t *testing.T) {
 func TestString(t *testing.T) {
 	var gotname string
 	var gotv *String
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*String)
@@ -82,7 +82,7 @@ func (m *Mystr) String() string {
 func TestPublish(t *testing.T) {
 	var gotname string
 	var gotv expvar.Var
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*Mystr)
@@ -110,7 +110,7 @@ func (f expvarFunc) String() string {
 func TestPublishFunc(t *testing.T) {
 	var gotname string
 	var gotv expvarFunc
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(expvarFunc)
@@ -125,7 +125,7 @@ func TestPublishFunc(t *testing.T) {
 }
 
 func TestDropVariable(t *testing.T) {
-	clear()
+	clearStats()
 	dropVariables = "dropTest"
 
 	// This should not panic.
@@ -161,7 +161,7 @@ func TestParseCommonTags(t *testing.T) {
 }
 
 func TestStringMapWithMultiLabels(t *testing.T) {
-	clear()
+	clearStats()
 	c := NewStringMapFuncWithMultiLabels("stringMap1", "help", []string{"aaa", "bbb"}, "ccc", func() map[string]string {
 		m := make(map[string]string)
 		m["c1a.c1b"] = "1"

--- a/go/stats/histogram_test.go
+++ b/go/stats/histogram_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestHistogram(t *testing.T) {
-	clear()
+	clearStats()
 	h := NewHistogram("hist1", "help", []int64{1, 5})
 	for i := 0; i < 10; i++ {
 		h.Add(int64(i))
@@ -54,7 +54,7 @@ func TestHistogram(t *testing.T) {
 }
 
 func TestGenericHistogram(t *testing.T) {
-	clear()
+	clearStats()
 	h := NewGenericHistogram(
 		"histgen",
 		"help",
@@ -72,7 +72,7 @@ func TestGenericHistogram(t *testing.T) {
 func TestHistogramHook(t *testing.T) {
 	var gotname string
 	var gotv *Histogram
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*Histogram)

--- a/go/stats/multidimensional_test.go
+++ b/go/stats/multidimensional_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMultiTimingsCounterFor(t *testing.T) {
-	clear()
+	clearStats()
 	mtm := NewMultiTimings("multitimings3", "help", []string{"dim1", "dim2"})
 
 	mtm.Add([]string{"tag1a", "tag1b"}, 500*time.Microsecond)

--- a/go/stats/rates_test.go
+++ b/go/stats/rates_test.go
@@ -41,7 +41,7 @@ func TestRates(t *testing.T) {
 		return now
 	}
 
-	clear()
+	clearStats()
 	c := NewCountersWithSingleLabel("rcounter1", "rcounter help", "label")
 	r := NewRates("rates1", c, 3, -1*time.Second)
 	r.snapshot()
@@ -89,7 +89,7 @@ func TestRatesConsistency(t *testing.T) {
 	// This tests the following invariant: in the time window
 	// covered by rates, the sum of the rates reported must be
 	// equal to the count reported by the counter.
-	clear()
+	clearStats()
 	c := NewCountersWithSingleLabel("rcounter4", "rcounter4 help", "label")
 	r := NewRates("rates4", c, 100, -1*time.Second)
 	r.snapshot()
@@ -122,11 +122,11 @@ func TestRatesConsistency(t *testing.T) {
 }
 
 func TestRatesHook(t *testing.T) {
-	clear()
+	clearStats()
 	c := NewCountersWithSingleLabel("rcounter2", "rcounter2 help", "label")
 	var gotname string
 	var gotv *Rates
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*Rates)

--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -61,7 +61,7 @@ func NewTimings(name, help, label string, categories ...string) *Timings {
 	return t
 }
 
-// Reset will clear histograms: used during testing
+// Reset will clearStats histograms: used during testing
 func (t *Timings) Reset() {
 	t.mu.RLock()
 	t.histograms = make(map[string]*Histogram)

--- a/go/stats/timings_test.go
+++ b/go/stats/timings_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestTimings(t *testing.T) {
-	clear()
+	clearStats()
 	tm := NewTimings("timings1", "help", "category")
 	tm.Add("tag1", 500*time.Microsecond)
 	tm.Add("tag1", 1*time.Millisecond)
@@ -38,7 +38,7 @@ func TestTimings(t *testing.T) {
 }
 
 func TestMultiTimings(t *testing.T) {
-	clear()
+	clearStats()
 	mtm := NewMultiTimings("maptimings1", "help", []string{"dim1", "dim2"})
 	mtm.Add([]string{"tag1a", "tag1b"}, 500*time.Microsecond)
 	mtm.Add([]string{"tag1a", "tag1b"}, 1*time.Millisecond)
@@ -50,7 +50,7 @@ func TestMultiTimings(t *testing.T) {
 }
 
 func TestMultiTimingsDot(t *testing.T) {
-	clear()
+	clearStats()
 	mtm := NewMultiTimings("maptimings2", "help", []string{"label"})
 	mtm.Add([]string{"value.dot"}, 500*time.Microsecond)
 	safe := safeLabel("value.dot")
@@ -64,7 +64,7 @@ func TestMultiTimingsDot(t *testing.T) {
 func TestTimingsHook(t *testing.T) {
 	var gotname string
 	var gotv *Timings
-	clear()
+	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
 		gotv = v.(*Timings)
@@ -81,7 +81,7 @@ func TestTimingsHook(t *testing.T) {
 }
 
 func TestTimingsCombineDimension(t *testing.T) {
-	clear()
+	clearStats()
 	combineDimensions = "a,c"
 
 	t1 := NewTimings("timing_combine_dim1", "help", "label")

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -262,18 +262,11 @@ func GetFormatter[T any](logger *StreamLogger[T]) LogFormatter {
 // ShouldEmitLog returns whether the log with the given SQL query
 // should be emitted or filtered
 func ShouldEmitLog(sql string, rowsAffected, rowsReturned uint64) bool {
-	if queryLogRowThreshold > maxUint64(rowsAffected, rowsReturned) && queryLogFilterTag == "" {
+	if queryLogRowThreshold > max(rowsAffected, rowsReturned) && queryLogFilterTag == "" {
 		return false
 	}
 	if queryLogFilterTag != "" {
 		return strings.Contains(sql, queryLogFilterTag)
 	}
 	return true
-}
-
-func maxUint64(a, b uint64) uint64 {
-	if a < b {
-		return b
-	}
-	return a
 }

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -21,14 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql"

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -18,12 +18,12 @@ package aggregation
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"

--- a/go/test/endtoend/vtgate/queries/random/query_gen.go
+++ b/go/test/endtoend/vtgate/queries/random/query_gen.go
@@ -19,11 +19,9 @@ package random
 import (
 	"fmt"
 	"math/rand"
+	"slices"
 
 	"vitess.io/vitess/go/slice"
-
-	"golang.org/x/exp/slices"
-
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 )

--- a/go/tools/astfmtgen/main.go
+++ b/go/tools/astfmtgen/main.go
@@ -25,10 +25,10 @@ import (
 	"log"
 	"os"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/packages"
 

--- a/go/tools/asthelpergen/clone_gen.go
+++ b/go/tools/asthelpergen/clone_gen.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"go/types"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/dave/jennifer/jen"
-	"golang.org/x/exp/slices"
 )
 
 type CloneOptions struct {

--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -278,13 +278,6 @@ func (a tabletLagSnapshotList) Len() int           { return len(a) }
 func (a tabletLagSnapshotList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a tabletLagSnapshotList) Less(i, j int) bool { return a[i].replag < a[j].replag }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // mean calculates the mean value over the given list,
 // while excluding the item with the specified index.
 func mean(tabletHealthList []*TabletHealth, idxExclude int) (uint64, error) {

--- a/go/vt/throttler/throttlerlogz.go
+++ b/go/vt/throttler/throttlerlogz.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/google/safehtml/template"
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/vt/logz"
 	"vitess.io/vitess/go/vt/servenv"

--- a/go/vt/throttler/throttlerz.go
+++ b/go/vt/throttler/throttlerz.go
@@ -18,10 +18,10 @@ package throttler
 
 import (
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/google/safehtml/template"
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -19,13 +19,12 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-
+	"vitess.io/vitess/go/maps2"
 	"vitess.io/vitess/go/mysql/replication"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -370,7 +369,7 @@ func (dr *switcherDryRun) resetSequences(ctx context.Context) error {
 }
 
 func (dr *switcherDryRun) initializeTargetSequences(ctx context.Context, sequencesByBackingTable map[string]*sequenceMetadata) error {
-	sortedBackingTableNames := maps.Keys(sequencesByBackingTable)
+	sortedBackingTableNames := maps2.Keys(sequencesByBackingTable)
 	slices.Sort(sortedBackingTableNames)
 	dr.drLog.Log(fmt.Sprintf("The following sequence backing tables used by tables being moved will be initialized: %s",
 		strings.Join(sortedBackingTableNames, ",")))

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -25,10 +25,10 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	"vitess.io/vitess/go/json2"
+	"vitess.io/vitess/go/maps2"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -1331,7 +1331,7 @@ func (ts *trafficSwitcher) getTargetSequenceMetadata(ctx context.Context) (map[s
 // error if any is seen.
 func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspace) (map[string]*sequenceMetadata, bool, error) {
 	allFullyQualified := true
-	targets := maps.Values(ts.Targets())
+	targets := maps2.Values(ts.Targets())
 	if len(targets) == 0 || targets[0].GetPrimary() == nil { // This should never happen
 		return nil, false, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "no primary tablet found for target keyspace %s", ts.targetKeyspace)
 	}

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -19,16 +19,13 @@ package evalengine
 import (
 	"math"
 
-	"golang.org/x/exp/constraints"
-
 	"vitess.io/vitess/go/mysql/decimal"
-
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
-func dataOutOfRangeError[N1, N2 constraints.Integer | constraints.Float](v1 N1, v2 N2, typ, sign string) error {
+func dataOutOfRangeError[N1, N2 int | int64 | uint64 | float64](v1 N1, v2 N2, typ, sign string) error {
 	return vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.DataOutOfRange, "%s value is out of range in '(%v %s %v)'", typ, v1, sign, v2)
 }
 

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -326,12 +326,12 @@ func mathAdd_dx(v1 *evalDecimal, v2 evalNumeric) *evalDecimal {
 }
 
 func mathAdd_dd(v1, v2 *evalDecimal) *evalDecimal {
-	return newEvalDecimalWithPrec(v1.dec.Add(v2.dec), maxprec(v1.length, v2.length))
+	return newEvalDecimalWithPrec(v1.dec.Add(v2.dec), max(v1.length, v2.length))
 }
 
 func mathAdd_dd0(v1, v2 *evalDecimal) {
 	v1.dec = v1.dec.Add(v2.dec)
-	v1.length = maxprec(v1.length, v2.length)
+	v1.length = max(v1.length, v2.length)
 }
 
 func mathSub_ii(v1, v2 int64) (*evalInt64, error) {
@@ -417,12 +417,12 @@ func mathSub_xd(v1 evalNumeric, v2 *evalDecimal) *evalDecimal {
 }
 
 func mathSub_dd(v1, v2 *evalDecimal) *evalDecimal {
-	return newEvalDecimalWithPrec(v1.dec.Sub(v2.dec), maxprec(v1.length, v2.length))
+	return newEvalDecimalWithPrec(v1.dec.Sub(v2.dec), max(v1.length, v2.length))
 }
 
 func mathSub_dd0(v1, v2 *evalDecimal) {
 	v1.dec = v1.dec.Sub(v2.dec)
-	v1.length = maxprec(v1.length, v2.length)
+	v1.length = max(v1.length, v2.length)
 }
 
 func mathMul_ii(v1, v2 int64) (*evalInt64, error) {
@@ -479,13 +479,6 @@ func mathMul_fx(v1 float64, v2 evalNumeric) (eval, error) {
 
 func mathMul_ff(v1, v2 float64) *evalFloat {
 	return newEvalFloat(v1 * v2)
-}
-
-func maxprec(a, b int32) int32 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func mathMul_dx(v1 *evalDecimal, v2 evalNumeric) *evalDecimal {

--- a/go/vt/vtgate/evalengine/mysql_test.go
+++ b/go/vt/vtgate/evalengine/mysql_test.go
@@ -22,10 +22,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vtgate/evalengine/testcases/helpers.go
+++ b/go/vt/vtgate/evalengine/testcases/helpers.go
@@ -78,13 +78,6 @@ func genSubsets(args []string, subsetLen int, yield func([]string)) {
 	genSubsets1(args, subset, 0, 0, yield)
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func mustJSON(j string) sqltypes.Value {
 	v, err := sqltypes.NewJSON(j)
 	if err != nil {

--- a/go/vt/vtgate/evalengine/weights_test.go
+++ b/go/vt/vtgate/evalengine/weights_test.go
@@ -19,11 +19,11 @@ package evalengine
 import (
 	"fmt"
 	"math/rand"
+	"slices"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -18,10 +18,9 @@ package operators
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -18,9 +18,8 @@ package operators
 
 import (
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -18,10 +18,9 @@ package operators
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -17,7 +17,7 @@ limitations under the License.
 package operators
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -17,9 +17,8 @@ limitations under the License.
 package operators
 
 import (
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -17,7 +17,7 @@ limitations under the License.
 package operators
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -17,10 +17,9 @@ limitations under the License.
 package operators
 
 import (
+	"maps"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -17,9 +17,8 @@ limitations under the License.
 package operators
 
 import (
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -18,9 +18,8 @@ package operators
 
 import (
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -19,10 +19,9 @@ package operators
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/planbuilder/operators/rewrite/rewriters.go
+++ b/go/vt/vtgate/planbuilder/operators/rewrite/rewriters.go
@@ -18,8 +18,7 @@ package rewrite
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"

--- a/go/vt/vtgate/planbuilder/operators/sharded_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/sharded_routing.go
@@ -17,7 +17,7 @@ limitations under the License.
 package operators
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/slice"

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -18,8 +18,7 @@ package operators
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vtgate/schema/tracker.go
+++ b/go/vt/vtgate/schema/tracker.go
@@ -18,11 +18,10 @@ package schema
 
 import (
 	"context"
+	"maps"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/maps"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vtgate/semantics/bitset/bitset.go
+++ b/go/vt/vtgate/semantics/bitset/bitset.go
@@ -50,16 +50,9 @@ func toBitset(words []byte) Bitset {
 	return *(*Bitset)(unsafe.Pointer(&words))
 }
 
-func minlen(a, b Bitset) int {
-	if len(a) < len(b) {
-		return len(a)
-	}
-	return len(b)
-}
-
 // Overlaps returns whether this Bitset and the input have any bits in common
 func (bs Bitset) Overlaps(b2 Bitset) bool {
-	min := minlen(bs, b2)
+	min := min(len(bs), len(b2))
 	for i := 0; i < min; i++ {
 		if bs[i]&b2[i] != 0 {
 			return true
@@ -126,7 +119,7 @@ func (bs Bitset) And(b2 Bitset) Bitset {
 		return ""
 	}
 
-	merged := make([]byte, minlen(bs, b2))
+	merged := make([]byte, min(len(bs), len(b2)))
 	m := 0
 
 	for m = 0; m < len(merged); m++ {

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/spf13/pflag"
-
-	"golang.org/x/exp/slices"
 
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"

--- a/go/vt/vttablet/endtoend/healthstream_test.go
+++ b/go/vt/vttablet/endtoend/healthstream_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package endtoend
 
 import (
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"

--- a/go/vt/vttablet/endtoend/streamtimeout/healthstream_test.go
+++ b/go/vt/vttablet/endtoend/streamtimeout/healthstream_test.go
@@ -18,11 +18,11 @@ package streamtimeout
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"

--- a/go/vt/vttablet/tabletserver/schema/db_test.go
+++ b/go/vt/vttablet/tabletserver/schema/db_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	"vitess.io/vitess/go/constants/sidecar"
+	"vitess.io/vitess/go/maps2"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
@@ -145,7 +145,7 @@ func TestGetChangedViewNames(t *testing.T) {
 	got, err := getChangedViewNames(context.Background(), conn, true)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
-	require.ElementsMatch(t, maps.Keys(got), []string{"v1", "v2", "lead"})
+	require.ElementsMatch(t, maps2.Keys(got), []string{"v1", "v2", "lead"})
 	require.NoError(t, db.LastError())
 
 	// Not serving primary
@@ -181,7 +181,7 @@ func TestGetViewDefinition(t *testing.T) {
 	got, err := collectGetViewDefinitions(conn, bv)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
-	require.ElementsMatch(t, maps.Keys(got), []string{"v1", "lead"})
+	require.ElementsMatch(t, maps2.Keys(got), []string{"v1", "lead"})
 	require.Equal(t, "create_view_v1", got["v1"])
 	require.Equal(t, "create_view_lead", got["lead"])
 	require.NoError(t, db.LastError())
@@ -351,7 +351,7 @@ func TestGetMismatchedTableNames(t *testing.T) {
 			if tc.expectedError != "" {
 				require.ErrorContains(t, err, tc.expectedError)
 			} else {
-				require.ElementsMatch(t, maps.Keys(mismatchedTableNames), tc.expectedTableNames)
+				require.ElementsMatch(t, maps2.Keys(mismatchedTableNames), tc.expectedTableNames)
 				require.NoError(t, db.LastError())
 			}
 		})

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -26,10 +26,8 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/maps"
-
 	"vitess.io/vitess/go/constants/sidecar"
-
+	"vitess.io/vitess/go/maps2"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/mysql/sqlerror"
 
@@ -588,7 +586,7 @@ func (se *Engine) getDroppedTables(curTables map[string]bool, changedViews map[s
 		}
 	}
 
-	return maps.Values(dropped)
+	return maps2.Values(dropped)
 }
 
 func getTableData(ctx context.Context, conn *connpool.DBConn, includeStats bool) (*sqltypes.Result, error) {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -850,10 +850,7 @@ func smallerTimeout(t1, t2 time.Duration) time.Duration {
 	if t2 == 0 {
 		return t1
 	}
-	if t1 < t2 {
-		return t1
-	}
-	return t2
+	return min(t1, t2)
 }
 
 // StreamExecute executes the query and streams the result.

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -19,13 +19,12 @@ package wrangler
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-
+	"vitess.io/vitess/go/maps2"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/vt/vtctl/workflow"
 
@@ -388,7 +387,7 @@ func (dr *switcherDryRun) resetSequences(ctx context.Context) error {
 }
 
 func (dr *switcherDryRun) initializeTargetSequences(ctx context.Context, sequencesByBackingTable map[string]*sequenceMetadata) error {
-	sortedBackingTableNames := maps.Keys(sequencesByBackingTable)
+	sortedBackingTableNames := maps2.Keys(sequencesByBackingTable)
 	slices.Sort(sortedBackingTableNames)
 	dr.drLog.Log(fmt.Sprintf("The following sequence backing tables used by tables being moved will be initialized: %s",
 		strings.Join(sortedBackingTableNames, ",")))

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -26,10 +26,10 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	"vitess.io/vitess/go/json2"
+	"vitess.io/vitess/go/maps2"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -2053,7 +2053,7 @@ func (ts *trafficSwitcher) getTargetSequenceMetadata(ctx context.Context) (map[s
 // error if any is seen.
 func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspace) (map[string]*sequenceMetadata, bool, error) {
 	allFullyQualified := true
-	targets := maps.Values(ts.Targets())
+	targets := maps2.Values(ts.Targets())
 	if len(targets) == 0 || targets[0].GetPrimary() == nil { // This should never happen
 		return nil, false, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "no primary tablet found for target keyspace %s", ts.targetKeyspace)
 	}


### PR DESCRIPTION
## Description

Now that the codebase has been upgraded to Go 1.21, we get to remove some crusty old code that has been made redundant by new language/stdlib features in the new Go version.

To note:

1. Remove the dependency on the `exp/slices` and `exp/maps` package. These packages are now part of the stdlib! ...Except for `maps.Values` and `maps.Keys`, which [was dropped at the very last moment](https://github.com/golang/go/issues/61538) because it's expected to be stabilized in 1.22 using iterators (???). Whatever. We'll vendor those.

2. `min` and `max` are now language built-ins (there truly is no end to the amount of programming language design innovation that the Go designers can bestow upon us in this blessed year of Our Lord 2023). So we get to remove the same function peppered several times all over the place.

3. `clear` is a new language built-in that handles several slice clearing patterns more efficiently (\**disclaimer: it does not actually handle them more efficiently; these patterns were already special cased by the compiler*). I've found a few of these with these [`gopatch`](https://github.com/uber-go/gopatch) patches I wrote:

```diff
@@
var x expression
var i identifier
@@
-for i := range x {
-	x[i] = 0
-}
+clear(x)
```

```diff
@@
var x expression
var i identifier
@@
-for i := range x {
-	delete(x, i)
-}
+clear(x)
```

4. The `exp/constraints` package was being (ab)used to make too broad generic functions in the `regexp` package. I cleaned that up and we get to drop the whole package from our codebase.

cc @frouioui @dbussink 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
