### PR TITLE
VReplication: error on vtctldclient commands w/o tablet types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,8 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/cache @vmg
 /go/cmd @ajm188 @deepthi
 /go/cmd/vtadmin @ajm188 @notfelineit
-/go/cmd/vtctldclient @ajm188 @notfelineit
+/go/cmd/vtctldclient @ajm188 @mattlord
+/go/cmd/vtctldclient/command/vreplication @mattlord @rohit-nayak-ps
 /go/internal/flag @ajm188 @rohit-nayak-ps
 /go/mysql @harshit-gangal @systay @mattlord
 /go/pools @deepthi @harshit-gangal

--- a/go/cmd/vtctldclient/command/vreplication/common/utils.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils.go
@@ -106,10 +106,17 @@ func ParseCells(cmd *cobra.Command) {
 	}
 }
 
-func ParseTabletTypes(cmd *cobra.Command) {
-	if !cmd.Flags().Lookup("tablet-types").Changed {
-		CreateOptions.TabletTypes = tabletTypesDefault
+func ParseTabletTypes(cmd *cobra.Command) error {
+	ttf := cmd.Flags().Lookup("tablet-types")
+	if ttf == nil {
+		return fmt.Errorf("no tablet-types flag found")
 	}
+	if !ttf.Changed {
+		CreateOptions.TabletTypes = tabletTypesDefault
+	} else if strings.TrimSpace(ttf.Value.String()) == "" {
+		return fmt.Errorf("invalid table-types value, at least one valid tablet type must be specified")
+	}
+	return nil
 }
 
 func validateOnDDL(cmd *cobra.Command) error {
@@ -124,7 +131,9 @@ func ParseAndValidateCreateOptions(cmd *cobra.Command) error {
 		return err
 	}
 	ParseCells(cmd)
-	ParseTabletTypes(cmd)
+	if err := ParseTabletTypes(cmd); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/go/cmd/vtctldclient/command/vreplication/common/utils.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils.go
@@ -114,7 +114,7 @@ func ParseTabletTypes(cmd *cobra.Command) error {
 	if !ttf.Changed {
 		CreateOptions.TabletTypes = tabletTypesDefault
 	} else if strings.TrimSpace(ttf.Value.String()) == "" {
-		return fmt.Errorf("invalid table-types value, at least one valid tablet type must be specified")
+		return fmt.Errorf("invalid tablet-types value, at least one valid tablet type must be specified")
 	}
 	return nil
 }

--- a/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestParseAndValidateCreateOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		setFunc func(*cobra.Command) error
+		wantErr bool
+	}{
+		{
+			name: "invalid tablet type",
+			setFunc: func(cmd *cobra.Command) error {
+				tabletTypesFlag := cmd.Flags().Lookup("tablet-types")
+				err := tabletTypesFlag.Value.Set("invalid")
+				tabletTypesFlag.Changed = true
+				return err
+			},
+			wantErr: true,
+		},
+		{
+			name: "no tablet types",
+			setFunc: func(cmd *cobra.Command) error {
+				tabletTypesFlag := cmd.Flags().Lookup("tablet-types")
+				err := tabletTypesFlag.Value.Set("")
+				tabletTypesFlag.Changed = true
+				return err
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid tablet types",
+			setFunc: func(cmd *cobra.Command) error {
+				tabletTypesFlag := cmd.Flags().Lookup("tablet-types")
+				err := tabletTypesFlag.Value.Set("rdonly,replica")
+				tabletTypesFlag.Changed = true
+				return err
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			AddCommonCreateFlags(cmd)
+			test := func() error {
+				if tt.setFunc != nil {
+					if err := tt.setFunc(cmd); err != nil {
+						return err
+					}
+				}
+				if err := ParseAndValidateCreateOptions(cmd); err != nil {
+					return err
+				}
+				return nil
+			}
+			if err := test(); (err != nil) != tt.wantErr {
+				t.Errorf("ParseAndValidateCreateOptions() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/go/cmd/vtctldclient/command/vreplication/workflow/update.go
+++ b/go/cmd/vtctldclient/command/vreplication/workflow/update.go
@@ -60,6 +60,9 @@ var (
 				updateOptions.Cells = textutil.SimulatedNullStringSlice
 			}
 			if cmd.Flags().Lookup("tablet-types").Changed {
+				if err := common.ParseTabletTypes(cmd); err != nil {
+					return err
+				}
 				changes = true
 			} else {
 				updateOptions.TabletTypes = []topodatapb.TabletType{topodatapb.TabletType(textutil.SimulatedNullInt)}


### PR DESCRIPTION
## Description

For a VReplication workflow to start, it must be able to use at least one valid tablet type.

Today we allow a user to explicitly (I would assume accidentally) specify an empty string which passes our validation.

We instead should return an error in this case as I cannot think of a valid use case for doing so.

### Example

```
❯ vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer create --source-keyspace commerce --tables "customer,corder" --tablet-types=""
E1017 00:04:31.361147   46464 main.go:56] invalid tablet-types value, at least one valid tablet type must be specified
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/14293

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required