### PR TITLE
inputs method to return additional information about the input primitive

### DIFF
--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -340,8 +340,8 @@ func (c *Concatenate) NeedsTransaction() bool {
 }
 
 // Inputs returns the input primitives for this
-func (c *Concatenate) Inputs() []Primitive {
-	return c.Sources
+func (c *Concatenate) Inputs() ([]Primitive, []map[string]any) {
+	return c.Sources, nil
 }
 
 func (c *Concatenate) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/distinct.go
+++ b/go/vt/vtgate/engine/distinct.go
@@ -246,8 +246,8 @@ func (d *Distinct) NeedsTransaction() bool {
 }
 
 // Inputs implements the Primitive interface
-func (d *Distinct) Inputs() []Primitive {
-	return []Primitive{d.Source}
+func (d *Distinct) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{d.Source}, nil
 }
 
 func (d *Distinct) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/exec_prepared_statement.go
+++ b/go/vt/vtgate/engine/exec_prepared_statement.go
@@ -61,8 +61,8 @@ func (e *ExecStmt) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVa
 	return vcursor.StreamExecutePrimitive(ctx, e.Input, bindVars, wantfields, callback)
 }
 
-func (e *ExecStmt) Inputs() []Primitive {
-	return []Primitive{e.Input}
+func (e *ExecStmt) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{e.Input}, nil
 }
 
 func (e *ExecStmt) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -43,8 +43,8 @@ type fakePrimitive struct {
 	allResultsInOneCall bool
 }
 
-func (f *fakePrimitive) Inputs() []Primitive {
-	return []Primitive{}
+func (f *fakePrimitive) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{}, nil
 }
 
 var _ Primitive = (*fakePrimitive)(nil)

--- a/go/vt/vtgate/engine/filter.go
+++ b/go/vt/vtgate/engine/filter.go
@@ -108,8 +108,8 @@ func (f *Filter) GetFields(ctx context.Context, vcursor VCursor, bindVars map[st
 }
 
 // Inputs returns the input to limit
-func (f *Filter) Inputs() []Primitive {
-	return []Primitive{f.Input}
+func (f *Filter) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{f.Input}, nil
 }
 
 func (f *Filter) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/hash_join.go
+++ b/go/vt/vtgate/engine/hash_join.go
@@ -234,8 +234,8 @@ func (hj *HashJoin) NeedsTransaction() bool {
 }
 
 // Inputs implements the Primitive interface
-func (hj *HashJoin) Inputs() []Primitive {
-	return []Primitive{hj.Left, hj.Right}
+func (hj *HashJoin) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{hj.Left, hj.Right}, nil
 }
 
 // description implements the Primitive interface

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -108,11 +108,11 @@ type (
 	ksID = []byte
 )
 
-func (ins *Insert) Inputs() []Primitive {
+func (ins *Insert) Inputs() ([]Primitive, []map[string]any) {
 	if ins.Input == nil {
-		return nil
+		return nil, nil
 	}
-	return []Primitive{ins.Input}
+	return []Primitive{ins.Input}, nil
 }
 
 // NewQueryInsert creates an Insert with a query string.

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -189,8 +189,8 @@ func (jn *Join) GetFields(ctx context.Context, vcursor VCursor, bindVars map[str
 }
 
 // Inputs returns the input primitives for this join
-func (jn *Join) Inputs() []Primitive {
-	return []Primitive{jn.Left, jn.Right}
+func (jn *Join) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{jn.Left, jn.Right}, nil
 }
 
 func joinFields(lfields, rfields []*querypb.Field, cols []int) []*querypb.Field {

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -154,8 +154,8 @@ func (l *Limit) GetFields(ctx context.Context, vcursor VCursor, bindVars map[str
 }
 
 // Inputs returns the input to limit
-func (l *Limit) Inputs() []Primitive {
-	return []Primitive{l.Input}
+func (l *Limit) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{l.Input}, nil
 }
 
 // NeedsTransaction implements the Primitive interface.

--- a/go/vt/vtgate/engine/memory_sort.go
+++ b/go/vt/vtgate/engine/memory_sort.go
@@ -150,8 +150,8 @@ func (ms *MemorySort) GetFields(ctx context.Context, vcursor VCursor, bindVars m
 }
 
 // Inputs returns the input to memory sort
-func (ms *MemorySort) Inputs() []Primitive {
-	return []Primitive{ms.Input}
+func (ms *MemorySort) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{ms.Input}, nil
 }
 
 // NeedsTransaction implements the Primitive interface

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -251,8 +251,8 @@ func (oa *OrderedAggregate) GetFields(ctx context.Context, vcursor VCursor, bind
 }
 
 // Inputs returns the Primitive input for this aggregation
-func (oa *OrderedAggregate) Inputs() []Primitive {
-	return []Primitive{oa.Input}
+func (oa *OrderedAggregate) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{oa.Input}, nil
 }
 
 // NeedsTransaction implements the Primitive interface

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -223,7 +223,7 @@ type (
 		TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error
 
 		// Inputs is a slice containing the inputs to this Primitive
-		Inputs() []Primitive
+		Inputs() ([]Primitive, []map[string]any)
 
 		// description is the description, sans the inputs, of this Primitive.
 		// to get the plan description with all children, use PrimitiveToPlanDescription()
@@ -245,7 +245,8 @@ func Find(isMatch Match, start Primitive) Primitive {
 	if isMatch(start) {
 		return start
 	}
-	for _, input := range start.Inputs() {
+	inputs, _ := start.Inputs()
+	for _, input := range inputs {
 		result := Find(isMatch, input)
 		if result != nil {
 			return result
@@ -260,8 +261,8 @@ func Exists(m Match, p Primitive) bool {
 }
 
 // Inputs implements no inputs
-func (noInputs) Inputs() []Primitive {
-	return nil
+func (noInputs) Inputs() ([]Primitive, []map[string]any) {
+	return nil, nil
 }
 
 func (noTxNeeded) NeedsTransaction() bool {

--- a/go/vt/vtgate/engine/projection.go
+++ b/go/vt/vtgate/engine/projection.go
@@ -165,8 +165,8 @@ func (p *Projection) evalFields(env *evalengine.ExpressionEnv, infields []*query
 }
 
 // Inputs implements the Primitive interface
-func (p *Projection) Inputs() []Primitive {
-	return []Primitive{p.Input}
+func (p *Projection) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{p.Input}, nil
 }
 
 // description implements the Primitive interface

--- a/go/vt/vtgate/engine/pullout_subquery.go
+++ b/go/vt/vtgate/engine/pullout_subquery.go
@@ -43,8 +43,8 @@ type PulloutSubquery struct {
 }
 
 // Inputs returns the input primitives for this join
-func (ps *PulloutSubquery) Inputs() []Primitive {
-	return []Primitive{ps.Subquery, ps.Underlying}
+func (ps *PulloutSubquery) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{ps.Subquery, ps.Underlying}, nil
 }
 
 // RouteType returns a description of the query routing type used by the primitive

--- a/go/vt/vtgate/engine/pullout_subquery.go
+++ b/go/vt/vtgate/engine/pullout_subquery.go
@@ -44,7 +44,11 @@ type PulloutSubquery struct {
 
 // Inputs returns the input primitives for this join
 func (ps *PulloutSubquery) Inputs() ([]Primitive, []map[string]any) {
-	return []Primitive{ps.Subquery, ps.Underlying}, nil
+	return []Primitive{ps.Subquery, ps.Underlying}, []map[string]any{{
+		inputName: "SubQuery",
+	}, {
+		inputName: "Outer",
+	}}
 }
 
 // RouteType returns a description of the query routing type used by the primitive

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -110,8 +110,8 @@ func (r *RenameFields) GetFields(ctx context.Context, vcursor VCursor, bindVars 
 }
 
 // Inputs implements the primitive interface
-func (r *RenameFields) Inputs() []Primitive {
-	return []Primitive{r.Input}
+func (r *RenameFields) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{r.Input}, nil
 }
 
 // description implements the primitive interface

--- a/go/vt/vtgate/engine/replace_variables.go
+++ b/go/vt/vtgate/engine/replace_variables.go
@@ -77,8 +77,8 @@ func (r *ReplaceVariables) GetFields(ctx context.Context, vcursor VCursor, bindV
 }
 
 // Inputs implements the Primitive interface
-func (r *ReplaceVariables) Inputs() []Primitive {
-	return []Primitive{r.Input}
+func (r *ReplaceVariables) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{r.Input}, nil
 }
 
 // description implements the Primitive interface

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -212,8 +212,8 @@ func createEmptyValueFor(opcode AggregateOpcode) (sqltypes.Value, error) {
 }
 
 // Inputs implements the Primitive interface
-func (sa *ScalarAggregate) Inputs() []Primitive {
-	return []Primitive{sa.Input}
+func (sa *ScalarAggregate) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{sa.Input}, nil
 }
 
 // description implements the Primitive interface

--- a/go/vt/vtgate/engine/semi_join.go
+++ b/go/vt/vtgate/engine/semi_join.go
@@ -102,8 +102,8 @@ func (jn *SemiJoin) GetFields(ctx context.Context, vcursor VCursor, bindVars map
 }
 
 // Inputs returns the input primitives for this SemiJoin
-func (jn *SemiJoin) Inputs() []Primitive {
-	return []Primitive{jn.Left, jn.Right}
+func (jn *SemiJoin) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{jn.Left, jn.Right}, nil
 }
 
 // RouteType returns a description of the query routing type used by the primitive

--- a/go/vt/vtgate/engine/semi_join.go
+++ b/go/vt/vtgate/engine/semi_join.go
@@ -103,7 +103,11 @@ func (jn *SemiJoin) GetFields(ctx context.Context, vcursor VCursor, bindVars map
 
 // Inputs returns the input primitives for this SemiJoin
 func (jn *SemiJoin) Inputs() ([]Primitive, []map[string]any) {
-	return []Primitive{jn.Left, jn.Right}, nil
+	return []Primitive{jn.Left, jn.Right}, []map[string]any{{
+		inputName: "Outer",
+	}, {
+		inputName: "SubQuery",
+	}}
 }
 
 // RouteType returns a description of the query routing type used by the primitive

--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -153,8 +153,8 @@ func (s *Set) GetFields(context.Context, VCursor, map[string]*querypb.BindVariab
 }
 
 // Inputs implements the Primitive interface
-func (s *Set) Inputs() []Primitive {
-	return []Primitive{s.Input}
+func (s *Set) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{s.Input}, nil
 }
 
 func (s *Set) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/simple_projection.go
+++ b/go/vt/vtgate/engine/simple_projection.go
@@ -79,8 +79,8 @@ func (sc *SimpleProjection) GetFields(ctx context.Context, vcursor VCursor, bind
 }
 
 // Inputs returns the input to this primitive
-func (sc *SimpleProjection) Inputs() []Primitive {
-	return []Primitive{sc.Input}
+func (sc *SimpleProjection) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{sc.Input}, nil
 }
 
 // buildResult builds a new result by pulling the necessary columns from

--- a/go/vt/vtgate/engine/sql_calc_found_rows.go
+++ b/go/vt/vtgate/engine/sql_calc_found_rows.go
@@ -114,8 +114,8 @@ func (s SQLCalcFoundRows) NeedsTransaction() bool {
 }
 
 // Inputs implements the Primitive interface
-func (s SQLCalcFoundRows) Inputs() []Primitive {
-	return []Primitive{s.LimitPrimitive, s.CountPrimitive}
+func (s SQLCalcFoundRows) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{s.LimitPrimitive, s.CountPrimitive}, nil
 }
 
 func (s SQLCalcFoundRows) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/vexplain.go
+++ b/go/vt/vtgate/engine/vexplain.go
@@ -170,11 +170,22 @@ func primitiveToPlanDescriptionWithSQLResults(in Primitive, res map[Primitive]st
 		this.Other["mysql_explain_json"] = json.RawMessage(v)
 	}
 
-	for _, input := range in.Inputs() {
-		this.Inputs = append(this.Inputs, primitiveToPlanDescriptionWithSQLResults(input, res))
+	inputs, infos := in.Inputs()
+	for idx, input := range inputs {
+		pd := primitiveToPlanDescriptionWithSQLResults(input, res)
+		if infos != nil {
+			for k, v := range infos[idx] {
+				if k == inputName {
+					pd.InputName = v.(string)
+					continue
+				}
+				pd.Other[k] = v
+			}
+		}
+		this.Inputs = append(this.Inputs, pd)
 	}
 
-	if len(in.Inputs()) == 0 {
+	if len(inputs) == 0 {
 		this.Inputs = []PrimitiveDescription{}
 	}
 
@@ -206,8 +217,8 @@ func convertToVExplainQueriesResult(logs []ExecuteEntry) *sqltypes.Result {
 }
 
 // Inputs implements the Primitive interface
-func (v *VExplain) Inputs() []Primitive {
-	return []Primitive{v.Input}
+func (v *VExplain) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{v.Input}, nil
 }
 
 func (v *VExplain) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/vindex_lookup.go
+++ b/go/vt/vtgate/engine/vindex_lookup.go
@@ -136,12 +136,12 @@ func (vr *VindexLookup) TryStreamExecute(ctx context.Context, vcursor VCursor, b
 }
 
 // Inputs implements the Primitive interface
-func (vr *VindexLookup) Inputs() []Primitive {
+func (vr *VindexLookup) Inputs() ([]Primitive, []map[string]any) {
 	if vr.Lookup != nil {
-		return []Primitive{vr.Lookup, vr.SendTo}
+		return []Primitive{vr.Lookup, vr.SendTo}, nil
 	}
 
-	return []Primitive{vr.SendTo}
+	return []Primitive{vr.SendTo}, nil
 }
 
 // description implements the Primitive interface

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -1691,6 +1691,7 @@
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -1703,6 +1704,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2556,6 +2558,7 @@
                 "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
+                    "InputName": "Outer",
                     "OperatorType": "Route",
                     "Variant": "Scatter",
                     "Keyspace": {
@@ -2567,6 +2570,7 @@
                     "Table": "`user`"
                   },
                   {
+                    "InputName": "SubQuery",
                     "OperatorType": "Route",
                     "Variant": "Scatter",
                     "Keyspace": {
@@ -3259,6 +3263,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "SimpleProjection",
             "Columns": [
               0
@@ -3291,6 +3296,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -4160,6 +4160,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -4171,6 +4172,7 @@
             "Table": "unsharded"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Update",
             "Variant": "Scatter",
             "Keyspace": {
@@ -4203,6 +4205,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -4214,6 +4217,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Update",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -4246,6 +4250,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "R:0",
@@ -4283,6 +4288,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Update",
             "Variant": "Unsharded",
             "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -1897,6 +1897,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -1908,6 +1909,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -1944,6 +1946,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -1955,6 +1958,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -1986,6 +1990,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Limit",
             "Count": "INT64(1)",
             "Inputs": [
@@ -2003,6 +2008,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2035,6 +2041,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2046,6 +2053,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2082,6 +2090,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Subquery",
             "Variant": "PulloutIn",
             "PulloutVars": [
@@ -2090,6 +2099,7 @@
             ],
             "Inputs": [
               {
+                "InputName": "SubQuery",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
@@ -2101,6 +2111,7 @@
                 "Table": "`user`"
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
@@ -2114,6 +2125,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2172,6 +2184,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -2183,6 +2196,7 @@
             "Table": "unsharded"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2449,6 +2463,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2464,6 +2479,7 @@
             "Vindex": "user_index"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Subquery",
             "Variant": "PulloutNotIn",
             "PulloutVars": [
@@ -2472,6 +2488,7 @@
             ],
             "Inputs": [
               {
+                "InputName": "SubQuery",
                 "OperatorType": "Route",
                 "Variant": "EqualUnique",
                 "Keyspace": {
@@ -2487,6 +2504,7 @@
                 "Vindex": "user_index"
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Route",
                 "Variant": "IN",
                 "Keyspace": {
@@ -2623,6 +2641,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -2634,6 +2653,7 @@
             "Table": "unsharded"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -2812,6 +2832,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2827,6 +2848,7 @@
             "Vindex": "user_index"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2859,6 +2881,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2874,6 +2897,7 @@
             "Vindex": "user_index"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2911,6 +2935,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2926,6 +2951,7 @@
             "Vindex": "user_index"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -3214,6 +3240,7 @@
             ],
             "Inputs": [
               {
+                "InputName": "SubQuery",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
@@ -3225,6 +3252,7 @@
                 "Table": "music"
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
@@ -4208,6 +4236,7 @@
         "TableName": "unsharded_`user`_unsharded",
         "Inputs": [
           {
+            "InputName": "Outer",
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "R:0,L:0",
@@ -4238,6 +4267,7 @@
             ]
           },
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -72,9 +72,34 @@
       "Original": "delete from multicol_tbl1 where cola = 1 and  colb = 2 and colc = 3",
       "Instructions": {
         "OperatorType": "FkCascade",
-        "Children": [
+        "Inputs": [
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "FieldQuery": "select colb, cola, y, colc, x from multicol_tbl1 where 1 != 1",
+            "Query": "select colb, cola, y, colc, x from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3 lock in share mode",
+            "Table": "multicol_tbl1",
+            "Values": [
+              "INT64(1)",
+              "INT64(2)",
+              "INT64(3)"
+            ],
+            "Vindex": "multicolIdx"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "Delete",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
             "BvName": "fkc_vals",
             "Cols": [
               0,
@@ -83,55 +108,28 @@
               3,
               4
             ],
-            "Inputs": [
-              {
-                "OperatorType": "Delete",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "sharded_fk_allow",
-                  "Sharded": true
-                },
-                "TargetTabletType": "PRIMARY",
-                "Query": "delete from multicol_tbl2 where (colb, cola, x, colc, y) in ::fkc_vals",
-                "Table": "multicol_tbl2"
-              }
-            ]
+            "Query": "delete from multicol_tbl2 where (colb, cola, x, colc, y) in ::fkc_vals",
+            "Table": "multicol_tbl2"
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Delete",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "delete from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
+            "Table": "multicol_tbl1",
+            "Values": [
+              "INT64(1)",
+              "INT64(2)",
+              "INT64(3)"
+            ],
+            "Vindex": "multicolIdx"
           }
-        ],
-        "Parent": {
-          "OperatorType": "Delete",
-          "Variant": "EqualUnique",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "delete from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
-          "Table": "multicol_tbl1",
-          "Values": [
-            "INT64(1)",
-            "INT64(2)",
-            "INT64(3)"
-          ],
-          "Vindex": "multicolIdx"
-        },
-        "Selection": {
-          "OperatorType": "Route",
-          "Variant": "EqualUnique",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "FieldQuery": "select colb, cola, y, colc, x from multicol_tbl1 where 1 != 1",
-          "Query": "select colb, cola, y, colc, x from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3 lock in share mode",
-          "Table": "multicol_tbl1",
-          "Values": [
-            "INT64(1)",
-            "INT64(2)",
-            "INT64(3)"
-          ],
-          "Vindex": "multicolIdx"
-        }
+        ]
       },
       "TablesUsed": [
         "sharded_fk_allow.multicol_tbl1",
@@ -147,70 +145,64 @@
       "Original": "delete from tbl5",
       "Instructions": {
         "OperatorType": "FkCascade",
-        "Children": [
+        "Inputs": [
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "FieldQuery": "select col5, t5col5 from tbl5 where 1 != 1",
+            "Query": "select col5, t5col5 from tbl5 lock in share mode",
+            "Table": "tbl5"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "Delete",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
             "BvName": "fkc_vals",
             "Cols": [
               0
             ],
-            "Inputs": [
-              {
-                "OperatorType": "Delete",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "sharded_fk_allow",
-                  "Sharded": true
-                },
-                "TargetTabletType": "PRIMARY",
-                "Query": "delete from tbl4 where (col4) in ::fkc_vals",
-                "Table": "tbl4"
-              }
-            ]
+            "Query": "delete from tbl4 where (col4) in ::fkc_vals",
+            "Table": "tbl4"
           },
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "CascadeChild-2",
+            "OperatorType": "Delete",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
             "BvName": "fkc_vals1",
             "Cols": [
               1
             ],
-            "Inputs": [
-              {
-                "OperatorType": "Delete",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "sharded_fk_allow",
-                  "Sharded": true
-                },
-                "TargetTabletType": "PRIMARY",
-                "Query": "delete from tbl4 where (t4col4) in ::fkc_vals1",
-                "Table": "tbl4"
-              }
-            ]
+            "Query": "delete from tbl4 where (t4col4) in ::fkc_vals1",
+            "Table": "tbl4"
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Delete",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "delete from tbl5",
+            "Table": "tbl5"
           }
-        ],
-        "Parent": {
-          "OperatorType": "Delete",
-          "Variant": "Scatter",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "delete from tbl5",
-          "Table": "tbl5"
-        },
-        "Selection": {
-          "OperatorType": "Route",
-          "Variant": "Scatter",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "FieldQuery": "select col5, t5col5 from tbl5 where 1 != 1",
-          "Query": "select col5, t5col5 from tbl5 lock in share mode",
-          "Table": "tbl5"
-        }
+        ]
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl4",
@@ -231,50 +223,48 @@
       "Original": "delete from u_tbl9 where col9 = 5",
       "Instructions": {
         "OperatorType": "FkCascade",
-        "Children": [
+        "Inputs": [
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
+            "Query": "select col9 from u_tbl9 where col9 = 5 lock in share mode",
+            "Table": "u_tbl9"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "Update",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
             "BvName": "fkc_vals",
             "Cols": [
               0
             ],
-            "Inputs": [
-              {
-                "OperatorType": "Update",
-                "Variant": "Unsharded",
-                "Keyspace": {
-                  "Name": "unsharded_fk_allow",
-                  "Sharded": false
-                },
-                "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
-              }
-            ]
+            "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals",
+            "Table": "u_tbl8"
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Delete",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "delete from u_tbl9 where col9 = 5",
+            "Table": "u_tbl9"
           }
-        ],
-        "Parent": {
-          "OperatorType": "Delete",
-          "Variant": "Unsharded",
-          "Keyspace": {
-            "Name": "unsharded_fk_allow",
-            "Sharded": false
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "delete from u_tbl9 where col9 = 5",
-          "Table": "u_tbl9"
-        },
-        "Selection": {
-          "OperatorType": "Route",
-          "Variant": "Unsharded",
-          "Keyspace": {
-            "Name": "unsharded_fk_allow",
-            "Sharded": false
-          },
-          "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
-          "Query": "select col9 from u_tbl9 where col9 = 5 lock in share mode",
-          "Table": "u_tbl9"
-        }
+        ]
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl8",
@@ -312,50 +302,48 @@
       "Original": "update u_tbl2 set col2 = 'bar' where id = 1",
       "Instructions": {
         "OperatorType": "FkCascade",
-        "Children": [
+        "Inputs": [
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "FieldQuery": "select col2 from u_tbl2 where 1 != 1",
+            "Query": "select col2 from u_tbl2 where id = 1 lock in share mode",
+            "Table": "u_tbl2"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "Update",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
             "BvName": "fkc_vals",
             "Cols": [
               0
             ],
-            "Inputs": [
-              {
-                "OperatorType": "Update",
-                "Variant": "Unsharded",
-                "Keyspace": {
-                  "Name": "unsharded_fk_allow",
-                  "Sharded": false
-                },
-                "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ('bar')",
-                "Table": "u_tbl3"
-              }
-            ]
+            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ('bar')",
+            "Table": "u_tbl3"
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Update",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "update u_tbl2 set col2 = 'bar' where id = 1",
+            "Table": "u_tbl2"
           }
-        ],
-        "Parent": {
-          "OperatorType": "Update",
-          "Variant": "Unsharded",
-          "Keyspace": {
-            "Name": "unsharded_fk_allow",
-            "Sharded": false
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "update u_tbl2 set col2 = 'bar' where id = 1",
-          "Table": "u_tbl2"
-        },
-        "Selection": {
-          "OperatorType": "Route",
-          "Variant": "Unsharded",
-          "Keyspace": {
-            "Name": "unsharded_fk_allow",
-            "Sharded": false
-          },
-          "FieldQuery": "select col2 from u_tbl2 where 1 != 1",
-          "Query": "select col2 from u_tbl2 where id = 1 lock in share mode",
-          "Table": "u_tbl2"
-        }
+        ]
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl2",
@@ -425,50 +413,48 @@
       "Original": "update tbl5 set t5col5 = 'foo'",
       "Instructions": {
         "OperatorType": "FkCascade",
-        "Children": [
+        "Inputs": [
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "FieldQuery": "select t5col5 from tbl5 where 1 != 1",
+            "Query": "select t5col5 from tbl5 lock in share mode",
+            "Table": "tbl5"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "Update",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
             "BvName": "fkc_vals",
             "Cols": [
               0
             ],
-            "Inputs": [
-              {
-                "OperatorType": "Update",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "sharded_fk_allow",
-                  "Sharded": true
-                },
-                "TargetTabletType": "PRIMARY",
-                "Query": "update tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in ('foo')",
-                "Table": "tbl4"
-              }
-            ]
+            "Query": "update tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in ('foo')",
+            "Table": "tbl4"
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Update",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "update tbl5 set t5col5 = 'foo'",
+            "Table": "tbl5"
           }
-        ],
-        "Parent": {
-          "OperatorType": "Update",
-          "Variant": "Scatter",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "update tbl5 set t5col5 = 'foo'",
-          "Table": "tbl5"
-        },
-        "Selection": {
-          "OperatorType": "Route",
-          "Variant": "Scatter",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "FieldQuery": "select t5col5 from tbl5 where 1 != 1",
-          "Query": "select t5col5 from tbl5 lock in share mode",
-          "Table": "tbl5"
-        }
+        ]
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl4",
@@ -521,58 +507,56 @@
       "Original": "delete from tbl9 where col9 = 34",
       "Instructions": {
         "OperatorType": "FkCascade",
-        "Children": [
+        "Inputs": [
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "FieldQuery": "select col9 from tbl9 where 1 != 1",
+            "Query": "select col9 from tbl9 where col9 = 34 lock in share mode",
+            "Table": "tbl9",
+            "Values": [
+              "INT64(34)"
+            ],
+            "Vindex": "hash_vin"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "Update",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
             "BvName": "fkc_vals",
             "Cols": [
               0
             ],
-            "Inputs": [
-              {
-                "OperatorType": "Update",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "sharded_fk_allow",
-                  "Sharded": true
-                },
-                "TargetTabletType": "PRIMARY",
-                "Query": "update tbl4 set col_ref = null where (col_ref) in ::fkc_vals",
-                "Table": "tbl4"
-              }
-            ]
+            "Query": "update tbl4 set col_ref = null where (col_ref) in ::fkc_vals",
+            "Table": "tbl4"
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Delete",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "delete from tbl9 where col9 = 34",
+            "Table": "tbl9",
+            "Values": [
+              "INT64(34)"
+            ],
+            "Vindex": "hash_vin"
           }
-        ],
-        "Parent": {
-          "OperatorType": "Delete",
-          "Variant": "EqualUnique",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "delete from tbl9 where col9 = 34",
-          "Table": "tbl9",
-          "Values": [
-            "INT64(34)"
-          ],
-          "Vindex": "hash_vin"
-        },
-        "Selection": {
-          "OperatorType": "Route",
-          "Variant": "EqualUnique",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "FieldQuery": "select col9 from tbl9 where 1 != 1",
-          "Query": "select col9 from tbl9 where col9 = 34 lock in share mode",
-          "Table": "tbl9",
-          "Values": [
-            "INT64(34)"
-          ],
-          "Vindex": "hash_vin"
-        }
+        ]
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl4",
@@ -588,142 +572,132 @@
       "Original": "update u_tbl1 set col1 = 'foo'",
       "Instructions": {
         "OperatorType": "FkCascade",
-        "Children": [
+        "Inputs": [
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "FieldQuery": "select col1, col1 from u_tbl1 where 1 != 1",
+            "Query": "select col1, col1 from u_tbl1 lock in share mode",
+            "Table": "u_tbl1"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "FkCascade",
             "BvName": "fkc_vals",
             "Cols": [
               0
             ],
             "Inputs": [
               {
-                "OperatorType": "FkCascade",
-                "Children": [
-                  {
-                    "OperatorType": "FkCascadeChild",
-                    "BvName": "fkc_vals1",
-                    "Cols": [
-                      0
-                    ],
-                    "Inputs": [
-                      {
-                        "OperatorType": "Update",
-                        "Variant": "Unsharded",
-                        "Keyspace": {
-                          "Name": "unsharded_fk_allow",
-                          "Sharded": false
-                        },
-                        "TargetTabletType": "PRIMARY",
-                        "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ('foo')",
-                        "Table": "u_tbl3"
-                      }
-                    ]
-                  }
-                ],
-                "Parent": {
-                  "OperatorType": "Update",
-                  "Variant": "Unsharded",
-                  "Keyspace": {
-                    "Name": "unsharded_fk_allow",
-                    "Sharded": false
-                  },
-                  "TargetTabletType": "PRIMARY",
-                  "Query": "update u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals",
-                  "Table": "u_tbl2"
+                "InputName": "Selection",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
                 },
-                "Selection": {
-                  "OperatorType": "Route",
-                  "Variant": "Unsharded",
-                  "Keyspace": {
-                    "Name": "unsharded_fk_allow",
-                    "Sharded": false
-                  },
-                  "FieldQuery": "select col2 from u_tbl2 where 1 != 1",
-                  "Query": "select col2 from u_tbl2 where (col2) in ::fkc_vals",
-                  "Table": "u_tbl2"
-                }
+                "FieldQuery": "select col2 from u_tbl2 where 1 != 1",
+                "Query": "select col2 from u_tbl2 where (col2) in ::fkc_vals",
+                "Table": "u_tbl2"
+              },
+              {
+                "InputName": "CascadeChild-1",
+                "OperatorType": "Update",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "TargetTabletType": "PRIMARY",
+                "BvName": "fkc_vals1",
+                "Cols": [
+                  0
+                ],
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ('foo')",
+                "Table": "u_tbl3"
+              },
+              {
+                "InputName": "Parent",
+                "OperatorType": "Update",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "TargetTabletType": "PRIMARY",
+                "Query": "update u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals",
+                "Table": "u_tbl2"
               }
             ]
           },
           {
-            "OperatorType": "FkCascadeChild",
+            "InputName": "CascadeChild-2",
+            "OperatorType": "FkCascade",
             "BvName": "fkc_vals2",
             "Cols": [
               1
             ],
             "Inputs": [
               {
-                "OperatorType": "FkCascade",
-                "Children": [
-                  {
-                    "OperatorType": "FkCascadeChild",
-                    "BvName": "fkc_vals3",
-                    "Cols": [
-                      0
-                    ],
-                    "Inputs": [
-                      {
-                        "OperatorType": "Update",
-                        "Variant": "Unsharded",
-                        "Keyspace": {
-                          "Name": "unsharded_fk_allow",
-                          "Sharded": false
-                        },
-                        "TargetTabletType": "PRIMARY",
-                        "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                        "Table": "u_tbl8"
-                      }
-                    ]
-                  }
-                ],
-                "Parent": {
-                  "OperatorType": "Update",
-                  "Variant": "Unsharded",
-                  "Keyspace": {
-                    "Name": "unsharded_fk_allow",
-                    "Sharded": false
-                  },
-                  "TargetTabletType": "PRIMARY",
-                  "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ('foo')",
-                  "Table": "u_tbl9"
+                "InputName": "Selection",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
                 },
-                "Selection": {
-                  "OperatorType": "Route",
-                  "Variant": "Unsharded",
-                  "Keyspace": {
-                    "Name": "unsharded_fk_allow",
-                    "Sharded": false
-                  },
-                  "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
-                  "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ('foo')",
-                  "Table": "u_tbl9"
-                }
+                "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
+                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ('foo')",
+                "Table": "u_tbl9"
+              },
+              {
+                "InputName": "CascadeChild-1",
+                "OperatorType": "Update",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "TargetTabletType": "PRIMARY",
+                "BvName": "fkc_vals3",
+                "Cols": [
+                  0
+                ],
+                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
+                "Table": "u_tbl8"
+              },
+              {
+                "InputName": "Parent",
+                "OperatorType": "Update",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "TargetTabletType": "PRIMARY",
+                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ('foo')",
+                "Table": "u_tbl9"
               }
             ]
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Update",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "update u_tbl1 set col1 = 'foo'",
+            "Table": "u_tbl1"
           }
-        ],
-        "Parent": {
-          "OperatorType": "Update",
-          "Variant": "Unsharded",
-          "Keyspace": {
-            "Name": "unsharded_fk_allow",
-            "Sharded": false
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "update u_tbl1 set col1 = 'foo'",
-          "Table": "u_tbl1"
-        },
-        "Selection": {
-          "OperatorType": "Route",
-          "Variant": "Unsharded",
-          "Keyspace": {
-            "Name": "unsharded_fk_allow",
-            "Sharded": false
-          },
-          "FieldQuery": "select col1, col1 from u_tbl1 where 1 != 1",
-          "Query": "select col1, col1 from u_tbl1 lock in share mode",
-          "Table": "u_tbl1"
-        }
+        ]
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl1",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -2058,6 +2058,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2069,6 +2070,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -2102,6 +2104,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2113,6 +2116,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -2147,6 +2151,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2158,6 +2163,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -2192,6 +2198,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2203,6 +2210,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
@@ -2255,6 +2263,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2266,6 +2275,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Join",
             "Variant": "LeftJoin",
             "JoinColumnIndexes": "L:0",
@@ -2318,6 +2328,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2329,6 +2340,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "R:0",
@@ -3155,6 +3167,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Limit",
             "Count": "INT64(1)",
             "Inputs": [
@@ -3172,6 +3185,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Subquery",
             "Variant": "PulloutIn",
             "PulloutVars": [
@@ -3180,6 +3194,7 @@
             ],
             "Inputs": [
               {
+                "InputName": "SubQuery",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
@@ -3191,6 +3206,7 @@
                 "Table": "user_extra"
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Route",
                 "Variant": "IN",
                 "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -945,6 +945,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Concatenate",
             "Inputs": [
               {
@@ -974,6 +975,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "DBA",
             "Keyspace": {
@@ -1048,6 +1050,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Concatenate",
             "Inputs": [
               {
@@ -1076,6 +1079,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "DBA",
             "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1010,6 +1010,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Concatenate",
             "Inputs": [
               {
@@ -1039,6 +1040,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "DBA",
             "Keyspace": {
@@ -1113,6 +1115,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Concatenate",
             "Inputs": [
               {
@@ -1141,6 +1144,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "DBA",
             "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -125,6 +125,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -136,6 +137,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -417,6 +419,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -428,6 +431,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -620,6 +624,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -631,6 +636,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -738,6 +744,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -749,6 +756,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -1260,6 +1268,7 @@
             ],
             "Inputs": [
               {
+                "InputName": "SubQuery",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
@@ -1271,6 +1280,7 @@
                 "Table": "`user`"
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1233,6 +1233,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -1244,6 +1245,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -1276,6 +1278,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -1287,6 +1290,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Unsharded",
             "Keyspace": {
@@ -2030,6 +2034,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Limit",
             "Count": "INT64(1)",
             "Inputs": [
@@ -2047,6 +2052,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
@@ -2105,6 +2111,7 @@
             ],
             "Inputs": [
               {
+                "InputName": "SubQuery",
                 "OperatorType": "Limit",
                 "Count": "INT64(1)",
                 "Inputs": [
@@ -2122,6 +2129,7 @@
                 ]
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0",
@@ -2243,6 +2251,7 @@
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2254,6 +2263,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2291,6 +2301,7 @@
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2303,6 +2314,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -2341,6 +2353,7 @@
         "TableName": "`user`_`user`_user_extra",
         "Inputs": [
           {
+            "InputName": "Outer",
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,R:0,L:1",
@@ -2371,6 +2384,7 @@
             ]
           },
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2404,6 +2418,7 @@
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2415,6 +2430,7 @@
             "Table": "`user`"
           },
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2697,6 +2713,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Limit",
             "Count": "INT64(1)",
             "Inputs": [
@@ -2716,6 +2733,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {
@@ -2978,6 +2996,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Limit",
             "Count": "INT64(1)",
             "Inputs": [
@@ -2995,6 +3014,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Reference",
             "Keyspace": {
@@ -3542,6 +3562,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "any_value(0) AS id",
@@ -3563,6 +3584,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -3599,6 +3621,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Limit",
             "Count": "INT64(10)",
             "Inputs": [
@@ -3616,6 +3639,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -3678,6 +3702,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
             "Aggregates": "max(0) AS max(music.id)",
@@ -3700,6 +3725,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -3736,6 +3762,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -3751,6 +3778,7 @@
             "Vindex": "user_index"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -3787,6 +3815,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Route",
             "Variant": "EqualUnique",
             "Keyspace": {
@@ -3802,6 +3831,7 @@
             "Vindex": "user_index"
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -3890,6 +3920,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "SimpleProjection",
             "Columns": [
               0
@@ -3919,6 +3950,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -3955,6 +3987,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "SimpleProjection",
             "Columns": [
               0
@@ -3980,6 +4013,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -169,6 +169,7 @@
                 "TableName": "orders_lineitem",
                 "Inputs": [
                   {
+                    "InputName": "Outer",
                     "OperatorType": "Route",
                     "Variant": "Scatter",
                     "Keyspace": {
@@ -181,6 +182,7 @@
                     "Table": "orders"
                   },
                   {
+                    "InputName": "SubQuery",
                     "OperatorType": "VindexLookup",
                     "Variant": "EqualUnique",
                     "Keyspace": {
@@ -1144,6 +1146,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
             "Aggregates": "max(0) AS max(total_revenue)",
@@ -1162,6 +1165,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "Scatter",
             "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
@@ -615,6 +615,7 @@
         ],
         "Inputs": [
           {
+            "InputName": "SubQuery",
             "OperatorType": "Limit",
             "Count": "INT64(10)",
             "Inputs": [
@@ -654,6 +655,7 @@
             ]
           },
           {
+            "InputName": "Outer",
             "OperatorType": "Route",
             "Variant": "IN",
             "Keyspace": {
@@ -694,6 +696,7 @@
             ],
             "Inputs": [
               {
+                "InputName": "SubQuery",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
@@ -705,6 +708,7 @@
                 "Table": "`user`"
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:1,R:0,L:2",


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR modified the `inputs` method on the engine primitive to return additional information about the input primitive which is used in plan description.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
