### PR TITLE
Build and push Docker `vitess/vttestserver` DockerHub from GitHub Actions

### DIFF
--- a/.github/workflows/docker_build_vttestserver.yml
+++ b/.github/workflows/docker_build_vttestserver.yml
@@ -1,0 +1,66 @@
+name: Docker Build VtTestServer
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Docker Build VtTestServer')
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  build_and_push:
+    name: Build and push vitess/vttestserver Docker images
+    runs-on: ubuntu-latest
+#    runs-on: gh-hosted-runners-16cores-1
+#    if: github.repository == 'vitessio/vitess'
+
+    strategy:
+      fail-fast: true
+      matrix:
+        branch: [ mysql57, mysql80 ]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Dockerfile path
+        run: |
+          echo "DOCKERFILE=./docker/vttestserver/Dockerfile.${{ matrix.branch }}" >> $GITHUB_ENV
+
+      - name: Build and push on main
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          tags: frouioui/vttestserver:${{ matrix.branch }}
+
+      - name: Get the Git tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Set Docker tag name
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "DOCKER_TAG=frouioui/vttestserver:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
+
+      - name: Build and push on tags
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          tags: ${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker_build_vttestserver.yml
+++ b/.github/workflows/docker_build_vttestserver.yml
@@ -1,4 +1,4 @@
-name: Docker Build VtTestServer
+name: Docker Build vttestserver
 on:
   push:
     branches:
@@ -7,7 +7,7 @@ on:
       - '*'
 
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Docker Build VtTestServer')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Docker Build vttestserver')
   cancel-in-progress: true
 
 permissions: read-all
@@ -15,9 +15,8 @@ permissions: read-all
 jobs:
   build_and_push:
     name: Build and push vitess/vttestserver Docker images
-    runs-on: ubuntu-latest
-#    runs-on: gh-hosted-runners-16cores-1
-#    if: github.repository == 'vitessio/vitess'
+    runs-on: gh-hosted-runners-16cores-1
+    if: github.repository == 'vitessio/vitess'
 
     strategy:
       fail-fast: true
@@ -45,7 +44,7 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE }}
           push: true
-          tags: frouioui/vttestserver:${{ matrix.branch }}
+          tags: vitess/vttestserver:${{ matrix.branch }}
 
       - name: Get the Git tag
         if: startsWith(github.ref, 'refs/tags/')
@@ -54,7 +53,7 @@ jobs:
       - name: Set Docker tag name
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          echo "DOCKER_TAG=frouioui/vttestserver:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
+          echo "DOCKER_TAG=vitess/vttestserver:${TAG_NAME}-${{ matrix.branch }}" >> $GITHUB_ENV
 
       - name: Build and push on tags
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Description

This PR adds `vitess/vttestserver` to the list of images that are going to be built by GitHub Actions rather than by DockerHub.

Example runs of this workflow are available on my fork:
- [Run on `main`](https://github.com/frouioui/vitess/actions/runs/6578452550)
  - [`mysql80` tag on DockerHub](https://hub.docker.com/layers/frouioui/vttestserver/mysql80/images/sha256-7254937730f28a9ebf0d47048bf5fa99070b0699df33d9284d908c36b1329bab?context=repo)
  - [`mysql57` tag on DockerHub](https://hub.docker.com/layers/frouioui/vttestserver/mysql57/images/sha256-178310ca93e3bcb20be204b12451057d4219737187bd995a5be99291e6cf641e?context=repo)
- [Run on a tag](https://github.com/frouioui/vitess/actions/runs/6578645485)
  - [`v99.99.9-mysql57` tag on DockerHub](https://hub.docker.com/layers/frouioui/vttestserver/v99.99.9-mysql57/images/sha256-61c14f8a77b60483bf96f865d26f3f6e3dbb6a744b3e963893e0b9f6fc9375f6?context=repo)
  - [`v99.99.9-mysql80` tag on DockerHub](https://hub.docker.com/layers/frouioui/vttestserver/v99.99.9-mysql80/images/sha256-3672d840daaf91b572586e50bc4a456a84fd18facbf1defbfe58822c9f2f3a27?context=repo)

## Related Issue(s)

- Part #14149 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
