### PR TITLE
bugfix: use the proper interface for comment directives

### DIFF
--- a/go/test/endtoend/vtgate/queries/no_scatter/main_test.go
+++ b/go/test/endtoend/vtgate/queries/no_scatter/main_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation
+
+import (
+	_ "embed"
+	"flag"
+	"os"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	keyspaceName    = "ks"
+	cell            = "test"
+
+	//go:embed schema.sql
+	schemaSQL string
+
+	//go:embed vschema.json
+	vschema string
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, "localhost")
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: schemaSQL,
+			VSchema:   vschema,
+		}
+		clusterInstance.VtGateExtraArgs = []string{"--no_scatter=true"}
+		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
+		if err != nil {
+			return 1
+		}
+		// Start vtgate
+		err = clusterInstance.StartVtgate()
+		if err != nil {
+			return 1
+		}
+
+		vtParams = clusterInstance.GetVTParams(keyspaceName)
+
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}

--- a/go/test/endtoend/vtgate/queries/no_scatter/queries_test.go
+++ b/go/test/endtoend/vtgate/queries/no_scatter/queries_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+)
+
+func start(t *testing.T) (*mysql.Conn, func()) {
+	vtConn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+
+	deleteAll := func() {
+		tables := []string{"music", "user"}
+		for _, table := range tables {
+			utils.Exec(t, vtConn, "delete from "+table)
+		}
+	}
+
+	deleteAll()
+
+	return vtConn, func() {
+		deleteAll()
+		vtConn.Close()
+		cluster.PanicHandler(t)
+	}
+}
+
+func TestFailsWhenForcedToScatter(t *testing.T) {
+	vtconn, closer := start(t)
+	defer closer()
+
+	utils.Exec(t, vtconn, "insert into music(id, user_id) values(1,1), (2,5), (3,1), (4,2), (5,3), (6,4), (7,5)")
+	utils.Exec(t, vtconn, "insert into user(id, name) values(1,'toto'), (2,'tata'), (3,'titi'), (4,'tete'), (5,'foo')")
+
+	_, err := utils.ExecAllowError(t, vtconn, "select * from user") // fails since we have disallowed scatter
+	require.ErrorContains(t, err, "plan includes scatter, which is disallowed")
+
+	_ = utils.Exec(t, vtconn, "select /*vt+ ALLOW_SCATTER */ * from user")          // passes thanks to the comment directive
+	_ = utils.Exec(t, vtconn, "vexplain select /*vt+ ALLOW_SCATTER */ * from user") // passes thanks to the comment directive
+}

--- a/go/test/endtoend/vtgate/queries/no_scatter/schema.sql
+++ b/go/test/endtoend/vtgate/queries/no_scatter/schema.sql
@@ -1,0 +1,13 @@
+create table user
+(
+    id            bigint,
+    name varchar(255),
+    primary key (id)
+) Engine = InnoDB;
+
+create table music
+(
+    id            bigint,
+    user_id bigint,
+    primary key (id)
+) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/queries/no_scatter/vschema.json
+++ b/go/test/endtoend/vtgate/queries/no_scatter/vschema.json
@@ -1,0 +1,26 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "user_index": {
+      "type": "hash"
+    }
+  },
+  "tables": {
+    "user": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "user_index"
+        }
+      ]
+    },
+    "music": {
+      "column_vindexes": [
+        {
+          "column": "user_id",
+          "name": "user_index"
+        }
+      ]
+    }
+  }
+}

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -142,7 +142,12 @@ func CanNormalize(stmt Statement) bool {
 
 // CachePlan takes Statement and returns true if the query plan should be cached
 func CachePlan(stmt Statement) bool {
-	return !checkDirective(stmt, DirectiveSkipQueryPlanCache)
+	switch stmt.(type) {
+	case *Select, *Insert, *Update, *Delete, *Union, *Stream:
+		return !checkDirective(stmt, DirectiveSkipQueryPlanCache)
+	default:
+		return false
+	}
 }
 
 // MustRewriteAST takes Statement and returns true if RewriteAST must run on it for correct execution irrespective of user flags.

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -142,22 +142,7 @@ func CanNormalize(stmt Statement) bool {
 
 // CachePlan takes Statement and returns true if the query plan should be cached
 func CachePlan(stmt Statement) bool {
-	var comments *ParsedComments
-	switch stmt := stmt.(type) {
-	case *Select:
-		comments = stmt.Comments
-	case *Insert:
-		comments = stmt.Comments
-	case *Update:
-		comments = stmt.Comments
-	case *Delete:
-		comments = stmt.Comments
-	case *Union, *Stream:
-		return true
-	default:
-		return false
-	}
-	return !comments.Directives().IsSet(DirectiveSkipQueryPlanCache)
+	return !checkDirective(stmt, DirectiveSkipQueryPlanCache)
 }
 
 // MustRewriteAST takes Statement and returns true if RewriteAST must run on it for correct execution irrespective of user flags.

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1387,6 +1387,14 @@ func (node *ExplainStmt) GetParsedComments() *ParsedComments {
 
 // GetParsedComments implements Commented interface.
 func (node *VExplainStmt) GetParsedComments() *ParsedComments {
+	if node.Comments == nil {
+		cmt, ok := node.Statement.(Commented)
+		if !ok {
+			return nil
+		}
+		return cmt.GetParsedComments()
+	}
+
 	return node.Comments
 }
 

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -325,11 +325,6 @@ func MultiShardAutocommitDirective(stmt Statement) bool {
 	return checkDirective(stmt, DirectiveMultiShardAutocommit)
 }
 
-// SkipQueryPlanCacheDirective returns true if skip query plan cache directive is set to true in query.
-func SkipQueryPlanCacheDirective(stmt Statement) bool {
-	return checkDirective(stmt, DirectiveSkipQueryPlanCache)
-}
-
 // IgnoreMaxPayloadSizeDirective returns true if the max payload size override
 // directive is set to true.
 func IgnoreMaxPayloadSizeDirective(stmt Statement) bool {

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -394,29 +394,19 @@ func TestExtractCommentDirectives(t *testing.T) {
 
 func TestSkipQueryPlanCacheDirective(t *testing.T) {
 	stmt, _ := Parse("insert /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ into user(id) values (1), (2)")
-	if !SkipQueryPlanCacheDirective(stmt) {
-		t.Errorf("d.SkipQueryPlanCacheDirective(stmt) should be true")
-	}
+	assert.False(t, CachePlan(stmt))
 
 	stmt, _ = Parse("insert into user(id) values (1), (2)")
-	if SkipQueryPlanCacheDirective(stmt) {
-		t.Errorf("d.SkipQueryPlanCacheDirective(stmt) should be false")
-	}
+	assert.True(t, CachePlan(stmt))
 
 	stmt, _ = Parse("update /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ users set name=1")
-	if !SkipQueryPlanCacheDirective(stmt) {
-		t.Errorf("d.SkipQueryPlanCacheDirective(stmt) should be true")
-	}
+	assert.False(t, CachePlan(stmt))
 
 	stmt, _ = Parse("select /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ * from users")
-	if !SkipQueryPlanCacheDirective(stmt) {
-		t.Errorf("d.SkipQueryPlanCacheDirective(stmt) should be true")
-	}
+	assert.False(t, CachePlan(stmt))
 
 	stmt, _ = Parse("delete /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ from users")
-	if !SkipQueryPlanCacheDirective(stmt) {
-		t.Errorf("d.SkipQueryPlanCacheDirective(stmt) should be true")
-	}
+	assert.False(t, CachePlan(stmt))
 }
 
 func TestIgnoreMaxPayloadSizeDirective(t *testing.T) {

--- a/go/vt/vtgate/executor_ddl_test.go
+++ b/go/vt/vtgate/executor_ddl_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestDDLFlags(t *testing.T) {
-	executor, _, _, _, ctx := createExecutorEnv(t)
-	session := NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded})
 	defer func() {
 		enableOnlineDDL = true
 		enableDirectDDL = true
@@ -57,6 +55,8 @@ func TestDDLFlags(t *testing.T) {
 	}
 	for _, testcase := range testcases {
 		t.Run(fmt.Sprintf("%s-%v-%v", testcase.sql, testcase.enableDirectDDL, testcase.enableOnlineDDL), func(t *testing.T) {
+			executor, _, _, _, ctx := createExecutorEnv(t)
+			session := NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded})
 			enableDirectDDL = testcase.enableDirectDDL
 			enableOnlineDDL = testcase.enableOnlineDDL
 			_, err := executor.Execute(ctx, nil, "TestDDLFlags", session, testcase.sql, nil)

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1372,8 +1372,6 @@ func TestExecutorDDL(t *testing.T) {
 }
 
 func TestExecutorDDLFk(t *testing.T) {
-	executor, _, _, sbc, ctx := createExecutorEnv(t)
-
 	mName := "TestExecutorDDLFk"
 	stmts := []string{
 		"create table t1(id bigint primary key, foreign key (id) references t2(id))",
@@ -1383,6 +1381,7 @@ func TestExecutorDDLFk(t *testing.T) {
 	for _, stmt := range stmts {
 		for _, fkMode := range []string{"allow", "disallow"} {
 			t.Run(stmt+fkMode, func(t *testing.T) {
+				executor, _, _, sbc, ctx := createExecutorEnv(t)
 				sbc.ExecCount.Store(0)
 				foreignKeyMode = fkMode
 				_, err := executor.Execute(ctx, nil, mName, NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded}), stmt, nil)

--- a/go/vt/vtgate/planbuilder/vexplain.go
+++ b/go/vt/vtgate/planbuilder/vexplain.go
@@ -118,10 +118,9 @@ func buildVExplainLoggingPlan(ctx context.Context, explain *sqlparser.VExplainSt
 	switch input.primitive.(type) {
 	case *engine.Insert, *engine.Delete, *engine.Update:
 		directives := explain.GetParsedComments().Directives()
-		if directives.IsSet(sqlparser.DirectiveVExplainRunDMLQueries) {
-			break
+		if !directives.IsSet(sqlparser.DirectiveVExplainRunDMLQueries) {
+			return nil, vterrors.VT09008()
 		}
-		return nil, vterrors.VT09008()
 	}
 
 	return &planResult{primitive: &engine.VExplain{Input: input.primitive, Type: explain.Type}, tables: input.tables}, nil

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -370,11 +370,11 @@ func (qe *QueryEngine) getPlan(curSchema *currentSchema, sql string) (*TabletPla
 	plan := &TabletPlan{Plan: splan, Original: sql}
 	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableNames()...)
 	plan.buildAuthorized()
-	if plan.PlanID == planbuilder.PlanDDL || plan.PlanID == planbuilder.PlanSet || sqlparser.SkipQueryPlanCacheDirective(statement) {
-		return plan, errNoCache
+	if sqlparser.CachePlan(statement) {
+		return plan, nil
 	}
 
-	return plan, nil
+	return plan, errNoCache
 }
 
 // GetPlan returns the TabletPlan that for the query. Plans are cached in a theine LRU cache.
@@ -417,11 +417,11 @@ func (qe *QueryEngine) getStreamPlan(curSchema *currentSchema, sql string) (*Tab
 	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableName().String())
 	plan.buildAuthorized()
 
-	if sqlparser.SkipQueryPlanCacheDirective(statement) {
-		return plan, errNoCache
+	if sqlparser.CachePlan(statement) {
+		return plan, nil
 	}
 
-	return plan, nil
+	return plan, errNoCache
 }
 
 // GetStreamPlan returns the TabletPlan that for the query. Plans are cached in a theine LRU cache.

--- a/test/config.json
+++ b/test/config.json
@@ -563,6 +563,15 @@
 			"RetryMax": 2,
 			"Tags": []
 		},
+		"vtgate_queries_no_scatter": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/queries/no_scatter"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_queries",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtgate_queries_orderby": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/queries/orderby", "-timeout", "20m"],


### PR DESCRIPTION
## Description
The bug report #14090 exposed an issue where we where not reading comment directives correctly for most statement types. This PR makes sure we read the directives correctly in a lot more situations.

## Related Issue(s)
Fixes #14090

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
