### PR TITLE
[release-16.0] Tablet throttler: fix race condition by removing goroutine call (#14179)

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -630,7 +630,7 @@ func (throttler *Throttler) Operate(ctx context.Context) {
 				{
 					// sparse
 					if atomic.LoadInt64(&throttler.isOpen) > 0 {
-						go throttler.refreshMySQLInventory(ctx)
+						throttler.refreshMySQLInventory(ctx)
 					}
 				}
 			case probes := <-throttler.mysqlClusterProbesChan:


### PR DESCRIPTION
## Backport of https://github.com/vitessio/vitess/pull/14179 into release-16.0

## Description

Per https://github.com/vitessio/vitess/issues/14178, the function `throttler.refreshMySQLInventory()` should run on same goroutine as the `select` clause.

A note about testing: this of course would have been caught by race detection. We have a followup PR that make a lot of refactoring to the throttler code, and adds sufficient unit testing to validate the changes and to catch race conditions.

This PR is a one line extract from the followup PR, and without the unit testing. The reasoning is that the refactor is a post-v18 change, while the fix in this PR should be backported to `v18`, `v17` and `v16`, which cannot support the many changes implied by the unit testing. And so this PR does not include those tests.

Said followup PR is https://github.com/vitessio/vitess/pull/14181.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14178

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
