### PR TITLE
java: update to latest dependencies for grpc and protobuf

### DIFF
--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -54,26 +54,26 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.5.15</version>
+      <version>3.12.4</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.7</version>
+      <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-core</artifactId>
-      <version>2.0.7</version>
+      <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.7</version>
+      <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -66,14 +66,14 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Define versions which are also used by grpc-client/pom.xml. -->
-    <grpc.version>1.44.0</grpc.version>
+    <grpc.version>1.57.1</grpc.version>
     <!-- NOTE Netty handler and boring SSL must be kept compatible with grpc
       https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.handler.version>4.1.72.Final</netty.handler.version>
-    <tcnative.boring.ssl.version>2.0.46.Final</tcnative.boring.ssl.version>
+    <netty.handler.version>4.1.93.Final</netty.handler.version>
+    <tcnative.boring.ssl.version>2.0.61.Final</tcnative.boring.ssl.version>
 
-    <protobuf.java.version>3.19.6</protobuf.java.version>
-    <protobuf.protoc.version>3.19.4</protobuf.protoc.version>
+    <protobuf.java.version>3.24.3</protobuf.java.version>
+    <protobuf.protoc.version>3.24.3</protobuf.protoc.version>
     <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
     <log4j2.version>2.17.1</log4j2.version>
   </properties>
@@ -248,6 +248,7 @@
               <outputXML>true</outputXML>
               <ignoredUnusedDeclaredDependencies>
                 <dependency>mysql:mysql-connector-java</dependency>
+                <dependency>io.grpc:grpc-context</dependency>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>
@@ -287,7 +288,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -298,7 +299,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
+            <version>2.4</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -311,7 +312,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.4</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -324,7 +325,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR updates the java dependencies to latest grpc and protobuf version

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI

