### PR TITLE
[release-17.0] backport mysqlctl CLI compatibility fix to 17.0

### DIFF
--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -158,8 +158,9 @@ ssl_key={{.ServerKey}}
 		} else {
 			tmpProcess.Args = append(tmpProcess.Args, "start")
 		}
+	} else {
+		tmpProcess.Args = append(tmpProcess.Args, "start")
 	}
-	tmpProcess.Args = append(tmpProcess.Args, "start")
 	log.Infof("Starting mysqlctl with command: %v", tmpProcess.Args)
 	return tmpProcess, tmpProcess.Start()
 }

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -47,6 +47,7 @@ type MysqlctlProcess struct {
 	ExtraArgs       []string
 	InitMysql       bool
 	SecureTransport bool
+	MajorVersion    int
 }
 
 // InitDb executes mysqlctl command to add cell info
@@ -54,8 +55,13 @@ func (mysqlctl *MysqlctlProcess) InitDb() (err error) {
 	args := []string{"--log_dir", mysqlctl.LogDirectory,
 		"--tablet_uid", fmt.Sprintf("%d", mysqlctl.TabletUID),
 		"--mysql_port", fmt.Sprintf("%d", mysqlctl.MySQLPort),
-		"init", "--",
-		"--init_db_sql_file", mysqlctl.InitDBFile}
+		"init",
+	}
+	if mysqlctl.MajorVersion < 18 {
+		args = append(args, "--")
+	}
+
+	args = append(args, "--init_db_sql_file", mysqlctl.InitDBFile)
 	if *isCoverage {
 		args = append([]string{"--test.coverprofile=" + getCoveragePath("mysql-initdb.out"), "--test.v"}, args...)
 	}
@@ -143,8 +149,14 @@ ssl_key={{.ServerKey}}
 		}
 
 		if init {
-			tmpProcess.Args = append(tmpProcess.Args, "init", "--",
-				"--init_db_sql_file", mysqlctl.InitDBFile)
+			tmpProcess.Args = append(tmpProcess.Args, "init")
+			if mysqlctl.MajorVersion < 18 {
+				tmpProcess.Args = append(tmpProcess.Args, "--")
+			}
+
+			tmpProcess.Args = append(tmpProcess.Args, "--init_db_sql_file", mysqlctl.InitDBFile)
+		} else {
+			tmpProcess.Args = append(tmpProcess.Args, "start")
 		}
 	}
 	tmpProcess.Args = append(tmpProcess.Args, "start")
@@ -238,11 +250,17 @@ func MysqlCtlProcessInstanceOptionalInit(tabletUID int, mySQLPort int, tmpDirect
 	if err != nil {
 		return nil, err
 	}
+
+	version, err := GetMajorVersion("mysqlctl")
+	if err != nil {
+		log.Warningf("failed to get major mysqlctl version; backwards-compatibility for CLI changes may not work: %s", err)
+	}
 	mysqlctl := &MysqlctlProcess{
 		Name:         "mysqlctl",
 		Binary:       "mysqlctl",
 		LogDirectory: tmpDirectory,
 		InitDBFile:   initFile,
+		MajorVersion: version,
 	}
 	mysqlctl.MySQLPort = mySQLPort
 	mysqlctl.TabletUID = tabletUID


### PR DESCRIPTION
## Description

This backports 514c946457c8c54dbbb1f6d5890c337932811c48 to 17.0, which is needed so upgrade/downgrade tests (upgrading _to_ 18.0 on 17.0) work properly.

## Related Issue(s)

#13946 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
