### PR TITLE
Fix broken link in docker readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ The structure of this directory and our Dockerfile files is guided by the follow
 * The configuration of each Vitess image is in the directory `docker/<image>/`.
 * Configurations for other images e.g. our internal tool Keytar (see below), can be in a different location.
 * Images with more complex build steps have a `build.sh` script e.g.
-  see [lite/build.sh](https://github.com/vitessio/vitess/blob/main/docker/lite/build.sh).
+  see [bootstrap/build.sh](https://github.com/vitessio/vitess/blob/main/docker/bootstrap/build.sh).
 * Tags are used to provide (stable) versions e.g. see tag `v2.0` for the
   image [vitess/lite](https://hub.docker.com/r/vitess/lite/tags).
 * Where applicable, we provide a `latest` tag to reference the latest build of an image.


### PR DESCRIPTION
## Description

This is a fix of a broken link in the [docker readme](https://github.com/vitessio/vitess/blob/main/docker/README.md). In particular, the third bullet under the "Principles" heading links to [lite/build.sh](https://github.com/vitessio/vitess/blob/main/docker/lite/build.sh, which does not exist, and is therefore substituted with another `build.sh` file link that works. 

## Related Issue(s)

Fixes #14221 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
