### PR TITLE
Adding X.509 SPIFFE auth

### DIFF
--- a/go/flags/endtoend/mysqlctld.txt
+++ b/go/flags/endtoend/mysqlctld.txt
@@ -42,6 +42,7 @@ Usage of mysqlctld:
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
+      --grpc_auth_spiffe_allowed_trust_domains string                    List of allowed SPIFFE Trust Domains for client SVIDs (separated by comma).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -57,6 +57,7 @@ Flags:
       --gcs_backup_storage_root string                                   Root prefix for all backup-related object names.
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
+      --grpc_auth_spiffe_allowed_trust_domains string                    List of allowed SPIFFE Trust Domains for client SVIDs (separated by comma).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -67,6 +67,7 @@ Flags:
       --grpc-use-static-authentication-callerid                          If set, will set the immediate caller id to the username authenticated by the static auth plugin.
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
+      --grpc_auth_spiffe_allowed_trust_domains string                    List of allowed SPIFFE Trust Domains for client SVIDs (separated by comma).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -168,6 +168,7 @@ Flags:
       --gh-ost-path string                                               override default gh-ost binary full path
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
+      --grpc_auth_spiffe_allowed_trust_domains string                    List of allowed SPIFFE Trust Domains for client SVIDs (separated by comma).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -40,6 +40,7 @@ Usage of vttestserver:
       --foreign_key_mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
+      --grpc_auth_spiffe_allowed_trust_domains string                    List of allowed SPIFFE Trust Domains for client SVIDs (separated by comma).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -55,8 +55,8 @@ import (
 // Note servenv.GRPCServer can only be used in servenv.OnRun,
 // and not before, as it is initialized right before calling OnRun.
 var (
-	// gRPCAuth specifies which auth plugin to use. Currently only "static" and
-	// "mtls" are supported.
+	// gRPCAuth specifies which auth plugin to use. Currently only "static",
+	// "mtls", and "spiffe" are supported.
 	//
 	// To expose this flag, call RegisterGRPCAuthServerFlags before ParseFlags.
 	gRPCAuth string

--- a/go/vt/servenv/grpc_server_auth_spiffe.go
+++ b/go/vt/servenv/grpc_server_auth_spiffe.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"context"
+	"crypto/x509"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+var (
+	// spiffeTrustDomains list of allowed SPIFFE Trust Domains for client SVIDs during authorization
+	spiffeTrustDomains string
+	// SPIFFEAuthPlugin implements AuthPlugin interface
+	_ Authenticator = (*SPIFFEAuthPlugin)(nil)
+)
+
+// The datatype for spiffe auth Context keys
+type spiffeIdKey int
+
+const (
+	// Internal Context key for the authenticated SPIFFE ID
+	spiffeId spiffeIdKey = 0
+)
+
+func registerGRPCServerAuthSPIFFEFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&spiffeTrustDomains, "grpc_auth_spiffe_allowed_trust_domains", spiffeTrustDomains, "List of allowed SPIFFE Trust Domains for client SVIDs (separated by comma).")
+}
+
+// SPIFFEAuthPlugin implements X.509-based SVID for SPIFFE authentication for grpc. It contains an array of trust domains
+// that will be authorized to connect to the grpc server.
+type SPIFFEAuthPlugin struct {
+	spiffeTrustDomains []string
+}
+
+// Authenticate implements Authenticator interface. This method will be used inside a middleware in grpc_server to authenticate
+// incoming requests.
+func (spa *SPIFFEAuthPlugin) Authenticate(ctx context.Context, fullMethod string) (context.Context, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "no peer connection info")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "not connected via TLS")
+	}
+
+	cert := tlsInfo.State.PeerCertificates[0] // Only check the leaf certificate
+	spiffeIdUrl, ok := validateSVIDCert(cert, spa.spiffeTrustDomains)
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "client certificate not authorized")
+	}
+
+	log.Infof("SPIFFE auth plugin has authenticated client with SPIFFE ID %v", spiffeId)
+	return newSPIFFEAuthContext(ctx, spiffeIdUrl), nil
+}
+
+// Validates the given certificate as a valid SVID leaf certificate based on
+// https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#4-constraints-and-usage
+// and https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#5-validation
+func validateSVIDCert(cert *x509.Certificate, trustedDomains []string) (*url.URL, bool) {
+	issuedForTrustedDomain := false
+
+	// Leaf SVIDs should have exactly one URI SAN
+	if len(cert.URIs) != 1 {
+		return nil, false
+	}
+
+	if cert.URIs[0].Scheme != "spiffe" {
+		return nil, false
+	}
+
+	for _, trustDomain := range trustedDomains {
+		if cert.URIs[0].Hostname() == trustDomain {
+			issuedForTrustedDomain = true
+			break
+		}
+	}
+
+	if !issuedForTrustedDomain {
+		return nil, false
+	}
+
+	// Leaf SVIDs should not be CA certs
+	if cert.IsCA {
+		return nil, false
+	}
+
+	// Leaf SVIDs should not have CA usage
+	if cert.KeyUsage&x509.KeyUsageCertSign != 0 {
+		return nil, false
+	}
+
+	// Leaf SVIDs should not have CRL signing usage
+	if cert.KeyUsage&x509.KeyUsageCRLSign != 0 {
+		return nil, false
+	}
+
+	// Leaf SVIDs must have Digital Signature usage
+	if cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+		return nil, false
+	}
+
+	return cert.URIs[0], true
+}
+
+func newSPIFFEAuthContext(ctx context.Context, foundSPIFFEId *url.URL) context.Context {
+	return context.WithValue(ctx, spiffeId, foundSPIFFEId)
+}
+
+func spiffeAuthPluginInitializer() (Authenticator, error) {
+	spiffeAuthPlugin := &SPIFFEAuthPlugin{
+		spiffeTrustDomains: strings.Split(spiffeTrustDomains, ","),
+	}
+	log.Infof("SPIFFE auth plugin has initialized successfully with allowed trust domains of %v", spiffeTrustDomains)
+	return spiffeAuthPlugin, nil
+}
+
+// SPIFFEIdFromContext returns the SPIFFE ID authenticated by the spiffe auth plugin and stored in the Context, if any
+func SPIFFEIdFromContext(ctx context.Context) *url.URL {
+	spiffeId, ok := ctx.Value(spiffeId).(*url.URL)
+	if ok {
+		return spiffeId
+	}
+	return nil
+}
+
+// SPIFFETrustDomains returns the value of the
+// `--grpc_auth_spiffe_allowed_trust_domains` flag.
+func SPIFFETrustDomains() string {
+	return spiffeTrustDomains
+}
+
+func init() {
+	RegisterAuthPlugin("spiffe", spiffeAuthPluginInitializer)
+	grpcAuthServerFlagHooks = append(grpcAuthServerFlagHooks, registerGRPCServerAuthSPIFFEFlags)
+}

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -258,6 +258,15 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 	if servenv.GRPCAuth() == "mtls" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--grpc_auth_mode", servenv.GRPCAuth(), "--grpc_key", servenv.GRPCKey(), "--grpc_cert", servenv.GRPCCert(), "--grpc_ca", servenv.GRPCCertificateAuthority(), "--grpc_auth_mtls_allowed_substrings", servenv.ClientCertSubstrings()}...)
 	}
+	if servenv.GRPCAuth() == "spiffe" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{
+			"--grpc_auth_mode", servenv.GRPCAuth(),
+			"--grpc_key", servenv.GRPCKey(),
+			"--grpc_cert", servenv.GRPCCert(),
+			"--grpc_ca", servenv.GRPCCertificateAuthority(),
+			"--grpc_auth_spiffe_allowed_trust_domains", servenv.SPIFFETrustDomains(),
+		}...)
+	}
 	if args.VSchemaDDLAuthorizedUsers != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--vschema_ddl_authorized_users", args.VSchemaDDLAuthorizedUsers}...)
 	}


### PR DESCRIPTION
## Description

Attempts to implement #14083.

This change adds a new gRPC server option that enables X.509 SVIDs for authentication.

Support for this auth plugin requires the use of `--grpc_auth_mode=spiffe` and `--grpc_auth_spiffe_allowed_trust_domains` (plus the existing `--grpc_key`, `--grpc_cert`, `--grpc_ca`, `--vtctld_grpc_key`, `--vtctld_grpc_cert`, `--vtctld_grpc_ca` parameters, used the same as the `mtls` auth mode).

When enabled, gRPC servers will expect that clients will provide valid X.509 Leaf SVIDs as client auth certificates. These are described in the [SPIFFE documentation](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#31-leaf-certificates) as:

> A leaf certificate is an SVID that serves to identify a caller or resource and is suitable for use in authentication processes. A leaf certificate [...] is the only type that may serve to identify a resource or caller.
>
>Leaf certificate SPIFFE IDs MUST have a non-root path component. The `Subject` field is not required, however, the URI SAN extension MUST be marked as `critical` if `Subject` is omitted, per section 4.1.2.6 of [RFC 5280](https://tools.ietf.org/html/rfc5280).

Its validation is [further described](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#52-leaf-validation) as:

> When validating an X.509 SVID for authentication purposes, the validator MUST ensure that the `CA` field in the basic constraints extension is set to `false`, and that `keyCertSign` and `cRLSign` are not set in the key usage extension. The validator must also ensure that the scheme of the SPIFFE ID is set to `spiffe://`. SVIDs containing more than one URI SAN MUST be rejected.

Thus an X.509 SVID is an mTLS client cert with specific features. Crafting them is fairly straightforward and there are several tools to help do this automatically.

## Related Issue(s)

* #14083 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

None that I'm aware of, other than a TLS infrastructure that can issue valid SVIDs.