### PR TITLE
[cobra] vtgate and vttablet

### DIFF
--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -47,8 +47,13 @@ var (
 	Main = &cobra.Command{
 		Use:   "vtgate",
 		Short: "VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution. It speaks both the MySQL Protocol and a gRPC protocol.",
-		Example: `
-vtgate \
+		Long: `VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution. It speaks both the MySQL Protocol and a gRPC protocol.
+
+### Key Options
+` +
+			"`--srv_topo_cache_ttl`: There may be instances where you will need to increase the cached TTL from the default of 1 second to a higher number:\n" +
+			`* You may want to increase this option if you see that your topo leader goes down and keeps your queries waiting for a few seconds.`,
+		Example: `vtgate \
 	--topo_implementation etcd2 \
 	--topo_global_server_address localhost:2379 \
 	--topo_global_root /vitess/global \

--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -45,8 +45,23 @@ var (
 	resilientServer   *srvtopo.ResilientServer
 
 	Main = &cobra.Command{
-		Use:     "vtgate",
-		Short:   "", // TODO
+		Use:   "vtgate",
+		Short: "VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution. It speaks both the MySQL Protocol and a gRPC protocol.",
+		Example: `
+vtgate \
+	--topo_implementation etcd2 \
+	--topo_global_server_address localhost:2379 \
+	--topo_global_root /vitess/global \
+	--log_dir $VTDATAROOT/tmp \
+	--port 15001 \
+	--grpc_port 15991 \
+	--mysql_server_port 15306 \
+	--cell test \
+	--cells_to_watch test \
+	--tablet_types_to_wait PRIMARY,REPLICA \
+	--service_map 'grpc-vtgateservice' \
+	--pid_file $VTDATAROOT/tmp/vtgate.pid \
+	--mysql_auth_server_impl none`,
 		Args:    cobra.NoArgs,
 		Version: servenv.AppVersion.String(),
 		PreRunE: servenv.CobraPreRunE,

--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -51,8 +51,8 @@ var (
 
 ### Key Options
 ` +
-			"`--srv_topo_cache_ttl`: There may be instances where you will need to increase the cached TTL from the default of 1 second to a higher number:\n" +
-			`* You may want to increase this option if you see that your topo leader goes down and keeps your queries waiting for a few seconds.`,
+			"\n* `--srv_topo_cache_ttl`: There may be instances where you will need to increase the cached TTL from the default of 1 second to a higher number:\n" +
+			`	* You may want to increase this option if you see that your topo leader goes down and keeps your queries waiting for a few seconds.`,
 		Example: `vtgate \
 	--topo_implementation etcd2 \
 	--topo_global_server_address localhost:2379 \

--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/exit"
+	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
+)
+
+var (
+	cell              string
+	tabletTypesToWait []topodatapb.TabletType
+	plannerName       string
+	resilientServer   *srvtopo.ResilientServer
+
+	Main = &cobra.Command{
+		Use:     "vtgate",
+		Short:   "", // TODO
+		Args:    cobra.NoArgs,
+		Version: servenv.AppVersion.String(),
+		PreRunE: servenv.CobraPreRunE,
+		RunE:    run,
+	}
+)
+
+// CheckCellFlags will check validation of cell and cells_to_watch flag
+// it will help to avoid strange behaviors when vtgate runs but actually does not work
+func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cellsToWatch string) error {
+	// topo check
+	var topoServer *topo.Server
+	if serv != nil {
+		var err error
+		topoServer, err = serv.GetTopoServer()
+		if err != nil {
+			return fmt.Errorf("Unable to create gateway: %w", err)
+		}
+	} else {
+		return fmt.Errorf("topo server cannot be nil")
+	}
+	cellsInTopo, err := topoServer.GetKnownCells(ctx)
+	if err != nil {
+		return err
+	}
+	if len(cellsInTopo) == 0 {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "topo server should have at least one cell")
+	}
+
+	// cell valid check
+	if cell == "" {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell flag must be set")
+	}
+	hasCell := false
+	for _, v := range cellsInTopo {
+		if v == cell {
+			hasCell = true
+			break
+		}
+	}
+	if !hasCell {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell:[%v] does not exist in topo", cell)
+	}
+
+	// cells_to_watch valid check
+	cells := make([]string, 0, 1)
+	for _, c := range strings.Split(cellsToWatch, ",") {
+		if c == "" {
+			continue
+		}
+		// cell should contained in cellsInTopo
+		if exists := topo.InCellList(c, cellsInTopo); !exists {
+			return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell: [%v] is not valid. Available cells: [%v]", c, strings.Join(cellsInTopo, ","))
+		}
+		cells = append(cells, c)
+	}
+	if len(cells) == 0 {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cells_to_watch flag cannot be empty")
+	}
+
+	return nil
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	defer exit.Recover()
+
+	servenv.Init()
+	defer servenv.Close()
+
+	ts := topo.Open()
+	defer ts.Close()
+
+	resilientServer = srvtopo.NewResilientServer(context.Background(), ts, "ResilientSrvTopoServer")
+
+	tabletTypes := make([]topodatapb.TabletType, 0, 1)
+	for _, tt := range tabletTypesToWait {
+		if topoproto.IsServingType(tt) {
+			tabletTypes = append(tabletTypes, tt)
+		}
+	}
+
+	if len(tabletTypes) == 0 {
+		return fmt.Errorf("tablet_types_to_wait must contain at least one serving tablet type")
+	}
+
+	err := CheckCellFlags(context.Background(), resilientServer, cell, vtgate.CellsToWatch)
+	if err != nil {
+		return fmt.Errorf("cells_to_watch validation failed: %v", err)
+	}
+
+	plannerVersion, _ := plancontext.PlannerNameToVersion(plannerName)
+
+	// pass nil for HealthCheck and it will be created
+	vtg := vtgate.Init(context.Background(), nil, resilientServer, cell, tabletTypes, plannerVersion)
+
+	servenv.OnRun(func() {
+		// Flags are parsed now. Parse the template using the actual flag value and overwrite the current template.
+		discovery.ParseTabletURLTemplateFromFlag()
+		addStatusParts(vtg)
+	})
+	servenv.OnClose(func() {
+		_ = vtg.Gateway().Close(context.Background())
+	})
+	servenv.RunDefault()
+
+	return nil
+}
+
+func init() {
+	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
+	servenv.RegisterGRPCServerFlags()
+	servenv.RegisterGRPCServerAuthFlags()
+	servenv.RegisterServiceMapFlag()
+
+	servenv.MoveFlagsToCobraCommand(Main)
+
+	acl.RegisterFlags(Main.Flags())
+	Main.Flags().StringVar(&cell, "cell", cell, "cell to use")
+	Main.Flags().Var((*topoproto.TabletTypeListFlag)(&tabletTypesToWait), "tablet_types_to_wait", "Wait till connected for specified tablet types during Gateway initialization. Should be provided as a comma-separated set of tablet types.")
+	Main.Flags().StringVar(&plannerName, "planner-version", plannerName, "Sets the default planner to use when the session has not changed it. Valid values are: Gen4, Gen4Greedy, Gen4Left2Right")
+
+	Main.MarkFlagRequired("tablet_types_to_wait")
+}

--- a/go/cmd/vtgate/cli/plugin_auth_clientcert.go
+++ b/go/cmd/vtgate/cli/plugin_auth_clientcert.go
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports opentsdb to register the opentsdb stats backend.
+// This plugin imports clientcert to register the client certificate implementation of AuthServer.
 
 import (
-	"vitess.io/vitess/go/stats/opentsdb"
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/vtgate"
 )
 
 func init() {
-	opentsdb.Init("vtgate")
+	vtgate.RegisterPluginInitializer(func() { mysql.InitAuthServerClientCert() })
 }

--- a/go/cmd/vtgate/cli/plugin_auth_ldap.go
+++ b/go/cmd/vtgate/cli/plugin_auth_ldap.go
@@ -7,25 +7,22 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports Prometheus to allow for instrumentation
-// with the Prometheus client library
+// This plugin imports ldapauthserver to register the LDAP implementation of AuthServer.
 
 import (
-	"vitess.io/vitess/go/stats/prometheusbackend"
-	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/mysql/ldapauthserver"
+	"vitess.io/vitess/go/vt/vtgate"
 )
 
 func init() {
-	servenv.OnRun(func() {
-		prometheusbackend.Init("vtgate")
-	})
+	vtgate.RegisterPluginInitializer(func() { ldapauthserver.Init() })
 }

--- a/go/cmd/vtgate/cli/plugin_auth_static.go
+++ b/go/cmd/vtgate/cli/plugin_auth_static.go
@@ -7,23 +7,22 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// This plugin imports staticauthserver to register the flat-file implementation of AuthServer.
 
 import (
-	"vitess.io/vitess/go/trace"
-	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/vtgate"
 )
 
 func init() {
-	servenv.OnInit(func() {
-		closer := trace.StartTracing("vtgate")
-		servenv.OnClose(trace.LogErrorsWhenClosing(closer))
-	})
+	vtgate.RegisterPluginInitializer(func() { mysql.InitAuthServerStatic() })
 }

--- a/go/cmd/vtgate/cli/plugin_auth_vault.go
+++ b/go/cmd/vtgate/cli/plugin_auth_vault.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports ldapauthserver to register the LDAP implementation of AuthServer.
+// This plugin imports InitAuthServerVault to register the HashiCorp Vault implementation of AuthServer.
 
 import (
-	"vitess.io/vitess/go/mysql/ldapauthserver"
+	"vitess.io/vitess/go/mysql/vault"
 	"vitess.io/vitess/go/vt/vtgate"
 )
 
 func init() {
-	vtgate.RegisterPluginInitializer(func() { ldapauthserver.Init() })
+	vtgate.RegisterPluginInitializer(func() { vault.InitAuthServerVault() })
 }

--- a/go/cmd/vtgate/cli/plugin_consultopo.go
+++ b/go/cmd/vtgate/cli/plugin_consultopo.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,15 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports InitAuthServerVault to register the HashiCorp Vault implementation of AuthServer.
+// This plugin imports consultopo to register the consul implementation of TopoServer.
 
 import (
-	"vitess.io/vitess/go/mysql/vault"
-	"vitess.io/vitess/go/vt/vtgate"
+	_ "vitess.io/vitess/go/vt/topo/consultopo"
 )
-
-func init() {
-	vtgate.RegisterPluginInitializer(func() { vault.InitAuthServerVault() })
-}

--- a/go/cmd/vtgate/cli/plugin_etcd2topo.go
+++ b/go/cmd/vtgate/cli/plugin_etcd2topo.go
@@ -7,17 +7,17 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports consultopo to register the consul implementation of TopoServer.
+// This plugin imports etcd2topo to register the etcd2 implementation of TopoServer.
 
 import (
-	_ "vitess.io/vitess/go/vt/topo/consultopo"
+	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
 )

--- a/go/cmd/vtgate/cli/plugin_grpctabletconn.go
+++ b/go/cmd/vtgate/cli/plugin_grpctabletconn.go
@@ -14,15 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports clientcert to register the client certificate implementation of AuthServer.
+// Imports and register the gRPC tabletconn client
 
 import (
-	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/vt/vtgate"
+	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
 )
-
-func init() {
-	vtgate.RegisterPluginInitializer(func() { mysql.InitAuthServerClientCert() })
-}

--- a/go/cmd/vtgate/cli/plugin_grpcvtgateservice.go
+++ b/go/cmd/vtgate/cli/plugin_grpcvtgateservice.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports etcd2topo to register the etcd2 implementation of TopoServer.
+// Imports and register the gRPC vtgateservice server
 
 import (
-	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
+	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateservice"
 )

--- a/go/cmd/vtgate/cli/plugin_opentracing.go
+++ b/go/cmd/vtgate/cli/plugin_opentracing.go
@@ -7,22 +7,23 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// This plugin imports staticauthserver to register the flat-file implementation of AuthServer.
+package cli
 
 import (
-	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/vt/vtgate"
+	"vitess.io/vitess/go/trace"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 func init() {
-	vtgate.RegisterPluginInitializer(func() { mysql.InitAuthServerStatic() })
+	servenv.OnInit(func() {
+		closer := trace.StartTracing("vtgate")
+		servenv.OnClose(trace.LogErrorsWhenClosing(closer))
+	})
 }

--- a/go/cmd/vtgate/cli/plugin_opentsdb.go
+++ b/go/cmd/vtgate/cli/plugin_opentsdb.go
@@ -14,10 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the gRPC vtgateservice server
+// This plugin imports opentsdb to register the opentsdb stats backend.
 
 import (
-	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateservice"
+	"vitess.io/vitess/go/stats/opentsdb"
 )
+
+func init() {
+	opentsdb.Init("vtgate")
+}

--- a/go/cmd/vtgate/cli/plugin_prometheusbackend.go
+++ b/go/cmd/vtgate/cli/plugin_prometheusbackend.go
@@ -7,16 +7,25 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// This plugin imports Prometheus to allow for instrumentation
+// with the Prometheus client library
 
 import (
-	// Imports and register the zk2 TopologyServer
-	_ "vitess.io/vitess/go/vt/topo/zk2topo"
+	"vitess.io/vitess/go/stats/prometheusbackend"
+	"vitess.io/vitess/go/vt/servenv"
 )
+
+func init() {
+	servenv.OnRun(func() {
+		prometheusbackend.Init("vtgate")
+	})
+}

--- a/go/cmd/vtgate/cli/plugin_statsd.go
+++ b/go/cmd/vtgate/cli/plugin_statsd.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2023 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,15 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-import (
-	"vitess.io/vitess/go/cmd/vtgate/cli"
-	"vitess.io/vitess/go/vt/log"
-)
+import "vitess.io/vitess/go/stats/statsd"
 
-func main() {
-	if err := cli.Main.Execute(); err != nil {
-		log.Exit(err)
-	}
+func init() {
+	statsd.Init("vtgate")
 }

--- a/go/cmd/vtgate/cli/plugin_zk2topo.go
+++ b/go/cmd/vtgate/cli/plugin_zk2topo.go
@@ -7,17 +7,16 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// Imports and register the gRPC tabletconn client
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
+	// Imports and register the zk2 TopologyServer
+	_ "vitess.io/vitess/go/vt/topo/zk2topo"
 )

--- a/go/cmd/vtgate/cli/status.go
+++ b/go/cmd/vtgate/cli/status.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/cmd/vtgate/docgen/main.go
+++ b/go/cmd/vtgate/docgen/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2023 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,12 +17,21 @@ limitations under the License.
 package main
 
 import (
+	"github.com/spf13/cobra"
+
+	"vitess.io/vitess/go/cmd/internal/docgen"
 	"vitess.io/vitess/go/cmd/vtgate/cli"
-	"vitess.io/vitess/go/vt/log"
 )
 
 func main() {
-	if err := cli.Main.Execute(); err != nil {
-		log.Exit(err)
+	var dir string
+	cmd := cobra.Command{
+		Use: "docgen [-d <dir>]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return docgen.GenerateMarkdownTree(cli.Main, dir)
+		},
 	}
+
+	cmd.Flags().StringVarP(&dir, "dir", "d", "doc", "output directory to write documentation")
+	_ = cmd.Execute()
 }

--- a/go/cmd/vtgate/docgen/main.go
+++ b/go/cmd/vtgate/docgen/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/cmd/internal/docgen"
 	"vitess.io/vitess/go/cmd/vtgate/cli"
@@ -31,6 +32,10 @@ func main() {
 			return docgen.GenerateMarkdownTree(cli.Main, dir)
 		},
 	}
+
+	// Here because we inadvertently transfer the required "tablet-types-to-wait"
+	// flag during vtgate/cli's init func.
+	pflag.CommandLine = cmd.Flags()
 
 	cmd.Flags().StringVarP(&dir, "dir", "d", "doc", "output directory to write documentation")
 	_ = cmd.Execute()

--- a/go/cmd/vtgate/plugin_statsd.go
+++ b/go/cmd/vtgate/plugin_statsd.go
@@ -1,7 +1,0 @@
-package main
-
-import "vitess.io/vitess/go/stats/statsd"
-
-func init() {
-	statsd.Init("vtgate")
-}

--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -57,8 +57,15 @@ var (
 	tm *tabletmanager.TabletManager
 
 	Main = &cobra.Command{
-		Use:     "vttablet",
-		Short:   "", // TODO
+		Use:   "vttablet",
+		Short: "The VTTablet server controls a running MySQL server.",
+		Long: fmt.Sprintf(`The VTTablet server _controls_ a running MySQL server. VTTablet supports two primary types of deployments:
+
+* Managed MySQL (most common)
+* External MySQL
+
+In addition to these deployment types, a partially managed VTTablet is also possible by setting %s.`, "`--disable_active_reparents`"),
+		Example: "", // TODO:
 		Args:    cobra.NoArgs,
 		Version: servenv.AppVersion.String(),
 		PreRunE: servenv.CobraPreRunE,

--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -59,12 +59,30 @@ var (
 	Main = &cobra.Command{
 		Use:   "vttablet",
 		Short: "The VTTablet server controls a running MySQL server.",
-		Long: fmt.Sprintf(`The VTTablet server _controls_ a running MySQL server. VTTablet supports two primary types of deployments:
+		Long: `The VTTablet server _controls_ a running MySQL server. VTTablet supports two primary types of deployments:
 
 * Managed MySQL (most common)
 * External MySQL
 
-In addition to these deployment types, a partially managed VTTablet is also possible by setting %s.`, "`--disable_active_reparents`"),
+In addition to these deployment types, a partially managed VTTablet is also possible by setting ` + "`--disable_active_reparents`." + `
+
+### Managed MySQL
+
+In this mode, Vitess actively manages MySQL.
+
+### External MySQL.
+
+In this mode, an external MySQL can be used such as AWS RDS, AWS Aurora, Google CloudSQL; or just an existing (vanilla) MySQL installation.
+
+See "Unmanaged Tablet" for the full guide.
+
+Even if a MySQL is external, you can still make vttablet perform some management functions. They are as follows:
+
+` +
+			"* `--disable_active_reparents`: If this flag is set, then any reparent or replica commands will not be allowed. These are InitShardPrimary, PlannedReparentShard, EmergencyReparentShard, and ReparentTablet. In this mode, you should use the TabletExternallyReparented command to inform vitess of the current primary.\n" +
+			"* `--replication_connect_retry`: This value is give to mysql when it connects a replica to the primary as the retry duration parameter.\n" +
+			"* `--enable_replication_reporter`: If this flag is set, then vttablet will transmit replica lag related information to the vtgates, which will allow it to balance load better. Additionally, enabling this will also cause vttablet to restart replication if it was stopped. However, it will do this only if `--disable_active_reparents` was not turned on.\n" +
+			"* `--heartbeat_enable` and `--heartbeat_interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.\n",
 		Example: `
 vttablet \
 	--topo_implementation etcd2 \

--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/vt/binlog"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/tableacl"
+	"vitess.io/vitess/go/vt/tableacl/simpleacl"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vttablet/onlineddl"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+	"vitess.io/vitess/go/yaml2"
+	"vitess.io/vitess/resources"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+var (
+	enforceTableACLConfig        bool
+	tableACLConfig               string
+	tableACLConfigReloadInterval time.Duration
+	tabletPath                   string
+	tabletConfig                 string
+
+	tm *tabletmanager.TabletManager
+
+	Main = &cobra.Command{
+		Use:     "vttablet",
+		Short:   "", // TODO
+		Args:    cobra.NoArgs,
+		Version: servenv.AppVersion.String(),
+		PreRunE: servenv.CobraPreRunE,
+		RunE:    run,
+	}
+)
+
+func run(cmd *cobra.Command, args []string) error {
+	servenv.Init()
+	defer servenv.Close()
+
+	tabletAlias, err := topoproto.ParseTabletAlias(tabletPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse --tablet-path: %w", err)
+	}
+
+	// config and mycnf initializations are intertwined.
+	config, mycnf, err := initConfig(tabletAlias)
+	if err != nil {
+		return err
+	}
+
+	ts := topo.Open()
+	qsc, err := createTabletServer(context.Background(), config, ts, tabletAlias)
+	if err != nil {
+		ts.Close()
+		return err
+	}
+
+	mysqld := mysqlctl.NewMysqld(config.DB)
+	servenv.OnClose(mysqld.Close)
+
+	if err := extractOnlineDDL(); err != nil {
+		ts.Close()
+		return fmt.Errorf("failed to extract online DDL binaries: %w", err)
+	}
+
+	// Initialize and start tm.
+	gRPCPort := int32(0)
+	if servenv.GRPCPort() != 0 {
+		gRPCPort = int32(servenv.GRPCPort())
+	}
+	tablet, err := tabletmanager.BuildTabletFromInput(tabletAlias, int32(servenv.Port()), gRPCPort, config.DB)
+	if err != nil {
+		return fmt.Errorf("failed to parse --tablet-path: %w", err)
+	}
+	tm = &tabletmanager.TabletManager{
+		BatchCtx:            context.Background(),
+		TopoServer:          ts,
+		Cnf:                 mycnf,
+		MysqlDaemon:         mysqld,
+		DBConfigs:           config.DB.Clone(),
+		QueryServiceControl: qsc,
+		UpdateStream:        binlog.NewUpdateStream(ts, tablet.Keyspace, tabletAlias.Cell, qsc.SchemaEngine()),
+		VREngine:            vreplication.NewEngine(config, ts, tabletAlias.Cell, mysqld, qsc.LagThrottler()),
+		VDiffEngine:         vdiff.NewEngine(config, ts, tablet),
+	}
+	if err := tm.Start(tablet, config.Healthcheck.IntervalSeconds.Get()); err != nil {
+		ts.Close()
+		return fmt.Errorf("failed to parse --tablet-path or initialize DB credentials: %w", err)
+	}
+	servenv.OnClose(func() {
+		// Close the tm so that our topo entry gets pruned properly and any
+		// background goroutines that use the topo connection are stopped.
+		tm.Close()
+
+		// tm uses ts. So, it should be closed after tm.
+		ts.Close()
+	})
+
+	servenv.RunDefault()
+
+	return nil
+}
+
+func initConfig(tabletAlias *topodatapb.TabletAlias) (*tabletenv.TabletConfig, *mysqlctl.Mycnf, error) {
+	tabletenv.Init()
+	// Load current config after tabletenv.Init, because it changes it.
+	config := tabletenv.NewCurrentConfig()
+	if err := config.Verify(); err != nil {
+		return nil, nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	if tabletConfig != "" {
+		bytes, err := os.ReadFile(tabletConfig)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error reading config file %s: %w", tabletConfig, err)
+		}
+		if err := yaml2.Unmarshal(bytes, config); err != nil {
+			return nil, nil, fmt.Errorf("error parsing config file %s: %w", bytes, err)
+		}
+	}
+	gotBytes, _ := yaml2.Marshal(config)
+	log.Infof("Loaded config file %s successfully:\n%s", tabletConfig, gotBytes)
+
+	var (
+		mycnf      *mysqlctl.Mycnf
+		socketFile string
+	)
+	// If no connection parameters were specified, load the mycnf file
+	// and use the socket from it. If connection parameters were specified,
+	// we assume that the mysql is not local, and we skip loading mycnf.
+	// This also means that backup and restore will not be allowed.
+	if !config.DB.HasGlobalSettings() {
+		var err error
+		if mycnf, err = mysqlctl.NewMycnfFromFlags(tabletAlias.Uid); err != nil {
+			return nil, nil, fmt.Errorf("mycnf read failed: %w", err)
+		}
+
+		socketFile = mycnf.SocketFile
+	} else {
+		log.Info("connection parameters were specified. Not loading my.cnf.")
+	}
+
+	// If connection parameters were specified, socketFile will be empty.
+	// Otherwise, the socketFile (read from mycnf) will be used to initialize
+	// dbconfigs.
+	config.DB.InitWithSocket(socketFile)
+	for _, cfg := range config.ExternalConnections {
+		cfg.InitWithSocket("")
+	}
+	return config, mycnf, nil
+}
+
+// extractOnlineDDL extracts the gh-ost binary from this executable. gh-ost is appended
+// to vttablet executable by `make build` with a go:embed
+func extractOnlineDDL() error {
+	if binaryFileName, isOverride := onlineddl.GhostBinaryFileName(); !isOverride {
+		if err := os.WriteFile(binaryFileName, resources.GhostBinary, 0755); err != nil {
+			// One possibility of failure is that gh-ost is up and running. In that case,
+			// let's pause and check if the running gh-ost is exact same binary as the one we wish to extract.
+			foundBytes, _ := os.ReadFile(binaryFileName)
+			if bytes.Equal(resources.GhostBinary, foundBytes) {
+				// OK, it's the same binary, there is no need to extract the file anyway
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createTabletServer(ctx context.Context, config *tabletenv.TabletConfig, ts *topo.Server, tabletAlias *topodatapb.TabletAlias) (*tabletserver.TabletServer, error) {
+	if tableACLConfig != "" {
+		// To override default simpleacl, other ACL plugins must set themselves to be default ACL factory
+		tableacl.Register("simpleacl", &simpleacl.Factory{})
+	} else if enforceTableACLConfig {
+		return nil, fmt.Errorf("table acl config has to be specified with table-acl-config flag because enforce-tableacl-config is set.")
+	}
+	// creates and registers the query service
+	qsc := tabletserver.NewTabletServer(ctx, "", config, ts, tabletAlias)
+	servenv.OnRun(func() {
+		qsc.Register()
+		addStatusParts(qsc)
+	})
+	servenv.OnClose(qsc.StopService)
+	qsc.InitACL(tableACLConfig, enforceTableACLConfig, tableACLConfigReloadInterval)
+	return qsc, nil
+}
+
+func init() {
+	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
+	servenv.RegisterGRPCServerFlags()
+	servenv.RegisterGRPCServerAuthFlags()
+	servenv.RegisterServiceMapFlag()
+
+	dbconfigs.RegisterFlags(dbconfigs.All...)
+	mysqlctl.RegisterFlags()
+
+	servenv.MoveFlagsToCobraCommand(Main)
+
+	acl.RegisterFlags(Main.Flags())
+	Main.Flags().BoolVar(&enforceTableACLConfig, "enforce-tableacl-config", enforceTableACLConfig, "if this flag is true, vttablet will fail to start if a valid tableacl config does not exist")
+	Main.Flags().StringVar(&tableACLConfig, "table-acl-config", tableACLConfig, "path to table access checker config file; send SIGHUP to reload this file")
+	Main.Flags().DurationVar(&tableACLConfigReloadInterval, "table-acl-config-reload-interval", tableACLConfigReloadInterval, "Ticker to reload ACLs. Duration flag, format e.g.: 30s. Default: do not reload")
+	Main.Flags().StringVar(&tabletPath, "tablet-path", tabletPath, "tablet alias")
+	Main.Flags().StringVar(&tabletConfig, "tablet_config", tabletConfig, "YAML file config for tablet")
+}

--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -65,7 +65,18 @@ var (
 * External MySQL
 
 In addition to these deployment types, a partially managed VTTablet is also possible by setting %s.`, "`--disable_active_reparents`"),
-		Example: "", // TODO:
+		Example: `
+vttablet \
+	--topo_implementation etcd2 \
+	--topo_global_server_address localhost:2379 \
+	--topo_global_root /vitess/ \
+	--tablet-path $alias \
+	--init_keyspace $keyspace \
+	--init_shard $shard \
+	--init_tablet_type $tablet_type \
+	--port $port \
+	--grpc_port $grpc_port \
+	--service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream'` + "\n\n`$alias` needs to be of the form: `<cell>-id`, and the cell should match one of the local cells that was created in the topology. The id can be left padded with zeroes: `cell-100` and `cell-000000100` are synonymous.",
 		Args:    cobra.NoArgs,
 		Version: servenv.AppVersion.String(),
 		PreRunE: servenv.CobraPreRunE,

--- a/go/cmd/vttablet/cli/plugin_azblobbackupstorage.go
+++ b/go/cmd/vttablet/cli/plugin_azblobbackupstorage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,10 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// This plugin imports etcd2topo to register the etcd2 implementation of TopoServer.
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
+	_ "vitess.io/vitess/go/vt/mysqlctl/azblobbackupstorage"
 )

--- a/go/cmd/vttablet/cli/plugin_cephbackupstorage.go
+++ b/go/cmd/vttablet/cli/plugin_cephbackupstorage.go
@@ -7,17 +7,15 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// Imports and register the gRPC tabletconn client
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
+	_ "vitess.io/vitess/go/vt/mysqlctl/cephbackupstorage"
 )

--- a/go/cmd/vttablet/cli/plugin_consultopo.go
+++ b/go/cmd/vttablet/cli/plugin_consultopo.go
@@ -7,17 +7,17 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the file-based query logger
+// This plugin imports consultopo to register the consul implementation of TopoServer.
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/filelogger"
+	_ "vitess.io/vitess/go/vt/topo/consultopo"
 )

--- a/go/cmd/vttablet/cli/plugin_etcd2topo.go
+++ b/go/cmd/vttablet/cli/plugin_etcd2topo.go
@@ -7,17 +7,17 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the syslog-based query logger
+// This plugin imports etcd2topo to register the etcd2 implementation of TopoServer.
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/sysloglogger"
+	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
 )

--- a/go/cmd/vttablet/cli/plugin_filebackupstorage.go
+++ b/go/cmd/vttablet/cli/plugin_filebackupstorage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/azblobbackupstorage"
+	_ "vitess.io/vitess/go/vt/mysqlctl/filebackupstorage"
 )

--- a/go/cmd/vttablet/cli/plugin_filecustomrule.go
+++ b/go/cmd/vttablet/cli/plugin_filecustomrule.go
@@ -14,20 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the gRPC queryservice server
+// Imports and register the file custom rule source
 
 import (
-	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/vttablet/grpcqueryservice"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver"
+	_ "vitess.io/vitess/go/vt/vttablet/customrule/filecustomrule"
 )
-
-func init() {
-	tabletserver.RegisterFunctions = append(tabletserver.RegisterFunctions, func(qsc tabletserver.Controller) {
-		if servenv.GRPCCheckServiceMap("queryservice") {
-			grpcqueryservice.Register(servenv.GRPCServer, qsc.QueryService())
-		}
-	})
-}

--- a/go/cmd/vttablet/cli/plugin_filelogger.go
+++ b/go/cmd/vttablet/cli/plugin_filelogger.go
@@ -14,16 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// vt tablet server: Serves queries and performs housekeeping jobs.
-package main
+package cli
+
+// Imports and register the file-based query logger
 
 import (
-	"vitess.io/vitess/go/cmd/vttablet/cli"
-	"vitess.io/vitess/go/vt/log"
+	_ "vitess.io/vitess/go/vt/vttablet/filelogger"
 )
-
-func main() {
-	if err := cli.Main.Execute(); err != nil {
-		log.Exit(err)
-	}
-}

--- a/go/cmd/vttablet/cli/plugin_gcsbackupstorage.go
+++ b/go/cmd/vttablet/cli/plugin_gcsbackupstorage.go
@@ -7,17 +7,15 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// This plugin imports consultopo to register the consul implementation of TopoServer.
+package cli
 
 import (
-	_ "vitess.io/vitess/go/vt/topo/consultopo"
+	_ "vitess.io/vitess/go/vt/mysqlctl/gcsbackupstorage"
 )

--- a/go/cmd/vttablet/cli/plugin_grpcbinlogplayer.go
+++ b/go/cmd/vttablet/cli/plugin_grpcbinlogplayer.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the gRPC binlog streamer
+// Imports and register the gRPC binlog player
 
 import (
-	_ "vitess.io/vitess/go/vt/binlog/grpcbinlogstreamer"
+	_ "vitess.io/vitess/go/vt/binlog/grpcbinlogplayer"
 )

--- a/go/cmd/vttablet/cli/plugin_grpcbinlogstreamer.go
+++ b/go/cmd/vttablet/cli/plugin_grpcbinlogstreamer.go
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the gRPC binlog streamer
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/gcsbackupstorage"
+	_ "vitess.io/vitess/go/vt/binlog/grpcbinlogstreamer"
 )

--- a/go/cmd/vttablet/cli/plugin_grpcqueryservice.go
+++ b/go/cmd/vttablet/cli/plugin_grpcqueryservice.go
@@ -14,10 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the topo custom rule source
+// Imports and register the gRPC queryservice server
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/customrule/topocustomrule"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vttablet/grpcqueryservice"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver"
 )
+
+func init() {
+	tabletserver.RegisterFunctions = append(tabletserver.RegisterFunctions, func(qsc tabletserver.Controller) {
+		if servenv.GRPCCheckServiceMap("queryservice") {
+			grpcqueryservice.Register(servenv.GRPCServer, qsc.QueryService())
+		}
+	})
+}

--- a/go/cmd/vttablet/cli/plugin_grpctabletconn.go
+++ b/go/cmd/vttablet/cli/plugin_grpctabletconn.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the gRPC throttler server.
+// Imports and register the gRPC tabletconn client
 
 import (
-	_ "vitess.io/vitess/go/vt/throttler/grpcthrottlerserver"
+	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
 )

--- a/go/cmd/vttablet/cli/plugin_grpcthrottlerserver.go
+++ b/go/cmd/vttablet/cli/plugin_grpcthrottlerserver.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the gRPC binlog player
+// Imports and register the gRPC throttler server.
 
 import (
-	_ "vitess.io/vitess/go/vt/binlog/grpcbinlogplayer"
+	_ "vitess.io/vitess/go/vt/throttler/grpcthrottlerserver"
 )

--- a/go/cmd/vttablet/cli/plugin_grpctmclient.go
+++ b/go/cmd/vttablet/cli/plugin_grpctmclient.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the file custom rule source
+// Imports and register the gRPC tabletmanager client
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/customrule/filecustomrule"
+	_ "vitess.io/vitess/go/vt/vttablet/grpctmclient"
 )

--- a/go/cmd/vttablet/cli/plugin_grpctmserver.go
+++ b/go/cmd/vttablet/cli/plugin_grpctmserver.go
@@ -7,15 +7,17 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the gRPC tabletmanager server
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/cephbackupstorage"
+	_ "vitess.io/vitess/go/vt/vttablet/grpctmserver"
 )

--- a/go/cmd/vttablet/cli/plugin_opentracing.go
+++ b/go/cmd/vttablet/cli/plugin_opentracing.go
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// vt tablet server: Serves queries and performs housekeeping jobs.
-package main
+package cli
 
 import (
-	"vitess.io/vitess/go/cmd/vttablet/cli"
-	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/trace"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
-func main() {
-	if err := cli.Main.Execute(); err != nil {
-		log.Exit(err)
-	}
+func init() {
+	servenv.OnInit(func() {
+		closer := trace.StartTracing("vttablet")
+		servenv.OnClose(trace.LogErrorsWhenClosing(closer))
+	})
 }

--- a/go/cmd/vttablet/cli/plugin_opentsdb.go
+++ b/go/cmd/vttablet/cli/plugin_opentsdb.go
@@ -14,18 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// This plugin imports Prometheus to allow for instrumentation
-// with the Prometheus client library
+// This plugin imports opentsdb to register the opentsdb stats backend.
 
 import (
-	"vitess.io/vitess/go/stats/prometheusbackend"
-	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/stats/opentsdb"
 )
 
 func init() {
-	servenv.OnRun(func() {
-		prometheusbackend.Init("vttablet")
-	})
+	opentsdb.Init("vttablet")
 }

--- a/go/cmd/vttablet/cli/plugin_prometheusbackend.go
+++ b/go/cmd/vttablet/cli/plugin_prometheusbackend.go
@@ -14,10 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
-// Imports and register the gRPC tabletmanager client
+// This plugin imports Prometheus to allow for instrumentation
+// with the Prometheus client library
 
 import (
-	_ "vitess.io/vitess/go/vt/vttablet/grpctmclient"
+	"vitess.io/vitess/go/stats/prometheusbackend"
+	"vitess.io/vitess/go/vt/servenv"
 )
+
+func init() {
+	servenv.OnRun(func() {
+		prometheusbackend.Init("vttablet")
+	})
+}

--- a/go/cmd/vttablet/cli/plugin_s3backupstorage.go
+++ b/go/cmd/vttablet/cli/plugin_s3backupstorage.go
@@ -7,21 +7,15 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-// This plugin imports opentsdb to register the opentsdb stats backend.
+package cli
 
 import (
-	"vitess.io/vitess/go/stats/opentsdb"
+	_ "vitess.io/vitess/go/vt/mysqlctl/s3backupstorage"
 )
-
-func init() {
-	opentsdb.Init("vttablet")
-}

--- a/go/cmd/vttablet/cli/plugin_statsd.go
+++ b/go/cmd/vttablet/cli/plugin_statsd.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2023 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,11 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+package cli
 
-package main
+import "vitess.io/vitess/go/stats/statsd"
 
-// Imports and register the gRPC tabletmanager server
-
-import (
-	_ "vitess.io/vitess/go/vt/vttablet/grpctmserver"
-)
+func init() {
+	statsd.Init("vttablet")
+}

--- a/go/cmd/vttablet/cli/plugin_sysloglogger.go
+++ b/go/cmd/vttablet/cli/plugin_sysloglogger.go
@@ -7,15 +7,17 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the syslog-based query logger
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/filebackupstorage"
+	_ "vitess.io/vitess/go/vt/vttablet/sysloglogger"
 )

--- a/go/cmd/vttablet/cli/plugin_topocustomrule.go
+++ b/go/cmd/vttablet/cli/plugin_topocustomrule.go
@@ -7,15 +7,17 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
+
+// Imports and register the topo custom rule source
 
 import (
-	_ "vitess.io/vitess/go/vt/mysqlctl/s3backupstorage"
+	_ "vitess.io/vitess/go/vt/vttablet/customrule/topocustomrule"
 )

--- a/go/cmd/vttablet/cli/plugin_zk2topo.go
+++ b/go/cmd/vttablet/cli/plugin_zk2topo.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 // Imports and register the zk2 TopologyServer
 

--- a/go/cmd/vttablet/cli/status.go
+++ b/go/cmd/vttablet/cli/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2023 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
 	"vitess.io/vitess/go/vt/servenv"

--- a/go/cmd/vttablet/docgen/main.go
+++ b/go/cmd/vttablet/docgen/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2023 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,13 +17,21 @@ limitations under the License.
 package main
 
 import (
-	"vitess.io/vitess/go/trace"
-	"vitess.io/vitess/go/vt/servenv"
+	"github.com/spf13/cobra"
+
+	"vitess.io/vitess/go/cmd/internal/docgen"
+	"vitess.io/vitess/go/cmd/vttablet/cli"
 )
 
-func init() {
-	servenv.OnInit(func() {
-		closer := trace.StartTracing("vttablet")
-		servenv.OnClose(trace.LogErrorsWhenClosing(closer))
-	})
+func main() {
+	var dir string
+	cmd := cobra.Command{
+		Use: "docgen [-d <dir>]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return docgen.GenerateMarkdownTree(cli.Main, dir)
+		},
+	}
+
+	cmd.Flags().StringVarP(&dir, "dir", "d", "doc", "output directory to write documentation")
+	_ = cmd.Execute()
 }

--- a/go/cmd/vttablet/plugin_statsd.go
+++ b/go/cmd/vttablet/plugin_statsd.go
@@ -1,7 +1,0 @@
-package main
-
-import "vitess.io/vitess/go/stats/statsd"
-
-func init() {
-	statsd.Init("vttablet")
-}

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -1,5 +1,4 @@
-VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution.
-It speaks both the MySQL Protocol and a gRPC protocol.
+VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution. It speaks both the MySQL Protocol and a gRPC protocol.
 
 ### Key Options
 
@@ -10,7 +9,6 @@ Usage:
   vtgate [flags]
 
 Examples:
-
 vtgate \
 	--topo_implementation etcd2 \
 	--topo_global_server_address localhost:2379 \

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -1,4 +1,7 @@
-Usage of vtgate:
+Usage:
+  vtgate [flags]
+
+Flags:
       --allow-kill-statement                                             Allows the execution of kill statement
       --allowed_tablet_types strings                                     Specifies the tablet types this vtgate is allowed to route queries to. Should be provided as a comma-separated set of tablet types.
       --alsologtostderr                                                  log to standard error as well as files
@@ -69,7 +72,7 @@ Usage of vtgate:
       --grpc_use_effective_callerid                                      If set, and SSL is not used, will set the immediate caller id from the effective caller id's principal.
       --healthcheck_retry_delay duration                                 health check retry delay (default 2ms)
       --healthcheck_timeout duration                                     the health check timeout period (default 1m0s)
-  -h, --help                                                             display usage and exit
+  -h, --help                                                             help for vtgate
       --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -1,4 +1,10 @@
-VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution. It speaks both the MySQL Protocol and a gRPC protocol.
+VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution.
+It speaks both the MySQL Protocol and a gRPC protocol.
+
+### Key Options
+
+* `--srv_topo_cache_ttl`: There may be instances where you will need to increase the cached TTL from the default of 1 second to a higher number:
+	* You may want to increase this option if you see that your topo leader goes down and keeps your queries waiting for a few seconds.
 
 Usage:
   vtgate [flags]

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -1,5 +1,24 @@
+VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution. It speaks both the MySQL Protocol and a gRPC protocol.
+
 Usage:
   vtgate [flags]
+
+Examples:
+
+vtgate \
+	--topo_implementation etcd2 \
+	--topo_global_server_address localhost:2379 \
+	--topo_global_root /vitess/global \
+	--log_dir $VTDATAROOT/tmp \
+	--port 15001 \
+	--grpc_port 15991 \
+	--mysql_server_port 15306 \
+	--cell test \
+	--cells_to_watch test \
+	--tablet_types_to_wait PRIMARY,REPLICA \
+	--service_map 'grpc-vtgateservice' \
+	--pid_file $VTDATAROOT/tmp/vtgate.pid \
+	--mysql_auth_server_impl none
 
 Flags:
       --allow-kill-statement                                             Allows the execution of kill statement

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -1,4 +1,7 @@
-Usage of vttablet:
+Usage:
+  vttablet [flags]
+
+Flags:
       --alsologtostderr                                                  log to standard error as well as files
       --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app_pool_size int                                                Size of the connection pool for app connections (default 40)
@@ -152,7 +155,7 @@ Usage of vttablet:
       --heartbeat_enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the sidecar database's heartbeat table. The result is used to inform the serving state of the vttablet via healthchecks.
       --heartbeat_interval duration                                      How frequently to read and write replication heartbeat. (default 1s)
       --heartbeat_on_demand_duration duration                            If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently; when requests are infrequent heartbeat may completely stop between requests
-  -h, --help                                                             display usage and exit
+  -h, --help                                                             help for vttablet
       --hot_row_protection_concurrent_transactions int                   Number of concurrent transactions let through to the txpool/MySQL for the same hot row. Should be > 1 to have enough 'ready' transactions in MySQL and benefit from a pipelining effect. (default 5)
       --hot_row_protection_max_global_queue_size int                     Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)
       --hot_row_protection_max_queue_size int                            Maximum number of BeginExecute RPCs which will be queued for the same row (range). (default 20)
@@ -257,8 +260,6 @@ Usage of vttablet:
       --restore_from_backup                                              (init restore parameter) will check BackupStorage for a recent backup at startup and start there
       --restore_from_backup_ts string                                    (init restore parameter) if set, restore the latest backup taken at or before this timestamp. Example: '2021-04-29.133050'
       --retain_online_ddl_tables duration                                How long should vttablet keep an old migrated table before purging it (default 24h0m0s)
-      --s2a_enable_appengine_dialer                                      If true, opportunistically use AppEngine-specific dialer to call S2A.
-      --s2a_timeout duration                                             Timeout enforced on the connection to the S2A service for handshake. (default 3s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -5,6 +5,23 @@ The VTTablet server _controls_ a running MySQL server. VTTablet supports two pri
 
 In addition to these deployment types, a partially managed VTTablet is also possible by setting `--disable_active_reparents`.
 
+### Managed MySQL
+
+In this mode, Vitess actively manages MySQL.
+
+### External MySQL.
+
+In this mode, an external MySQL can be used such as AWS RDS, AWS Aurora, Google CloudSQL; or just an existing (vanilla) MySQL installation.
+
+See "Unmanaged Tablet" for the full guide.
+
+Even if a MySQL is external, you can still make vttablet perform some management functions. They are as follows:
+
+* `--disable_active_reparents`: If this flag is set, then any reparent or replica commands will not be allowed. These are InitShardPrimary, PlannedReparentShard, EmergencyReparentShard, and ReparentTablet. In this mode, you should use the TabletExternallyReparented command to inform vitess of the current primary.
+* `--replication_connect_retry`: This value is give to mysql when it connects a replica to the primary as the retry duration parameter.
+* `--enable_replication_reporter`: If this flag is set, then vttablet will transmit replica lag related information to the vtgates, which will allow it to balance load better. Additionally, enabling this will also cause vttablet to restart replication if it was stopped. However, it will do this only if `--disable_active_reparents` was not turned on.
+* `--heartbeat_enable` and `--heartbeat_interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.
+
 Usage:
   vttablet [flags]
 

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -1,3 +1,10 @@
+The VTTablet server _controls_ a running MySQL server. VTTablet supports two primary types of deployments:
+
+* Managed MySQL (most common)
+* External MySQL
+
+In addition to these deployment types, a partially managed VTTablet is also possible by setting `--disable_active_reparents`.
+
 Usage:
   vttablet [flags]
 

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -8,6 +8,22 @@ In addition to these deployment types, a partially managed VTTablet is also poss
 Usage:
   vttablet [flags]
 
+Examples:
+
+vttablet \
+	--topo_implementation etcd2 \
+	--topo_global_server_address localhost:2379 \
+	--topo_global_root /vitess/ \
+	--tablet-path $alias \
+	--init_keyspace $keyspace \
+	--init_shard $shard \
+	--init_tablet_type $tablet_type \
+	--port $port \
+	--grpc_port $grpc_port \
+	--service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream'
+
+`$alias` needs to be of the form: `<cell>-id`, and the cell should match one of the local cells that was created in the topology. The id can be left padded with zeroes: `cell-100` and `cell-000000100` are synonymous.
+
 Flags:
       --alsologtostderr                                                  log to standard error as well as files
       --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -378,6 +378,8 @@ func MoveFlagsToCobraCommand(cmd *cobra.Command) {
 	cmd.Flags().AddGoFlag(flag.Lookup("stderrthreshold"))
 	cmd.Flags().AddGoFlag(flag.Lookup("log_dir"))
 	cmd.Flags().AddGoFlag(flag.Lookup("vmodule"))
+
+	pflag.CommandLine = cmd.Flags()
 }
 
 // CobraPreRunE returns the common function that commands will need to load


### PR DESCRIPTION

## Description

Migrates the `vtgate` and `vttablet` binaries to cobra.

## Related Issue(s)

#13918 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required => https://github.com/vitessio/website/pull/1580

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
