### PR TITLE
Clean up deprecated slice header usage and unused code

### DIFF
--- a/go/hack/hack.go
+++ b/go/hack/hack.go
@@ -21,7 +21,6 @@ limitations under the License.
 package hack
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -37,10 +36,5 @@ func String(b []byte) (s string) {
 // StringBytes returns the underlying bytes for a string. Modifying this byte slice
 // will lead to undefined behavior.
 func StringBytes(s string) []byte {
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
-	hdr.Cap = len(s)
-	hdr.Len = len(s)
-	return b
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/go/hack/runtime.go
+++ b/go/hack/runtime.go
@@ -19,7 +19,6 @@ limitations under the License.
 package hack
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -35,8 +34,7 @@ func strhash(p unsafe.Pointer, h uintptr) uintptr
 // This is an optimal hash function which takes an input seed and is potentially implemented in hardware
 // for most architectures. This is the same hash function that the language's `map` uses.
 func RuntimeMemhash(b []byte, seed uint64) uint64 {
-	pstring := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	return uint64(memhash(unsafe.Pointer(pstring.Data), uintptr(seed), uintptr(pstring.Len)))
+	return uint64(memhash(unsafe.Pointer(unsafe.SliceData(b)), uintptr(seed), uintptr(len(b))))
 }
 
 // RuntimeStrhash provides access to the Go runtime's default hash function for strings.

--- a/go/mysql/collations/charset/korean/tables.go
+++ b/go/mysql/collations/charset/korean/tables.go
@@ -17056,8 +17056,6 @@ var decode = [...]uint16{
 	17629: 0x8A70,
 }
 
-const numEncodeTables = 7
-
 // encodeX are the encoding tables from Unicode to EUC-KR code,
 // sorted by decreasing length.
 // encode0: 20893 entries for runes in [19968, 40861).

--- a/go/mysql/collations/charset/simplifiedchinese/tables.go
+++ b/go/mysql/collations/charset/simplifiedchinese/tables.go
@@ -22091,8 +22091,6 @@ var decode = [...]uint16{
 	23844: 0x4DAE,
 }
 
-const numEncodeTables = 5
-
 // encodeX are the encoding tables from Unicode to GBK code,
 // sorted by decreasing length.
 // encode0: 28965 entries for runes in [11905, 40870).

--- a/go/mysql/collations/colldata/mysqlucadata.go
+++ b/go/mysql/collations/colldata/mysqlucadata.go
@@ -20,7 +20,6 @@ package colldata
 
 import (
 	_ "embed"
-	reflect "reflect"
 	unsafe "unsafe"
 )
 
@@ -1418,5 +1417,5 @@ var weightTable_uca520 = []*[]uint16{
 var weightsUCA_embed_data string
 
 func weightsUCA_embed(pos, length int) []uint16 {
-	return (*[0x7fff0000]uint16)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&weightsUCA_embed_data)).Data))[pos : pos+length]
+	return (*[0x7fff0000]uint16)(unsafe.Pointer(unsafe.StringData(weightsUCA_embed_data)))[pos : pos+length]
 }

--- a/go/mysql/collations/colldata/uca_tables_test.go
+++ b/go/mysql/collations/colldata/uca_tables_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"strconv"
 	"testing"
 	"unsafe"
@@ -95,12 +94,12 @@ func TestWeightsForAllCodepoints(t *testing.T) {
 }
 
 func TestWeightTablesAreDeduplicated(t *testing.T) {
-	sliceptr := func(table uca.Weights) uintptr {
-		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&table))
-		return hdr.Data
+	sliceptr := func(table uca.Weights) unsafe.Pointer {
+		data := unsafe.SliceData(table)
+		return unsafe.Pointer(data)
 	}
 
-	uniqueTables := make(map[uintptr]int)
+	uniqueTables := make(map[unsafe.Pointer]int)
 	for _, col := range testall() {
 		var weights uca.Weights
 		switch col := col.(type) {

--- a/go/mysql/collations/internal/uca/contractions.go
+++ b/go/mysql/collations/internal/uca/contractions.go
@@ -18,7 +18,6 @@ package uca
 
 import (
 	"fmt"
-	"unicode/utf8"
 
 	"vitess.io/vitess/go/mysql/collations/charset"
 )
@@ -26,19 +25,6 @@ import (
 type trie struct {
 	children map[rune]*trie
 	weights  []uint16
-}
-
-func (t *trie) walkUTF8(remainder []byte) ([]uint16, []byte) {
-	if len(remainder) > 0 {
-		cp, width := utf8.DecodeRune(remainder)
-		if cp == utf8.RuneError && width < 3 {
-			return nil, nil
-		}
-		if ch := t.children[cp]; ch != nil {
-			return ch.walkUTF8(remainder[width:])
-		}
-	}
-	return t.weights, remainder
 }
 
 func (t *trie) walkCharset(cs charset.Charset, remainder []byte, depth int) ([]uint16, []byte, int) {

--- a/go/mysql/collations/tools/makecolldata/codegen/tablegen.go
+++ b/go/mysql/collations/tools/makecolldata/codegen/tablegen.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"math/bits"
 	"os"
-	"reflect"
 
 	"vitess.io/vitess/go/mysql/collations/internal/uca"
 )
@@ -91,7 +90,6 @@ func (pg *EmbedPageGenerator) WritePage16(g *Generator, varname string, values [
 
 func (pg *EmbedPageGenerator) WriteTrailer(g *Generator, embedfile string) {
 	unsafe := Package("unsafe")
-	reflect := Package("reflect")
 	g.UsePackage("embed")
 
 	g.P()
@@ -99,7 +97,7 @@ func (pg *EmbedPageGenerator) WriteTrailer(g *Generator, embedfile string) {
 	g.P("var weightsUCA_embed_data string")
 	g.P()
 	g.P("func weightsUCA_embed(pos, length int) []uint16 {")
-	g.P("return (*[0x7fff0000]uint16)(", unsafe, ".Pointer((*", reflect, ".StringHeader)(", unsafe, ".Pointer(&weightsUCA_embed_data)).Data))[pos:pos+length]")
+	g.P("return (*[0x7fff0000]uint16)(", unsafe, ".Pointer(", unsafe, ".StringData(weightsUCA_embed_data)))[pos:pos+length]")
 	g.P("}")
 }
 
@@ -126,21 +124,10 @@ type entry struct {
 	weights []uint16
 }
 
-func (e *entry) adjustHangulWeights(tb *TableGenerator, jamos []rune) {
-	for _, jamo := range jamos {
-		_, entry := tb.entryForCodepoint(jamo)
-		e.weights = append(e.weights, entry.weights[0], entry.weights[1], entry.weights[2]+1)
-	}
-}
-
 type page struct {
 	n          int
 	entryCount int
 	entries    [uca.CodepointsPerPage]entry
-}
-
-func (p *page) equals(other *page) bool {
-	return reflect.DeepEqual(p, other)
 }
 
 func (p *page) name(uca string) string {


### PR DESCRIPTION
The collations and hack packages use deprecated reflect usage, this fixes that up. It also removes some unused bits of code as well.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required