### PR TITLE
fix: cost to include subshard opcode

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/sharded_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/sharded_routing.go
@@ -327,7 +327,7 @@ func (tr *ShardedRouting) Cost() int {
 	switch tr.RouteOpCode {
 	case engine.EqualUnique:
 		return 1
-	case engine.Equal:
+	case engine.Equal, engine.SubShard:
 		return 5
 	case engine.IN:
 		return 10

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4039,5 +4039,53 @@
         "main.unsharded_authoritative"
       ]
     }
+  },
+  {
+    "comment": "join query using table with muticolumn vindex",
+    "query": "select 1 from multicol_tbl m1 join multicol_tbl m2 on m1.cola = m2.cola",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from multicol_tbl m1 join multicol_tbl m2 on m1.cola = m2.cola",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "JoinVars": {
+          "m1_cola": 1
+        },
+        "TableName": "multicol_tbl_multicol_tbl",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1, m1.cola from multicol_tbl as m1 where 1 != 1",
+            "Query": "select 1, m1.cola from multicol_tbl as m1",
+            "Table": "multicol_tbl"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "SubShard",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from multicol_tbl as m2 where 1 != 1",
+            "Query": "select 1 from multicol_tbl as m2 where m2.cola = :m1_cola",
+            "Table": "multicol_tbl",
+            "Values": [
+              ":m1_cola"
+            ],
+            "Vindex": "multicolIdx"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.multicol_tbl"
+      ]
+    }
   }
 ]


### PR DESCRIPTION

## Description

This PR adds the missing `SubShard` opcode to the cost model.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/13021

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required

