### PR TITLE
[staticcheck] miscellaneous tidying

### DIFF
--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -247,15 +247,6 @@ func (flv *filePosFlavor) status(c *Conn) (replication.ReplicationStatus, error)
 	return replication.ParseFilePosReplicationStatus(resultMap)
 }
 
-func parseFilePosReplicationStatus(resultMap map[string]string) (replication.ReplicationStatus, error) {
-	status := replication.ParseReplicationStatus(resultMap)
-
-	status.Position = status.FilePosition
-	status.RelayLogPosition = status.RelayLogSourceBinlogEquivalentPosition
-
-	return status, nil
-}
-
 // primaryStatus is part of the Flavor interface.
 func (flv *filePosFlavor) primaryStatus(c *Conn) (replication.PrimaryStatus, error) {
 	qr, err := c.ExecuteFetch("SHOW MASTER STATUS", 100, true /* wantfields */)

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -157,7 +157,7 @@ func LaunchCluster(setupType int, streamMode string, stripes int, cDetails *Comp
 
 		// if streamMode is xbstream, add some additional args to test other xtrabackup flags
 		if streamMode == "xbstream" {
-			xtrabackupArgs = append(xtrabackupArgs, "--xtrabackup_prepare_flags", fmt.Sprintf("--use-memory=100M")) //nolint
+			xtrabackupArgs = append(xtrabackupArgs, "--xtrabackup_prepare_flags", "--use-memory=100M")
 		}
 
 		commonTabletArg = append(commonTabletArg, xtrabackupArgs...)

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -35,7 +35,6 @@ import (
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
 	"vitess.io/vitess/go/test/endtoend/throttler"
 	"vitess.io/vitess/go/vt/schema"
-	throttlebase "vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/base"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -45,7 +44,6 @@ var (
 	clusterInstance *cluster.LocalProcessCluster
 	shards          []cluster.Shard
 	vtParams        mysql.ConnParams
-	httpClient      = throttlebase.SetupHTTPClient(time.Second)
 
 	normalMigrationWait   = 45 * time.Second
 	extendedMigrationWait = 60 * time.Second

--- a/go/test/endtoend/onlineddl/vtctlutil.go
+++ b/go/test/endtoend/onlineddl/vtctlutil.go
@@ -18,14 +18,11 @@ package onlineddl
 
 import (
 	"testing"
-	"time"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 
 	"github.com/stretchr/testify/assert"
 )
-
-var throttlerConfigTimeout = 90 * time.Second
 
 // CheckCancelAllMigrations cancels all pending migrations. There is no validation for affected migrations.
 func CheckCancelAllMigrationsViaVtctl(t *testing.T, vtctlclient *cluster.VtctlClientProcess, keyspace string) {

--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -19,16 +19,13 @@ package onlineddl
 import (
 	"context"
 	"fmt"
-	"io"
 	"math"
-	"net/http"
 	"os"
 	"testing"
 	"time"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
@@ -370,22 +367,6 @@ func WaitForThrottledTimestamp(t *testing.T, vtParams *mysql.ConnParams, uuid st
 	}
 	t.Error("timeout waiting for last_throttled_timestamp to have nonempty value")
 	return
-}
-
-func getHTTPBody(url string) string {
-	resp, err := http.Get(url)
-	if err != nil {
-		log.Infof("http Get returns %+v", err)
-		return ""
-	}
-	if resp.StatusCode != 200 {
-		log.Infof("http Get returns status %d", resp.StatusCode)
-		return ""
-	}
-	respByte, _ := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
-	body := string(respByte)
-	return body
 }
 
 // ValidateSequentialMigrationIDs validates that schem_migrations.id column, which is an AUTO_INCREMENT, does

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -52,8 +52,6 @@ var (
 	hostname        = "localhost"
 	keyspaceName    = "ks"
 	shardName       = "0"
-	dbName          = "vt_ks"
-	mysqlUsers      = []string{"vt_dba", "vt_app", "vt_appdebug", "vt_repl", "vt_filtered"}
 	mysqlPassword   = "VtDbaPass"
 	vtgateUser      = "vtgate_user"
 	vtgatePassword  = "password123"

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -535,17 +534,6 @@ func getDebugVar(t *testing.T, port int, varPath []string) (string, error) {
 	val, _, _, err = jsonparser.Get([]byte(body), varPath...)
 	require.NoError(t, err)
 	return string(val), nil
-}
-
-func getDebugVars(t *testing.T, port int) map[string]any {
-	out := map[string]any{}
-	response, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/vars", port))
-	if err != nil {
-		return out
-	}
-	defer response.Body.Close()
-	_ = json.NewDecoder(response.Body).Decode(&out)
-	return out
 }
 
 func confirmWorkflowHasCopiedNoData(t *testing.T, targetKS, workflow string) {

--- a/go/test/endtoend/vreplication/partial_movetables_seq_test.go
+++ b/go/test/endtoend/vreplication/partial_movetables_seq_test.go
@@ -59,7 +59,6 @@ type workflow struct {
 	fromKeyspace string
 	toKeyspace   string
 	typ          string
-	tables       []string
 	tc           *vrepTestCase
 	options      *workflowOptions
 }
@@ -67,7 +66,6 @@ type workflow struct {
 type vrepTestCase struct {
 	testName        string
 	t               *testing.T
-	cellNames       []string
 	defaultCellName string
 	vtgateConn      *mysql.Conn
 	keyspaces       map[string]*keyspace

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -26,9 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
-	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/log"
 	vdiff2 "vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 	"vitess.io/vitess/go/vt/wrangler"
@@ -222,30 +220,6 @@ func encodeString(in string) string {
 	var buf strings.Builder
 	sqltypes.NewVarChar(in).EncodeSQL(&buf)
 	return buf.String()
-}
-
-// updateTableStats runs ANALYZE TABLE on each table involved in the workflow.
-// You should execute this if you leverage table information from e.g.
-// information_schema.tables in your test.
-func updateTableStats(t *testing.T, tablet *cluster.VttabletProcess, tables string) {
-	dbName := "vt_" + tablet.Keyspace
-	tableList := strings.Split(strings.TrimSpace(tables), ",")
-	if len(tableList) == 0 {
-		// we need to get all of the tables in the keyspace
-		res, err := tablet.QueryTabletWithDB("show tables", dbName)
-		require.NoError(t, err)
-		for _, row := range res.Rows {
-			tableList = append(tableList, row[0].String())
-		}
-	}
-	for _, table := range tableList {
-		table = strings.TrimSpace(table)
-		if table != "" {
-			res, err := tablet.QueryTabletWithDB(fmt.Sprintf(sqlAnalyzeTable, sqlescape.EscapeID(table)), dbName)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(res.Rows))
-		}
-	}
 }
 
 // generateMoreCustomers creates additional test data for better tests

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -624,8 +624,6 @@ func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	shardCustomer(t, true, []*Cell{cell1, cell2}, "alias", false)
 }
 
-var queryErrorCount int64
-
 // testVStreamFrom confirms that the "vstream * from" endpoint is serving data
 func testVStreamFrom(t *testing.T, table string, expectedRowCount int) {
 	ctx := context.Background()

--- a/go/test/endtoend/vtgate/queries/random/query_gen.go
+++ b/go/test/endtoend/vtgate/queries/random/query_gen.go
@@ -96,16 +96,6 @@ func newSelectGenerator(r *rand.Rand, genConfig sqlparser.ExprGeneratorConfig, m
 	}
 }
 
-// getColumnName returns tableName.name (if tableName is nonempty), otherwise name
-func (c *column) getColumnName() string {
-	var columnName string
-	if c.tableName != "" {
-		columnName += c.tableName + "."
-	}
-
-	return columnName + c.name
-}
-
 // getASTExpr returns the AST representation of a column
 func (c *column) getASTExpr() sqlparser.Expr {
 	return sqlparser.NewColNameWithQualifier(c.name, sqlparser.NewTableName(c.tableName))

--- a/go/tools/asthelpergen/copy_on_rewrite_gen.go
+++ b/go/tools/asthelpergen/copy_on_rewrite_gen.go
@@ -132,22 +132,6 @@ func (c *cowGen) basicMethod(t types.Type, basic *types.Basic, spi generatorSPI)
 	return nil
 }
 
-func (c *cowGen) copySliceElement(t types.Type, elType types.Type, spi generatorSPI) jen.Code {
-	if !isNamed(t) && isBasic(elType) {
-		//	copy(res, n)
-		return jen.Id("copy").Call(jen.Id("res"), jen.Id("n"))
-	}
-
-	// for i := range n {
-	//  res[i] = CloneAST(x)
-	// }
-	spi.addType(elType)
-
-	return jen.For(jen.List(jen.Id("i"), jen.Id("x"))).Op(":=").Range().Id("n").Block(
-		jen.Id("res").Index(jen.Id("i")).Op("=").Add(c.readValueOfType(elType, jen.Id("x"), spi)),
-	)
-}
-
 func ifNotNil(id string, stmts ...jen.Code) *jen.Statement {
 	return jen.If(jen.Id(id).Op("!=").Nil()).Block(stmts...)
 }

--- a/go/trace/trace_test.go
+++ b/go/trace/trace_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -102,15 +101,6 @@ func (f *fakeTracer) AddGrpcClientOptions(addInterceptors func(s grpc.StreamClie
 
 func (f *fakeTracer) Close() error {
 	panic("implement me")
-}
-
-func (f *fakeTracer) assertNoSpanWith(t *testing.T, substr string) {
-	t.Helper()
-	for _, logLine := range f.log {
-		if strings.Contains(logLine, substr) {
-			t.Fatalf("expected to not find [%v] but found it in [%v]", substr, logLine)
-		}
-	}
 }
 
 type mockSpan struct {

--- a/go/vt/mysqlctl/tmutils/schema_test.go
+++ b/go/vt/mysqlctl/tmutils/schema_test.go
@@ -234,7 +234,7 @@ func TestSchemaDiff(t *testing.T) {
 	})
 
 	testDiff(t, sd4, sd5, "sd4", "sd5", []string{
-		fmt.Sprintf("schemas differ on table type for table table2:\nsd4: VIEW\n differs from:\nsd5: BASE TABLE"), //nolint
+		"schemas differ on table type for table table2:\nsd4: VIEW\n differs from:\nsd5: BASE TABLE",
 	})
 
 	sd1.DatabaseSchema = "CREATE DATABASE {{.DatabaseName}}"

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -261,7 +261,7 @@ func TestSetAutocommitON(t *testing.T) {
 			t.Errorf("SET statement value is not StrVal: %T", v)
 		}
 
-		if "on" != v.Val {
+		if v.Val != "on" {
 			t.Errorf("SET statement value want: on, got: %s", v.Val)
 		}
 	default:
@@ -286,7 +286,7 @@ func TestSetAutocommitON(t *testing.T) {
 			t.Errorf("SET statement value is not StrVal: %T", v)
 		}
 
-		if "on" != v.Val {
+		if v.Val != "on" {
 			t.Errorf("SET statement value want: on, got: %s", v.Val)
 		}
 	default:
@@ -313,7 +313,7 @@ func TestSetAutocommitOFF(t *testing.T) {
 			t.Errorf("SET statement value is not StrVal: %T", v)
 		}
 
-		if "off" != v.Val {
+		if v.Val != "off" {
 			t.Errorf("SET statement value want: on, got: %s", v.Val)
 		}
 	default:
@@ -338,7 +338,7 @@ func TestSetAutocommitOFF(t *testing.T) {
 			t.Errorf("SET statement value is not StrVal: %T", v)
 		}
 
-		if "off" != v.Val {
+		if v.Val != "off" {
 			t.Errorf("SET statement value want: on, got: %s", v.Val)
 		}
 	default:

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -6195,7 +6195,7 @@ func testFile(t *testing.T, filename, tempDir string) {
 		if fail && tempDir != "" {
 			gotFile := fmt.Sprintf("%s/%s", tempDir, filename)
 			_ = os.WriteFile(gotFile, []byte(strings.TrimSpace(expected.String())+"\n"), 0644)
-			fmt.Println(fmt.Sprintf("Errors found in parse tests. If the output is correct, run `cp %s/* testdata/` to update test expectations", tempDir)) // nolint
+			fmt.Printf("Errors found in parse tests. If the output is correct, run `cp %s/* testdata/` to update test expectations\n", tempDir)
 		}
 	})
 }

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -217,7 +217,7 @@ func TestRandom(t *testing.T) {
 	// The idea is to generate random queries, and pass them through the parser and then the unparser, and one more time. The result of the first unparse should be the same as the second result.
 	seed := time.Now().UnixNano()
 	r := rand.New(rand.NewSource(seed))
-	fmt.Println(fmt.Sprintf("seed is %d", seed)) // nolint
+	fmt.Printf("seed is %d\n", seed)
 	g := NewGenerator(r, 5)
 	endBy := time.Now().Add(1 * time.Second)
 

--- a/go/vt/throttler/max_replication_lag_module.go
+++ b/go/vt/throttler/max_replication_lag_module.go
@@ -599,7 +599,7 @@ func (m *MaxReplicationLagModule) decreaseAndGuessRate(r *result, now time.Time,
 
 	if replicationLagChange == equal {
 		// The replication lag did not change. Keep going at the current rate.
-		r.Reason = fmt.Sprintf("did not decrease the rate because the lag did not change (assuming a 1s error margin)") // nolint
+		r.Reason = "did not decrease the rate because the lag did not change (assuming a 1s error margin)"
 		return
 	}
 

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -21,7 +21,6 @@ package consultopo
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -90,7 +89,7 @@ func getClientCreds() (creds map[string]*ClientAuthCred, err error) {
 	}
 
 	if err := json.Unmarshal(data, &creds); err != nil {
-		err = vterrors.Wrapf(err, fmt.Sprintf("Error parsing consul_auth_static_file")) //nolint
+		err = vterrors.Wrapf(err, "Error parsing consul_auth_static_file")
 		return creds, err
 	}
 	return creds, nil

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -78,20 +78,6 @@ func (cc *mockClientConn) assertUpdateWithin(t testing.TB, timeout time.Duration
 	}
 }
 
-func (cc *mockClientConn) assertErrorReportedWithin(t testing.TB, timeout time.Duration, msgAndArgs ...any) bool {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	select {
-	case <-ctx.Done():
-		return assert.Fail(t, "failed to receive reported error", "did not receive reported error within %v: %s", timeout, ctx.Err())
-	case actual := <-cc.errors:
-		return assert.Error(t, actual, msgAndArgs...)
-	}
-}
-
 func (cc *mockClientConn) UpdateState(state grpcresolver.State) error {
 	select {
 	case <-cc.ctx.Done():

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -98,11 +98,6 @@ func (q *Queue) startMonitoring() {
 	}
 }
 
-// Stop monitoring the queue
-func (q *Queue) stopMonitoring() {
-	q.done <- struct{}{}
-}
-
 // do a check of the entries in the queue, both those active and queued
 func (q *Queue) collectStatistics() {
 	q.Lock()

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -638,17 +638,3 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos replication.P
 
 	return nil
 }
-
-func (tm *TabletManager) getLocalMetadataValues(tabletType topodatapb.TabletType) map[string]string {
-	tablet := tm.Tablet()
-	values := map[string]string{
-		"Alias":         topoproto.TabletAliasString(tablet.Alias),
-		"ClusterAlias":  fmt.Sprintf("%s.%s", tablet.Keyspace, tablet.Shard),
-		"DataCenter":    tablet.Alias.Cell,
-		"PromotionRule": "must_not",
-	}
-	if isPrimaryEligible(tabletType) {
-		values["PromotionRule"] = "neutral"
-	}
-	return values
-}

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -817,58 +817,6 @@ func (td *tableDiffer) adjustForSourceTimeZone(targetSelectExprs sqlparser.Selec
 	return targetSelectExprs
 }
 
-// updateTableStats runs ANALYZE TABLE on the table in order to update the
-// statistics, then it reads those updated stats (specifically the number of
-// rows in the table) and saves them in the vdiff_table record.
-func (td *tableDiffer) updateTableStats(dbClient binlogplayer.DBClient) error {
-	// First update the stats.
-	stmt := sqlparser.BuildParsedQuery(sqlAnalyzeTable,
-		td.wd.ct.vde.dbName,
-		td.table.Name,
-	)
-	if _, err := dbClient.ExecuteFetch(stmt.Query, -1); err != nil {
-		return err
-	}
-	// Now read the updated stats.
-	query, err := sqlparser.ParseAndBind(sqlGetTableRows,
-		sqltypes.StringBindVariable(td.wd.ct.vde.dbName),
-		sqltypes.StringBindVariable(td.table.Name),
-	)
-	if err != nil {
-		return err
-	}
-	isqr, err := dbClient.ExecuteFetch(query, 1)
-	if err != nil {
-		return err
-	}
-	if isqr == nil || len(isqr.Rows) != 1 {
-		rows := 0
-		if isqr != nil {
-			rows = len(isqr.Rows)
-		}
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unexpected number of rows returned from %s: %d", query, rows)
-	}
-	// And finally save the updated stats.
-	row := isqr.Named().Row()
-	tableRows, err := row.ToInt64("table_rows")
-	if err != nil {
-		strVal, _ := row.ToString("table_rows")
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid value (%s) returned from %s: %v", strVal, query, err)
-	}
-	query, err = sqlparser.ParseAndBind(sqlUpdateTableRows,
-		sqltypes.Int64BindVariable(tableRows),
-		sqltypes.Int64BindVariable(td.wd.ct.id),
-		sqltypes.StringBindVariable(td.table.Name),
-	)
-	if err != nil {
-		return err
-	}
-	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {
-		return err
-	}
-	return nil
-}
-
 func getColumnNameForSelectExpr(selectExpression sqlparser.SelectExpr) (string, error) {
 	aliasedExpr := selectExpression.(*sqlparser.AliasedExpr)
 	expr := aliasedExpr.Expr

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -124,8 +124,7 @@ type Status struct {
 	Keyspace string
 	Shard    string
 
-	isPrimary bool
-	IsOpen    bool
+	IsOpen bool
 
 	purgingTables []string
 }

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -965,12 +965,6 @@ func (mm *messageManager) readPending(ctx context.Context, bindVars map[string]*
 	return qr, err
 }
 
-func (mm *messageManager) getReceiverCount() int {
-	mm.mu.Lock()
-	defer mm.mu.Unlock()
-	return len(mm.receivers)
-}
-
 func (mm *messageManager) getLastPollPosition() *replication.Position {
 	mm.cacheManagementMu.Lock()
 	defer mm.cacheManagementMu.Unlock()

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"syscall"
@@ -267,9 +266,7 @@ func TestTabletServerRedoLogIsKeptBetweenRestarts(t *testing.T) {
 	want = []string{"update test_table set `name` = 2 where pk = 1 limit 10001"}
 	utils.MustMatch(t, want, got, "Prepared queries")
 	wantFailed := map[string]error{"a:b:20": errPrepFailed}
-	if !reflect.DeepEqual(tsv.te.preparedPool.reserved, wantFailed) {
-		t.Errorf("Failed dtids: %v, want %v", tsv.te.preparedPool.reserved, wantFailed)
-	}
+	utils.MustMatch(t, tsv.te.preparedPool.reserved, wantFailed, fmt.Sprintf("Failed dtids: %v, want %v", tsv.te.preparedPool.reserved, wantFailed))
 	// Verify last id got adjusted.
 	assert.EqualValues(t, 20, tsv.te.txPool.scp.lastID.Load(), "tsv.te.txPool.lastID.Get()")
 	turnOffTxEngine()


### PR DESCRIPTION
## Description

- unnecessary sprintf/println
- avoiding deep equality on errors
- reversing conditional orders (this one is new to me! see https://staticcheck.dev/docs/checks/#ST1017)
- last of the "unused code" violations (i think)

## Related Issue(s)

#13877 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
