### PR TITLE
go/cmd/vtbackup: report replication status metrics during catch-up phase

### DIFF
--- a/changelog/18.0/18.0.0/summary.md
+++ b/changelog/18.0/18.0.0/summary.md
@@ -18,6 +18,7 @@
     - [Deleted `vtgr`](#deleted-vtgr)
   - **[New stats](#new-stats)**
     - [VTGate Vindex unknown parameters](#vtgate-vindex-unknown-parameters)
+    - [VTBackup stat `PhaseStatus`](#vtbackup-stat-phase-status)
   - **[VTTablet](#vttablet)**
     - [VTTablet: New ResetSequences RPC](#vttablet-new-rpc-reset-sequences)
   - **[Docker](#docker)**
@@ -119,6 +120,14 @@ The `vtgr` has been deprecated in Vitess 17, also see https://github.com/vitessi
 #### <a id="vtgate-vindex-unknown-parameters"/>VTGate Vindex unknown parameters
 
 The VTGate stat `VindexUnknownParameters` gauges unknown Vindex parameters found in the latest VSchema pulled from the topology.
+
+#### <a id="vtbackup-stat-phase-status"/>VTBackup `PhaseStatus` stat
+
+`PhaseStatus` reports a 1 (active) or a 0 (inactive) for each of the following phases and statuses:
+
+ * `CatchUpReplication` phase has statuses `Stalled` and `Stopped`.
+    * `Stalled` is set to `1` when replication stops advancing.
+    * `Stopped` is set to `1` when replication stops before `vtbackup` catches up with the primary.
 
 ### <a id="vttablet"/>VTTablet
 

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -221,7 +221,7 @@ func main() {
 	// Initialize stats.
 	for phaseName, statuses := range phaseStatuses {
 		for _, status := range statuses {
-			phaseStatus.Set([]string{phaseName, status}, int64(0))
+			phaseStatus.Set([]string{phaseName, status}, 0)
 		}
 	}
 

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -455,10 +455,13 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	backupParams.BackupTime = time.Now()
 
 	// Wait for replication to catch up.
-	var lastStatus replication.ReplicationStatus
-	var status replication.ReplicationStatus
-	var statusErr error
-	waitStartTime := time.Now()
+	var (
+		lastStatus replication.ReplicationStatus
+		status replication.ReplicationStatus
+		statusErr error
+
+		waitStartTime = time.Now()
+	)
 	for {
 		select {
 		case <-ctx.Done():

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -457,8 +457,8 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	// Wait for replication to catch up.
 	var (
 		lastStatus replication.ReplicationStatus
-		status replication.ReplicationStatus
-		statusErr error
+		status     replication.ReplicationStatus
+		statusErr  error
 
 		waitStartTime = time.Now()
 	)


### PR DESCRIPTION
## Description

Emit `vtbackup_phase_status` to report issues with individual phases of `vtbackup`. Specifically, during the catch-up phase of `vtbackup`, either of these metrics can be set to either `0` or `1`. At the beginning of `vtbackup` execution they are set to 0. If they are set to 1, that indicates a problem that may require manual intervention to resolve.

```
vtbackup_phase_status{phase="CatchUpReplication",status="Stalled"} 0
vtbackup_phase_status{phase="CatchUpReplication",status="Stopped"} 0
```

## Related Issue(s)

Fixes #13994

Have a metric test framework for `vtbackup` in https://github.com/vitessio/vitess/pull/12973, when that gets merged I can use that to test these new metrics.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] [Documentation](https://github.com/vitessio/website/pull/1585) was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
