### PR TITLE
ci: pool-related test flakyness

### DIFF
--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -250,17 +251,19 @@ func TestHealthCheckSchemaChangeSignal(t *testing.T) {
 
 func verifyHealthStreamSchemaChangeSignals(t *testing.T, vtgateConn *mysql.Conn, primaryTablet *cluster.Vttablet, viewsEnabled bool) {
 	var streamErr error
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
+	var ranOnce atomic.Bool
+	var finished atomic.Bool
+
 	wg.Add(1)
-	ranOnce := false
-	finished := false
 	ch := make(chan *querypb.StreamHealthResponse)
+
 	go func() {
 		defer wg.Done()
 		streamErr = clusterInstance.StreamTabletHealthUntil(context.Background(), primaryTablet, 30*time.Second, func(shr *querypb.StreamHealthResponse) bool {
-			ranOnce = true
+			ranOnce.Store(true)
 			// If we are finished, then close the channel and end the stream.
-			if finished {
+			if finished.Load() {
 				close(ch)
 				return true
 			}
@@ -272,11 +275,12 @@ func verifyHealthStreamSchemaChangeSignals(t *testing.T, vtgateConn *mysql.Conn,
 	// The test becomes flaky if we run the DDL immediately after starting the above go routine because the client for the Stream
 	// sometimes isn't registered by the time DDL runs, and it misses the update we get. To prevent this situation, we wait for one Stream packet
 	// to have returned. Once we know we received a Stream packet, then we know that we are registered for the health stream and can execute the DDL.
-	for i := 0; i < 30; i++ {
-		if ranOnce {
-			break
-		}
+	for i := 0; i < 30 && !ranOnce.Load(); i++ {
 		time.Sleep(1 * time.Second)
+	}
+
+	if !ranOnce.Load() {
+		t.Fatalf("HealthCheck did not ran?")
 	}
 
 	verifyTableDDLSchemaChangeSignal(t, vtgateConn, ch, "CREATE TABLE `area` (`id` int NOT NULL, `country` varchar(30), PRIMARY KEY (`id`))", "area")
@@ -288,7 +292,7 @@ func verifyHealthStreamSchemaChangeSignals(t *testing.T, vtgateConn *mysql.Conn,
 	verifyViewDDLSchemaChangeSignal(t, vtgateConn, ch, "DROP VIEW v2", viewsEnabled)
 	verifyTableDDLSchemaChangeSignal(t, vtgateConn, ch, "DROP TABLE `area`", "area")
 
-	finished = true
+	finished.Store(true)
 	wg.Wait()
 	require.NoError(t, streamErr)
 }

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -131,7 +131,6 @@ BEGIN
 	insert into allDefaults () values ();
     select * from allDefaults;
 	delete from allDefaults;
-    set autocommit = 0;
 END;
 
 CREATE PROCEDURE in_parameter(IN val int)

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -290,6 +290,18 @@ func (db *LocalCluster) MySQLAppDebugConnParams() mysql.ConnParams {
 	return connParams
 }
 
+// MySQLCleanConnParams returns connection params that can be used to connect
+// directly to MySQL, even if there's a toxyproxy instance on the way.
+func (db *LocalCluster) MySQLCleanConnParams() mysql.ConnParams {
+	mysqlctl := db.mysql
+	if toxiproxy, ok := mysqlctl.(*Toxiproxyctl); ok {
+		mysqlctl = toxiproxy.mysqlctl
+	}
+	connParams := mysqlctl.Params(db.DbName())
+	connParams.Charset = db.Config.Charset
+	return connParams
+}
+
 // SimulateMySQLHang simulates a scenario where the backend MySQL stops all data from flowing through.
 // Please ensure to `defer db.StopSimulateMySQLHang()` after calling this method.
 func (db *LocalCluster) SimulateMySQLHang() error {


### PR DESCRIPTION
## Description

While developing https://github.com/vitessio/vitess/pull/14034 I found several data races and flakyness on tests that have always been there, and that were exposed because of the new LIFO semantics of the new pool.

Let's split these test fixes into their own PR to make the tests less flaky for everybody!

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/14034

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
