### PR TITLE
Fix `ApplySchema --batch-size` with ` --allow-zero-in-date`

### DIFF
--- a/go/test/endtoend/vtgate/schema/schema_test.go
+++ b/go/test/endtoend/vtgate/schema/schema_test.go
@@ -238,6 +238,18 @@ func testApplySchemaBatch(t *testing.T) {
 		require.NoError(t, err)
 		checkTables(t, totalTableCount)
 	}
+	{
+		sqls := "create table batch1(id int primary key);create table batch2(id int primary key);create table batch3(id int primary key);create table batch4(id int primary key);create table batch5(id int primary key);"
+		_, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ApplySchema", "--", "--ddl_strategy", "direct --allow-zero-in-date", "--sql", sqls, "--batch_size", "2", keyspaceName)
+		require.NoError(t, err)
+		checkTables(t, totalTableCount+5)
+	}
+	{
+		sqls := "drop table batch1; drop table batch2; drop table batch3; drop table batch4; drop table batch5"
+		_, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ApplySchema", "--", "--sql", sqls, keyspaceName)
+		require.NoError(t, err)
+		checkTables(t, totalTableCount)
+	}
 }
 
 // checkTables checks the number of tables in the first two shards.

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -450,7 +450,7 @@ func applyAllowZeroInDate(sql string) (string, error) {
 	if err != nil {
 		return sql, err
 	}
-	modifiedSqls := []string{}
+	var modifiedSqls []string
 	for _, singleSQL := range sqls {
 		// --allow-zero-in-date Applies to DDLs
 		stmt, err := sqlparser.Parse(singleSQL)

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -737,7 +737,22 @@ func TestSplitStatementToPieces(t *testing.T) {
 			"`createtime` datetime NOT NULL DEFAULT NOW() COMMENT 'create time;'," +
 			"`comment` varchar(100) NOT NULL DEFAULT '' COMMENT 'comment'," +
 			"PRIMARY KEY (`id`))",
-	}}
+	}, {
+		input:  "create table t1 (id int primary key); create table t2 (id int primary key);",
+		output: "create table t1 (id int primary key); create table t2 (id int primary key)",
+	}, {
+		input:  ";;; create table t1 (id int primary key);;; ;create table t2 (id int primary key);",
+		output: " create table t1 (id int primary key);create table t2 (id int primary key)",
+	}, {
+		// The input doesn't have to be valid SQL statements!
+		input:  ";create table t1 ;create table t2 (id;",
+		output: "create table t1 ;create table t2 (id",
+	}, {
+		// Ignore quoted semicolon
+		input:  ";create table t1 ';';;;create table t2 (id;",
+		output: "create table t1 ';';create table t2 (id",
+	},
+	}
 
 	for _, tcase := range testcases {
 		t.Run(tcase.input, func(t *testing.T) {


### PR DESCRIPTION
## Description

As described in https://github.com/vitessio/vitess/issues/13950, when DDL strategy is `--allow-zero-in-date`, `TabletExecutor` attempts to edit the SQL; but with `--batch-size` the SQL (`--sql` or `--sql-file`) could be multiple statements. In this PR `TabletExecutor` is able to parse and edit the SQL even if it contains multiple statements.

Added the necessary tests that would have prevented the bug in #13693

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/13950
- Continues https://github.com/vitessio/vitess/pull/13693
- Objective: https://github.com/vitessio/vitess/issues/13692

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
