### PR TITLE
Rewrite `USING` to `ON` condition for joins

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -296,3 +296,11 @@ func TestBuggyOuterJoin(t *testing.T) {
 	mcmp.Exec("insert into t1(id1, id2) values (1,2), (42,5), (5, 42)")
 	mcmp.Exec("select t1.id1, t2.id1 from t1 left join t1 as t2 on t2.id1 = t2.id2")
 }
+
+func TestLeftJoinUsingUnsharded(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	utils.Exec(t, mcmp.VtConn, "insert into uks.unsharded(id1) values (1),(2),(3),(4),(5)")
+	utils.Exec(t, mcmp.VtConn, "select * from uks.unsharded as A left join uks.unsharded as B using(id1)")
+}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -631,7 +631,7 @@ func TestViewReferences(t *testing.T) {
 				"create table t2(id int primary key, n int, info int)",
 				"create view v1 as select id, c as ch from t1 where id > 0",
 				"create view v2 as select n as num, info from t2",
-				"create view v3 as select num, v1.id, ch from v1 join v2 using (id) where info > 5",
+				"create view v3 as select num, v1.id, ch from v1 join v2 on v1.id = v2.num where info > 5",
 			},
 		},
 		{

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4017,5 +4017,27 @@
         "zlookup_unique.t1"
       ]
     }
+  },
+  {
+    "comment": "left join with using has to be transformed into inner join with on condition",
+    "query": "SELECT * FROM unsharded_authoritative as A LEFT JOIN unsharded_authoritative as B USING(col1)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT * FROM unsharded_authoritative as A LEFT JOIN unsharded_authoritative as B USING(col1)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select A.col1 as col1, A.col2 as col2, B.col2 as col2 from unsharded_authoritative as A left join unsharded_authoritative as B on A.col1 = B.col1 where 1 != 1",
+        "Query": "select A.col1 as col1, A.col2 as col2, B.col2 as col2 from unsharded_authoritative as A left join unsharded_authoritative as B on A.col1 = B.col1",
+        "Table": "unsharded_authoritative"
+      },
+      "TablesUsed": [
+        "main.unsharded_authoritative"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -37,12 +37,12 @@
   {
     "comment": "join with USING construct",
     "query": "select * from user join user_extra using(id)",
-    "plan": "can't handle JOIN USING without authoritative tables"
+    "plan": "VT03019: column id not found"
   },
   {
     "comment": "join with USING construct with 3 tables",
     "query": "select user.id from user join user_extra using(id) join music using(id2)",
-    "plan": "can't handle JOIN USING without authoritative tables"
+    "plan": "VT03019: column id2 not found"
   },
   {
     "comment": "natural left join",

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -37,12 +37,12 @@
   {
     "comment": "join with USING construct",
     "query": "select * from user join user_extra using(id)",
-    "plan": "column id not found, can't handle JOIN USING without authoritative tables"
+    "plan": "VT09015: schema tracking required"
   },
   {
     "comment": "join with USING construct with 3 tables",
     "query": "select user.id from user join user_extra using(id) join music using(id2)",
-    "plan": "column id2 not found, can't handle JOIN USING without authoritative tables"
+    "plan": "VT09015: schema tracking required"
   },
   {
     "comment": "natural left join",

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -37,12 +37,12 @@
   {
     "comment": "join with USING construct",
     "query": "select * from user join user_extra using(id)",
-    "plan": "VT03019: column id not found"
+    "plan": "column id not found, can't handle JOIN USING without authoritative tables"
   },
   {
     "comment": "join with USING construct with 3 tables",
     "query": "select user.id from user join user_extra using(id) join music using(id2)",
-    "plan": "VT03019: column id2 not found"
+    "plan": "column id2 not found, can't handle JOIN USING without authoritative tables"
   },
   {
     "comment": "natural left join",

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -192,6 +192,11 @@ func (a *analyzer) analyzeUp(cursor *sqlparser.Cursor) bool {
 		return false
 	}
 
+	if err := a.rewriter.up(cursor); err != nil {
+		a.setError(err)
+		return true
+	}
+
 	a.leaveProjection(cursor)
 	return a.shouldContinue()
 }

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -74,32 +74,6 @@ func (b *binder) up(cursor *sqlparser.Cursor) error {
 		b.subqueryRef[node] = sq
 
 		b.setSubQueryDependencies(node, currScope)
-	case *sqlparser.JoinTableExpr:
-		currScope := b.scoper.currentScope()
-		if len(node.Condition.Using) == 0 {
-			return nil
-		}
-		err := rewriteJoinUsing(b, node)
-		if err != nil {
-			return err
-		}
-		err = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-			column, isColumn := node.(*sqlparser.ColName)
-			if !isColumn {
-				return true, nil
-			}
-			deps, err := b.resolveColumn(column, currScope, false)
-			if err != nil {
-				return false, err
-			}
-			b.recursive[column] = deps.recursive
-			b.direct[column] = deps.direct
-			return true, nil
-		}, node.Condition.On)
-		if err != nil {
-			return err
-		}
-		node.Condition.Using = nil
 	case *sqlparser.JoinCondition:
 		currScope := b.scoper.currentScope()
 		for _, ident := range node.Using {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -455,7 +455,7 @@ func findTablesWithColumn(b *binder, join *sqlparser.JoinTableExpr, column sqlpa
 	}
 
 	if leftTableInfo == nil || rightTableInfo == nil {
-		return nil, ShardedError{Inner: vterrors.VT03019(column.String())}
+		return nil, ShardedError{Inner: fmt.Errorf("column %s not found, can't handle JOIN USING without authoritative tables", column.String())}
 	}
 	var tableNames []sqlparser.TableName
 	for _, info := range leftTableInfo {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -455,7 +455,7 @@ func findTablesWithColumn(b *binder, join *sqlparser.JoinTableExpr, column sqlpa
 	}
 
 	if leftTableInfo == nil || rightTableInfo == nil {
-		return nil, ShardedError{Inner: fmt.Errorf("column %s not found, can't handle JOIN USING without authoritative tables", column.String())}
+		return nil, ShardedError{Inner: vterrors.VT09015()}
 	}
 	var tableNames []sqlparser.TableName
 	for _, info := range leftTableInfo {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -145,6 +145,12 @@ func TestExpandStar(t *testing.T) {
 		sql:    "select * from t1 join t2 on t1.a = t2.c1",
 		expSQL: "select t1.a as a, t1.b as b, t1.c as c, t2.c1 as c1, t2.c2 as c2 from t1 join t2 on t1.a = t2.c1",
 	}, {
+		sql:    "select * from t1 left join t2 on t1.a = t2.c1",
+		expSQL: "select t1.a as a, t1.b as b, t1.c as c, t2.c1 as c1, t2.c2 as c2 from t1 left join t2 on t1.a = t2.c1",
+	}, {
+		sql:    "select * from t1 right join t2 on t1.a = t2.c1",
+		expSQL: "select t1.a as a, t1.b as b, t1.c as c, t2.c1 as c1, t2.c2 as c2 from t1 right join t2 on t1.a = t2.c1",
+	}, {
 		sql:      "select * from t2 join t4 using (c1)",
 		expSQL:   "select t2.c1 as c1, t2.c2 as c2, t4.c4 as c4 from t2 join t4 on t2.c1 = t4.c1",
 		expanded: "main.t2.c1, main.t2.c2, main.t4.c4",

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -278,6 +278,9 @@ func TestRewriteJoinUsingColumns(t *testing.T) {
 	}, {
 		sql:    "select 1 from t1 join t2 using (a), t1 as b join t3 on (a) where a = 42",
 		expErr: "Column 'a' in field list is ambiguous",
+	}, {
+		sql:    "select 1 from t1 left join t2 using (a) where a = 42",
+		expSQL: "select 1 from t1 left join t2 on t1.a = t2.a where t1.a = 42",
 	}}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -146,24 +146,24 @@ func TestExpandStar(t *testing.T) {
 		expSQL: "select t1.a as a, t1.b as b, t1.c as c, t2.c1 as c1, t2.c2 as c2 from t1 join t2 on t1.a = t2.c1",
 	}, {
 		sql:      "select * from t2 join t4 using (c1)",
-		expSQL:   "select t2.c1 as c1, t2.c2 as c2, t4.c4 as c4 from t2 join t4 where t2.c1 = t4.c1",
+		expSQL:   "select t2.c1 as c1, t2.c2 as c2, t4.c4 as c4 from t2 join t4 on t2.c1 = t4.c1",
 		expanded: "main.t2.c1, main.t2.c2, main.t4.c4",
 	}, {
 		sql:    "select * from t2 join t4 using (c1) join t2 as X using (c1)",
-		expSQL: "select t2.c1 as c1, t2.c2 as c2, t4.c4 as c4, X.c2 as c2 from t2 join t4 join t2 as X where t2.c1 = t4.c1 and t2.c1 = X.c1 and t4.c1 = X.c1",
+		expSQL: "select t2.c1 as c1, t2.c2 as c2, t4.c4 as c4, X.c2 as c2 from t2 join t4 on t2.c1 = t4.c1 join t2 as X on t2.c1 = t4.c1 and t2.c1 = X.c1 and t4.c1 = X.c1",
 	}, {
 		sql:    "select * from t2 join t4 using (c1), t2 as t2b join t4 as t4b using (c1)",
-		expSQL: "select t2.c1 as c1, t2.c2 as c2, t4.c4 as c4, t2b.c1 as c1, t2b.c2 as c2, t4b.c4 as c4 from t2 join t4, t2 as t2b join t4 as t4b where t2b.c1 = t4b.c1 and t2.c1 = t4.c1",
+		expSQL: "select t2.c1 as c1, t2.c2 as c2, t4.c4 as c4, t2b.c1 as c1, t2b.c2 as c2, t4b.c4 as c4 from t2 join t4 on t2.c1 = t4.c1, t2 as t2b join t4 as t4b on t2b.c1 = t4b.c1",
 	}, {
 		sql:      "select * from t1 join t5 using (b)",
-		expSQL:   "select t1.b as b, t1.a as a, t1.c as c, t5.a as a from t1 join t5 where t1.b = t5.b",
+		expSQL:   "select t1.b as b, t1.a as a, t1.c as c, t5.a as a from t1 join t5 on t1.b = t5.b",
 		expanded: "main.t1.a, main.t1.b, main.t1.c, main.t5.a",
 	}, {
 		sql:    "select * from t1 join t5 using (b) having b = 12",
-		expSQL: "select t1.b as b, t1.a as a, t1.c as c, t5.a as a from t1 join t5 where t1.b = t5.b having b = 12",
+		expSQL: "select t1.b as b, t1.a as a, t1.c as c, t5.a as a from t1 join t5 on t1.b = t5.b having b = 12",
 	}, {
 		sql:    "select 1 from t1 join t5 using (b) having b = 12",
-		expSQL: "select 1 from t1 join t5 where t1.b = t5.b having t1.b = 12",
+		expSQL: "select 1 from t1 join t5 on t1.b = t5.b having t1.b = 12",
 	}, {
 		sql:    "select * from (select 12) as t",
 		expSQL: "select t.`12` from (select 12 from dual) as t",
@@ -265,7 +265,7 @@ func TestRewriteJoinUsingColumns(t *testing.T) {
 		expErr string
 	}{{
 		sql:    "select 1 from t1 join t2 using (a) where a = 42",
-		expSQL: "select 1 from t1 join t2 where t1.a = t2.a and t1.a = 42",
+		expSQL: "select 1 from t1 join t2 on t1.a = t2.a where t1.a = 42",
 	}, {
 		sql:    "select 1 from t1 join t2 using (a), t3 where a = 42",
 		expErr: "Column 'a' in field list is ambiguous",


### PR DESCRIPTION
## Description

This PR rewrites `USING` condition to `ON` instead of `WHERE` to avoid the issue mentioned in https://github.com/vitessio/vitess/issues/13929.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/13929

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
