### PR TITLE
test: added test to check binlogs to contain the cascade events

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/main_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/main_test.go
@@ -25,19 +25,19 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/utils"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
 var (
-	clusterInstance *cluster.LocalProcessCluster
-	vtParams        mysql.ConnParams
-	mysqlParams     mysql.ConnParams
-	shardedKs       = "ks"
-	unshardedKs     = "uks"
-	Cell            = "test"
+	clusterInstance   *cluster.LocalProcessCluster
+	vtParams          mysql.ConnParams
+	mysqlParams       mysql.ConnParams
+	vtgateGrpcAddress string
+	shardedKs         = "ks"
+	unshardedKs       = "uks"
+	Cell              = "test"
 	//go:embed sharded_schema.sql
 	shardedSchemaSQL string
 
@@ -82,7 +82,7 @@ func TestMain(m *testing.M) {
 			SchemaSQL: unshardedSchemaSQL,
 			VSchema:   unshardedVSchema,
 		}
-		err = clusterInstance.StartUnshardedKeyspace(*uKs, 0, false)
+		err = clusterInstance.StartUnshardedKeyspace(*uKs, 1, false)
 		if err != nil {
 			return 1
 		}
@@ -101,6 +101,7 @@ func TestMain(m *testing.M) {
 			Host: clusterInstance.Hostname,
 			Port: clusterInstance.VtgateMySQLPort,
 		}
+		vtgateGrpcAddress = fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateGrpcPort)
 
 		connParams, closer, err := utils.NewMySQL(clusterInstance, shardedKs, shardedSchemaSQL)
 		if err != nil {


### PR DESCRIPTION
## Description

This PR adds a test using VStream to stream the binlogs to view the effect of executing query with foreign key cascade and expects the relevant row events.

## Related Issue(s)

- #12967 

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
