### PR TITLE
OnlineDDL: fix nil 'completed_timestamp' for cancelled migrations

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -362,6 +362,13 @@ func testScheduler(t *testing.T) {
 		`
 	)
 
+	testCompletedTimetamp := func(t *testing.T, uuid string) {
+		rs := onlineddl.ReadMigrations(t, &vtParams, uuid)
+		require.NotNil(t, rs)
+		for _, row := range rs.Named().Rows {
+			assert.False(t, row["completed_timestamp"].IsNull())
+		}
+	}
 	testReadTimestamp := func(t *testing.T, uuid string, timestampColumn string) (timestamp string) {
 		rs := onlineddl.ReadMigrations(t, &vtParams, uuid)
 		require.NotNil(t, rs)
@@ -691,6 +698,7 @@ func testScheduler(t *testing.T) {
 			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, drop1uuid, normalWaitTime, schema.OnlineDDLStatusFailed, schema.OnlineDDLStatusCancelled)
 			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 			onlineddl.CheckMigrationStatus(t, &vtParams, shards, drop1uuid, schema.OnlineDDLStatusCancelled)
+			testCompletedTimetamp(t, drop1uuid)
 		})
 		t.Run("complete t1", func(t *testing.T) {
 			// t1 should be still running!
@@ -824,6 +832,7 @@ func testScheduler(t *testing.T) {
 			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalWaitTime, schema.OnlineDDLStatusFailed, schema.OnlineDDLStatusCancelled)
 			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusCancelled)
+			testCompletedTimetamp(t, uuid)
 		})
 
 		// now, we submit the exact same migratoin again: same UUID, same migration context.

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -850,6 +850,9 @@ func TestSchemaChange(t *testing.T) {
 	t.Run("summary: validate sequential migration IDs", func(t *testing.T) {
 		onlineddl.ValidateSequentialMigrationIDs(t, &vtParams, shards)
 	})
+	t.Run("summary: validate completed_timestamp", func(t *testing.T) {
+		onlineddl.ValidateCompletedTimestamp(t, &vtParams)
+	})
 }
 
 func insertRow(t *testing.T) {

--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -420,6 +420,7 @@ func ValidateCompletedTimestamp(t *testing.T, vtParams *mysql.ConnParams) {
 	require.False(t, testsStartupTime.IsZero())
 	r := VtgateExecQuery(t, vtParams, "show vitess_migrations", "")
 
+	completedTimestampNumValidations := 0
 	for _, row := range r.Named().Rows {
 		migrationStatus := row.AsString("migration_status", "")
 		require.NotEmpty(t, migrationStatus)
@@ -434,7 +435,9 @@ func ValidateCompletedTimestamp(t *testing.T, vtParams *mysql.ConnParams) {
 				completedTime, err := time.Parse(sqltypes.TimestampFormat, timestamp)
 				assert.NoError(t, err)
 				assert.Greater(t, completedTime.Unix(), testsStartupTime.Unix())
+				completedTimestampNumValidations++
 			}
 		}
 	}
+	assert.NotZero(t, completedTimestampNumValidations)
 }

--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -415,7 +415,7 @@ func ValidateSequentialMigrationIDs(t *testing.T, vtParams *mysql.ConnParams, sh
 }
 
 // ValidateCompletedTimestamp ensures that any migration in `cancelled`, `completed`, `failed` statuses
-// has a non-nil and valid `compelted_timestamp` value.
+// has a non-nil and valid `completed_timestamp` value.
 func ValidateCompletedTimestamp(t *testing.T, vtParams *mysql.ConnParams) {
 	require.False(t, testsStartupTime.IsZero())
 	r := VtgateExecQuery(t, vtParams, "show vitess_migrations", "")

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -76,7 +76,7 @@ var (
 )
 
 var (
-	// fixCompletedTimestampOnce fixes a nil `completed_tiemstamp` columns, see
+	// fixCompletedTimestampDone fixes a nil `completed_tiemstamp` columns, see
 	// https://github.com/vitessio/vitess/issues/13927
 	// The fix is in release-18.0
 	// TODO: remove in release-19.0

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -75,6 +75,14 @@ var (
 	ErrMigrationNotFound = errors.New("migration not found")
 )
 
+var (
+	// fixCompletedTimestampOnce fixes a nil `completed_tiemstamp` columns, see
+	// https://github.com/vitessio/vitess/issues/13927
+	// The fix is in release-18.0
+	// TODO: remove in release-19.0
+	fixCompletedTimestampDone bool
+)
+
 var emptyResult = &sqltypes.Result{}
 var acceptableDropTableIfExistsErrorCodes = []sqlerror.ErrorCode{sqlerror.ERCantFindFile, sqlerror.ERNoSuchTable}
 var copyAlgorithm = sqlparser.AlgorithmValue(sqlparser.CopyStr)
@@ -3740,11 +3748,15 @@ func (e *Executor) gcArtifacts(ctx context.Context) error {
 	e.migrationMutex.Lock()
 	defer e.migrationMutex.Unlock()
 
-	if _, err := e.execQuery(ctx, sqlFixCompletedTimestamp); err != nil {
-		// This query fixes a bug where stale migrations were marked as 'cancelled' without updating 'completed_timestamp'
-		// Running this query retroactively sets completed_timestamp
-		// This fix is created in v18 and can be removed in v19
-		return err
+	// v18 fix. Remove in v19
+	if !fixCompletedTimestampDone {
+		if _, err := e.execQuery(ctx, sqlFixCompletedTimestamp); err != nil {
+			// This query fixes a bug where stale migrations were marked as 'cancelled' or 'failed' without updating 'completed_timestamp'
+			// Running this query retroactively sets completed_timestamp
+			// This fix is created in v18 and can be removed in v19
+			return err
+		}
+		fixCompletedTimestampDone = true
 	}
 
 	query, err := sqlparser.ParseAndBind(sqlSelectUncollectedArtifacts,

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -357,7 +357,7 @@ const (
 		SET
 			completed_timestamp=NOW(6)
 		WHERE
-			migration_status='cancelled'
+			migration_status IN ('cancelled', 'failed')
 			AND cleanup_timestamp IS NULL
 			AND completed_timestamp IS NULL
 	`

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -66,7 +66,8 @@ const (
 			migration_uuid=%a
 	`
 	sqlUpdateMigrationStatusFailedOrCancelled = `UPDATE _vt.schema_migrations
-			SET migration_status=IF(cancelled_timestamp IS NULL, 'failed', 'cancelled')
+			SET migration_status=IF(cancelled_timestamp IS NULL, 'failed', 'cancelled'),
+			completed_timestamp=NOW(6)
 		WHERE
 			migration_uuid=%a
 	`
@@ -356,7 +357,7 @@ const (
 		SET
 			completed_timestamp=NOW(6)
 		WHERE
-			migration_status='failed'
+			migration_status='cancelled'
 			AND cleanup_timestamp IS NULL
 			AND completed_timestamp IS NULL
 	`


### PR DESCRIPTION

## Description

This PR ensures to set `completed_timestamp` when transitioning a migration into `cancelled` or `failed` state. This, in turn, ensures a proper cleanup (destorying the migration's artifacts).

It also retroactively fixes `completed_timestamp` in all cases where it's left `nil` on `cancelled`.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/13927
- Generally similar to https://github.com/vitessio/vitess/pull/8500/files#diff-059c9f46e8d270d9c5514ef2b08679035eb0daaa8d95074e34ef43a81d50dc37

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
