### PR TITLE
Tell shellcheck to follow sourced files

### DIFF
--- a/misc/git/hooks/shellcheck
+++ b/misc/git/hooks/shellcheck
@@ -20,7 +20,9 @@ do
   # The -e SC1090,SC1091 suppressing warnings about trying to find
   # files imported with "source foo.sh". We only want to lint
   # the files modified as part of this current diff.
-  errors+=$(shellcheck -e SC1090,SC1091 "$file" 2>&1)
+  # The -x flag tells shellcheck to follow the files we source
+  # and properly validate them as well.
+  errors+=$(shellcheck -x -e SC1090,SC1091 "$file" 2>&1)
 done
 
 [ -z "$errors" ] && exit 0


### PR DESCRIPTION
## Description

This is a minor improvement that will help eliminate unhelpful shellcheck errors — surfaced via the pre-commit hooks: `.git/hooks/pre-commit` -> `misc/git/hooks/shellcheck` — as well as potentially surface new things.

It does this by adding the `-x` shell flag so that shellcheck will follow the files and validate them as well. Here's an example:
```
❯ shellcheck tools/remove_dependencies.sh

In tools/remove_dependencies.sh line 21:
source build.env
       ^-------^ SC1091 (info): Not following: build.env was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: build.env was not ...

❯ shellcheck -x tools/remove_dependencies.sh
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required