### PR TITLE
TableGC: support DROP VIEW

### DIFF
--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -424,10 +424,10 @@ func TestDropView(t *testing.T) {
 	_, err = primaryTablet.VttabletProcess.QueryTablet(createStatement, keyspaceName, true)
 	require.NoError(t, err)
 
-	// view should be there
+	// view should be there, because the timestamp hint is still in the near future.
 	validateTableExists(t, viewName)
 
 	time.Sleep(tableTransitionExpiration / 2)
-	// View was created with an old timestamp, so it should have been dropped by now
+	// But by now, after the above sleep, the view's timestamp hint is in the past, and we expect TableGC to have dropped the view.
 	validateTableDoesNotExist(t, viewName)
 }

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -417,7 +417,7 @@ func TestPurgeView(t *testing.T) {
 }
 
 func TestDropView(t *testing.T) {
-	viewName, err := schema.GenerateGCTableName(schema.DropTableGCState, time.Now().Add(tableTransitionExpiration)) // way in the past
+	viewName, err := schema.GenerateGCTableName(schema.DropTableGCState, time.Now().Add(tableTransitionExpiration)) // shortly in the future
 	require.NoError(t, err)
 	createStatement := fmt.Sprintf("create or replace view %s as select 1", viewName)
 

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -18,6 +18,7 @@ package tablegc
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -413,4 +414,20 @@ func TestPurgeView(t *testing.T) {
 	// table still untouched
 	validateTableExists(t, "t1")
 	validateAnyState(t, 1024, schema.EvacTableGCState, schema.DropTableGCState, schema.TableDroppedGCState)
+}
+
+func TestDropView(t *testing.T) {
+	viewName, err := schema.GenerateGCTableName(schema.DropTableGCState, time.Now().Add(tableTransitionExpiration)) // way in the past
+	require.NoError(t, err)
+	createStatement := fmt.Sprintf("create or replace view %s as select 1", viewName)
+
+	_, err = primaryTablet.VttabletProcess.QueryTablet(createStatement, keyspaceName, true)
+	require.NoError(t, err)
+
+	// view should be there
+	validateTableExists(t, viewName)
+
+	time.Sleep(tableTransitionExpiration / 2)
+	// View was created with an old timestamp, so it should have been dropped by now
+	validateTableDoesNotExist(t, viewName)
 }

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -72,8 +72,14 @@ var (
 	sqlPurgeTable       = `delete from %a limit 50`
 	sqlShowVtTables     = `show full tables like '\_vt\_%'`
 	sqlDropTable        = "drop table if exists `%a`"
+	sqlDropView         = "drop view if exists `%a`"
 	purgeReentranceFlag int64
 )
+
+type gcTable struct {
+	tableName   string
+	isBaseTable bool
+}
 
 // transitionRequest encapsulates a request to transition a table to next state
 type transitionRequest struct {
@@ -223,7 +229,7 @@ func (collector *TableGC) Close() {
 // operate is the main entry point for the table garbage collector operation and logic.
 func (collector *TableGC) operate(ctx context.Context) {
 
-	dropTablesChan := make(chan string)
+	dropTablesChan := make(chan *gcTable)
 	purgeRequestsChan := make(chan bool)
 	transitionRequestsChan := make(chan *transitionRequest)
 
@@ -251,7 +257,11 @@ func (collector *TableGC) operate(ctx context.Context) {
 		case <-tableCheckTicker.C:
 			{
 				log.Info("TableGC: tableCheckTicker")
-				_ = collector.checkTables(ctx, dropTablesChan, transitionRequestsChan)
+				gcTables, err := collector.readTables(ctx)
+				if err != nil {
+					log.Errorf("TableGC: error while reading tables: %+v", err)
+				}
+				_ = collector.checkTables(ctx, gcTables, dropTablesChan, transitionRequestsChan)
 			}
 		case <-purgeReentranceTicker.C:
 			{
@@ -280,11 +290,11 @@ func (collector *TableGC) operate(ctx context.Context) {
 					time.AfterFunc(time.Second, func() { purgeRequestsChan <- true })
 				}()
 			}
-		case dropTableName := <-dropTablesChan:
+		case dropTable := <-dropTablesChan:
 			{
-				log.Info("TableGC: dropTablesChan")
-				if err := collector.dropTable(ctx, dropTableName); err != nil {
-					log.Errorf("TableGC: error dropping table %s: %+v", dropTableName, err)
+				log.Infof("TableGC: found %v in dropTablesChan", dropTable.tableName)
+				if err := collector.dropTable(ctx, dropTable.tableName, dropTable.isBaseTable); err != nil {
+					log.Errorf("TableGC: error dropping table %s: %+v", dropTable.tableName, err)
 				}
 			}
 		case transition := <-transitionRequestsChan:
@@ -368,29 +378,39 @@ func (collector *TableGC) shouldTransitionTable(tableName string) (shouldTransit
 	return true, state, uuid, nil
 }
 
-// checkTables looks for potential GC tables in the MySQL server+schema.
-// It lists _vt_% tables, then filters through those which are due-date.
-// It then applies the necessary operation per table.
-func (collector *TableGC) checkTables(ctx context.Context, dropTablesChan chan<- string, transitionRequestsChan chan<- *transitionRequest) error {
+// readTables reads the list of _vt_% tables from the database
+func (collector *TableGC) readTables(ctx context.Context) (gcTables []*gcTable, err error) {
 	conn, err := collector.pool.Get(ctx, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer conn.Recycle()
 
-	log.Infof("TableGC: check tables")
+	log.Infof("TableGC: read tables")
 
 	res, err := conn.Exec(ctx, sqlShowVtTables, math.MaxInt32, true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, row := range res.Rows {
 		tableName := row[0].ToString()
 		tableType := row[1].ToString()
 		isBaseTable := (tableType == "BASE TABLE")
+		gcTables = append(gcTables, &gcTable{tableName: tableName, isBaseTable: isBaseTable})
+	}
+	return gcTables, nil
+}
 
-		shouldTransition, state, uuid, err := collector.shouldTransitionTable(tableName)
+// checkTables looks for potential GC tables in the MySQL server+schema.
+// It lists _vt_% tables, then filters through those which are due-date.
+// It then applies the necessary operation per table.
+func (collector *TableGC) checkTables(ctx context.Context, gcTables []*gcTable, dropTablesChan chan<- *gcTable, transitionRequestsChan chan<- *transitionRequest) error {
+	log.Infof("TableGC: check tables")
+
+	for i := range gcTables {
+		table := gcTables[i] // we capture as local variable as we will later use this in a goroutine
+		shouldTransition, state, uuid, err := collector.shouldTransitionTable(table.tableName)
 
 		if err != nil {
 			log.Errorf("TableGC: error while checking tables: %+v", err)
@@ -401,30 +421,32 @@ func (collector *TableGC) checkTables(ctx context.Context, dropTablesChan chan<-
 			continue
 		}
 
-		log.Infof("TableGC: will operate on table %s", tableName)
+		log.Infof("TableGC: will operate on table %s", table.tableName)
 
 		if state == schema.HoldTableGCState {
 			// Hold period expired. Moving to next state
-			collector.submitTransitionRequest(ctx, transitionRequestsChan, state, tableName, isBaseTable, uuid)
+			collector.submitTransitionRequest(ctx, transitionRequestsChan, state, table.tableName, table.isBaseTable, uuid)
 		}
 		if state == schema.PurgeTableGCState {
-			if isBaseTable {
+			if table.isBaseTable {
 				// This table needs to be purged. Make sure to enlist it (we may already have)
-				if !collector.addPurgingTable(tableName) {
-					collector.submitTransitionRequest(ctx, transitionRequestsChan, state, tableName, isBaseTable, uuid)
+				if !collector.addPurgingTable(table.tableName) {
+					collector.submitTransitionRequest(ctx, transitionRequestsChan, state, table.tableName, table.isBaseTable, uuid)
 				}
 			} else {
 				// This is a view. We don't need to delete rows from views. Just transition into next phase
-				collector.submitTransitionRequest(ctx, transitionRequestsChan, state, tableName, isBaseTable, uuid)
+				collector.submitTransitionRequest(ctx, transitionRequestsChan, state, table.tableName, table.isBaseTable, uuid)
 			}
 		}
 		if state == schema.EvacTableGCState {
 			// This table was in EVAC state for the required period. It will transition into DROP state
-			collector.submitTransitionRequest(ctx, transitionRequestsChan, state, tableName, isBaseTable, uuid)
+			collector.submitTransitionRequest(ctx, transitionRequestsChan, state, table.tableName, table.isBaseTable, uuid)
 		}
 		if state == schema.DropTableGCState {
 			// This table needs to be dropped immediately.
-			go func() { dropTablesChan <- tableName }()
+			go func() {
+				dropTablesChan <- table
+			}()
 		}
 	}
 
@@ -520,21 +542,25 @@ func (collector *TableGC) purge(ctx context.Context) (tableName string, err erro
 
 // dropTable runs an actual DROP TABLE statement, and marks the end of the line for the
 // tables' GC lifecycle.
-func (collector *TableGC) dropTable(ctx context.Context, tableName string) error {
-	conn, err := collector.pool.Get(ctx, nil)
+func (collector *TableGC) dropTable(ctx context.Context, tableName string, isBaseTable bool) error {
+	conn, err := dbconnpool.NewDBConnection(ctx, collector.env.Config().DB.DbaWithDB())
 	if err != nil {
 		return err
 	}
-	defer conn.Recycle()
+	defer conn.Close()
 
-	parsed := sqlparser.BuildParsedQuery(sqlDropTable, tableName)
+	sqlDrop := sqlDropTable
+	if !isBaseTable {
+		sqlDrop = sqlDropView
+	}
+	parsed := sqlparser.BuildParsedQuery(sqlDrop, tableName)
 
 	log.Infof("TableGC: dropping table: %s", tableName)
-	_, err = conn.Exec(ctx, parsed.Query, 1, true)
+	_, err = conn.ExecuteFetch(parsed.Query, 1, false)
 	if err != nil {
 		return err
 	}
-	log.Infof("TableGC: dropped table: %s", tableName)
+	log.Infof("TableGC: dropped table: %s, isBaseTable: %v", tableName, isBaseTable)
 	return nil
 }
 


### PR DESCRIPTION

## Description

Per https://github.com/vitessio/vitess/issues/14018, the [Table GC](https://vitess.io/docs/18.0/user-guides/schema-changes/table-lifecycle/) mechanism was unable to drop views.

In this PR tableGC makes the distinction between tables and views in `DROP` statements. I refactored the code a bit to add unit testing, and also added an `endtoend` test.

Also, using `DB.DbaWithDB()` to drop the view, as dropping a view requires privileges to make changes to the `DEFINER` of the view.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14018

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
