### PR TITLE
move routed tables rewriting to the semantic analysis

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -396,13 +396,13 @@ func createRouteFromVSchemaTable(
 	planAlternates bool,
 ) (*Route, error) {
 	if vschemaTable.Name.String() != queryTable.Table.Name.String() {
-		// we are dealing with a routed table
+		// we are dealing with a reference table
 		queryTable = queryTable.Clone()
 		name := queryTable.Table.Name
 		queryTable.Table.Name = vschemaTable.Name
 		astTable, ok := queryTable.Alias.Expr.(sqlparser.TableName)
 		if !ok {
-			return nil, vterrors.VT13001("a derived table should never be a routed table")
+			return nil, vterrors.VT13001("a derived table should never be a reference table")
 		}
 		realTableName := sqlparser.NewIdentifierCS(vschemaTable.Name.String())
 		astTable.Name = realTableName

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -397,26 +397,23 @@ func TestUnknownColumnMap2(t *testing.T) {
 
 	queries := []string{"select col from a, b", "select col from a as user, b as extra"}
 	for _, query := range queries {
-		t.Run(query, func(t *testing.T) {
-			parse, _ := sqlparser.Parse(query)
-			expr := extract(parse.(*sqlparser.Select), 0)
-
-			for _, test := range tests {
-				t.Run(test.name, func(t *testing.T) {
-					si := &FakeSI{Tables: test.schema}
-					tbl, err := Analyze(parse, "", si)
-					if test.err {
-						require.True(t, err != nil || tbl.NotSingleRouteErr != nil)
-					} else {
-						require.NoError(t, err)
-						require.NoError(t, tbl.NotSingleRouteErr)
-						typ, _, found := tbl.TypeForExpr(expr)
-						assert.True(t, found)
-						assert.Equal(t, test.typ, typ)
-					}
-				})
-			}
-		})
+		for _, test := range tests {
+			t.Run(query+":"+test.name, func(t *testing.T) {
+				parse, _ := sqlparser.Parse(query)
+				expr := extract(parse.(*sqlparser.Select), 0)
+				si := &FakeSI{Tables: test.schema}
+				tbl, err := Analyze(parse, "", si)
+				if test.err {
+					require.True(t, err != nil || tbl.NotSingleRouteErr != nil)
+				} else {
+					require.NoError(t, err)
+					require.NoError(t, tbl.NotSingleRouteErr)
+					typ, _, found := tbl.TypeForExpr(expr)
+					assert.True(t, found)
+					assert.Equal(t, test.typ, typ)
+				}
+			})
+		}
 	}
 }
 

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -115,6 +115,13 @@ func (tc *tableCollector) visitAliasedTableExpr(node *sqlparser.AliasedTableExpr
 
 		scope := tc.scoper.currentScope()
 		tableInfo := tc.createTable(t, node, tbl, isInfSchema, vindex)
+		if tbl != nil && t.Name != tbl.Name {
+			if node.As.IsEmpty() {
+				node.As = sqlparser.NewIdentifierCS(t.Name.String())
+			}
+			t.Name = tbl.Name
+			node.Expr = t
+		}
 
 		tc.Tables = append(tc.Tables, tableInfo)
 		return scope.addTable(tableInfo)


### PR DESCRIPTION
## Description
Small refactoring that moves the handling of routed tables to an earlier part of the planning process. This makes later parts simpler.

This allows subqueries to be handled as expressions even if they contain routed tables.