### PR TITLE
evalengine: Use the right unknown type to initialize

### DIFF
--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -193,7 +193,7 @@ func (ast *astCompiler) translateBindVar(arg *sqlparser.Argument) (Expr, error) 
 }
 
 func (ast *astCompiler) translateColOffset(col *sqlparser.Offset) (Expr, error) {
-	var typ Type
+	typ := UnknownType()
 	if ast.cfg.ResolveType != nil {
 		typ, _ = ast.cfg.ResolveType(col.Original)
 	}
@@ -216,7 +216,7 @@ func (ast *astCompiler) translateColName(colname *sqlparser.ColName) (Expr, erro
 	if err != nil {
 		return nil, err
 	}
-	var typ Type
+	typ := UnknownType()
 	if ast.cfg.ResolveType != nil {
 		typ, _ = ast.cfg.ResolveType(colname)
 	}


### PR DESCRIPTION
We need to start off here with the unknown type, not the null type which is the default for `0`.

## Related Issue(s)

Broken in #14292 which is part of #14310

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required