### PR TITLE
stats: export vttablet_tablet_type to prometheus

### DIFF
--- a/changelog/19.0/19.0.0/summary.md
+++ b/changelog/19.0/19.0.0/summary.md
@@ -6,6 +6,8 @@
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
   - **[Docker](#docker)**
     - [New MySQL Image](#mysql-image)
+  - **[New stats](#new-stats)**
+    - [VTTablet tablet type for Prometheus](#vttablet-tablet-type-for-prometheus)
 
 ## <a id="major-changes"/>Major Changes
 
@@ -21,3 +23,21 @@ In `v19.0` the Vitess team is shipping a new image: `vitess/mysql`.
 This lightweight image is a replacement of `vitess/lite` to only run `mysqld`.
 
 Several tags are available to let you choose what version of MySQL you want to use: `vitess/mysql:8.0.30`, `vitess/mysql:8.0.34`.
+
+### <a id="new-stats"/> New stats
+
+
+#### <a id="vttablet-tablet-type-for-prometheus"/> VTTablet tablet type for Prometheus
+
+VTTablet publishes the `TabletType` status which reports the current type of the tablet. For example, here's what it looks like in the local cluster example after setting up the initial cluster:
+
+```
+"TabletType": "primary"
+```
+
+Prior to v19, this data was not available via the Prometheus backend. In v19, this is also published as a Prometheus gauge with a `tablet_type` label and a value of `1.0`. For example:
+
+```
+$ curl -s localhost:15100/metrics | grep tablet_type{
+vttablet_tablet_type{tablet_type="primary"} 1
+```

--- a/go/stats/export_test.go
+++ b/go/stats/export_test.go
@@ -44,13 +44,13 @@ func TestNoHook(t *testing.T) {
 
 func TestString(t *testing.T) {
 	var gotname string
-	var gotv *String
+	var gotv *StringValue
 	clearStats()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
-		gotv = v.(*String)
+		gotv = v.(*StringValue)
 	})
-	v := NewString("String")
+	v := NewStringValue("String")
 	if gotname != "String" {
 		t.Errorf("want String, got %s", gotname)
 	}
@@ -188,4 +188,19 @@ func TestStringMapWithMultiLabels(t *testing.T) {
 	require.Equal(t, keyLabels[1], "bbb")
 
 	require.Equal(t, c.ValueLabel(), "ccc")
+}
+
+func TestStringValueWithLabel(t *testing.T) {
+	clearStats()
+	c := NewStringValueWithLabel("stringValue1", "help", "aaa", "ccc")
+
+	s := c.String()
+	require.Equal(t, "\"ccc\"", s)
+
+	label := c.Label()
+	require.Equal(t, "aaa", label)
+
+	c.Set("ddd")
+	s = c.String()
+	require.Equal(t, "\"ddd\"", s)
 }

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -87,7 +87,9 @@ func (be PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 		newHistogramCollector(st, be.buildPromName(name))
 	case *stats.StringMapFuncWithMultiLabels:
 		newStringMapFuncWithMultiLabelsCollector(st, be.buildPromName(name))
-	case *stats.String, stats.StringFunc, stats.StringMapFunc, *stats.Rates, *stats.RatesFunc:
+	case *stats.StringValueWithLabel:
+		newStringValueWithLabelCollector(st, be.buildPromName(name))
+	case *stats.StringValue, stats.StringFunc, stats.StringMapFunc, *stats.Rates, *stats.RatesFunc:
 		// Silently ignore these types since they don't make sense to
 		// export to Prometheus' data model.
 	default:

--- a/go/stats/prometheusbackend/prometheusbackend_test.go
+++ b/go/stats/prometheusbackend/prometheusbackend_test.go
@@ -258,6 +258,16 @@ func TestPrometheusStringMapFuncWithMultiLabels(t *testing.T) {
 	checkHandlerForMetricWithMultiLabels(t, name, allLabels, []string{"bar", "baz", "world"}, 1)
 }
 
+func TestPrometheusStringValueWithLabel(t *testing.T) {
+	name := "blah_stringvaluewithlabel"
+	label := "label"
+	value := "value"
+
+	stats.NewStringValueWithLabel(name, "help", label, value)
+
+	checkHandlerForMetricWithMultiLabels(t, name, []string{label}, []string{value}, 1)
+}
+
 func checkHandlerForMetricWithMultiLabels(t *testing.T, metric string, labels []string, labelValues []string, value int64) {
 	response := testMetricsHandler(t)
 

--- a/go/stats/statsd/statsd.go
+++ b/go/stats/statsd/statsd.go
@@ -202,7 +202,7 @@ func (sb StatsBackend) addExpVar(kv expvar.KeyValue) {
 				}
 			}
 		}
-	case *stats.String:
+	case *stats.StringValue:
 		if k == "BuildGitRev" {
 			buildGitRecOnce.Do(func() {
 				checksum := crc32.ChecksumIEEE([]byte(v.Get()))

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -54,5 +54,5 @@ func MaxMessageSize() int {
 }
 
 func init() {
-	stats.NewString("GrpcVersion").Set(grpc.Version)
+	stats.NewStringValue("GrpcVersion").Set(grpc.Version)
 }

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -118,15 +118,15 @@ func init() {
 		goArch:             runtime.GOARCH,
 		version:            versionName,
 	}
-	stats.NewString("BuildHost").Set(AppVersion.buildHost)
-	stats.NewString("BuildUser").Set(AppVersion.buildUser)
+	stats.NewStringValue("BuildHost").Set(AppVersion.buildHost)
+	stats.NewStringValue("BuildUser").Set(AppVersion.buildUser)
 	stats.NewGauge("BuildTimestamp", "build timestamp").Set(AppVersion.buildTime)
-	stats.NewString("BuildGitRev").Set(AppVersion.buildGitRev)
-	stats.NewString("BuildGitBranch").Set(AppVersion.buildGitBranch)
+	stats.NewStringValue("BuildGitRev").Set(AppVersion.buildGitRev)
+	stats.NewStringValue("BuildGitBranch").Set(AppVersion.buildGitBranch)
 	stats.NewGauge("BuildNumber", "build number").Set(AppVersion.jenkinsBuildNumber)
-	stats.NewString("GoVersion").Set(AppVersion.goVersion)
-	stats.NewString("GoOS").Set(AppVersion.goOS)
-	stats.NewString("GoArch").Set(AppVersion.goArch)
+	stats.NewStringValue("GoVersion").Set(AppVersion.goVersion)
+	stats.NewStringValue("GoOS").Set(AppVersion.goOS)
+	stats.NewStringValue("GoArch").Set(AppVersion.goArch)
 
 	buildLabels := []string{"BuildHost", "BuildUser", "BuildTimestamp", "BuildGitRev", "BuildGitBranch", "BuildNumber"}
 	buildValues := []string{

--- a/go/vt/servenv/exporter_test.go
+++ b/go/vt/servenv/exporter_test.go
@@ -624,7 +624,7 @@ func TestHistogram(t *testing.T) {
 
 func TestPublish(t *testing.T) {
 	ebd := NewExporter("", "")
-	s := stats.NewString("")
+	s := stats.NewStringValue("")
 	ebd.Publish("gpub", s)
 	s.Set("1")
 	assert.Equal(t, `"1"`, expvar.Get("gpub").String())

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -59,8 +59,8 @@ var (
 	restoreConcurrency     = 4
 	waitForBackupInterval  time.Duration
 
-	statsRestoreBackupTime     *stats.String
-	statsRestoreBackupPosition *stats.String
+	statsRestoreBackupTime     *stats.StringValue
+	statsRestoreBackupPosition *stats.StringValue
 )
 
 func registerRestoreFlags(fs *pflag.FlagSet) {
@@ -116,8 +116,8 @@ func init() {
 	servenv.OnParseFor("vtcombo", registerPointInTimeRestoreFlags)
 	servenv.OnParseFor("vttablet", registerPointInTimeRestoreFlags)
 
-	statsRestoreBackupTime = stats.NewString("RestoredBackupTime")
-	statsRestoreBackupPosition = stats.NewString("RestorePosition")
+	statsRestoreBackupTime = stats.NewStringValue("RestoredBackupTime")
+	statsRestoreBackupPosition = stats.NewStringValue("RestorePosition")
 }
 
 // RestoreData is the main entry point for backup restore.

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -103,7 +103,7 @@ func registerInitFlags(fs *pflag.FlagSet) {
 
 var (
 	// statsTabletType is set to expose the current tablet type.
-	statsTabletType *stats.String
+	statsTabletType *stats.StringValueWithLabel
 
 	// statsTabletTypeCount exposes the current tablet type as a label,
 	// with the value counting the occurrences of the respective tablet type.
@@ -116,11 +116,11 @@ var (
 	// statsIsInSrvKeyspace is set to 1 (true), 0 (false) whether the tablet is in the serving keyspace
 	statsIsInSrvKeyspace *stats.Gauge
 
-	statsKeyspace      = stats.NewString("TabletKeyspace")
-	statsShard         = stats.NewString("TabletShard")
-	statsKeyRangeStart = stats.NewString("TabletKeyRangeStart")
-	statsKeyRangeEnd   = stats.NewString("TabletKeyRangeEnd")
-	statsAlias         = stats.NewString("TabletAlias")
+	statsKeyspace      = stats.NewStringValue("TabletKeyspace")
+	statsShard         = stats.NewStringValue("TabletShard")
+	statsKeyRangeStart = stats.NewStringValue("TabletKeyRangeStart")
+	statsKeyRangeEnd   = stats.NewStringValue("TabletKeyRangeEnd")
+	statsAlias         = stats.NewStringValue("TabletAlias")
 
 	// The following variables can be changed to speed up tests.
 	mysqlPortRetryInterval       = 1 * time.Second
@@ -131,7 +131,7 @@ func init() {
 	servenv.OnParseFor("vtcombo", registerInitFlags)
 	servenv.OnParseFor("vttablet", registerInitFlags)
 
-	statsTabletType = stats.NewString("TabletType")
+	statsTabletType = stats.NewStringValueWithLabel("TabletType", "Current tablet type", "TabletType", "")
 	statsTabletTypeCount = stats.NewCountersWithSingleLabel("TabletTypeCount", "Number of times the tablet changed to the labeled type", "type")
 	statsBackupIsRunning = stats.NewGaugesWithMultiLabels("BackupIsRunning", "Whether a backup is running", []string{"mode"})
 	statsIsInSrvKeyspace = stats.NewGauge("IsInSrvKeyspace", "Whether the vttablet is in the serving keyspace (1 = true / 0 = false)")


### PR DESCRIPTION
## Description

This PR is very similar in spirit to https://github.com/vitessio/vitess/pull/12772.

We already have a `TabletType` string that is exported to Golang expvars. E.g. after `./examples/local/101_initial_cluster.sh`:

```
bash-5.2$ curl -s localhost:15100/debug/vars | jq -r '.TabletType'
primary
```

However, this is not exported to Prometheus. It's a pretty valuable thing to know for monitoring purposes, e.g. to detect and alert on conditions like "primary tablet is not serving".

This PR exposes the `vttablet_tablet_type` via `/metrics`, without changing the shape of the data currently exported via `/debug/vars`.

E.g., after `./examples/local/101_initial_cluster.sh`.

```
bash-5.2$ curl -s localhost:15100/metrics | grep tablet_type{
vttablet_tablet_type{tablet_type="primary"} 1
bash-5.2$ curl -s localhost:15101/metrics | grep tablet_type{
vttablet_tablet_type{tablet_type="replica"} 1
bash-5.2$ curl -s localhost:15102/metrics | grep tablet_type{
vttablet_tablet_type{tablet_type="rdonly"} 1
```

## Notes

**`tablet_type` label**

A note about the label name, `tablet_type`. There is another metric `vttablet_tablet_type_count` that has the label `type`, but there is another set of more recent metrics by @rafer https://github.com/vitessio/vitess/pull/13521 that have the label `tablet_type`. I had to pick one of these, so I went with the more recent one, which I happen to prefer, personally.

**The "right way"**

The "right way" to export Prometheus metrics is to define the time series at process start up, and then only change their value.

That means that this metric in its current form is using Prometheus the "wrong way" - a `ChangeTabletType` or reparent will change the value of the `tablet_type` label, which from Prometheus' point of view means that one time series has disappeared, and a new time series has suddenly appeared.

The current way should be somewhat usable, but will prevent Prometheus users from using the metric to its fullest.

Perhaps a better approach would be to define a new metric like `vttablet_tablet_types`, which is a map of tablet types to either 0 or 1. These time series would be registered at VTTablet startup, and then change during `ChangeTabletType` and reparents. I opted not to do this because it seemed like a bigger change, and would also emit a lot more metrics. But happy to change it if people prefer.

## Related Issue(s)

Fixes #14300

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
