### PR TITLE
Mark non-unique lookup vindex as backfill to ignore vindex selection

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -4665,6 +4665,28 @@
     }
   },
   {
+    "comment": "name is in backfill vindex - not selected for vindex lookup",
+    "query": "select * from customer where name = 'x'",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select * from customer where name = 'x'",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select * from customer where 1 != 1",
+        "Query": "select * from customer where name = 'x'",
+        "Table": "customer"
+      },
+      "TablesUsed": [
+        "user.customer"
+      ]
+    }
+  },
+  {
     "comment": "email vindex is costly than phone vindex - but phone vindex is backfiling hence ignored",
     "query": "select * from customer where email = 'a@mail.com' and phone = 123456",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -4678,7 +4678,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from customer where 1 != 1",
-        "Query": "select * from customer where name = 'x'",
+        "Query": "select * from customer where `name` = 'x'",
         "Table": "customer"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -166,6 +166,16 @@
               "to": "keyspace_id",
               "cost": "300"
             }
+        },
+        "lkp_bf_vdx": {
+          "type": "name_lkp_test",
+          "owner": "customer",
+          "params": {
+            "table": "lkp_shard_vdx",
+            "from": " ",
+            "to": "keyspace_id",
+            "write_only": "true"
+          }
         }
       },
       "tables": {
@@ -476,6 +486,10 @@
             {
               "column": "phone",
               "name": "unq_lkp_bf_vdx"
+            },
+            {
+              "column": "name",
+              "name": "lkp_bf_vdx"
             }
           ]
         },

--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -489,7 +489,7 @@ func (lu *clCommon) GetCommitOrder() vtgatepb.CommitOrder {
 }
 
 // IsBackfilling implements the LookupBackfill interface
-func (lu *ConsistentLookupUnique) IsBackfilling() bool {
+func (lu *clCommon) IsBackfilling() bool {
 	return lu.writeOnly
 }
 

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -181,6 +181,11 @@ func (ln *LookupNonUnique) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ln.lkp)
 }
 
+// IsBackfilling implements the LookupBackfill interface
+func (ln *LookupNonUnique) IsBackfilling() bool {
+	return ln.writeOnly
+}
+
 // Query implements the LookupPlanable interface
 func (ln *LookupNonUnique) Query() (selQuery string, arguments []string) {
 	return ln.lkp.query()


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

As a follow-up to https://github.com/vitessio/vitess/pull/13505, this PR enables non-unique lookups to support the `isBackfilling` interface. This will prevent non-unique lookups from vindex selection during a backfill (i.e. when `write_only` is set to `true`).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- https://github.com/vitessio/vitess/issues/13486

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
