### PR TITLE
vstreamer: include gtid events in binlog commit queries

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -501,6 +501,9 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 			})
 		case sqlparser.StmtCommit:
 			vevents = append(vevents, &binlogdatapb.VEvent{
+				Type: binlogdatapb.VEventType_GTID,
+				Gtid: replication.EncodePosition(vs.pos),
+			}, &binlogdatapb.VEvent{
 				Type: binlogdatapb.VEventType_COMMIT,
 			})
 		case sqlparser.StmtDDL:


### PR DESCRIPTION
## Description

The `vstreamer` assumes that commit events in the binlog take the form of `Xid` events. This poses a problem when doing `MoveTables` from external datastores that produce different kinds of binlogs, such as MySQL NDB clusters.

### Details

Given a schema like:

```
CREATE TABLE `test_innodb` (
  `id` int NOT NULL AUTO_INCREMENT,
  `data` varchar(10) DEFAULT NULL,
  `delta` varchar(10) DEFAULT NULL,
  `version` int DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```

Inserting a row produces a binlog like:

```
#230929 16:53:07 server id 1  end_log_pos 378 CRC32 0x4c190295  Table_map: `app`.`test_innodb` mapped to number 492
# has_generated_invisible_primary_key=0
# at 378
#230929 16:53:07 server id 1  end_log_pos 434 CRC32 0xb7f9c4d4  Write_rows: table id 492 flags: STMT_END_F
# at 434
#230929 16:53:07 server id 1  end_log_pos 465 CRC32 0x72c26022  Xid = 77448
```

Notice the `Xid` event. The VTTablet `vstreamer` only produces GTID VEvents when it encounters these `Xid` binlog events: https://github.com/vitessio/vitess/blob/2f1fc13024a27c390697205d1c8c683030ba85b5/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go#L451-L457

Meanwhile, the `vplayer` depends on these GTID VEvents in order to advance the `vreplication.pos`: https://github.com/vitessio/vitess/blob/2f1fc13024a27c390697205d1c8c683030ba85b5/go/vt/vttablet/tabletmanager/vreplication/vplayer.go#L481-L486

This setup won't work for MySQL NDB clusters, which, given the same schema and insert above, produce binlogs that look like this:

```
# at 615
#230929 16:53:13 server id 1  end_log_pos 680 CRC32 0x6645bfe1  Table_map: `app`.`test_ndb` mapped to number 453
# has_generated_invisible_primary_key=0
# at 680
#230929 16:53:13 server id 1  end_log_pos 752 CRC32 0x91bcbe1e  Table_map: `mysql`.`ndb_apply_status` mapped to number 450
# has_generated_invisible_primary_key=0
# at 752
#230929 16:53:13 server id 1  end_log_pos 817 CRC32 0xad022d11  Write_rows: table id 450
# at 817
#230929 16:53:13 server id 1  end_log_pos 873 CRC32 0x1f9d1b61  Write_rows: table id 453 flags: STMT_END_F
# at 873
#230929 16:53:13 server id 1  end_log_pos 945 CRC32 0x6f300b74  Query   thread_id=2     exec_time=0     error_code=0
```

## Related Issue(s)

Addresses https://github.com/vitessio/vitess/issues/14166

## Checklist

TODO

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation ~was added or~ is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
