### PR TITLE
Online DDL: support DROP FOREIGN KEY statement

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -2122,6 +2122,12 @@ func testForeignKeys(t *testing.T) {
 			allowForeignKeys: true,
 			expectHint:       "new_fk",
 		},
+		{
+			name:             "drop foreign key from a child",
+			sql:              "alter table child_table DROP FOREIGN KEY child_parent_fk",
+			allowForeignKeys: true,
+			expectHint:       "child_hint",
+		},
 	}
 
 	createParams := func(ddlStatement string, ddlStrategy string, executeStrategy string, expectHint string, expectError string, skipWait bool) *testOnlineDDLStatementParams {

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1195,8 +1195,8 @@ func (e *Executor) validateAndEditAlterTableStatement(ctx context.Context, onlin
 	validateWalk := func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		switch node := node.(type) {
 		case *sqlparser.DropKey:
-			if node.Type == sqlparser.CheckKeyType {
-				// drop a check constraint
+			if node.Type == sqlparser.CheckKeyType || node.Type == sqlparser.ForeignKeyType {
+				// drop a check or a foreign key constraint
 				mappedName, ok := constraintMap[node.Name.String()]
 				if !ok {
 					return false, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Found DROP CONSTRAINT: %v, but could not find constraint name in map", sqlparser.CanonicalString(node))

--- a/go/vt/vttablet/onlineddl/executor_test.go
+++ b/go/vt/vttablet/onlineddl/executor_test.go
@@ -158,6 +158,7 @@ func TestValidateAndEditAlterTableStatement(t *testing.T) {
 	e := Executor{}
 	tt := []struct {
 		alter  string
+		m      map[string]string
 		expect []string
 	}{
 		{
@@ -208,6 +209,13 @@ func TestValidateAndEditAlterTableStatement(t *testing.T) {
 			alter:  "alter table t add constraint t_fk_1 foreign key (parent_id) references onlineddl_test_parent (id) on delete no action, add constraint some_check check (id != 1)",
 			expect: []string{"alter table t add constraint fk_1_6fmhzdlya89128u5j3xapq34i foreign key (parent_id) references onlineddl_test_parent (id) on delete no action, add constraint some_check_aulpn7bjeortljhguy86phdn9 check (id != 1), algorithm = copy"},
 		},
+		{
+			alter: "alter table t drop foreign key t_fk_1",
+			m: map[string]string{
+				"t_fk_1": "fk_1_aaaaaaaaaaaaaa",
+			},
+			expect: []string{"alter table t drop foreign key fk_1_aaaaaaaaaaaaaa, algorithm = copy"},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.alter, func(t *testing.T) {
@@ -217,6 +225,9 @@ func TestValidateAndEditAlterTableStatement(t *testing.T) {
 			require.True(t, ok)
 
 			m := map[string]string{}
+			for k, v := range tc.m {
+				m[k] = v
+			}
 			onlineDDL := &schema.OnlineDDL{UUID: "a5a563da_dc1a_11ec_a416_0a43f95f28a3", Table: "t", Options: "--unsafe-allow-foreign-keys"}
 			alters, err := e.validateAndEditAlterTableStatement(context.Background(), onlineDDL, alterTable, m)
 			assert.NoError(t, err)


### PR DESCRIPTION

## Description

For the ongoing, experimental foreign key support, this PR adds support for `ALTER TABLE ... DROP FOREIGN KEY`. As you might see from the change, there's very little to this PR; all the support has been created long ago, but due to an oversight we did not include `DROP FOREIGN KEY` in the logic.

Just to explain the change: in Online DDL we actually drop the foreign key on the shadow table. Since foreign key constraints, like check constraints, have schema-level naming scope, the shadow table's foreign key constraint is different than the original's.

Without this PR, a `ALTER TABLE t DROP FOREIGN KEY t_id_fk` fails because it attempts to drop the constraint `t_id_fk` from the shadow tables. But on the shadow table the constraint might be named e.g. `fk_aulpn7bjeortljhguy86phdn9`. The fix in this PR is to use the constraint mapping between original and shadow table.

## Related Issue(s)

Tracking: https://github.com/vitessio/vitess/issues/11975


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
