### PR TITLE
datetime: obey the evalengine's environment time

### DIFF
--- a/go/mysql/datetime/datetime.go
+++ b/go/mysql/datetime/datetime.go
@@ -94,8 +94,8 @@ func (t Time) FormatDecimal() decimal.Decimal {
 	return dec
 }
 
-func (t Time) ToDateTime() (out DateTime) {
-	return NewDateTimeFromStd(t.ToStdTime(time.Local))
+func (t Time) ToDateTime(now time.Time) (out DateTime) {
+	return NewDateTimeFromStd(t.ToStdTime(now))
 }
 
 func (t Time) IsZero() bool {
@@ -421,9 +421,9 @@ func (t Time) toStdTime(year int, month time.Month, day int, loc *time.Location)
 	return time.Date(year, month, day, hours, minutes, secs, nsecs, loc)
 }
 
-func (t Time) ToStdTime(loc *time.Location) (out time.Time) {
-	year, month, day := time.Now().Date()
-	return t.toStdTime(year, month, day, loc)
+func (t Time) ToStdTime(now time.Time) (out time.Time) {
+	year, month, day := now.Date()
+	return t.toStdTime(year, month, day, now.Location())
 }
 
 func (t Time) AddInterval(itv *Interval, stradd bool) (Time, uint8, bool) {
@@ -444,7 +444,7 @@ func (d Date) ToStdTime(loc *time.Location) (out time.Time) {
 	return time.Date(d.Year(), time.Month(d.Month()), d.Day(), 0, 0, 0, 0, loc)
 }
 
-func (dt DateTime) ToStdTime(loc *time.Location) time.Time {
+func (dt DateTime) ToStdTime(now time.Time) time.Time {
 	zerodate := dt.Date.IsZero()
 	zerotime := dt.Time.IsZero()
 
@@ -452,12 +452,12 @@ func (dt DateTime) ToStdTime(loc *time.Location) time.Time {
 	case zerodate && zerotime:
 		return time.Time{}
 	case zerodate:
-		return dt.Time.ToStdTime(loc)
+		return dt.Time.ToStdTime(now)
 	case zerotime:
-		return dt.Date.ToStdTime(loc)
+		return dt.Date.ToStdTime(now.Location())
 	default:
 		year, month, day := dt.Date.Year(), time.Month(dt.Date.Month()), dt.Date.Day()
-		return dt.Time.toStdTime(year, month, day, loc)
+		return dt.Time.toStdTime(year, month, day, now.Location())
 	}
 }
 
@@ -527,7 +527,10 @@ func (dt DateTime) Compare(dt2 DateTime) int {
 		// if we're comparing a time to a datetime, we need to normalize them
 		// both into datetimes; this normalization is not trivial because negative
 		// times result in a date change, so let the standard library handle this
-		return dt.ToStdTime(time.Local).Compare(dt2.ToStdTime(time.Local))
+
+		// Using the current time is OK here since the comparison is relative
+		now := time.Now()
+		return dt.ToStdTime(now).Compare(dt2.ToStdTime(now))
 	}
 	if cmp := dt.Date.Compare(dt2.Date); cmp != 0 {
 		return cmp
@@ -559,9 +562,10 @@ func (dt DateTime) Round(p int) (r DateTime) {
 	r = dt
 	if n == 1e9 {
 		r.Time.nanosecond = 0
-		return NewDateTimeFromStd(r.ToStdTime(time.Local).Add(time.Second))
+		r.addInterval(&Interval{timeparts: timeparts{sec: 1}, unit: IntervalSecond})
+	} else {
+		r.Time.nanosecond = uint32(n)
 	}
-	r.Time.nanosecond = uint32(n)
 	return r
 }
 

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -678,7 +678,7 @@ func (v *Value) MarshalDate() string {
 
 func (v *Value) MarshalDateTime() string {
 	if dt, ok := v.DateTime(); ok {
-		return dt.ToStdTime(time.Local).Format("2006-01-02 15:04:05.000000")
+		return dt.ToStdTime(time.Now()).Format("2006-01-02 15:04:05.000000")
 	}
 	return ""
 }

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -529,12 +529,12 @@ func (asm *assembler) CmpCase(cases int, hasElse bool, tt sqltypes.Type, cc coll
 		end := env.vm.sp - elseOffset
 		for sp := env.vm.sp - stackDepth; sp < end; sp += 2 {
 			if env.vm.stack[sp].(*evalInt64).i != 0 {
-				env.vm.stack[env.vm.sp-stackDepth], env.vm.err = evalCoerce(env.vm.stack[sp+1], tt, cc.Collation)
+				env.vm.stack[env.vm.sp-stackDepth], env.vm.err = evalCoerce(env.vm.stack[sp+1], tt, cc.Collation, env.now)
 				goto done
 			}
 		}
 		if elseOffset != 0 {
-			env.vm.stack[env.vm.sp-stackDepth], env.vm.err = evalCoerce(env.vm.stack[env.vm.sp-1], tt, cc.Collation)
+			env.vm.stack[env.vm.sp-stackDepth], env.vm.err = evalCoerce(env.vm.stack[env.vm.sp-1], tt, cc.Collation, env.now)
 		} else {
 			env.vm.stack[env.vm.sp-stackDepth] = nil
 		}
@@ -1110,7 +1110,7 @@ func (asm *assembler) Convert_xD(offset int) {
 		// Need to explicitly check here or we otherwise
 		// store a nil wrapper in an interface vs. a direct
 		// nil.
-		d := evalToDate(env.vm.stack[env.vm.sp-offset])
+		d := evalToDate(env.vm.stack[env.vm.sp-offset], env.now)
 		if d == nil {
 			env.vm.stack[env.vm.sp-offset] = nil
 		} else {
@@ -1125,7 +1125,7 @@ func (asm *assembler) Convert_xD_nz(offset int) {
 		// Need to explicitly check here or we otherwise
 		// store a nil wrapper in an interface vs. a direct
 		// nil.
-		d := evalToDate(env.vm.stack[env.vm.sp-offset])
+		d := evalToDate(env.vm.stack[env.vm.sp-offset], env.now)
 		if d == nil || d.isZero() {
 			env.vm.stack[env.vm.sp-offset] = nil
 		} else {
@@ -1140,7 +1140,7 @@ func (asm *assembler) Convert_xDT(offset, prec int) {
 		// Need to explicitly check here or we otherwise
 		// store a nil wrapper in an interface vs. a direct
 		// nil.
-		dt := evalToDateTime(env.vm.stack[env.vm.sp-offset], prec)
+		dt := evalToDateTime(env.vm.stack[env.vm.sp-offset], prec, env.now)
 		if dt == nil {
 			env.vm.stack[env.vm.sp-offset] = nil
 		} else {
@@ -1155,7 +1155,7 @@ func (asm *assembler) Convert_xDT_nz(offset, prec int) {
 		// Need to explicitly check here or we otherwise
 		// store a nil wrapper in an interface vs. a direct
 		// nil.
-		dt := evalToDateTime(env.vm.stack[env.vm.sp-offset], prec)
+		dt := evalToDateTime(env.vm.stack[env.vm.sp-offset], prec, env.now)
 		if dt == nil || dt.isZero() {
 			env.vm.stack[env.vm.sp-offset] = nil
 		} else {
@@ -4252,7 +4252,7 @@ func (asm *assembler) Fn_DATEADD_D(unit datetime.IntervalType, sub bool) {
 		}
 
 		tmp := env.vm.stack[env.vm.sp-2].(*evalTemporal)
-		env.vm.stack[env.vm.sp-2] = tmp.addInterval(interval, collations.TypedCollation{})
+		env.vm.stack[env.vm.sp-2] = tmp.addInterval(interval, collations.TypedCollation{}, env.now)
 		env.vm.sp--
 		return 1
 	}, "FN DATEADD TEMPORAL(SP-2), INTERVAL(SP-1)")
@@ -4274,7 +4274,7 @@ func (asm *assembler) Fn_DATEADD_s(unit datetime.IntervalType, sub bool, col col
 			goto baddate
 		}
 
-		env.vm.stack[env.vm.sp-2] = tmp.addInterval(interval, col)
+		env.vm.stack[env.vm.sp-2] = tmp.addInterval(interval, col, env.now)
 		env.vm.sp--
 		return 1
 

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -457,6 +457,8 @@ func TestCompilerSingle(t *testing.T) {
 		},
 	}
 
+	tz, _ := time.LoadLocation("Europe/Madrid")
+
 	for _, tc := range testCases {
 		t.Run(tc.expression, func(t *testing.T) {
 			expr, err := sqlparser.ParseExpr(tc.expression)
@@ -478,6 +480,7 @@ func TestCompilerSingle(t *testing.T) {
 			}
 
 			env := evalengine.EmptyExpressionEnv()
+			env.SetTime(time.Date(2023, 10, 24, 12, 0, 0, 0, tz))
 			env.Row = tc.values
 
 			expected, err := env.Evaluate(evalengine.Deoptimize(converted))

--- a/go/vt/vtgate/evalengine/eval.go
+++ b/go/vt/vtgate/evalengine/eval.go
@@ -18,6 +18,7 @@ package evalengine
 
 import (
 	"strconv"
+	"time"
 	"unicode/utf8"
 
 	"vitess.io/vitess/go/hack"
@@ -167,7 +168,7 @@ func evalIsTruthy(e eval) boolean {
 	}
 }
 
-func evalCoerce(e eval, typ sqltypes.Type, col collations.ID) (eval, error) {
+func evalCoerce(e eval, typ sqltypes.Type, col collations.ID, now time.Time) (eval, error) {
 	if e == nil {
 		return nil, nil
 	}
@@ -199,9 +200,9 @@ func evalCoerce(e eval, typ sqltypes.Type, col collations.ID) (eval, error) {
 	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint32, sqltypes.Uint64:
 		return evalToInt64(e).toUint64(), nil
 	case sqltypes.Date:
-		return evalToDate(e), nil
+		return evalToDate(e, now), nil
 	case sqltypes.Datetime, sqltypes.Timestamp:
-		return evalToDateTime(e, -1), nil
+		return evalToDateTime(e, -1, now), nil
 	case sqltypes.Time:
 		return evalToTime(e, -1), nil
 	default:
@@ -329,7 +330,7 @@ func valueToEvalCast(v sqltypes.Value, typ sqltypes.Type, collation collations.I
 			return nil, err
 		}
 		// Separate return here to avoid nil wrapped in interface type
-		d := evalToDate(e)
+		d := evalToDate(e, time.Now())
 		if d == nil {
 			return nil, nil
 		}
@@ -340,7 +341,7 @@ func valueToEvalCast(v sqltypes.Value, typ sqltypes.Type, collation collations.I
 			return nil, err
 		}
 		// Separate return here to avoid nil wrapped in interface type
-		dt := evalToDateTime(e, -1)
+		dt := evalToDateTime(e, -1, time.Now())
 		if dt == nil {
 			return nil, nil
 		}

--- a/go/vt/vtgate/evalengine/expr_convert.go
+++ b/go/vt/vtgate/evalengine/expr_convert.go
@@ -125,12 +125,12 @@ func (c *ConvertExpr) eval(env *ExpressionEnv) (eval, error) {
 		case p > 6:
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Too-big precision %d specified for 'CONVERT'. Maximum is 6.", p)
 		}
-		if dt := evalToDateTime(e, c.Length); dt != nil {
+		if dt := evalToDateTime(e, c.Length, env.now); dt != nil {
 			return dt, nil
 		}
 		return nil, nil
 	case "DATE":
-		if d := evalToDate(e); d != nil {
+		if d := evalToDate(e, env.now); d != nil {
 			return d, nil
 		}
 		return nil, nil

--- a/go/vt/vtgate/evalengine/expr_logical.go
+++ b/go/vt/vtgate/evalengine/expr_logical.go
@@ -520,7 +520,7 @@ func (c *CaseExpr) eval(env *ExpressionEnv) (eval, error) {
 		return nil, nil
 	}
 	t, _ := c.typeof(env, nil)
-	return evalCoerce(result, t, ca.result().Collation)
+	return evalCoerce(result, t, ca.result().Collation, env.now)
 }
 
 func (c *CaseExpr) typeof(env *ExpressionEnv, fields []*querypb.Field) (sqltypes.Type, typeFlag) {

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -352,7 +352,7 @@ func compareResult(local, remote Result, cmp *testcases.Comparison) error {
 		remoteCollationName = env.LookupName(coll)
 	}
 
-	equals, err := cmp.Equals(local.Value, remote.Value)
+	equals, err := cmp.Equals(local.Value, remote.Value, time.Now())
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtgate/evalengine/testcases/helpers.go
+++ b/go/vt/vtgate/evalengine/testcases/helpers.go
@@ -164,7 +164,7 @@ func (cmp *Comparison) closeFloat(a, b float64) bool {
 	return math.Abs((a-b)/b) < tolerance
 }
 
-func (cmp *Comparison) Equals(local, remote sqltypes.Value) (bool, error) {
+func (cmp *Comparison) Equals(local, remote sqltypes.Value, now time.Time) (bool, error) {
 	switch {
 	case local.IsFloat() && remote.IsFloat():
 		localFloat, err := local.ToFloat64()
@@ -185,7 +185,7 @@ func (cmp *Comparison) Equals(local, remote sqltypes.Value) (bool, error) {
 		if !ok {
 			return false, fmt.Errorf("error converting remote value '%s' to datetime", remote)
 		}
-		return cmp.closeDatetime(localDatetime.ToStdTime(time.Local), remoteDatetime.ToStdTime(time.Local), 1*time.Second), nil
+		return cmp.closeDatetime(localDatetime.ToStdTime(now), remoteDatetime.ToStdTime(now), 1*time.Second), nil
 	case cmp.LooseTime && local.IsTime() && remote.IsTime():
 		localTime, _, ok := datetime.ParseTime(local.ToString(), -1)
 		if !ok {
@@ -195,7 +195,7 @@ func (cmp *Comparison) Equals(local, remote sqltypes.Value) (bool, error) {
 		if !ok {
 			return false, fmt.Errorf("error converting remote value '%s' to time", remote)
 		}
-		return cmp.closeDatetime(localTime.ToStdTime(time.Local), remoteTime.ToStdTime(time.Local), 1*time.Second), nil
+		return cmp.closeDatetime(localTime.ToStdTime(now), remoteTime.ToStdTime(now), 1*time.Second), nil
 	default:
 		return local.String() == remote.String(), nil
 	}


### PR DESCRIPTION
## Description

The evaluation environment in the `evalengine` sets a frozen `time.Time` value upon creation, to ensure that all time-related APIs in the engine are evaluated consistently, following MySQL's behavior.

However, there are APIs in the `datetime` package that call `time.Now()` directly, particularly when converting from a time value to a datetime value. This is not correct! These APIs must use the frozen time set in the `evalengine`. This PR updates the APIs to take a time input when necessary.

cc @dbussink 

## Related Issue(s)

Found when working on #14310, follow up to #14351 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
