### PR TITLE
evalengine: Mark UUID() function as non-constant

### DIFF
--- a/go/vt/vtgate/evalengine/fn_misc.go
+++ b/go/vt/vtgate/evalengine/fn_misc.go
@@ -586,6 +586,10 @@ func (call *builtinUUID) compile(c *compiler) (ctype, error) {
 	return ctype{Type: sqltypes.VarChar, Flag: 0, Col: collationUtf8mb3}, nil
 }
 
+func (call *builtinUUID) constant() bool {
+	return false
+}
+
 func (call *builtinUUIDToBin) eval(env *ExpressionEnv) (eval, error) {
 	arg, err := call.arg1(env)
 	if arg == nil || err != nil {


### PR DESCRIPTION
This was missed when this was added in
https://github.com/vitessio/vitess/pull/13097, since the UUID() function needs to be evaluated each time and not cached.

## Related Issue(s)

Fixes #14050 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required