### PR TITLE
reorder tablet checks in vtgate tablet gateway

### DIFF
--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -67,7 +67,7 @@ const (
 type RetryDoneFunc context.CancelFunc
 
 const (
-	ClusterEventReshardingInProgress = "current keyspace is being resharded"
+	ClusterEventReshardingInProgress = "current keyspace is potentially being resharded"
 	ClusterEventReparentInProgress   = "primary is not serving, there may be a reparent operation in progress"
 	ClusterEventMoveTables           = "disallowed due to rule"
 )

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -283,20 +283,22 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 			// if we have a keyspace event watcher, check if the reason why our primary is not available is that it's currently being resharded
 			// or if a reparent operation is in progress.
 			if kev := gw.kev; kev != nil {
-				if kev.TargetIsBeingResharded(ctx, target) {
-					log.V(2).Infof("current keyspace is being resharded, retrying: %s: %s", target.Keyspace, debug.Stack())
-					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, buffer.ClusterEventReshardingInProgress)
-					continue
-				}
 				primary, notServing := kev.PrimaryIsNotServing(ctx, target)
 				if notServing {
 					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, buffer.ClusterEventReparentInProgress)
 					continue
 				}
+
 				// if primary is serving, but we initially found no tablet, we're in an inconsistent state
 				// we then retry the entire loop
 				if primary != nil {
 					err = vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "inconsistent state detected, primary is serving but initially found no available tablet")
+					continue
+				}
+
+				if kev.TargetIsBeingResharded(ctx, target) {
+					log.V(2).Infof("current keyspace is potentally being resharded, retrying: %s: %s", target.Keyspace, debug.Stack())
+					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, buffer.ClusterEventReshardingInProgress)
 					continue
 				}
 			}


### PR DESCRIPTION
## Description

The error message returned from the tablet gateway is misleading.

I swapped the tablet checks to check if the primary is serving before checking the resharding state.

For example, during a recent incident where a primary mysql was down Vitess was returning `current keyspace is being resharded` error messages back to an application which is very confusing. If we look at the tablet serving state however we can see that the primary is `NOT_SERVING`.

```
ro@cluster(replica)> show vitess_tablets;
+-------------+----------------------------------+-------+------------+-------------+------------------------+---------------+----------------------+
| Cell        | Keyspace                         | Shard | TabletType | State       | Alias                  | Hostname      | PrimaryTermStartTime |
+-------------+----------------------------------+-------+------------+-------------+------------------------+---------------+----------------------+
...
| us-east1    | keyspace1 | -10   | PRIMARY    | NOT_SERVING | us-east1-0000000097    | 247.4.117.26  | 2023-10-11T19:16:00Z |
| us-east1    | keyspace1 | -10   | REPLICA    | NOT_SERVING | us-east1-0000000102    | 247.2.54.58   |                      |
...
+-------------+----------------------------------+-------+------------+-------------+------------------------+---------------+----------------------+
68 rows in set (0.00 sec)
```

With this change we should at least return an error message of `primary is not serving, there could be a reparent operation in progress` which is more informational than a "potential" resharding message.