### PR TITLE
moved timeout test to different package

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -96,58 +96,6 @@ func TestInvalidDateTimeTimestampVals(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestQueryTimeoutWithDual(t *testing.T) {
-	mcmp, closer := start(t)
-	defer closer()
-
-	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.04) from dual")
-	assert.NoError(t, err)
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.24) from dual")
-	assert.Error(t, err)
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "set @@session.query_timeout=20")
-	require.NoError(t, err)
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.04) from dual")
-	assert.Error(t, err)
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.01) from dual")
-	assert.NoError(t, err)
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=500 */ sleep(0.24) from dual")
-	assert.NoError(t, err)
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=10 */ sleep(0.04) from dual")
-	assert.Error(t, err)
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=15 */ sleep(0.001) from dual")
-	assert.NoError(t, err)
-}
-
-func TestQueryTimeoutWithTables(t *testing.T) {
-	mcmp, closer := start(t)
-	defer closer()
-
-	// unsharded
-	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into uks.unsharded(id1) values (1),(2),(3),(4),(5)")
-	for i := 0; i < 12; i++ {
-		utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=2000 */ into uks.unsharded(id1) select id1+5 from uks.unsharded")
-	}
-
-	utils.Exec(t, mcmp.VtConn, "select count(*) from uks.unsharded where id1 > 31")
-	utils.Exec(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=100 */ count(*) from uks.unsharded where id1 > 31")
-
-	// the query usually takes more than 5ms to return. So this should fail.
-	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=1 */ count(*) from uks.unsharded where id1 > 31")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
-	assert.Contains(t, err.Error(), "(errno 1317) (sqlstate 70100)")
-
-	// sharded
-	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into ks_misc.t1(id1, id2) values (1,2),(2,4),(3,6),(4,8),(5,10)")
-
-	// sleep take in seconds, so 0.1 is 100ms
-	utils.Exec(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=500 */ sleep(0.1) from t1 where id1 = 1")
-	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=20 */ sleep(0.1) from t1 where id1 = 1")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
-	assert.Contains(t, err.Error(), "(errno 1317) (sqlstate 70100)")
-}
-
 // TestIntervalWithMathFunctions tests that the Interval keyword can be used with math functions.
 func TestIntervalWithMathFunctions(t *testing.T) {
 	mcmp, closer := start(t)
@@ -214,7 +162,7 @@ func TestHighNumberOfParams(t *testing.T) {
 	defer db.Close()
 
 	// run the query
-	r, err := db.Query(fmt.Sprintf("SELECT /*vt+ QUERY_TIMEOUT_MS=10000 */ id1 FROM t1 WHERE id1 in (%s) ORDER BY id1 ASC", strings.Join(params, ", ")), vals...)
+	r, err := db.Query(fmt.Sprintf("SELECT id1 FROM t1 WHERE id1 in (%s) ORDER BY id1 ASC", strings.Join(params, ", ")), vals...)
 	require.NoError(t, err)
 	defer r.Close()
 
@@ -301,6 +249,6 @@ func TestLeftJoinUsingUnsharded(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
 
-	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into uks.unsharded(id1) values (1),(2),(3),(4),(5)")
-	utils.Exec(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from uks.unsharded as A left join uks.unsharded as B using(id1)")
+	utils.Exec(t, mcmp.VtConn, "insert into uks.unsharded(id1) values (1),(2),(3),(4),(5)")
+	utils.Exec(t, mcmp.VtConn, "select * from uks.unsharded as A left join uks.unsharded as B using(id1)")
 }

--- a/go/test/endtoend/vtgate/queries/timeout/main_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/main_test.go
@@ -62,7 +62,9 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs,
-			"--queryserver-config-max-result-size", "1000000")
+			"--queryserver-config-max-result-size", "1000000",
+			"--queryserver-config-query-timeout", "200",
+			"--queryserver-config-query-pool-timeout", "200")
 		// Start Unsharded keyspace
 		ukeyspace := &cluster.Keyspace{
 			Name:      uks,
@@ -84,6 +86,8 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+			"--query-timeout", "100")
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/timeout/schema.sql
+++ b/go/test/endtoend/vtgate/queries/timeout/schema.sql
@@ -1,0 +1,5 @@
+create table if not exists t1(
+                   id1 bigint,
+                   id2 bigint,
+                   primary key(id1)
+) Engine=InnoDB;

--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package misc
+
+import (
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+)
+
+func start(t *testing.T) (utils.MySQLCompare, func()) {
+	mcmp, err := utils.NewMySQLCompare(t, vtParams, mysqlParams)
+	require.NoError(t, err)
+
+	deleteAll := func() {
+		tables := []string{"t1", "uks.unsharded"}
+		for _, table := range tables {
+			_, _ = mcmp.ExecAndIgnore("delete from " + table)
+		}
+	}
+
+	deleteAll()
+
+	return mcmp, func() {
+		deleteAll()
+		mcmp.Close()
+		cluster.PanicHandler(t)
+	}
+}
+
+func TestQueryTimeoutWithDual(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.04) from dual")
+	assert.NoError(t, err)
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.24) from dual")
+	assert.Error(t, err)
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "set @@session.query_timeout=20")
+	require.NoError(t, err)
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.04) from dual")
+	assert.Error(t, err)
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(0.01) from dual")
+	assert.NoError(t, err)
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=500 */ sleep(0.24) from dual")
+	assert.NoError(t, err)
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=10 */ sleep(0.04) from dual")
+	assert.Error(t, err)
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=15 */ sleep(0.001) from dual")
+	assert.NoError(t, err)
+}
+
+func TestQueryTimeoutWithTables(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	// unsharded
+	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into uks.unsharded(id1) values (1),(2),(3),(4),(5)")
+	for i := 0; i < 12; i++ {
+		utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=2000 */ into uks.unsharded(id1) select id1+5 from uks.unsharded")
+	}
+
+	utils.Exec(t, mcmp.VtConn, "select count(*) from uks.unsharded where id1 > 31")
+	utils.Exec(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=100 */ count(*) from uks.unsharded where id1 > 31")
+
+	// the query usually takes more than 5ms to return. So this should fail.
+	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=1 */ count(*) from uks.unsharded where id1 > 31")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.Contains(t, err.Error(), "(errno 1317) (sqlstate 70100)")
+
+	// sharded
+	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into ks_misc.t1(id1, id2) values (1,2),(2,4),(3,6),(4,8),(5,10)")
+
+	// sleep take in seconds, so 0.1 is 100ms
+	utils.Exec(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=500 */ sleep(0.1) from t1 where id1 = 1")
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=20 */ sleep(0.1) from t1 where id1 = 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.Contains(t, err.Error(), "(errno 1317) (sqlstate 70100)")
+}

--- a/go/test/endtoend/vtgate/queries/timeout/uschema.sql
+++ b/go/test/endtoend/vtgate/queries/timeout/uschema.sql
@@ -1,0 +1,5 @@
+create table unsharded(
+    id1 bigint,
+    id2 bigint,
+    key(id1)
+) Engine=InnoDB;

--- a/go/test/endtoend/vtgate/queries/timeout/vschema.json
+++ b/go/test/endtoend/vtgate/queries/timeout/vschema.json
@@ -1,0 +1,18 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "hash": {
+      "type": "hash"
+    }
+  },
+  "tables": {
+    "t1": {
+      "column_vindexes": [
+        {
+          "column": "id1",
+          "name": "hash"
+        }
+      ]
+    }
+  }
+}

--- a/test/config.json
+++ b/test/config.json
@@ -545,6 +545,15 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"vtgate_queries_timeout": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/queries/timeout"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_queries",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtgate_queries_normalize": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/queries/normalize"],


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR moves out timeout related test to different packages it the timeout values are very restrictive and causing other test to be flaky.

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required
