### PR TITLE
Vtctld SwitchReads: fix bug where writes were also being switched as part of switching reads when all traffic was switched using SwitchTraffic

### DIFF
--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2940,17 +2940,18 @@ func (s *Server) WorkflowSwitchTraffic(ctx context.Context, req *vtctldatapb.Wor
 
 // switchReads is a generic way of switching read traffic for a workflow.
 func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitchTrafficRequest, ts *trafficSwitcher, state *State, timeout time.Duration, cancel bool, direction TrafficSwitchDirection) (*[]string, error) {
-	var tabletTypes []topodatapb.TabletType
-	// when we are switching all traffic we also get the primary tablet type, which we need to filter out for switching reads
+	var roTabletTypes []topodatapb.TabletType
+	// When we are switching all traffic we also get the primary tablet type, which we need to
+	// filter out for switching reads.
 	for _, tabletType := range req.TabletTypes {
 		if tabletType != topodatapb.TabletType_PRIMARY {
-			tabletTypes = append(tabletTypes, tabletType)
+			roTabletTypes = append(roTabletTypes, tabletType)
 		}
 	}
 
-	roTypesToSwitchStr := topoproto.MakeStringTypeCSV(tabletTypes)
+	roTypesToSwitchStr := topoproto.MakeStringTypeCSV(roTabletTypes)
 	var switchReplica, switchRdonly bool
-	for _, roType := range tabletTypes {
+	for _, roType := range roTabletTypes {
 		switch roType {
 		case topodatapb.TabletType_REPLICA:
 			switchReplica = true
@@ -2961,14 +2962,13 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 
 	// Consistently handle errors by logging and returning them.
 	handleError := func(message string, err error) (*[]string, error) {
-		werr := vterrors.Errorf(vtrpcpb.Code_INTERNAL, fmt.Sprintf("%s: %v", message, err))
-		ts.Logger().Error(werr)
-		return nil, werr
+		ts.Logger().Error(err)
+		return nil, err
 	}
 
 	log.Infof("Switching reads: %s.%s tablet types: %s, cells: %s, workflow state: %s", ts.targetKeyspace, ts.workflow, roTypesToSwitchStr, ts.optCells, state.String())
 	if !switchReplica && !switchRdonly {
-		return handleError("invalid tablet types", vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "tablet types must be REPLICA or RDONLY: %s", roTypesToSwitchStr))
+		return handleError("invalid tablet types", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "tablet types must be REPLICA or RDONLY: %s", roTypesToSwitchStr))
 	}
 	if !ts.isPartialMigration { // shard level traffic switching is all or nothing
 		if direction == DirectionBackward && switchReplica && len(state.ReplicaCellsSwitched) == 0 {
@@ -2995,7 +2995,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 			return nil, err
 		}
 		if !rdonlyTabletsExist {
-			tabletTypes = append(tabletTypes, topodatapb.TabletType_RDONLY)
+			roTabletTypes = append(roTabletTypes, topodatapb.TabletType_RDONLY)
 		}
 	}
 
@@ -3028,13 +3028,13 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 	if ts.MigrationType() == binlogdatapb.MigrationType_TABLES {
 		if ts.isPartialMigration {
 			ts.Logger().Infof("Partial migration, skipping switchTableReads as traffic is all or nothing per shard and overridden for reads AND writes in the ShardRoutingRule created when switching writes.")
-		} else if err := sw.switchTableReads(ctx, cells, tabletTypes, direction); err != nil {
+		} else if err := sw.switchTableReads(ctx, cells, roTabletTypes, direction); err != nil {
 			return handleError("failed to switch read traffic for the tables", err)
 		}
 		return sw.logs(), nil
 	}
 	ts.Logger().Infof("About to switchShardReads: %+v, %+s, %+v", cells, roTypesToSwitchStr, direction)
-	if err := sw.switchShardReads(ctx, cells, tabletTypes, direction); err != nil {
+	if err := sw.switchShardReads(ctx, cells, roTabletTypes, direction); err != nil {
 		return handleError("failed to switch read traffic for the shards", err)
 	}
 

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -587,6 +587,10 @@ func (ts *trafficSwitcher) switchTableReads(ctx context.Context, cells []string,
 	// For forward migration, we add tablet type specific rules to redirect traffic to the target.
 	// For backward, we redirect to source.
 	for _, servedType := range servedTypes {
+		if servedType != topodatapb.TabletType_REPLICA && servedType != topodatapb.TabletType_RDONLY {
+			return fmt.Errorf("invalid tablet type specified for switchTableReads: %v", servedType)
+		}
+
 		tt := strings.ToLower(servedType.String())
 		for _, table := range ts.Tables() {
 			if direction == DirectionForward {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -588,7 +588,7 @@ func (ts *trafficSwitcher) switchTableReads(ctx context.Context, cells []string,
 	// For backward, we redirect to source.
 	for _, servedType := range servedTypes {
 		if servedType != topodatapb.TabletType_REPLICA && servedType != topodatapb.TabletType_RDONLY {
-			return fmt.Errorf("invalid tablet type specified for switchTableReads: %v", servedType)
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid tablet type specified when switching reads: %v", servedType)
 		}
 
 		tt := strings.ToLower(servedType.String())


### PR DESCRIPTION
## Description

While porting over the switchReads() code to vtctldclient, the code was incorrectly using the tablet types passed in the command request while updating routing rules. When all trafffic is switched, the list of tablet types includes primary tablets as well. This caused writes to be switched to the target even before the switchWrites() code was called.

This was caught in https://github.com/vitessio/vitess/issues/13954, because vdiff alerted about mismatches in the reverse replication workflow. The reason other e2e tests have not caught it is that, the new one has a load generator script that runs concurrently to the vtctld call which switches writes. 


## Related Issue(s)

https://github.com/vitessio/vitess/issues/12152

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
