### PR TITLE
Remove duplicate ACL check in tabletserver handleHTTPConsolidations

### DIFF
--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -625,10 +625,6 @@ func (qe *QueryEngine) handleHTTPConsolidations(response http.ResponseWriter, re
 		acl.SendError(response, err)
 		return
 	}
-	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
-		acl.SendError(response, err)
-		return
-	}
 	items := qe.consolidator.Items()
 	response.Header().Set("Content-Type", "text/plain")
 	if items == nil {


### PR DESCRIPTION
## Description

This endpoint checks the ACL role twice unnecessarily.

## Related Issue(s)

None

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

None