### PR TITLE
docker: add dedicated vtorc container

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=base /vt/bin/vtgate /vt/bin/
 COPY --from=base /vt/bin/vttablet /vt/bin/
 COPY --from=base /vt/bin/vtbackup /vt/bin/
 COPY --from=base /vt/bin/vtadmin /vt/bin/
+COPY --from=base /vt/bin/vtorc /vt/bin/
 
 # copy web admin files
 COPY --from=base $VTROOT/web /vt/web/

--- a/docker/k8s/vtorc/Dockerfile
+++ b/docker/k8s/vtorc/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2019 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=stable-slim
+
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:${DEBIAN_VER}
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin && mkdir -p /vtdataroot
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy binaries
+COPY --from=k8s /vt/bin/vtorc /vt/bin/
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/docker/release.sh
+++ b/docker/release.sh
@@ -21,6 +21,11 @@ do
   docker push vitess/vtadmin:$vt_base_version-$debian_version
   if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vtadmin:$vt_base_version; fi
 
+  docker build --platform linux/amd64 --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtorc:$vt_base_version-$debian_version k8s/vtorc
+  docker tag vitess/vtorc:$vt_base_version-$debian_version vitess/vtorc:$vt_base_version
+  docker push vitess/vtorc:$vt_base_version-$debian_version
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vtorc:$vt_base_version; fi
+
   docker build --platform linux/amd64 --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtgate:$vt_base_version-$debian_version k8s/vtgate
   docker tag vitess/vtgate:$vt_base_version-$debian_version vitess/vtgate:$vt_base_version
   docker push vitess/vtgate:$vt_base_version-$debian_version


### PR DESCRIPTION
## Description

We don't currently publish a vtorc image, so this adds it and sets it to build with releases. I've tested it and it runs just fine using the configuration in the docs 
https://vitess.io/docs/17.0/user-guides/configuration-basic/vtorc/#example-invocation-of-vtorc

Fixes https://github.com/vitessio/vitess/issues/14144
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
