### PR TITLE
go/vt/wrangler: add len(qr.Rows) check to no streams found log msg

### DIFF
--- a/go/vt/wrangler/vexec_plan.go
+++ b/go/vt/wrangler/vexec_plan.go
@@ -77,7 +77,7 @@ func (p vreplicationPlanner) exec(
 	if err != nil {
 		return nil, err
 	}
-	if qr.RowsAffected == 0 {
+	if qr.RowsAffected == 0 && len(qr.Rows) == 0 {
 		log.Infof("no matching streams found for workflow %s, tablet %s, query %s", p.vx.workflow, primaryAlias, query)
 	}
 	return qr, nil


### PR DESCRIPTION
## Description

Very minor improvement to `vexec_plan.go` log message for when no matching streams are found.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/14060

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
