### PR TITLE
Silence 'CheckThrottler' gRPC calls

### DIFF
--- a/go/vt/vttablet/grpctmserver/server.go
+++ b/go/vt/vttablet/grpctmserver/server.go
@@ -545,7 +545,7 @@ func (s *server) RestoreFromBackup(request *tabletmanagerdatapb.RestoreFromBacku
 }
 
 func (s *server) CheckThrottler(ctx context.Context, request *tabletmanagerdatapb.CheckThrottlerRequest) (response *tabletmanagerdatapb.CheckThrottlerResponse, err error) {
-	defer s.tm.HandleRPCPanic(ctx, "CheckThrottler", request, response, true /*verbose*/, &err)
+	defer s.tm.HandleRPCPanic(ctx, "CheckThrottler", request, response, false /*verbose*/, &err)
 	ctx = callinfo.GRPCCallInfo(ctx)
 	response, err = s.tm.CheckThrottler(ctx, request)
 	return response, err

--- a/go/vt/vttablet/tmrpctest/test_tm_rpc.go
+++ b/go/vt/vttablet/tmrpctest/test_tm_rpc.go
@@ -1319,7 +1319,7 @@ func tmRPCTestRestoreFromBackupPanic(ctx context.Context, t *testing.T, client t
 
 func tmRPCTestCheckThrottler(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.CheckThrottlerRequest) {
 	_, err := client.CheckThrottler(ctx, tablet, req)
-	expectHandleRPCPanic(t, "CheckThrottler", true /*verbose*/, err)
+	expectHandleRPCPanic(t, "CheckThrottler", false /*verbose*/, err)
 }
 
 //


### PR DESCRIPTION
## Description

Silences the noise coming from `CheckThrottler` calls.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/13924

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
