### PR TITLE
Performance Fixes for Vitess 18

### DIFF
--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -153,6 +153,19 @@ var (
 					Name:   "hash",
 				}},
 			},
+			"oltp_test": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "id",
+					Name:   "hash",
+				}},
+				Columns: []*vschemapb.Column{{
+					Name: "c",
+					Type: sqltypes.Char,
+				}, {
+					Name: "pad",
+					Type: sqltypes.Char,
+				}},
+			},
 		},
 	}
 

--- a/go/vt/vtgate/endtoend/oltp_test.go
+++ b/go/vt/vtgate/endtoend/oltp_test.go
@@ -1,0 +1,132 @@
+package endtoend
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+// 10 groups, 119 characters
+const cValueTemplate = "###########-###########-###########-" +
+	"###########-###########-###########-" +
+	"###########-###########-###########-" +
+	"###########"
+
+// 5 groups, 59 characters
+const padValueTemplate = "###########-###########-###########-" +
+	"###########-###########"
+
+func sysbenchRandom(rng *rand.Rand, template string) []byte {
+	out := make([]byte, 0, len(template))
+	for i := range template {
+		switch template[i] {
+		case '#':
+			out = append(out, '0'+byte(rng.Intn(10)))
+		default:
+			out = append(out, template[i])
+		}
+	}
+	return out
+}
+
+var oltpInitOnce sync.Once
+
+func BenchmarkOLTP(b *testing.B) {
+	const MaxRows = 10000
+	const RangeSize = 100
+
+	rng := rand.New(rand.NewSource(1234))
+
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+
+	var query bytes.Buffer
+
+	oltpInitOnce.Do(func() {
+		b.Logf("seeding database for benchmark...")
+
+		var rows int = 1
+		for i := 0; i < MaxRows/10; i++ {
+			query.Reset()
+			query.WriteString("insert into oltp_test(id, k, c, pad) values ")
+			for j := 0; j < 10; j++ {
+				if j > 0 {
+					query.WriteString(", ")
+				}
+				_, _ = fmt.Fprintf(&query, "(%d, %d, '%s', '%s')", rows, rng.Int31n(0xFFFF), sysbenchRandom(rng, cValueTemplate), sysbenchRandom(rng, padValueTemplate))
+				rows++
+			}
+
+			_, err = conn.ExecuteFetch(query.String(), -1, false)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.Logf("finshed (inserted %d rows)", rows)
+	})
+
+	b.Run("SimpleRanges", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := rng.Intn(MaxRows)
+
+			query.Reset()
+			_, _ = fmt.Fprintf(&query, "SELECT c FROM oltp_test WHERE id BETWEEN %d AND %d", id, id+rng.Intn(RangeSize)-1)
+			_, err := conn.ExecuteFetch(query.String(), 1000, false)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("SumRanges", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := rng.Intn(MaxRows)
+
+			query.Reset()
+			_, _ = fmt.Fprintf(&query, "SELECT SUM(k) FROM oltp_test WHERE id BETWEEN %d AND %d", id, id+rng.Intn(RangeSize)-1)
+			_, err := conn.ExecuteFetch(query.String(), 1000, false)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("OrderRanges", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := rng.Intn(MaxRows)
+
+			query.Reset()
+			_, _ = fmt.Fprintf(&query, "SELECT c FROM oltp_test WHERE id BETWEEN %d AND %d ORDER BY c", id, id+rng.Intn(RangeSize)-1)
+			_, err := conn.ExecuteFetch(query.String(), 1000, false)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("DistinctRanges", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			id := rng.Intn(MaxRows)
+
+			query.Reset()
+			_, _ = fmt.Fprintf(&query, "SELECT DISTINCT c FROM oltp_test WHERE id BETWEEN %d AND %d ORDER BY c", id, id+rng.Intn(RangeSize)-1)
+			_, err := conn.ExecuteFetch(query.String(), 1000, false)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}

--- a/go/vt/vtgate/endtoend/schema.sql
+++ b/go/vt/vtgate/endtoend/schema.sql
@@ -72,3 +72,11 @@ create table t1_sharded(
                            id2 bigint,
                            primary key(id1)
 ) Engine=InnoDB;
+
+create table oltp_test(
+    id bigint not null auto_increment,
+    k bigint default 0 not null,
+    c char(120) default '' not null,
+    pad char(60) default '' not null,
+    primary key (id)
+) Engine=InnoDB;

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -114,6 +114,35 @@ func (oa *OrderedAggregate) TryExecute(ctx context.Context, vcursor VCursor, bin
 	return qr.Truncate(oa.TruncateColumnCount), nil
 }
 
+func (oa *OrderedAggregate) executeGroupBy(result *sqltypes.Result) (*sqltypes.Result, error) {
+	if len(result.Rows) < 1 {
+		return result, nil
+	}
+
+	out := &sqltypes.Result{
+		Fields: result.Fields,
+		Rows:   result.Rows[:0],
+	}
+
+	var currentKey []sqltypes.Value
+	var lastRow sqltypes.Row
+	var err error
+	for _, row := range result.Rows {
+		var nextGroup bool
+
+		currentKey, nextGroup, err = oa.nextGroupBy(currentKey, row)
+		if err != nil {
+			return nil, err
+		}
+		if nextGroup {
+			out.Rows = append(out.Rows, lastRow)
+		}
+		lastRow = row
+	}
+	out.Rows = append(out.Rows, lastRow)
+	return out, nil
+}
+
 func (oa *OrderedAggregate) execute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	result, err := vcursor.ExecutePrimitive(
 		ctx,
@@ -124,6 +153,10 @@ func (oa *OrderedAggregate) execute(ctx context.Context, vcursor VCursor, bindVa
 	if err != nil {
 		return nil, err
 	}
+	if len(oa.Aggregates) == 0 {
+		return oa.executeGroupBy(result)
+	}
+
 	agg, fields, err := newAggregation(result.Fields, oa.Aggregates)
 	if err != nil {
 		return nil, err
@@ -169,43 +202,75 @@ func (oa *OrderedAggregate) TryStreamExecute(ctx context.Context, vcursor VCurso
 	var agg aggregationState
 	var fields []*querypb.Field
 	var currentKey []sqltypes.Value
+	var lastRow sqltypes.Row
+	var visitor func(qr *sqltypes.Result) error
 
-	visitor := func(qr *sqltypes.Result) error {
-		var err error
+	if len(oa.Aggregates) > 0 {
+		visitor = func(qr *sqltypes.Result) error {
+			var err error
 
-		if agg == nil && len(qr.Fields) != 0 {
-			agg, fields, err = newAggregation(qr.Fields, oa.Aggregates)
-			if err != nil {
-				return err
-			}
-			if err = cb(&sqltypes.Result{Fields: fields}); err != nil {
-				return err
-			}
-		}
-
-		// This code is similar to the one in Execute.
-		for _, row := range qr.Rows {
-			var nextGroup bool
-
-			currentKey, nextGroup, err = oa.nextGroupBy(currentKey, row)
-			if err != nil {
-				return err
+			if agg == nil && len(qr.Fields) != 0 {
+				agg, fields, err = newAggregation(qr.Fields, oa.Aggregates)
+				if err != nil {
+					return err
+				}
+				if err = cb(&sqltypes.Result{Fields: fields}); err != nil {
+					return err
+				}
 			}
 
-			if nextGroup {
-				// this is a new grouping. let's yield the old one, and start a new
-				if err := cb(&sqltypes.Result{Rows: [][]sqltypes.Value{agg.finish()}}); err != nil {
+			// This code is similar to the one in Execute.
+			for _, row := range qr.Rows {
+				var nextGroup bool
+
+				currentKey, nextGroup, err = oa.nextGroupBy(currentKey, row)
+				if err != nil {
 					return err
 				}
 
-				agg.reset()
-			}
+				if nextGroup {
+					// this is a new grouping. let's yield the old one, and start a new
+					if err := cb(&sqltypes.Result{Rows: [][]sqltypes.Value{agg.finish()}}); err != nil {
+						return err
+					}
 
-			if err := agg.add(row); err != nil {
-				return err
+					agg.reset()
+				}
+
+				if err := agg.add(row); err != nil {
+					return err
+				}
 			}
+			return nil
 		}
-		return nil
+	} else {
+		visitor = func(qr *sqltypes.Result) error {
+			var err error
+			if fields == nil && len(qr.Fields) > 0 {
+				fields = qr.Fields
+				if err = cb(&sqltypes.Result{Fields: fields}); err != nil {
+					return err
+				}
+			}
+			for _, row := range qr.Rows {
+				var nextGroup bool
+
+				currentKey, nextGroup, err = oa.nextGroupBy(currentKey, row)
+				if err != nil {
+					return err
+				}
+
+				if nextGroup {
+					// this is a new grouping. let's yield the old one, and start a new
+					if err := cb(&sqltypes.Result{Rows: []sqltypes.Row{lastRow}}); err != nil {
+						return err
+					}
+				}
+
+				lastRow = row
+			}
+			return nil
+		}
 	}
 
 	/* we need the input fields types to correctly calculate the output types */
@@ -214,8 +279,8 @@ func (oa *OrderedAggregate) TryStreamExecute(ctx context.Context, vcursor VCurso
 		return err
 	}
 
-	if currentKey != nil {
-		if err := cb(&sqltypes.Result{Rows: [][]sqltypes.Value{agg.finish()}}); err != nil {
+	if lastRow != nil {
+		if err := cb(&sqltypes.Result{Rows: [][]sqltypes.Value{lastRow}}); err != nil {
 			return err
 		}
 	}

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -447,7 +447,6 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 			if cmp != 0 {
 				return cmp
 			}
-			return cmp
 		}
 		return 0
 	})

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -428,10 +429,10 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 
 	comparers := extractSlices(route.OrderBy)
 
-	sort.Slice(out.Rows, func(i, j int) bool {
+	slices.SortFunc(out.Rows, func(a, b sqltypes.Row) int {
 		var cmp int
 		if err != nil {
-			return true
+			return -1
 		}
 		// If there are any errors below, the function sets
 		// the external err and returns true. Once err is set,
@@ -439,16 +440,16 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 		// Slice think that all elements are in the correct
 		// order and return more quickly.
 		for _, c := range comparers {
-			cmp, err = c.compare(out.Rows[i], out.Rows[j])
+			cmp, err = c.compare(a, b)
 			if err != nil {
-				return true
+				return -1
 			}
-			if cmp == 0 {
-				continue
+			if cmp != 0 {
+				return cmp
 			}
-			return cmp < 0
+			return cmp
 		}
-		return true
+		return 0
 	})
 
 	return out.Truncate(route.TruncateColumnCount), err

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -673,7 +673,7 @@ func (db *LocalCluster) applyVschema(keyspace string, migration string) error {
 func (db *LocalCluster) reloadSchemaKeyspace(keyspace string) error {
 	server := fmt.Sprintf("localhost:%v", db.vt.PortGrpc)
 	args := []string{"ReloadSchemaKeyspace", "--include_primary=true", keyspace}
-	fmt.Printf("Reloading keyspace schema %v", args)
+	log.Infof("Reloading keyspace schema %v", args)
 
 	err := vtctlclient.RunCommandAndWait(context.Background(), server, args, func(e *logutil.Event) {
 		log.Info(e)

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 
 	"google.golang.org/protobuf/encoding/prototext"
@@ -141,8 +142,10 @@ func (vtp *VtProcess) WaitStart() (err error) {
 	vtp.proc.Env = append(vtp.proc.Env, os.Environ()...)
 	vtp.proc.Env = append(vtp.proc.Env, vtp.Env...)
 
-	vtp.proc.Stderr = os.Stderr
-	vtp.proc.Stdout = os.Stdout
+	if testing.Verbose() {
+		vtp.proc.Stderr = os.Stderr
+		vtp.proc.Stdout = os.Stdout
+	}
 
 	log.Infof("%v %v", strings.Join(vtp.proc.Args, " "))
 	err = vtp.proc.Start()


### PR DESCRIPTION
## Description

I'm investigating the performance regressions in the Vitess 18 release compared to Vitess 17.

From reproducing the synthetic benchmarks, there are two issues I've encountered:

1. The aggregation code now allocates rows when no aggregation is performed (i.e. when you run a `DISTINCT` without aggregation). I've fixed that in this PR by optimizing this particular case which I hadn't considered before. This is a very common pattern in the OLTP benchmarks so I think this will revert some of the regression.
2. The `sort` primitive in the engine is extremely hot. This is nothing new -- it has always been hot, but it can now be optimized with the new generics-based implementation, which should be much faster for all cases. I've done this optimization in this PR and the results are very good locally -- let's see how it fares in arewefast. Note that this is not fixing a regression, it's just a new optimization.
3. From bisecting in synthetic benchmarks, I can see https://github.com/vitessio/vitess/pull/13800 as a global performance regression. It kinda makes sense to me because `sqltypes.Value` is used _a lot_ throughout the codebase, so growing it from 32 bytes to 64 has a very significant impact in memory allocations and cache locality. I haven't attempted to fix that in this PR because the fix is very involved. I'll have to discuss this with @harshit-gangal.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
