### PR TITLE
VTGate FK stress tests suite: improvements

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -308,6 +308,7 @@ func TestMain(m *testing.M) {
 			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
+			"--migration_check_interval", "5s",
 			"--watch_replication_stream",
 			"--vreplication_tablet_type", "primary",
 		}

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -555,7 +555,9 @@ func TestStressFK(t *testing.T) {
 	})
 
 	runOnlineDDL := false
-
+	if val, present := os.LookupEnv("FK_STRESS_ONLINE_DDL"); present && val != "" {
+		runOnlineDDL = true
+	}
 	// Without workload ; with workload
 	for _, workload := range []bool{false, true} {
 		// For any type of ON DELETE action

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -472,6 +472,7 @@ type testCase struct {
 // - Either one of ON UPDATE actions
 // - Potentially running an Online DDL on an indicated table (this will not work in Vanilla MySQL, see https://vitess.io/blog/2021-06-15-online-ddl-why-no-fk/)
 func ExecuteFKTest(t *testing.T, tcase *testCase) {
+	t.Logf("==== test setup: maxConcurrency=%v, singleConnectionSleepInterval=%v", maxConcurrency, singleConnectionSleepInterval)
 	workloadName := "static data"
 	if tcase.workload {
 		workloadName = "workload"

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -945,10 +945,8 @@ func runMultipleConnections(ctx context.Context, t *testing.T, tableName string)
 			runSingleConnection(ctx, t, tableName)
 		}()
 	}
-	<-ctx.Done()
-	log.Infof("Running multiple connections: done")
 	wg.Wait()
-	log.Infof("All connections cancelled")
+	log.Infof("Running multiple connections: done")
 }
 
 func wrapWithNoFKChecks(sql string) string {

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -453,8 +453,8 @@ func TestInitialSetup(t *testing.T) {
 
 	if val, present := os.LookupEnv("GITHUB_ACTIONS"); present && val != "" {
 		// This is the place to fine tune the stress parameters if GitHub actions are too slow
-		maxConcurrency = maxConcurrency * 1
-		singleConnectionSleepInterval = singleConnectionSleepInterval * 1
+		maxConcurrency = maxConcurrency / 2
+		singleConnectionSleepInterval = singleConnectionSleepInterval * 2
 	}
 	t.Logf("==== test setup: maxConcurrency=%v, singleConnectionSleepInterval=%v", maxConcurrency, singleConnectionSleepInterval)
 }
@@ -573,6 +573,10 @@ func TestStressFK(t *testing.T) {
 	}
 
 	if runOnlineDDL {
+		// Foreign keys introduce some overhead. We reduce concurrency so that GitHub CI can accommodate.
+		maxConcurrency = maxConcurrency * 4 / 5
+		singleConnectionSleepInterval = singleConnectionSleepInterval * 2
+
 		// Running Online DDL on all test tables. We don't use all of the combinations
 		// presented above; we will run with workload, and suffice with same ON DELETE - ON UPDATE actions.
 		for _, action := range referenceActions {


### PR DESCRIPTION
## Description

Followup to https://github.com/vitessio/vitess/pull/13799

https://github.com/vitessio/vitess/pull/13799 introduced a new `endtoend` stress test suite. This PR improves the design and performance as follows:

- Better logging/auditing of parameters used per test.
- Adapt concurrency/intervals per platform and test (relax on GitHub, relax on potential OnlineDDL).
- Idiomatic use of `context.WithTimeout`, remove excessive timers and flags.
- Evaluate server position by connection/query rather than invoking `vtctl` (reduces load).
- For potential Online DDL, reduce `--migration_check_interval`.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/11975

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
