### PR TITLE
[vtctld] more cobra binaries

### DIFF
--- a/go/cmd/vtctld/cli/cli.go
+++ b/go/cmd/vtctld/cli/cli.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtctld"
+)
+
+var (
+	ts   *topo.Server
+	Main = &cobra.Command{
+		Use:     "vtctld",
+		Short:   "The Vitess cluster management daemon.",
+		Args:    cobra.NoArgs,
+		Version: servenv.AppVersion.String(),
+		PreRunE: servenv.CobraPreRunE,
+		RunE:    run,
+	}
+)
+
+func run(cmd *cobra.Command, args []string) error {
+	servenv.Init()
+	defer servenv.Close()
+
+	ts = topo.Open()
+	defer ts.Close()
+
+	// Init the vtctld core
+	if err := vtctld.InitVtctld(ts); err != nil {
+		return err
+	}
+
+	// Register http debug/health
+	vtctld.RegisterDebugHealthHandler(ts)
+
+	// Start schema manager service.
+	initSchema()
+
+	// And run the server.
+	servenv.RunDefault()
+
+	return nil
+}
+
+func init() {
+	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
+	servenv.RegisterGRPCServerFlags()
+	servenv.RegisterGRPCServerAuthFlags()
+	servenv.RegisterServiceMapFlag()
+
+	servenv.MoveFlagsToCobraCommand(Main)
+
+	acl.RegisterFlags(Main.Flags())
+}

--- a/go/cmd/vtctld/cli/plugin_azblobbackupstorage.go
+++ b/go/cmd/vtctld/cli/plugin_azblobbackupstorage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
-	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
+	_ "vitess.io/vitess/go/vt/mysqlctl/azblobbackupstorage"
 )
-
-func init() {
-	servenv.OnRun(func() {
-		if servenv.GRPCCheckServiceMap("vtctld") {
-			grpcvtctldserver.StartServer(servenv.GRPCServer, ts)
-		}
-	})
-}

--- a/go/cmd/vtctld/cli/plugin_cephbackupstorage.go
+++ b/go/cmd/vtctld/cli/plugin_cephbackupstorage.go
@@ -7,21 +7,15 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// This plugin imports opentsdb to register the opentsdb stats backend.
+package cli
 
 import (
-	"vitess.io/vitess/go/stats/opentsdb"
+	_ "vitess.io/vitess/go/vt/mysqlctl/cephbackupstorage"
 )
-
-func init() {
-	opentsdb.Init("vtctld")
-}

--- a/go/cmd/vtctld/cli/plugin_consultopo.go
+++ b/go/cmd/vtctld/cli/plugin_consultopo.go
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the 'consul' topo.Server.
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/cephbackupstorage"
+	_ "vitess.io/vitess/go/vt/topo/consultopo"
 )

--- a/go/cmd/vtctld/cli/plugin_etcd2topo.go
+++ b/go/cmd/vtctld/cli/plugin_etcd2topo.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the gRPC tabletconn client
+// Imports and register the 'etcd2' topo.Server.
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
+	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
 )

--- a/go/cmd/vtctld/cli/plugin_filebackupstorage.go
+++ b/go/cmd/vtctld/cli/plugin_filebackupstorage.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
 	_ "vitess.io/vitess/go/vt/mysqlctl/filebackupstorage"

--- a/go/cmd/vtctld/cli/plugin_gcsbackupstorage.go
+++ b/go/cmd/vtctld/cli/plugin_gcsbackupstorage.go
@@ -7,17 +7,15 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// Imports and register the 'consul' topo.Server.
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/topo/consultopo"
+	_ "vitess.io/vitess/go/vt/mysqlctl/gcsbackupstorage"
 )

--- a/go/cmd/vtctld/cli/plugin_grpctabletconn.go
+++ b/go/cmd/vtctld/cli/plugin_grpctabletconn.go
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the gRPC tabletconn client
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/gcsbackupstorage"
+	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
 )

--- a/go/cmd/vtctld/cli/plugin_grpctmclient.go
+++ b/go/cmd/vtctld/cli/plugin_grpctmclient.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 // Imports and register the gRPC tabletmanager client
 

--- a/go/cmd/vtctld/cli/plugin_grpcvtctldserver.go
+++ b/go/cmd/vtctld/cli/plugin_grpcvtctldserver.go
@@ -7,22 +7,24 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
-	"vitess.io/vitess/go/cmd/vtctld/cli"
-	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
 )
 
-func main() {
-	if err := cli.Main.Execute(); err != nil {
-		log.Fatal(err)
-	}
+func init() {
+	servenv.OnRun(func() {
+		if servenv.GRPCCheckServiceMap("vtctld") {
+			grpcvtctldserver.StartServer(servenv.GRPCServer, ts)
+		}
+	})
 }

--- a/go/cmd/vtctld/cli/plugin_grpcvtctlserver.go
+++ b/go/cmd/vtctld/cli/plugin_grpcvtctlserver.go
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
-	"vitess.io/vitess/go/trace"
-
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vtctl/grpcvtctlserver"
 )
 
 func init() {
-	servenv.OnInit(func() {
-		closer := trace.StartTracing("vtctld")
-		servenv.OnClose(trace.LogErrorsWhenClosing(closer))
+	servenv.OnRun(func() {
+		if servenv.GRPCCheckServiceMap("vtctl") {
+			grpcvtctlserver.StartServer(servenv.GRPCServer, ts)
+		}
 	})
 }

--- a/go/cmd/vtctld/cli/plugin_grpcvtgateconn.go
+++ b/go/cmd/vtctld/cli/plugin_grpcvtgateconn.go
@@ -14,17 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the gRPC vtgateconn client
 
 import (
-	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/vtctl/grpcvtctlserver"
+	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
 )
-
-func init() {
-	servenv.OnRun(func() {
-		if servenv.GRPCCheckServiceMap("vtctl") {
-			grpcvtctlserver.StartServer(servenv.GRPCServer, ts)
-		}
-	})
-}

--- a/go/cmd/vtctld/cli/plugin_opentracing.go
+++ b/go/cmd/vtctld/cli/plugin_opentracing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,8 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/azblobbackupstorage"
+	"vitess.io/vitess/go/trace"
+	"vitess.io/vitess/go/vt/servenv"
 )
+
+func init() {
+	servenv.OnInit(func() {
+		closer := trace.StartTracing("vtctld")
+		servenv.OnClose(trace.LogErrorsWhenClosing(closer))
+	})
+}

--- a/go/cmd/vtctld/cli/plugin_opentsdb.go
+++ b/go/cmd/vtctld/cli/plugin_opentsdb.go
@@ -14,18 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports Prometheus to allow for instrumentation
-// with the Prometheus client library
+// This plugin imports opentsdb to register the opentsdb stats backend.
 
 import (
-	"vitess.io/vitess/go/stats/prometheusbackend"
-	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/stats/opentsdb"
 )
 
 func init() {
-	servenv.OnRun(func() {
-		prometheusbackend.Init("vtctld")
-	})
+	opentsdb.Init("vtctld")
 }

--- a/go/cmd/vtctld/cli/plugin_prometheusbackend.go
+++ b/go/cmd/vtctld/cli/plugin_prometheusbackend.go
@@ -7,17 +7,25 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the 'zk2' topo.Server.
+// This plugin imports Prometheus to allow for instrumentation
+// with the Prometheus client library
 
 import (
-	_ "vitess.io/vitess/go/vt/topo/zk2topo"
+	"vitess.io/vitess/go/stats/prometheusbackend"
+	"vitess.io/vitess/go/vt/servenv"
 )
+
+func init() {
+	servenv.OnRun(func() {
+		prometheusbackend.Init("vtctld")
+	})
+}

--- a/go/cmd/vtctld/cli/plugin_s3backupstorage.go
+++ b/go/cmd/vtctld/cli/plugin_s3backupstorage.go
@@ -7,17 +7,15 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// Imports and register the gRPC vtgateconn client
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
+	_ "vitess.io/vitess/go/vt/mysqlctl/s3backupstorage"
 )

--- a/go/cmd/vtctld/cli/plugin_zk2topo.go
+++ b/go/cmd/vtctld/cli/plugin_zk2topo.go
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the 'zk2' topo.Server.
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/s3backupstorage"
+	_ "vitess.io/vitess/go/vt/topo/zk2topo"
 )

--- a/go/cmd/vtctld/cli/schema.go
+++ b/go/cmd/vtctld/cli/schema.go
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
 	"context"
 	"time"
-
-	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -41,14 +39,12 @@ var (
 )
 
 func init() {
-	servenv.OnParse(func(fs *pflag.FlagSet) {
-		fs.StringVar(&schemaChangeDir, "schema_change_dir", schemaChangeDir, "Directory containing schema changes for all keyspaces. Each keyspace has its own directory, and schema changes are expected to live in '$KEYSPACE/input' dir. (e.g. 'test_keyspace/input/*sql'). Each sql file represents a schema change.")
-		fs.StringVar(&schemaChangeController, "schema_change_controller", schemaChangeController, "Schema change controller is responsible for finding schema changes and responding to schema change events.")
-		fs.StringVar(&schemaChangeUser, "schema_change_user", schemaChangeUser, "The user who schema changes are submitted on behalf of.")
+	Main.Flags().StringVar(&schemaChangeDir, "schema_change_dir", schemaChangeDir, "Directory containing schema changes for all keyspaces. Each keyspace has its own directory, and schema changes are expected to live in '$KEYSPACE/input' dir. (e.g. 'test_keyspace/input/*sql'). Each sql file represents a schema change.")
+	Main.Flags().StringVar(&schemaChangeController, "schema_change_controller", schemaChangeController, "Schema change controller is responsible for finding schema changes and responding to schema change events.")
+	Main.Flags().StringVar(&schemaChangeUser, "schema_change_user", schemaChangeUser, "The user who schema changes are submitted on behalf of.")
 
-		fs.DurationVar(&schemaChangeCheckInterval, "schema_change_check_interval", schemaChangeCheckInterval, "How often the schema change dir is checked for schema changes. This value must be positive; if zero or lower, the default of 1m is used.")
-		fs.DurationVar(&schemaChangeReplicasTimeout, "schema_change_replicas_timeout", schemaChangeReplicasTimeout, "How long to wait for replicas to receive a schema change.")
-	})
+	Main.Flags().DurationVar(&schemaChangeCheckInterval, "schema_change_check_interval", schemaChangeCheckInterval, "How often the schema change dir is checked for schema changes. This value must be positive; if zero or lower, the default of 1m is used.")
+	Main.Flags().DurationVar(&schemaChangeReplicasTimeout, "schema_change_replicas_timeout", schemaChangeReplicasTimeout, "How long to wait for replicas to receive a schema change.")
 }
 
 func initSchema() {

--- a/go/cmd/vtctld/docgen/main.go
+++ b/go/cmd/vtctld/docgen/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2023 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,22 @@ limitations under the License.
 
 package main
 
-// Imports and register the 'etcd2' topo.Server.
-
 import (
-	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
+	"github.com/spf13/cobra"
+
+	"vitess.io/vitess/go/cmd/internal/docgen"
+	"vitess.io/vitess/go/cmd/vtctld/cli"
 )
+
+func main() {
+	var dir string
+	cmd := cobra.Command{
+		Use: "docgen [-d <dir>]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return docgen.GenerateMarkdownTree(cli.Main, dir)
+		},
+	}
+
+	cmd.Flags().StringVarP(&dir, "dir", "d", "doc", "output directory to write documentation")
+	_ = cmd.Execute()
+}

--- a/go/cmd/vtorc/cli/cli.go
+++ b/go/cmd/vtorc/cli/cli.go
@@ -32,7 +32,7 @@ var (
 	configFile string
 	Main       = &cobra.Command{
 		Use:     "vtorc",
-		Short:   "VTOrc is the automated fault detection and repair tool of Vitess.",
+		Short:   "VTOrc is the automated fault detection and repair tool in Vitess.",
 		Args:    cobra.NoArgs,
 		Version: servenv.AppVersion.String(),
 		PreRunE: servenv.CobraPreRunE,

--- a/go/cmd/vtorc/cli/cli.go
+++ b/go/cmd/vtorc/cli/cli.go
@@ -17,15 +17,9 @@ limitations under the License.
 package cli
 
 import (
-	"flag"
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"vitess.io/vitess/go/acl"
-	_flag "vitess.io/vitess/go/internal/flag"
-	"vitess.io/vitess/go/viperutil"
-	viperdebug "vitess.io/vitess/go/viperutil/debug"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtorc/config"
@@ -38,22 +32,11 @@ var (
 	configFile string
 	Main       = &cobra.Command{
 		Use:     "vtorc",
-		Short:   "", // TODO
+		Short:   "VTOrc is the automated fault detection and repair tool of Vitess.",
 		Args:    cobra.NoArgs,
 		Version: servenv.AppVersion.String(),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			_flag.TrickGlog()
-
-			watchCancel, err := viperutil.LoadConfig()
-			if err != nil {
-				return fmt.Errorf("%s: failed to read in config: %s", cmd.Name(), err)
-			}
-
-			servenv.OnTerm(watchCancel)
-			servenv.HTTPHandleFunc("/debug/config", viperdebug.HandlerFunc)
-			return nil
-		},
-		Run: run,
+		PreRunE: servenv.CobraPreRunE,
+		Run:     run,
 	}
 )
 
@@ -101,14 +84,7 @@ func init() {
 	servenv.RegisterDefaultFlags()
 	servenv.RegisterFlags()
 
-	Main.Flags().AddFlagSet(servenv.GetFlagSetFor("vtorc"))
-
-	// glog flags, no better way to do this
-	_flag.PreventGlogVFlagFromClobberingVersionFlagShorthand(Main.Flags())
-	Main.Flags().AddGoFlag(flag.Lookup("logtostderr"))
-	Main.Flags().AddGoFlag(flag.Lookup("alsologtostderr"))
-	Main.Flags().AddGoFlag(flag.Lookup("stderrthreshold"))
-	Main.Flags().AddGoFlag(flag.Lookup("log_dir"))
+	servenv.MoveFlagsToCobraCommand(Main)
 
 	logic.RegisterFlags(Main.Flags())
 	server.RegisterFlags(Main.Flags())

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -1,4 +1,9 @@
-Usage of vtctld:
+The Vitess cluster management daemon.
+
+Usage:
+  vtctld [flags]
+
+Flags:
       --action_timeout duration                                          time to wait for an action before resorting to force (default 1m0s)
       --alsologtostderr                                                  log to standard error as well as files
       --azblob_backup_account_key_file string                            Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
@@ -58,7 +63,7 @@ Usage of vtctld:
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-  -h, --help                                                             display usage and exit
+  -h, --help                                                             help for vtctld
       --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
@@ -79,8 +84,6 @@ Usage of vtctld:
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
-      --s2a_enable_appengine_dialer                                      If true, opportunistically use AppEngine-specific dialer to call S2A.
-      --s2a_timeout duration                                             Timeout enforced on the connection to the S2A service for handshake. (default 3s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -1,4 +1,4 @@
-VTOrc is the automated fault detection and repair tool of Vitess.
+VTOrc is the automated fault detection and repair tool in Vitess.
 
 Usage:
   vtorc [flags]

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -1,3 +1,5 @@
+VTOrc is the automated fault detection and repair tool of Vitess.
+
 Usage:
   vtorc [flags]
 
@@ -34,6 +36,7 @@ Flags:
       --keep_logs_by_mtime duration                                 keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                    keep running at least this long after SIGTERM before stopping (default 50ms)
       --lock-timeout duration                                       Maximum time for which a shard/keyspace lock can be acquired for (default 45s)
+      --log_backtrace_at traceLocation                              when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                                              If non-empty, write log files in this directory
       --log_err_stacks                                              log stack traces for errors
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
@@ -89,4 +92,5 @@ Flags:
       --topo_zk_tls_key string                                      the key to use to connect to the zk topo server, enables TLS
       --v Level                                                     log level for V logs
   -v, --version                                                     print binary version
+      --vmodule moduleSpec                                          comma-separated list of pattern=N settings for file-filtered logging
       --wait-replicas-timeout duration                              Duration for which to wait for replica's to respond when issuing RPCs (default 30s)

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -29,6 +29,8 @@ limitations under the License.
 package servenv
 
 import (
+	"flag"
+	"fmt"
 	"net/url"
 	"os"
 	"os/signal"
@@ -38,6 +40,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/event"
@@ -360,6 +363,40 @@ func ParseFlagsForTests(cmd string) {
 	pflag.Parse()
 	viperutil.BindFlags(fs)
 	loadViper(cmd)
+}
+
+// MoveFlagsToCobraCommand moves the servenv-registered flags to the flagset of
+// the given cobra command, then copies over the glog flags that otherwise
+// require manual transferring.
+func MoveFlagsToCobraCommand(cmd *cobra.Command) {
+	cmd.Flags().AddFlagSet(GetFlagSetFor(cmd.Use))
+	// glog flags, no better way to do this
+	_flag.PreventGlogVFlagFromClobberingVersionFlagShorthand(cmd.Flags())
+	cmd.Flags().AddGoFlag(flag.Lookup("logtostderr"))
+	cmd.Flags().AddGoFlag(flag.Lookup("log_backtrace_at"))
+	cmd.Flags().AddGoFlag(flag.Lookup("alsologtostderr"))
+	cmd.Flags().AddGoFlag(flag.Lookup("stderrthreshold"))
+	cmd.Flags().AddGoFlag(flag.Lookup("log_dir"))
+	cmd.Flags().AddGoFlag(flag.Lookup("vmodule"))
+}
+
+// CobraPreRunE returns the common function that commands will need to load
+// viper infrastructure. It matches the signature of cobra's (Pre|Post)RunE-type
+// functions.
+func CobraPreRunE(cmd *cobra.Command, args []string) error {
+	_flag.TrickGlog()
+
+	watchCancel, err := viperutil.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("%s: failed to read in config: %s", cmd.Name(), err)
+	}
+
+	OnTerm(watchCancel)
+	HTTPHandleFunc("/debug/config", viperdebug.HandlerFunc)
+
+	logutil.PurgeLogs()
+
+	return nil
 }
 
 // GetFlagSetFor returns the flag set for a given command.


### PR DESCRIPTION

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

this moves generic stuff into servenv to support cobra commands, fixes some missing glog flags in the previous `vtorc` move, and migrates `vtctld` to cobra

docs: https://github.com/vitessio/website/pull/1578

## Related Issue(s)

#13918 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
