### PR TITLE
Fix merge conflict with new tests

### DIFF
--- a/go/ioutil/timeout_closer.go
+++ b/go/ioutil/timeout_closer.go
@@ -45,7 +45,10 @@ func (c *TimeoutCloser) Close() error {
 
 	go func() {
 		defer close(done)
-		done <- c.closer.Close()
+		select {
+		case done <- c.closer.Close():
+		case <-ctx.Done():
+		}
 	}()
 	select {
 	case err := <-done:

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -46,7 +46,6 @@ func TestGetSrvKeyspace(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts, factory := memorytopo.NewServerAndFactory(ctx, "test_cell")
-	defer ts.Close()
 	srvTopoCacheTTL = 200 * time.Millisecond
 	srvTopoCacheRefresh = 80 * time.Millisecond
 	defer func() {
@@ -365,7 +364,6 @@ func TestSrvKeyspaceCachedError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "test_cell")
-	defer ts.Close()
 	srvTopoCacheTTL = 100 * time.Millisecond
 	srvTopoCacheRefresh = 40 * time.Millisecond
 	defer func() {
@@ -437,7 +435,6 @@ func TestWatchSrvVSchema(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "test_cell")
-	defer ts.Close()
 	rs := NewResilientServer(ctx, ts, "TestWatchSrvVSchema")
 
 	// mu protects watchValue and watchErr.
@@ -523,7 +520,6 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts, factory := memorytopo.NewServerAndFactory(ctx, "test_cell")
-	defer ts.Close()
 
 	time.Sleep(1 * time.Second)
 
@@ -682,7 +678,6 @@ func TestSrvKeyspaceWatcher(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts, factory := memorytopo.NewServerAndFactory(ctx, "test_cell")
-	defer ts.Close()
 	srvTopoCacheTTL = 100 * time.Millisecond
 	srvTopoCacheRefresh = 40 * time.Millisecond
 	defer func() {
@@ -809,7 +804,6 @@ func TestSrvKeyspaceListener(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "test_cell")
-	defer ts.Close()
 	srvTopoCacheTTL = 100 * time.Millisecond
 	srvTopoCacheRefresh = 40 * time.Millisecond
 	defer func() {

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -1254,8 +1254,9 @@ func TestCancelSchemaMigration(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 
-			ctx := context.Background()
-			ts := memorytopo.NewServer("zone1")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ts := memorytopo.NewServer(ctx, "zone1")
 
 			testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{
 				AlsoSetShardPrimary: true,


### PR DESCRIPTION
This was merged while we also merged the context leak fixes, so now `main` is broken. This fixes it.

See #13835 where this was refactored and #13860 which was merged concurrently. 