### PR TITLE
tooling: don't add bots to authors list

### DIFF
--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -201,6 +201,10 @@ func loadMergedPRsAndAuthors(name string) (pris []pullRequestInformation, author
 	authorMap := map[string]bool{}
 	for _, pri := range pris {
 		login := pri.Author.Login
+		if strings.HasPrefix(login, "@app") {
+			// skip the bots
+			continue
+		}
 		if ok := authorMap[login]; !ok {
 			authors = append(authors, login)
 			authorMap[login] = true


### PR DESCRIPTION
## Description
When doing releases, we list all PR authors. This change removes our bots from the list of authors.

Example of what the release with bots look like: https://github.com/vitessio/vitess/blob/main/changelog/16.0/16.0.5/release_notes.md
