### PR TITLE
Build and push Docker `vitess/lite` to DockerHub from GitHub Actions

### DIFF
--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -15,8 +15,8 @@ permissions: read-all
 jobs:
   build_and_push:
     name: Build and push vitess/lite Docker images
-    runs-on: ubuntu-latest # TODO: replace by larger runners
-    #TODO: uncomment: if: github.repository == 'vitessio/vitess'
+    runs-on: gh-hosted-runners-16cores-1
+    if: github.repository == 'vitessio/vitess'
 
     strategy:
       fail-fast: true
@@ -48,7 +48,7 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE }}
           push: true
-          tags: frouioui/lite:${{ matrix.branch }}
+          tags: vitess/lite:${{ matrix.branch }}
 
       - name: Get the Git tag
         if: startsWith(github.ref, 'refs/tags/')
@@ -58,9 +58,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           if [[ "${{ matrix.branch }}" == "latest" ]]; then
-            echo "DOCKER_TAG=frouioui/lite:${TAG_NAME}" >> $GITHUB_ENV
+            echo "DOCKER_TAG=vitess/lite:${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "DOCKER_TAG=frouioui/lite:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
+            echo "DOCKER_TAG=vitess/lite:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
           fi
 
       - name: Build and push on main

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -24,6 +24,9 @@ jobs:
         branch: [ latest, mysql57, mysql80, percona57, percona80 ]
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -42,6 +45,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v5
         with:
+          context: .
           file: ${{ env.DOCKERFILE }}
           push: true
           tags: vitess/lite:${{ matrix.branch }}
@@ -63,6 +67,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v5
         with:
+          context: .
           file: ${{ env.DOCKERFILE }}
           push: true
           tags: ${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -48,7 +48,7 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE }}
           push: true
-          tags: vitess/lite:${{ matrix.branch }}
+          tags: frouioui/lite:${{ matrix.branch }}
 
       - name: Get the Git tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -58,9 +58,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           if [[ "${{ matrix.branch }}" == "latest" ]]; then
-            echo "DOCKER_TAG=vitess/lite:${TAG_NAME}" >> $GITHUB_ENV
+            echo "DOCKER_TAG=frouioui/lite:${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "DOCKER_TAG=vitess/lite:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
+            echo "DOCKER_TAG=frouioui/lite:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
           fi
 
       - name: Build and push on main

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -16,7 +16,7 @@ jobs:
   build_and_push:
     name: Build and push vitess/lite Docker images
     runs-on: ubuntu-latest # TODO: replace by larger runners
-    if: github.repository == 'vitessio/vitess'
+    #TODO: uncomment: if: github.repository == 'vitessio/vitess'
 
     strategy:
       fail-fast: true

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -1,0 +1,48 @@
+name: Docker Build Lite
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Docker Build Lite')
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  build_and_push:
+    name: Build and push vitess/lite Docker images
+    runs-on: gh-hosted-runners-16cores-1
+    if: github.repository == 'vitessio/vitess'
+
+    strategy:
+      fail-fast: true
+      matrix:
+        branch: [ latest, mysql57, mysql80, percona57, percona80 ]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+#      - name: Build and push
+#        uses: docker/build-push-action@v5
+#        with:
+#          push: true
+#          tags: vitess/lite:$$matrix

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -24,12 +24,6 @@ jobs:
         branch: [ latest, mysql57, mysql80, percona57, percona80 ]
 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -15,7 +15,7 @@ permissions: read-all
 jobs:
   build_and_push:
     name: Build and push vitess/lite Docker images
-    runs-on: gh-hosted-runners-16cores-1
+    runs-on: ubuntu-latest # TODO: replace by larger runners
     if: github.repository == 'vitessio/vitess'
 
     strategy:
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -41,8 +39,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-#      - name: Build and push
-#        uses: docker/build-push-action@v5
-#        with:
-#          push: true
-#          tags: vitess/lite:$$matrix
+      - name: Build and push on main
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' + matrix.branch }}
+          push: true
+          tags: vitess/lite:${{ matrix.branch }}
+
+      - name: Get the tag name
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build and push on main
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' + matrix.branch }}
+          push: true
+          tags: ${{ (matrix.branch == 'latest') && 'vitess/lite:' + env.TAG_NAME || 'vitess/lite:' + env.TAG_NAME + '-' + matrix.branch }}

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -43,7 +43,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v5
         with:
-          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' + matrix.branch }}
+          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' matrix.branch }}
           push: true
           tags: vitess/lite:${{ matrix.branch }}
 
@@ -55,6 +55,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v5
         with:
-          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' + matrix.branch }}
+          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' matrix.branch }}
           push: true
-          tags: ${{ (matrix.branch == 'latest') && 'vitess/lite:' + env.TAG_NAME || 'vitess/lite:' + env.TAG_NAME + '-' + matrix.branch }}
+          tags: ${{ (matrix.branch == 'latest' && 'vitess/lite:' env.TAG_NAME) || ('vitess/lite:' env.TAG_NAME '-' matrix.branch) }}

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -24,9 +24,6 @@ jobs:
         branch: [ latest, mysql57, mysql80, percona57, percona80 ]
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -39,22 +39,39 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set Dockerfile path
+        run: |
+          if [[ "${{ matrix.branch }}" == "latest" ]]; then
+            echo "DOCKERFILE=./docker/lite/Dockerfile" >> $GITHUB_ENV
+          else
+            echo "DOCKERFILE=./docker/lite/Dockerfile.${{ matrix.branch }}" >> $GITHUB_ENV
+          fi
+
       - name: Build and push on main
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v5
         with:
-          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' matrix.branch }}
+          file: ${{ env.DOCKERFILE }}
           push: true
           tags: vitess/lite:${{ matrix.branch }}
 
-      - name: Get the tag name
+      - name: Get the Git tag
         if: startsWith(github.ref, 'refs/tags/')
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Set Docker tag name
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          if [[ "${{ matrix.branch }}" == "latest" ]]; then
+            echo "DOCKER_TAG=vitess/lite:${TAG_NAME}" >> $GITHUB_ENV
+          else
+            echo "DOCKER_TAG=vitess/lite:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
+          fi
 
       - name: Build and push on main
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v5
         with:
-          file: ${{ (matrix.branch == 'latest') && './docker/lite/Dockerfile' || './docker/lite/Dockerfile.' matrix.branch }}
+          file: ${{ env.DOCKERFILE }}
           push: true
-          tags: ${{ (matrix.branch == 'latest' && 'vitess/lite:' env.TAG_NAME) || ('vitess/lite:' env.TAG_NAME '-' matrix.branch) }}
+          tags: ${{ env.DOCKER_TAG }}


### PR DESCRIPTION
## Description

This PR adds automatic builds for the `vitess/lite` Docker Image on GitHub Actions instead of building them on DockerHub. An example of how the build works can be found below:

- [Build on `v1.1.3` on my own fork](https://github.com/frouioui/vitess/actions/runs/6501861605)
- [Build on `main` on my own fork](https://github.com/frouioui/vitess/actions/runs/6501773987)
- [List of tags on `frouioui/lite`](https://hub.docker.com/repository/docker/frouioui/lite/tags?page=1&ordering=last_updated)

> Note to self: remove DockerHub auto build once this is merged.

> Note to reviewers: the new secrets have already been added to the repository.

## Related Issue(s)

- Part of #14149 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
