### PR TITLE
Online DDL: lint DDL strategy flags

### DIFF
--- a/go/vt/schema/ddl_strategy.go
+++ b/go/vt/schema/ddl_strategy.go
@@ -118,7 +118,7 @@ func ParseDDLStrategy(strategyVariable string) (*DDLStrategySetting, error) {
 	}
 
 	switch setting.Strategy {
-	case DDLStrategyVitess, DDLStrategyOnline:
+	case DDLStrategyVitess, DDLStrategyOnline, DDLStrategyMySQL, DDLStrategyDirect:
 		if opts := setting.RuntimeOptions(); len(opts) > 0 {
 			return nil, fmt.Errorf("invalid flags for vitess strategy: %s", strings.Join(opts, " "))
 		}

--- a/go/vt/schema/ddl_strategy.go
+++ b/go/vt/schema/ddl_strategy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/shlex"
@@ -115,6 +116,14 @@ func ParseDDLStrategy(strategyVariable string) (*DDLStrategySetting, error) {
 	if _, err := setting.RetainArtifactsDuration(); err != nil {
 		return nil, err
 	}
+
+	switch setting.Strategy {
+	case DDLStrategyVitess, DDLStrategyOnline:
+		if opts := setting.RuntimeOptions(); len(opts) > 0 {
+			return nil, fmt.Errorf("invalid flags for vitess strategy: %s", strings.Join(opts, " "))
+		}
+	}
+
 	return setting, nil
 }
 

--- a/go/vt/schema/ddl_strategy_test.go
+++ b/go/vt/schema/ddl_strategy_test.go
@@ -41,19 +41,23 @@ func TestIsDirect(t *testing.T) {
 
 func TestIsCutOverThresholdFlag(t *testing.T) {
 	tt := []struct {
-		s      string
-		expect bool
-		val    string
-		d      time.Duration
+		s           string
+		expect      bool
+		expectError string
+		val         string
+		d           time.Duration
 	}{
 		{
-			s: "something",
+			s:           "something",
+			expectError: "invalid flags",
 		},
 		{
-			s: "-cut-over-threshold",
+			s:           "-cut-over-threshold",
+			expectError: "invalid flags",
 		},
 		{
-			s: "--cut-over-threshold",
+			s:           "--cut-over-threshold",
+			expectError: "invalid flags",
 		},
 		{
 			s:      "--cut-over-threshold=",
@@ -87,6 +91,11 @@ func TestIsCutOverThresholdFlag(t *testing.T) {
 	for _, ts := range tt {
 		t.Run(ts.s, func(t *testing.T) {
 			setting, err := ParseDDLStrategy("online " + ts.s)
+			if ts.expectError != "" {
+				assert.ErrorContains(t, err, ts.expectError)
+				return
+			}
+
 			assert.NoError(t, err)
 
 			val, isCutOver := isCutOverThresholdFlag(ts.s)
@@ -104,19 +113,23 @@ func TestIsCutOverThresholdFlag(t *testing.T) {
 
 func TestIsExpireArtifactsFlag(t *testing.T) {
 	tt := []struct {
-		s      string
-		expect bool
-		val    string
-		d      time.Duration
+		s           string
+		expect      bool
+		expectError string
+		val         string
+		d           time.Duration
 	}{
 		{
-			s: "something",
+			s:           "something",
+			expectError: "invalid flags",
 		},
 		{
-			s: "-retain-artifacts",
+			s:           "-retain-artifacts",
+			expectError: "invalid flags",
 		},
 		{
-			s: "--retain-artifacts",
+			s:           "--retain-artifacts",
+			expectError: "invalid flags",
 		},
 		{
 			s:      "--retain-artifacts=",
@@ -150,6 +163,10 @@ func TestIsExpireArtifactsFlag(t *testing.T) {
 	for _, ts := range tt {
 		t.Run(ts.s, func(t *testing.T) {
 			setting, err := ParseDDLStrategy("online " + ts.s)
+			if ts.expectError != "" {
+				assert.ErrorContains(t, err, ts.expectError)
+				return
+			}
 			assert.NoError(t, err)
 
 			val, isRetainArtifacts := isRetainArtifactsFlag(ts.s)


### PR DESCRIPTION

## Description

See description in https://github.com/vitessio/vitess/issues/14372

Superfluous/unknown flags are now invalid for these strategies: `vitess`, `online`, `mysql`, `direct`. Superfluous flags are allowed for 3rd party strategies: `gh-ost` and `pt-osc`.

## Related Issue(s)

Fixed #14372 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
