### PR TITLE
TestStreamMigrateMainflow: fix panic in test

### DIFF
--- a/go/vt/wrangler/fake_tablet_test.go
+++ b/go/vt/wrangler/fake_tablet_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 	"time"
 
+	vdiff2 "vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -187,7 +190,7 @@ func (ft *fakeTablet) StartActionLoop(t *testing.T, wr *Wrangler) {
 	ft.Tablet.PortMap["vt"] = vtPort
 	ft.Tablet.PortMap["grpc"] = gRPCPort
 	ft.Tablet.Hostname = "127.0.0.1"
-
+	config := &tabletenv.TabletConfig{}
 	// Create a test tm on that port, and re-read the record
 	// (it has new ports and IP).
 	ft.TM = &tabletmanager.TabletManager{
@@ -196,6 +199,7 @@ func (ft *fakeTablet) StartActionLoop(t *testing.T, wr *Wrangler) {
 		MysqlDaemon:         ft.FakeMysqlDaemon,
 		DBConfigs:           &dbconfigs.DBConfigs{},
 		QueryServiceControl: tabletservermock.NewController(),
+		VDiffEngine:         vdiff2.NewEngine(config, wr.TopoServer(), ft.Tablet),
 	}
 	if err := ft.TM.Start(ft.Tablet, 0); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description

The test environment was not being properly initialized resulting in panics related to vdiff goroutines. This was not relevant to the test and not failing the tests, but the panics were being logged.

# Related Issue(s)


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
