### PR TITLE
set vreplication net read and net write timeout session vars to high values

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -405,8 +405,6 @@ Flags:
       --vreplication_healthcheck_topology_refresh duration               refresh interval for re-reading the topology (default 30s)
       --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
       --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
-      --vreplication_net_read_timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)
-      --vreplication_net_write_timeout int                               Session value of net_read_timeout for vreplication, in seconds (default 600)
       --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of the sidecar database's vreplication table

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -405,6 +405,8 @@ Flags:
       --vreplication_healthcheck_topology_refresh duration               refresh interval for re-reading the topology (default 30s)
       --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
       --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
+      --vreplication_net_read_timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)
+      --vreplication_net_write_timeout int                               Session value of net_read_timeout for vreplication, in seconds (default 600)
       --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of the sidecar database's vreplication table

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -412,7 +412,7 @@ Flags:
       --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
       --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
       --vreplication_net_read_timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)
-      --vreplication_net_write_timeout int                               Session value of net_read_timeout for vreplication, in seconds (default 600)
+      --vreplication_net_write_timeout int                               Session value of net_write_timeout for vreplication, in seconds (default 600)
       --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of the sidecar database's vreplication table

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -411,6 +411,8 @@ Flags:
       --vreplication_healthcheck_topology_refresh duration               refresh interval for re-reading the topology (default 30s)
       --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
       --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
+      --vreplication_net_read_timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)
+      --vreplication_net_write_timeout int                               Session value of net_read_timeout for vreplication, in seconds (default 600)
       --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of the sidecar database's vreplication table

--- a/go/vt/vttablet/flags.go
+++ b/go/vt/vttablet/flags.go
@@ -18,7 +18,6 @@ package vttablet
 
 import (
 	"github.com/spf13/pflag"
-
 	"vitess.io/vitess/go/vt/servenv"
 )
 
@@ -27,7 +26,11 @@ const (
 	VReplicationExperimentalFlagAllowNoBlobBinlogRowImage = int64(2)
 )
 
-var VReplicationExperimentalFlags = VReplicationExperimentalFlagOptimizeInserts | VReplicationExperimentalFlagAllowNoBlobBinlogRowImage
+var (
+	VReplicationExperimentalFlags = VReplicationExperimentalFlagOptimizeInserts | VReplicationExperimentalFlagAllowNoBlobBinlogRowImage
+	VReplicationNetReadTimeout    = 300
+	VReplicationNetWriteTimeout   = 600
+)
 
 func init() {
 	servenv.OnParseFor("vttablet", registerFlags)
@@ -36,4 +39,6 @@ func init() {
 func registerFlags(fs *pflag.FlagSet) {
 	fs.Int64Var(&VReplicationExperimentalFlags, "vreplication_experimental_flags", VReplicationExperimentalFlags,
 		"(Bitmask) of experimental features in vreplication to enable")
+	fs.IntVar(&VReplicationNetReadTimeout, "vreplication_net_read_timeout", VReplicationNetReadTimeout, "Session value of net_read_timeout for vreplication, in seconds")
+	fs.IntVar(&VReplicationNetWriteTimeout, "vreplication_net_write_timeout", VReplicationNetWriteTimeout, "Session value of net_write_timeout for vreplication, in seconds")
 }

--- a/go/vt/vttablet/flags.go
+++ b/go/vt/vttablet/flags.go
@@ -18,6 +18,7 @@ package vttablet
 
 import (
 	"github.com/spf13/pflag"
+
 	"vitess.io/vitess/go/vt/servenv"
 )
 

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -24,6 +24,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"testing"
+
 	"vitess.io/vitess/go/vt/vttablet"
 
 	"github.com/stretchr/testify/require"

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -60,6 +60,8 @@ const (
 	getAutoIncrementStep     = "select @@session.auto_increment_increment"
 	setSessionTZ             = "set @@session.time_zone = '+00:00'"
 	setNames                 = "set names 'binary'"
+	setNetReadTimeout        = "set @@session.net_read_timeout = 300"
+	setNetWriteTimeout       = "set @@session.net_write_timeout = 600"
 	getBinlogRowImage        = "select @@binlog_row_image"
 	insertStreamsCreatedLog  = "insert into _vt.vreplication_log(vrepl_id, type, state, message) values(1, 'Stream Created', '', '%s'"
 	getVReplicationRecord    = "select * from _vt.vreplication where id = 1"
@@ -324,6 +326,8 @@ func TestMoveTables(t *testing.T) {
 		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(updatePickedSourceTablet, tenv.cells[0], sourceTabletUID), &sqltypes.Result{}, nil)
 		ftc.vrdbClient.ExpectRequest(setSessionTZ, &sqltypes.Result{}, nil)
 		ftc.vrdbClient.ExpectRequest(setNames, &sqltypes.Result{}, nil)
+		ftc.vrdbClient.ExpectRequest(setNetReadTimeout, &sqltypes.Result{}, nil)
+		ftc.vrdbClient.ExpectRequest(setNetWriteTimeout, &sqltypes.Result{}, nil)
 		ftc.vrdbClient.ExpectRequest(getRowsCopied,
 			sqltypes.MakeTestResult(
 				sqltypes.MakeTestFields(
@@ -895,6 +899,8 @@ func TestFailedMoveTablesCreateCleanup(t *testing.T) {
 		&sqltypes.Result{}, nil)
 	targetTablet.vrdbClient.ExpectRequest(setSessionTZ, &sqltypes.Result{}, nil)
 	targetTablet.vrdbClient.ExpectRequest(setNames, &sqltypes.Result{}, nil)
+	targetTablet.vrdbClient.ExpectRequest(setNetReadTimeout, &sqltypes.Result{}, nil)
+	targetTablet.vrdbClient.ExpectRequest(setNetWriteTimeout, &sqltypes.Result{}, nil)
 	targetTablet.vrdbClient.ExpectRequest(getRowsCopied,
 		sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -24,6 +24,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"testing"
+	"vitess.io/vitess/go/vt/vttablet"
 
 	"github.com/stretchr/testify/require"
 
@@ -60,8 +61,6 @@ const (
 	getAutoIncrementStep     = "select @@session.auto_increment_increment"
 	setSessionTZ             = "set @@session.time_zone = '+00:00'"
 	setNames                 = "set names 'binary'"
-	setNetReadTimeout        = "set @@session.net_read_timeout = 300"
-	setNetWriteTimeout       = "set @@session.net_write_timeout = 600"
 	getBinlogRowImage        = "select @@binlog_row_image"
 	insertStreamsCreatedLog  = "insert into _vt.vreplication_log(vrepl_id, type, state, message) values(1, 'Stream Created', '', '%s'"
 	getVReplicationRecord    = "select * from _vt.vreplication where id = 1"
@@ -86,7 +85,9 @@ var (
 			},
 		},
 	}
-	position = fmt.Sprintf("%s/%s", gtidFlavor, gtidPosition)
+	position           = fmt.Sprintf("%s/%s", gtidFlavor, gtidPosition)
+	setNetReadTimeout  = fmt.Sprintf("set @@session.net_read_timeout = %v", vttablet.VReplicationNetReadTimeout)
+	setNetWriteTimeout = fmt.Sprintf("set @@session.net_write_timeout = %v", vttablet.VReplicationNetWriteTimeout)
 )
 
 // TestCreateVReplicationWorkflow tests the query generated

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
 	"vitess.io/vitess/go/vt/vttablet"
 
 	"google.golang.org/protobuf/encoding/prototext"

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"vitess.io/vitess/go/vt/vttablet"
 
 	"google.golang.org/protobuf/encoding/prototext"
 
@@ -227,10 +228,10 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 		if _, err := dbClient.ExecuteFetch("set names 'binary'", 10000); err != nil {
 			return err
 		}
-		if _, err := dbClient.ExecuteFetch("set @@session.net_read_timeout = 300", 10000); err != nil {
+		if _, err := dbClient.ExecuteFetch(fmt.Sprintf("set @@session.net_read_timeout = %v", vttablet.VReplicationNetReadTimeout), 10000); err != nil {
 			return err
 		}
-		if _, err := dbClient.ExecuteFetch("set @@session.net_write_timeout = 600", 10000); err != nil {
+		if _, err := dbClient.ExecuteFetch(fmt.Sprintf("set @@session.net_write_timeout = %v", vttablet.VReplicationNetWriteTimeout), 10000); err != nil {
 			return err
 		}
 		// We must apply AUTO_INCREMENT values precisely as we got them. This include the 0 value, which is not recommended in AUTO_INCREMENT, and yet is valid.

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -227,6 +227,12 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 		if _, err := dbClient.ExecuteFetch("set names 'binary'", 10000); err != nil {
 			return err
 		}
+		if _, err := dbClient.ExecuteFetch("set @@session.net_read_timeout = 300", 10000); err != nil {
+			return err
+		}
+		if _, err := dbClient.ExecuteFetch("set @@session.net_write_timeout = 600", 10000); err != nil {
+			return err
+		}
 		// We must apply AUTO_INCREMENT values precisely as we got them. This include the 0 value, which is not recommended in AUTO_INCREMENT, and yet is valid.
 		if _, err := dbClient.ExecuteFetch("set @@session.sql_mode = CONCAT(@@session.sql_mode, ',NO_AUTO_VALUE_ON_ZERO')", 10000); err != nil {
 			return err

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"vitess.io/vitess/go/vt/vttablet"
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/mysql/replication"
@@ -137,10 +138,10 @@ func (rs *rowStreamer) Stream() error {
 		if _, err := rs.conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
 			return err
 		}
-		if _, err := conn.ExecuteFetch("set @@session.net_read_timeout = 300", 1, false); err != nil {
+		if _, err := conn.ExecuteFetch(fmt.Sprintf("set @@session.net_read_timeout = %v", vttablet.VReplicationNetReadTimeout), 1, false); err != nil {
 			return err
 		}
-		if _, err := conn.ExecuteFetch("set @@session.net_write_timeout = 600", 1, false); err != nil {
+		if _, err := conn.ExecuteFetch(fmt.Sprintf("set @@session.net_write_timeout = %v", vttablet.VReplicationNetWriteTimeout), 1, false); err != nil {
 			return err
 		}
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
 	"vitess.io/vitess/go/vt/vttablet"
 
 	"vitess.io/vitess/go/mysql/collations"

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -137,6 +137,12 @@ func (rs *rowStreamer) Stream() error {
 		if _, err := rs.conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
 			return err
 		}
+		if _, err := conn.ExecuteFetch("set @@session.net_read_timeout = 300", 1, false); err != nil {
+			return err
+		}
+		if _, err := conn.ExecuteFetch("set @@session.net_write_timeout = 600", 1, false); err != nil {
+			return err
+		}
 	}
 	return rs.streamQuery(rs.send)
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 	"sync/atomic"
+	"vitess.io/vitess/go/vt/vttablet"
 
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
@@ -108,10 +109,10 @@ func (ts *tableStreamer) Stream() error {
 	if _, err := conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
 		return err
 	}
-	if _, err := conn.ExecuteFetch("set @@session.net_read_timeout = 300", 1, false); err != nil {
+	if _, err := conn.ExecuteFetch(fmt.Sprintf("set @@session.net_read_timeout = %v", vttablet.VReplicationNetReadTimeout), 1, false); err != nil {
 		return err
 	}
-	if _, err := conn.ExecuteFetch("set @@session.net_write_timeout = 600", 1, false); err != nil {
+	if _, err := conn.ExecuteFetch(fmt.Sprintf("set @@session.net_write_timeout = %v", vttablet.VReplicationNetWriteTimeout), 1, false); err != nil {
 		return err
 	}
 

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
@@ -108,6 +108,12 @@ func (ts *tableStreamer) Stream() error {
 	if _, err := conn.ExecuteFetch("set names 'binary'", 1, false); err != nil {
 		return err
 	}
+	if _, err := conn.ExecuteFetch("set @@session.net_read_timeout = 300", 1, false); err != nil {
+		return err
+	}
+	if _, err := conn.ExecuteFetch("set @@session.net_write_timeout = 600", 1, false); err != nil {
+		return err
+	}
 
 	rs, err := conn.ExecuteFetch("show tables", -1, true)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 	"sync/atomic"
+
 	"vitess.io/vitess/go/vt/vttablet"
 
 	"vitess.io/vitess/go/sqlescape"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
On some particularly busy tables, we cannot run vitess onlineddl schema changes because it fails with `unexpected EOF\nio.ReadFull(packet body of length 287) failed (errno 2013) (sqlstate HY000)`. Note that ghost also fails on these tables, but we have higher hopes for vitess. 

In several slack threads, the recommendation was to increase `net_read_timeout` (default is 30, recommended for vreplication is 300) and `net_write_timeout` (default is 60, recommended for vreplication is 600). However, we don't want to modify these values globally, would be nice if only vreplication's session had these higher values - and this PR does just that

Update: with these changes, we were able to successfully run onlineddl schema changes on an incredibly busy table that was previously unable to run any kind of migrations
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes https://github.com/vitessio/vitess/issues/14202

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
