### PR TITLE
Fix the `SELECT` query we run on the child table to verify that update is allowed on a RESTRICT constraint

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -556,13 +556,13 @@ func createFkVerifyOpForParentFKForUpdate(ctx *plancontext.PlanningContext, updS
 }
 
 // Each child foreign key constraint is verified by a join query of the form:
-// select 1 from child_tbl join parent_tbl on <columns in fk> where <clause same as original update> limit 1
+// select 1 from child_tbl join parent_tbl on <columns in fk> where <clause same as original update> [AND <parent_columns_in_fk> NOT IN (<bind variables in the SET clause of the original update>)] limit 1
 // E.g:
 // Child (c1, c2) references Parent (p1, p2)
 // update Parent set p1 = 1 where id = 1
 // verify query:
 // select 1 from Child join Parent on Parent.p1 = Child.c1 and Parent.p2 = Child.c2
-// where Parent.id = 1 limit 1
+// where Parent.id = 1 and (parent.p1) NOT IN ((1)) limit 1
 func createFkVerifyOpForChildFKForUpdate(ctx *plancontext.PlanningContext, updStmt *sqlparser.Update, cFk vindexes.ChildFKInfo) (ops.Operator, error) {
 	// ON UPDATE RESTRICT foreign keys that require validation, should only be allowed in the case where we
 	// are verifying all the FKs on vtgate level.
@@ -595,6 +595,32 @@ func createFkVerifyOpForChildFKForUpdate(ctx *plancontext.PlanningContext, updSt
 	if updStmt.Where != nil {
 		whereCond = prefixColNames(parentTbl, updStmt.Where.Expr)
 	}
+
+	// We don't want to fail the RESTRICT for the case where the parent columns remains unchanged on the update.
+	// We need to add a condition to the where clause to handle this case.
+	// The additional condition looks like [AND <parent_columns_in_fk> NOT IN (<bind variables in the SET clause of the original update>)].
+	// If any of the parent columns is being set to NULL, then we don't need this condition.
+	var updateValues sqlparser.ValTuple
+	colSetToNull := false
+	for _, updateExpr := range updStmt.Exprs {
+		colIdx := cFk.ParentColumns.FindColumn(updateExpr.Name.Name)
+		if colIdx >= 0 {
+			if sqlparser.IsNull(updateExpr.Expr) {
+				colSetToNull = true
+				break
+			}
+			updateValues = append(updateValues, updateExpr.Expr)
+		}
+	}
+	if !colSetToNull {
+		// Create a ValTuple of child column names
+		var valTuple sqlparser.ValTuple
+		for _, column := range cFk.ParentColumns {
+			valTuple = append(valTuple, sqlparser.NewColNameWithQualifier(column.String(), parentTbl))
+		}
+		whereCond = sqlparser.AndExpressions(whereCond, sqlparser.NewComparisonExpr(sqlparser.NotInOp, valTuple, sqlparser.ValTuple{updateValues}, nil))
+	}
+
 	return createSelectionOp(ctx,
 		sqlparser.SelectExprs{sqlparser.NewAliasedExpr(sqlparser.NewIntLiteral("1"), "")},
 		[]sqlparser.TableExpr{

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -1220,7 +1220,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and u_tbl4.col4 = u_tbl9.col9 limit 1 lock in share mode",
+                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (u_tbl4.col4) not in (('foo')) and u_tbl4.col4 = u_tbl9.col9 limit 1 lock in share mode",
                 "Table": "u_tbl4, u_tbl9"
               },
               {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description


This PR fixes the bug described in https://github.com/vitessio/vitess/issues/13992.

For a update like `update parent_tbl set col = 2 where id = 1`
Previously an update on a parent table that has a child with a RESTRICT constraint, and the verification is done by Vtgate created a query like -
```
select 1 
from child_tbl 
	join parent_tbl on parent_tbl.col = child_tbl.col 
where parent_tbl.id = 1 
limit 1
```

This query would get whether there were any rows in the child table that are related to the parent table rows that are being updated.

This query in general worked fine, but for the very specific case, where the update doesn't actually lead to any row changes on the parent, then we actually shouldn't be failing the update query, but we should be passing it like MySQL does.

In order to not fail the query, the `SELECT` query had to be changed as follows - 
```
select 1 
from child_tbl 
	join parent_tbl on parent_tbl.col = child_tbl.col 
where parent_tbl.id = 1 
	and (parent_tbl.col) NOT IN ((2)) 
limit 1
```

Now, if the update doesn't lead to any row changes, then the SELECT query also doesn't return any rows.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #13992 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
