### PR TITLE
Change internal vindex type recommendation for integrals to xxhash

### DIFF
--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1226,7 +1226,8 @@ func LoadFormalKeyspace(filename string) (*vschemapb.Keyspace, error) {
 	return formal, nil
 }
 
-// ChooseVindexForType chooses the most appropriate vindex for the give type.
+// ChooseVindexForType chooses the most appropriate vindex type for
+// the given SQL data type.
 func ChooseVindexForType(typ querypb.Type) (string, error) {
 	switch {
 	case sqltypes.IsIntegral(typ):

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1230,7 +1230,7 @@ func LoadFormalKeyspace(filename string) (*vschemapb.Keyspace, error) {
 func ChooseVindexForType(typ querypb.Type) (string, error) {
 	switch {
 	case sqltypes.IsIntegral(typ):
-		return "hash", nil
+		return "xxhash", nil
 	case sqltypes.IsText(typ):
 		return "unicode_loose_md5", nil
 	case sqltypes.IsBinary(typ):

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -901,11 +901,11 @@ func TestChooseVindexForType(t *testing.T) {
 		// used for a vindex. If the test case provides an empty output
 		// value then we expect an error.
 		if tcase.out == "" {
-			assert.Error(t, err, "unexpectedly got a recommended vindex type of %s for input column type: %v",
+			assert.Error(t, err, "unexpectedly got a recommended vindex type of %s for input column type %v",
 				out, tcase.in)
 			continue
 		}
-		assert.Equal(t, out, tcase.out, "expected a recommended vindex type of %s for %v but got: %q",
+		assert.Equal(t, out, tcase.out, "expected a recommended vindex type of %s for input column type %v but got %s",
 			tcase.out, tcase.in, out)
 	}
 }

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -805,37 +805,37 @@ func TestChooseVindexForType(t *testing.T) {
 		out: "",
 	}, {
 		in:  sqltypes.Int8,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Uint8,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Int16,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Uint16,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Int24,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Uint24,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Int32,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Uint32,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Int64,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Uint64,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Float32,
-		out: "hash",
+		out: "",
 	}, {
 		in:  sqltypes.Float64,
 		out: "",
@@ -853,7 +853,7 @@ func TestChooseVindexForType(t *testing.T) {
 		out: "",
 	}, {
 		in:  sqltypes.Year,
-		out: "hash",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Decimal,
 		out: "",
@@ -897,11 +897,16 @@ func TestChooseVindexForType(t *testing.T) {
 
 	for _, tcase := range testcases {
 		out, err := ChooseVindexForType(tcase.in)
-		if out == "" {
-			assert.Error(t, err, tcase.in)
+		// If no type is returned then we do not recommend the column be
+		// used for a vindex. If the test case provides an empty output
+		// value then we expect an error.
+		if tcase.out == "" {
+			assert.Error(t, err, "unexpectedly got a recommended vindex type of %s for input column type: %v",
+				out, tcase.in)
 			continue
 		}
-		assert.Equal(t, out, tcase.out, tcase.in)
+		assert.Equal(t, out, tcase.out, "expected a recommended vindex type of %s for %v but got: %q",
+			tcase.out, tcase.in, out)
 	}
 }
 

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -326,14 +326,14 @@ func TestCreateLookupVindexFull(t *testing.T) {
 	sourceVSchema := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}},
 			},
@@ -370,8 +370,8 @@ func TestCreateLookupVindexFull(t *testing.T) {
 	wantvschema := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 			"v": {
 				Type: "lookup_unique",
@@ -387,7 +387,7 @@ func TestCreateLookupVindexFull(t *testing.T) {
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}, {
 					Name:   "v",
@@ -423,15 +423,15 @@ func TestCreateLookupVindexCreateDDL(t *testing.T) {
 	vs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "col1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -678,14 +678,14 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 		sourceVSchema: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 			},
 			Tables: map[string]*vschemapb.Table{
 				"t1": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col1",
 					}},
 				},
@@ -694,8 +694,8 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 				"v": {
 					Type: "lookup_unique",
@@ -711,7 +711,7 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 			Tables: map[string]*vschemapb.Table{
 				"t1": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col1",
 					}, {
 						Name:   "v",
@@ -725,8 +725,8 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 		sourceVSchema: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 				"v": {
 					Type: "lookup_unique",
@@ -742,7 +742,7 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 			Tables: map[string]*vschemapb.Table{
 				"t1": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col1",
 					}},
 				},
@@ -751,8 +751,8 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 				"v": {
 					Type: "lookup_unique",
@@ -768,7 +768,7 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 			Tables: map[string]*vschemapb.Table{
 				"t1": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col1",
 					}, {
 						Name:   "v",
@@ -782,8 +782,8 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 		sourceVSchema: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 				"v": {
 					Type: "lookup_unique",
@@ -799,10 +799,10 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 			Tables: map[string]*vschemapb.Table{
 				"t1": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col1",
 					}, {
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col2",
 					}},
 				},
@@ -811,8 +811,8 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 				"v": {
 					Type: "lookup_unique",
@@ -828,10 +828,10 @@ func TestCreateLookupVindexSourceVSchema(t *testing.T) {
 			Tables: map[string]*vschemapb.Table{
 				"t1": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col1",
 					}, {
-						Name:   "hash",
+						Name:   "xxhash",
 						Column: "col2",
 					}, {
 						Name:   "v",
@@ -882,15 +882,15 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 	sourcevs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "col1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -903,15 +903,15 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 	withTable := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t2": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -960,15 +960,15 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 			},
 			Tables: map[string]*vschemapb.Table{
 				"lkp": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
 						Column: "c1",
-						Name:   "hash",
+						Name:   "xxhash",
 					}},
 				},
 			},
@@ -1001,24 +1001,23 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 		targetVSchema: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				// Create a misleading vindex name.
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 			},
 		},
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 			},
 			Tables: map[string]*vschemapb.Table{
 				"lkp": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
 						Column: "c1",
-						Name:   "hash",
+						Name:   "xxhash",
 					}},
 				},
 			},
@@ -1031,12 +1030,12 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
 				// Create a misleading vindex name.
-				"hash": {
+				"xxhash": {
 					Type: "unicode_loose_md5",
 				},
 			},
 		},
-		err: "a conflicting vindex named hash already exists in the target vschema",
+		err: "a conflicting vindex named xxhash already exists in the target vschema",
 	}, {
 		description:     "sharded, int64, good table",
 		targetTable:     "t2",
@@ -1045,15 +1044,15 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"hash": {
-					Type: "hash",
+				"xxhash": {
+					Type: "xxhash",
 				},
 			},
 			Tables: map[string]*vschemapb.Table{
 				"t2": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
 						Column: "c1",
-						Name:   "hash",
+						Name:   "xxhash",
 					}},
 				},
 			},
@@ -1151,14 +1150,14 @@ func TestCreateLookupVindexSameKeyspace(t *testing.T) {
 	vschema := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}},
 			},
@@ -1167,8 +1166,8 @@ func TestCreateLookupVindexSameKeyspace(t *testing.T) {
 	want := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 			"v": {
 				Type: "lookup_unique",
@@ -1184,7 +1183,7 @@ func TestCreateLookupVindexSameKeyspace(t *testing.T) {
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}, {
 					Name:   "v",
@@ -1194,7 +1193,7 @@ func TestCreateLookupVindexSameKeyspace(t *testing.T) {
 			"lkp": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -1263,14 +1262,14 @@ func TestCreateCustomizedVindex(t *testing.T) {
 	vschema := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}},
 			},
@@ -1279,8 +1278,8 @@ func TestCreateCustomizedVindex(t *testing.T) {
 	want := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 			"v": {
 				Type: "lookup_unique",
@@ -1296,7 +1295,7 @@ func TestCreateCustomizedVindex(t *testing.T) {
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}, {
 					Name:   "v",
@@ -1306,7 +1305,7 @@ func TestCreateCustomizedVindex(t *testing.T) {
 			"lkp": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -1377,14 +1376,14 @@ func TestCreateLookupVindexIgnoreNulls(t *testing.T) {
 	vschema := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}},
 			},
@@ -1394,8 +1393,8 @@ func TestCreateLookupVindexIgnoreNulls(t *testing.T) {
 	wantKs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 			"v": {
 				Type: "consistent_lookup",
@@ -1412,7 +1411,7 @@ func TestCreateLookupVindexIgnoreNulls(t *testing.T) {
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}, {
 					Name:    "v",
@@ -1422,7 +1421,7 @@ func TestCreateLookupVindexIgnoreNulls(t *testing.T) {
 			"lkp": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "col2",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -1496,14 +1495,14 @@ func TestStopAfterCopyFlag(t *testing.T) {
 	vschema := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}},
 			},
@@ -1556,7 +1555,7 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
 			"other": {
-				Type: "hash",
+				Type: "xxhash",
 			},
 			"v": {
 				Type: "lookup_unique",
@@ -1593,10 +1592,10 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 		input: &vschemapb.Keyspace{
 			Vindexes: map[string]*vschemapb.Vindex{
 				"v1": {
-					Type: "hash",
+					Type: "xxhash",
 				},
 				"v2": {
-					Type: "hash",
+					Type: "xxhash",
 				},
 			},
 		},
@@ -1606,11 +1605,11 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 		input: &vschemapb.Keyspace{
 			Vindexes: map[string]*vschemapb.Vindex{
 				"v": {
-					Type: "hash",
+					Type: "xxhash",
 				},
 			},
 		},
-		err: "vindex hash is not a lookup type",
+		err: "vindex xxhash is not a lookup type",
 	}, {
 		description: "unqualified table",
 		input: &vschemapb.Keyspace{
@@ -1822,8 +1821,8 @@ func TestExternalizeVindex(t *testing.T) {
 	sourceVSchema := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 			"owned": {
 				Type: "lookup_unique",
@@ -1856,7 +1855,7 @@ func TestExternalizeVindex(t *testing.T) {
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "hash",
+					Name:   "xxhash",
 					Column: "col1",
 				}, {
 					Name:   "owned",
@@ -2051,15 +2050,15 @@ func TestMaterializerOneToMany(t *testing.T) {
 	vs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -2074,13 +2073,13 @@ func TestMaterializerOneToMany(t *testing.T) {
 	env.tmc.expectVRQuery(
 		200,
 		insertPrefix+
-			`.*shard:\\"0\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.hash.*-80.*`,
+			`.*shard:\\"0\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.xxhash.*-80.*`,
 		&sqltypes.Result{},
 	)
 	env.tmc.expectVRQuery(
 		210,
 		insertPrefix+
-			`.*shard:\\"0\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.hash.*80-.*`,
+			`.*shard:\\"0\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.xxhash.*80-.*`,
 		&sqltypes.Result{},
 	)
 	env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
@@ -2111,15 +2110,15 @@ func TestMaterializerManyToMany(t *testing.T) {
 	vs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -2134,15 +2133,15 @@ func TestMaterializerManyToMany(t *testing.T) {
 	env.tmc.expectVRQuery(
 		200,
 		insertPrefix+
-			`.*shard:\\"-40\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.hash.*-80.*`+
-			`.*shard:\\"40-\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.hash.*-80.*`,
+			`.*shard:\\"-40\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.xxhash.*-80.*`+
+			`.*shard:\\"40-\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.xxhash.*-80.*`,
 		&sqltypes.Result{},
 	)
 	env.tmc.expectVRQuery(
 		210,
 		insertPrefix+
-			`.*shard:\\"-40\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.hash.*80-.*`+
-			`.*shard:\\"40-\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.hash.*80-.*`,
+			`.*shard:\\"-40\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.xxhash.*80-.*`+
+			`.*shard:\\"40-\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.xxhash.*80-.*`,
 		&sqltypes.Result{},
 	)
 	env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
@@ -2747,15 +2746,15 @@ func TestMaterializerComplexVindexExpression(t *testing.T) {
 	vs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -2790,15 +2789,15 @@ func TestMaterializerNoVindexInExpression(t *testing.T) {
 	vs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -2968,15 +2967,15 @@ func TestMaterializerManyToManySomeUnreachable(t *testing.T) {
 	vs := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{
-			"hash": {
-				Type: "hash",
+			"xxhash": {
+				Type: "xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
 			"t1": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "hash",
+					Name:   "xxhash",
 				}},
 			},
 		},
@@ -3019,7 +3018,7 @@ func TestMaterializerManyToManySomeUnreachable(t *testing.T) {
 	}
 
 	getStreamInsert := func(sourceShard, targetShard string) string {
-		return fmt.Sprintf(`.*shard:\\"%s\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.hash.*%s.*`, sourceShard, targetShard)
+		return fmt.Sprintf(`.*shard:\\"%s\\" filter:{rules:{match:\\"t1\\" filter:\\"select.*t1 where in_keyrange\(c1.*targetks\.xxhash.*%s.*`, sourceShard, targetShard)
 	}
 
 	for _, tcase := range testcases {
@@ -3176,7 +3175,7 @@ func TestAddTablesToVSchema(t *testing.T) {
 						ColumnVindexes: []*vschemapb.ColumnVindex{ // Should be stripped on target
 							{
 								Column: "c1",
-								Name:   "hash",
+								Name:   "xxhash",
 							},
 						},
 					},
@@ -3223,7 +3222,7 @@ func TestAddTablesToVSchema(t *testing.T) {
 						ColumnVindexes: []*vschemapb.ColumnVindex{ // Should be stripped on target
 							{
 								Column: "c1",
-								Name:   "hash",
+								Name:   "xxhash",
 							},
 						},
 					},


### PR DESCRIPTION
## Description

Changing the recommended [vindex type](https://vitess.io/docs/reference/features/vindexes/#predefined-vindexes) from `hash` to `xxhash` deals with usage of `hash` — which is based on NULL-KEY 3DES (not actually used for cryptography in Vitess but hashing keyspace IDs) — getting flagged because [DES is considered insecure](https://en.wikipedia.org/wiki/Data_Encryption_Standard). And while it's not actually used for cryptography in Vitess it can be difficult to work around appropriate controls that prohibit its use for any reason. `xxhash` should also be significantly faster overall so we should generally recommend that over `hash` (3DES) in Vitess going forward.

The immediate practical impact of this change is that the [`CreateLookupVindex`](https://vitess.io/docs/reference/vreplication/createlookupvindex/) command, when adding a [primary vindex](https://vitess.io/docs/reference/features/vindexes/#the-primary-vindex) on the [lookup vindex's](https://vitess.io/docs/reference/features/vindexes/#functional-and-lookup-vindex) backing table in the target keyspace _if it's sharded_, will use `xxhash` for the vindex type when the underlying source column used is an integral (native integer) type. 

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13955

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were updated
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation is not required