### PR TITLE
Refactor: New operator InsertionSelection to adhere to the operator model

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/insert.go
+++ b/go/vt/vtgate/planbuilder/operators/insert.go
@@ -40,8 +40,6 @@ type Insert struct {
 	AutoIncrement *Generate
 	// Ignore specifies whether to ignore duplicate key errors during insertion.
 	Ignore bool
-	// ForceNonStreaming when true, select first then insert, this is to avoid locking rows by select for insert.
-	ForceNonStreaming bool
 
 	// ColVindexes are the vindexes that will use the VindexValues or VindexValueOffset
 	ColVindexes []*vindexes.ColumnVindex
@@ -53,24 +51,9 @@ type Insert struct {
 	// that will appear in the result set of the select query.
 	VindexValueOffset [][]int
 
-	// Insert using select query will have select plan as input operator for the insert operation.
-	Input ops.Operator
-
+	noInputs
 	noColumns
 	noPredicates
-}
-
-func (i *Insert) Inputs() []ops.Operator {
-	if i.Input == nil {
-		return nil
-	}
-	return []ops.Operator{i.Input}
-}
-
-func (i *Insert) SetInputs(inputs []ops.Operator) {
-	if len(inputs) > 0 {
-		i.Input = inputs[0]
-	}
 }
 
 // Generate represents an auto-increment generator for the insert operation.
@@ -102,18 +85,12 @@ func (i *Insert) GetOrdering(*plancontext.PlanningContext) []ops.OrderBy {
 
 var _ ops.Operator = (*Insert)(nil)
 
-func (i *Insert) Clone(inputs []ops.Operator) ops.Operator {
-	var input ops.Operator
-	if len(inputs) > 0 {
-		input = inputs[0]
-	}
+func (i *Insert) Clone([]ops.Operator) ops.Operator {
 	return &Insert{
-		Input:             input,
 		VTable:            i.VTable,
 		AST:               i.AST,
 		AutoIncrement:     i.AutoIncrement,
 		Ignore:            i.Ignore,
-		ForceNonStreaming: i.ForceNonStreaming,
 		ColVindexes:       i.ColVindexes,
 		VindexValues:      i.VindexValues,
 		VindexValueOffset: i.VindexValueOffset,
@@ -211,15 +188,12 @@ func createInsertOperator(ctx *plancontext.PlanningContext, insStmt *sqlparser.I
 			return nil, err
 		}
 	case sqlparser.SelectStatement:
-		route.Source, err = insertSelectPlan(ctx, insOp, insStmt, rows)
-		if err != nil {
-			return nil, err
-		}
+		return insertSelectPlan(ctx, insOp, route, insStmt, rows)
 	}
 	return route, nil
 }
 
-func insertSelectPlan(ctx *plancontext.PlanningContext, insOp *Insert, ins *sqlparser.Insert, sel sqlparser.SelectStatement) (*Insert, error) {
+func insertSelectPlan(ctx *plancontext.PlanningContext, insOp *Insert, routeOp *Route, ins *sqlparser.Insert, sel sqlparser.SelectStatement) (*InsertSelection, error) {
 	if columnMismatch(insOp.AutoIncrement, ins, sel) {
 		return nil, vterrors.VT03006()
 	}
@@ -229,23 +203,26 @@ func insertSelectPlan(ctx *plancontext.PlanningContext, insOp *Insert, ins *sqlp
 		return nil, err
 	}
 
-	// select plan will be taken as input to insert rows into the table.
-	insOp.Input = selOp
+	// output of the select plan will be used to insert rows into the table.
+	insertSelect := &InsertSelection{
+		SelectionOp: selOp,
+		InsertionOp: routeOp,
+	}
 
-	// When the table you are steaming data from and table you are inserting from are same.
+	// When the table you are streaming data from and table you are inserting from are same.
 	// Then due to locking of the index range on the table we might not be able to insert into the table.
 	// Therefore, instead of streaming, this flag will ensure the records are first read and then inserted.
 	insertTbl := insOp.TablesUsed()[0]
 	selTables := TablesUsed(selOp)
 	for _, tbl := range selTables {
 		if insertTbl == tbl {
-			insOp.ForceNonStreaming = true
+			insertSelect.ForceNonStreaming = true
 			break
 		}
 	}
 
 	if len(insOp.ColVindexes) == 0 {
-		return insOp, nil
+		return insertSelect, nil
 	}
 
 	colVindexes := insOp.ColVindexes
@@ -266,7 +243,7 @@ func insertSelectPlan(ctx *plancontext.PlanningContext, insOp *Insert, ins *sqlp
 		}
 	}
 	insOp.VindexValueOffset = vv
-	return insOp, nil
+	return insertSelect, nil
 }
 
 func columnMismatch(gen *Generate, ins *sqlparser.Insert, sel sqlparser.SelectStatement) bool {

--- a/go/vt/vtgate/planbuilder/operators/insert_selection.go
+++ b/go/vt/vtgate/planbuilder/operators/insert_selection.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+)
+
+// InsertSelection operator represents an INSERT into SELECT FROM query.
+// It holds the operators for running the selection and insertion.
+type InsertSelection struct {
+	SelectionOp ops.Operator
+	InsertionOp ops.Operator
+
+	// ForceNonStreaming when true, select first then insert, this is to avoid locking rows by select for insert.
+	ForceNonStreaming bool
+
+	noColumns
+	noPredicates
+}
+
+func (is *InsertSelection) Clone(inputs []ops.Operator) ops.Operator {
+	return &InsertSelection{
+		SelectionOp: inputs[0],
+		InsertionOp: inputs[1],
+	}
+}
+
+func (is *InsertSelection) Inputs() []ops.Operator {
+	return []ops.Operator{is.SelectionOp, is.InsertionOp}
+}
+
+func (is *InsertSelection) SetInputs(inputs []ops.Operator) {
+	is.SelectionOp = inputs[0]
+	is.InsertionOp = inputs[1]
+}
+
+func (is *InsertSelection) ShortDescription() string {
+	return ""
+}
+
+func (is *InsertSelection) GetOrdering(*plancontext.PlanningContext) []ops.OrderBy {
+	return nil
+}
+
+var _ ops.Operator = (*InsertSelection)(nil)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
In the operator model that we have, a Route represents a part of the operator that should be converted to a query and run as a single unit. It therefore doesn't make sense to have a Route operator nested inside another.

Previously for a query like `insert into music(id, user_id) select * from user`, the operator tree looked like - 
```
Route (Scatter on user Seen:[<nil>])
└── Insert (user.music)
    └── Route (Scatter on user Seen:[<nil>])
        └── Horizon
            └── Table (user.user)
```

This refactor introduces a new operator called InsertionSelection to remedy this situation.

After the refactor the operator tree looks like - 
```
InsertSelection
├── Route (Scatter on user Seen:[<nil>])
│   └── Horizon
│       └── Table (user.user)
└── Route (Scatter on user Seen:[<nil>])
    └── Insert (user.music)
```

## Related Issue(s)
Tracking issue https://github.com/vitessio/vitess/issues/11626
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
