### PR TITLE
go/cmd/vtbackup: wait for plugins to finish initializing

### DIFF
--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -229,7 +229,14 @@ func run(_ *cobra.Command, args []string) error {
 		<-ctx.Done()
 	}()
 
+	// Some plugins use OnRun to initialize. Use a channel to signal to
+	// ourselves that these plugins have been initialized.
+	runCh := make(chan struct{})
+	servenv.OnRun(func() {
+		close(runCh)
+	})
 	go servenv.RunDefault()
+	<-runCh
 
 	if detachedMode {
 		// this method will call os.Exit and kill this process


### PR DESCRIPTION
## Description

VTB E2E tests sometimes fail due to:

 1. Some VTB plugins (in particular `plugin_opentsdb.go` register with `servenv.OnRun` https://github.com/vitessio/vitess/blob/30385807689b40668d60dbb5059ea0987f19da5c/go/cmd/vtbackup/cli/plugin_opentsdb.go#L24 https://github.com/vitessio/vitess/blob/30385807689b40668d60dbb5059ea0987f19da5c/go/stats/opentsdb/init.go#L36-L38
 1.  VTB starts `servenv` in a goroutine https://github.com/vitessio/vitess/blob/30385807689b40668d60dbb5059ea0987f19da5c/go/cmd/vtbackup/cli/vtbackup.go#L232
 1. VTB starts writing stats shortly after https://github.com/vitessio/vitess/blob/30385807689b40668d60dbb5059ea0987f19da5c/go/cmd/vtbackup/cli/vtbackup.go#L258

This sequence means that sometimes VTB starts writing stats before `servenv` plugins have finished initializing, which makes the E2E test that verifies stats flaky.

This PR is a hacky way to deflake. There are less hacky ways we could do this, e.g. exposing some kind of readiness indicator directly from the `servenv` package.

## Related Issue(s)

Fixes #14114 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were ~added or~ are not required (this PR deflakes existing tests)
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation ~was added or~ is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
