### PR TITLE
Fix setup order to avoid races

### DIFF
--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -114,7 +114,10 @@ func TestPersistentMode(t *testing.T) {
 	// reboot the persistent cluster
 	cluster.TearDown()
 	cluster, err = startPersistentCluster(dir)
-	defer cluster.TearDown()
+	defer func() {
+		cluster.PersistentMode = false // Cleanup the tmpdir as we're done
+		cluster.TearDown()
+	}()
 	assert.NoError(t, err)
 
 	// rerun our sanity checks to make sure vschema is persisted correctly

--- a/go/test/utils/noleak.go
+++ b/go/test/utils/noleak.go
@@ -18,16 +18,10 @@ package utils
 
 import (
 	"context"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"go.uber.org/goleak"
-
-	"vitess.io/vitess/go/vt/log"
 )
 
 // LeakCheckContext returns a Context that will be automatically cancelled at the end
@@ -73,9 +67,6 @@ func ensureNoLeaks() error {
 	if err := ensureNoGoroutines(); err != nil {
 		return err
 	}
-	if err := ensureNoOpenSockets(); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -100,21 +91,6 @@ func ensureNoGoroutines() error {
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
-	}
-	return err
-}
-
-func ensureNoOpenSockets() error {
-	cmd := exec.Command("lsof", "-a", "-p", strconv.Itoa(os.Getpid()), "-i", "-P", "-V")
-	cmd.Stderr = nil
-	lsof, err := cmd.Output()
-	if err == nil {
-		log.Errorf("found open sockets:\n%s", lsof)
-	} else {
-		if strings.Contains(string(lsof), "no Internet files located") {
-			return nil
-		}
-		log.Errorf("failed to run `lsof`: %v (%q)", err, lsof)
 	}
 	return err
 }

--- a/go/vt/vtgate/schema/tracker.go
+++ b/go/vt/vtgate/schema/tracker.go
@@ -151,6 +151,10 @@ func (t *Tracker) Start() {
 		for {
 			select {
 			case th := <-t.ch:
+				if th == nil {
+					// channel closed
+					return
+				}
 				ksUpdater := t.getKeyspaceUpdateController(th)
 				ksUpdater.add(th)
 			case <-ctx.Done():


### PR DESCRIPTION
This ensures that we always set up the sandbox instances first with the correct vschema etc. so that anything that starts goroutines afterwards like `newTestResolver` won't race with reading the vschema while it still might be written.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required