### PR TITLE
Experiment: observe behavior when we do not 'set names binary' in vreplication

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -323,7 +323,6 @@ func TestMoveTables(t *testing.T) {
 			), nil)
 		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(updatePickedSourceTablet, tenv.cells[0], sourceTabletUID), &sqltypes.Result{}, nil)
 		ftc.vrdbClient.ExpectRequest(setSessionTZ, &sqltypes.Result{}, nil)
-		ftc.vrdbClient.ExpectRequest(setNames, &sqltypes.Result{}, nil)
 		ftc.vrdbClient.ExpectRequest(getRowsCopied,
 			sqltypes.MakeTestResult(
 				sqltypes.MakeTestFields(
@@ -894,7 +893,6 @@ func TestFailedMoveTablesCreateCleanup(t *testing.T) {
 	targetTablet.vrdbClient.ExpectRequest(fmt.Sprintf(updatePickedSourceTablet, tenv.cells[0], sourceTabletUID),
 		&sqltypes.Result{}, nil)
 	targetTablet.vrdbClient.ExpectRequest(setSessionTZ, &sqltypes.Result{}, nil)
-	targetTablet.vrdbClient.ExpectRequest(setNames, &sqltypes.Result{}, nil)
 	targetTablet.vrdbClient.ExpectRequest(getRowsCopied,
 		sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -224,9 +224,9 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 		}
 		// Tables may have varying character sets. To ship the bits without interpreting them
 		// we set the character set to be binary.
-		if _, err := dbClient.ExecuteFetch("set names 'binary'", 10000); err != nil {
-			return err
-		}
+		// if _, err := dbClient.ExecuteFetch("set names 'binary'", 10000); err != nil {
+		// 	return err
+		// }
 		// We must apply AUTO_INCREMENT values precisely as we got them. This include the 0 value, which is not recommended in AUTO_INCREMENT, and yet is valid.
 		if _, err := dbClient.ExecuteFetch("set @@session.sql_mode = CONCAT(@@session.sql_mode, ',NO_AUTO_VALUE_ON_ZERO')", 10000); err != nil {
 			return err

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -133,9 +133,9 @@ func (rs *rowStreamer) Stream() error {
 		}
 		rs.conn = conn
 		defer rs.conn.Close()
-		// if _, err := rs.conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
-		// 	return err
-		// }
+		if _, err := rs.conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
+			return err
+		}
 	}
 	return rs.streamQuery(rs.send)
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -133,9 +133,9 @@ func (rs *rowStreamer) Stream() error {
 		}
 		rs.conn = conn
 		defer rs.conn.Close()
-		if _, err := rs.conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
-			return err
-		}
+		// if _, err := rs.conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
+		// 	return err
+		// }
 	}
 	return rs.streamQuery(rs.send)
 }


### PR DESCRIPTION

## Description

This is an experimental PR to see what the impact is if we remove `set names 'binary'` from `vreplication`. Which tests fail?


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
