### PR TITLE
Use panic instead of errors inside the operator package

### DIFF
--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -303,10 +303,7 @@ func getEvalEngingeExpr(ctx *plancontext.PlanningContext, pe *operators.ProjExpr
 // useSimpleProjection uses nothing at all if the output is already correct,
 // or SimpleProjection when we have to reorder or truncate the columns
 func useSimpleProjection(ctx *plancontext.PlanningContext, op *operators.Projection, cols []int, src logicalPlan) (logicalPlan, error) {
-	columns, err := op.Source.GetColumns(ctx)
-	if err != nil {
-		return nil, err
-	}
+	columns := op.Source.GetColumns(ctx)
 	if len(columns) == len(cols) && elementsMatchIndices(cols) {
 		// the columns are already in the right order. we don't need anything at all here
 		return src, nil

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -429,10 +429,7 @@ func buildAggregation(op *Aggregator, qb *queryBuilder) {
 
 	qb.clearProjections()
 
-	cols, err := op.GetColumns(qb.ctx)
-	if err != nil {
-		panic(err)
-	}
+	cols := op.GetColumns(qb.ctx)
 	for _, column := range cols {
 		qb.addProjection(column)
 	}

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -41,12 +41,11 @@ func (qb *queryBuilder) asSelectStatement() sqlparser.SelectStatement {
 	return qb.stmt.(sqlparser.SelectStatement)
 }
 
-func ToSQL(ctx *plancontext.PlanningContext, op ops.Operator) (sqlparser.Statement, ops.Operator, error) {
+func ToSQL(ctx *plancontext.PlanningContext, op ops.Operator) (_ sqlparser.Statement, _ ops.Operator, err error) {
+	defer PanicHandler(&err)
+
 	q := &queryBuilder{ctx: ctx}
-	err := buildQuery(op, q)
-	if err != nil {
-		return nil, nil, err
-	}
+	buildQuery(op, q)
 	if ctx.SemTable != nil {
 		q.sortTables()
 	}
@@ -119,22 +118,24 @@ func (qb *queryBuilder) addGroupBy(original sqlparser.Expr) {
 	sel.GroupBy = append(sel.GroupBy, original)
 }
 
-func (qb *queryBuilder) addProjection(projection sqlparser.SelectExpr) error {
+func (qb *queryBuilder) addProjection(projection sqlparser.SelectExpr) {
 	switch stmt := qb.stmt.(type) {
 	case *sqlparser.Select:
 		stmt.SelectExprs = append(stmt.SelectExprs, projection)
-		return nil
+		return
 	case *sqlparser.Union:
 		if ae, ok := projection.(*sqlparser.AliasedExpr); ok {
 			if col, ok := ae.Expr.(*sqlparser.ColName); ok {
-				return checkUnionColumnByName(col, stmt)
+				checkUnionColumnByName(col, stmt)
+				return
 			}
 		}
 
 		qb.pushUnionInsideDerived()
-		return qb.addProjection(projection)
+		qb.addProjection(projection)
+		return
 	}
-	return vterrors.VT13001(fmt.Sprintf("unknown select statement type: %T", qb.stmt))
+	panic(vterrors.VT13001(fmt.Sprintf("unknown select statement type: %T", qb.stmt)))
 }
 
 func (qb *queryBuilder) pushUnionInsideDerived() {
@@ -166,7 +167,7 @@ func unionSelects(exprs sqlparser.SelectExprs) (selectExprs sqlparser.SelectExpr
 	return
 }
 
-func checkUnionColumnByName(column *sqlparser.ColName, sel sqlparser.SelectStatement) error {
+func checkUnionColumnByName(column *sqlparser.ColName, sel sqlparser.SelectStatement) {
 	colName := column.Name.String()
 	exprs := sqlparser.GetFirstSelect(sel).SelectExprs
 	offset := slices.IndexFunc(exprs, func(expr sqlparser.SelectExpr) bool {
@@ -180,9 +181,8 @@ func checkUnionColumnByName(column *sqlparser.ColName, sel sqlparser.SelectState
 		return false
 	})
 	if offset == -1 {
-		return vterrors.VT12001(fmt.Sprintf("did not find column [%s] on UNION", sqlparser.String(column)))
+		panic(vterrors.VT12001(fmt.Sprintf("did not find column [%s] on UNION", sqlparser.String(column))))
 	}
-	return nil
 }
 
 func (qb *queryBuilder) clearProjections() {
@@ -316,14 +316,12 @@ func removeKeyspaceFromSelectExpr(expr sqlparser.SelectExpr) {
 	}
 }
 
-func stripDownQuery(from, to sqlparser.SelectStatement) error {
-	var err error
-
+func stripDownQuery(from, to sqlparser.SelectStatement) {
 	switch node := from.(type) {
 	case *sqlparser.Select:
 		toNode, ok := to.(*sqlparser.Select)
 		if !ok {
-			return vterrors.VT13001("AST did not match")
+			panic(vterrors.VT13001("AST did not match"))
 		}
 		toNode.Distinct = node.Distinct
 		toNode.GroupBy = node.GroupBy
@@ -338,52 +336,43 @@ func stripDownQuery(from, to sqlparser.SelectStatement) error {
 	case *sqlparser.Union:
 		toNode, ok := to.(*sqlparser.Union)
 		if !ok {
-			return vterrors.VT13001("AST did not match")
+			panic(vterrors.VT13001("AST did not match"))
 		}
-		err = stripDownQuery(node.Left, toNode.Left)
-		if err != nil {
-			return err
-		}
-		err = stripDownQuery(node.Right, toNode.Right)
-		if err != nil {
-			return err
-		}
+		stripDownQuery(node.Left, toNode.Left)
+		stripDownQuery(node.Right, toNode.Right)
 		toNode.OrderBy = node.OrderBy
 	default:
-		return vterrors.VT13001(fmt.Sprintf("this should not happen - we have covered all implementations of SelectStatement %T", from))
+		panic(vterrors.VT13001(fmt.Sprintf("this should not happen - we have covered all implementations of SelectStatement %T", from)))
 	}
-	return nil
 }
 
 // buildQuery recursively builds the query into an AST, from an operator tree
-func buildQuery(op ops.Operator, qb *queryBuilder) error {
+func buildQuery(op ops.Operator, qb *queryBuilder) {
 	switch op := op.(type) {
 	case *Table:
 		buildTable(op, qb)
 	case *Projection:
-		return buildProjection(op, qb)
+		buildProjection(op, qb)
 	case *ApplyJoin:
-		return buildApplyJoin(op, qb)
+		buildApplyJoin(op, qb)
 	case *Filter:
-		return buildFilter(op, qb)
+		buildFilter(op, qb)
 	case *Horizon:
 		if op.TableId != nil {
-			return buildDerived(op, qb)
+			buildDerived(op, qb)
+			return
 		}
-		return buildHorizon(op, qb)
+		buildHorizon(op, qb)
 	case *Limit:
-		return buildLimit(op, qb)
+		buildLimit(op, qb)
 	case *Ordering:
-		return buildOrdering(op, qb)
+		buildOrdering(op, qb)
 	case *Aggregator:
-		return buildAggregation(op, qb)
+		buildAggregation(op, qb)
 	case *Union:
-		return buildUnion(op, qb)
+		buildUnion(op, qb)
 	case *Distinct:
-		err := buildQuery(op.Source, qb)
-		if err != nil {
-			return err
-		}
+		buildQuery(op.Source, qb)
 		qb.asSelectStatement().MakeDistinct()
 	case *Update:
 		buildUpdate(op, qb)
@@ -392,9 +381,8 @@ func buildQuery(op ops.Operator, qb *queryBuilder) error {
 	case *Insert:
 		buildDML(op, qb)
 	default:
-		return vterrors.VT13001(fmt.Sprintf("unknown operator to convert to SQL: %T", op))
+		panic(vterrors.VT13001(fmt.Sprintf("unknown operator to convert to SQL: %T", op)))
 	}
-	return nil
 }
 
 func buildUpdate(op *Update, qb *queryBuilder) {
@@ -436,23 +424,17 @@ func buildDML(op OpWithAST, qb *queryBuilder) {
 	qb.dmlOperator = op
 }
 
-func buildAggregation(op *Aggregator, qb *queryBuilder) error {
-	err := buildQuery(op.Source, qb)
-	if err != nil {
-		return err
-	}
+func buildAggregation(op *Aggregator, qb *queryBuilder) {
+	buildQuery(op.Source, qb)
 
 	qb.clearProjections()
 
 	cols, err := op.GetColumns(qb.ctx)
 	if err != nil {
-		return err
+		panic(err)
 	}
 	for _, column := range cols {
-		err := qb.addProjection(column)
-		if err != nil {
-			return err
-		}
+		qb.addProjection(column)
 	}
 
 	for _, by := range op.Grouping {
@@ -462,29 +444,19 @@ func buildAggregation(op *Aggregator, qb *queryBuilder) error {
 			qb.addGroupBy(weightStringFor(simplified))
 		}
 	}
-
-	return nil
 }
 
-func buildOrdering(op *Ordering, qb *queryBuilder) error {
-	err := buildQuery(op.Source, qb)
-	if err != nil {
-		return err
-	}
+func buildOrdering(op *Ordering, qb *queryBuilder) {
+	buildQuery(op.Source, qb)
 
 	for _, order := range op.Order {
 		qb.asSelectStatement().AddOrder(order.Inner)
 	}
-	return nil
 }
 
-func buildLimit(op *Limit, qb *queryBuilder) error {
-	err := buildQuery(op.Source, qb)
-	if err != nil {
-		return err
-	}
+func buildLimit(op *Limit, qb *queryBuilder) {
+	buildQuery(op.Source, qb)
 	qb.asSelectStatement().SetLimit(op.AST)
-	return nil
 }
 
 func buildTable(op *Table, qb *queryBuilder) {
@@ -498,31 +470,22 @@ func buildTable(op *Table, qb *queryBuilder) {
 		qb.addPredicate(pred)
 	}
 	for _, name := range op.Columns {
-		err := qb.addProjection(&sqlparser.AliasedExpr{Expr: name})
-		if err != nil {
-			return
-		}
+		qb.addProjection(&sqlparser.AliasedExpr{Expr: name})
 	}
 }
 
-func buildProjection(op *Projection, qb *queryBuilder) error {
-	err := buildQuery(op.Source, qb)
-	if err != nil {
-		return err
-	}
+func buildProjection(op *Projection, qb *queryBuilder) {
+	buildQuery(op.Source, qb)
 
 	_, isSel := qb.stmt.(*sqlparser.Select)
 	if isSel {
 		qb.clearProjections()
 		cols, err := op.GetSelectExprs(qb.ctx)
 		if err != nil {
-			return err
+			panic(err)
 		}
 		for _, column := range cols {
-			err := qb.addProjection(column)
-			if err != nil {
-				return err
-			}
+			qb.addProjection(column)
 		}
 	}
 
@@ -539,24 +502,16 @@ func buildProjection(op *Projection, qb *queryBuilder) error {
 	if !isSel {
 		cols, err := op.GetSelectExprs(qb.ctx)
 		if err != nil {
-			return err
+			panic(err)
 		}
 		for _, column := range cols {
-			err := qb.addProjection(column)
-			if err != nil {
-				return err
-			}
+			qb.addProjection(column)
 		}
 	}
-
-	return nil
 }
 
-func buildApplyJoin(op *ApplyJoin, qb *queryBuilder) error {
-	err := buildQuery(op.LHS, qb)
-	if err != nil {
-		return err
-	}
+func buildApplyJoin(op *ApplyJoin, qb *queryBuilder) {
+	buildQuery(op.LHS, qb)
 	// If we are going to add the predicate used in join here
 	// We should not add the predicate's copy of when it was split into
 	// two parts. To avoid this, we use the SkipPredicates map.
@@ -564,24 +519,18 @@ func buildApplyJoin(op *ApplyJoin, qb *queryBuilder) error {
 		qb.ctx.SkipPredicates[expr] = nil
 	}
 	qbR := &queryBuilder{ctx: qb.ctx}
-	err = buildQuery(op.RHS, qbR)
-	if err != nil {
-		return err
-	}
+	buildQuery(op.RHS, qbR)
+
 	if op.LeftJoin {
 		qb.joinOuterWith(qbR, op.Predicate)
 	} else {
 		qb.joinInnerWith(qbR, op.Predicate)
 	}
-	return nil
 }
 
-func buildUnion(op *Union, qb *queryBuilder) error {
+func buildUnion(op *Union, qb *queryBuilder) {
 	// the first input is built first
-	err := buildQuery(op.Sources[0], qb)
-	if err != nil {
-		return err
-	}
+	buildQuery(op.Sources[0], qb)
 
 	for i, src := range op.Sources {
 		if i == 0 {
@@ -590,49 +539,41 @@ func buildUnion(op *Union, qb *queryBuilder) error {
 
 		// now we can go over the remaining inputs and UNION them together
 		qbOther := &queryBuilder{ctx: qb.ctx}
-		err = buildQuery(src, qbOther)
-		if err != nil {
-			return err
-		}
+		buildQuery(src, qbOther)
 		qb.unionWith(qbOther, op.distinct)
 	}
-
-	return nil
 }
 
-func buildFilter(op *Filter, qb *queryBuilder) error {
-	err := buildQuery(op.Source, qb)
-	if err != nil {
-		return err
-	}
+func buildFilter(op *Filter, qb *queryBuilder) {
+	buildQuery(op.Source, qb)
+
 	for _, pred := range op.Predicates {
 		qb.addPredicate(pred)
 	}
-	return nil
 }
 
-func buildDerived(op *Horizon, qb *queryBuilder) error {
-	err := buildQuery(op.Source, qb)
-	if err != nil {
-		return err
-	}
+func buildDerived(op *Horizon, qb *queryBuilder) {
+	buildQuery(op.Source, qb)
+
 	sqlparser.RemoveKeyspace(op.Query)
 
 	stmt := qb.stmt
 	qb.stmt = nil
 	switch sel := stmt.(type) {
 	case *sqlparser.Select:
-		return buildDerivedSelect(op, qb, sel)
+		buildDerivedSelect(op, qb, sel)
+		return
 	case *sqlparser.Union:
-		return buildDerivedUnion(op, qb, sel)
+		buildDerivedUnion(op, qb, sel)
+		return
 	}
 	panic(fmt.Sprintf("unknown select statement type: %T", stmt))
 }
 
-func buildDerivedUnion(op *Horizon, qb *queryBuilder, union *sqlparser.Union) error {
+func buildDerivedUnion(op *Horizon, qb *queryBuilder, union *sqlparser.Union) {
 	opQuery, ok := op.Query.(*sqlparser.Union)
 	if !ok {
-		return vterrors.VT12001("Horizon contained SELECT but statement was UNION")
+		panic(vterrors.VT12001("Horizon contained SELECT but statement was UNION"))
 	}
 
 	union.Limit = opQuery.Limit
@@ -642,14 +583,12 @@ func buildDerivedUnion(op *Horizon, qb *queryBuilder, union *sqlparser.Union) er
 	qb.addTableExpr(op.Alias, op.Alias, TableID(op), &sqlparser.DerivedTable{
 		Select: union,
 	}, nil, op.ColumnAliases)
-
-	return nil
 }
 
-func buildDerivedSelect(op *Horizon, qb *queryBuilder, sel *sqlparser.Select) error {
+func buildDerivedSelect(op *Horizon, qb *queryBuilder, sel *sqlparser.Select) {
 	opQuery, ok := op.Query.(*sqlparser.Select)
 	if !ok {
-		return vterrors.VT12001("Horizon contained UNION but statement was SELECT")
+		panic(vterrors.VT12001("Horizon contained UNION but statement was SELECT"))
 	}
 	sel.Limit = opQuery.Limit
 	sel.OrderBy = opQuery.OrderBy
@@ -660,32 +599,21 @@ func buildDerivedSelect(op *Horizon, qb *queryBuilder, sel *sqlparser.Select) er
 		Select: sel,
 	}, nil, op.ColumnAliases)
 	for _, col := range op.Columns {
-		err := qb.addProjection(&sqlparser.AliasedExpr{Expr: col})
-		if err != nil {
-			return err
-		}
+		qb.addProjection(&sqlparser.AliasedExpr{Expr: col})
 	}
-	return nil
-
 }
 
-func buildHorizon(op *Horizon, qb *queryBuilder) error {
-	err := buildQuery(op.Source, qb)
-	if err != nil {
-		return err
-	}
+func buildHorizon(op *Horizon, qb *queryBuilder) {
+	buildQuery(op.Source, qb)
 
-	err = stripDownQuery(op.Query, qb.asSelectStatement())
-	if err != nil {
-		return err
-	}
+	stripDownQuery(op.Query, qb.asSelectStatement())
+
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		if aliasedExpr, ok := node.(sqlparser.SelectExpr); ok {
 			removeKeyspaceFromSelectExpr(aliasedExpr)
 		}
 		return true, nil
 	}, qb.stmt)
-	return nil
 }
 
 func mergeHaving(h1, h2 *sqlparser.Where) *sqlparser.Where {

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -477,10 +477,7 @@ func buildProjection(op *Projection, qb *queryBuilder) {
 	_, isSel := qb.stmt.(*sqlparser.Select)
 	if isSel {
 		qb.clearProjections()
-		cols, err := op.GetSelectExprs(qb.ctx)
-		if err != nil {
-			panic(err)
-		}
+		cols := op.GetSelectExprs(qb.ctx)
 		for _, column := range cols {
 			qb.addProjection(column)
 		}
@@ -497,10 +494,7 @@ func buildProjection(op *Projection, qb *queryBuilder) {
 	}
 
 	if !isSel {
-		cols, err := op.GetSelectExprs(qb.ctx)
-		if err != nil {
-			panic(err)
-		}
+		cols := op.GetSelectExprs(qb.ctx)
 		for _, column := range cols {
 			qb.addProjection(column)
 		}

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -98,10 +98,7 @@ func pushAggregationThroughSubquery(
 			if idx >= 0 {
 				continue
 			}
-			_, err := pushedAggr.addColumnWithoutPushing(ctx, aeWrap(colName), true)
-			if err != nil {
-				return nil, nil, err
-			}
+			pushedAggr.addColumnWithoutPushing(ctx, aeWrap(colName), true)
 		}
 	}
 
@@ -256,10 +253,7 @@ withNextColumn:
 				continue withNextColumn
 			}
 		}
-		_, err := pushedAggr.addColumnWithoutPushing(ctx, aeWrap(col), true)
-		if err != nil {
-			return nil, nil, err
-		}
+		pushedAggr.addColumnWithoutPushing(ctx, aeWrap(col), true)
 	}
 
 	// Set the source of the filter to the new aggregator placed below the route.

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -109,7 +109,7 @@ func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, e
 	return offset
 }
 
-func (a *Aggregator) addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, groupby []bool, exprs []*sqlparser.AliasedExpr) (offsets []int, err error) {
+func (a *Aggregator) addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, groupby []bool, exprs []*sqlparser.AliasedExpr) (offsets []int) {
 	for i, ae := range exprs {
 		offset := a.addColumnWithoutPushing(ctx, ae, groupby[i])
 		offsets = append(offsets, offset)

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -80,11 +80,11 @@ func (a *Aggregator) SetInputs(operators []ops.Operator) {
 	a.Source = operators[0]
 }
 
-func (a *Aggregator) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+func (a *Aggregator) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
 	return &Filter{
 		Source:     a,
 		Predicates: []sqlparser.Expr{expr},
-	}, nil
+	}
 }
 
 func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) (int, error) {

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -87,7 +87,7 @@ func (a *Aggregator) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser
 	}
 }
 
-func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) (int, error) {
+func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) int {
 	offset := len(a.Columns)
 	a.Columns = append(a.Columns, expr)
 
@@ -106,15 +106,12 @@ func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, e
 		aggr.ColOffset = offset
 		a.Aggregations = append(a.Aggregations, aggr)
 	}
-	return offset, nil
+	return offset
 }
 
 func (a *Aggregator) addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, groupby []bool, exprs []*sqlparser.AliasedExpr) (offsets []int, err error) {
 	for i, ae := range exprs {
-		offset, err := a.addColumnWithoutPushing(ctx, ae, groupby[i])
-		if err != nil {
-			return nil, err
-		}
+		offset := a.addColumnWithoutPushing(ctx, ae, groupby[i])
 		offsets = append(offsets, offset)
 	}
 	return

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -271,7 +271,7 @@ func (a *Aggregator) ShortDescription() string {
 	return fmt.Sprintf("%s%s group by %s", org, strings.Join(columns, ", "), strings.Join(grouping, ","))
 }
 
-func (a *Aggregator) GetOrdering() ([]ops.OrderBy, error) {
+func (a *Aggregator) GetOrdering() []ops.OrderBy {
 	return a.Source.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -80,7 +80,7 @@ func (a *Aggregator) SetInputs(operators []ops.Operator) {
 	a.Source = operators[0]
 }
 
-func (a *Aggregator) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+func (a *Aggregator) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
 	return &Filter{
 		Source:     a,
 		Predicates: []sqlparser.Expr{expr},
@@ -125,10 +125,7 @@ func (a *Aggregator) isDerived() bool {
 }
 
 func (a *Aggregator) FindCol(ctx *plancontext.PlanningContext, in sqlparser.Expr, _ bool) int {
-	expr, err := a.DT.RewriteExpression(ctx, in)
-	if err != nil {
-		panic(err)
-	}
+	expr := a.DT.RewriteExpression(ctx, in)
 	if offset, found := canReuseColumn(ctx, a.Columns, expr, extractExpr); found {
 		return offset
 	}
@@ -136,10 +133,7 @@ func (a *Aggregator) FindCol(ctx *plancontext.PlanningContext, in sqlparser.Expr
 }
 
 func (a *Aggregator) AddColumn(ctx *plancontext.PlanningContext, reuse bool, groupBy bool, ae *sqlparser.AliasedExpr) int {
-	rewritten, err := a.DT.RewriteExpression(ctx, ae.Expr)
-	if err != nil {
-		panic(err)
-	}
+	rewritten := a.DT.RewriteExpression(ctx, ae.Expr)
 
 	ae = &sqlparser.AliasedExpr{
 		Expr: rewritten,
@@ -192,10 +186,7 @@ func (a *Aggregator) findColInternal(ctx *plancontext.PlanningContext, ae *sqlpa
 	if offset >= 0 {
 		return offset, nil
 	}
-	expr, err := a.DT.RewriteExpression(ctx, expr)
-	if err != nil {
-		return 0, err
-	}
+	expr = a.DT.RewriteExpression(ctx, expr)
 
 	// Aggregator is little special and cannot work if the input offset are not matched with the aggregation columns.
 	// So, before pushing anything from above the aggregator offset planning needs to be completed.

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -239,7 +239,7 @@ func (a *Aggregator) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.A
 	return a.Columns
 }
 
-func (a *Aggregator) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (a *Aggregator) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return transformColumnsToSelectExprs(ctx, a)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -221,25 +221,22 @@ func (a *Aggregator) findColInternal(ctx *plancontext.PlanningContext, ae *sqlpa
 	return -1, nil
 }
 
-func (a *Aggregator) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (a *Aggregator) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	if _, isSourceDerived := a.Source.(*Horizon); isSourceDerived {
-		return a.Columns, nil
+		return a.Columns
 	}
 
 	// we update the incoming columns, so we know about any new columns that have been added
 	// in the optimization phase, other operators could be pushed down resulting in additional columns for aggregator.
 	// Aggregator should be made aware of these to truncate them in final result.
-	columns, err := a.Source.GetColumns(ctx)
-	if err != nil {
-		return nil, err
-	}
+	columns := a.Source.GetColumns(ctx)
 
 	// if this operator is producing more columns than expected, we want to know about it
 	if len(columns) > len(a.Columns) {
 		a.Columns = append(a.Columns, columns[len(a.Columns):]...)
 	}
 
-	return a.Columns, nil
+	return a.Columns
 }
 
 func (a *Aggregator) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -167,8 +167,8 @@ func (aj *ApplyJoin) pushColRight(ctx *plancontext.PlanningContext, e *sqlparser
 	return offset, nil
 }
 
-func (aj *ApplyJoin) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
-	return slice.Map(aj.JoinColumns, joinColumnToAliasedExpr), nil
+func (aj *ApplyJoin) GetColumns(*plancontext.PlanningContext) []*sqlparser.AliasedExpr {
+	return slice.Map(aj.JoinColumns, joinColumnToAliasedExpr)
 }
 
 func (aj *ApplyJoin) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -175,7 +175,7 @@ func (aj *ApplyJoin) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser
 	return transformColumnsToSelectExprs(ctx, aj)
 }
 
-func (aj *ApplyJoin) GetOrdering() ([]ops.OrderBy, error) {
+func (aj *ApplyJoin) GetOrdering() []ops.OrderBy {
 	return aj.LHS.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -110,7 +110,7 @@ func (aj *ApplyJoin) Clone(inputs []ops.Operator) ops.Operator {
 	return &kopy
 }
 
-func (aj *ApplyJoin) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+func (aj *ApplyJoin) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
 	return AddPredicate(ctx, aj, expr, false, newFilter)
 }
 
@@ -156,10 +156,7 @@ func (aj *ApplyJoin) AddJoinPredicate(ctx *plancontext.PlanningContext, expr sql
 		return err
 	}
 	aj.JoinPredicates = append(aj.JoinPredicates, col)
-	rhs, err := aj.RHS.AddPredicate(ctx, col.RHSExpr)
-	if err != nil {
-		return err
-	}
+	rhs := aj.RHS.AddPredicate(ctx, col.RHSExpr)
 	aj.RHS = rhs
 
 	return nil

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -214,12 +214,12 @@ func (aj *ApplyJoin) getJoinColumnFor(ctx *plancontext.PlanningContext, orig *sq
 	return
 }
 
-func (aj *ApplyJoin) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, _ bool) (int, error) {
+func (aj *ApplyJoin) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, _ bool) int {
 	offset, found := canReuseColumn(ctx, aj.JoinColumns, expr, joinColumnToExpr)
 	if !found {
-		return -1, nil
+		return -1
 	}
-	return offset, nil
+	return offset
 }
 
 func (aj *ApplyJoin) AddColumn(
@@ -229,10 +229,7 @@ func (aj *ApplyJoin) AddColumn(
 	expr *sqlparser.AliasedExpr,
 ) int {
 	if reuse {
-		offset, err := aj.FindCol(ctx, expr.Expr, false)
-		if err != nil {
-			panic(err)
-		}
+		offset := aj.FindCol(ctx, expr.Expr, false)
 		if offset != -1 {
 			return offset
 		}

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -243,14 +243,11 @@ func (aj *ApplyJoin) AddColumn(
 	return offset
 }
 
-func (aj *ApplyJoin) planOffsets(ctx *plancontext.PlanningContext) (err error) {
+func (aj *ApplyJoin) planOffsets(ctx *plancontext.PlanningContext) {
 	for _, col := range aj.JoinColumns {
 		// Read the type description for JoinColumn to understand the following code
 		for _, lhsExpr := range col.LHSExprs {
 			offset := aj.LHS.AddColumn(ctx, true, col.GroupBy, aeWrap(lhsExpr.Expr))
-			if err != nil {
-				return err
-			}
 			if col.RHSExpr == nil {
 				// if we don't have an RHS expr, it means that this is a pure LHS expression
 				aj.addOffset(-offset - 1)
@@ -269,16 +266,12 @@ func (aj *ApplyJoin) planOffsets(ctx *plancontext.PlanningContext) (err error) {
 			offset := aj.LHS.AddColumn(ctx, true, false, aeWrap(lhsExpr.Expr))
 			aj.Vars[lhsExpr.Name] = offset
 		}
-		if err != nil {
-			return err
-		}
 	}
 
 	for _, lhsExpr := range aj.ExtraLHSVars {
 		offset := aj.LHS.AddColumn(ctx, true, false, aeWrap(lhsExpr.Expr))
 		aj.Vars[lhsExpr.Name] = offset
 	}
-	return nil
 }
 
 func (aj *ApplyJoin) addOffset(offset int) {

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -171,7 +171,7 @@ func (aj *ApplyJoin) GetColumns(*plancontext.PlanningContext) []*sqlparser.Alias
 	return slice.Map(aj.JoinColumns, joinColumnToAliasedExpr)
 }
 
-func (aj *ApplyJoin) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (aj *ApplyJoin) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return transformColumnsToSelectExprs(ctx, aj)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -91,10 +91,7 @@ func addWherePredicates(ctx *plancontext.PlanningContext, expr sqlparser.Expr, o
 		if subq != nil {
 			continue
 		}
-		op, err = op.AddPredicate(ctx, expr)
-		if err != nil {
-			return nil, err
-		}
+		op = op.AddPredicate(ctx, expr)
 		addColumnEquality(ctx, expr)
 	}
 	return sqc.getRootOperator(op), nil

--- a/go/vt/vtgate/planbuilder/operators/comments.go
+++ b/go/vt/vtgate/planbuilder/operators/comments.go
@@ -46,13 +46,9 @@ func (l *LockAndComment) SetInputs(operators []ops.Operator) {
 	l.Source = operators[0]
 }
 
-func (l *LockAndComment) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	newSrc, err := l.Source.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	l.Source = newSrc
-	return l, nil
+func (l *LockAndComment) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	l.Source = l.Source.AddPredicate(ctx, expr)
+	return l
 }
 
 func (l *LockAndComment) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/comments.go
+++ b/go/vt/vtgate/planbuilder/operators/comments.go
@@ -63,7 +63,7 @@ func (l *LockAndComment) GetColumns(ctx *plancontext.PlanningContext) []*sqlpars
 	return l.Source.GetColumns(ctx)
 }
 
-func (l *LockAndComment) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (l *LockAndComment) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return l.Source.GetSelectExprs(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/comments.go
+++ b/go/vt/vtgate/planbuilder/operators/comments.go
@@ -55,7 +55,7 @@ func (l *LockAndComment) AddPredicate(ctx *plancontext.PlanningContext, expr sql
 	return l, nil
 }
 
-func (l *LockAndComment) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) (int, error) {
+func (l *LockAndComment) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) int {
 	return l.Source.AddColumn(ctx, reuseExisting, addToGroupBy, expr)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/comments.go
+++ b/go/vt/vtgate/planbuilder/operators/comments.go
@@ -55,7 +55,7 @@ func (l *LockAndComment) AddColumn(ctx *plancontext.PlanningContext, reuseExisti
 	return l.Source.AddColumn(ctx, reuseExisting, addToGroupBy, expr)
 }
 
-func (l *LockAndComment) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (l *LockAndComment) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	return l.Source.FindCol(ctx, expr, underRoute)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/comments.go
+++ b/go/vt/vtgate/planbuilder/operators/comments.go
@@ -59,7 +59,7 @@ func (l *LockAndComment) FindCol(ctx *plancontext.PlanningContext, expr sqlparse
 	return l.Source.FindCol(ctx, expr, underRoute)
 }
 
-func (l *LockAndComment) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (l *LockAndComment) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return l.Source.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/comments.go
+++ b/go/vt/vtgate/planbuilder/operators/comments.go
@@ -76,6 +76,6 @@ func (l *LockAndComment) ShortDescription() string {
 	return strings.Join(s, " ")
 }
 
-func (l *LockAndComment) GetOrdering() ([]ops.OrderBy, error) {
+func (l *LockAndComment) GetOrdering() []ops.OrderBy {
 	return l.Source.GetOrdering()
 }

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -62,8 +62,8 @@ func (d *Delete) TablesUsed() []string {
 	return nil
 }
 
-func (d *Delete) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (d *Delete) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 func (d *Delete) ShortDescription() string {

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -90,13 +90,9 @@ func (d *Distinct) SetInputs(operators []ops.Operator) {
 	d.Source = operators[0]
 }
 
-func (d *Distinct) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	newSrc, err := d.Source.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	d.Source = newSrc
-	return d, nil
+func (d *Distinct) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	d.Source = d.Source.AddPredicate(ctx, expr)
+	return d
 }
 
 func (d *Distinct) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -118,7 +118,7 @@ func (d *Distinct) ShortDescription() string {
 	return "Performance"
 }
 
-func (d *Distinct) GetOrdering() ([]ops.OrderBy, error) {
+func (d *Distinct) GetOrdering() []ops.OrderBy {
 	return d.Source.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -46,7 +46,7 @@ type (
 	}
 )
 
-func (d *Distinct) planOffsets(ctx *plancontext.PlanningContext) error {
+func (d *Distinct) planOffsets(ctx *plancontext.PlanningContext) {
 	columns := d.GetColumns(ctx)
 	for idx, col := range columns {
 		e := d.QP.GetSimplifiedExpr(col.Expr)
@@ -65,7 +65,6 @@ func (d *Distinct) planOffsets(ctx *plancontext.PlanningContext) error {
 			Collation: coll,
 		})
 	}
-	return nil
 }
 
 func (d *Distinct) Clone(inputs []ops.Operator) ops.Operator {

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -57,10 +57,7 @@ func (d *Distinct) planOffsets(ctx *plancontext.PlanningContext) error {
 		typ, coll, _ := ctx.SemTable.TypeForExpr(e)
 
 		if ctx.SemTable.NeedsWeightString(e) {
-			offset, err := d.Source.AddColumn(ctx, true, false, aeWrap(weightStringFor(e)))
-			if err != nil {
-				return err
-			}
+			offset := d.Source.AddColumn(ctx, true, false, aeWrap(weightStringFor(e)))
 			wsCol = &offset
 		}
 
@@ -102,7 +99,7 @@ func (d *Distinct) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser
 	return d, nil
 }
 
-func (d *Distinct) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) (int, error) {
+func (d *Distinct) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
 	return d.Source.AddColumn(ctx, reuse, gb, expr)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -47,10 +47,7 @@ type (
 )
 
 func (d *Distinct) planOffsets(ctx *plancontext.PlanningContext) error {
-	columns, err := d.GetColumns(ctx)
-	if err != nil {
-		return err
-	}
+	columns := d.GetColumns(ctx)
 	for idx, col := range columns {
 		e := d.QP.GetSimplifiedExpr(col.Expr)
 		var wsCol *int
@@ -103,7 +100,7 @@ func (d *Distinct) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr
 	return d.Source.FindCol(ctx, expr, underRoute)
 }
 
-func (d *Distinct) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (d *Distinct) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return d.Source.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -104,7 +104,7 @@ func (d *Distinct) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.Ali
 	return d.Source.GetColumns(ctx)
 }
 
-func (d *Distinct) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (d *Distinct) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return d.Source.GetSelectExprs(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -99,7 +99,7 @@ func (d *Distinct) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bo
 	return d.Source.AddColumn(ctx, reuse, gb, expr)
 }
 
-func (d *Distinct) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (d *Distinct) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	return d.Source.FindCol(ctx, expr, underRoute)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -89,7 +89,7 @@ func (f *Filter) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.E
 	return f, nil
 }
 
-func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) (int, error) {
+func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
 	return f.Source.AddColumn(ctx, reuse, gb, expr)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -97,7 +97,7 @@ func (f *Filter) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.Alias
 	return f.Source.GetColumns(ctx)
 }
 
-func (f *Filter) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (f *Filter) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return f.Source.GetSelectExprs(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -93,7 +93,7 @@ func (f *Filter) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, 
 	return f.Source.FindCol(ctx, expr, underRoute)
 }
 
-func (f *Filter) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (f *Filter) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return f.Source.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -89,7 +89,7 @@ func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool
 	return f.Source.AddColumn(ctx, reuse, gb, expr)
 }
 
-func (f *Filter) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (f *Filter) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	return f.Source.FindCol(ctx, expr, underRoute)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -101,7 +101,7 @@ func (f *Filter) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.Sel
 	return f.Source.GetSelectExprs(ctx)
 }
 
-func (f *Filter) GetOrdering() ([]ops.OrderBy, error) {
+func (f *Filter) GetOrdering() []ops.OrderBy {
 	return f.Source.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -80,13 +80,9 @@ func (f *Filter) UnsolvedPredicates(st *semantics.SemTable) []sqlparser.Expr {
 	return result
 }
 
-func (f *Filter) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	newSrc, err := f.Source.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	f.Source = newSrc
-	return f, nil
+func (f *Filter) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	f.Source = f.Source.AddPredicate(ctx, expr)
+	return f
 }
 
 func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/fk_cascade.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_cascade.go
@@ -96,8 +96,8 @@ func (fkc *FkCascade) Clone(inputs []ops.Operator) ops.Operator {
 }
 
 // GetOrdering implements the Operator interface
-func (fkc *FkCascade) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (fkc *FkCascade) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 // ShortDescription implements the Operator interface

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -70,8 +70,8 @@ func (fkv *FkVerify) Clone(inputs []ops.Operator) ops.Operator {
 }
 
 // GetOrdering implements the Operator interface
-func (fkv *FkVerify) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (fkv *FkVerify) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 // ShortDescription implements the Operator interface

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -118,10 +118,7 @@ func (h *Horizon) AddColumn(ctx *plancontext.PlanningContext, reuse bool, _ bool
 	if !ok {
 		panic(vterrors.VT13001("cannot push non-ColName expression to horizon"))
 	}
-	offset, err := h.FindCol(ctx, col, false)
-	if err != nil {
-		panic(err)
-	}
+	offset := h.FindCol(ctx, col, false)
 	if offset < 0 {
 		panic(errNoNewColumns)
 	}
@@ -147,18 +144,18 @@ func canReuseColumn[T any](
 	return
 }
 
-func (h *Horizon) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, _ bool) (int, error) {
+func (h *Horizon) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, _ bool) int {
 	for idx, se := range sqlparser.GetFirstSelect(h.Query).SelectExprs {
 		ae, ok := se.(*sqlparser.AliasedExpr)
 		if !ok {
-			return 0, vterrors.VT09015()
+			panic(vterrors.VT09015())
 		}
 		if ctx.SemTable.EqualsExprWithDeps(ae.Expr, expr) {
-			return idx, nil
+			return idx
 		}
 	}
 
-	return -1, nil
+	return -1
 }
 
 func (h *Horizon) GetColumns(ctx *plancontext.PlanningContext) (exprs []*sqlparser.AliasedExpr, err error) {

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -174,11 +174,11 @@ func (h *Horizon) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.Select
 	return sqlparser.GetFirstSelect(h.Query).SelectExprs, nil
 }
 
-func (h *Horizon) GetOrdering() ([]ops.OrderBy, error) {
+func (h *Horizon) GetOrdering() []ops.OrderBy {
 	if h.QP == nil {
-		return nil, vterrors.VT13001("QP should already be here")
+		panic(vterrors.VT13001("QP should already be here"))
 	}
-	return h.QP.OrderExprs, nil
+	return h.QP.OrderExprs
 }
 
 // TODO: REMOVE

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operators
 
 import (
+	"errors"
 	"slices"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -93,7 +94,7 @@ func (h *Horizon) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.
 	}
 	tableInfo, err := ctx.SemTable.TableInfoForExpr(expr)
 	if err != nil {
-		if err == semantics.ErrNotSingleTable {
+		if errors.Is(err, semantics.ErrNotSingleTable) {
 			return &Filter{
 				Source:     h,
 				Predicates: []sqlparser.Expr{expr},
@@ -158,16 +159,16 @@ func (h *Horizon) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr,
 	return -1
 }
 
-func (h *Horizon) GetColumns(ctx *plancontext.PlanningContext) (exprs []*sqlparser.AliasedExpr, err error) {
+func (h *Horizon) GetColumns(ctx *plancontext.PlanningContext) (exprs []*sqlparser.AliasedExpr) {
 	for _, expr := range ctx.SemTable.SelectExprs(h.Query) {
 		ae, ok := expr.(*sqlparser.AliasedExpr)
 		if !ok {
-			return nil, vterrors.VT09015()
+			panic(vterrors.VT09015())
 		}
 		exprs = append(exprs, ae)
 	}
 
-	return exprs, nil
+	return exprs
 }
 
 func (h *Horizon) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.SelectExprs, error) {

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -171,8 +171,8 @@ func (h *Horizon) GetColumns(ctx *plancontext.PlanningContext) (exprs []*sqlpars
 	return exprs
 }
 
-func (h *Horizon) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
-	return sqlparser.GetFirstSelect(h.Query).SelectExprs, nil
+func (h *Horizon) GetSelectExprs(*plancontext.PlanningContext) sqlparser.SelectExprs {
+	return sqlparser.GetFirstSelect(h.Query).SelectExprs
 }
 
 func (h *Horizon) GetOrdering() []ops.OrderBy {

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -114,22 +114,22 @@ func (h *Horizon) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.
 	return h, nil
 }
 
-func (h *Horizon) AddColumn(ctx *plancontext.PlanningContext, reuse bool, _ bool, expr *sqlparser.AliasedExpr) (int, error) {
+func (h *Horizon) AddColumn(ctx *plancontext.PlanningContext, reuse bool, _ bool, expr *sqlparser.AliasedExpr) int {
 	if !reuse {
-		return 0, errNoNewColumns
+		panic(errNoNewColumns)
 	}
 	col, ok := expr.Expr.(*sqlparser.ColName)
 	if !ok {
-		return 0, vterrors.VT13001("cannot push non-ColName expression to horizon")
+		panic(vterrors.VT13001("cannot push non-ColName expression to horizon"))
 	}
 	offset, err := h.FindCol(ctx, col, false)
 	if err != nil {
-		return 0, err
+		panic(err)
 	}
 	if offset < 0 {
-		return 0, errNoNewColumns
+		panic(errNoNewColumns)
 	}
-	return offset, nil
+	return offset
 }
 
 var errNoNewColumns = vterrors.VT13001("can't add new columns to Horizon")

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -169,7 +169,7 @@ func isTableOrSchemaRoutable(cmp *sqlparser.ComparisonExpr) (
 	return false, nil
 }
 
-func tryMergeInfoSchemaRoutings(ctx *plancontext.PlanningContext, routingA, routingB Routing, m merger, lhsRoute, rhsRoute *Route) (*Route, error) {
+func tryMergeInfoSchemaRoutings(ctx *plancontext.PlanningContext, routingA, routingB Routing, m merger, lhsRoute, rhsRoute *Route) *Route {
 	// we have already checked type earlier, so this should always be safe
 	isrA := routingA.(*InfoSchemaRouting)
 	isrB := routingB.(*InfoSchemaRouting)
@@ -188,7 +188,7 @@ func tryMergeInfoSchemaRoutings(ctx *plancontext.PlanningContext, routingA, rout
 		for k, expr := range isrB.SysTableTableName {
 			if e, found := isrA.SysTableTableName[k]; found && !sqlparser.Equals.Expr(expr, e) {
 				// schema names are the same, but we have contradicting table names, so we give up
-				return nil, nil
+				return nil
 			}
 			isrA.SysTableTableName[k] = expr
 		}
@@ -203,9 +203,8 @@ func tryMergeInfoSchemaRoutings(ctx *plancontext.PlanningContext, routingA, rout
 
 	// give up
 	default:
-		return nil, nil
+		return nil
 	}
-
 }
 
 var (

--- a/go/vt/vtgate/planbuilder/operators/insert.go
+++ b/go/vt/vtgate/planbuilder/operators/insert.go
@@ -96,8 +96,8 @@ func (i *Insert) ShortDescription() string {
 	return i.VTable.String()
 }
 
-func (i *Insert) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (i *Insert) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 var _ ops.Operator = (*Insert)(nil)

--- a/go/vt/vtgate/planbuilder/operators/join.go
+++ b/go/vt/vtgate/planbuilder/operators/join.go
@@ -127,15 +127,12 @@ func createInnerJoin(ctx *plancontext.PlanningContext, tableExpr *sqlparser.Join
 		if subq != nil {
 			continue
 		}
-		op, err = op.AddPredicate(ctx, pred)
-		if err != nil {
-			return nil, err
-		}
+		op = op.AddPredicate(ctx, pred)
 	}
 	return sqc.getRootOperator(op), nil
 }
 
-func (j *Join) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+func (j *Join) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
 	return AddPredicate(ctx, j, expr, false, newFilter)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/join.go
+++ b/go/vt/vtgate/planbuilder/operators/join.go
@@ -48,8 +48,8 @@ func (j *Join) Clone(inputs []ops.Operator) ops.Operator {
 	}
 }
 
-func (j *Join) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (j *Join) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 // Inputs implements the Operator interface

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -64,7 +64,7 @@ func (l *Limit) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.Aliase
 	return l.Source.GetColumns(ctx)
 }
 
-func (l *Limit) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (l *Limit) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return l.Source.GetSelectExprs(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -47,13 +47,9 @@ func (l *Limit) SetInputs(operators []ops.Operator) {
 	l.Source = operators[0]
 }
 
-func (l *Limit) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	newSrc, err := l.Source.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	l.Source = newSrc
-	return l, nil
+func (l *Limit) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	l.Source = l.Source.AddPredicate(ctx, expr)
+	return l
 }
 
 func (l *Limit) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -56,7 +56,7 @@ func (l *Limit) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool,
 	return l.Source.AddColumn(ctx, reuse, gb, expr)
 }
 
-func (l *Limit) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (l *Limit) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	return l.Source.FindCol(ctx, expr, underRoute)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -56,7 +56,7 @@ func (l *Limit) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 	return l, nil
 }
 
-func (l *Limit) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) (int, error) {
+func (l *Limit) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
 	return l.Source.AddColumn(ctx, reuse, gb, expr)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -60,7 +60,7 @@ func (l *Limit) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, u
 	return l.Source.FindCol(ctx, expr, underRoute)
 }
 
-func (l *Limit) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (l *Limit) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return l.Source.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -68,7 +68,7 @@ func (l *Limit) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.Sele
 	return l.Source.GetSelectExprs(ctx)
 }
 
-func (l *Limit) GetOrdering() ([]ops.OrderBy, error) {
+func (l *Limit) GetOrdering() []ops.OrderBy {
 	return l.Source.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -152,7 +152,7 @@ func pullDistinctFromUNION(_ *plancontext.PlanningContext, root ops.Operator) (o
 func getOffsetRewritingVisitor(
 	ctx *plancontext.PlanningContext,
 	// this is the function that will be called to try to find the offset for an expression
-	findCol func(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error),
+	findCol func(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int,
 	// this function will be called when an expression has been found on the input
 	found func(sqlparser.Expr, int),
 	// if we have an expression that mush be fetched, this method will be called
@@ -167,11 +167,7 @@ func getOffsetRewritingVisitor(
 		if !ok {
 			return true
 		}
-		var offset int
-		offset, err = findCol(ctx, e, false)
-		if err != nil {
-			return false
-		}
+		offset := findCol(ctx, e, false)
 		if offset >= 0 {
 			found(e, offset)
 			return false

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -68,10 +68,7 @@ func useOffsets(ctx *plancontext.PlanningContext, expr sqlparser.Expr, op ops.Op
 
 	notFound := func(e sqlparser.Expr) error {
 		_, addToGroupBy := e.(*sqlparser.ColName)
-		offset, err := in.AddColumn(ctx, true, addToGroupBy, aeWrap(e))
-		if err != nil {
-			return err
-		}
+		offset := in.AddColumn(ctx, true, addToGroupBy, aeWrap(e))
 		exprOffset = sqlparser.NewOffset(offset, e)
 		return nil
 	}

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -106,10 +106,7 @@ func addColumnsToInput(ctx *plancontext.PlanningContext, root ops.Operator) (ops
 		found := func(expr sqlparser.Expr, i int) {}
 		notFound := func(e sqlparser.Expr) error {
 			_, addToGroupBy := e.(*sqlparser.ColName)
-			_, err := proj.addColumnWithoutPushing(ctx, aeWrap(e), addToGroupBy)
-			if err != nil {
-				return err
-			}
+			proj.addColumnWithoutPushing(ctx, aeWrap(e), addToGroupBy)
 			addedColumns = true
 			return nil
 		}

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -30,7 +30,7 @@ import (
 // planOffsets will walk the tree top down, adding offset information to columns in the tree for use in further optimization,
 func planOffsets(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
 	type offsettable interface {
-		planOffsets(ctx *plancontext.PlanningContext) error
+		planOffsets(ctx *plancontext.PlanningContext)
 	}
 
 	visitor := func(in ops.Operator, _ semantics.TableSet, _ bool) (ops.Operator, *rewrite.ApplyResult, error) {
@@ -39,7 +39,7 @@ func planOffsets(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Opera
 		case *Horizon:
 			return nil, nil, vterrors.VT13001(fmt.Sprintf("should not see %T here", in))
 		case offsettable:
-			err = op.planOffsets(ctx)
+			op.planOffsets(ctx)
 		}
 		if err != nil {
 			return nil, nil, err
@@ -60,7 +60,7 @@ func fetchByOffset(e sqlparser.SQLNode) bool {
 }
 
 // useOffsets rewrites an expression to use values from the input
-func useOffsets(ctx *plancontext.PlanningContext, expr sqlparser.Expr, op ops.Operator) (sqlparser.Expr, error) {
+func useOffsets(ctx *plancontext.PlanningContext, expr sqlparser.Expr, op ops.Operator) sqlparser.Expr {
 	var exprOffset *sqlparser.Offset
 
 	in := op.Inputs()[0]
@@ -85,7 +85,7 @@ func useOffsets(ctx *plancontext.PlanningContext, expr sqlparser.Expr, op ops.Op
 
 	rewritten := sqlparser.CopyOnRewrite(expr, visitor, up, ctx.SemTable.CopySemanticInfo)
 
-	return rewritten.(sqlparser.Expr), nil
+	return rewritten.(sqlparser.Expr)
 }
 
 // addColumnsToInput adds columns needed by an operator to its input.

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -133,8 +133,8 @@ func (noColumns) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.SelectE
 }
 
 // AddPredicate implements the Operator interface
-func (noPredicates) AddPredicate(*plancontext.PlanningContext, sqlparser.Expr) (ops.Operator, error) {
-	return nil, vterrors.VT13001("the noColumns operator cannot accept predicates")
+func (noPredicates) AddPredicate(*plancontext.PlanningContext, sqlparser.Expr) ops.Operator {
+	panic(vterrors.VT13001("the noColumns operator cannot accept predicates"))
 }
 
 // tryTruncateColumnsAt will see if we can truncate the columns by just asking the operator to do it for us

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -120,8 +120,8 @@ func (noColumns) AddColumn(*plancontext.PlanningContext, bool, bool, *sqlparser.
 	panic(vterrors.VT13001("noColumns operators have no column"))
 }
 
-func (noColumns) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
-	return nil, vterrors.VT13001("noColumns operators have no column")
+func (noColumns) GetColumns(*plancontext.PlanningContext) []*sqlparser.AliasedExpr {
+	panic(vterrors.VT13001("noColumns operators have no column"))
 }
 
 func (noColumns) FindCol(*plancontext.PlanningContext, sqlparser.Expr, bool) int {
@@ -165,10 +165,7 @@ func tryTruncateColumnsAt(op ops.Operator, truncateAt int) bool {
 }
 
 func transformColumnsToSelectExprs(ctx *plancontext.PlanningContext, op ops.Operator) (sqlparser.SelectExprs, error) {
-	columns, err := op.GetColumns(ctx)
-	if err != nil {
-		return nil, err
-	}
+	columns := op.GetColumns(ctx)
 	selExprs := slice.Map(columns, func(from *sqlparser.AliasedExpr) sqlparser.SelectExpr {
 		return from
 	})

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -128,8 +128,8 @@ func (noColumns) FindCol(*plancontext.PlanningContext, sqlparser.Expr, bool) int
 	panic(vterrors.VT13001("noColumns operators have no column"))
 }
 
-func (noColumns) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
-	return nil, vterrors.VT13001("noColumns operators have no column")
+func (noColumns) GetSelectExprs(*plancontext.PlanningContext) sqlparser.SelectExprs {
+	panic(vterrors.VT13001("noColumns operators have no column"))
 }
 
 // AddPredicate implements the Operator interface
@@ -164,10 +164,10 @@ func tryTruncateColumnsAt(op ops.Operator, truncateAt int) bool {
 	}
 }
 
-func transformColumnsToSelectExprs(ctx *plancontext.PlanningContext, op ops.Operator) (sqlparser.SelectExprs, error) {
+func transformColumnsToSelectExprs(ctx *plancontext.PlanningContext, op ops.Operator) sqlparser.SelectExprs {
 	columns := op.GetColumns(ctx)
 	selExprs := slice.Map(columns, func(from *sqlparser.AliasedExpr) sqlparser.SelectExpr {
 		return from
 	})
-	return selExprs, nil
+	return selExprs
 }

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -124,8 +124,8 @@ func (noColumns) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedE
 	return nil, vterrors.VT13001("noColumns operators have no column")
 }
 
-func (noColumns) FindCol(*plancontext.PlanningContext, sqlparser.Expr, bool) (int, error) {
-	return 0, vterrors.VT13001("noColumns operators have no column")
+func (noColumns) FindCol(*plancontext.PlanningContext, sqlparser.Expr, bool) int {
+	panic(vterrors.VT13001("noColumns operators have no column"))
 }
 
 func (noColumns) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.SelectExprs, error) {

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -46,7 +46,7 @@ type (
 
 		AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) int
 
-		FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error)
+		FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int
 
 		GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error)
 		GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error)

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -42,7 +42,7 @@ type (
 		// If we encounter a join and the predicate depends on both sides of the join, the predicate will be split into two parts,
 		// where data is fetched from the LHS of the join to be used in the evaluation on the RHS
 		// TODO: we should remove this and replace it with rewriters
-		AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (Operator, error)
+		AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) Operator
 
 		AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) int
 

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -53,7 +53,7 @@ type (
 
 		ShortDescription() string
 
-		GetOrdering() ([]OrderBy, error)
+		GetOrdering() []OrderBy
 	}
 
 	// OrderBy contains the expression to used in order by and also if ordering is needed at VTGate level then what the weight_string function expression to be sent down for evaluation.

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -48,7 +48,7 @@ type (
 
 		FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int
 
-		GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error)
+		GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr
 		GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error)
 
 		ShortDescription() string

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -49,7 +49,7 @@ type (
 		FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int
 
 		GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr
-		GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error)
+		GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs
 
 		ShortDescription() string
 

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -44,7 +44,7 @@ type (
 		// TODO: we should remove this and replace it with rewriters
 		AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (Operator, error)
 
-		AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) (int, error)
+		AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) int
 
 		FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error)
 

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -66,7 +66,7 @@ func (o *Ordering) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr
 	return o.Source.FindCol(ctx, expr, underRoute)
 }
 
-func (o *Ordering) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (o *Ordering) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return o.Source.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -62,7 +62,7 @@ func (o *Ordering) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bo
 	return o.Source.AddColumn(ctx, reuse, gb, expr)
 }
 
-func (o *Ordering) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (o *Ordering) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	return o.Source.FindCol(ctx, expr, underRoute)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -62,7 +62,7 @@ func (o *Ordering) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser
 	return o, nil
 }
 
-func (o *Ordering) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) (int, error) {
+func (o *Ordering) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
 	return o.Source.AddColumn(ctx, reuse, gb, expr)
 }
 
@@ -84,10 +84,7 @@ func (o *Ordering) GetOrdering() ([]ops.OrderBy, error) {
 
 func (o *Ordering) planOffsets(ctx *plancontext.PlanningContext) error {
 	for _, order := range o.Order {
-		offset, err := o.Source.AddColumn(ctx, true, false, aeWrap(order.SimplifiedExpr))
-		if err != nil {
-			return err
-		}
+		offset := o.Source.AddColumn(ctx, true, false, aeWrap(order.SimplifiedExpr))
 		o.Offset = append(o.Offset, offset)
 
 		if !ctx.SemTable.NeedsWeightString(order.SimplifiedExpr) {
@@ -96,10 +93,7 @@ func (o *Ordering) planOffsets(ctx *plancontext.PlanningContext) error {
 		}
 
 		wsExpr := &sqlparser.WeightStringFuncExpr{Expr: order.SimplifiedExpr}
-		offset, err = o.Source.AddColumn(ctx, true, false, aeWrap(wsExpr))
-		if err != nil {
-			return err
-		}
+		offset = o.Source.AddColumn(ctx, true, false, aeWrap(wsExpr))
 		o.WOffset = append(o.WOffset, offset)
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -53,13 +53,9 @@ func (o *Ordering) SetInputs(operators []ops.Operator) {
 	o.Source = operators[0]
 }
 
-func (o *Ordering) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	newSrc, err := o.Source.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	o.Source = newSrc
-	return o, nil
+func (o *Ordering) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	o.Source = o.Source.AddPredicate(ctx, expr)
+	return o
 }
 
 func (o *Ordering) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -74,8 +74,8 @@ func (o *Ordering) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.S
 	return o.Source.GetSelectExprs(ctx)
 }
 
-func (o *Ordering) GetOrdering() ([]ops.OrderBy, error) {
-	return o.Order, nil
+func (o *Ordering) GetOrdering() []ops.OrderBy {
+	return o.Order
 }
 
 func (o *Ordering) planOffsets(ctx *plancontext.PlanningContext) error {

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -78,7 +78,7 @@ func (o *Ordering) GetOrdering() []ops.OrderBy {
 	return o.Order
 }
 
-func (o *Ordering) planOffsets(ctx *plancontext.PlanningContext) error {
+func (o *Ordering) planOffsets(ctx *plancontext.PlanningContext) {
 	for _, order := range o.Order {
 		offset := o.Source.AddColumn(ctx, true, false, aeWrap(order.SimplifiedExpr))
 		o.Offset = append(o.Offset, offset)
@@ -92,8 +92,6 @@ func (o *Ordering) planOffsets(ctx *plancontext.PlanningContext) error {
 		offset = o.Source.AddColumn(ctx, true, false, aeWrap(wsExpr))
 		o.WOffset = append(o.WOffset, offset)
 	}
-
-	return nil
 }
 
 func (o *Ordering) ShortDescription() string {

--- a/go/vt/vtgate/planbuilder/operators/ordering.go
+++ b/go/vt/vtgate/planbuilder/operators/ordering.go
@@ -70,7 +70,7 @@ func (o *Ordering) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.Ali
 	return o.Source.GetColumns(ctx)
 }
 
-func (o *Ordering) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (o *Ordering) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return o.Source.GetSelectExprs(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -165,10 +165,7 @@ func needsOrdering(ctx *plancontext.PlanningContext, in *Aggregator) (bool, erro
 	if len(requiredOrder) == 0 {
 		return false, nil
 	}
-	srcOrdering, err := in.Source.GetOrdering()
-	if err != nil {
-		return false, err
-	}
+	srcOrdering := in.Source.GetOrdering()
 	if len(srcOrdering) < len(requiredOrder) {
 		return true, nil
 	}

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -88,7 +88,7 @@ func (p Phase) act(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Opera
 	case cleanOutPerfDistinct:
 		return removePerformanceDistinctAboveRoute(ctx, op)
 	case subquerySettling:
-		return settleSubqueries(ctx, op)
+		return settleSubqueries(ctx, op), nil
 	}
 
 	return op, nil

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -296,16 +296,16 @@ func (p *Projection) addColumnWithoutPushing(ctx *plancontext.PlanningContext, e
 	return column
 }
 
-func (p *Projection) addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, _ []bool, exprs []*sqlparser.AliasedExpr) ([]int, error) {
+func (p *Projection) addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, _ []bool, exprs []*sqlparser.AliasedExpr) []int {
 	offsets := make([]int, len(exprs))
 	for idx, expr := range exprs {
 		offset, err := p.addColumn(ctx, reuse, false, expr, false)
 		if err != nil {
-			return nil, err
+			panic(err)
 		}
 		offsets[idx] = offset
 	}
-	return offsets, nil
+	return offsets
 }
 
 func (p *Projection) AddColumn(ctx *plancontext.PlanningContext, reuse bool, addToGroupBy bool, ae *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -56,15 +56,15 @@ func (dt *DerivedTable) String() string {
 	return fmt.Sprintf("DERIVED %s(%s)", dt.Alias, sqlparser.String(dt.Columns))
 }
 
-func (dt *DerivedTable) RewriteExpression(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (sqlparser.Expr, error) {
+func (dt *DerivedTable) RewriteExpression(ctx *plancontext.PlanningContext, expr sqlparser.Expr) sqlparser.Expr {
 	if dt == nil {
-		return expr, nil
+		return expr
 	}
 	tableInfo, err := ctx.SemTable.TableInfoFor(dt.TableID)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
-	return semantics.RewriteDerivedTableExpression(expr, tableInfo), nil
+	return semantics.RewriteDerivedTableExpression(expr, tableInfo)
 }
 
 func (dt *DerivedTable) introducesTableID() semantics.TableSet {
@@ -319,10 +319,7 @@ func (p *Projection) addColumn(
 	ae *sqlparser.AliasedExpr,
 	push bool,
 ) (int, error) {
-	expr, err := p.DT.RewriteExpression(ctx, ae.Expr)
-	if err != nil {
-		return 0, err
-	}
+	expr := p.DT.RewriteExpression(ctx, ae.Expr)
 
 	if reuse {
 		offset := p.FindCol(ctx, expr, false)

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -390,10 +390,10 @@ func (p *Projection) GetColumns(*plancontext.PlanningContext) []*sqlparser.Alias
 	return p.Columns.GetColumns()
 }
 
-func (p *Projection) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (p *Projection) GetSelectExprs(*plancontext.PlanningContext) sqlparser.SelectExprs {
 	switch cols := p.Columns.(type) {
 	case StarProjections:
-		return sqlparser.SelectExprs(cols), nil
+		return sqlparser.SelectExprs(cols)
 	case AliasedProjections:
 		var output sqlparser.SelectExprs
 		for _, pe := range cols {
@@ -405,7 +405,7 @@ func (p *Projection) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.Sel
 			}
 			output = append(output, ae)
 		}
-		return output, nil
+		return output
 	default:
 		panic("unknown type")
 	}

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -77,7 +77,7 @@ func (dt *DerivedTable) introducesTableID() semantics.TableSet {
 type (
 	// ProjCols is used to enable projections that are only valid if we can push them into a route, and we never need to ask it about offsets
 	ProjCols interface {
-		GetColumns() ([]*sqlparser.AliasedExpr, error)
+		GetColumns() []*sqlparser.AliasedExpr
 		GetSelectExprs() sqlparser.SelectExprs
 		AddColumn(*sqlparser.AliasedExpr) (ProjCols, int, error)
 	}
@@ -135,8 +135,8 @@ func newAliasedProjection(src ops.Operator) *Projection {
 	}
 }
 
-func (sp StarProjections) GetColumns() ([]*sqlparser.AliasedExpr, error) {
-	return nil, vterrors.VT09015()
+func (sp StarProjections) GetColumns() []*sqlparser.AliasedExpr {
+	panic(vterrors.VT09015())
 }
 
 func (sp StarProjections) AddColumn(*sqlparser.AliasedExpr) (ProjCols, int, error) {
@@ -147,10 +147,10 @@ func (sp StarProjections) GetSelectExprs() sqlparser.SelectExprs {
 	return sqlparser.SelectExprs(sp)
 }
 
-func (ap AliasedProjections) GetColumns() ([]*sqlparser.AliasedExpr, error) {
+func (ap AliasedProjections) GetColumns() []*sqlparser.AliasedExpr {
 	return slice.Map(ap, func(from *ProjExpr) *sqlparser.AliasedExpr {
 		return aeWrap(from.ColExpr)
-	}), nil
+	})
 }
 
 func (ap AliasedProjections) GetSelectExprs() sqlparser.SelectExprs {
@@ -386,7 +386,7 @@ func (p *Projection) AddPredicate(ctx *plancontext.PlanningContext, expr sqlpars
 	return p
 }
 
-func (p *Projection) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (p *Projection) GetColumns(*plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return p.Columns.GetColumns()
 }
 
@@ -535,7 +535,7 @@ func (p *Projection) compactWithRoute(ctx *plancontext.PlanningContext, rb *Rout
 			return p, rewrite.SameTree, nil
 		}
 	}
-	columns, err := rb.GetColumns(ctx)
+	columns := rb.GetColumns(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -383,14 +383,10 @@ func (p *Projection) SetInputs(operators []ops.Operator) {
 	p.Source = operators[0]
 }
 
-func (p *Projection) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+func (p *Projection) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
 	// we just pass through the predicate to our source
-	src, err := p.Source.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	p.Source = src
-	return p, nil
+	p.Source = p.Source.AddPredicate(ctx, expr)
+	return p
 }
 
 func (p *Projection) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -411,7 +411,7 @@ func (p *Projection) GetSelectExprs(*plancontext.PlanningContext) (sqlparser.Sel
 	}
 }
 
-func (p *Projection) GetOrdering() ([]ops.OrderBy, error) {
+func (p *Projection) GetOrdering() []ops.OrderBy {
 	return p.Source.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -244,23 +244,23 @@ func (p *Projection) isDerived() bool {
 	return p.DT != nil
 }
 
-func (p *Projection) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (p *Projection) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	ap, err := p.GetAliasedProjections()
 	if err != nil {
-		return 0, err
+		panic(err)
 	}
 
 	if underRoute && p.isDerived() {
-		return -1, nil
+		return -1
 	}
 
 	for offset, pe := range ap {
 		if ctx.SemTable.EqualsExprWithDeps(pe.ColExpr, expr) {
-			return offset, nil
+			return offset
 		}
 	}
 
-	return -1, nil
+	return -1
 }
 
 func (p *Projection) addProjExpr(pe *ProjExpr) (int, error) {
@@ -325,10 +325,7 @@ func (p *Projection) addColumn(
 	}
 
 	if reuse {
-		offset, err := p.FindCol(ctx, expr, false)
-		if err != nil {
-			return 0, err
-		}
+		offset := p.FindCol(ctx, expr, false)
 		if offset >= 0 {
 			return offset, nil
 		}

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -288,8 +288,12 @@ func (p *Projection) addSubqueryExpr(ae *sqlparser.AliasedExpr, expr sqlparser.E
 	return err
 }
 
-func (p *Projection) addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, _ bool) (int, error) {
-	return p.addColumn(ctx, true, false, expr, false)
+func (p *Projection) addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, _ bool) int {
+	column, err := p.addColumn(ctx, true, false, expr, false)
+	if err != nil {
+		panic(err)
+	}
+	return column
 }
 
 func (p *Projection) addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, _ []bool, exprs []*sqlparser.AliasedExpr) ([]int, error) {

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -564,10 +564,10 @@ func (p *Projection) needsEvaluation(ctx *plancontext.PlanningContext, e sqlpars
 	return false
 }
 
-func (p *Projection) planOffsets(ctx *plancontext.PlanningContext) error {
+func (p *Projection) planOffsets(ctx *plancontext.PlanningContext) {
 	ap, err := p.GetAliasedProjections()
 	if err != nil {
-		return err
+		panic(err)
 	}
 
 	for _, pe := range ap {
@@ -577,10 +577,7 @@ func (p *Projection) planOffsets(ctx *plancontext.PlanningContext) error {
 		}
 
 		// first step is to replace the expressions we expect to get from our input with the offsets for these
-		rewritten, err := useOffsets(ctx, pe.EvalExpr, p)
-		if err != nil {
-			return err
-		}
+		rewritten := useOffsets(ctx, pe.EvalExpr, p)
 		pe.EvalExpr = rewritten
 
 		// if we get a pure offset back. No need to do anything else
@@ -593,15 +590,13 @@ func (p *Projection) planOffsets(ctx *plancontext.PlanningContext) error {
 		// for everything else, we'll turn to the evalengine
 		eexpr, err := evalengine.Translate(rewritten, nil)
 		if err != nil {
-			return err
+			panic(err)
 		}
 
 		pe.Info = &EvalEngine{
 			EExpr: eexpr,
 		}
 	}
-
-	return nil
 }
 
 func (p *Projection) introducesTableID() semantics.TableSet {

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -269,10 +269,7 @@ func pushProjectionInVindex(
 		return nil, nil, err
 	}
 	for _, pe := range ap {
-		_, err = src.AddColumn(ctx, true, false, aeWrap(pe.EvalExpr))
-		if err != nil {
-			return nil, nil, err
-		}
+		src.AddColumn(ctx, true, false, aeWrap(pe.EvalExpr))
 	}
 	return src, rewrite.NewTree("push projection into vindex", p), nil
 }

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -858,11 +858,7 @@ func addTruncationOrProjectionToReturnOutput(ctx *plancontext.PlanningContext, o
 		return output, nil
 	}
 
-	cols, err := output.GetSelectExprs(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+	cols := output.GetSelectExprs(ctx)
 	sel := sqlparser.GetFirstSelect(horizon.Query)
 	if len(sel.SelectExprs) == len(cols) {
 		return output, nil

--- a/go/vt/vtgate/planbuilder/operators/querygraph.go
+++ b/go/vt/vtgate/planbuilder/operators/querygraph.go
@@ -176,8 +176,8 @@ func (qg *QueryGraph) Clone([]ops.Operator) ops.Operator {
 	return result
 }
 
-func (qg *QueryGraph) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (qg *QueryGraph) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 func (qg *QueryGraph) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {

--- a/go/vt/vtgate/planbuilder/operators/querygraph.go
+++ b/go/vt/vtgate/planbuilder/operators/querygraph.go
@@ -180,11 +180,11 @@ func (qg *QueryGraph) GetOrdering() ([]ops.OrderBy, error) {
 	return nil, nil
 }
 
-func (qg *QueryGraph) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+func (qg *QueryGraph) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
 	for _, e := range sqlparser.SplitAndExpression(nil, expr) {
 		qg.collectPredicate(ctx, e)
 	}
-	return qg, nil
+	return qg
 }
 
 // Clone implements the Operator interface

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -568,14 +568,14 @@ func (r *Route) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool,
 	}
 	r.Source = src
 
-	offsets, _ = src.addColumnsWithoutPushing(ctx, reuse, []bool{gb}, []*sqlparser.AliasedExpr{expr})
+	offsets = src.addColumnsWithoutPushing(ctx, reuse, []bool{gb}, []*sqlparser.AliasedExpr{expr})
 	return offsets[0]
 }
 
 type selectExpressions interface {
 	ops.Operator
 	addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) int
-	addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, addToGroupBy []bool, exprs []*sqlparser.AliasedExpr) ([]int, error)
+	addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, addToGroupBy []bool, exprs []*sqlparser.AliasedExpr) []int
 	isDerived() bool
 }
 
@@ -625,7 +625,7 @@ func addMultipleColumnsToInput(ctx *plancontext.PlanningContext, operator ops.Op
 			// we have to add a new projection and can't build on this one
 			return op, false, nil
 		}
-		offset, _ := op.addColumnsWithoutPushing(ctx, reuse, addToGroupBy, exprs)
+		offset := op.addColumnsWithoutPushing(ctx, reuse, addToGroupBy, exprs)
 		return op, true, offset
 
 	case *Union:

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -664,7 +664,7 @@ func (r *Route) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.Sele
 	return r.Source.GetSelectExprs(ctx)
 }
 
-func (r *Route) GetOrdering() ([]ops.OrderBy, error) {
+func (r *Route) GetOrdering() []ops.OrderBy {
 	return r.Source.GetOrdering()
 }
 
@@ -696,9 +696,9 @@ func (r *Route) planOffsets(ctx *plancontext.PlanningContext) (err error) {
 
 	// if we are getting results from multiple shards, we need to do a merge-sort
 	// between them to get the final output correctly sorted
-	ordering, err := r.Source.GetOrdering()
-	if err != nil || len(ordering) == 0 {
-		return err
+	ordering := r.Source.GetOrdering()
+	if len(ordering) == 0 {
+		return nil
 	}
 
 	for _, order := range ordering {
@@ -743,11 +743,7 @@ func (r *Route) ShortDescription() string {
 		first += " " + info.extraInfo()
 	}
 
-	orderBy, err := r.Source.GetOrdering()
-	if err != nil {
-		return first
-	}
-
+	orderBy := r.Source.GetOrdering()
 	ordering := ""
 	if len(orderBy) > 0 {
 		var oo []string

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -574,7 +574,7 @@ func (r *Route) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool,
 
 type selectExpressions interface {
 	ops.Operator
-	addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) (int, error)
+	addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) int
 	addColumnsWithoutPushing(ctx *plancontext.PlanningContext, reuse bool, addToGroupBy []bool, exprs []*sqlparser.AliasedExpr) ([]int, error)
 	isDerived() bool
 }

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -654,7 +654,7 @@ func (r *Route) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.Aliase
 	return r.Source.GetColumns(ctx)
 }
 
-func (r *Route) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (r *Route) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return r.Source.GetSelectExprs(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -518,21 +518,17 @@ func createAlternateRoutesFromVSchemaTable(
 	return routes, nil
 }
 
-func (r *Route) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+func (r *Route) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
 	// first we see if the predicate changes how we route
 	newRouting, err := UpdateRoutingLogic(ctx, expr, r.Routing)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	r.Routing = newRouting
 
 	// we also need to push the predicate down into the query
-	newSrc, err := r.Source.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	r.Source = newSrc
-	return r, err
+	r.Source = r.Source.AddPredicate(ctx, expr)
+	return r
 }
 
 func createProjection(ctx *plancontext.PlanningContext, src ops.Operator) (*Projection, error) {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -550,10 +550,7 @@ func (r *Route) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool,
 	removeKeyspaceFromSelectExpr(expr)
 
 	if reuse {
-		offset, err := r.FindCol(ctx, expr.Expr, true)
-		if err != nil {
-			panic(err)
-		}
+		offset := r.FindCol(ctx, expr.Expr, true)
 		if offset != -1 {
 			return offset
 		}
@@ -655,7 +652,7 @@ func addMultipleColumnsToInput(ctx *plancontext.PlanningContext, operator ops.Op
 	}
 }
 
-func (r *Route) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, _ bool) (int, error) {
+func (r *Route) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, _ bool) int {
 	return r.Source.FindCol(ctx, expr, true)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -533,10 +533,7 @@ func (r *Route) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 
 func createProjection(ctx *plancontext.PlanningContext, src ops.Operator) (*Projection, error) {
 	proj := newAliasedProjection(src)
-	cols, err := src.GetColumns(ctx)
-	if err != nil {
-		return nil, err
-	}
+	cols := src.GetColumns(ctx)
 	for _, col := range cols {
 		_, err := proj.addUnexploredExpr(col, col.Expr)
 		if err != nil {
@@ -634,10 +631,7 @@ func addMultipleColumnsToInput(ctx *plancontext.PlanningContext, operator ops.Op
 	case *Union:
 		tableID := semantics.SingleTableSet(len(ctx.SemTable.Tables))
 		ctx.SemTable.Tables = append(ctx.SemTable.Tables, nil)
-		unionColumns, err := op.GetColumns(ctx)
-		if err != nil {
-			return op, false, nil
-		}
+		unionColumns := op.GetColumns(ctx)
 		proj := &Projection{
 			Source:  op,
 			Columns: AliasedProjections(slice.Map(unionColumns, newProjExpr)),
@@ -656,7 +650,7 @@ func (r *Route) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, _
 	return r.Source.FindCol(ctx, expr, true)
 }
 
-func (r *Route) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (r *Route) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return r.Source.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -682,17 +682,17 @@ func isSpecialOrderBy(o ops.OrderBy) bool {
 	return isFunction && f.Name.Lowered() == "rand"
 }
 
-func (r *Route) planOffsets(ctx *plancontext.PlanningContext) (err error) {
+func (r *Route) planOffsets(ctx *plancontext.PlanningContext) {
 	// if operator is returning data from a single shard, we don't need to do anything more
 	if r.IsSingleShard() {
-		return nil
+		return
 	}
 
 	// if we are getting results from multiple shards, we need to do a merge-sort
 	// between them to get the final output correctly sorted
 	ordering := r.Source.GetOrdering()
 	if len(ordering) == 0 {
-		return nil
+		return
 	}
 
 	for _, order := range ordering {
@@ -714,8 +714,6 @@ func (r *Route) planOffsets(ctx *plancontext.PlanningContext) (err error) {
 		}
 		r.Ordering = append(r.Ordering, o)
 	}
-
-	return nil
 }
 
 func weightStringFor(expr sqlparser.Expr) sqlparser.Expr {

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -362,10 +362,7 @@ func requiresSwitchingSides(ctx *plancontext.PlanningContext, op ops.Operator) b
 }
 
 func mergeOrJoin(ctx *plancontext.PlanningContext, lhs, rhs ops.Operator, joinPredicates []sqlparser.Expr, inner bool) (ops.Operator, *rewrite.ApplyResult, error) {
-	newPlan, err := mergeJoinInputs(ctx, lhs, rhs, joinPredicates, newJoinMerge(joinPredicates, inner))
-	if err != nil {
-		return nil, nil, err
-	}
+	newPlan := mergeJoinInputs(ctx, lhs, rhs, joinPredicates, newJoinMerge(joinPredicates, inner))
 	if newPlan != nil {
 		return newPlan, rewrite.NewTree("merge routes into single operator", newPlan), nil
 	}

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -224,10 +224,7 @@ func seedOperatorList(ctx *plancontext.PlanningContext, qg *QueryGraph) ([]ops.O
 			return nil, err
 		}
 		if qg.NoDeps != nil {
-			plan, err = plan.AddPredicate(ctx, qg.NoDeps)
-			if err != nil {
-				return nil, err
-			}
+			plan = plan.AddPredicate(ctx, qg.NoDeps)
 		}
 		plans[i] = plan
 	}
@@ -621,10 +618,7 @@ func pushJoinPredicates(ctx *plancontext.PlanningContext, exprs []sqlparser.Expr
 	}
 
 	for _, expr := range exprs {
-		_, err := AddPredicate(ctx, op, expr, true, newFilter)
-		if err != nil {
-			return nil, err
-		}
+		AddPredicate(ctx, op, expr, true, newFilter)
 	}
 
 	return op, nil

--- a/go/vt/vtgate/planbuilder/operators/sharded_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/sharded_routing.go
@@ -578,7 +578,7 @@ func tryMergeJoinShardedRouting(
 	routeA, routeB *Route,
 	m merger,
 	joinPredicates []sqlparser.Expr,
-) (*Route, error) {
+) *Route {
 	sameKeyspace := routeA.Routing.Keyspace() == routeB.Routing.Keyspace()
 	tblA := routeA.Routing.(*ShardedRouting)
 	tblB := routeB.Routing.(*ShardedRouting)
@@ -605,20 +605,20 @@ func tryMergeJoinShardedRouting(
 			// If we are doing two Scatters, we have to make sure that the
 			// joins are on the correct vindex to allow them to be merged
 			// no join predicates - no vindex
-			return nil, nil
+			return nil
 		}
 
 		if !sameKeyspace {
-			return nil, vterrors.VT12001("cross-shard correlated subquery")
+			panic(vterrors.VT12001("cross-shard correlated subquery"))
 		}
 
 		canMerge := canMergeOnFilters(ctx, routeA, routeB, joinPredicates)
 		if !canMerge {
-			return nil, nil
+			return nil
 		}
 		return m.mergeShardedRouting(ctx, tblA, tblB, routeA, routeB)
 	}
-	return nil, nil
+	return nil
 }
 
 // makeEvalEngineExpr transforms the given sqlparser.Expr into an evalengine expression

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -126,7 +126,7 @@ func (sq *SubQuery) Clone(inputs []ops.Operator) ops.Operator {
 	return &klone
 }
 
-func (sq *SubQuery) GetOrdering() ([]ops.OrderBy, error) {
+func (sq *SubQuery) GetOrdering() []ops.OrderBy {
 	return sq.Outer.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -168,13 +168,9 @@ func (sq *SubQuery) ShortDescription() string {
 	return fmt.Sprintf("%s %v%s", typ, sq.FilterType.String(), pred)
 }
 
-func (sq *SubQuery) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	newOuter, err := sq.Outer.AddPredicate(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	sq.Outer = newOuter
-	return sq, nil
+func (sq *SubQuery) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	sq.Outer = sq.Outer.AddPredicate(ctx, expr)
+	return sq
 }
 
 func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, exprs *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -185,7 +185,7 @@ func (sq *SubQuery) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.Al
 	return sq.Outer.GetColumns(ctx)
 }
 
-func (sq *SubQuery) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (sq *SubQuery) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return sq.Outer.GetSelectExprs(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -181,7 +181,7 @@ func (sq *SubQuery) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Exp
 	return sq.Outer.FindCol(ctx, expr, underRoute)
 }
 
-func (sq *SubQuery) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (sq *SubQuery) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return sq.Outer.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -177,7 +177,7 @@ func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bo
 	return sq.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, exprs)
 }
 
-func (sq *SubQuery) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (sq *SubQuery) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	return sq.Outer.FindCol(ctx, expr, underRoute)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -62,10 +62,7 @@ func (sq *SubQuery) planOffsets(ctx *plancontext.PlanningContext) error {
 	}
 	for _, jc := range columns {
 		for _, lhsExpr := range jc.LHSExprs {
-			offset, err := sq.Outer.AddColumn(ctx, true, false, aeWrap(lhsExpr.Expr))
-			if err != nil {
-				return err
-			}
+			offset := sq.Outer.AddColumn(ctx, true, false, aeWrap(lhsExpr.Expr))
 			sq.Vars[lhsExpr.Name] = offset
 		}
 	}
@@ -180,7 +177,7 @@ func (sq *SubQuery) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparse
 	return sq, nil
 }
 
-func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, exprs *sqlparser.AliasedExpr) (int, error) {
+func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, exprs *sqlparser.AliasedExpr) int {
 	return sq.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, exprs)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -54,11 +54,11 @@ type SubQuery struct {
 	IsProjection bool
 }
 
-func (sq *SubQuery) planOffsets(ctx *plancontext.PlanningContext) error {
+func (sq *SubQuery) planOffsets(ctx *plancontext.PlanningContext) {
 	sq.Vars = make(map[string]int)
 	columns, err := sq.GetJoinColumns(ctx, sq.Outer)
 	if err != nil {
-		return err
+		panic(err)
 	}
 	for _, jc := range columns {
 		for _, lhsExpr := range jc.LHSExprs {
@@ -66,7 +66,6 @@ func (sq *SubQuery) planOffsets(ctx *plancontext.PlanningContext) error {
 			sq.Vars[lhsExpr.Name] = offset
 		}
 	}
-	return nil
 }
 
 func (sq *SubQuery) OuterExpressionsNeeded(ctx *plancontext.PlanningContext, outer ops.Operator) (result []*sqlparser.ColName, err error) {

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -77,7 +77,7 @@ func (sqc *SubQueryContainer) AddPredicate(ctx *plancontext.PlanningContext, exp
 	return sqc, err
 }
 
-func (sqc *SubQueryContainer) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, exprs *sqlparser.AliasedExpr) (int, error) {
+func (sqc *SubQueryContainer) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, exprs *sqlparser.AliasedExpr) int {
 	return sqc.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, exprs)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -80,7 +80,7 @@ func (sqc *SubQueryContainer) AddColumn(ctx *plancontext.PlanningContext, reuseE
 	return sqc.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, exprs)
 }
 
-func (sqc *SubQueryContainer) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (sqc *SubQueryContainer) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	return sqc.Outer.FindCol(ctx, expr, underRoute)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -49,7 +49,7 @@ func (sqc *SubQueryContainer) Clone(inputs []ops.Operator) ops.Operator {
 	return result
 }
 
-func (sqc *SubQueryContainer) GetOrdering() ([]ops.OrderBy, error) {
+func (sqc *SubQueryContainer) GetOrdering() []ops.OrderBy {
 	return sqc.Outer.GetOrdering()
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -84,7 +84,7 @@ func (sqc *SubQueryContainer) FindCol(ctx *plancontext.PlanningContext, expr sql
 	return sqc.Outer.FindCol(ctx, expr, underRoute)
 }
 
-func (sqc *SubQueryContainer) GetColumns(ctx *plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
+func (sqc *SubQueryContainer) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
 	return sqc.Outer.GetColumns(ctx)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -88,6 +88,6 @@ func (sqc *SubQueryContainer) GetColumns(ctx *plancontext.PlanningContext) []*sq
 	return sqc.Outer.GetColumns(ctx)
 }
 
-func (sqc *SubQueryContainer) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (sqc *SubQueryContainer) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return sqc.Outer.GetSelectExprs(ctx)
 }

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -71,10 +71,9 @@ func (sqc *SubQueryContainer) ShortDescription() string {
 	return ""
 }
 
-func (sqc *SubQueryContainer) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	newSrc, err := sqc.Outer.AddPredicate(ctx, expr)
-	sqc.Outer = newSrc
-	return sqc, err
+func (sqc *SubQueryContainer) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	sqc.Outer = sqc.Outer.AddPredicate(ctx, expr)
+	return sqc
 }
 
 func (sqc *SubQueryContainer) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, exprs *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -69,19 +69,19 @@ func (to *Table) AddColumn(*plancontext.PlanningContext, bool, bool, *sqlparser.
 	panic(vterrors.VT13001("did not expect this method to be called"))
 }
 
-func (to *Table) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (to *Table) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	colToFind, ok := expr.(*sqlparser.ColName)
 	if !ok {
-		return -1, nil
+		return -1
 	}
 
 	for idx, colName := range to.Columns {
 		if colName.Name.Equal(colToFind.Name) {
-			return idx, nil
+			return idx
 		}
 	}
 
-	return -1, nil
+	return -1
 }
 
 func (to *Table) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -84,8 +84,8 @@ func (to *Table) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, 
 	return -1
 }
 
-func (to *Table) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
-	return slice.Map(to.Columns, colNameToExpr), nil
+func (to *Table) GetColumns(*plancontext.PlanningContext) []*sqlparser.AliasedExpr {
+	return slice.Map(to.Columns, colNameToExpr)
 }
 
 func (to *Table) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -61,8 +61,8 @@ func (to *Table) introducesTableID() semantics.TableSet {
 }
 
 // AddPredicate implements the PhysicalOperator interface
-func (to *Table) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
-	return newFilter(to, expr), nil
+func (to *Table) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser.Expr) ops.Operator {
+	return newFilter(to, expr)
 }
 
 func (to *Table) AddColumn(*plancontext.PlanningContext, bool, bool, *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -65,8 +65,8 @@ func (to *Table) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser.Exp
 	return newFilter(to, expr), nil
 }
 
-func (to *Table) AddColumn(*plancontext.PlanningContext, bool, bool, *sqlparser.AliasedExpr) (int, error) {
-	return 0, vterrors.VT13001("did not expect this method to be called")
+func (to *Table) AddColumn(*plancontext.PlanningContext, bool, bool, *sqlparser.AliasedExpr) int {
+	panic(vterrors.VT13001("did not expect this method to be called"))
 }
 
 func (to *Table) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
@@ -111,20 +111,20 @@ func (to *Table) TablesUsed() []string {
 	return SingleQualifiedIdentifier(to.VTable.Keyspace, to.VTable.Name)
 }
 
-func addColumn(ctx *plancontext.PlanningContext, op ColNameColumns, e sqlparser.Expr) (int, error) {
+func addColumn(ctx *plancontext.PlanningContext, op ColNameColumns, e sqlparser.Expr) int {
 	col, ok := e.(*sqlparser.ColName)
 	if !ok {
-		return 0, vterrors.VT09018(fmt.Sprintf("cannot add '%s' expression to a table/vindex", sqlparser.String(e)))
+		panic(vterrors.VT09018(fmt.Sprintf("cannot add '%s' expression to a table/vindex", sqlparser.String(e))))
 	}
 	sqlparser.RemoveKeyspaceFromColName(col)
 	cols := op.GetColNames()
 	colAsExpr := func(c *sqlparser.ColName) sqlparser.Expr { return c }
 	if offset, found := canReuseColumn(ctx, cols, e, colAsExpr); found {
-		return offset, nil
+		return offset
 	}
 	offset := len(cols)
 	op.AddCol(col)
-	return offset, nil
+	return offset
 }
 
 func (to *Table) ShortDescription() string {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -92,8 +92,8 @@ func (to *Table) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.Sel
 	return transformColumnsToSelectExprs(ctx, to)
 }
 
-func (to *Table) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (to *Table) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 func (to *Table) GetColNames() []*sqlparser.ColName {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -88,7 +88,7 @@ func (to *Table) GetColumns(*plancontext.PlanningContext) []*sqlparser.AliasedEx
 	return slice.Map(to.Columns, colNameToExpr)
 }
 
-func (to *Table) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (to *Table) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return transformColumnsToSelectExprs(ctx, to)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -182,11 +182,7 @@ func (u *Union) GetSelectFor(source int) (*sqlparser.Select, error) {
 
 func (u *Union) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
 	if reuse {
-		offset, err := u.FindCol(ctx, expr.Expr, false)
-		if err != nil {
-			panic(err)
-		}
-
+		offset := u.FindCol(ctx, expr.Expr, false)
 		if offset >= 0 {
 			return offset
 		}
@@ -249,19 +245,19 @@ func (u *Union) addWeightStringToOffset(ctx *plancontext.PlanningContext, argIdx
 	return
 }
 
-func (u *Union) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (u *Union) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	columns, err := u.GetColumns(ctx)
 	if err != nil {
-		return 0, err
+		panic(err)
 	}
 
 	for idx, col := range columns {
 		if ctx.SemTable.EqualsExprWithDeps(expr, col.Expr) {
-			return idx, nil
+			return idx
 		}
 	}
 
-	return -1, nil
+	return -1
 }
 
 func (u *Union) GetColumns(ctx *plancontext.PlanningContext) (result []*sqlparser.AliasedExpr, err error) {

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -279,21 +279,17 @@ func (u *Union) GetColumns(ctx *plancontext.PlanningContext) (result []*sqlparse
 	return u.unionColumnsAsAlisedExprs
 }
 
-func (u *Union) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (u *Union) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	// if any of the inputs has more columns that we expect, we want to show on top of UNION, so the results can
 	// be truncated to the expected result columns and nothing else
 	for _, src := range u.Sources {
-		columns, err := src.GetSelectExprs(ctx)
-		if err != nil {
-			return nil, err
-		}
-
+		columns := src.GetSelectExprs(ctx)
 		for len(columns) > len(u.unionColumns) {
 			u.unionColumns = append(u.unionColumns, aeWrap(sqlparser.NewIntLiteral("0")))
 		}
 	}
 
-	return u.unionColumns, nil
+	return u.unionColumns
 }
 
 func (u *Union) NoLHSTableSet() {}

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -183,20 +183,20 @@ func (u *Union) GetSelectFor(source int) (*sqlparser.Select, error) {
 	}
 }
 
-func (u *Union) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) (int, error) {
+func (u *Union) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
 	if reuse {
 		offset, err := u.FindCol(ctx, expr.Expr, false)
 		if err != nil {
-			return 0, err
+			panic(err)
 		}
 
 		if offset >= 0 {
-			return offset, nil
+			return offset
 		}
 	}
 	cols, err := u.GetColumns(ctx)
 	if err != nil {
-		return 0, err
+		panic(err)
 	}
 
 	switch e := expr.Expr.(type) {
@@ -206,9 +206,9 @@ func (u *Union) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool,
 			return e.Name.EqualString(expr.ColumnName())
 		})
 		if offset == -1 {
-			return 0, vterrors.VT13001(fmt.Sprintf("could not find the column '%s' on the UNION", sqlparser.String(e)))
+			panic(vterrors.VT13001(fmt.Sprintf("could not find the column '%s' on the UNION", sqlparser.String(e))))
 		}
-		return offset, nil
+		return offset
 	case *sqlparser.WeightStringFuncExpr:
 		wsArg := e.Expr
 		argIdx := slices.IndexFunc(cols, func(expr *sqlparser.AliasedExpr) bool {
@@ -216,17 +216,17 @@ func (u *Union) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool,
 		})
 
 		if argIdx == -1 {
-			return 0, vterrors.VT13001(fmt.Sprintf("could not find the argument to the weight_string function: %s", sqlparser.String(wsArg)))
+			panic(vterrors.VT13001(fmt.Sprintf("could not find the argument to the weight_string function: %s", sqlparser.String(wsArg))))
 		}
 
 		outputOffset, err := u.addWeightStringToOffset(ctx, argIdx, gb)
 		if err != nil {
-			return 0, err
+			panic(err)
 		}
 
-		return outputOffset, nil
+		return outputOffset
 	default:
-		return 0, vterrors.VT13001(fmt.Sprintf("only weight_string function is expected - got %s", sqlparser.String(expr)))
+		panic(vterrors.VT13001(fmt.Sprintf("only weight_string function is expected - got %s", sqlparser.String(expr))))
 	}
 }
 
@@ -238,10 +238,7 @@ func (u *Union) addWeightStringToOffset(ctx *plancontext.PlanningContext, argIdx
 		if !ok {
 			return 0, vterrors.VT09015()
 		}
-		thisOffset, err := src.AddColumn(ctx, false, addToGroupBy, aeWrap(weightStringFor(ae.Expr)))
-		if err != nil {
-			return 0, err
-		}
+		thisOffset := src.AddColumn(ctx, false, addToGroupBy, aeWrap(weightStringFor(ae.Expr)))
 
 		// all offsets for the newly added ws need to line up
 		if i == 0 {

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -58,8 +58,8 @@ func (u *Union) Clone(inputs []ops.Operator) ops.Operator {
 	return &newOp
 }
 
-func (u *Union) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (u *Union) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 // Inputs implements the Operator interface

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -76,8 +76,8 @@ func (u *Update) Clone([]ops.Operator) ops.Operator {
 	return &upd
 }
 
-func (u *Update) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (u *Update) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 func (u *Update) TablesUsed() []string {

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -101,8 +101,8 @@ func (v *Vindex) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.Sel
 	return transformColumnsToSelectExprs(ctx, v)
 }
 
-func (v *Vindex) GetOrdering() ([]ops.OrderBy, error) {
-	return nil, nil
+func (v *Vindex) GetOrdering() []ops.OrderBy {
+	return nil
 }
 
 func (v *Vindex) GetColNames() []*sqlparser.ColName {

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -97,7 +97,7 @@ func (v *Vindex) GetColumns(*plancontext.PlanningContext) []*sqlparser.AliasedEx
 	return slice.Map(v.Columns, colNameToExpr)
 }
 
-func (v *Vindex) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {
+func (v *Vindex) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return transformColumnsToSelectExprs(ctx, v)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -62,17 +62,17 @@ func (v *Vindex) Clone([]ops.Operator) ops.Operator {
 	return &clone
 }
 
-func (v *Vindex) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, ae *sqlparser.AliasedExpr) (int, error) {
+func (v *Vindex) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, ae *sqlparser.AliasedExpr) int {
 	if gb {
-		return 0, vterrors.VT13001("tried to add group by to a table")
+		panic(vterrors.VT13001("tried to add group by to a table"))
 	}
 	if reuse {
 		offset, err := v.FindCol(ctx, ae.Expr, true)
 		if err != nil {
-			return 0, err
+			panic(err)
 		}
 		if offset > -1 {
-			return offset, nil
+			return offset
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -67,10 +67,7 @@ func (v *Vindex) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool
 		panic(vterrors.VT13001("tried to add group by to a table"))
 	}
 	if reuse {
-		offset, err := v.FindCol(ctx, ae.Expr, true)
-		if err != nil {
-			panic(err)
-		}
+		offset := v.FindCol(ctx, ae.Expr, true)
 		if offset > -1 {
 			return offset
 		}
@@ -86,14 +83,14 @@ func colNameToExpr(c *sqlparser.ColName) *sqlparser.AliasedExpr {
 	}
 }
 
-func (v *Vindex) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) (int, error) {
+func (v *Vindex) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
 	for idx, col := range v.Columns {
 		if ctx.SemTable.EqualsExprWithDeps(expr, col) {
-			return idx, nil
+			return idx
 		}
 	}
 
-	return -1, nil
+	return -1
 }
 
 func (v *Vindex) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -93,8 +93,8 @@ func (v *Vindex) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, 
 	return -1
 }
 
-func (v *Vindex) GetColumns(*plancontext.PlanningContext) ([]*sqlparser.AliasedExpr, error) {
-	return slice.Map(v.Columns, colNameToExpr), nil
+func (v *Vindex) GetColumns(*plancontext.PlanningContext) []*sqlparser.AliasedExpr {
+	return slice.Map(v.Columns, colNameToExpr)
 }
 
 func (v *Vindex) GetSelectExprs(ctx *plancontext.PlanningContext) (sqlparser.SelectExprs, error) {


### PR DESCRIPTION
## Description
To simplify the code and remove most of the 

```go
if err != nil { return err }
```

 lines we have, this PR uses panics and a panic handler instead of returning errors. This way we can write code that doesn't need to do error checking, which is more compact and easier to read.

The idea is to use the operator package as an API, and the panics only exist inside the package. Whenever we are returning something to the outside of the package, we transform the panics back into errors, so users of the `operator` package don't need to do anything different.

We still use errors in a couple of places in the operator package, for situations where the error is handled. The panics are only for errors that are failures we can't fix inside the package.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
