### PR TITLE
add release-18.0 to golang upgrade

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-17.0, release-16.0, release-15.0 ]
+        branch: [ main, release-18.0, release-17.0, release-16.0, release-15.0 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds release-18.0 in github workflow to be used when new go version is available.