### PR TITLE
vtgate: Allow more errors for the warning check

### DIFF
--- a/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
+++ b/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
@@ -141,9 +141,9 @@ func TestScatterErrsAsWarns(t *testing.T) {
 			utils.Exec(t, mode.conn, fmt.Sprintf("set workload = %s", mode.m))
 
 			utils.AssertMatches(t, mode.conn, query1, `[[INT64(4)]]`)
-			assertContainsOneOf(t, mode.conn, showQ, "no valid tablet", "no healthy tablet", "mysql.sock: connect: no such file or directory")
+			assertContainsOneOf(t, mode.conn, showQ, "operation not allowed in state SHUTTING_DOWN", "no valid tablet", "no healthy tablet", "mysql.sock: connect: no such file or directory")
 			utils.AssertMatches(t, mode.conn, query2, `[[INT64(4)]]`)
-			assertContainsOneOf(t, mode.conn, showQ, "no valid tablet", "no healthy tablet", "mysql.sock: connect: no such file or directory")
+			assertContainsOneOf(t, mode.conn, showQ, "operation not allowed in state SHUTTING_DOWN", "no valid tablet", "no healthy tablet", "mysql.sock: connect: no such file or directory")
 
 			// invalid_field should throw error and not warning
 			_, err = mode.conn.ExecuteFetch("SELECT /*vt+ PLANNER=Gen4 SCATTER_ERRORS_AS_WARNINGS */ invalid_field from t1;", 1, false)


### PR DESCRIPTION
The MySQL shutdown is racy, so we might also see this message that it's still shutting down.

Improves the test flakyness hopefully of these tests.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required
