### PR TITLE
throttler: Remove global throttler ticker goroutine

### DIFF
--- a/go/test/utils/noleak.go
+++ b/go/test/utils/noleak.go
@@ -79,8 +79,6 @@ func ensureNoGoroutines() error {
 		goleak.IgnoreTopFunction("vitess.io/vitess/go/vt/vtgate.processQueryInfo"),
 		goleak.IgnoreTopFunction("github.com/patrickmn/go-cache.(*janitor).Run"),
 		goleak.IgnoreTopFunction("vitess.io/vitess/go/vt/logutil.(*ThrottledLogger).log.func1"),
-		goleak.IgnoreTopFunction("vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.initThrottleTicker.func1.1"),
-		goleak.IgnoreTopFunction("vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.NewBackgroundClient.initThrottleTicker.func1.1"),
 		goleak.IgnoreTopFunction("testing.tRunner.func1"),
 	}
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -295,6 +295,9 @@ func (vre *Engine) IsOpen() bool {
 func (vre *Engine) Close() {
 	vre.mu.Lock()
 	defer vre.mu.Unlock()
+	if vre.throttlerClient != nil {
+		vre.throttlerClient.Close()
+	}
 
 	// If we're retrying, we're not open.
 	// Just cancel the retry loop.

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -210,6 +210,8 @@ func (collector *TableGC) Close() {
 	collector.stateMutex.Lock()
 	defer collector.stateMutex.Unlock()
 	log.Infof("TableGC - acquired lock")
+	collector.throttlerClient.Close()
+
 	if collector.isOpen == 0 {
 		log.Infof("TableGC - no collector is open")
 		// not open

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1726,6 +1726,7 @@ func (tsv *TabletServer) Close(ctx context.Context) error {
 	tsv.sm.closeAll()
 	tsv.qe.Close()
 	tsv.stats.Stop()
+	tsv.lagThrottler.Close()
 	return nil
 }
 

--- a/go/vt/vttablet/tabletserver/throttle/client.go
+++ b/go/vt/vttablet/tabletserver/throttle/client.go
@@ -138,8 +138,5 @@ func (c *Client) Throttle(ctx context.Context) {
 }
 
 func (c *Client) Close() {
-	if c.throttler != nil {
-		c.throttler.Close()
-	}
 	c.cancel()
 }

--- a/go/vt/vttablet/tabletserver/throttle/client.go
+++ b/go/vt/vttablet/tabletserver/throttle/client.go
@@ -86,8 +86,7 @@ func (c *Client) ThrottleCheckOK(ctx context.Context, overrideAppName throttlera
 		// no throttler
 		return true
 	}
-	lastTick := c.ticks.Load()
-	if c.lastSuccessfulThrottle >= lastTick {
+	if c.lastSuccessfulThrottle >= c.ticks.Load() {
 		// if last check was OK just very recently there is no need to check again
 		return true
 	}
@@ -100,7 +99,7 @@ func (c *Client) ThrottleCheckOK(ctx context.Context, overrideAppName throttlera
 	if checkResult.StatusCode != http.StatusOK {
 		return false
 	}
-	c.lastSuccessfulThrottle = lastTick
+	c.lastSuccessfulThrottle = c.ticks.Load()
 	return true
 
 }


### PR DESCRIPTION
This moves the logic to a separate goroutine for the client that we can also stop when we need to on cleanup.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required
