### PR TITLE
Fix stray vtadmin package-lock.json content

### DIFF
--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -10531,11 +10531,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/npm/node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "dev": true,
@@ -10762,18 +10757,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
@@ -11717,11 +11700,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/npm/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
@@ -25001,10 +24979,6 @@
           "dev": true,
           "optional": true
         },
-        "@gar/promisify": {
-          "version": "1.1.3",
-          "dev": true
-        },
         "@isaacs/cliui": {
           "version": "8.0.2",
           "bundled": true,
@@ -25168,14 +25142,6 @@
             "json-parse-even-better-errors": "^3.0.0",
             "pacote": "^15.0.0",
             "semver": "^7.3.5"
-          }
-        },
-        "@npmcli/move-file": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "mkdirp": "^1.0.4",
-            "rimraf": "^3.0.2"
           }
         },
         "@npmcli/name-from-folder": {
@@ -25781,10 +25747,6 @@
         "indent-string": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "infer-owner": {
-          "version": "1.0.4",
           "dev": true
         },
         "inflight": {


### PR DESCRIPTION
No idea how this passed CI before, but it seems stuff is broken atm and showing a diff. This fixes that diff.

## Related Issue(s)

Broken in #14336

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required