### PR TITLE
Bypass cobra completion commands so they still function

### DIFF
--- a/go/cmd/vtctldclient/command/root.go
+++ b/go/cmd/vtctldclient/command/root.go
@@ -136,6 +136,13 @@ func getClientForCommand(cmd *cobra.Command) (vtctldclient.VtctldClient, error) 
 		}
 	}
 
+	// Reserved cobra commands for shell completion that we don't want to fail
+	// here.
+	switch {
+	case cmd.Name() == "__complete", cmd.Parent() != nil && cmd.Parent().Name() == "completion":
+		return nil, nil
+	}
+
 	if VtctldClientProtocol != "local" && server == "" {
 		return nil, errNoServer
 	}


### PR DESCRIPTION
## Description

Was putting together a demo of shell completion for the upcoming release and noticed that `vtctldclient` wasn't working (`zk`, on the other hand, works fine).

Worked it out to the fact that, technically, the secret cobra completion commands still execute the PersistentPreRunE, and since they (obviously) don't specify a server, it was failing.

⚠️ I'd like to get this backported to 18.0 so it's in the final release if at all possible. ⚠️ 

See 
![output](https://github.com/vitessio/vitess/assets/4276638/219eea83-6c07-4c5f-8c1c-afab5f95d63a)


## Related Issue(s)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
