### PR TITLE
switch casing in onlineddl subcommand help text

### DIFF
--- a/go/cmd/vtctldclient/command/onlineddl.go
+++ b/go/cmd/vtctldclient/command/onlineddl.go
@@ -48,7 +48,7 @@ var (
 	}
 	OnlineDDLCancel = &cobra.Command{
 		Use:                   "cancel <keyspace> <uuid|all>",
-		Short:                 "cancel one or all migrations, terminating any running ones as needed.",
+		Short:                 "Cancel one or all migrations, terminating any running ones as needed.",
 		Example:               "OnlineDDL cancel test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90",
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
@@ -64,7 +64,7 @@ var (
 	}
 	OnlineDDLComplete = &cobra.Command{
 		Use:                   "complete <keyspace> <uuid|all>",
-		Short:                 "complete one or all migrations executed with --postpone-completion",
+		Short:                 "Complete one or all migrations executed with --postpone-completion",
 		Example:               "OnlineDDL complete test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90",
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
@@ -72,7 +72,7 @@ var (
 	}
 	OnlineDDLLaunch = &cobra.Command{
 		Use:                   "launch <keyspace> <uuid|all>",
-		Short:                 "launch one or all migrations executed with --postpone-launch",
+		Short:                 "Launch one or all migrations executed with --postpone-launch",
 		Example:               "OnlineDDL launch test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90",
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -139,6 +139,7 @@ Flags:
       --gc_check_interval duration                                       Interval between garbage collection checks (default 1h0m0s)
       --gc_purge_check_interval duration                                 Interval between purge discovery checks (default 1m0s)
       --gh-ost-path string                                               override default gh-ost binary full path
+      --grpc-send-session-in-streaming                                   If set, will send the session as last packet in streaming api to support transactions in streaming
       --grpc-use-effective-groups                                        If set, and SSL is not used, will set the immediate caller's security groups from the effective caller id's groups.
       --grpc-use-static-authentication-callerid                          If set, will set the immediate caller id to the username authenticated by the static auth plugin.
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)


### PR DESCRIPTION
## Description

This is to standardize around proper sentencing in help texts.

## Related Issue(s)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required: https://github.com/vitessio/website/pull/1598

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
