### PR TITLE
Automatic approval of `vitess-bot` clean backports

### DIFF
--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Approve Pull Request
-        if: ${{ github.event.pull_request.user.login == 'vitess-bot[bot]' }} && ${{ github.event.pull_request.draft == 'false' }}
+        if: github.event.pull_request.user.login == 'vitess-bot[bot]' && github.event.pull_request.draft == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -1,0 +1,19 @@
+name: Auto Approval of Bot Pull Requests
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  auto_approve:
+    name: Approve Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Approve Pull Request
+        if: ${{ github.event.pull_request.user.login == 'vitess-bot[bot]' }} && ${{ github.event.pull_request.draft == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} --approve

--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -15,6 +15,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ "${{github.event.pull_request.user.login}}" ==  "bot-vitess[bot]" ]] && [[ "${{github.event.pull_request.draft}}" == "false" ]]; then
+          if [[ "${{github.event.pull_request.user.login}}" ==  "vitess-bot[bot]" ]] && [[ "${{github.event.pull_request.draft}}" == "false" ]]; then
             gh pr review ${{ github.event.pull_request.number }} --approve
           fi

--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -5,16 +5,19 @@ on:
 
 jobs:
   auto_approve:
-    name: Approve Pull Request
+    name: Auto Approve Pull Request
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Approve Pull Request
+      - name: Auto Approve Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # here we are checking that the PR has been created by the vitess-bot[bot] account and that it is not a draft
+          # if there is a merge conflict in the backport, the PR will always be created as a draft, meaning we can rely
+          # on checking whether or not the PR is a draft
           if [[ "${{github.event.pull_request.user.login}}" ==  "vitess-bot[bot]" ]] && [[ "${{github.event.pull_request.draft}}" == "false" ]]; then
             gh pr review ${{ github.event.pull_request.number }} --approve
           fi

--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Approve Pull Request
-        if: github.event.pull_request.user.login == 'vitess-bot[bot]' && github.event.pull_request.draft == 'false'
+        if: github.event.pull_request.user.login == 'bot-vitess[bot]' && github.event.pull_request.draft == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -12,8 +12,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Approve Pull Request
-        if: github.event.pull_request.user.login == 'bot-vitess[bot]' && github.event.pull_request.draft == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr review ${{ github.event.pull_request.number }} --approve
+          if [[ "${{github.event.pull_request.user.login}}" ==  "bot-vitess[bot]" ]] && [[ "${{github.event.pull_request.draft}}" == "false" ]]; then
+            gh pr review ${{ github.event.pull_request.number }} --approve
+          fi


### PR DESCRIPTION
## Description

This PR adds a workflow to auto-approve clean backports made by the `vitess-bot`. GitHub Actions will now give one of the two required approvals for backports. Meaning that we will still need at least one manual approval + a manual intervention to hit the merge button of the backport.

Examples:
- Auto approval of a clean backport: https://github.com/frouioui/vitess/pull/107
- No approval on a backport with merge conflicts: https://github.com/frouioui/vitess/pull/109 with its `Auto Approval` workflow being skipped: https://github.com/frouioui/vitess/actions/runs/6631335864?pr=109

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
