### PR TITLE
vttablet: do not notify `vtgate` about internal tables

### DIFF
--- a/go/vt/vttablet/endtoend/healthstream_test.go
+++ b/go/vt/vttablet/endtoend/healthstream_test.go
@@ -34,35 +34,48 @@ func TestSchemaChange(t *testing.T) {
 		tName          string
 		expectedChange string
 		ddl            string
+		expectTimeout  bool
 	}{
 		{
 			"create table 1",
 			"vitess_sc1",
 			"create table vitess_sc1(id bigint primary key)",
+			false,
 		}, {
 			"create table 2",
 			"vitess_sc2",
 			"create table vitess_sc2(id bigint primary key)",
+			false,
+		}, {
+			"create internal table",
+			"_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			"create table _vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410(id bigint primary key)",
+			true,
 		}, {
 			"add column 1",
 			"vitess_sc1",
 			"alter table vitess_sc1 add column newCol varchar(50)",
+			false,
 		}, {
 			"add column 2",
 			"vitess_sc2",
 			"alter table vitess_sc2 add column newCol varchar(50)",
+			false,
 		}, {
 			"remove column",
 			"vitess_sc1",
 			"alter table vitess_sc1 drop column newCol",
+			false,
 		}, {
 			"drop table 2",
 			"vitess_sc2",
 			"drop table vitess_sc2",
+			false,
 		}, {
 			"drop table 1",
 			"vitess_sc1",
 			"drop table vitess_sc1",
+			false,
 		},
 	}
 
@@ -85,9 +98,14 @@ func TestSchemaChange(t *testing.T) {
 				select {
 				case res := <-ch: // get the schema notification
 					if slices.Contains(res, tc.expectedChange) {
+						assert.False(t, tc.expectTimeout)
 						return
 					}
 				case <-timeout:
+					if tc.expectTimeout {
+						// This is what we wanted!
+						return
+					}
 					t.Errorf("timed out waiting for a schema notification")
 					return
 				}

--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -314,7 +314,7 @@ var tableACLConfig = `{
     },
     {
       "name": "vitess_healthstream",
-      "table_names_or_prefixes": ["vitess_sc1", "vitess_sc2"],
+      "table_names_or_prefixes": ["vitess_sc1", "vitess_sc2", "_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410"],
       "readers": ["dev"],
       "writers": ["dev"],
       "admins": ["dev"]

--- a/go/vt/vttablet/tabletserver/health_streamer.go
+++ b/go/vt/vttablet/tabletserver/health_streamer.go
@@ -29,6 +29,7 @@ import (
 
 	"vitess.io/vitess/go/constants/sidecar"
 
+	vtschema "vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 
 	"vitess.io/vitess/go/vt/servenv"
@@ -365,6 +366,9 @@ func (hs *healthStreamer) reload(full map[string]*schema.Table, created, altered
 	// Range over the tables that are created/altered and split them up based on their type.
 	for _, table := range append(append(dropped, created...), altered...) {
 		tableName := table.Name.String()
+		if vtschema.IsInternalOperationTableName(tableName) {
+			continue
+		}
 		if table.Type == schema.View && hs.viewsEnabled {
 			views = append(views, tableName)
 		} else {


### PR DESCRIPTION

## Description

Closes https://github.com/vitessio/vitess/issues/13894

`vttablet` will skip internal-table names when reporting RealtimeStats. As result, `vtgate` will never learn about those.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/13894
- https://github.com/vitessio/vitess/issues/12967


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
