### PR TITLE
Move all examples to vtctldclient

### DIFF
--- a/examples/backups/start_cluster.sh
+++ b/examples/backups/start_cluster.sh
@@ -42,8 +42,8 @@ done
 vtctldclient PlannedReparentShard commerce/0 --new-primary "zone1-100"
 
 # create the schema for commerce
-vtctlclient ApplySchema -- --sql-file ./create_commerce_schema.sql commerce || fail "Could not apply schema for the commerce keyspace"
-vtctlclient ApplyVSchema -- --vschema_file ../local/vschema_commerce_seq.json commerce || fail "Could not apply vschema for the commerce keyspace"
+vtctldclient ApplySchema --sql-file ./create_commerce_schema.sql commerce || fail "Could not apply schema for the commerce keyspace"
+vtctldclient ApplyVSchema --vschema-file ../local/vschema_commerce_seq.json commerce || fail "Could not apply vschema for the commerce keyspace"
 
 # Create keyspace and set the semi_sync durability policy.
 vtctldclient CreateKeyspace --durability-policy=semi_sync customer || fail "Failed to create and configure the customer keyspace"
@@ -67,8 +67,8 @@ for shard in "-80" "80-"; do
 done
 
 # create the schema for customer
-vtctlclient ApplySchema -- --sql-file ./create_customer_schema.sql customer || fail "Could not apply schema for the customer keyspace"
-vtctlclient ApplyVSchema -- --vschema_file ../local/vschema_customer_sharded.json customer || fail "Could not apply vschema for the customer keyspace"
+vtctldclient ApplySchema --sql-file ./create_customer_schema.sql customer || fail "Could not apply schema for the customer keyspace"
+vtctldclient ApplyVSchema --vschema-file ../local/vschema_customer_sharded.json customer || fail "Could not apply vschema for the customer keyspace"
 
 
 # start vtgate

--- a/examples/backups/stop_tablets.sh
+++ b/examples/backups/stop_tablets.sh
@@ -29,7 +29,7 @@ for tablet in 100 200 300; do
       echo "Shutting down mysql zone1-$uid"
       CELL=zone1 TABLET_UID=$uid ../common/scripts/mysqlctl-down.sh
       echo "Removing tablet directory zone1-$uid"
-      vtctldclient DeleteTablets --allow-primary=true zone1-$uid
+      vtctldclient DeleteTablets --allow-primary zone1-$uid
       rm -Rf $VTDATAROOT/vt_0000000$uid
     done
   fi

--- a/examples/backups/stop_tablets.sh
+++ b/examples/backups/stop_tablets.sh
@@ -20,7 +20,7 @@
 source ../common/env.sh
 
 for tablet in 100 200 300; do
-  if vtctlclient --action_timeout 1s --server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1; then
+  if vtctldclient --action_timeout 1s --server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1; then
     # The zero tablet is up. Try to shutdown 0-2 tablet + mysqlctl
     for i in 0 1 2; do
       uid=$(($tablet + $i))
@@ -29,7 +29,7 @@ for tablet in 100 200 300; do
       echo "Shutting down mysql zone1-$uid"
       CELL=zone1 TABLET_UID=$uid ../common/scripts/mysqlctl-down.sh
       echo "Removing tablet directory zone1-$uid"
-      vtctlclient DeleteTablet -- --allow_primary=true zone1-$uid
+      vtctldclient DeleteTablets --allow-primary=true zone1-$uid
       rm -Rf $VTDATAROOT/vt_0000000$uid
     done
   fi

--- a/examples/backups/take_backups.sh
+++ b/examples/backups/take_backups.sh
@@ -20,5 +20,5 @@
 source ../common/env.sh
 
 for shard in "customer/-80" "customer/80-" "commerce/0"; do
-	vtctlclient BackupShard "${shard}" || fail "Failed to backup shard: ${shard}"
+	vtctldclient BackupShard "${shard}" || fail "Failed to backup shard: ${shard}"
 done

--- a/examples/backups/upgrade_cluster.sh
+++ b/examples/backups/upgrade_cluster.sh
@@ -26,7 +26,7 @@ for i in 101 102; do
   echo "Shutting down mysql zone1-$i"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
   echo "Removing tablet directory zone1-$i"
-  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  vtctldclient DeleteTablets --allow-primary=true zone1-$i
   rm -Rf $VTDATAROOT/vt_0000000$i
   echo "Starting tablet zone1-$i again"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
@@ -39,7 +39,7 @@ for i in 201 202; do
   echo "Shutting down mysql zone1-$i"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
   echo "Removing tablet directory zone1-$i"
-  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  vtctldclient DeleteTablets --allow-primary=true zone1-$i
   rm -Rf $VTDATAROOT/vt_0000000$i
   echo "Starting tablet zone1-$i again"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
@@ -52,7 +52,7 @@ for i in 301 302; do
   echo "Shutting down mysql zone1-$i"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
   echo "Removing tablet directory zone1-$i"
-  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  vtctldclient DeleteTablets --allow-primary=true zone1-$i
   rm -Rf $VTDATAROOT/vt_0000000$i
   echo "Starting tablet zone1-$i again"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh

--- a/examples/backups/upgrade_cluster.sh
+++ b/examples/backups/upgrade_cluster.sh
@@ -26,7 +26,7 @@ for i in 101 102; do
   echo "Shutting down mysql zone1-$i"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
   echo "Removing tablet directory zone1-$i"
-  vtctldclient DeleteTablets --allow-primary=true zone1-$i
+  vtctldclient DeleteTablets --allow-primary zone1-$i
   rm -Rf $VTDATAROOT/vt_0000000$i
   echo "Starting tablet zone1-$i again"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
@@ -39,7 +39,7 @@ for i in 201 202; do
   echo "Shutting down mysql zone1-$i"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
   echo "Removing tablet directory zone1-$i"
-  vtctldclient DeleteTablets --allow-primary=true zone1-$i
+  vtctldclient DeleteTablets --allow-primary zone1-$i
   rm -Rf $VTDATAROOT/vt_0000000$i
   echo "Starting tablet zone1-$i again"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
@@ -52,7 +52,7 @@ for i in 301 302; do
   echo "Shutting down mysql zone1-$i"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
   echo "Removing tablet directory zone1-$i"
-  vtctldclient DeleteTablets --allow-primary=true zone1-$i
+  vtctldclient DeleteTablets --allow-primary zone1-$i
   rm -Rf $VTDATAROOT/vt_0000000$i
   echo "Starting tablet zone1-$i again"
   CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh

--- a/examples/common/env.sh
+++ b/examples/common/env.sh
@@ -26,11 +26,11 @@ fi
 
 # mysqld might be in /usr/sbin which will not be in the default PATH
 PATH="/usr/sbin:$PATH"
-for binary in mysqld etcd etcdctl curl vtctlclient vtctldclient vttablet vtgate vtctld mysqlctl; do
+for binary in mysqld etcd etcdctl curl vtctldclient vttablet vtgate vtctld mysqlctl; do
   command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. See https://vitess.io/docs/get-started/local/ for install instructions."
 done;
 
-# vtctlclient has a separate alias setup below
+# vtctldclient has a separate alias setup below
 for binary in vttablet vtgate vtctld mysqlctl vtorc vtctl; do
   alias $binary="$binary --config-file-not-found-handling=ignore"
 done;
@@ -77,7 +77,6 @@ mkdir -p "${VTDATAROOT}/tmp"
 # such as ~/.my.cnf
 
 alias mysql="command mysql --no-defaults -h 127.0.0.1 -P 15306"
-alias vtctlclient="command vtctlclient --server localhost:15999 --log_dir ${VTDATAROOT}/tmp --alsologtostderr --config-file-not-found-handling=ignore"
 alias vtctldclient="command vtctldclient --server localhost:15999"
 
 # Make sure aliases are expanded in non-interactive shell

--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -108,13 +108,13 @@ function wait_for_shard_vreplication_engine() {
         local wait_secs=90
 
         for _ in $(seq 1 ${wait_secs}); do
-                if vtctlclient --server=localhost:15999 Workflow -- "${keyspace}" listall &>/dev/null; then
+                if vtctldclient --server=localhost:15999 workflow --keyspace "${keyspace}" list &>/dev/null; then
                         break
                 fi
                 sleep 1
         done;
 
-        if ! vtctlclient --server=localhost:15999 Workflow -- "${keyspace}" listall &>/dev/null; then
+        if ! vtctldclient --server=localhost:15999 workflow --keyspace "${keyspace}" list &>/dev/null; then
                 fail "Timed out after ${wait_secs} seconds waiting for the primary tablet's VReplication engine to open in ${keyspace}/${shard}"
         fi
 }

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -222,17 +222,7 @@ The vreplication container included performs the following actions;
 4. Prints out helpful debug information for you.
 ```
 vitess/examples/compose$ docker-compose logs -f vreplication
-vreplication_1      | + /vt/bin/vtctlclient --server vtctld:15999 VReplicationExec local-0000000101 'insert into _vt.vreplication (db_name, source, pos, max_tps, max_replication_lag, tablet_types, time_updated, transaction_timestamp, state) values('\''commerce'\'', '\''keyspace:\"ext_commerce\" shard:\"0\" filter:<rules:<match:\"/.*\" > > on_ddl:EXEC_IGNORE '\'', '\'''\'', 9999, 9999, '\''primary'\'', 0, 0, '\''Running'\'')'
-vreplication_1      | + /vt/bin/vtctlclient --server vtctld:15999 VReplicationExec local-0000000101 'select * from _vt.vreplication'
-vreplication_1      | +----+----------+--------------------------------+-----+----------+---------+---------------------+------+--------------+--------------+-----------------------+---------+---------+----------+
-vreplication_1      | | id | workflow |             source             | pos | stop_pos | max_tps | max_replication_lag | cell | tablet_types | time_updated | transaction_timestamp |  state  | message | db_name  |
-vreplication_1      | +----+----------+--------------------------------+-----+----------+---------+---------------------+------+--------------+--------------+-----------------------+---------+---------+----------+
-vreplication_1      | |  1 |          | keyspace:"ext_commerce"        |     |          |    9999 |                9999 |      | primary       |            0 |                     0 | Running |         | commerce |
-vreplication_1      | |    |          | shard:"0"                      |     |          |         |                     |      |              |              |                       |         |         |         |
-vreplication_1      | |    |          | filter:<rules:<match:"/.*" > > |     |          |         |                     |      |              |              |                       |         |         |         |
-vreplication_1      | |    |          | on_ddl:EXEC_IGNORE             |     |          |         |                     |      |              |              |                       |         |         |         |
-vreplication_1      | +----+----------+--------------------------------+-----+----------+---------+---------------------+------+--------------+--------------+-----------------------+---------+---------+----------+
-compose_vreplication_1 exited with code 0
+...
 ```
 
 ### Connect to vgate and run queries

--- a/examples/compose/externaldb_vreplication.sh
+++ b/examples/compose/externaldb_vreplication.sh
@@ -43,17 +43,17 @@ dest_tablet=$(echo "$TABLET_INFO "| grep -v "ext_" | grep "primary" | awk '{ pri
 
 
 # Disable foreign_key checks on destination
-/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias 'SET GLOBAL FOREIGN_KEY_CHECKS=0;'
+/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDBA $dest_alias 'SET GLOBAL FOREIGN_KEY_CHECKS=0;'
 
 # Get source_sql mode
-source_sql_mode=$(/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $source_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}')
+source_sql_mode=$(/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDBA $source_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}')
 
 # Apply source sql_mode to destination
 # The intention is to avoid replication errors
-/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias "SET GLOBAL sql_mode='$source_sql_mode';"
+/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDBA $dest_alias "SET GLOBAL sql_mode='$source_sql_mode';"
 
 # Verify sql_mode matches
-[ $source_sql_mode == $(/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}') ] && \
+[ $source_sql_mode == $(/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDBA $dest_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}') ] && \
 echo "Source and Destination sql_mode Match." || echo "sql_mode MisMatch"
 
 until /vt/bin/vtctldclient --server $VTCTLD_SERVER GetSchema $dest_alias; do

--- a/examples/compose/externaldb_vreplication.sh
+++ b/examples/compose/externaldb_vreplication.sh
@@ -19,19 +19,19 @@ set -ex
 VTCTLD_SERVER=${VTCTLD_SERVER:-'vtctld:15999'}
 
 # Wait until source and destination primaries are available
-until (/vt/bin/vtctlclient --server $VTCTLD_SERVER ListAllTablets | grep "ext_" | grep "primary" ); do
+until (/vt/bin/vtctldclient --server $VTCTLD_SERVER GetTablets | grep "ext_" | grep "primary" ); do
   echo 'waiting for external primary..';
   sleep 1;
 done
 
-until (/vt/bin/vtctlclient --server $VTCTLD_SERVER ListAllTablets | grep -v "ext_" | grep "primary" ); do
+until (/vt/bin/vtctldclient --server $VTCTLD_SERVER GetTablets | grep -v "ext_" | grep "primary" ); do
   echo 'waiting for managed primary..';
   sleep 1;
 done
 
 
 # Get source and destination tablet and shard information
-TABLET_INFO=$(/vt/bin/vtctlclient --server $VTCTLD_SERVER ListAllTablets)
+TABLET_INFO=$(/vt/bin/vtctldclient --server $VTCTLD_SERVER GetTablets)
 source_alias=$(echo "$TABLET_INFO "| grep "ext_" | grep "primary" | awk '{ print $1 }')
 dest_alias=$(echo "$TABLET_INFO "| grep -v "ext_" | grep "primary" | awk '{ print $1 }')
 source_keyspace=$(echo "$TABLET_INFO "| grep "ext_" | grep "primary" | awk '{ print $2 }')
@@ -43,33 +43,27 @@ dest_tablet=$(echo "$TABLET_INFO "| grep -v "ext_" | grep "primary" | awk '{ pri
 
 
 # Disable foreign_key checks on destination
-/vt/bin/vtctlclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias 'SET GLOBAL FOREIGN_KEY_CHECKS=0;'
+/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias 'SET GLOBAL FOREIGN_KEY_CHECKS=0;'
 
 # Get source_sql mode
-source_sql_mode=$(/vt/bin/vtctlclient --server $VTCTLD_SERVER ExecuteFetchAsDba $source_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}')
+source_sql_mode=$(/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $source_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}')
 
 # Apply source sql_mode to destination
 # The intention is to avoid replication errors
-/vt/bin/vtctlclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias "SET GLOBAL sql_mode='$source_sql_mode';"
+/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias "SET GLOBAL sql_mode='$source_sql_mode';"
 
 # Verify sql_mode matches
-[ $source_sql_mode == $(/vt/bin/vtctlclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}') ] && \
+[ $source_sql_mode == $(/vt/bin/vtctldclient --server $VTCTLD_SERVER ExecuteFetchAsDba $dest_alias 'SELECT @@GLOBAL.sql_mode' | awk 'NR==4 {print $2}') ] && \
 echo "Source and Destination sql_mode Match." || echo "sql_mode MisMatch"
 
-until /vt/bin/vtctlclient --server $VTCTLD_SERVER GetSchema $dest_alias; do
+until /vt/bin/vtctldclient --server $VTCTLD_SERVER GetSchema $dest_alias; do
   echo "Waiting for destination schema to be ready..";
   sleep 3;
 done
 
-# Copy schema from source to destination shard
-/vt/bin/vtctlclient --server $VTCTLD_SERVER CopySchemaShard $source_tablet $dest_tablet || true
-
-# Verify schema
-/vt/bin/vtctlclient --server $VTCTLD_SERVER GetSchema $dest_alias
-
-# Start vreplication
-/vt/bin/vtctlclient --server $VTCTLD_SERVER VReplicationExec $dest_alias 'insert into _vt.vreplication (db_name, source, pos, max_tps, max_replication_lag, tablet_types, time_updated, transaction_timestamp, state) values('"'"''"$dest_keyspace"''"'"', '"'"'keyspace:\"'"$source_keyspace"'\" shard:\"'"$source_shard"'\" filter:<rules:<match:\"/.*\" > > on_ddl:EXEC_IGNORE '"'"', '"'"''"'"', 9999, 9999, '"'"'primary'"'"', 0, 0, '"'"'Running'"'"')'
+# Start vreplication workflow
+/vt/bin/vtctldclient --server $VTCTLD_SERVER MoveTables --workflow ext_commerce2commerce --target-keyspace $dest_keyspace create --source-keyspace $source_keyspace --all-tables
 
 # Check vreplication status
-/vt/bin/vtctlclient --server $VTCTLD_SERVER VReplicationExec $dest_alias 'select * from _vt.vreplication'
+/vt/bin/vtctldclient --server $VTCTLD_SERVER MoveTables --workflow ext_commerce2commerce --target-keyspace $dest_keyspace show
 

--- a/examples/compose/lvtctl.sh
+++ b/examples/compose/lvtctl.sh
@@ -20,5 +20,5 @@ if [[ "$OSTYPE" == "msys" ]]; then
         tty=winpty
 fi
 
-# This is a convenience script to run vtctlclient against the local example.
-exec $tty docker-compose exec ${CS:-vtctld} /vt/bin/vtctlclient --server vtctld:15999 "$@"
+# This is a convenience script to run vtctldclient against the local example.
+exec $tty docker-compose exec ${CS:-vtctld} /vt/bin/vtctldclient --server vtctld:15999 "$@"

--- a/examples/compose/schemaload.sh
+++ b/examples/compose/schemaload.sh
@@ -26,23 +26,23 @@ sleep $sleeptime
 
 if [ ! -f schema_run ]; then
   while true; do
-    vtctlclient --server vtctld:$GRPC_PORT GetTablet $targettab && break
+    vtctldclient --server vtctld:$GRPC_PORT GetTablet $targettab && break
     sleep 1
   done
   if [ "$external_db" = "0" ]; then
     for schema_file in $schema_files; do
       echo "Applying Schema ${schema_file} to ${KEYSPACE}"
-      vtctlclient --server vtctld:$GRPC_PORT -- ApplySchema --sql-file /script/tables/${schema_file} $KEYSPACE || \
-      vtctlclient --server vtctld:$GRPC_PORT -- ApplySchema --sql "$(cat /script/tables/${schema_file})" $KEYSPACE || true
+      vtctldclient --server vtctld:$GRPC_PORT ApplySchema --sql-file /script/tables/${schema_file} $KEYSPACE || \
+      vtctldclient --server vtctld:$GRPC_PORT ApplySchema --sql "$(cat /script/tables/${schema_file})" $KEYSPACE || true
     done
   fi
   echo "Applying VSchema ${vschema_file} to ${KEYSPACE}"
   
-  vtctlclient --server vtctld:$GRPC_PORT -- ApplyVSchema --vschema_file /script/${vschema_file} $KEYSPACE || \
-  vtctlclient --server vtctld:$GRPC_PORT -- ApplyVSchema --vschema "$(cat /script/${vschema_file})" $KEYSPACE
+  vtctldclient --server vtctld:$GRPC_PORT ApplyVSchema --vschema-file /script/${vschema_file} $KEYSPACE || \
+  vtctldclient --server vtctld:$GRPC_PORT ApplyVSchema --vschema "$(cat /script/${vschema_file})" $KEYSPACE
   
   echo "List All Tablets"
-  vtctlclient --server vtctld:$GRPC_PORT ListAllTablets
+  vtctldclient --server vtctld:$GRPC_PORT GetTablets
     
   if [ -n "$load_file" ]; then
     # vtgate can take a REALLY long time to come up fully

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -534,7 +534,7 @@ func generateDefaultShard(tabAlias int, shard string, keyspaceData keyspaceInfo,
   path: /services/init_shard_primary%[2]d
   value:
     image: vitess/lite:${VITESS_TAG:-latest}
-    command: ["sh", "-c", "/vt/bin/vtctlclient %[5]s InitShardPrimary -force %[4]s/%[3]s %[6]s-%[2]d "]
+    command: ["sh", "-c", "/vt/bin/vtctldclient %[5]s InitShardPrimary --force %[4]s/%[3]s %[6]s-%[2]d "]
     %[1]s
 `, dependsOn, aliases[0], shard, keyspaceData.keyspace, opts.topologyFlags, opts.cell)
 }

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -108,7 +108,7 @@ sleep $sleeptime
 
 # Create the cell
 # https://vitess.io/blog/2020-04-27-life-of-a-cluster/
-$VTROOT/bin/vtctlclient --server vtctld:$GRPC_PORT -- AddCellInfo --root vitess/$CELL --server_address consul1:8500 $CELL || true
+$VTROOT/bin/vtctldclient --server vtctld:$GRPC_PORT AddCellInfo --root vitess/$CELL --server-address consul1:8500 $CELL || true
 
 #Populate external db conditional args
 if [ $tablet_role = "externalprimary" ]; then

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -19,35 +19,38 @@ mysql --table < ../common/select_commerce_data.sql
 ./201_customer_tablets.sh
 
 # Initiate move tables
-vtctlclient MoveTables -- --source commerce --tables 'customer,corder' Create customer.commerce2customer
+vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer create --source-keyspace commerce --tables "customer,corder"
 
 # Validate
-vtctlclient VDiff customer.commerce2customer
+vtctldclient vdiff --workflow commerce2customer --target-keyspace customer create
+vtctldclient vdiff --workflow commerce2customer --target-keyspace customer show last
 
 # Cut-over
-vtctlclient MoveTables -- --tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer
-vtctlclient MoveTables -- --tablet_types=primary SwitchTraffic customer.commerce2customer
+vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer switchtraffic --tablet-types "rdonly,replica"
+vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer switchtraffic --tablet-types primary
 
 # Clean-up
-vtctlclient MoveTables Complete customer.commerce2customer
+vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer complete
 
 # Prepare for resharding
 ./301_customer_sharded.sh
 ./302_new_shards.sh
 
 # Reshard
-vtctlclient Reshard -- --source_shards '0' --target_shards '-80,80-' Create customer.cust2cust
+vtctldclient Reshard --workflow cust2cust --target-keyspace customer create --source-shards '0' --target-shards '-80,80-'
 
 # Validate
-vtctlclient VDiff customer.cust2cust
+vtctldclient vdiff --workflow cust2cust --target-keyspace customer create
+vtctldclient vdiff --workflow cust2cust --target-keyspace customer show last
 
 # Cut-over
-vtctlclient Reshard -- --tablet_types=rdonly,replica SwitchTraffic customer.cust2cust
-vtctlclient Reshard -- --tablet_types=primary SwitchTraffic customer.cust2cust
+vtctldclient Reshard --workflow cust2cust --target-keyspace customer switchtraffic --tablet-types "rdonly,replica"
+vtctldclient Reshard --workflow cust2cust --target-keyspace customer switchtraffic --tablet-types primary
 
 # Down shard 0
+vtctldclient Reshard --workflow cust2cust --target-keyspace customer complete
 ./306_down_shard_0.sh
-vtctlclient DeleteShard -- --force --recursive customer/0
+vtctldclient DeleteShards --force --recursive customer/0
 
 # Down cluster
 ./401_teardown.sh

--- a/examples/operator/pf.sh
+++ b/examples/operator/pf.sh
@@ -8,7 +8,6 @@ kubectl port-forward --address localhost "$(kubectl get service --selector="plan
 process_id3=$!
 sleep 2
 echo "You may point your browser to http://localhost:15000, use the following aliases as shortcuts:"
-echo 'alias vtctlclient="vtctlclient --server=localhost:15999 --logtostderr"'
 echo 'alias vtctldclient="vtctldclient --server=localhost:15999 --logtostderr"'
 echo 'alias mysql="mysql -h 127.0.0.1 -P 15306 -u user"'
 echo "Hit Ctrl-C to stop the port forwards"

--- a/examples/region_sharding/201_main_sharded.sh
+++ b/examples/region_sharding/201_main_sharded.sh
@@ -20,14 +20,14 @@ source ../common/env.sh
 vtctldclient ApplyVSchema --vschema-file main_vschema_sharded.json main || fail "Failed to apply vschema for the sharded main keyspace"
 
 # optional: create the schema needed for lookup vindex
-#vtctlclient ApplySchema --sql-file create_lookup_schema.sql main
+#vtctldclient ApplySchema --sql-file create_lookup_schema.sql main
 
 # create the lookup vindex
-vtctlclient CreateLookupVindex -- --tablet_types=PRIMARY main "$(cat lookup_vindex.json)" || fail "Failed to create lookup vindex in main keyspace"
+vtctldclient LookupVindex --name customer_region_lookup --table-keyspace main create --keyspace main --type consistent_lookup_unique --table-owner customer --table-owner-columns=id --tablet-types=PRIMARY || fail "Failed to create lookup vindex in main keyspace"
 
 # we have to wait for replication to catch up
 # Can see on vttablet status page Vreplication that copy is complete
 sleep 5
 
 # externalize vindex
-vtctlclient ExternalizeVindex main.customer_region_lookup || fail "Failed to externalize customer_region_lookup vindex in the main keyspace"
+vtctldclient LookupVindex --name customer_region_lookup --table-keyspace main externalize --keyspace main || fail "Failed to externalize customer_region_lookup vindex in the main keyspace"

--- a/examples/region_sharding/203_reshard.sh
+++ b/examples/region_sharding/203_reshard.sh
@@ -16,4 +16,4 @@
 
 source ../common/env.sh
 
-vtctlclient Reshard -- --source_shards '0' --target_shards '-40,40-80,80-c0,c0-' --tablet_types=PRIMARY Create main.main2regions
+vtctldclient reshard --workflow main2regions --target-keyspace main create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY

--- a/examples/region_sharding/204_switch_reads.sh
+++ b/examples/region_sharding/204_switch_reads.sh
@@ -18,4 +18,4 @@
 
 source ../common/env.sh
 
-vtctlclient Reshard -- --tablet_types=rdonly,replica SwitchTraffic main.main2regions
+vtctldclient reshard --workflow main2regions --target-keyspace main SwitchTraffic --tablet-types=rdonly,replica

--- a/examples/region_sharding/205_switch_writes.sh
+++ b/examples/region_sharding/205_switch_writes.sh
@@ -18,7 +18,7 @@
 
 source ../common/env.sh
 
-vtctlclient Reshard -- --tablet_types=primary SwitchTraffic main.main2regions
+vtctldclient reshard --workflow main2regions --target-keyspace main SwitchTraffic --tablet-types=primary
 
 # to go back to unsharded
 # call Reshard ReverseTraffic with all tablet types

--- a/examples/region_sharding/301_teardown.sh
+++ b/examples/region_sharding/301_teardown.sh
@@ -26,7 +26,7 @@ source ../common/env.sh
 ../common/scripts/vtgate-down.sh
 
 for tablet in 100 200 300 400 500; do
-	if vtctlclient --server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1; then
+	if vtctldclient --server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1; then
 		printf -v alias '%s-%010d' 'zone1' $tablet
 		echo "Shutting down tablet $alias"
 		CELL=zone1 TABLET_UID=$tablet ../common/scripts/vttablet-down.sh

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -128,7 +128,7 @@ var (
 	create = &cobra.Command{
 		Use:   "create",
 		Short: "Create and run a VDiff to compare the tables involved in a VReplication workflow between the source and target.",
-		Example: `vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer
+		Example: `vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create
 vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create b3f59678-5241-11ee-be56-0242ac120002`,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
## Description

[`vtctldclient` is replacing the legacy `vtctlclient`](https://github.com/vitessio/vitess/pull/12866). Starting with the v18 GA (after https://github.com/vitessio/vitess/issues/12152 is done) all users should use `vtctldclient` rather than `vtctlclient`. This PR updates the examples accordingly.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/14209
  - Part of: https://github.com/vitessio/vitess/issues/12152

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required