### PR TITLE
Fix foreign key plan tests expectation

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -1314,7 +1314,7 @@
               "Sharded": false
             },
             "FieldQuery": "select cola, colb from u_multicol_tbl1 where 1 != 1",
-            "Query": "select cola, colb from u_multicol_tbl1 where id = 3 lock in share mode",
+            "Query": "select cola, colb from u_multicol_tbl1 where id = 3 for update",
             "Table": "u_multicol_tbl1"
           },
           {


### PR DESCRIPTION
## Description

The foreign key query serving test `TestForeignKeyPlanning` was failing on CI on `main` due to https://github.com/vitessio/vitess/pull/13988 being merged before https://github.com/vitessio/vitess/pull/13985, and https://github.com/vitessio/vitess/pull/13985 not catching the changes made in https://github.com/vitessio/vitess/pull/13988. This PR fixes the expectation to unblock other PRs' CI.


## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
