### PR TITLE
VTOrc converts a tablet to DRAINED type if it detects errant GTIDs on it

### DIFF
--- a/changelog/18.0/18.0.0/summary.md
+++ b/changelog/18.0/18.0.0/summary.md
@@ -7,6 +7,7 @@
     - [Local examples now use etcd v3 storage and API](#local-examples-etcd-v3)
   - **[New command line flags and behavior](#new-flag)**
     - [VTOrc flag `--allow-emergency-reparent`](#new-flag-toggle-ers)
+    - [VTOrc flag `--convert-tablets-with-errant-gtids`](#new-flag-errant-gtid-convert)
     - [ERS sub flag `--wait-for-all-tablets`](#new-ers-subflag)
   - **[VTAdmin](#vtadmin)**
     - [Updated to node v18.16.0](#update-node)
@@ -45,6 +46,14 @@ VTOrc has a new flag `--allow-emergency-reparent` that allows the users to toggl
 reparent operations. The users that want VTOrc to fix the replication issues, but don't want it to run any reparents
 should start using this flag. By default, VTOrc will be able to run `EmergencyReparentShard`. The users must specify the
 flag to `false` to change the behaviour.
+
+#### <a id="new-flag-errant-gtid-convert"/>VTOrc flag `--convert-tablets-with-errant-gtids`
+
+VTOrc has a new flag `--convert-tablets-with-errant-gtids` that allows the users to toggle the ability of VTOrc to change the 
+tablet type of tablets with errant GTIDs to `DRAINED`. By default, the flag is false.
+
+This feature allows the users to configure VTOrc such that any tablet that encounters errant GTIDs is automatically taken out of the
+serving graph. These tablets can then be inspected for what the errant GTIDs are, and once fixed, they can rejoin the cluster.
 
 #### <a id="new-ers-subflag"/>ERS sub flag `--wait-for-all-tablets`
 

--- a/changelog/18.0/18.0.0/summary.md
+++ b/changelog/18.0/18.0.0/summary.md
@@ -7,7 +7,7 @@
     - [Local examples now use etcd v3 storage and API](#local-examples-etcd-v3)
   - **[New command line flags and behavior](#new-flag)**
     - [VTOrc flag `--allow-emergency-reparent`](#new-flag-toggle-ers)
-    - [VTOrc flag `--convert-tablets-with-errant-gtids`](#new-flag-errant-gtid-convert)
+    - [VTOrc flag `--change-tablets-with-errant-gtid-to-drained`](#new-flag-errant-gtid-convert)
     - [ERS sub flag `--wait-for-all-tablets`](#new-ers-subflag)
   - **[VTAdmin](#vtadmin)**
     - [Updated to node v18.16.0](#update-node)
@@ -47,12 +47,12 @@ reparent operations. The users that want VTOrc to fix the replication issues, bu
 should start using this flag. By default, VTOrc will be able to run `EmergencyReparentShard`. The users must specify the
 flag to `false` to change the behaviour.
 
-#### <a id="new-flag-errant-gtid-convert"/>VTOrc flag `--convert-tablets-with-errant-gtids`
+#### <a id="new-flag-errant-gtid-convert"/>VTOrc flag `--change-tablets-with-errant-gtid-to-drained`
 
-VTOrc has a new flag `--convert-tablets-with-errant-gtids` that allows the users to toggle the ability of VTOrc to change the 
+VTOrc has a new flag `--change-tablets-with-errant-gtid-to-drained` that allows users to choose whether VTOrc should change the
 tablet type of tablets with errant GTIDs to `DRAINED`. By default, the flag is false.
 
-This feature allows the users to configure VTOrc such that any tablet that encounters errant GTIDs is automatically taken out of the
+This feature allows users to configure VTOrc such that any tablet that encounters errant GTIDs is automatically taken out of the
 serving graph. These tablets can then be inspected for what the errant GTIDs are, and once fixed, they can rejoin the cluster.
 
 #### <a id="new-ers-subflag"/>ERS sub flag `--wait-for-all-tablets`

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -15,6 +15,7 @@ Usage of vtorc:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.
+      --convert-tablets-with-errant-gtids                           Whether VTOrc should be changing the type of the tablets with errant GTIDs to DRAINED
       --emit_stats                                                  If set, emit stats to push-based monitoring and stats backends
       --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -6,6 +6,7 @@ Usage of vtorc:
       --audit-to-backend                                            Whether to store the audit log in the VTOrc database
       --audit-to-syslog                                             Whether to store the audit log in the syslog
       --catch-sigpipe                                               catch and ignore SIGPIPE on stdout and stderr if specified
+      --change-tablets-with-errant-gtid-to-drained                  Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED
       --clusters_to_watch strings                                   Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
       --config string                                               config file name
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
@@ -15,7 +16,6 @@ Usage of vtorc:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.
-      --convert-tablets-with-errant-gtids                           Whether VTOrc should be changing the type of the tablets with errant GTIDs to DRAINED
       --emit_stats                                                  If set, emit stats to push-based monitoring and stats backends
       --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -105,7 +105,7 @@ func TestKeyspaceShard(t *testing.T) {
 func TestVTOrcRepairs(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
 	defer cluster.PanicHandler(t)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 0, []string{"--convert-tablets-with-errant-gtids"}, cluster.VTOrcConfiguration{
+	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 0, []string{"--change-tablets-with-errant-gtid-to-drained"}, cluster.VTOrcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
 	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -215,6 +215,15 @@ func TestVTOrcRepairs(t *testing.T) {
 		// check that the writes still succeed
 		utils.VerifyWritesSucceed(t, clusterInfo, curPrimary, []*cluster.Vttablet{replica, otherReplica}, 10*time.Second)
 	})
+
+	t.Run("Errant GTID Detected", func(t *testing.T) {
+		// insert an errant GTID in the replica
+		_, err := utils.RunSQL(t, "insert into vt_insert_test(id, msg) values (10173, 'test 178342')", replica, "vt_ks")
+		require.NoError(t, err)
+		// When VTOrc detects errant GTIDs, it should change the tablet to a drained type.
+		utils.WaitForTabletType(t, replica, "drained")
+	})
+
 }
 
 func TestRepairAfterTER(t *testing.T) {

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -105,7 +105,7 @@ func TestKeyspaceShard(t *testing.T) {
 func TestVTOrcRepairs(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
 	defer cluster.PanicHandler(t)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 0, nil, cluster.VTOrcConfiguration{
+	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 0, []string{"--convert-tablets-with-errant-gtids"}, cluster.VTOrcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
 	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -969,6 +969,13 @@ func WaitForSuccessfulRecoveryCount(t *testing.T, vtorcInstance *cluster.VTOrcPr
 	assert.EqualValues(t, countExpected, successCount)
 }
 
+// WaitForTabletType waits for the tablet to reach a certain type.
+func WaitForTabletType(t *testing.T, tablet *cluster.Vttablet, expectedTabletType string) {
+	t.Helper()
+	err := tablet.VttabletProcess.WaitForTabletTypes([]string{expectedTabletType})
+	require.NoError(t, err)
+}
+
 // WaitForInstancePollSecondsExceededCount waits for 30 seconds and then queries api/aggregated-discovery-metrics.
 // It expects to find minimum occurrence or exact count of `keyName` provided.
 func WaitForInstancePollSecondsExceededCount(t *testing.T, vtorcInstance *cluster.VTOrcProcess, keyName string, minCountExpected float64, enforceEquality bool) {

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -62,7 +62,7 @@ var (
 	topoInformationRefreshDuration = 15 * time.Second
 	recoveryPollDuration           = 1 * time.Second
 	ersEnabled                     = true
-	convertTabletWithErrantGTIDs   = false
+	convertTabletsWithErrantGTIDs  = false
 )
 
 // RegisterFlags registers the flags required by VTOrc
@@ -83,7 +83,7 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&topoInformationRefreshDuration, "topo-information-refresh-duration", topoInformationRefreshDuration, "Timer duration on which VTOrc refreshes the keyspace and vttablet records from the topology server")
 	fs.DurationVar(&recoveryPollDuration, "recovery-poll-duration", recoveryPollDuration, "Timer duration on which VTOrc polls its database to run a recovery")
 	fs.BoolVar(&ersEnabled, "allow-emergency-reparent", ersEnabled, "Whether VTOrc should be allowed to run emergency reparent operation when it detects a dead primary")
-	fs.BoolVar(&convertTabletWithErrantGTIDs, "convert-tablets-with-errant-gtids", convertTabletWithErrantGTIDs, "Whether VTOrc should be changing the type of the tablets with errant GTIDs to DRAINED")
+	fs.BoolVar(&convertTabletsWithErrantGTIDs, "change-tablets-with-errant-gtid-to-drained", convertTabletsWithErrantGTIDs, "Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED")
 }
 
 // Configuration makes for vtorc configuration input, which can be provided by user via JSON formatted file.
@@ -147,12 +147,12 @@ func SetERSEnabled(val bool) {
 
 // ConvertTabletWithErrantGTIDs reports whether VTOrc is allowed to change the tablet type of tablets with errant GTIDs to DRAINED.
 func ConvertTabletWithErrantGTIDs() bool {
-	return convertTabletWithErrantGTIDs
+	return convertTabletsWithErrantGTIDs
 }
 
 // SetConvertTabletWithErrantGTIDs sets the value for the convertTabletWithErrantGTIDs variable. This should only be used from tests.
 func SetConvertTabletWithErrantGTIDs(val bool) {
-	convertTabletWithErrantGTIDs = val
+	convertTabletsWithErrantGTIDs = val
 }
 
 // LogConfigValues is used to log the config values.

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -147,12 +147,12 @@ func SetERSEnabled(val bool) {
 
 // ConvertTabletWithErrantGTIDs reports whether VTOrc is allowed to change the tablet type of tablets with errant GTIDs to DRAINED.
 func ConvertTabletWithErrantGTIDs() bool {
-	return ersEnabled
+	return convertTabletWithErrantGTIDs
 }
 
 // SetConvertTabletWithErrantGTIDs sets the value for the convertTabletWithErrantGTIDs variable. This should only be used from tests.
 func SetConvertTabletWithErrantGTIDs(val bool) {
-	ersEnabled = val
+	convertTabletWithErrantGTIDs = val
 }
 
 // LogConfigValues is used to log the config values.

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -62,6 +62,7 @@ var (
 	topoInformationRefreshDuration = 15 * time.Second
 	recoveryPollDuration           = 1 * time.Second
 	ersEnabled                     = true
+	convertTabletWithErrantGTIDs   = false
 )
 
 // RegisterFlags registers the flags required by VTOrc
@@ -82,6 +83,7 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&topoInformationRefreshDuration, "topo-information-refresh-duration", topoInformationRefreshDuration, "Timer duration on which VTOrc refreshes the keyspace and vttablet records from the topology server")
 	fs.DurationVar(&recoveryPollDuration, "recovery-poll-duration", recoveryPollDuration, "Timer duration on which VTOrc polls its database to run a recovery")
 	fs.BoolVar(&ersEnabled, "allow-emergency-reparent", ersEnabled, "Whether VTOrc should be allowed to run emergency reparent operation when it detects a dead primary")
+	fs.BoolVar(&convertTabletWithErrantGTIDs, "convert-tablets-with-errant-gtids", convertTabletWithErrantGTIDs, "Whether VTOrc should be changing the type of the tablets with errant GTIDs to DRAINED")
 }
 
 // Configuration makes for vtorc configuration input, which can be provided by user via JSON formatted file.
@@ -140,6 +142,16 @@ func ERSEnabled() bool {
 
 // SetERSEnabled sets the value for the ersEnabled variable. This should only be used from tests.
 func SetERSEnabled(val bool) {
+	ersEnabled = val
+}
+
+// ConvertTabletWithErrantGTIDs reports whether VTOrc is allowed to change the tablet type of tablets with errant GTIDs to DRAINED.
+func ConvertTabletWithErrantGTIDs() bool {
+	return ersEnabled
+}
+
+// SetConvertTabletWithErrantGTIDs sets the value for the convertTabletWithErrantGTIDs variable. This should only be used from tests.
+func SetConvertTabletWithErrantGTIDs(val bool) {
 	ersEnabled = val
 }
 

--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -58,6 +58,7 @@ const (
 	PrimaryWithoutReplicas                 AnalysisCode = "PrimaryWithoutReplicas"
 	BinlogServerFailingToConnectToPrimary  AnalysisCode = "BinlogServerFailingToConnectToPrimary"
 	GraceFulPrimaryTakeover                AnalysisCode = "GracefulPrimaryTakeover"
+	ErrantGTIDDetected                     AnalysisCode = "ErrantGTIDDetected"
 )
 
 const (
@@ -118,6 +119,7 @@ type ReplicationAnalysis struct {
 	ReplicationDepth                          uint
 	IsFailingToConnectToPrimary               bool
 	ReplicationStopped                        bool
+	ErrantGTID                                string
 	Analysis                                  AnalysisCode
 	Description                               string
 	StructureAnalysis                         []StructureAnalysisCode

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -477,7 +477,7 @@ func GetReplicationAnalysis(keyspace string, shard string, hints *ReplicationAna
 			a.Analysis = PrimarySemiSyncMustNotBeSet
 			a.Description = "Primary semi-sync must not be set"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && a.ErrantGTID != "" {
+		} else if topo.IsReplicaType(a.TabletType) && a.ErrantGTID != "" && config.ConvertTabletWithErrantGTIDs() {
 			a.Analysis = ErrantGTIDDetected
 			a.Description = "Tablet has errant GTIDs"
 		} else if topo.IsReplicaType(a.TabletType) && ca.primaryAlias == "" && a.ShardPrimaryTermTimestamp == "" {

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -477,7 +477,7 @@ func GetReplicationAnalysis(keyspace string, shard string, hints *ReplicationAna
 			a.Analysis = PrimarySemiSyncMustNotBeSet
 			a.Description = "Primary semi-sync must not be set"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && a.ErrantGTID != "" && config.ConvertTabletWithErrantGTIDs() {
+		} else if topo.IsReplicaType(a.TabletType) && a.ErrantGTID != "" {
 			a.Analysis = ErrantGTIDDetected
 			a.Description = "Tablet has errant GTIDs"
 		} else if topo.IsReplicaType(a.TabletType) && ca.primaryAlias == "" && a.ShardPrimaryTermTimestamp == "" {

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -646,6 +646,47 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
 			codeWanted:     InvalidPrimary,
+		}, {
+			name: "ErrantGTID",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy:              "none",
+				LastCheckValid:                1,
+				CountReplicas:                 4,
+				CountValidReplicas:            4,
+				CountValidReplicatingReplicas: 3,
+				CountValidOracleGTIDReplicas:  4,
+				CountLoggingReplicas:          2,
+				IsPrimary:                     1,
+			}, {
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				DurabilityPolicy: "none",
+				ErrantGTID:       "some errant GTID",
+				PrimaryTabletInfo: &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+				},
+				LastCheckValid: 1,
+				ReadOnly:       1,
+			}},
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ErrantGTIDDetected,
 		},
 	}
 	for _, tt := range tests {

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -687,6 +687,47 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
 			codeWanted:     ErrantGTIDDetected,
+		}, {
+			name: "ErrantGTID on a non-replica",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy:              "none",
+				LastCheckValid:                1,
+				CountReplicas:                 4,
+				CountValidReplicas:            4,
+				CountValidReplicatingReplicas: 3,
+				CountValidOracleGTIDReplicas:  4,
+				CountLoggingReplicas:          2,
+				IsPrimary:                     1,
+			}, {
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_DRAINED,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				DurabilityPolicy: "none",
+				ErrantGTID:       "some errant GTID",
+				PrimaryTabletInfo: &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+				},
+				LastCheckValid: 1,
+				ReadOnly:       1,
+			}},
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     NoProblem,
 		},
 	}
 	for _, tt := range tests {

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -26,6 +26,7 @@ import (
 
 	"vitess.io/vitess/go/vt/external/golib/sqlutils"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vtorc/config"
 	"vitess.io/vitess/go/vt/vtorc/db"
 	"vitess.io/vitess/go/vt/vtorc/test"
 )
@@ -52,12 +53,13 @@ var (
 // rows that are specified in the test.
 func TestGetReplicationAnalysisDecision(t *testing.T) {
 	tests := []struct {
-		name           string
-		info           []*test.InfoForRecoveryAnalysis
-		codeWanted     AnalysisCode
-		shardWanted    string
-		keyspaceWanted string
-		wantErr        string
+		name                         string
+		info                         []*test.InfoForRecoveryAnalysis
+		codeWanted                   AnalysisCode
+		shardWanted                  string
+		keyspaceWanted               string
+		wantErr                      string
+		convertTabletWithErrantGTIDs bool
 	}{
 		{
 			name: "ClusterHasNoPrimary",
@@ -684,9 +686,52 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				LastCheckValid: 1,
 				ReadOnly:       1,
 			}},
-			keyspaceWanted: "ks",
-			shardWanted:    "0",
-			codeWanted:     ErrantGTIDDetected,
+			keyspaceWanted:               "ks",
+			shardWanted:                  "0",
+			codeWanted:                   ErrantGTIDDetected,
+			convertTabletWithErrantGTIDs: true,
+		}, {
+			name: "ErrantGTID - Config disallows",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy:              "none",
+				LastCheckValid:                1,
+				CountReplicas:                 4,
+				CountValidReplicas:            4,
+				CountValidReplicatingReplicas: 3,
+				CountValidOracleGTIDReplicas:  4,
+				CountLoggingReplicas:          2,
+				IsPrimary:                     1,
+			}, {
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				DurabilityPolicy: "none",
+				ErrantGTID:       "some errant GTID",
+				PrimaryTabletInfo: &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+				},
+				LastCheckValid: 1,
+				ReadOnly:       1,
+			}},
+			keyspaceWanted:               "ks",
+			shardWanted:                  "0",
+			codeWanted:                   NoProblem,
+			convertTabletWithErrantGTIDs: false,
 		}, {
 			name: "ErrantGTID on a non-replica",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -725,9 +770,10 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				LastCheckValid: 1,
 				ReadOnly:       1,
 			}},
-			keyspaceWanted: "ks",
-			shardWanted:    "0",
-			codeWanted:     NoProblem,
+			keyspaceWanted:               "ks",
+			shardWanted:                  "0",
+			codeWanted:                   NoProblem,
+			convertTabletWithErrantGTIDs: false,
 		},
 	}
 	for _, tt := range tests {
@@ -737,6 +783,11 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				db.Db = oldDB
 			}()
 
+			originalConvertTabletWithErrantGTIDs := config.ConvertTabletWithErrantGTIDs()
+			config.SetConvertTabletWithErrantGTIDs(tt.convertTabletWithErrantGTIDs)
+			defer func() {
+				config.SetConvertTabletWithErrantGTIDs(originalConvertTabletWithErrantGTIDs)
+			}()
 			var rowMaps []sqlutils.RowMap
 			for _, analysis := range tt.info {
 				analysis.SetValuesFromTabletInfo()

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -288,6 +288,11 @@ func setReadOnly(ctx context.Context, tablet *topodatapb.Tablet) error {
 	return tmc.SetReadOnly(ctx, tablet)
 }
 
+// changeTabletType calls the said RPC for the given tablet with the given parameters.
+func changeTabletType(ctx context.Context, tablet *topodatapb.Tablet, tabletType topodatapb.TabletType, semiSync bool) error {
+	return tmc.ChangeType(ctx, tablet, tabletType, semiSync)
+}
+
 // setReplicationSource calls the said RPC with the parameters provided
 func setReplicationSource(ctx context.Context, replica *topodatapb.Tablet, primary *topodatapb.Tablet, semiSync bool) error {
 	return tmc.SetReplicationSource(ctx, replica, primary.Alias, 0, "", true, semiSync)

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -409,6 +409,10 @@ func getCheckAndRecoverFunctionCode(analysisCode inst.AnalysisCode, tabletAlias 
 		}
 		return recoverPrimaryTabletDeletedFunc
 	case inst.ErrantGTIDDetected:
+		if !config.ConvertTabletWithErrantGTIDs() {
+			log.Infof("VTOrc not configured to do anything on detecting errant GTIDs, skipping recovering %v", analysisCode)
+			return noRecoveryFunc
+		}
 		return recoverErrantGTIDDetectedFunc
 	case inst.PrimaryHasPrimary:
 		return recoverPrimaryHasPrimaryFunc

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -240,6 +240,11 @@ func TestGetCheckAndRecoverFunctionCode(t *testing.T) {
 			ersEnabled:           false,
 			analysisCode:         inst.PrimarySemiSyncMustBeSet,
 			wantRecoveryFunction: fixPrimaryFunc,
+		}, {
+			name:                 "ErrantGTIDDetected",
+			ersEnabled:           false,
+			analysisCode:         inst.ErrantGTIDDetected,
+			wantRecoveryFunction: recoverErrantGTIDDetectedFunc,
 		},
 	}
 

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -195,10 +195,11 @@ func TestDifferentAnalysescHaveDifferentCooldowns(t *testing.T) {
 
 func TestGetCheckAndRecoverFunctionCode(t *testing.T) {
 	tests := []struct {
-		name                 string
-		ersEnabled           bool
-		analysisCode         inst.AnalysisCode
-		wantRecoveryFunction recoveryFunction
+		name                         string
+		ersEnabled                   bool
+		convertTabletWithErrantGTIDs bool
+		analysisCode                 inst.AnalysisCode
+		wantRecoveryFunction         recoveryFunction
 	}{
 		{
 			name:                 "DeadPrimary with ERS enabled",
@@ -241,10 +242,17 @@ func TestGetCheckAndRecoverFunctionCode(t *testing.T) {
 			analysisCode:         inst.PrimarySemiSyncMustBeSet,
 			wantRecoveryFunction: fixPrimaryFunc,
 		}, {
-			name:                 "ErrantGTIDDetected",
-			ersEnabled:           false,
-			analysisCode:         inst.ErrantGTIDDetected,
-			wantRecoveryFunction: recoverErrantGTIDDetectedFunc,
+			name:                         "ErrantGTIDDetected",
+			ersEnabled:                   false,
+			convertTabletWithErrantGTIDs: true,
+			analysisCode:                 inst.ErrantGTIDDetected,
+			wantRecoveryFunction:         recoverErrantGTIDDetectedFunc,
+		}, {
+			name:                         "ErrantGTIDDetected with --convert-tablets-with-errant-gtids false",
+			ersEnabled:                   false,
+			convertTabletWithErrantGTIDs: false,
+			analysisCode:                 inst.ErrantGTIDDetected,
+			wantRecoveryFunction:         noRecoveryFunc,
 		},
 	}
 
@@ -259,6 +267,10 @@ func TestGetCheckAndRecoverFunctionCode(t *testing.T) {
 			prevVal := config.ERSEnabled()
 			config.SetERSEnabled(tt.ersEnabled)
 			defer config.SetERSEnabled(prevVal)
+
+			convertErrantVal := config.ConvertTabletWithErrantGTIDs()
+			config.SetConvertTabletWithErrantGTIDs(tt.convertTabletWithErrantGTIDs)
+			defer config.SetConvertTabletWithErrantGTIDs(convertErrantVal)
 
 			gotFunc := getCheckAndRecoverFunctionCode(tt.analysisCode, "")
 			require.EqualValues(t, tt.wantRecoveryFunction, gotFunc)

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -248,7 +248,7 @@ func TestGetCheckAndRecoverFunctionCode(t *testing.T) {
 			analysisCode:                 inst.ErrantGTIDDetected,
 			wantRecoveryFunction:         recoverErrantGTIDDetectedFunc,
 		}, {
-			name:                         "ErrantGTIDDetected with --convert-tablets-with-errant-gtids false",
+			name:                         "ErrantGTIDDetected with --change-tablets-with-errant-gtid-to-drained false",
 			ersEnabled:                   false,
 			convertTabletWithErrantGTIDs: false,
 			analysisCode:                 inst.ErrantGTIDDetected,

--- a/go/vt/vtorc/test/recovery_analysis.go
+++ b/go/vt/vtorc/test/recovery_analysis.go
@@ -48,6 +48,7 @@ type InfoForRecoveryAnalysis struct {
 	LogPos                                    uint32
 	IsStaleBinlogCoordinates                  int
 	GTIDMode                                  string
+	ErrantGTID                                string
 	LastCheckValid                            int
 	LastCheckPartialSuccess                   int
 	CountReplicas                             uint
@@ -112,6 +113,7 @@ func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
 	rowMap["downtime_end_timestamp"] = sqlutils.CellData{String: info.DowntimeEndTimestamp, Valid: true}
 	rowMap["downtime_remaining_seconds"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.DowntimeRemainingSeconds), Valid: true}
 	rowMap["durability_policy"] = sqlutils.CellData{String: info.DurabilityPolicy, Valid: true}
+	rowMap["gtid_errant"] = sqlutils.CellData{String: info.ErrantGTID, Valid: true}
 	rowMap["gtid_mode"] = sqlutils.CellData{String: info.GTIDMode, Valid: true}
 	rowMap["hostname"] = sqlutils.CellData{String: info.Hostname, Valid: true}
 	rowMap["is_binlog_server"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsBinlogServer), Valid: true}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR introduces a new VTOrc flag `--change-tablets-with-errant-gtid-to-drained` that allows the users to toggle the ability of VTOrc to change the tablet type of tablets with errant GTIDs to `DRAINED`. By default, the flag is false.

This feature allows the users to configure VTOrc such that any tablet that encounters errant GTIDs is automatically taken out of the serving graph. These tablets can then be inspected for what the errant GTIDs are, and once fixed, they can rejoin the cluster.

When VTOrc changes the tablet to a DRAINED type, it also forgets it from its own datastore, and the user has to change the tablet back to its original type for VTOrc to start monitoring it again.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/13872

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required - https://github.com/vitessio/website/pull/1574

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
