### PR TITLE
refactor: move DML logic to sql_builder.go

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1150,6 +1150,22 @@ func (node *Update) AddWhere(expr Expr) {
 	}
 }
 
+// AddWhere adds the boolean expression to the
+// WHERE clause as an AND condition.
+func (node *Delete) AddWhere(expr Expr) {
+	if node.Where == nil {
+		node.Where = &Where{
+			Type: WhereClause,
+			Expr: expr,
+		}
+		return
+	}
+	node.Where.Expr = &AndExpr{
+		Left:  node.Where.Expr,
+		Right: expr,
+	}
+}
+
 // AddOrder adds an order by element
 func (node *Union) AddOrder(order *Order) {
 	node.OrderBy = append(node.OrderBy, order)

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -418,7 +418,7 @@ func transformRoutePlan(ctx *plancontext.PlanningContext, op *operators.Route) (
 	case *sqlparser.Insert:
 		return buildInsertLogicalPlan(ctx, op, dmlOp, stmt)
 	default:
-		panic(fmt.Sprintf("dont know how to %T", stmt))
+		return nil, vterrors.VT13001(fmt.Sprintf("dont know how to %T", stmt))
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -390,10 +390,17 @@ func buildQuery(op ops.Operator, qb *queryBuilder) error {
 	case *Update:
 		buildUpdate(op, qb)
 		return nil
+	case *Delete:
+		buildDelete(op, qb)
 	default:
 		return vterrors.VT13001(fmt.Sprintf("unknown operator to convert to SQL: %T", op))
 	}
 	return nil
+}
+
+func buildDelete(op *Delete, qb *queryBuilder) {
+	qb.stmt = op.AST
+	qb.dmlOperator = op
 }
 
 func buildUpdate(op *Update, qb *queryBuilder) {

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -30,20 +30,25 @@ import (
 
 type (
 	queryBuilder struct {
-		ctx        *plancontext.PlanningContext
-		sel        sqlparser.SelectStatement
-		tableNames []string
+		ctx         *plancontext.PlanningContext
+		stmt        sqlparser.Statement
+		tableNames  []string
+		dmlOperator ops.Operator
 	}
 )
 
-func ToSQL(ctx *plancontext.PlanningContext, op ops.Operator) (sqlparser.SelectStatement, error) {
+func (qb *queryBuilder) asSelectStatement() sqlparser.SelectStatement {
+	return qb.stmt.(sqlparser.SelectStatement)
+}
+
+func ToSQL(ctx *plancontext.PlanningContext, op ops.Operator) (sqlparser.Statement, ops.Operator, error) {
 	q := &queryBuilder{ctx: ctx}
 	err := buildQuery(op, q)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	q.sortTables()
-	return q.sel, nil
+	return q.stmt, q.dmlOperator, nil
 }
 
 func (qb *queryBuilder) addTable(db, tableName, alias string, tableID semantics.TableSet, hints sqlparser.IndexHints) {
@@ -61,10 +66,10 @@ func (qb *queryBuilder) addTableExpr(
 	hints sqlparser.IndexHints,
 	columnAliases sqlparser.Columns,
 ) {
-	if qb.sel == nil {
-		qb.sel = &sqlparser.Select{}
+	if qb.stmt == nil {
+		qb.stmt = &sqlparser.Select{}
 	}
-	sel := qb.sel.(*sqlparser.Select)
+	sel := qb.stmt.(*sqlparser.Select)
 	elems := &sqlparser.AliasedTableExpr{
 		Expr:       tblExpr,
 		Partitions: nil,
@@ -74,7 +79,7 @@ func (qb *queryBuilder) addTableExpr(
 	}
 	qb.ctx.SemTable.ReplaceTableSetFor(tableID, elems)
 	sel.From = append(sel.From, elems)
-	qb.sel = sel
+	qb.stmt = sel
 	qb.tableNames = append(qb.tableNames, tableName)
 }
 
@@ -85,34 +90,43 @@ func (qb *queryBuilder) addPredicate(expr sqlparser.Expr) {
 		return
 	}
 
-	sel := qb.sel.(*sqlparser.Select)
 	_, isSubQuery := expr.(*sqlparser.ExtractedSubquery)
 	var addPred func(sqlparser.Expr)
 
-	if sqlparser.ContainsAggregation(expr) && !isSubQuery {
-		addPred = sel.AddHaving
-	} else {
-		addPred = sel.AddWhere
+	switch stmt := qb.stmt.(type) {
+	case *sqlparser.Select:
+		if sqlparser.ContainsAggregation(expr) && !isSubQuery {
+			addPred = stmt.AddHaving
+		} else {
+			addPred = stmt.AddWhere
+		}
+	case *sqlparser.Update:
+		addPred = stmt.AddWhere
+	case *sqlparser.Delete:
+		addPred = stmt.AddWhere
+	default:
+		panic(fmt.Sprintf("cant add WHERE to %T", qb.stmt))
 	}
+
 	for _, exp := range sqlparser.SplitAndExpression(nil, expr) {
 		addPred(exp)
 	}
 }
 
 func (qb *queryBuilder) addGroupBy(original sqlparser.Expr) {
-	sel := qb.sel.(*sqlparser.Select)
+	sel := qb.stmt.(*sqlparser.Select)
 	sel.GroupBy = append(sel.GroupBy, original)
 }
 
 func (qb *queryBuilder) addProjection(projection *sqlparser.AliasedExpr) error {
-	switch stmt := qb.sel.(type) {
+	switch stmt := qb.stmt.(type) {
 	case *sqlparser.Select:
 		stmt.SelectExprs = append(stmt.SelectExprs, projection)
 		return nil
 	case *sqlparser.Union:
 		switch expr := projection.Expr.(type) {
 		case *sqlparser.ColName:
-			return checkUnionColumnByName(expr, qb.sel)
+			return checkUnionColumnByName(expr, stmt)
 		default:
 			// if there is more than just column names, we'll just push the UNION
 			// inside a derived table and then recurse into this method again
@@ -121,13 +135,14 @@ func (qb *queryBuilder) addProjection(projection *sqlparser.AliasedExpr) error {
 		}
 
 	}
-	return vterrors.VT13001(fmt.Sprintf("unknown select statement type: %T", qb.sel))
+	return vterrors.VT13001(fmt.Sprintf("unknown select statement type: %T", qb.stmt))
 }
 
 func (qb *queryBuilder) pushUnionInsideDerived() {
+	selStmt := qb.asSelectStatement()
 	dt := &sqlparser.DerivedTable{
 		Lateral: false,
-		Select:  qb.sel,
+		Select:  selStmt,
 	}
 	sel := &sqlparser.Select{
 		From: []sqlparser.TableExpr{&sqlparser.AliasedTableExpr{
@@ -135,8 +150,8 @@ func (qb *queryBuilder) pushUnionInsideDerived() {
 			As:   sqlparser.NewIdentifierCS("dt"),
 		}},
 	}
-	sel.SelectExprs = unionSelects(sqlparser.GetFirstSelect(qb.sel).SelectExprs)
-	qb.sel = sel
+	sel.SelectExprs = unionSelects(sqlparser.GetFirstSelect(selStmt).SelectExprs)
+	qb.stmt = sel
 }
 
 func unionSelects(exprs sqlparser.SelectExprs) (selectExprs sqlparser.SelectExprs) {
@@ -172,7 +187,7 @@ func checkUnionColumnByName(column *sqlparser.ColName, sel sqlparser.SelectState
 }
 
 func (qb *queryBuilder) clearProjections() {
-	sel, isSel := qb.sel.(*sqlparser.Select)
+	sel, isSel := qb.stmt.(*sqlparser.Select)
 	if !isSel {
 		return
 	}
@@ -180,16 +195,16 @@ func (qb *queryBuilder) clearProjections() {
 }
 
 func (qb *queryBuilder) unionWith(other *queryBuilder, distinct bool) {
-	qb.sel = &sqlparser.Union{
-		Left:     qb.sel,
-		Right:    other.sel,
+	qb.stmt = &sqlparser.Union{
+		Left:     qb.asSelectStatement(),
+		Right:    other.asSelectStatement(),
 		Distinct: distinct,
 	}
 }
 
 func (qb *queryBuilder) joinInnerWith(other *queryBuilder, onCondition sqlparser.Expr) {
-	sel := qb.sel.(*sqlparser.Select)
-	otherSel := other.sel.(*sqlparser.Select)
+	sel := qb.stmt.(*sqlparser.Select)
+	otherSel := other.stmt.(*sqlparser.Select)
 	sel.From = append(sel.From, otherSel.From...)
 	sel.SelectExprs = append(sel.SelectExprs, otherSel.SelectExprs...)
 
@@ -210,8 +225,8 @@ func (qb *queryBuilder) joinInnerWith(other *queryBuilder, onCondition sqlparser
 }
 
 func (qb *queryBuilder) joinOuterWith(other *queryBuilder, onCondition sqlparser.Expr) {
-	sel := qb.sel.(*sqlparser.Select)
-	otherSel := other.sel.(*sqlparser.Select)
+	sel := qb.stmt.(*sqlparser.Select)
+	otherSel := other.stmt.(*sqlparser.Select)
 	var lhs sqlparser.TableExpr
 	if len(sel.From) == 1 {
 		lhs = sel.From[0]
@@ -258,7 +273,7 @@ func (qb *queryBuilder) sortTables() {
 		}
 		sort.Sort(ts)
 		return true, nil
-	}, qb.sel)
+	}, qb.stmt)
 
 }
 
@@ -370,12 +385,20 @@ func buildQuery(op ops.Operator, qb *queryBuilder) error {
 		if err != nil {
 			return err
 		}
-		qb.sel.MakeDistinct()
+		qb.asSelectStatement().MakeDistinct()
+		return nil
+	case *Update:
+		buildUpdate(op, qb)
 		return nil
 	default:
 		return vterrors.VT13001(fmt.Sprintf("unknown operator to convert to SQL: %T", op))
 	}
 	return nil
+}
+
+func buildUpdate(op *Update, qb *queryBuilder) {
+	qb.stmt = op.AST
+	qb.dmlOperator = op
 }
 
 func buildAggregation(op *Aggregator, qb *queryBuilder) error {
@@ -415,7 +438,7 @@ func buildOrdering(op *Ordering, qb *queryBuilder) error {
 	}
 
 	for _, order := range op.Order {
-		qb.sel.AddOrder(order.Inner)
+		qb.asSelectStatement().AddOrder(order.Inner)
 	}
 	return nil
 }
@@ -425,7 +448,7 @@ func buildLimit(op *Limit, qb *queryBuilder) error {
 	if err != nil {
 		return err
 	}
-	qb.sel.SetLimit(op.AST)
+	qb.asSelectStatement().SetLimit(op.AST)
 	return nil
 }
 
@@ -453,7 +476,7 @@ func buildProjection(op *Projection, qb *queryBuilder) error {
 		return err
 	}
 
-	_, isSel := qb.sel.(*sqlparser.Select)
+	_, isSel := qb.stmt.(*sqlparser.Select)
 	if isSel {
 		qb.clearProjections()
 
@@ -468,10 +491,10 @@ func buildProjection(op *Projection, qb *queryBuilder) error {
 	// if the projection is on derived table, we use the select we have
 	// created above and transform it into a derived table
 	if op.TableID != nil {
-		sel := qb.sel
-		qb.sel = nil
+		sel := qb.stmt
+		qb.stmt = nil
 		qb.addTableExpr(op.Alias, op.Alias, TableID(op), &sqlparser.DerivedTable{
-			Select: sel,
+			Select: sel.(sqlparser.SelectStatement),
 		}, nil, nil)
 	}
 
@@ -553,8 +576,8 @@ func buildDerived(op *Horizon, qb *queryBuilder) error {
 	}
 	sqlparser.RemoveKeyspace(op.Query)
 
-	stmt := qb.sel
-	qb.sel = nil
+	stmt := qb.stmt
+	qb.stmt = nil
 	switch sel := stmt.(type) {
 	case *sqlparser.Select:
 		return buildDerivedSelect(op, qb, sel)
@@ -610,7 +633,7 @@ func buildHorizon(op *Horizon, qb *queryBuilder) error {
 		return err
 	}
 
-	err = stripDownQuery(op.Query, qb.sel)
+	err = stripDownQuery(op.Query, qb.asSelectStatement())
 	if err != nil {
 		return err
 	}
@@ -619,7 +642,7 @@ func buildHorizon(op *Horizon, qb *queryBuilder) error {
 			removeKeyspaceFromSelectExpr(aliasedExpr)
 		}
 		return true, nil
-	}, qb.sel)
+	}, qb.stmt)
 	return nil
 }
 

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -65,3 +65,7 @@ func (d *Delete) GetOrdering() ([]ops.OrderBy, error) {
 func (d *Delete) ShortDescription() string {
 	return fmt.Sprintf("%s.%s %s", d.VTable.Keyspace.Name, d.VTable.Name.String(), sqlparser.String(d.AST.Where))
 }
+
+func (d *Delete) Statement() sqlparser.Statement {
+	return d.AST
+}

--- a/go/vt/vtgate/planbuilder/operators/insert.go
+++ b/go/vt/vtgate/planbuilder/operators/insert.go
@@ -117,3 +117,7 @@ func (i *Insert) Clone(inputs []ops.Operator) ops.Operator {
 func (i *Insert) TablesUsed() []string {
 	return SingleQualifiedIdentifier(i.VTable.Keyspace, i.VTable.Name)
 }
+
+func (i *Insert) Statement() sqlparser.Statement {
+	return i.AST
+}

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -68,3 +68,7 @@ func (u *Update) TablesUsed() []string {
 func (u *Update) ShortDescription() string {
 	return u.VTable.String()
 }
+
+func (u *Update) Statement() sqlparser.Statement {
+	return u.AST
+}


### PR DESCRIPTION
## Description
In order to allow DML to be used inside subqueries, we need the DML plan path to use the `sql_builder` path for building the query. It's just cleaner to use mostly the same codepaths and share what we can.

## Related Issue(s)
Tracking issue https://github.com/vitessio/vitess/issues/11626
Needed by https://github.com/vitessio/vitess/pull/13750