### PR TITLE
[release-17.0] Fix upgrade tests

### DIFF
--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -53,7 +53,6 @@ vttablet \
  --grpc_port $grpc_port \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
- --vtctld_addr http://$hostname:$vtctld_web_port/ \
  --heartbeat_enable --heartbeat_interval=250ms --heartbeat_on_demand_duration=5s \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -154,7 +154,6 @@ exec $VTROOT/bin/vttablet \
   --port $web_port \
   --grpc_port $grpc_port \
   --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
-  --vtctld_addr "http://vtctld:$WEB_PORT/" \
   --init_keyspace $keyspace \
   --init_shard $shard \
   --backup_storage_implementation file \

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -108,8 +108,6 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"--backup_storage_implementation", vttablet.BackupStorageImplementation,
 		"--file_backup_storage_root", vttablet.FileBackupStorageRoot,
 		"--service_map", vttablet.ServiceMap,
-		"--vtctld_addr", vttablet.VtctldAddress,
-		"--vtctld_addr", vttablet.VtctldAddress,
 		"--vreplication_tablet_type", vttablet.VreplicationTabletType,
 		"--db_charset", vttablet.Charset,
 	)

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/schema"
 
@@ -154,8 +155,10 @@ func TestMain(m *testing.M) {
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
-			"--queryserver-config-schema-change-signal-interval", "0.1",
 			"--watch_replication_stream",
+		}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl_strategy", "online",

--- a/go/test/endtoend/utils/mysqlvsvitess/main_test.go
+++ b/go/test/endtoend/utils/mysqlvsvitess/main_test.go
@@ -83,7 +83,10 @@ func TestMain(m *testing.M) {
 			VSchema:   vschema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -85,7 +85,10 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*sKs, shardedKsShards, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/main_test.go
+++ b/go/test/endtoend/vtgate/main_test.go
@@ -73,7 +73,10 @@ func TestMain(m *testing.M) {
 			VSchema:   VSchema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1", "--queryserver-config-max-result-size", "100", "--queryserver-config-terse-errors"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-max-result-size", "100", "--queryserver-config-terse-errors"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/queries/aggregation/main_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/main_test.go
@@ -64,7 +64,10 @@ func TestMain(m *testing.M) {
 			VSchema:   vschema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/queries/foundrows/main_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/main_test.go
@@ -66,7 +66,10 @@ func TestMain(m *testing.M) {
 			VSchema:   vschema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/queries/informationschema/main_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/main_test.go
@@ -72,7 +72,10 @@ func TestMain(m *testing.M) {
 			VSchema:   vschema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
+++ b/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
@@ -69,7 +69,10 @@ func TestMain(m *testing.M) {
 			VSchema:   shardedVSchema,
 		}
 
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*sKs, shardedKsShards, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/queries/orderby/main_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/main_test.go
@@ -64,7 +64,10 @@ func TestMain(m *testing.M) {
 			VSchema:   vschema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/queries/subquery/main_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/main_test.go
@@ -64,7 +64,10 @@ func TestMain(m *testing.M) {
 			VSchema:   VSchema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/queries/union/main_test.go
+++ b/go/test/endtoend/vtgate/queries/union/main_test.go
@@ -63,7 +63,10 @@ func TestMain(m *testing.M) {
 			VSchema:   vschema,
 		}
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
+++ b/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
@@ -91,9 +91,9 @@ func TestMain(m *testing.M) {
 
 		// restart the tablet so that the schema.Engine gets a chance to start with existing schema
 		tablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
-		tablet.VttabletProcess.ExtraArgs = []string{
-			"--queryserver-config-schema-change-signal",
-			fmt.Sprintf("--queryserver-config-schema-change-signal-interval=%d", signalInterval),
+		tablet.VttabletProcess.ExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			tablet.VttabletProcess.ExtraArgs = append(tablet.VttabletProcess.ExtraArgs, fmt.Sprintf("--queryserver-config-schema-change-signal-interval=%d", signalInterval))
 		}
 		if err := tablet.RestartOnlyTablet(); err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -91,11 +91,13 @@ func TestMain(m *testing.M) {
 			"--schema_change_signal_user", "userData1"}
 		clusterInstance.VtGatePlannerVersion = planbuilder.Gen4
 		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal",
-			"--queryserver-config-schema-change-signal-interval", "0.1",
 			"--queryserver-config-strict-table-acl",
 			"--queryserver-config-acl-exempt-acl", "userData1",
 			"--table-acl-config", "dummy.json"}
 
+		if vttabletVer <= 16 {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		if vtgateVer >= 16 && vttabletVer >= 16 {
 			clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable-views")
 			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-enable-views")

--- a/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
@@ -146,7 +146,10 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal", "--schema_change_signal_user", "userData1"}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "5", "--queryserver-config-strict-table-acl", "--queryserver-config-acl-exempt-acl", "userData1", "--table-acl-config", "dummy.json"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-strict-table-acl", "--queryserver-config-acl-exempt-acl", "userData1", "--table-acl-config", "dummy.json"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "5")
+		}
 
 		// Start topo server
 		err = clusterInstance.StartTopo()

--- a/go/test/endtoend/vtgate/schematracker/unauthorized/unauthorized_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unauthorized/unauthorized_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/test/endtoend/utils"
+
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 )
@@ -69,10 +71,12 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--schema_change_signal")
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs,
 			"--queryserver-config-schema-change-signal",
-			"--queryserver-config-schema-change-signal-interval", "0.1",
 			"--queryserver-config-strict-table-acl",
 			"--queryserver-config-acl-exempt-acl", "userData1",
 			"--table-acl-config", "dummy.json")
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -83,7 +83,10 @@ func TestMain(m *testing.M) {
 			SchemaSQL:     sqlSchema,
 			SidecarDBName: sidecarDBName,
 		}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "0.1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal"}
+		if !utils.BinaryIsAtVersion(17, "vttablet") {
+			clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal-interval", "0.1")
+		}
 		err = clusterInstance.StartUnshardedKeyspace(*keyspace, 0, false)
 		if err != nil {
 			return 1

--- a/vitess-mixin/e2e/vttablet-up.sh
+++ b/vitess-mixin/e2e/vttablet-up.sh
@@ -154,7 +154,6 @@ exec $VTROOT/bin/vttablet \
   --port $web_port \
   --grpc_port $grpc_port \
   --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
-  --vtctld_addr "http://vtctld:$WEB_PORT/" \
   --init_keyspace $keyspace \
   --init_shard $shard \
   --backup_storage_implementation file \


### PR DESCRIPTION
## Description

This is a follow-up of https://github.com/vitessio/vitess/pull/14071 on `release-17.0`. In https://github.com/vitessio/vitess/pull/14071 we removed some deprecated flags, this PR remove the usage of `vtctld_addr` as it is deprecated anyway. This will unblock the upgrade tests.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
