### PR TITLE
Fix #14414:  resilient_server metrics name/prefix logic is inverted, leading to no metrics being recorded

### DIFF
--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -85,7 +85,7 @@ func NewResilientServer(ctx context.Context, base *topo.Server, counterPrefix st
 	}
 
 	var metric string
-	if counterPrefix == "" {
+	if counterPrefix != "" {
 		metric = counterPrefix + "Counts"
 	} else {
 		metric = ""

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -84,11 +84,9 @@ func NewResilientServer(ctx context.Context, base *topo.Server, counterPrefix st
 		log.Fatalf("srv_topo_cache_refresh must be less than or equal to srv_topo_cache_ttl")
 	}
 
-	var metric string
+	metric := ""
 	if counterPrefix != "" {
 		metric = counterPrefix + "Counts"
-	} else {
-		metric = ""
 	}
 	counts := stats.NewCountersWithSingleLabel(metric, "Resilient srvtopo server operations", "type")
 

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -811,7 +811,7 @@ func TestSrvKeyspaceListener(t *testing.T) {
 		srvTopoCacheRefresh = 1 * time.Second
 	}()
 
-	rs := NewResilientServer(ctx, ts, "TestGetSrvKeyspaceWatcher")
+	rs := NewResilientServer(ctx, ts, "TestGetSrvKeyspaceListener")
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	var callbackCount atomic.Int32

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -20,6 +20,7 @@ package testenv
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"regexp"
 	"strings"
@@ -75,7 +76,9 @@ func Init(ctx context.Context) (*Env, error) {
 	if err := te.TopoServ.CreateShard(ctx, te.KeyspaceName, te.ShardName); err != nil {
 		panic(err)
 	}
-	te.SrvTopo = srvtopo.NewResilientServer(ctx, te.TopoServ, "TestTopo")
+	// Add a random suffix to metric name to avoid panic. Another option would have been to generate a random string.
+	suffix := rand.Int()
+	te.SrvTopo = srvtopo.NewResilientServer(ctx, te.TopoServ, "TestTopo"+fmt.Sprint(suffix))
 
 	cfg := vttest.Config{
 		Topology: &vttestpb.VTTestTopology{


### PR DESCRIPTION
## Description

The logic for the topo resilient server has been apparently broken since it was introduced.  I fixed a single test that was mis-named, that led to a panic with this change.  I would like to test that the name of the metric is now correct, but the stats module does not make that easy, so something like an end-to-end test would be required, and I do not think this fix justifies that level of effort. 

Unnecessary to backport, affects metrics only.

## Related Issues
  - Fixes: https://github.com/vitessio/vitess/issues/14414

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required

