### PR TITLE
Update Cascade Planning leading to Foreign key constraint verification

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -136,10 +136,11 @@ func TestUpdateWithFK(t *testing.T) {
 	utils.Exec(t, conn, `insert into u_t2(id, col2) values (342, 123), (19, 1234)`)
 	utils.Exec(t, conn, `insert into u_t3(id, col3) values (32, 123), (1, 12)`)
 
-	t.Run("Cascade update with a new value", func(t *testing.T) {
-		t.Skip("This doesn't work right now. We are able to only cascade updates for which the data already exists in the parent table")
-		_ = utils.Exec(t, conn, `update u_t1 set col1 = 2 where id = 100`)
-	})
+	// Cascade update with a new value
+	_ = utils.Exec(t, conn, `update u_t1 set col1 = 2 where id = 100`)
+	// Verify the result in u_t2 and u_t3 as well.
+	utils.AssertMatches(t, conn, `select * from u_t2 order by id`, `[[INT64(19) INT64(1234)] [INT64(342) NULL]]`)
+	utils.AssertMatches(t, conn, `select * from u_t3 order by id`, `[[INT64(1) INT64(12)] [INT64(32) INT64(2)]]`)
 
 	// Update u_t1 which has a foreign key constraint to u_t2 with SET NULL type, and to u_t3 with CASCADE type.
 	qr = utils.Exec(t, conn, `update u_t1 set col1 = 13 where id = 100`)

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2532,3 +2532,14 @@ func (v *visitor) visitAllSelects(in SelectStatement, f func(p *Select, idx int)
 	}
 	panic("switch should be exhaustive")
 }
+
+func IsNonLiteral(updExprs UpdateExprs) bool {
+	for _, updateExpr := range updExprs {
+		switch updateExpr.Expr.(type) {
+		case *Argument, *NullVal, BoolVal, *Literal:
+		default:
+			return true
+		}
+	}
+	return false
+}

--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -82,7 +82,6 @@ var (
 
 	VT12001 = errorWithoutState("VT12001", vtrpcpb.Code_UNIMPLEMENTED, "unsupported: %s", "This statement is unsupported by Vitess. Please rewrite your query to use supported syntax.")
 	VT12002 = errorWithoutState("VT12002", vtrpcpb.Code_UNIMPLEMENTED, "unsupported: cross-shard foreign keys", "Vitess does not support cross shard foreign keys.")
-	VT12003 = errorWithoutState("VT12002", vtrpcpb.Code_UNIMPLEMENTED, "unsupported: foreign keys management at vitess", "Vitess does not support managing foreign keys tables.")
 
 	// VT13001 General Error
 	VT13001 = errorWithoutState("VT13001", vtrpcpb.Code_INTERNAL, "[BUG] %s", "This error should not happen and is a bug. Please file an issue on GitHub: https://github.com/vitessio/vitess/issues/new/choose.")
@@ -148,7 +147,6 @@ var (
 		VT10001,
 		VT12001,
 		VT12002,
-		VT12003,
 		VT13001,
 		VT13002,
 		VT14001,

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -302,13 +302,11 @@ func (cached *FkVerify) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(48)
 	}
-	// field Verify []vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	// field Verify []*vitess.io/vitess/go/vt/vtgate/engine.Verify
 	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Verify)) * int64(16))
+		size += hack.RuntimeAllocSize(int64(cap(cached.Verify)) * int64(8))
 		for _, elem := range cached.Verify {
-			if cc, ok := elem.(cachedObject); ok {
-				size += cc.CachedSize(true)
-			}
+			size += elem.CachedSize(true)
 		}
 	}
 	// field Exec vitess.io/vitess/go/vt/vtgate/engine.Primitive
@@ -1243,6 +1241,22 @@ func (cached *VStream) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(len(cached.TableName)))
 	// field Position string
 	size += hack.RuntimeAllocSize(int64(len(cached.Position)))
+	return size
+}
+func (cached *Verify) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(32)
+	}
+	// field Exec vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.Exec.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	// field Typ string
+	size += hack.RuntimeAllocSize(int64(len(cached.Typ)))
 	return size
 }
 func (cached *VindexFunc) CachedSize(alloc bool) int64 {

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -294,43 +294,6 @@ func (cached *FkChild) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
-func (cached *FkParent) CachedSize(alloc bool) int64 {
-	if cached == nil {
-		return int64(0)
-	}
-	size := int64(0)
-	if alloc {
-		size += int64(80)
-	}
-	// field Values []vitess.io/vitess/go/vt/sqlparser.Exprs
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Values)) * int64(24))
-		for _, elem := range cached.Values {
-			{
-				size += hack.RuntimeAllocSize(int64(cap(elem)) * int64(16))
-				for _, elem := range elem {
-					if cc, ok := elem.(cachedObject); ok {
-						size += cc.CachedSize(true)
-					}
-				}
-			}
-		}
-	}
-	// field Cols []vitess.io/vitess/go/vt/vtgate/engine.CheckCol
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Cols)) * int64(22))
-		for _, elem := range cached.Cols {
-			size += elem.CachedSize(false)
-		}
-	}
-	// field BvName string
-	size += hack.RuntimeAllocSize(int64(len(cached.BvName)))
-	// field Exec vitess.io/vitess/go/vt/vtgate/engine.Primitive
-	if cc, ok := cached.Exec.(cachedObject); ok {
-		size += cc.CachedSize(true)
-	}
-	return size
-}
 func (cached *FkVerify) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -339,11 +302,13 @@ func (cached *FkVerify) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(48)
 	}
-	// field Verify []*vitess.io/vitess/go/vt/vtgate/engine.FkParent
+	// field Verify []vitess.io/vitess/go/vt/vtgate/engine.Primitive
 	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Verify)) * int64(8))
+		size += hack.RuntimeAllocSize(int64(cap(cached.Verify)) * int64(16))
 		for _, elem := range cached.Verify {
-			size += elem.CachedSize(true)
+			if cc, ok := elem.(cachedObject); ok {
+				size += cc.CachedSize(true)
+			}
 		}
 	}
 	// field Exec vitess.io/vitess/go/vt/vtgate/engine.Primitive

--- a/go/vt/vtgate/engine/fk_verify.go
+++ b/go/vt/vtgate/engine/fk_verify.go
@@ -89,15 +89,15 @@ func (f *FkVerify) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVa
 func (f *FkVerify) Inputs() ([]Primitive, []map[string]any) {
 	var inputs []Primitive
 	var inputsMap []map[string]any
-	for idx, parent := range f.Verify {
+	for idx, verify := range f.Verify {
 		inputsMap = append(inputsMap, map[string]any{
-			inputName: fmt.Sprintf("VerifyParent-%d", idx+1),
+			inputName: fmt.Sprintf("Verify-%d", idx+1),
 		})
-		inputs = append(inputs, parent)
+		inputs = append(inputs, verify)
 	}
 	inputs = append(inputs, f.Exec)
 	inputsMap = append(inputsMap, map[string]any{
-		inputName: "Child",
+		inputName: "PostVerify",
 	})
 	return inputs, inputsMap
 

--- a/go/vt/vtgate/engine/fk_verify.go
+++ b/go/vt/vtgate/engine/fk_verify.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
+// Verify contains the verification primitve and its type i.e. parent or child
 type Verify struct {
 	Exec Primitive
 	Typ  string
@@ -40,6 +41,7 @@ type FkVerify struct {
 	txNeeded
 }
 
+// constants for verification type.
 const (
 	ParentVerify = "VerifyParent"
 	ChildVerify  = "VerifyChild"

--- a/go/vt/vtgate/engine/fk_verify_test.go
+++ b/go/vt/vtgate/engine/fk_verify_test.go
@@ -22,16 +22,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 func TestFKVerifyUpdate(t *testing.T) {
 	verifyP := &Route{
-		Query: "select distinct cola, colb from parent where (cola, colb) in ::__vals",
+		Query: "select 1 from child c left join parent p on p.cola = 1 and p.colb = 'a' where p.cola is null and p.colb is null",
 		RoutingParameters: &RoutingParameters{
 			Opcode:   Unsharded,
 			Keyspace: &vindexes.Keyspace{Name: "ks"},
@@ -47,29 +45,19 @@ func TestFKVerifyUpdate(t *testing.T) {
 		},
 	}
 	fkc := &FkVerify{
-		Verify: []*FkParent{
-			{
-				Values: []sqlparser.Exprs{{sqlparser.NewIntLiteral("1"), sqlparser.NewStrLiteral("a")}},
-				Cols: []CheckCol{
-					{Col: 0, Type: sqltypes.Int64, Collation: collations.CollationBinaryID},
-					{Col: 1, Type: sqltypes.VarChar, Collation: collations.CollationUtf8mb4ID},
-				},
-				BvName: "__vals",
-				Exec:   verifyP,
-			},
-		},
-		Exec: childP,
+		Verify: []Primitive{verifyP},
+		Exec:   childP,
 	}
 
 	t.Run("foreign key verification success", func(t *testing.T) {
-		fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "1|a")
+		fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("1", "int64"))
 		vc := newDMLTestVCursor("0")
 		vc.results = []*sqltypes.Result{fakeRes}
 		_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
 		require.NoError(t, err)
 		vc.ExpectLog(t, []string{
 			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`ExecuteMultiShard ks.0: select distinct cola, colb from parent where (cola, colb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}}} false false`,
+			`ExecuteMultiShard ks.0: select 1 from child c left join parent p on p.cola = 1 and p.colb = 'a' where p.cola is null and p.colb is null {} false false`,
 			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
 			`ExecuteMultiShard ks.0: update child set cola = 1, colb = 'a' where foo = 48 {} true true`,
 		})
@@ -79,7 +67,7 @@ func TestFKVerifyUpdate(t *testing.T) {
 		require.NoError(t, err)
 		vc.ExpectLog(t, []string{
 			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`StreamExecuteMulti select distinct cola, colb from parent where (cola, colb) in ::__vals ks.0: {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}}} `,
+			`StreamExecuteMulti select 1 from child c left join parent p on p.cola = 1 and p.colb = 'a' where p.cola is null and p.colb is null ks.0: {} `,
 			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
 			`ExecuteMultiShard ks.0: update child set cola = 1, colb = 'a' where foo = 48 {} true true`,
 		})
@@ -87,14 +75,14 @@ func TestFKVerifyUpdate(t *testing.T) {
 
 	t.Run("foreign key verification failure", func(t *testing.T) {
 		// No results from select, should cause the foreign key verification to fail.
-		fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"))
+		fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("1", "int64"), "1", "1", "1")
 		vc := newDMLTestVCursor("0")
 		vc.results = []*sqltypes.Result{fakeRes}
 		_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
 		require.ErrorContains(t, err, "Cannot add or update a child row: a foreign key constraint fails")
 		vc.ExpectLog(t, []string{
 			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`ExecuteMultiShard ks.0: select distinct cola, colb from parent where (cola, colb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}}} false false`,
+			`ExecuteMultiShard ks.0: select 1 from child c left join parent p on p.cola = 1 and p.colb = 'a' where p.cola is null and p.colb is null {} false false`,
 		})
 
 		vc.Rewind()
@@ -102,86 +90,7 @@ func TestFKVerifyUpdate(t *testing.T) {
 		require.ErrorContains(t, err, "Cannot add or update a child row: a foreign key constraint fails")
 		vc.ExpectLog(t, []string{
 			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`StreamExecuteMulti select distinct cola, colb from parent where (cola, colb) in ::__vals ks.0: {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}}} `,
-		})
-	})
-}
-
-// TestFKVerifyInsert tests the functionality of FkVerify Primitive to verify the validation of the foreign key constraints when executing an insert.
-func TestFKVerifyInsert(t *testing.T) {
-	verifyP := &Route{
-		Query: "select distinct cola, colb from parent where (cola, colb) in ::__vals",
-		RoutingParameters: &RoutingParameters{
-			Opcode:   Unsharded,
-			Keyspace: &vindexes.Keyspace{Name: "ks"},
-		},
-	}
-	childP := &Insert{
-		Opcode:   InsertUnsharded,
-		Query:    "insert into child (cola, colb, x) values (1, 'a', 1), (2, 'b', 2), (1, 'a', 3),",
-		Keyspace: &vindexes.Keyspace{Name: "ks"},
-	}
-	fkc := &FkVerify{
-		Verify: []*FkParent{
-			{
-				Values: []sqlparser.Exprs{
-					{sqlparser.NewIntLiteral("1"), sqlparser.NewStrLiteral("a")},
-					{sqlparser.NewIntLiteral("2"), sqlparser.NewStrLiteral("b")},
-					{sqlparser.NewIntLiteral("1"), sqlparser.NewStrLiteral("a")},
-				},
-				Cols: []CheckCol{
-					{Col: 0, Type: sqltypes.Int64, Collation: collations.CollationBinaryID},
-					{Col: 1, Type: sqltypes.VarChar, Collation: collations.CollationUtf8mb4ID},
-				},
-				BvName: "__vals",
-				Exec:   verifyP,
-			},
-		},
-		Exec: childP,
-	}
-
-	t.Run("foreign key verification success", func(t *testing.T) {
-		fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "1|a", "2|b")
-		vc := newDMLTestVCursor("0")
-		vc.results = []*sqltypes.Result{fakeRes}
-		_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
-		require.NoError(t, err)
-		vc.ExpectLog(t, []string{
-			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`ExecuteMultiShard ks.0: select distinct cola, colb from parent where (cola, colb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} false false`,
-			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`ExecuteMultiShard ks.0: insert into child (cola, colb, x) values (1, 'a', 1), (2, 'b', 2), (1, 'a', 3), {} true true`,
-		})
-
-		vc.Rewind()
-		err = fkc.TryStreamExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true, func(result *sqltypes.Result) error { return nil })
-		require.NoError(t, err)
-		vc.ExpectLog(t, []string{
-			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`StreamExecuteMulti select distinct cola, colb from parent where (cola, colb) in ::__vals ks.0: {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} `,
-			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`ExecuteMultiShard ks.0: insert into child (cola, colb, x) values (1, 'a', 1), (2, 'b', 2), (1, 'a', 3), {} true true`,
-		})
-	})
-
-	t.Run("foreign key verification failure", func(t *testing.T) {
-		// Only 1 result from select, should cause the foreign key verification to fail.
-		fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "2|b")
-		vc := newDMLTestVCursor("0")
-		vc.results = []*sqltypes.Result{fakeRes}
-		_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
-		require.ErrorContains(t, err, "Cannot add or update a child row: a foreign key constraint fails")
-		vc.ExpectLog(t, []string{
-			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`ExecuteMultiShard ks.0: select distinct cola, colb from parent where (cola, colb) in ::__vals {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} false false`,
-		})
-
-		vc.Rewind()
-		err = fkc.TryStreamExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true, func(result *sqltypes.Result) error { return nil })
-		require.ErrorContains(t, err, "Cannot add or update a child row: a foreign key constraint fails")
-		vc.ExpectLog(t, []string{
-			`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-			`StreamExecuteMulti select distinct cola, colb from parent where (cola, colb) in ::__vals ks.0: {__vals: type:TUPLE values:{type:TUPLE values:{type:INT64 value:"1"} values:{type:VARCHAR value:"a"}} values:{type:TUPLE values:{type:INT64 value:"2"} values:{type:VARCHAR value:"b"}}} `,
+			`StreamExecuteMulti select 1 from child c left join parent p on p.cola = 1 and p.colb = 'a' where p.cola is null and p.colb is null ks.0: {} `,
 		})
 	})
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -222,7 +222,8 @@ type (
 		TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error)
 		TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error
 
-		// Inputs is a slice containing the inputs to this Primitive
+		// Inputs is a slice containing the inputs to this Primitive.
+		// The returned map has additional information about the inputs, that is used in the description.
 		Inputs() ([]Primitive, []map[string]any)
 
 		// description is the description, sans the inputs, of this Primitive.

--- a/go/vt/vtgate/planbuilder/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/fk_verify.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+)
+
+var _ logicalPlan = (*fkVerify)(nil)
+
+// fkVerify is the logicalPlan for engine.FkVerify.
+type fkVerify struct {
+	input  logicalPlan
+	verify []*engine.FkParent
+}
+
+// newFkVerify builds a new fkVerify.
+func newFkVerify(input logicalPlan, verify []*engine.FkParent) *fkVerify {
+	return &fkVerify{
+		input:  input,
+		verify: verify,
+	}
+}
+
+// Primitive implements the logicalPlan interface
+func (fkc *fkVerify) Primitive() engine.Primitive {
+	return &engine.FkVerify{
+		Exec:   fkc.input.Primitive(),
+		Verify: fkc.verify,
+	}
+}
+
+// Wireup implements the logicalPlan interface
+func (fkc *fkVerify) Wireup(ctx *plancontext.PlanningContext) error {
+	return fkc.input.Wireup(ctx)
+}
+
+// Rewrite implements the logicalPlan interface
+func (fkc *fkVerify) Rewrite(inputs ...logicalPlan) error {
+	if len(inputs) != 1 {
+		return vterrors.VT13001("fkVerify: wrong number of inputs")
+	}
+	fkc.input = inputs[0]
+	return nil
+}
+
+// ContainsTables implements the logicalPlan interface
+func (fkc *fkVerify) ContainsTables() semantics.TableSet {
+	return fkc.input.ContainsTables()
+}
+
+// Inputs implements the logicalPlan interface
+func (fkc *fkVerify) Inputs() []logicalPlan {
+	return []logicalPlan{fkc.input}
+}
+
+// OutputColumns implements the logicalPlan interface
+func (fkc *fkVerify) OutputColumns() []sqlparser.SelectExpr {
+	return nil
+}

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -123,23 +123,13 @@ func transformFkVerify(ctx *plancontext.PlanningContext, fkv *operators.FkVerify
 	ctx.SemTable = nil
 
 	// Go over the children and convert them to Primitives too.
-	var parents []*engine.FkParent
-	for _, verify := range fkv.Verify {
-		verifyLP, err := transformToLogicalPlan(ctx, verify.Op)
+	var parents []logicalPlan
+	for _, op := range fkv.Verify {
+		verifyLP, err := transformToLogicalPlan(ctx, op)
 		if err != nil {
 			return nil, err
 		}
-		err = verifyLP.Wireup(ctx)
-		if err != nil {
-			return nil, err
-		}
-		verifyEngine := verifyLP.Primitive()
-		parents = append(parents, &engine.FkParent{
-			BvName: verify.BvName,
-			Values: verify.Values,
-			Cols:   verify.Cols,
-			Exec:   verifyEngine,
-		})
+		parents = append(parents, verifyLP)
 	}
 
 	return newFkVerify(inputLP, parents), nil

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -112,6 +112,7 @@ func transformFkCascade(ctx *plancontext.PlanningContext, fkc *operators.FkCasca
 	return newFkCascade(parentLP, selLP, children), nil
 }
 
+// transformFkVerify transforms a FkVerify operator into a logical plan.
 func transformFkVerify(ctx *plancontext.PlanningContext, fkv *operators.FkVerify) (logicalPlan, error) {
 	inputLP, err := transformToLogicalPlan(ctx, fkv.Input)
 	if err != nil {
@@ -123,16 +124,19 @@ func transformFkVerify(ctx *plancontext.PlanningContext, fkv *operators.FkVerify
 	ctx.SemTable = nil
 
 	// Go over the children and convert them to Primitives too.
-	var parents []logicalPlan
-	for _, op := range fkv.Verify {
-		verifyLP, err := transformToLogicalPlan(ctx, op)
+	var verify []*verifyLP
+	for _, v := range fkv.Verify {
+		lp, err := transformToLogicalPlan(ctx, v.Op)
 		if err != nil {
 			return nil, err
 		}
-		parents = append(parents, verifyLP)
+		verify = append(verify, &verifyLP{
+			verify: lp,
+			typ:    v.Typ,
+		})
 	}
 
-	return newFkVerify(inputLP, parents), nil
+	return newFkVerify(inputLP, verify), nil
 }
 
 func transformAggregator(ctx *plancontext.PlanningContext, op *operators.Aggregator) (logicalPlan, error) {

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -47,7 +47,9 @@ func ToSQL(ctx *plancontext.PlanningContext, op ops.Operator) (sqlparser.Stateme
 	if err != nil {
 		return nil, nil, err
 	}
-	q.sortTables()
+	if ctx.SemTable != nil {
+		q.sortTables()
+	}
 	return q.stmt, q.dmlOperator, nil
 }
 

--- a/go/vt/vtgate/planbuilder/operators/ast2op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast2op.go
@@ -592,11 +592,12 @@ func isRestrict(onDelete sqlparser.ReferenceAction) bool {
 // createSelectionOp creates the selection operator to select the parent columns for the foreign key constraints.
 // The Select statement looks something like this - `SELECT <parent_columns_in_fk for all the foreign key constraints> FROM <parent_table> WHERE <where_clause_of_update>`
 // TODO (@Harshit, @GuptaManan100): Compress the columns in the SELECT statement, if there are multiple foreign key constraints using the same columns.
-func createSelectionOp(ctx *plancontext.PlanningContext, selectExprs []sqlparser.SelectExpr, tableExprs sqlparser.TableExprs, where *sqlparser.Where) (ops.Operator, error) {
+func createSelectionOp(ctx *plancontext.PlanningContext, selectExprs []sqlparser.SelectExpr, tableExprs sqlparser.TableExprs, where *sqlparser.Where, limit *sqlparser.Limit) (ops.Operator, error) {
 	selectionStmt := &sqlparser.Select{
 		SelectExprs: selectExprs,
 		From:        tableExprs,
 		Where:       where,
+		Limit:       limit,
 	}
 	return createOpFromStmt(ctx, selectionStmt)
 }

--- a/go/vt/vtgate/planbuilder/operators/ast_to_delete_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_delete_op.go
@@ -55,7 +55,7 @@ func createOperatorFromDelete(ctx *plancontext.PlanningContext, deleteStmt *sqlp
 		return delOp, nil
 	}
 
-	childFks := vindexTable.ChildFKsNeedsHandling(vindexes.DeleteAction)
+	childFks := vindexTable.ChildFKsNeedsHandling(ctx.VerifyAllFKs, vindexes.DeleteAction)
 	// If there are no foreign key constraints, then we don't need to do anything.
 	if len(childFks) == 0 {
 		return delOp, nil
@@ -196,7 +196,8 @@ func createFkChildForDelete(ctx *plancontext.PlanningContext, fk vindexes.ChildF
 		return nil, vterrors.VT09016()
 	}
 
-	childOp, err := createOpFromStmt(ctx, childStmt)
+	// For the child statement of a DELETE query, we don't need to verify all the FKs on VTgate or ignore any foreign key explicitly.
+	childOp, err := createOpFromStmt(ctx, childStmt, false /* verifyAllFKs */, "" /* fkToIgnore */)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/ast_to_delete_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_delete_op.go
@@ -145,7 +145,7 @@ func createFkCascadeOpForDelete(ctx *plancontext.PlanningContext, parentOp ops.O
 		}
 		fkChildren = append(fkChildren, fkChild)
 	}
-	selectionOp, err := createSelectionOp(ctx, selectExprs, delStmt.TableExprs, delStmt.Where)
+	selectionOp, err := createSelectionOp(ctx, selectExprs, delStmt.TableExprs, delStmt.Where, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/ast_to_update_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_update_op.go
@@ -385,7 +385,7 @@ func createFKVerifyOp(ctx *plancontext.PlanningContext, childOp ops.Operator, up
 		}
 		Verify = append(Verify, &VerifyOp{
 			Op:  op,
-			Typ: ParentVerify,
+			Typ: engine.ParentVerify,
 		})
 	}
 	// This validates that the old values don't exist on the child table.
@@ -396,7 +396,7 @@ func createFKVerifyOp(ctx *plancontext.PlanningContext, childOp ops.Operator, up
 		}
 		Verify = append(Verify, &VerifyOp{
 			Op:  op,
-			Typ: ChildVerify,
+			Typ: engine.ChildVerify,
 		})
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/ast_to_update_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_update_op.go
@@ -376,14 +376,17 @@ func createFKVerifyOp(ctx *plancontext.PlanningContext, childOp ops.Operator, up
 		return childOp, nil
 	}
 
-	var Verify []ops.Operator
+	var Verify []*VerifyOp
 	// This validates that new values exists on the parent table.
 	for _, fk := range parentFks {
 		op, err := createFkVerifyOpForParentFKForUpdate(ctx, updStmt, fk)
 		if err != nil {
 			return nil, err
 		}
-		Verify = append(Verify, op)
+		Verify = append(Verify, &VerifyOp{
+			Op:  op,
+			Typ: ParentVerify,
+		})
 	}
 	// This validates that the old values don't exist on the child table.
 	for _, fk := range restrictChildFks {
@@ -391,7 +394,10 @@ func createFKVerifyOp(ctx *plancontext.PlanningContext, childOp ops.Operator, up
 		if err != nil {
 			return nil, err
 		}
-		Verify = append(Verify, op)
+		Verify = append(Verify, &VerifyOp{
+			Op:  op,
+			Typ: ChildVerify,
+		})
 	}
 
 	return &FkVerify{

--- a/go/vt/vtgate/planbuilder/operators/ast_to_update_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_update_op.go
@@ -59,7 +59,7 @@ func createOperatorFromUpdate(ctx *plancontext.PlanningContext, updStmt *sqlpars
 
 	// If the delete statement has a limit, we don't support it yet.
 	if updStmt.Limit != nil {
-		return nil, vterrors.VT12001("foreign keys management at vitess with limit")
+		return nil, vterrors.VT12001("update with limit with foreign key constraints")
 	}
 
 	return buildFkOperator(ctx, updOp, updClone, parentFks, childFks, vindexTable)
@@ -180,7 +180,7 @@ func getFKRequirementsForUpdate(ctx *plancontext.PlanningContext, updateExprs sq
 func buildFkOperator(ctx *plancontext.PlanningContext, updOp ops.Operator, updClone *sqlparser.Update, parentFks []vindexes.ParentFKInfo, childFks []vindexes.ChildFKInfo, updatedTable *vindexes.Table) (ops.Operator, error) {
 	// We only support simple expressions in update queries for foreign key handling.
 	if sqlparser.IsNonLiteral(updClone.Exprs) {
-		return nil, vterrors.VT12001("foreign keys management at vitess with non-literal values")
+		return nil, vterrors.VT12001("update expression with non-literal values with foreign key constraints")
 	}
 
 	restrictChildFks, cascadeChildFks := splitChildFks(childFks)

--- a/go/vt/vtgate/planbuilder/operators/fk_cascade.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_cascade.go
@@ -102,5 +102,5 @@ func (fkc *FkCascade) GetOrdering() ([]ops.OrderBy, error) {
 
 // ShortDescription implements the Operator interface
 func (fkc *FkCascade) ShortDescription() string {
-	return "FkCascade"
+	return ""
 }

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -76,5 +76,5 @@ func (fkv *FkVerify) GetOrdering() ([]ops.OrderBy, error) {
 
 // ShortDescription implements the Operator interface
 func (fkv *FkVerify) ShortDescription() string {
-	return "FkVerify"
+	return ""
 }

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -17,24 +17,14 @@ limitations under the License.
 package operators
 
 import (
-	"vitess.io/vitess/go/vt/sqlparser"
-	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
 )
-
-type FkParent struct {
-	Values []sqlparser.Exprs
-	Cols   []engine.CheckCol
-	BvName string
-
-	Op ops.Operator
-}
 
 // FkVerify is used to represent a foreign key verification operation
 // as an operator. This operator is created for DML queries that require
 // verifications on the existence of the rows in the parent table (for example, INSERT and UPDATE).
 type FkVerify struct {
-	Verify []*FkParent
+	Verify []ops.Operator
 	Input  ops.Operator
 
 	noColumns
@@ -47,45 +37,23 @@ var _ ops.Operator = (*FkVerify)(nil)
 func (fkv *FkVerify) Inputs() []ops.Operator {
 	var inputs []ops.Operator
 	inputs = append(inputs, fkv.Input)
-	for _, child := range fkv.Verify {
-		inputs = append(inputs, child.Op)
-	}
+	inputs = append(inputs, fkv.Verify...)
 	return inputs
 }
 
 // SetInputs implements the Operator interface
 func (fkv *FkVerify) SetInputs(operators []ops.Operator) {
-	if len(operators) < 1 {
-		panic("incorrect count of inputs for FkVerify")
-	}
 	fkv.Input = operators[0]
-	for idx, operator := range operators {
-		if idx < 1 {
-			continue
-		}
-		fkv.Verify[idx-1].Op = operator
+	fkv.Verify = nil
+	if len(operators) > 1 {
+		fkv.Verify = operators[1:]
 	}
 }
 
 // Clone implements the Operator interface
 func (fkv *FkVerify) Clone(inputs []ops.Operator) ops.Operator {
-	if len(inputs) < 1 {
-		panic("incorrect count of inputs for FkVerify")
-	}
-	newFkv := &FkVerify{
-		Input: inputs[0],
-	}
-	for idx, operator := range inputs {
-		if idx < 1 {
-			continue
-		}
-		newFkv.Verify = append(newFkv.Verify, &FkParent{
-			Values: fkv.Verify[idx-1].Values,
-			BvName: fkv.Verify[idx-1].BvName,
-			Cols:   fkv.Verify[idx-1].Cols,
-			Op:     operator,
-		})
-	}
+	newFkv := &FkVerify{}
+	newFkv.SetInputs(inputs)
 	return newFkv
 }
 

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -27,11 +27,6 @@ type VerifyOp struct {
 	Typ string
 }
 
-const (
-	ParentVerify = "VerifyParent"
-	ChildVerify  = "VerifyChild"
-)
-
 // FkVerify is used to represent a foreign key verification operation
 // as an operator. This operator is created for DML queries that require
 // verifications on the existence of the rows in the parent table (for example, INSERT and UPDATE).

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -35,8 +35,7 @@ var _ ops.Operator = (*FkVerify)(nil)
 
 // Inputs implements the Operator interface
 func (fkv *FkVerify) Inputs() []ops.Operator {
-	var inputs []ops.Operator
-	inputs = append(inputs, fkv.Input)
+	inputs := []ops.Operator{fkv.Input}
 	inputs = append(inputs, fkv.Verify...)
 	return inputs
 }

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
+)
+
+type FkParent struct {
+	Values []sqlparser.Exprs
+	Cols   []engine.CheckCol
+	BvName string
+
+	Op ops.Operator
+}
+
+// FkVerify is used to represent a foreign key verification operation
+// as an operator. This operator is created for DML queries that require
+// verifications on the existence of the rows in the parent table (for example, INSERT and UPDATE).
+type FkVerify struct {
+	Verify []*FkParent
+	Input  ops.Operator
+
+	noColumns
+	noPredicates
+}
+
+var _ ops.Operator = (*FkVerify)(nil)
+
+// Inputs implements the Operator interface
+func (fkv *FkVerify) Inputs() []ops.Operator {
+	var inputs []ops.Operator
+	inputs = append(inputs, fkv.Input)
+	for _, child := range fkv.Verify {
+		inputs = append(inputs, child.Op)
+	}
+	return inputs
+}
+
+// SetInputs implements the Operator interface
+func (fkv *FkVerify) SetInputs(operators []ops.Operator) {
+	if len(operators) < 1 {
+		panic("incorrect count of inputs for FkVerify")
+	}
+	fkv.Input = operators[0]
+	for idx, operator := range operators {
+		if idx < 1 {
+			continue
+		}
+		fkv.Verify[idx-1].Op = operator
+	}
+}
+
+// Clone implements the Operator interface
+func (fkv *FkVerify) Clone(inputs []ops.Operator) ops.Operator {
+	if len(inputs) < 1 {
+		panic("incorrect count of inputs for FkVerify")
+	}
+	newFkv := &FkVerify{
+		Input: inputs[0],
+	}
+	for idx, operator := range inputs {
+		if idx < 1 {
+			continue
+		}
+		newFkv.Verify = append(newFkv.Verify, &FkParent{
+			Values: fkv.Verify[idx-1].Values,
+			BvName: fkv.Verify[idx-1].BvName,
+			Cols:   fkv.Verify[idx-1].Cols,
+			Op:     operator,
+		})
+	}
+	return newFkv
+}
+
+// GetOrdering implements the Operator interface
+func (fkv *FkVerify) GetOrdering() ([]ops.OrderBy, error) {
+	return nil, nil
+}
+
+// ShortDescription implements the Operator interface
+func (fkv *FkVerify) ShortDescription() string {
+	return "FkVerify"
+}

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -342,10 +342,7 @@ func exposeColumnsThroughDerivedTable(ctx *plancontext.PlanningContext, p *Proje
 			}
 
 			expr = semantics.RewriteDerivedTableExpression(expr, derivedTbl)
-			out, err := prefixColNames(tblName, expr)
-			if err != nil {
-				return err
-			}
+			out := prefixColNames(tblName, expr)
 
 			alias := sqlparser.UnescapedString(out)
 			predicate.LHSExprs[idx] = sqlparser.NewColNameWithQualifier(alias, derivedTblName)
@@ -357,15 +354,14 @@ func exposeColumnsThroughDerivedTable(ctx *plancontext.PlanningContext, p *Proje
 
 // prefixColNames adds qualifier prefixes to all ColName:s.
 // We want to be more explicit than the user was to make sure we never produce invalid SQL
-func prefixColNames(tblName sqlparser.TableName, e sqlparser.Expr) (out sqlparser.Expr, err error) {
-	out = sqlparser.CopyOnRewrite(e, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
+func prefixColNames(tblName sqlparser.TableName, e sqlparser.Expr) sqlparser.Expr {
+	return sqlparser.CopyOnRewrite(e, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
 		col, ok := cursor.Node().(*sqlparser.ColName)
 		if !ok {
 			return
 		}
 		col.Qualifier = tblName
 	}, nil).(sqlparser.Expr)
-	return
 }
 
 func createProjectionWithTheseColumns(

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/test/vschemawrapper"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 
 	"github.com/nsf/jsondiff"
 	"github.com/stretchr/testify/require"
@@ -125,6 +126,7 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		_ = vschema.AddForeignKey("sharded_fk_allow", "tbl10", createFkDefinition([]string{"sk", "col"}, "tbl2", []string{"col2", "col"}, sqlparser.Restrict, sqlparser.Restrict))
 		// FK from tbl10 referencing tbl3 that is not shard scoped.
 		_ = vschema.AddForeignKey("sharded_fk_allow", "tbl10", createFkDefinition([]string{"col"}, "tbl3", []string{"col"}, sqlparser.Restrict, sqlparser.Restrict))
+		setCol(t, vschema, "sharded_fk_allow", "tbl3", "col", sqltypes.VarChar, "CollationUtf8mb4ID")
 
 		// FK from tbl4 referencing tbl5 that is shard scoped.
 		_ = vschema.AddForeignKey("sharded_fk_allow", "tbl4", createFkDefinition([]string{"col4"}, "tbl5", []string{"col5"}, sqlparser.SetNull, sqlparser.Cascade))
@@ -162,6 +164,12 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl6", createFkDefinition([]string{"col6"}, "u_tbl5", []string{"col5"}, sqlparser.DefaultAction, sqlparser.DefaultAction))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl8", createFkDefinition([]string{"col8"}, "u_tbl9", []string{"col9"}, sqlparser.SetNull, sqlparser.SetNull))
 	}
+}
+
+func setCol(t *testing.T, vschema *vindexes.VSchema, ks string, name string, col string, typ querypb.Type, coll string) {
+	tbl, err := vschema.FindTable(ks, name)
+	require.NoError(t, err)
+	tbl.Columns = append(tbl.Columns, vindexes.Column{Name: sqlparser.NewIdentifierCI(col), Type: typ, CollationName: coll})
 }
 
 func TestSystemTables57(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -154,7 +154,8 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		// u_tbl3(col2)  -> u_tbl2(col2)  Cascade Null.
 		// u_tbl4(col4)  -> u_tbl3(col3)  Restrict.
 		// u_tbl6(col6)  -> u_tbl5(col5)  Restrict.
-		// u_tbl8(col8)  -> u_tbl9(col9)  Cascade Null.
+		// u_tbl8(col8)  -> u_tbl9(col9)  Null Null.
+		// u_tbl8(col8)  -> u_tbl6(col6)  Cascade Null.
 
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl2", createFkDefinition([]string{"col2"}, "u_tbl1", []string{"col1"}, sqlparser.Cascade, sqlparser.Cascade))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl9", createFkDefinition([]string{"col9"}, "u_tbl1", []string{"col1"}, sqlparser.SetNull, sqlparser.NoAction))
@@ -163,6 +164,7 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl4", createFkDefinition([]string{"col4"}, "u_tbl3", []string{"col3"}, sqlparser.Restrict, sqlparser.Restrict))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl6", createFkDefinition([]string{"col6"}, "u_tbl5", []string{"col5"}, sqlparser.DefaultAction, sqlparser.DefaultAction))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl8", createFkDefinition([]string{"col8"}, "u_tbl9", []string{"col9"}, sqlparser.SetNull, sqlparser.SetNull))
+		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl8", createFkDefinition([]string{"col8"}, "u_tbl6", []string{"col6"}, sqlparser.Cascade, sqlparser.CASCADE))
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -28,14 +28,12 @@ import (
 	"strings"
 	"testing"
 
-	"vitess.io/vitess/go/test/vschemawrapper"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-
 	"github.com/nsf/jsondiff"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
+	"vitess.io/vitess/go/test/vschemawrapper"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/servenv"
@@ -126,7 +124,6 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		_ = vschema.AddForeignKey("sharded_fk_allow", "tbl10", createFkDefinition([]string{"sk", "col"}, "tbl2", []string{"col2", "col"}, sqlparser.Restrict, sqlparser.Restrict))
 		// FK from tbl10 referencing tbl3 that is not shard scoped.
 		_ = vschema.AddForeignKey("sharded_fk_allow", "tbl10", createFkDefinition([]string{"col"}, "tbl3", []string{"col"}, sqlparser.Restrict, sqlparser.Restrict))
-		setCol(t, vschema, "sharded_fk_allow", "tbl3", "col", sqltypes.VarChar, "CollationUtf8mb4ID")
 
 		// FK from tbl4 referencing tbl5 that is shard scoped.
 		_ = vschema.AddForeignKey("sharded_fk_allow", "tbl4", createFkDefinition([]string{"col4"}, "tbl5", []string{"col5"}, sqlparser.SetNull, sqlparser.Cascade))
@@ -170,12 +167,6 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl4", createFkDefinition([]string{"col4"}, "u_tbl7", []string{"col7"}, sqlparser.Cascade, sqlparser.Cascade))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl9", createFkDefinition([]string{"col9"}, "u_tbl4", []string{"col4"}, sqlparser.Restrict, sqlparser.Restrict))
 	}
-}
-
-func setCol(t *testing.T, vschema *vindexes.VSchema, ks string, name string, col string, typ querypb.Type, coll string) {
-	tbl, err := vschema.FindTable(ks, name)
-	require.NoError(t, err)
-	tbl.Columns = append(tbl.Columns, vindexes.Column{Name: sqlparser.NewIdentifierCI(col), Type: typ, CollationName: coll})
 }
 
 func TestSystemTables57(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -156,6 +156,8 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		// u_tbl6(col6)  -> u_tbl5(col5)  Restrict.
 		// u_tbl8(col8)  -> u_tbl9(col9)  Null Null.
 		// u_tbl8(col8)  -> u_tbl6(col6)  Cascade Null.
+		// u_tbl4(col4)  -> u_tbl7(col7)  Cascade Cascade.
+		// u_tbl9(col9)  -> u_tbl4(col4)  Restrict Restrict.
 
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl2", createFkDefinition([]string{"col2"}, "u_tbl1", []string{"col1"}, sqlparser.Cascade, sqlparser.Cascade))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl9", createFkDefinition([]string{"col9"}, "u_tbl1", []string{"col1"}, sqlparser.SetNull, sqlparser.NoAction))
@@ -165,6 +167,8 @@ func setFks(t *testing.T, vschema *vindexes.VSchema) {
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl6", createFkDefinition([]string{"col6"}, "u_tbl5", []string{"col5"}, sqlparser.DefaultAction, sqlparser.DefaultAction))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl8", createFkDefinition([]string{"col8"}, "u_tbl9", []string{"col9"}, sqlparser.SetNull, sqlparser.SetNull))
 		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl8", createFkDefinition([]string{"col8"}, "u_tbl6", []string{"col6"}, sqlparser.Cascade, sqlparser.CASCADE))
+		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl4", createFkDefinition([]string{"col4"}, "u_tbl7", []string{"col7"}, sqlparser.Cascade, sqlparser.Cascade))
+		_ = vschema.AddForeignKey("unsharded_fk_allow", "u_tbl9", createFkDefinition([]string{"col9"}, "u_tbl4", []string{"col4"}, sqlparser.Restrict, sqlparser.Restrict))
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -499,7 +499,7 @@
         "OperatorType": "FKVerify",
         "Inputs": [
           {
-            "InputName": "Verify-1",
+            "InputName": "VerifyParent-1",
             "OperatorType": "Projection",
             "Expressions": [
               "INT64(1) as 1"
@@ -823,7 +823,7 @@
         "OperatorType": "FKVerify",
         "Inputs": [
           {
-            "InputName": "Verify-1",
+            "InputName": "VerifyParent-1",
             "OperatorType": "Projection",
             "Expressions": [
               "INT64(1) as 1"
@@ -923,7 +923,7 @@
             ],
             "Inputs": [
               {
-                "InputName": "Verify-1",
+                "InputName": "VerifyParent-1",
                 "OperatorType": "Route",
                 "Variant": "Unsharded",
                 "Keyspace": {
@@ -999,7 +999,7 @@
             ],
             "Inputs": [
               {
-                "InputName": "Verify-1",
+                "InputName": "VerifyParent-1",
                 "OperatorType": "Route",
                 "Variant": "Unsharded",
                 "Keyspace": {
@@ -1011,7 +1011,7 @@
                 "Table": "u_tbl3, u_tbl4"
               },
               {
-                "InputName": "Verify-2",
+                "InputName": "VerifyChild-2",
                 "OperatorType": "Route",
                 "Variant": "Unsharded",
                 "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -500,30 +500,52 @@
         "Inputs": [
           {
             "InputName": "VerifyParent-1",
-            "OperatorType": "Distinct",
-            "BvName": "fkc_vals",
-            "Collations": [
-              "0: utf8mb4_0900_ai_ci"
-            ],
-            "Cols": [
-              {
-                "Col": 0,
-                "WsCol": null,
-                "Type": 6165,
-                "Collation": 0
-              }
+            "OperatorType": "Projection",
+            "Expressions": [
+              "INT64(1) as 1"
             ],
             "Inputs": [
               {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "sharded_fk_allow",
-                  "Sharded": true
-                },
-                "FieldQuery": "select col from tbl3 where 1 != 1",
-                "Query": "select distinct col from tbl3 where (col) in ::fkc_vals",
-                "Table": "tbl3"
+                "OperatorType": "Limit",
+                "Count": "INT64(1)",
+                "Inputs": [
+                  {
+                    "OperatorType": "Filter",
+                    "Predicate": "tbl3.col is null",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Join",
+                        "Variant": "LeftJoin",
+                        "JoinColumnIndexes": "R:0,R:0",
+                        "TableName": "tbl10_tbl3",
+                        "Inputs": [
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "sharded_fk_allow",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select 1 from tbl10 where 1 != 1",
+                            "Query": "select 1 from tbl10 lock in share mode",
+                            "Table": "tbl10"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "sharded_fk_allow",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select tbl3.col from tbl3 where 1 != 1",
+                            "Query": "select tbl3.col from tbl3 where tbl3.col = 'foo' lock in share mode",
+                            "Table": "tbl3"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -2,74 +2,7 @@
   {
     "comment": "Insertion in a table with cross-shard foreign keys disallowed",
     "query": "insert into tbl3 (col3, coly) values (1, 3)",
-    "plan": {
-      "QueryType": "INSERT",
-      "Original": "insert into tbl3 (col3, coly) values (1, 3)",
-      "Instructions": {
-        "OperatorType": "FKVerify",
-        "Child": {
-          "OperatorType": "Insert",
-          "Variant": "Sharded",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "insert into tbl3(col3, coly) values (:_col3_0, 3)",
-          "TableName": "tbl3",
-          "VindexValues": {
-            "hash_vin": "INT64(1)"
-          }
-        },
-        "Parent": [
-          {
-            "OperatorType": "FkVerifyParent",
-            "BvName": "fkv_vals",
-            "Cols": [
-              {
-                "Col": 0,
-                "WsCol": null,
-                "Type": 259,
-                "Collation": 63
-              }
-            ],
-            "Values": [
-              [
-                {
-                  "Type": 1,
-                  "Val": "3"
-                }
-              ]
-            ],
-            "Inputs": [
-              {
-                "OperatorType": "Distinct",
-                "Collations": [
-                  "(0:1)"
-                ],
-                "ResultColumns": 1,
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "sharded_fk_allow",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select t1col1, weight_string(t1col1) from tbl3 where 1 != 1",
-                    "Query": "select distinct t1col1, weight_string(t1col1) from tbl3 where (t1col1) in ::fkv_vals",
-                    "Table": "tbl3"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "TablesUsed": [
-        "sharded_fk_allow.tbl3"
-      ]
-    }
+    "plan": "VT12002: unsupported: cross-shard foreign keys"
   },
   {
     "comment": "Insertion in a table with shard-scoped foreign keys is allowed",
@@ -564,21 +497,14 @@
       "Original": "update tbl10 set col = 'foo'",
       "Instructions": {
         "OperatorType": "FKVerify",
-        "Child": {
-          "OperatorType": "Update",
-          "Variant": "Scatter",
-          "Keyspace": {
-            "Name": "sharded_fk_allow",
-            "Sharded": true
-          },
-          "TargetTabletType": "PRIMARY",
-          "Query": "update tbl10 set col = 'foo'",
-          "Table": "tbl10"
-        },
-        "Parent": [
+        "Inputs": [
           {
-            "OperatorType": "FkVerifyParent",
+            "InputName": "VerifyParent-1",
+            "OperatorType": "Distinct",
             "BvName": "fkc_vals",
+            "Collations": [
+              "0: utf8mb4_0900_ai_ci"
+            ],
             "Cols": [
               {
                 "Col": 0,
@@ -587,35 +513,31 @@
                 "Collation": 0
               }
             ],
-            "Values": [
-              [
-                {
-                  "Type": 0,
-                  "Val": "foo"
-                }
-              ]
-            ],
             "Inputs": [
               {
-                "OperatorType": "Distinct",
-                "Collations": [
-                  "0: utf8mb4_0900_ai_ci"
-                ],
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "sharded_fk_allow",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select col from tbl3 where 1 != 1",
-                    "Query": "select distinct col from tbl3 where (col) in ::fkc_vals",
-                    "Table": "tbl3"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "sharded_fk_allow",
+                  "Sharded": true
+                },
+                "FieldQuery": "select col from tbl3 where 1 != 1",
+                "Query": "select distinct col from tbl3 where (col) in ::fkc_vals",
+                "Table": "tbl3"
               }
             ]
+          },
+          {
+            "InputName": "Child",
+            "OperatorType": "Update",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "update tbl10 set col = 'foo'",
+            "Table": "tbl10"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -2,7 +2,74 @@
   {
     "comment": "Insertion in a table with cross-shard foreign keys disallowed",
     "query": "insert into tbl3 (col3, coly) values (1, 3)",
-    "plan": "VT12002: unsupported: cross-shard foreign keys"
+    "plan": {
+      "QueryType": "INSERT",
+      "Original": "insert into tbl3 (col3, coly) values (1, 3)",
+      "Instructions": {
+        "OperatorType": "FKVerify",
+        "Child": {
+          "OperatorType": "Insert",
+          "Variant": "Sharded",
+          "Keyspace": {
+            "Name": "sharded_fk_allow",
+            "Sharded": true
+          },
+          "TargetTabletType": "PRIMARY",
+          "Query": "insert into tbl3(col3, coly) values (:_col3_0, 3)",
+          "TableName": "tbl3",
+          "VindexValues": {
+            "hash_vin": "INT64(1)"
+          }
+        },
+        "Parent": [
+          {
+            "OperatorType": "FkVerifyParent",
+            "BvName": "fkv_vals",
+            "Cols": [
+              {
+                "Col": 0,
+                "WsCol": null,
+                "Type": 259,
+                "Collation": 63
+              }
+            ],
+            "Values": [
+              [
+                {
+                  "Type": 1,
+                  "Val": "3"
+                }
+              ]
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Distinct",
+                "Collations": [
+                  "(0:1)"
+                ],
+                "ResultColumns": 1,
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "sharded_fk_allow",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select t1col1, weight_string(t1col1) from tbl3 where 1 != 1",
+                    "Query": "select distinct t1col1, weight_string(t1col1) from tbl3 where (t1col1) in ::fkv_vals",
+                    "Table": "tbl3"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "sharded_fk_allow.tbl3"
+      ]
+    }
   },
   {
     "comment": "Insertion in a table with shard-scoped foreign keys is allowed",
@@ -492,7 +559,71 @@
   {
     "comment": "update table with column's parent foreign key cross shard - disallowed",
     "query": "update tbl10 set col = 'foo'",
-    "plan": "VT12002: unsupported: foreign keys management at vitess"
+    "plan": {
+      "QueryType": "UPDATE",
+      "Original": "update tbl10 set col = 'foo'",
+      "Instructions": {
+        "OperatorType": "FKVerify",
+        "Child": {
+          "OperatorType": "Update",
+          "Variant": "Scatter",
+          "Keyspace": {
+            "Name": "sharded_fk_allow",
+            "Sharded": true
+          },
+          "TargetTabletType": "PRIMARY",
+          "Query": "update tbl10 set col = 'foo'",
+          "Table": "tbl10"
+        },
+        "Parent": [
+          {
+            "OperatorType": "FkVerifyParent",
+            "BvName": "fkc_vals",
+            "Cols": [
+              {
+                "Col": 0,
+                "WsCol": null,
+                "Type": 6165,
+                "Collation": 0
+              }
+            ],
+            "Values": [
+              [
+                {
+                  "Type": 0,
+                  "Val": "foo"
+                }
+              ]
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Distinct",
+                "Collations": [
+                  "0: utf8mb4_0900_ai_ci"
+                ],
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "sharded_fk_allow",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select col from tbl3 where 1 != 1",
+                    "Query": "select distinct col from tbl3 where (col) in ::fkc_vals",
+                    "Table": "tbl3"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "sharded_fk_allow.tbl10",
+        "sharded_fk_allow.tbl3"
+      ]
+    }
   },
   {
     "comment": "delete table with shard scoped foreign key set default - disallowed",

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -499,7 +499,7 @@
         "OperatorType": "FKVerify",
         "Inputs": [
           {
-            "InputName": "VerifyParent-1",
+            "InputName": "Verify-1",
             "OperatorType": "Projection",
             "Expressions": [
               "INT64(1) as 1"
@@ -550,7 +550,7 @@
             ]
           },
           {
-            "InputName": "Child",
+            "InputName": "PostVerify",
             "OperatorType": "Update",
             "Variant": "Scatter",
             "Keyspace": {
@@ -823,7 +823,7 @@
         "OperatorType": "FKVerify",
         "Inputs": [
           {
-            "InputName": "VerifyParent-1",
+            "InputName": "Verify-1",
             "OperatorType": "Projection",
             "Expressions": [
               "INT64(1) as 1"
@@ -874,7 +874,7 @@
             ]
           },
           {
-            "InputName": "Child",
+            "InputName": "PostVerify",
             "OperatorType": "Update",
             "Variant": "Scatter",
             "Keyspace": {
@@ -923,7 +923,7 @@
             ],
             "Inputs": [
               {
-                "InputName": "VerifyParent-1",
+                "InputName": "Verify-1",
                 "OperatorType": "Route",
                 "Variant": "Unsharded",
                 "Keyspace": {
@@ -935,7 +935,7 @@
                 "Table": "u_tbl8, u_tbl9"
               },
               {
-                "InputName": "Child",
+                "InputName": "PostVerify",
                 "OperatorType": "Update",
                 "Variant": "Unsharded",
                 "Keyspace": {
@@ -999,7 +999,7 @@
             ],
             "Inputs": [
               {
-                "InputName": "VerifyParent-1",
+                "InputName": "Verify-1",
                 "OperatorType": "Route",
                 "Variant": "Unsharded",
                 "Keyspace": {
@@ -1011,7 +1011,7 @@
                 "Table": "u_tbl3, u_tbl4"
               },
               {
-                "InputName": "VerifyParent-2",
+                "InputName": "Verify-2",
                 "OperatorType": "Route",
                 "Variant": "Unsharded",
                 "Keyspace": {
@@ -1023,7 +1023,7 @@
                 "Table": "u_tbl4, u_tbl9"
               },
               {
-                "InputName": "Child",
+                "InputName": "PostVerify",
                 "OperatorType": "Update",
                 "Variant": "Unsharded",
                 "Keyspace": {

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -968,5 +968,94 @@
         "unsharded_fk_allow.u_tbl9"
       ]
     }
+  },
+  {
+    "comment": "Update that cascades and requires parent fk and restrict child fk verification",
+    "query": "update u_tbl7 set col7 = 'foo'",
+    "plan": {
+      "QueryType": "UPDATE",
+      "Original": "update u_tbl7 set col7 = 'foo'",
+      "Instructions": {
+        "OperatorType": "FkCascade",
+        "Inputs": [
+          {
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "FieldQuery": "select col7 from u_tbl7 where 1 != 1",
+            "Query": "select col7 from u_tbl7 lock in share mode",
+            "Table": "u_tbl7"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "FKVerify",
+            "BvName": "fkc_vals",
+            "Cols": [
+              0
+            ],
+            "Inputs": [
+              {
+                "InputName": "VerifyParent-1",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = 'foo' where 1 != 1",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = 'foo' where (u_tbl4.col4) in ::fkc_vals and u_tbl3.col3 is null limit 1",
+                "Table": "u_tbl3, u_tbl4"
+              },
+              {
+                "InputName": "VerifyParent-2",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
+                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and u_tbl4.col4 = u_tbl9.col9 limit 1",
+                "Table": "u_tbl4, u_tbl9"
+              },
+              {
+                "InputName": "Child",
+                "OperatorType": "Update",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "TargetTabletType": "PRIMARY",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = 'foo' where (u_tbl4.col4) in ::fkc_vals",
+                "Table": "u_tbl4"
+              }
+            ]
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Update",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "update u_tbl7 set col7 = 'foo'",
+            "Table": "u_tbl7"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "unsharded_fk_allow.u_tbl3",
+        "unsharded_fk_allow.u_tbl4",
+        "unsharded_fk_allow.u_tbl7",
+        "unsharded_fk_allow.u_tbl9"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -490,7 +490,7 @@
     }
   },
   {
-    "comment": "update table with column's parent foreign key cross shard - disallowed",
+    "comment": "update table with column's parent foreign key cross shard",
     "query": "update tbl10 set col = 'foo'",
     "plan": {
       "QueryType": "UPDATE",
@@ -807,5 +807,90 @@
     "comment": "delete in a table with limit - disallowed",
     "query": "delete from u_tbl2 limit 2",
     "plan": "VT12001: unsupported: foreign keys management at vitess with limit"
+  },
+  {
+    "comment": "update with fk on cross-shard with a where condition on non-literal value - disallowed",
+    "query": "update tbl3 set coly = colx + 10 where coly = 10",
+    "plan": "VT12001: unsupported: foreign keys management at vitess with non-literal values"
+  },
+  {
+    "comment": "update with fk on cross-shard with a where condition",
+    "query": "update tbl3 set coly = 20 where coly = 10",
+    "plan": {
+      "QueryType": "UPDATE",
+      "Original": "update tbl3 set coly = 20 where coly = 10",
+      "Instructions": {
+        "OperatorType": "FKVerify",
+        "Inputs": [
+          {
+            "InputName": "VerifyParent-1",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "INT64(1) as 1"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Limit",
+                "Count": "INT64(1)",
+                "Inputs": [
+                  {
+                    "OperatorType": "Filter",
+                    "Predicate": "tbl1.t1col1 is null",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Join",
+                        "Variant": "LeftJoin",
+                        "JoinColumnIndexes": "R:0,R:0",
+                        "TableName": "tbl3_tbl1",
+                        "Inputs": [
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "sharded_fk_allow",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select 1 from tbl3 where 1 != 1",
+                            "Query": "select 1 from tbl3 where tbl3.coly = 10 lock in share mode",
+                            "Table": "tbl3"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "sharded_fk_allow",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select tbl1.t1col1 from tbl1 where 1 != 1",
+                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = 20 lock in share mode",
+                            "Table": "tbl1"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "InputName": "Child",
+            "OperatorType": "Update",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "sharded_fk_allow",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "update tbl3 set coly = 20 where tbl3.coly = 10",
+            "Table": "tbl3"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "sharded_fk_allow.tbl1",
+        "sharded_fk_allow.tbl3"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -705,7 +705,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals",
                 "Table": "u_tbl2"
               }
             ]
@@ -890,6 +890,82 @@
       "TablesUsed": [
         "sharded_fk_allow.tbl1",
         "sharded_fk_allow.tbl3"
+      ]
+    }
+  },
+  {
+    "comment": "Update in a table with shard-scoped foreign keys with cascade that requires a validation of a different parent foreign key",
+    "query": "update u_tbl6 set col6 = 'foo'",
+    "plan": {
+      "QueryType": "UPDATE",
+      "Original": "update u_tbl6 set col6 = 'foo'",
+      "Instructions": {
+        "OperatorType": "FkCascade",
+        "Inputs": [
+          {
+            "InputName": "Selection",
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "FieldQuery": "select col6 from u_tbl6 where 1 != 1",
+            "Query": "select col6 from u_tbl6 lock in share mode",
+            "Table": "u_tbl6"
+          },
+          {
+            "InputName": "CascadeChild-1",
+            "OperatorType": "FKVerify",
+            "BvName": "fkc_vals",
+            "Cols": [
+              0
+            ],
+            "Inputs": [
+              {
+                "InputName": "VerifyParent-1",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = 'foo' where 1 != 1",
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = 'foo' where (u_tbl8.col8) in ::fkc_vals and u_tbl9.col9 is null limit 1",
+                "Table": "u_tbl8, u_tbl9"
+              },
+              {
+                "InputName": "Child",
+                "OperatorType": "Update",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "unsharded_fk_allow",
+                  "Sharded": false
+                },
+                "TargetTabletType": "PRIMARY",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl8 set col8 = 'foo' where (u_tbl8.col8) in ::fkc_vals",
+                "Table": "u_tbl8"
+              }
+            ]
+          },
+          {
+            "InputName": "Parent",
+            "OperatorType": "Update",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_fk_allow",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "update u_tbl6 set col6 = 'foo'",
+            "Table": "u_tbl6"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "unsharded_fk_allow.u_tbl6",
+        "unsharded_fk_allow.u_tbl8",
+        "unsharded_fk_allow.u_tbl9"
       ]
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -786,17 +786,17 @@
   {
     "comment": "update in a table with limit - disallowed",
     "query": "update u_tbl2 set col2 = 'bar' limit 2",
-    "plan": "VT12001: unsupported: foreign keys management at vitess with limit"
+    "plan": "VT12001: unsupported: update with limit with foreign key constraints"
   },
   {
     "comment": "update in a table with non-literal value - set null fail due to child update where condition",
     "query": "update u_tbl2 set m = 2, col2 = col1 + 'bar' where id = 1",
-    "plan": "VT12001: unsupported: foreign keys management at vitess with non-literal values"
+    "plan": "VT12001: unsupported: update expression with non-literal values with foreign key constraints"
   },
   {
     "comment": "update in a table with non-literal value - with cascade fail as the cascade value is not known",
     "query": "update u_tbl1 set m = 2, col1 = x + 'bar' where id = 1",
-    "plan": "VT12001: unsupported: foreign keys management at vitess with non-literal values"
+    "plan": "VT12001: unsupported: update expression with non-literal values with foreign key constraints"
   },
   {
     "comment": "update in a table with a child table having SET DEFAULT constraint - disallowed",
@@ -811,7 +811,7 @@
   {
     "comment": "update with fk on cross-shard with a where condition on non-literal value - disallowed",
     "query": "update tbl3 set coly = colx + 10 where coly = 10",
-    "plan": "VT12001: unsupported: foreign keys management at vitess with non-literal values"
+    "plan": "VT12001: unsupported: update expression with non-literal values with foreign key constraints"
   },
   {
     "comment": "update with fk on cross-shard with a where condition",

--- a/go/vt/vtgate/planbuilder/update.go
+++ b/go/vt/vtgate/planbuilder/update.go
@@ -24,7 +24,6 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-	"vitess.io/vitess/go/vt/vtgate/semantics"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
@@ -49,7 +48,7 @@ func gen4UpdateStmtPlanner(
 	}
 
 	if ks, tables := ctx.SemTable.SingleUnshardedKeyspace(); ks != nil {
-		if fkManagementNotRequiredForUpdate(ctx.SemTable, vschema, tables, updStmt.Exprs) {
+		if fkManagementNotRequiredForUpdate(ctx, vschema, tables, updStmt.Exprs) {
 			plan := updateUnshardedShortcut(updStmt, ks, tables)
 			plan = pushCommentDirectivesOnPlan(plan, updStmt)
 			return newPlanResult(plan.Primitive(), operators.QualifiedTables(ks, tables)...), nil
@@ -87,7 +86,7 @@ func gen4UpdateStmtPlanner(
 }
 
 // TODO: Handle all this in semantic analysis.
-func fkManagementNotRequiredForUpdate(semTable *semantics.SemTable, vschema plancontext.VSchema, vTables []*vindexes.Table, updateExprs sqlparser.UpdateExprs) bool {
+func fkManagementNotRequiredForUpdate(ctx *plancontext.PlanningContext, vschema plancontext.VSchema, vTables []*vindexes.Table, updateExprs sqlparser.UpdateExprs) bool {
 	childFkMap := make(map[string][]vindexes.ChildFKInfo)
 
 	// Find the foreign key mode and check for any managed child foreign keys.
@@ -99,14 +98,14 @@ func fkManagementNotRequiredForUpdate(semTable *semantics.SemTable, vschema plan
 		if ksMode != vschemapb.Keyspace_FK_MANAGED {
 			continue
 		}
-		childFks := vTable.ChildFKsNeedsHandling(vindexes.UpdateAction)
+		childFks := vTable.ChildFKsNeedsHandling(ctx.VerifyAllFKs, vindexes.UpdateAction)
 		if len(childFks) > 0 {
 			childFkMap[vTable.String()] = childFks
 		}
 	}
 
 	getFKInfo := func(expr *sqlparser.UpdateExpr) ([]vindexes.ParentFKInfo, []vindexes.ChildFKInfo) {
-		tblInfo, err := semTable.TableInfoForExpr(expr.Name)
+		tblInfo, err := ctx.SemTable.TableInfoForExpr(expr.Name)
 		if err != nil {
 			return nil, nil
 		}

--- a/go/vt/vtgate/vindexes/foreign_keys.go
+++ b/go/vt/vtgate/vindexes/foreign_keys.go
@@ -112,26 +112,6 @@ func NewChildFkInfo(childTbl *Table, fkDef *sqlparser.ForeignKeyDefinition) Chil
 	}
 }
 
-// AddForeignKey is for testing only.
-func (vschema *VSchema) AddForeignKey(ksname, childTableName string, fkConstraint *sqlparser.ForeignKeyDefinition) error {
-	ks, ok := vschema.Keyspaces[ksname]
-	if !ok {
-		return fmt.Errorf("keyspace %s not found in vschema", ksname)
-	}
-	cTbl, ok := ks.Tables[childTableName]
-	if !ok {
-		return fmt.Errorf("child table %s not found in keyspace %s", childTableName, ksname)
-	}
-	parentTableName := fkConstraint.ReferenceDefinition.ReferencedTable.Name.String()
-	pTbl, ok := ks.Tables[parentTableName]
-	if !ok {
-		return fmt.Errorf("parent table %s not found in keyspace %s", parentTableName, ksname)
-	}
-	pTbl.ChildForeignKeys = append(pTbl.ChildForeignKeys, NewChildFkInfo(cTbl, fkConstraint))
-	cTbl.ParentForeignKeys = append(cTbl.ParentForeignKeys, NewParentFkInfo(pTbl, fkConstraint))
-	return nil
-}
-
 // ParentFKsNeedsHandling returns all the parent fk constraints on this table that are not shard scoped.
 func (t *Table) ParentFKsNeedsHandling() (fks []ParentFKInfo) {
 	for _, fk := range t.ParentForeignKeys {
@@ -224,4 +204,24 @@ func isShardScoped(pTable *Table, cTable *Table, pCols sqlparser.Columns, cCols 
 		}
 	}
 	return true
+}
+
+// AddForeignKey is for testing only.
+func (vschema *VSchema) AddForeignKey(ksname, childTableName string, fkConstraint *sqlparser.ForeignKeyDefinition) error {
+	ks, ok := vschema.Keyspaces[ksname]
+	if !ok {
+		return fmt.Errorf("keyspace %s not found in vschema", ksname)
+	}
+	cTbl, ok := ks.Tables[childTableName]
+	if !ok {
+		return fmt.Errorf("child table %s not found in keyspace %s", childTableName, ksname)
+	}
+	parentTableName := fkConstraint.ReferenceDefinition.ReferencedTable.Name.String()
+	pTbl, ok := ks.Tables[parentTableName]
+	if !ok {
+		return fmt.Errorf("parent table %s not found in keyspace %s", parentTableName, ksname)
+	}
+	pTbl.ChildForeignKeys = append(pTbl.ChildForeignKeys, NewChildFkInfo(cTbl, fkConstraint))
+	cTbl.ParentForeignKeys = append(cTbl.ParentForeignKeys, NewParentFkInfo(pTbl, fkConstraint))
+	return nil
 }

--- a/go/vt/vtgate/vindexes/foreign_keys_test.go
+++ b/go/vt/vtgate/vindexes/foreign_keys_test.go
@@ -72,6 +72,8 @@ func TestTable_CrossShardParentFKs(t *testing.T) {
 		name                   string
 		table                  *Table
 		wantCrossShardFKTables []string
+		verifyAllFKs           bool
+		fkToIgnore             string
 	}{{
 		name: "No Parent FKs",
 		table: &Table{
@@ -88,12 +90,39 @@ func TestTable_CrossShardParentFKs(t *testing.T) {
 		},
 		wantCrossShardFKTables: []string{},
 	}, {
+		name:         "Unsharded keyspace with verify all FKs",
+		verifyAllFKs: true,
+		table: &Table{
+			ColumnVindexes:    []*ColumnVindex{col1Vindex},
+			Keyspace:          uks2,
+			ParentForeignKeys: []ParentFKInfo{pkInfo(unshardedTbl, []string{"col4"}, []string{"col1"})},
+		},
+		wantCrossShardFKTables: []string{"t1"},
+	}, {
 		name: "Keyspaces don't match", // parent table is on uks2
 		table: &Table{
 			Keyspace:          uks,
 			ParentForeignKeys: []ParentFKInfo{pkInfo(unshardedTbl, []string{"col4"}, []string{"col1"})},
 		},
 		wantCrossShardFKTables: []string{"t1"},
+	}, {
+		name:       "Keyspaces don't match with ignore fk", // parent table is on uks2
+		fkToIgnore: "uks.col1uks2.t1col4",
+		table: &Table{
+			Keyspace:          uks,
+			ParentForeignKeys: []ParentFKInfo{pkInfo(unshardedTbl, []string{"col4"}, []string{"col1"})},
+		},
+		wantCrossShardFKTables: []string{},
+	}, {
+		name:         "Unsharded keyspace with verify all FKs and fk to ignore",
+		verifyAllFKs: true,
+		fkToIgnore:   "uks2.col1uks2.t1col4",
+		table: &Table{
+			ColumnVindexes:    []*ColumnVindex{col1Vindex},
+			Keyspace:          uks2,
+			ParentForeignKeys: []ParentFKInfo{pkInfo(unshardedTbl, []string{"col4"}, []string{"col1"})},
+		},
+		wantCrossShardFKTables: []string{},
 	}, {
 		name: "Column Vindexes don't match", // primary vindexes on different vindex type
 		table: &Table{
@@ -137,7 +166,7 @@ func TestTable_CrossShardParentFKs(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			crossShardFks := tt.table.ParentFKsNeedsHandling()
+			crossShardFks := tt.table.ParentFKsNeedsHandling(tt.verifyAllFKs, tt.fkToIgnore)
 			var crossShardFkTables []string
 			for _, fk := range crossShardFks {
 				crossShardFkTables = append(crossShardFkTables, fk.Table.Name.String())
@@ -185,6 +214,7 @@ func TestChildFKs(t *testing.T) {
 	}
 
 	tests := []struct {
+		verifyAllFKs bool
 		name         string
 		table        *Table
 		expChildTbls []string
@@ -204,6 +234,15 @@ func TestChildFKs(t *testing.T) {
 		},
 		expChildTbls: []string{},
 	}, {
+		name:         "restrict unsharded with verify all fks",
+		verifyAllFKs: true,
+		table: &Table{
+			ColumnVindexes:   []*ColumnVindex{col1Vindex},
+			Keyspace:         uks2,
+			ChildForeignKeys: []ChildFKInfo{ckInfo(unshardedTbl, []string{"col4"}, []string{"col1"}, sqlparser.Restrict)},
+		},
+		expChildTbls: []string{"t1"},
+	}, {
 		name: "restrict shard scoped",
 		table: &Table{
 			ColumnVindexes:   []*ColumnVindex{col1Vindex},
@@ -211,6 +250,15 @@ func TestChildFKs(t *testing.T) {
 			ChildForeignKeys: []ChildFKInfo{ckInfo(shardedSingleColTbl, []string{"col1"}, []string{"col1"}, sqlparser.Restrict)},
 		},
 		expChildTbls: []string{},
+	}, {
+		name:         "restrict shard scoped with verify all fks",
+		verifyAllFKs: true,
+		table: &Table{
+			ColumnVindexes:   []*ColumnVindex{col1Vindex},
+			Keyspace:         sks,
+			ChildForeignKeys: []ChildFKInfo{ckInfo(shardedSingleColTbl, []string{"col1"}, []string{"col1"}, sqlparser.Restrict)},
+		},
+		expChildTbls: []string{"t1"},
 	}, {
 		name: "restrict Keyspaces don't match",
 		table: &Table{
@@ -246,7 +294,7 @@ func TestChildFKs(t *testing.T) {
 	deleteAction := func(fk ChildFKInfo) sqlparser.ReferenceAction { return fk.OnDelete }
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			childFks := tt.table.ChildFKsNeedsHandling(deleteAction)
+			childFks := tt.table.ChildFKsNeedsHandling(tt.verifyAllFKs, deleteAction)
 			var actualChildTbls []string
 			for _, fk := range childFks {
 				actualChildTbls = append(actualChildTbls, fk.Table.Name.String())

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1336,12 +1336,3 @@ func (t *Table) getReferenceInKeyspace(keyspace string) *Table {
 	}
 	return t
 }
-
-func (t *Table) FindColumn(column sqlparser.IdentifierCI) *Column {
-	for _, c := range t.Columns {
-		if c.Name.Equal(column) {
-			return &c
-		}
-	}
-	return nil
-}

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1336,3 +1336,12 @@ func (t *Table) getReferenceInKeyspace(keyspace string) *Table {
 	}
 	return t
 }
+
+func (t *Table) FindColumn(column sqlparser.IdentifierCI) *Column {
+	for _, c := range t.Columns {
+		if c.Name.Equal(column) {
+			return &c
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

This PR adds two planning support
- FK Cascade that validates that value exists on the parent table.
- FK Restrict that validates that the value does not exist on the child table.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/12967

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
