### PR TITLE
Remove FOSSA Test from CI until we can do it in a secure way

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -33,12 +33,6 @@ jobs:
         if: steps.skip-workflow.outputs.skip-workflow == 'false'
         uses: actions/checkout@v3
 
-      - name: Run FOSSA scan and upload build data
-        if: steps.skip-workflow.outputs.skip-workflow == 'false'
-        uses: fossa-contrib/fossa-action@v2
-        with:
-          fossa-api-key: ${{secrets.FOSSA_API_KEY}}
-
       - name: Check for changes in Go files
         if: steps.skip-workflow.outputs.skip-workflow == 'false'
         uses: frouioui/paths-filter@main

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.skip-workflow.outputs.skip-workflow == 'false'
         uses: fossa-contrib/fossa-action@v2
         with:
-          fossa-api-key: 76d7483ea206d530d9452e44bffe7ba8
+          fossa-api-key: ${{secrets.FOSSA_API_KEY}}
 
       - name: Check for changes in Go files
         if: steps.skip-workflow.outputs.skip-workflow == 'false'


### PR DESCRIPTION
## Description

The FOSSA API Key is currently inline in our CI workflow file, which is a security issue. For now removing this check until we get a new key and re-implement in a secure way.

## Related Issue(s)


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
