### PR TITLE
Update v17 Release notes with a Breaking Change

### DIFF
--- a/changelog/17.0/17.0.0/release_notes.md
+++ b/changelog/17.0/17.0.0/release_notes.md
@@ -7,6 +7,7 @@
   - [Schema-initialization stuck on semi-sync ACKs while upgrading to v17.0.0](#schema-init-upgrade)
 - **[Major Changes](#major-changes)**
   - **[Breaking Changes](#breaking-changes)**
+    - [VTTablet: Initializing all replicas with super_read_only](#vttablet-initialization)
     - [Default Local Cell Preference for TabletPicker](#tablet-picker-cell-preference)
     - [Dedicated stats for VTGate Prepare operations](#dedicated-vtgate-prepare-stats)
     - [VTAdmin web migrated from create-react-app to vite](#migrated-vtadmin)

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -6,6 +6,7 @@
   - [Schema-initialization stuck on semi-sync ACKs while upgrading to v17.0.0](#schema-init-upgrade)
 - **[Major Changes](#major-changes)**
   - **[Breaking Changes](#breaking-changes)**
+    - [VTTablet: Initializing all replicas with super_read_only](#vttablet-initialization)
     - [Default Local Cell Preference for TabletPicker](#tablet-picker-cell-preference)
     - [Dedicated stats for VTGate Prepare operations](#dedicated-vtgate-prepare-stats)
     - [VTAdmin web migrated from create-react-app to vite](#migrated-vtadmin)


### PR DESCRIPTION
## Description

Added a note to the Breaking Changes for the updated version of `init_db.sql`

## Related Issue(s)

https://github.com/vitessio/vitess/pull/12206

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

None.
