### PR TITLE
VDiff: correct handling of default source and target cells

### DIFF
--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -359,6 +359,35 @@ func TestPickCellPreferenceLocalAlias(t *testing.T) {
 	assert.True(t, proto.Equal(want, tablet), "Pick: %v, want %v", tablet, want)
 }
 
+func TestPickUsingCellAsAlias(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+
+	// The test env puts all cells into an alias called "cella".
+	// We're also going to specify an optional extraCell that is NOT
+	// added to the alias.
+	te := newPickerTestEnv(t, ctx, []string{"cell1", "cell2", "cell3"}, "xtracell")
+	// Specify the alias as the cell.
+	tp, err := NewTabletPicker(ctx, te.topoServ, []string{"cella"}, "cell1", te.keyspace, te.shard, "replica", TabletPickerOptions{})
+	require.NoError(t, err)
+
+	// Create a tablet in one of the main cells, it should be
+	// picked as it is part of the cella alias. This tablet is
+	// NOT part of the talbet picker's local cell (cell1) so it
+	// will not be given local preference.
+	want := addTablet(ctx, te, 101, topodatapb.TabletType_REPLICA, "cell2", true, true)
+	defer deleteTablet(t, te, want)
+	// Create a tablet in an extra cell which is thus NOT part of
+	// the cella alias so it should NOT be picked.
+	noWant := addTablet(ctx, te, 102, topodatapb.TabletType_REPLICA, "xtracell", true, true)
+	defer deleteTablet(t, te, noWant)
+	// Try it many times to be sure we don't ever pick the wrong one.
+	for i := 0; i < 100; i++ {
+		tablet, err := tp.PickForStreaming(ctx)
+		require.NoError(t, err)
+		assert.True(t, proto.Equal(want, tablet), "Pick: %v, want %v", tablet, want)
+	}
+}
+
 func TestPickUsingCellAliasOnlySpecified(t *testing.T) {
 	ctx := utils.LeakCheckContextTimeout(t, 200*time.Millisecond)
 
@@ -545,13 +574,18 @@ type pickerTestEnv struct {
 	topoServ *topo.Server
 }
 
-func newPickerTestEnv(t *testing.T, ctx context.Context, cells []string) *pickerTestEnv {
+// newPickerTestEnve creates a test environment for tablet picker tests.
+// It creates a cell alias called 'cella' which contains all of the cells.
+// If any optional extraCells are provided, those are NOT added to the
+// cell alias.
+func newPickerTestEnv(t *testing.T, ctx context.Context, cells []string, extraCells ...string) *pickerTestEnv {
+	allCells := append(cells, extraCells...)
 	te := &pickerTestEnv{
 		t:        t,
 		keyspace: "ks",
 		shard:    "0",
 		cells:    cells,
-		topoServ: memorytopo.NewServer(ctx, cells...),
+		topoServ: memorytopo.NewServer(ctx, allCells...),
 	}
 	// create cell alias
 	err := te.topoServ.CreateCellsAlias(ctx, "cella", &topodatapb.CellsAlias{

--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -359,6 +359,9 @@ func TestPickCellPreferenceLocalAlias(t *testing.T) {
 	assert.True(t, proto.Equal(want, tablet), "Pick: %v, want %v", tablet, want)
 }
 
+// TestPickUsingCellAsAlias confirms that when the tablet picker is
+// given a cell name that is an alias, it will choose a tablet that
+// exists within a cell that is part of the alias.
 func TestPickUsingCellAsAlias(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
 
@@ -574,10 +577,10 @@ type pickerTestEnv struct {
 	topoServ *topo.Server
 }
 
-// newPickerTestEnve creates a test environment for tablet picker tests.
-// It creates a cell alias called 'cella' which contains all of the cells.
-// If any optional extraCells are provided, those are NOT added to the
-// cell alias.
+// newPickerTestEnv creates a test environment for TabletPicker tests.
+// It creates a cell alias called 'cella' which contains all of the
+// provided cells. However, if any optional extraCells are provided, those
+// are NOT added to the cell alias.
 func newPickerTestEnv(t *testing.T, ctx context.Context, cells []string, extraCells ...string) *pickerTestEnv {
 	allCells := append(cells, extraCells...)
 	te := &pickerTestEnv{
@@ -587,7 +590,7 @@ func newPickerTestEnv(t *testing.T, ctx context.Context, cells []string, extraCe
 		cells:    cells,
 		topoServ: memorytopo.NewServer(ctx, allCells...),
 	}
-	// create cell alias
+	// Create cell alias containing the cells (but NOT the extraCells).
 	err := te.topoServ.CreateCellsAlias(ctx, "cella", &topodatapb.CellsAlias{
 		Cells: cells,
 	})

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -113,6 +113,9 @@ func (vde *Engine) getVDiffSummary(vdiffID int64, dbClient binlogplayer.DBClient
 // Validate vdiff options. Also setup defaults where applicable.
 func (vde *Engine) fixupOptions(options *tabletmanagerdatapb.VDiffOptions) (*tabletmanagerdatapb.VDiffOptions, error) {
 	// Assign defaults to sourceCell and targetCell if not specified.
+	if options == nil {
+		options = &tabletmanagerdatapb.VDiffOptions{}
+	}
 	sourceCell := options.PickerOptions.SourceCell
 	targetCell := options.PickerOptions.TargetCell
 	var defaultCell string

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -122,10 +123,10 @@ func (vde *Engine) fixupOptions(options *tabletmanagerdatapb.VDiffOptions) (*tab
 			return nil, err
 		}
 	}
-	if sourceCell == "" {
+	if sourceCell == "" { // Default is all cells
 		sourceCell = defaultCell
 	}
-	if targetCell == "" {
+	if targetCell == "" { // Default is all cells
 		targetCell = defaultCell
 	}
 	options.PickerOptions.SourceCell = sourceCell
@@ -134,6 +135,9 @@ func (vde *Engine) fixupOptions(options *tabletmanagerdatapb.VDiffOptions) (*tab
 	return options, nil
 }
 
+// getDefaultCell returns all of the cells in the topo as a comma
+// seperated string.
+// The default value is all cells.
 func (vde *Engine) getDefaultCell() (string, error) {
 	cells, err := vde.ts.GetCellInfoNames(vde.ctx)
 	if err != nil {
@@ -143,7 +147,7 @@ func (vde *Engine) getDefaultCell() (string, error) {
 		// Unreachable
 		return "", fmt.Errorf("there are no cells in the topo")
 	}
-	return cells[0], nil
+	return strings.Join(cells, ","), nil
 }
 
 func (vde *Engine) handleCreateResumeAction(ctx context.Context, dbClient binlogplayer.DBClient, action VDiffAction, req *tabletmanagerdatapb.VDiffRequest, resp *tabletmanagerdatapb.VDiffResponse) error {

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -140,8 +140,7 @@ func (vde *Engine) fixupOptions(options *tabletmanagerdatapb.VDiffOptions) (*tab
 }
 
 // getDefaultCell returns all of the cells in the topo as a comma
-// seperated string.
-// The default value is all cells.
+// separated string as the default value is all available cells.
 func (vde *Engine) getDefaultCell() (string, error) {
 	cells, err := vde.ts.GetCellInfoNames(vde.ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -150,6 +151,7 @@ func (vde *Engine) getDefaultCell() (string, error) {
 		// Unreachable
 		return "", fmt.Errorf("there are no cells in the topo")
 	}
+	sort.Strings(cells) // Ensure that the resulting value is deterministic
 	return strings.Join(cells, ","), nil
 }
 

--- a/go/vt/vttablet/tabletmanager/vdiff/action_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action_test.go
@@ -66,8 +66,9 @@ func TestPerformVDiffAction(t *testing.T) {
 					PickerOptions: &tabletmanagerdatapb.VDiffPickerOptions{},
 				},
 			},
-			// Add a second cell. The default cells are all cells, so this should then
-			// show up in the created vdiff record.
+			// Add a second cell. The default for source_cell and target_cell is all
+			// available cells, so this additional cell should then show up in the
+			// created vdiff record.
 			preFunc: func() error {
 				return tstenv.TopoServ.CreateCellInfo(ctx, "zone100_test", &topodatapb.CellInfo{})
 			},
@@ -91,8 +92,7 @@ func TestPerformVDiffAction(t *testing.T) {
 					},
 				},
 			},
-			// Add a second cell. The default cells are all cells, so this should then
-			// show up in the created vdiff record.
+			// Add a second cell and create an cell alias that contains it.
 			preFunc: func() error {
 				if err := tstenv.TopoServ.CreateCellInfo(ctx, "zone100_test", &topodatapb.CellInfo{}); err != nil {
 					return err

--- a/go/vt/vttablet/tabletmanager/vdiff/action_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action_test.go
@@ -24,11 +24,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
-	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 func TestPerformVDiffAction(t *testing.T) {
@@ -43,6 +46,8 @@ func TestPerformVDiffAction(t *testing.T) {
 		name          string
 		vde           *Engine
 		req           *tabletmanagerdatapb.VDiffRequest
+		preFunc       func() error
+		postFunc      func() error
 		want          *tabletmanagerdatapb.VDiffResponse
 		expectQueries []string
 		wantErr       error
@@ -51,6 +56,62 @@ func TestPerformVDiffAction(t *testing.T) {
 			name:    "engine not open",
 			vde:     &Engine{isOpen: false},
 			wantErr: vterrors.New(vtrpcpb.Code_UNAVAILABLE, "vdiff engine is closed"),
+		},
+		{
+			name: "create with defaults",
+			req: &tabletmanagerdatapb.VDiffRequest{
+				Action:    string(CreateAction),
+				VdiffUuid: uuid,
+				Options: &tabletmanagerdatapb.VDiffOptions{
+					PickerOptions: &tabletmanagerdatapb.VDiffPickerOptions{},
+				},
+			},
+			// Add a second cell. The default cells are all cells, so this should then
+			// show up in the created vdiff record.
+			preFunc: func() error {
+				return tstenv.TopoServ.CreateCellInfo(ctx, "zone100_test", &topodatapb.CellInfo{})
+			},
+			expectQueries: []string{
+				fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+				fmt.Sprintf(`insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values('', '', 'pending', '{\"picker_options\":{\"source_cell\":\"cell1,zone100_test\",\"target_cell\":\"cell1,zone100_test\"}}', '0', 'vt_vttest', %s)`, encodeString(uuid)),
+			},
+			postFunc: func() error {
+				return tstenv.TopoServ.DeleteCellInfo(ctx, "zone100_test", true)
+			},
+		},
+		{
+			name: "create with cell alias",
+			req: &tabletmanagerdatapb.VDiffRequest{
+				Action:    string(CreateAction),
+				VdiffUuid: uuid,
+				Options: &tabletmanagerdatapb.VDiffOptions{
+					PickerOptions: &tabletmanagerdatapb.VDiffPickerOptions{
+						SourceCell: "all",
+						TargetCell: "all",
+					},
+				},
+			},
+			// Add a second cell. The default cells are all cells, so this should then
+			// show up in the created vdiff record.
+			preFunc: func() error {
+				if err := tstenv.TopoServ.CreateCellInfo(ctx, "zone100_test", &topodatapb.CellInfo{}); err != nil {
+					return err
+				}
+				cells := append(tstenv.Cells, "zone100_test")
+				return tstenv.TopoServ.CreateCellsAlias(ctx, "all", &topodatapb.CellsAlias{
+					Cells: cells,
+				})
+			},
+			expectQueries: []string{
+				fmt.Sprintf("select id as id from _vt.vdiff where vdiff_uuid = %s", encodeString(uuid)),
+				fmt.Sprintf(`insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values('', '', 'pending', '{\"picker_options\":{\"source_cell\":\"all\",\"target_cell\":\"all\"}}', '0', 'vt_vttest', %s)`, encodeString(uuid)),
+			},
+			postFunc: func() error {
+				if err := tstenv.TopoServ.DeleteCellInfo(ctx, "zone100_test", true); err != nil {
+					return err
+				}
+				return tstenv.TopoServ.DeleteCellsAlias(ctx, "all")
+			},
 		},
 		{
 			name: "delete by uuid",
@@ -80,6 +141,10 @@ func TestPerformVDiffAction(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.preFunc != nil {
+				err := tt.preFunc()
+				require.NoError(t, err, "pre function failed: %v", err)
+			}
 			if tt.vde == nil {
 				tt.vde = vdiffenv.vde
 			}
@@ -93,6 +158,10 @@ func TestPerformVDiffAction(t *testing.T) {
 			}
 			if tt.want != nil && !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Engine.PerformVDiffAction() = %v, want %v", got, tt.want)
+			}
+			if tt.postFunc != nil {
+				err := tt.postFunc()
+				require.NoError(t, err, "post function failed: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

The documented default value for the `--source_cell` and `--target_cell` flags is 'any available cell': https://vitess.io/docs/reference/vreplication/vdiff/#parameters

And you can see that in the help output as well:
```
❯ vtctlclient vdiff -- --help
W0913 13:58:48.039694   71302 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/Users/matt/git/vitess]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
Usage: vdiff [--source_cell=<cell>] [--target_cell=<cell>] [--tablet_types=in_order:RDONLY,REPLICA,PRIMARY] [--limit=<max rows to diff>] [--tables=<table list>] [--format=json] [--auto-retry] [--verbose] [--max_extra_rows_to_compare=1000] [--filtered_replication_wait_time=30s] [--debug_query] [--only_pks] [--wait] [--wait-update-interval=1m] <keyspace.workflow> [<action>] [<UUID>]

Perform a diff of all tables in the workflow

      --auto-retry                                Should this vdiff automatically retry and continue in case of recoverable errors (default true)
      --checksum                                  Use row-level checksums to compare, not yet implemented
      --debug_query                               Adds a mysql query to the report that can be used for further debugging
      --filtered_replication_wait_time duration   Specifies the maximum time to wait, in seconds, for filtered replication to catch up on primary migrations. The migration will be cancelled on a timeout. (default 30s)
      --format string                             Format of report (default "text")
      --limit int                                 Max rows to stop comparing after (default 9223372036854775807)
      --max_extra_rows_to_compare int             If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
      --only_pks                                  When reporting missing rows, only show primary keys in the report.
      --sample_pct int                            How many rows to sample, not yet implemented (default 100)
      --source_cell string                        The source cell to compare from; default is any available cell
      --tables string                             Only run vdiff for these tables in the workflow
      --tablet_types string                       Tablet types for source (PRIMARY is always used on target) (default "in_order:RDONLY,REPLICA,PRIMARY")
      --target_cell string                        The target cell to compare with; default is any available cell
      --update-table-stats                        Update the table statistics, using ANALYZE TABLE, on each table involved in the VDiff during initialization. This will ensure that progress estimates are as accurate as possible -- but it does involve locks and can potentially impact query processing on the target keyspace.
      --v1                                        Use legacy VDiff v1
      --verbose                                   Show verbose vdiff output in summaries
      --wait                                      When creating or resuming a vdiff, wait for it to finish before exiting
      --wait-update-interval duration             When waiting on a vdiff to finish, check and display the current status this often (default 1m0s)
```

The code, however, was instead using the only the first cell available: https://github.com/vitessio/vitess/blob/45a94dec4fb6c408ec37ae2e171e1e3fc1364ece/go/vt/vttablet/tabletmanager/vdiff/action.go#L112-L147

This PR corrects that so that the intended/documented default of all cells is applied when no specific values are provided by the user.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13972

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
