### PR TITLE
schemadiff: improved heuristic for dependent migration permutation evaluation time

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package schemadiff
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -403,6 +404,7 @@ func TestDiffViews(t *testing.T) {
 }
 
 func TestDiffSchemas(t *testing.T) {
+	ctx := context.Background()
 	tt := []struct {
 		name        string
 		from        string
@@ -806,7 +808,7 @@ func TestDiffSchemas(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 
-				diffs, err := diff.OrderedDiffs()
+				diffs, err := diff.OrderedDiffs(ctx)
 				assert.NoError(t, err)
 				statements := []string{}
 				cstatements := []string{}
@@ -858,6 +860,7 @@ func TestDiffSchemas(t *testing.T) {
 }
 
 func TestSchemaApplyError(t *testing.T) {
+	ctx := context.Background()
 	tt := []struct {
 		name string
 		from string
@@ -900,7 +903,7 @@ func TestSchemaApplyError(t *testing.T) {
 			{
 				diff, err := schema1.SchemaDiff(schema2, hints)
 				require.NoError(t, err)
-				diffs, err := diff.OrderedDiffs()
+				diffs, err := diff.OrderedDiffs(ctx)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, diffs)
 				_, err = schema1.Apply(diffs)
@@ -911,7 +914,7 @@ func TestSchemaApplyError(t *testing.T) {
 			{
 				diff, err := schema2.SchemaDiff(schema1, hints)
 				require.NoError(t, err)
-				diffs, err := diff.OrderedDiffs()
+				diffs, err := diff.OrderedDiffs(ctx)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, diffs, "schema1: %v, schema2: %v", schema1.ToSQL(), schema2.ToSQL())
 				_, err = schema2.Apply(diffs)

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -40,8 +40,9 @@ type ImpossibleApplyDiffOrderError struct {
 
 func (e *ImpossibleApplyDiffOrderError) Error() string {
 	var b strings.Builder
-	b.WriteString("no valid applicable order for diffs. Diffs found conflicting:")
-	for _, s := range e.ConflictingStatements() {
+	conflictingStatements := e.ConflictingStatements()
+	b.WriteString(fmt.Sprintf("no valid applicable order for diffs. %d diffs found conflicting:", len(conflictingStatements)))
+	for _, s := range conflictingStatements {
 		b.WriteString("\n")
 		b.WriteString(s)
 	}

--- a/go/vt/schemadiff/schema_diff.go
+++ b/go/vt/schemadiff/schema_diff.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 
 	"vitess.io/vitess/go/mathutil"
-	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 type DiffDependencyType int
@@ -80,19 +79,21 @@ func sortDiffsHeuristically(diffs []EntityDiff) {
 		return
 	}
 	diffOrder := func(diff EntityDiff) int {
-		switch diff.Statement().(type) {
-		case *sqlparser.DropView:
+		switch diff.(type) {
+		case *DropViewEntityDiff:
 			return 0
-		case *sqlparser.DropTable:
+		case *DropTableEntityDiff:
 			return 1
-		case *sqlparser.AlterTable:
+		case *AlterTableEntityDiff:
 			return 2
-		case *sqlparser.AlterView:
+		case *RenameTableEntityDiff:
 			return 3
-		case *sqlparser.CreateTable:
+		case *AlterViewEntityDiff:
 			return 4
-		case *sqlparser.CreateView:
+		case *CreateTableEntityDiff:
 			return 5
+		case *CreateViewEntityDiff:
+			return 6
 		default:
 			return math.MaxInt
 		}

--- a/go/vt/schemadiff/schema_diff.go
+++ b/go/vt/schemadiff/schema_diff.go
@@ -112,6 +112,34 @@ func permDiff(ctx context.Context, a []EntityDiff, callback func([]EntityDiff) (
 		return true, err
 	}
 	for j := i + 1; j < len(a); j++ {
+		iIsCreateDropView := false
+		iIsTable := false
+		switch a[i].(type) {
+		case *DropViewEntityDiff, *CreateViewEntityDiff:
+			iIsCreateDropView = true
+		case *DropTableEntityDiff, *AlterTableEntityDiff, *CreateTableEntityDiff:
+			iIsTable = true
+		}
+
+		jIsCreateDropView := false
+		jIsTable := false
+		switch a[j].(type) {
+		case *DropViewEntityDiff, *CreateViewEntityDiff:
+			jIsCreateDropView = true
+		case *DropTableEntityDiff, *AlterTableEntityDiff, *CreateTableEntityDiff:
+			jIsTable = true
+		}
+
+		if iIsCreateDropView && jIsCreateDropView {
+			continue
+		}
+		if iIsCreateDropView && jIsTable {
+			continue
+		}
+		if iIsTable && jIsCreateDropView {
+			continue
+		}
+
 		a[i], a[j] = a[j], a[i]
 		if brk, err := permDiff(ctx, a, callback, i+1); brk {
 			return true, err

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -117,7 +117,7 @@ func TestPermutations(t *testing.T) {
 				allDiffs := schemaDiff.UnorderedDiffs()
 				originalSingleString := toSingleString(allDiffs)
 				numEquals := 0
-				earlyBreak, err := permutateDiffs(ctx, allDiffs, schemaDiff.dependencies, func(pdiffs []EntityDiff) (earlyBreak bool) {
+				earlyBreak, err := permutateDiffs(ctx, allDiffs, func(pdiffs []EntityDiff) (earlyBreak bool) {
 					defer func() { iteration++ }()
 					// cover all permutations
 					singleString := toSingleString(pdiffs)
@@ -138,7 +138,7 @@ func TestPermutations(t *testing.T) {
 				allPerms := map[string]bool{}
 				allDiffs := schemaDiff.UnorderedDiffs()
 				originalSingleString := toSingleString(allDiffs)
-				earlyBreak, err := permutateDiffs(ctx, allDiffs, schemaDiff.dependencies, func(pdiffs []EntityDiff) (earlyBreak bool) {
+				earlyBreak, err := permutateDiffs(ctx, allDiffs, func(pdiffs []EntityDiff) (earlyBreak bool) {
 					// Single visit
 					allPerms[toSingleString(pdiffs)] = true
 					// First permutation should be the same as original
@@ -165,7 +165,7 @@ func TestPermutationsContext(t *testing.T) {
 	cancel()
 
 	allDiffs := []EntityDiff{&DropViewEntityDiff{}}
-	earlyBreak, err := permutateDiffs(ctx, allDiffs, nil, func(pdiffs []EntityDiff) (earlyBreak bool) {
+	earlyBreak, err := permutateDiffs(ctx, allDiffs, func(pdiffs []EntityDiff) (earlyBreak bool) {
 		return false
 	})
 	assert.True(t, earlyBreak) // proves that termination was due to context cancel
@@ -706,7 +706,7 @@ func TestSchemaDiff(t *testing.T) {
 				assert.True(t, ok)
 				assert.Equal(t, tc.conflictingDiffs, len(impossibleOrderErr.ConflictingDiffs))
 			} else {
-				require.NoError(t, err)
+				require.NoErrorf(t, err, "Unordered diffs: %v", allDiffsStatements)
 			}
 			diffStatementStrings := []string{}
 			for _, diff := range orderedDiffs {

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -117,7 +117,7 @@ func TestPermutations(t *testing.T) {
 				allDiffs := schemaDiff.UnorderedDiffs()
 				originalSingleString := toSingleString(allDiffs)
 				numEquals := 0
-				earlyBreak, err := permutateDiffs(ctx, allDiffs, func(pdiffs []EntityDiff) (earlyBreak bool) {
+				earlyBreak, err := permutateDiffs(ctx, allDiffs, schemaDiff.dependencies, func(pdiffs []EntityDiff) (earlyBreak bool) {
 					defer func() { iteration++ }()
 					// cover all permutations
 					singleString := toSingleString(pdiffs)
@@ -138,7 +138,7 @@ func TestPermutations(t *testing.T) {
 				allPerms := map[string]bool{}
 				allDiffs := schemaDiff.UnorderedDiffs()
 				originalSingleString := toSingleString(allDiffs)
-				earlyBreak, err := permutateDiffs(ctx, allDiffs, func(pdiffs []EntityDiff) (earlyBreak bool) {
+				earlyBreak, err := permutateDiffs(ctx, allDiffs, schemaDiff.dependencies, func(pdiffs []EntityDiff) (earlyBreak bool) {
 					// Single visit
 					allPerms[toSingleString(pdiffs)] = true
 					// First permutation should be the same as original
@@ -165,7 +165,7 @@ func TestPermutationsContext(t *testing.T) {
 	cancel()
 
 	allDiffs := []EntityDiff{&DropViewEntityDiff{}}
-	earlyBreak, err := permutateDiffs(ctx, allDiffs, func(pdiffs []EntityDiff) (earlyBreak bool) {
+	earlyBreak, err := permutateDiffs(ctx, allDiffs, nil, func(pdiffs []EntityDiff) (earlyBreak bool) {
 		return false
 	})
 	assert.True(t, earlyBreak) // proves that termination was due to context cancel

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -36,7 +36,8 @@ type AlterTableEntityDiff struct {
 	to         *CreateTableEntity
 	alterTable *sqlparser.AlterTable
 
-	subsequentDiff *AlterTableEntityDiff
+	canonicalStatementString string
+	subsequentDiff           *AlterTableEntityDiff
 }
 
 // IsEmpty implements EntityDiff
@@ -79,11 +80,16 @@ func (d *AlterTableEntityDiff) StatementString() (s string) {
 }
 
 // CanonicalStatementString implements EntityDiff
-func (d *AlterTableEntityDiff) CanonicalStatementString() (s string) {
-	if stmt := d.Statement(); stmt != nil {
-		s = sqlparser.CanonicalString(stmt)
+func (d *AlterTableEntityDiff) CanonicalStatementString() string {
+	if d == nil {
+		return ""
 	}
-	return s
+	if d.canonicalStatementString == "" {
+		if stmt := d.Statement(); stmt != nil {
+			d.canonicalStatementString = sqlparser.CanonicalString(stmt)
+		}
+	}
+	return d.canonicalStatementString
 }
 
 // SubsequentDiff implements EntityDiff
@@ -118,6 +124,8 @@ func (d *AlterTableEntityDiff) addSubsequentDiff(diff *AlterTableEntityDiff) {
 type CreateTableEntityDiff struct {
 	to          *CreateTableEntity
 	createTable *sqlparser.CreateTable
+
+	canonicalStatementString string
 }
 
 // IsEmpty implements EntityDiff
@@ -160,11 +168,16 @@ func (d *CreateTableEntityDiff) StatementString() (s string) {
 }
 
 // CanonicalStatementString implements EntityDiff
-func (d *CreateTableEntityDiff) CanonicalStatementString() (s string) {
-	if stmt := d.Statement(); stmt != nil {
-		s = sqlparser.CanonicalString(stmt)
+func (d *CreateTableEntityDiff) CanonicalStatementString() string {
+	if d == nil {
+		return ""
 	}
-	return s
+	if d.canonicalStatementString == "" {
+		if stmt := d.Statement(); stmt != nil {
+			d.canonicalStatementString = sqlparser.CanonicalString(stmt)
+		}
+	}
+	return d.canonicalStatementString
 }
 
 // SubsequentDiff implements EntityDiff
@@ -179,6 +192,8 @@ func (d *CreateTableEntityDiff) SetSubsequentDiff(EntityDiff) {
 type DropTableEntityDiff struct {
 	from      *CreateTableEntity
 	dropTable *sqlparser.DropTable
+
+	canonicalStatementString string
 }
 
 // IsEmpty implements EntityDiff
@@ -221,11 +236,16 @@ func (d *DropTableEntityDiff) StatementString() (s string) {
 }
 
 // CanonicalStatementString implements EntityDiff
-func (d *DropTableEntityDiff) CanonicalStatementString() (s string) {
-	if stmt := d.Statement(); stmt != nil {
-		s = sqlparser.CanonicalString(stmt)
+func (d *DropTableEntityDiff) CanonicalStatementString() string {
+	if d == nil {
+		return ""
 	}
-	return s
+	if d.canonicalStatementString == "" {
+		if stmt := d.Statement(); stmt != nil {
+			d.canonicalStatementString = sqlparser.CanonicalString(stmt)
+		}
+	}
+	return d.canonicalStatementString
 }
 
 // SubsequentDiff implements EntityDiff
@@ -241,6 +261,8 @@ type RenameTableEntityDiff struct {
 	from        *CreateTableEntity
 	to          *CreateTableEntity
 	renameTable *sqlparser.RenameTable
+
+	canonicalStatementString string
 }
 
 // IsEmpty implements EntityDiff
@@ -283,11 +305,16 @@ func (d *RenameTableEntityDiff) StatementString() (s string) {
 }
 
 // CanonicalStatementString implements EntityDiff
-func (d *RenameTableEntityDiff) CanonicalStatementString() (s string) {
-	if stmt := d.Statement(); stmt != nil {
-		s = sqlparser.CanonicalString(stmt)
+func (d *RenameTableEntityDiff) CanonicalStatementString() string {
+	if d == nil {
+		return ""
 	}
-	return s
+	if d.canonicalStatementString == "" {
+		if stmt := d.Statement(); stmt != nil {
+			d.canonicalStatementString = sqlparser.CanonicalString(stmt)
+		}
+	}
+	return d.canonicalStatementString
 }
 
 // SubsequentDiff implements EntityDiff

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -26,6 +26,8 @@ type AlterViewEntityDiff struct {
 	from      *CreateViewEntity
 	to        *CreateViewEntity
 	alterView *sqlparser.AlterView
+
+	canonicalStatementString string
 }
 
 // IsEmpty implements EntityDiff
@@ -68,11 +70,16 @@ func (d *AlterViewEntityDiff) StatementString() (s string) {
 }
 
 // CanonicalStatementString implements EntityDiff
-func (d *AlterViewEntityDiff) CanonicalStatementString() (s string) {
-	if stmt := d.Statement(); stmt != nil {
-		s = sqlparser.CanonicalString(stmt)
+func (d *AlterViewEntityDiff) CanonicalStatementString() string {
+	if d == nil {
+		return ""
 	}
-	return s
+	if d.canonicalStatementString == "" {
+		if stmt := d.Statement(); stmt != nil {
+			d.canonicalStatementString = sqlparser.CanonicalString(stmt)
+		}
+	}
+	return d.canonicalStatementString
 }
 
 // SubsequentDiff implements EntityDiff
@@ -86,6 +93,8 @@ func (d *AlterViewEntityDiff) SetSubsequentDiff(EntityDiff) {
 
 type CreateViewEntityDiff struct {
 	createView *sqlparser.CreateView
+
+	canonicalStatementString string
 }
 
 // IsEmpty implements EntityDiff
@@ -129,11 +138,16 @@ func (d *CreateViewEntityDiff) StatementString() (s string) {
 }
 
 // CanonicalStatementString implements EntityDiff
-func (d *CreateViewEntityDiff) CanonicalStatementString() (s string) {
-	if stmt := d.Statement(); stmt != nil {
-		s = sqlparser.CanonicalString(stmt)
+func (d *CreateViewEntityDiff) CanonicalStatementString() string {
+	if d == nil {
+		return ""
 	}
-	return s
+	if d.canonicalStatementString == "" {
+		if stmt := d.Statement(); stmt != nil {
+			d.canonicalStatementString = sqlparser.CanonicalString(stmt)
+		}
+	}
+	return d.canonicalStatementString
 }
 
 // SubsequentDiff implements EntityDiff
@@ -148,6 +162,8 @@ func (d *CreateViewEntityDiff) SetSubsequentDiff(EntityDiff) {
 type DropViewEntityDiff struct {
 	from     *CreateViewEntity
 	dropView *sqlparser.DropView
+
+	canonicalStatementString string
 }
 
 // IsEmpty implements EntityDiff
@@ -182,11 +198,16 @@ func (d *DropViewEntityDiff) DropView() *sqlparser.DropView {
 }
 
 // CanonicalStatementString implements EntityDiff
-func (d *DropViewEntityDiff) CanonicalStatementString() (s string) {
-	if stmt := d.Statement(); stmt != nil {
-		s = sqlparser.CanonicalString(stmt)
+func (d *DropViewEntityDiff) CanonicalStatementString() string {
+	if d == nil {
+		return ""
 	}
-	return s
+	if d.canonicalStatementString == "" {
+		if stmt := d.Statement(); stmt != nil {
+			d.canonicalStatementString = sqlparser.CanonicalString(stmt)
+		}
+	}
+	return d.canonicalStatementString
 }
 
 // StatementString implements EntityDiff


### PR DESCRIPTION

## Description

See story in https://github.com/vitessio/vitess/issues/14248. In this PR:

- We re-apply an ordering heuristic (where `DROP`s come first, then `ALTER`s, then `CREATE`s) before evaluating dependency permutations. This begins the search with a heuristically probable solution, and followed by "nearby" solutions.
- We copy less objects in the duration of the search. When evaluating a permutation we apply schema changes in-line. It's only at the beginning of a permutation search that we do one copy of the schema.
- We support `context.Context` for premature exit. This changes the function signature for `OrderedDiffs(...)`


## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14248

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
