### PR TITLE
Properly treat general tablespace names as case sensitive

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -86,7 +86,7 @@ type IndexOption struct {
 	String string
 }
 
-// TableOption is used for create table options like AUTO_INCREMENT, INSERT_METHOD, etc
+// TableOption is used for create table options like ENGINE, AUTO_INCREMENT, TABLESPACE, etc.
 type TableOption struct {
 	Name          string
 	Value         *Literal

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -13470,7 +13470,7 @@ yydefault:
 		var yyLOCAL *TableOption
 //line sql.y:2829
 		{
-			yyLOCAL = &TableOption{Name: string(yyDollar[1].str), String: (yyDollar[3].identifierCI.String() + yyDollar[4].str)}
+			yyLOCAL = &TableOption{Name: string(yyDollar[1].str), String: (yyDollar[3].identifierCI.String() + yyDollar[4].str), CaseSensitive: true}
 		}
 		yyVAL.union = yyLOCAL
 	case 495:

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -2827,7 +2827,7 @@ table_option:
   }
 | TABLESPACE equal_opt sql_id storage_opt
   {
-    $$ = &TableOption{Name:string($1), String: ($3.String() + $4)}
+    $$ = &TableOption{Name:string($1), String: ($3.String() + $4), CaseSensitive: true}
   }
 | UNION equal_opt '(' table_name_list ')'
   {

--- a/go/vt/sqlparser/tracked_buffer_test.go
+++ b/go/vt/sqlparser/tracked_buffer_test.go
@@ -104,6 +104,10 @@ func TestCanonicalOutput(t *testing.T) {
 			"create table a (v varchar(32)) engine=InnoDB",
 			"CREATE TABLE `a` (\n\t`v` varchar(32)\n) ENGINE InnoDB",
 		},
+		{ // tablespace names are case-sensitive: https://dev.mysql.com/doc/refman/en/general-tablespaces.html
+			"create table a (v varchar(32)) engine=InnoDB tablespace=innodb_system",
+			"CREATE TABLE `a` (\n\t`v` varchar(32)\n) ENGINE InnoDB,\n  TABLESPACE innodb_system",
+		},
 		{
 			"create table a (id int not null primary key) engine InnoDB, charset utf8mb4, collate utf8mb4_0900_ai_ci partition by range (`id`) (partition `p10` values less than(10) engine InnoDB tablespace foo)",
 			"CREATE TABLE `a` (\n\t`id` int NOT NULL PRIMARY KEY\n) ENGINE InnoDB,\n  CHARSET utf8mb4,\n  COLLATE utf8mb4_0900_ai_ci\nPARTITION BY RANGE (`id`)\n(PARTITION `p10` VALUES LESS THAN (10) ENGINE InnoDB TABLESPACE foo)",


### PR DESCRIPTION
## Description

In the Vitess parser, however, we were treating them as case-insensitive. This could lead to query failures handling SQL statements containing a `TABLESPACE` clause in any path where we call [`SetUpperCase(true)`](https://github.com/vitessio/vitess/blob/99271d4d92a4d86f3dbd22e31ab295119d3f3ca2/go/vt/sqlparser/tracked_buffer.go#L77-L87) on a [`sqlparser.TrackedBuffer`](https://github.com/vitessio/vitess/blob/99271d4d92a4d86f3dbd22e31ab295119d3f3ca2/go/vt/sqlparser/tracked_buffer.go#L28-L43) such as indirectly anywhere that calls [`sqlparser.CanonicalString()`](https://github.com/vitessio/vitess/blob/99271d4d92a4d86f3dbd22e31ab295119d3f3ca2/go/vt/sqlparser/tracked_buffer.go#L337-L349).

>**Note**
> `PARTITION` clauses can contain their own _independent_ `TABLESPACE` definition and in that case it IS handled properly today via astPrintf formatting here: https://github.com/vitessio/vitess/blob/99271d4d92a4d86f3dbd22e31ab295119d3f3ca2/go/vt/sqlparser/ast_format.go#L487-L489

The newly added unit test case fails on main:
```
go test -timeout 30s -run ^TestCanonicalOutput$ vitess.io/vitess/go/vt/sqlparser

--- FAIL: TestCanonicalOutput (0.00s)
    --- FAIL: TestCanonicalOutput/create_table_a_(v_varchar(32))_engine=InnoDB_tablespace=innodb_system (0.00s)
        /Users/matt/git/vitess/go/vt/sqlparser/tracked_buffer_test.go:287: 
            	Error Trace:	/Users/matt/git/vitess/go/vt/sqlparser/tracked_buffer_test.go:287
            	Error:      	Not equal: 
            	            	expected: "CREATE TABLE `a` (\n\t`v` varchar(32)\n) ENGINE InnoDB,\n  TABLESPACE innodb_system"
            	            	actual  : "CREATE TABLE `a` (\n\t`v` varchar(32)\n) ENGINE InnoDB,\n  TABLESPACE INNODB_SYSTEM"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -3,2 +3,2 @@
            	            	 ) ENGINE InnoDB,
            	            	-  TABLESPACE innodb_system
            	            	+  TABLESPACE INNODB_SYSTEM
            	Test:       	TestCanonicalOutput/create_table_a_(v_varchar(32))_engine=InnoDB_tablespace=innodb_system
            	Messages:   	bad serialization
FAIL
FAIL	vitess.io/vitess/go/vt/sqlparser	0.449s
FAIL
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13887

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation is not required