### PR TITLE
[staticcheck] Cleanup deprecations

### DIFF
--- a/examples/compose/client.go
+++ b/examples/compose/client.go
@@ -42,7 +42,6 @@ var (
 
 func main() {
 	pflag.Parse()
-	rand.Seed(time.Now().UnixNano())
 
 	// Connect to vtgate.
 	db, err := vitessdriver.Open(*server, "@primary")

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -197,7 +197,6 @@ func run() (*results, error) {
 	if maxSeqID > minSeqID {
 		go func() {
 			if useRandom {
-				rand.Seed(time.Now().UnixNano())
 				for {
 					seqChan <- rand.Intn(maxSeqID-minSeqID) + minSeqID
 				}

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"context"
-	"math/rand"
 	"strings"
-	"time"
 
 	"github.com/spf13/pflag"
 
@@ -56,7 +54,6 @@ func registerFlags(fs *pflag.FlagSet) {
 var resilientServer *srvtopo.ResilientServer
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
 	servenv.RegisterDefaultFlags()
 	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()

--- a/go/netutil/netutil_test.go
+++ b/go/netutil/netutil_test.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func checkDistribution(t *testing.T, rand *rand.Rand, data []*net.SRV, margin float64) {
@@ -59,7 +58,7 @@ func testUniformity(t *testing.T, size int, margin float64) {
 	for i := 0; i < size; i++ {
 		data[i] = &net.SRV{Target: fmt.Sprintf("%c", 'a'+i), Weight: 1}
 	}
-	checkDistribution(t, rand.New(rand.NewSource(time.Now().UTC().UnixNano())), data, margin)
+	checkDistribution(t, rand.New(rand.NewSource(1)), data, margin)
 }
 
 func TestUniformity(t *testing.T) {

--- a/go/netutil/netutil_test.go
+++ b/go/netutil/netutil_test.go
@@ -22,9 +22,10 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 )
 
-func checkDistribution(t *testing.T, data []*net.SRV, margin float64) {
+func checkDistribution(t *testing.T, rand *rand.Rand, data []*net.SRV, margin float64) {
 	sum := 0
 	for _, srv := range data {
 		sum += int(srv.Weight)
@@ -36,7 +37,7 @@ func checkDistribution(t *testing.T, data []*net.SRV, margin float64) {
 	for j := 0; j < count; j++ {
 		d := make([]*net.SRV, len(data))
 		copy(d, data)
-		byPriorityWeight(d).shuffleByWeight()
+		byPriorityWeight(d).shuffleByWeight(rand)
 		key := d[0].Target
 		results[key] = results[key] + 1
 	}
@@ -54,12 +55,11 @@ func checkDistribution(t *testing.T, data []*net.SRV, margin float64) {
 }
 
 func testUniformity(t *testing.T, size int, margin float64) {
-	rand.Seed(1)
 	data := make([]*net.SRV, size)
 	for i := 0; i < size; i++ {
 		data[i] = &net.SRV{Target: fmt.Sprintf("%c", 'a'+i), Weight: 1}
 	}
-	checkDistribution(t, data, margin)
+	checkDistribution(t, rand.New(rand.NewSource(time.Now().UTC().UnixNano())), data, margin)
 }
 
 func TestUniformity(t *testing.T) {
@@ -70,13 +70,12 @@ func TestUniformity(t *testing.T) {
 }
 
 func testWeighting(t *testing.T, margin float64) {
-	rand.Seed(1)
 	data := []*net.SRV{
 		{Target: "a", Weight: 60},
 		{Target: "b", Weight: 30},
 		{Target: "c", Weight: 10},
 	}
-	checkDistribution(t, data, margin)
+	checkDistribution(t, rand.New(rand.NewSource(1)), data, margin)
 }
 
 func TestWeighting(t *testing.T) {

--- a/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
+++ b/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
@@ -251,7 +251,6 @@ func (bt *BufferingTest) createCluster() (*cluster.LocalProcessCluster, int) {
 	if err := clusterInstance.StartVtgate(); err != nil {
 		return nil, 1
 	}
-	rand.Seed(time.Now().UnixNano())
 	return clusterInstance, 0
 }
 

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -307,7 +307,6 @@ func init() {
 	if os.Getenv("VREPLICATION_E2E_DEBUG") != "" {
 		debugMode = true
 	}
-	rand.Seed(time.Now().UTC().UnixNano())
 	originalVtdataroot = os.Getenv("VTDATAROOT")
 	var mainVtDataRoot string
 	if debugMode {

--- a/go/test/endtoend/vtgate/keyspace_watches/keyspace_watch_test.go
+++ b/go/test/endtoend/vtgate/keyspace_watches/keyspace_watch_test.go
@@ -23,10 +23,8 @@ package keyspacewatches
 import (
 	"database/sql"
 	"fmt"
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
@@ -115,7 +113,6 @@ func createCluster(extraVTGateArgs []string) (*cluster.LocalProcessCluster, int)
 		Host: clusterInstance.Hostname,
 		Port: clusterInstance.VtgateMySQLPort,
 	}
-	rand.Seed(time.Now().UnixNano())
 	return clusterInstance, 0
 }
 

--- a/go/tools/asthelpergen/asthelpergen.go
+++ b/go/tools/asthelpergen/asthelpergen.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 
 	"github.com/dave/jennifer/jen"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/tools/go/packages"
 
 	"vitess.io/vitess/go/tools/codegen"
@@ -304,7 +306,7 @@ func printableTypeName(t types.Type) string {
 	case *types.Named:
 		return t.Obj().Name()
 	case *types.Basic:
-		return strings.Title(t.Name()) // nolint
+		return cases.Title(language.AmericanEnglish).String(t.Name())
 	case *types.Interface:
 		return t.String()
 	default:

--- a/go/vt/tableacl/testlib/testlib.go
+++ b/go/vt/tableacl/testlib/testlib.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	tableaclpb "vitess.io/vitess/go/vt/proto/tableacl"
@@ -126,8 +125,4 @@ func checkAccess(config *tableaclpb.Config, tableName string, role tableacl.Role
 		return fmt.Errorf("got %v, want %v", got, want)
 	}
 	return nil
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -348,8 +348,8 @@ func RevokeCertAndRegenerateCRL(root, parent, name string) {
 		log.Fatal(err)
 	}
 
-	revoked := crlList.RevokedCertificates
-	revoked = append(revoked, pkix.RevokedCertificate{
+	revoked := crlList.RevokedCertificateEntries
+	revoked = append(revoked, x509.RevocationListEntry{
 		SerialNumber:   certificate.SerialNumber,
 		RevocationTime: time.Now(),
 	})
@@ -365,8 +365,8 @@ func RevokeCertAndRegenerateCRL(root, parent, name string) {
 
 	var crlNumber big.Int
 	newCrl, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
-		RevokedCertificates: revoked,
-		Number:              crlNumber.Add(crlList.Number, big.NewInt(1)),
+		RevokedCertificateEntries: revoked,
+		Number:                    crlNumber.Add(crlList.Number, big.NewInt(1)),
 	}, caCert, caKey.(crypto.Signer))
 	if err != nil {
 		log.Fatal(err)

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -25,7 +25,6 @@ import (
 	"math/rand"
 	"strings"
 	"sync"
-	"time"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
@@ -348,8 +347,4 @@ func (f *Factory) recursiveDelete(n *node) {
 	if len(parent.children) == 0 {
 		f.recursiveDelete(parent)
 	}
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }

--- a/go/vt/topotools/shard_test.go
+++ b/go/vt/topotools/shard_test.go
@@ -22,7 +22,6 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
-	"time"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -109,7 +108,6 @@ func TestGetOrCreateShard(t *testing.T) {
 	// and do massive parallel GetOrCreateShard
 	keyspace := "test_keyspace"
 	wg := sync.WaitGroup{}
-	rand.Seed(time.Now().UnixNano())
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func(i int) {

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -82,10 +81,6 @@ type transitionRequest struct {
 	isBaseTable   bool
 	toGCState     schema.TableGCState
 	uuid          string
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 // TableGC is the main entity in the table garbage collection mechanism.

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2682,8 +2681,4 @@ func addTabletServerSupportedQueries(db *fakesqldb.DB) {
 			Type: sqltypes.Int64,
 		}},
 	})
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -110,10 +110,6 @@ const (
 	ThrottleCheckSelf
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 // Throttler is the main entity in the throttling mechanism. This service runs, probes, collects data,
 // aggregates, reads inventory, provides information, etc.
 type Throttler struct {

--- a/go/vt/vttablet/tabletserver/vstreamer/packet_size_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/packet_size_test.go
@@ -21,6 +21,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type polynomial []float64
@@ -89,9 +91,6 @@ func TestPacketSizeSimulation(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			seed := time.Now().UnixNano()
-			rand.Seed(seed)
-
 			// Simulate a replication using the given polynomial and the dynamic packet sizer
 			ps1 := newDynamicPacketSizer(tc.baseSize)
 			elapsed1, sent1 := simulate(t, ps1, tc.baseSize, tc.baseSize*1000, tc.p.fit)
@@ -103,12 +102,8 @@ func TestPacketSizeSimulation(t *testing.T) {
 			// the simulation for dynamic packet sizing should always be faster then the fixed packet,
 			// and should also send fewer packets in total
 			delta := elapsed1 - elapsed2
-			if delta > tc.error {
-				t.Errorf("packet-adjusted simulation is %v slower than fixed approach, seed %d", delta, seed)
-			}
-			if sent1 > sent2 {
-				t.Errorf("packet-adjusted simulation sent more packets (%d) than fixed approach (%d), seed %d", sent1, sent2, seed)
-			}
+			assert.LessOrEqualf(t, tc.error, delta, "packet-adjusted simulation is %v slower than fixed approach", delta)
+			assert.LessOrEqualf(t, sent2, sent1, "packet-adjusted simulation sent more packets (%d) than fixed approach (%d)", sent1, sent2)
 			// t.Logf("dynamic = (%v, %d), fixed = (%v, %d)", elapsed1, sent1, elapsed2, sent2)
 		})
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/packet_size_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/packet_size_test.go
@@ -35,7 +35,7 @@ func (p polynomial) fit(x float64) float64 {
 	return y
 }
 
-func simulate(t *testing.T, ps PacketSizer, base, mustSend int, interpolate func(float64) float64) (time.Duration, int) {
+func simulate(t *testing.T, rand *rand.Rand, ps PacketSizer, base, mustSend int, interpolate func(float64) float64) (time.Duration, int) {
 	t.Helper()
 
 	var elapsed time.Duration
@@ -91,19 +91,22 @@ func TestPacketSizeSimulation(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			seed := time.Now().UnixNano()
+			rand := rand.New(rand.NewSource(seed))
+
 			// Simulate a replication using the given polynomial and the dynamic packet sizer
 			ps1 := newDynamicPacketSizer(tc.baseSize)
-			elapsed1, sent1 := simulate(t, ps1, tc.baseSize, tc.baseSize*1000, tc.p.fit)
+			elapsed1, sent1 := simulate(t, rand, ps1, tc.baseSize, tc.baseSize*1000, tc.p.fit)
 
 			// Simulate the same polynomial using a fixed packet size
 			ps2 := newFixedPacketSize(tc.baseSize)
-			elapsed2, sent2 := simulate(t, ps2, tc.baseSize, tc.baseSize*1000, tc.p.fit)
+			elapsed2, sent2 := simulate(t, rand, ps2, tc.baseSize, tc.baseSize*1000, tc.p.fit)
 
 			// the simulation for dynamic packet sizing should always be faster then the fixed packet,
 			// and should also send fewer packets in total
 			delta := elapsed1 - elapsed2
-			assert.LessOrEqualf(t, tc.error, delta, "packet-adjusted simulation is %v slower than fixed approach", delta)
-			assert.LessOrEqualf(t, sent2, sent1, "packet-adjusted simulation sent more packets (%d) than fixed approach (%d)", sent1, sent2)
+			assert.LessOrEqualf(t, delta, tc.error, "packet-adjusted simulation is %v slower than fixed approach", delta)
+			assert.LessOrEqualf(t, sent1, sent2, "packet-adjusted simulation sent more packets (%d) than fixed approach (%d)", sent1, sent2)
 			// t.Logf("dynamic = (%v, %d), fixed = (%v, %d)", elapsed1, sent1, elapsed2, sent2)
 		})
 	}

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"vitess.io/vitess/go/vt/proto/vttest"
 
@@ -299,10 +298,6 @@ func NewLocalTestEnvWithDirectory(flavor string, basePort int, directory string)
 
 func defaultEnvFactory() (Environment, error) {
 	return NewLocalTestEnv("", 0)
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 // NewDefaultEnv is an user-configurable callback that returns a new Environment

--- a/go/vt/vttls/crl.go
+++ b/go/vt/vttls/crl.go
@@ -33,7 +33,7 @@ func certIsRevoked(cert *x509.Certificate, crl *x509.RevocationList) bool {
 		log.Warningf("The current Certificate Revocation List (CRL) is past expiry date and must be updated. Revoked certificates will still be rejected in this state.")
 	}
 
-	for _, revoked := range crl.RevokedCertificates {
+	for _, revoked := range crl.RevokedCertificateEntries {
 		if cert.SerialNumber.Cmp(revoked.SerialNumber) == 0 {
 			return true
 		}

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -42,7 +42,6 @@ var (
 
 func main() {
 	pflag.Parse()
-	rand.Seed(time.Now().UnixNano())
 
 	// Connect to vtgate.
 	db, err := vitessdriver.Open(*server, "@primary")


### PR DESCRIPTION
## Description

- update deprecated grpc dial options
- replace deprecated `strings.Title` with recommended replacement
- RevokedCertificates=>RevokedCertificateEntries
- Stop seeding rand with timestamps, it no longer auto-seeds with a constant (See https://github.com/golang/go/issues/56319)

## Related Issue(s)

#13877 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
