### PR TITLE
TableGC: speed up GC process via `RequestChecks()`. Utilized by Online DDL for artifact cleanup

### DIFF
--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/gc"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
@@ -128,13 +129,18 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func checkTableRows(t *testing.T, tableName string, expect int64) {
+func getTableRows(t *testing.T, tableName string) int64 {
 	require.NotEmpty(t, tableName)
 	query := `select count(*) as c from %a`
 	parsed := sqlparser.BuildParsedQuery(query, tableName)
 	rs, err := primaryTablet.VttabletProcess.QueryTablet(parsed.Query, keyspaceName, true)
 	require.NoError(t, err)
 	count := rs.Named().Row().AsInt64("c", 0)
+	return count
+}
+
+func checkTableRows(t *testing.T, tableName string, expect int64) {
+	count := getTableRows(t, tableName)
 	assert.Equal(t, expect, count)
 }
 
@@ -176,19 +182,18 @@ func validateTableDoesNotExist(t *testing.T, tableExpr string) {
 	defer cancel()
 
 	ticker := time.NewTicker(time.Second)
-	var foundTableName string
-	var exists bool
-	var err error
+	defer ticker.Stop()
+
 	for {
+		exists, foundTableName, err := tableExists(tableExpr)
+		require.NoError(t, err)
+		if !exists {
+			return
+		}
 		select {
 		case <-ticker.C:
-			exists, foundTableName, err = tableExists(tableExpr)
-			require.NoError(t, err)
-			if !exists {
-				return
-			}
 		case <-ctx.Done():
-			assert.NoError(t, ctx.Err(), "validateTableDoesNotExist timed out, table %v still exists (%v)", tableExpr, foundTableName)
+			assert.Failf(t, "validateTableDoesNotExist timed out, table %v still exists (%v)", tableExpr, foundTableName)
 			return
 		}
 	}
@@ -199,59 +204,78 @@ func validateTableExists(t *testing.T, tableExpr string) {
 	defer cancel()
 
 	ticker := time.NewTicker(time.Second)
-	var exists bool
-	var err error
+	defer ticker.Stop()
+
 	for {
+		exists, _, err := tableExists(tableExpr)
+		require.NoError(t, err)
+		if exists {
+			return
+		}
 		select {
 		case <-ticker.C:
-			exists, _, err = tableExists(tableExpr)
-			require.NoError(t, err)
-			if exists {
-				return
-			}
 		case <-ctx.Done():
-			assert.NoError(t, ctx.Err(), "validateTableExists timed out, table %v still does not exist", tableExpr)
+			assert.Failf(t, "validateTableExists timed out, table %v still does not exist", tableExpr)
 			return
 		}
 	}
 }
 
 func validateAnyState(t *testing.T, expectNumRows int64, states ...schema.TableGCState) {
-	for _, state := range states {
-		expectTableToExist := true
-		searchExpr := ""
-		switch state {
-		case schema.HoldTableGCState:
-			searchExpr = `\_vt\_HOLD\_%`
-		case schema.PurgeTableGCState:
-			searchExpr = `\_vt\_PURGE\_%`
-		case schema.EvacTableGCState:
-			searchExpr = `\_vt\_EVAC\_%`
-		case schema.DropTableGCState:
-			searchExpr = `\_vt\_DROP\_%`
-		case schema.TableDroppedGCState:
-			searchExpr = `\_vt\_%`
-			expectTableToExist = false
-		default:
-			t.Log("Unknown state")
-			t.Fail()
-		}
-		exists, tableName, err := tableExists(searchExpr)
-		require.NoError(t, err)
+	t.Run(fmt.Sprintf("validateAnyState: expectNumRows=%v, states=%v", expectNumRows, states), func(t *testing.T) {
+		timeout := gc.NextChecksIntervals[len(gc.NextChecksIntervals)-1] + 5*time.Second
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
 
-		if exists {
-			if expectNumRows >= 0 {
-				checkTableRows(t, tableName, expectNumRows)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for {
+			// Attempt validation:
+			for _, state := range states {
+				expectTableToExist := true
+				searchExpr := ""
+				switch state {
+				case schema.HoldTableGCState:
+					searchExpr = `\_vt\_HOLD\_%`
+				case schema.PurgeTableGCState:
+					searchExpr = `\_vt\_PURGE\_%`
+				case schema.EvacTableGCState:
+					searchExpr = `\_vt\_EVAC\_%`
+				case schema.DropTableGCState:
+					searchExpr = `\_vt\_DROP\_%`
+				case schema.TableDroppedGCState:
+					searchExpr = `\_vt\_%`
+					expectTableToExist = false
+				default:
+					require.Failf(t, "unknown state", "%v", state)
+				}
+				exists, tableName, err := tableExists(searchExpr)
+				require.NoError(t, err)
+
+				var foundRows int64
+				if exists {
+					foundRows = getTableRows(t, tableName)
+					// Now that the table is validated, we can drop it (test cleanup)
+					dropTable(t, tableName)
+				}
+				t.Logf("=== exists: %v, tableName: %v, rows: %v", exists, tableName, foundRows)
+				if exists == expectTableToExist {
+					// expectNumRows < 0 means "don't care"
+					if expectNumRows < 0 || (expectNumRows == foundRows) {
+						// All conditions are met
+						return
+					}
+				}
 			}
-			// Now that the table is validated, we can drop it
-			dropTable(t, tableName)
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				assert.Failf(t, "timeout in validateAnyState", " waiting for any of these states: %v, expecting rows: %v", states, expectNumRows)
+				return
+			}
 		}
-		if exists == expectTableToExist {
-			// condition met
-			return
-		}
-	}
-	assert.Failf(t, "could not match any of the states", "states=%v", states)
+	})
 }
 
 // dropTable drops a table
@@ -309,17 +333,22 @@ func TestHold(t *testing.T) {
 }
 
 func TestEvac(t *testing.T) {
-	populateTable(t)
-	query, tableName, err := schema.GenerateRenameStatement("t1", schema.EvacTableGCState, time.Now().UTC().Add(tableTransitionExpiration))
-	assert.NoError(t, err)
+	var tableName string
+	t.Run("setting up EVAC table", func(t *testing.T) {
+		populateTable(t)
+		var query string
+		var err error
+		query, tableName, err = schema.GenerateRenameStatement("t1", schema.EvacTableGCState, time.Now().UTC().Add(tableTransitionExpiration))
+		assert.NoError(t, err)
 
-	_, err = primaryTablet.VttabletProcess.QueryTablet(query, keyspaceName, true)
-	assert.NoError(t, err)
+		_, err = primaryTablet.VttabletProcess.QueryTablet(query, keyspaceName, true)
+		assert.NoError(t, err)
 
-	validateTableDoesNotExist(t, "t1")
+		validateTableDoesNotExist(t, "t1")
+	})
 
-	time.Sleep(tableTransitionExpiration / 2)
-	{
+	t.Run("validating before expiration", func(t *testing.T) {
+		time.Sleep(tableTransitionExpiration / 2)
 		// Table was created with +10s timestamp, so it should still exist
 		if fastDropTable {
 			// EVAC state is skipped in mysql 8.0.23 and beyond
@@ -328,13 +357,28 @@ func TestEvac(t *testing.T) {
 			validateTableExists(t, tableName)
 			checkTableRows(t, tableName, 1024)
 		}
-	}
+	})
 
-	time.Sleep(tableTransitionExpiration)
-	// We're now both beyond table's timestamp as well as a tableGC interval
-	validateTableDoesNotExist(t, tableName)
-	// Table should be renamed as _vt_DROP_... and then dropped!
-	validateAnyState(t, 0, schema.DropTableGCState, schema.TableDroppedGCState)
+	t.Run("validating rows evacuated", func(t *testing.T) {
+		// ctx, cancel := context.WithTimeout(ctx, tableTransitionExpiration+gc.CheckTablesReentryMinInterval)
+		// defer cancel()
+
+		// ticker := time.NewTicker(time.Second)
+		// defer ticker.Stop()
+
+		// for {
+		// 	select {
+
+		// 	case <-ctx.Done():
+		// 	case <-ticker.C:
+		// 	}
+		// }
+		// time.Sleep(tableTransitionExpiration + gc.CheckTablesReentryMinInterval)
+		// We're now both beyond table's timestamp as well as a tableGC interval
+		validateTableDoesNotExist(t, tableName)
+		// Table should be renamed as _vt_DROP_... and then dropped!
+		validateAnyState(t, 0, schema.DropTableGCState, schema.TableDroppedGCState)
+	})
 }
 
 func TestDrop(t *testing.T) {

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -360,20 +360,6 @@ func TestEvac(t *testing.T) {
 	})
 
 	t.Run("validating rows evacuated", func(t *testing.T) {
-		// ctx, cancel := context.WithTimeout(ctx, tableTransitionExpiration+gc.CheckTablesReentryMinInterval)
-		// defer cancel()
-
-		// ticker := time.NewTicker(time.Second)
-		// defer ticker.Stop()
-
-		// for {
-		// 	select {
-
-		// 	case <-ctx.Done():
-		// 	case <-ticker.C:
-		// 	}
-		// }
-		// time.Sleep(tableTransitionExpiration + gc.CheckTablesReentryMinInterval)
 		// We're now both beyond table's timestamp as well as a tableGC interval
 		validateTableDoesNotExist(t, tableName)
 		// Table should be renamed as _vt_DROP_... and then dropped!

--- a/go/timer/suspendable_ticker_test.go
+++ b/go/timer/suspendable_ticker_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2023 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/timer/suspendable_ticker_test.go
+++ b/go/timer/suspendable_ticker_test.go
@@ -25,12 +25,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	fastTickerInterval = 10 * time.Millisecond
+)
+
 func TestInitiallySuspended(t *testing.T) {
 	ctx := context.Background()
 	t.Run("true", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
-		ticker := NewSuspendableTicker(10*time.Millisecond, true)
+		ticker := NewSuspendableTicker(fastTickerInterval, true)
 		defer ticker.Stop()
 		select {
 		case <-ticker.C:
@@ -42,7 +46,7 @@ func TestInitiallySuspended(t *testing.T) {
 	t.Run("false", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
-		ticker := NewSuspendableTicker(10*time.Millisecond, false)
+		ticker := NewSuspendableTicker(fastTickerInterval, false)
 		defer ticker.Stop()
 		select {
 		case <-ticker.C:
@@ -56,7 +60,7 @@ func TestInitiallySuspended(t *testing.T) {
 func TestSuspendableTicker(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ticker := NewSuspendableTicker(10*time.Millisecond, false)
+	ticker := NewSuspendableTicker(fastTickerInterval, false)
 	defer ticker.Stop()
 
 	var ticks atomic.Int64

--- a/go/timer/suspendable_ticker_test.go
+++ b/go/timer/suspendable_ticker_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitiallySuspended(t *testing.T) {
+	ctx := context.Background()
+	t.Run("true", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		ticker := NewSuspendableTicker(10*time.Millisecond, true)
+		defer ticker.Stop()
+		select {
+		case <-ticker.C:
+			assert.Fail(t, "unexpected tick. Was supposed to be suspended")
+		case <-ctx.Done():
+			return
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		ticker := NewSuspendableTicker(10*time.Millisecond, false)
+		defer ticker.Stop()
+		select {
+		case <-ticker.C:
+			return
+		case <-ctx.Done():
+			assert.Fail(t, "unexpected timeout. Expected tick")
+		}
+	})
+}
+
+func TestSuspendableTicker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ticker := NewSuspendableTicker(10*time.Millisecond, false)
+	defer ticker.Stop()
+
+	var ticks atomic.Int64
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				ticks.Add(1)
+			}
+		}
+	}()
+	t.Run("ticks running", func(t *testing.T) {
+		time.Sleep(time.Second)
+		after := ticks.Load()
+		assert.Greater(t, after, int64(10)) // should be about 100
+	})
+	t.Run("ticks suspended", func(t *testing.T) {
+		ticker.Suspend()
+		before := ticks.Load()
+		time.Sleep(time.Second)
+		after := ticks.Load()
+		assert.Less(t, after-before, int64(10))
+	})
+	t.Run("ticks resumed", func(t *testing.T) {
+		ticker.Resume()
+		before := ticks.Load()
+		time.Sleep(time.Second)
+		after := ticks.Load()
+		assert.Greater(t, after-before, int64(10))
+	})
+	t.Run("ticker stopped", func(t *testing.T) {
+		ticker.Stop()
+		before := ticks.Load()
+		time.Sleep(time.Second)
+		after := ticks.Load()
+		assert.Less(t, after-before, int64(10))
+	})
+}
+
+func TestSuspendableTickerTick(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ticker := NewSuspendableTicker(time.Hour, false)
+	defer ticker.Stop()
+
+	var ticks atomic.Int64
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				ticks.Add(1)
+			}
+		}
+	}()
+	t.Run("nothing going on", func(t *testing.T) {
+		time.Sleep(time.Second)
+		after := ticks.Load()
+		assert.Zero(t, after)
+	})
+	t.Run("tick now", func(t *testing.T) {
+		before := ticks.Load()
+		ticker.TickNow()
+		time.Sleep(time.Second)
+		after := ticks.Load()
+		assert.Equal(t, int64(1), after-before)
+	})
+	t.Run("tick after", func(t *testing.T) {
+		before := ticks.Load()
+		ticker.TickAfter(1 * time.Second)
+		time.Sleep(time.Second)
+		after := ticks.Load()
+		assert.Zero(t, after-before)
+		time.Sleep(3 * time.Second)
+		after = ticks.Load()
+		assert.Equal(t, int64(1), after-before)
+	})
+}

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -176,6 +176,7 @@ type Executor struct {
 	ts                    *topo.Server
 	lagThrottler          *throttle.Throttler
 	toggleBufferTableFunc func(cancelCtx context.Context, tableName string, timeout time.Duration, bufferQueries bool)
+	requestGCChecksFunc   func()
 	tabletAlias           *topodatapb.TabletAlias
 
 	keyspace string
@@ -251,6 +252,7 @@ func NewExecutor(env tabletenv.Env, tabletAlias *topodatapb.TabletAlias, ts *top
 	lagThrottler *throttle.Throttler,
 	tabletTypeFunc func() topodatapb.TabletType,
 	toggleBufferTableFunc func(cancelCtx context.Context, tableName string, timeout time.Duration, bufferQueries bool),
+	requestGCChecksFunc func(),
 ) *Executor {
 	// sanitize flags
 	if maxConcurrentOnlineDDLs < 1 {
@@ -268,6 +270,7 @@ func NewExecutor(env tabletenv.Env, tabletAlias *topodatapb.TabletAlias, ts *top
 		ts:                    ts,
 		lagThrottler:          lagThrottler,
 		toggleBufferTableFunc: toggleBufferTableFunc,
+		requestGCChecksFunc:   requestGCChecksFunc,
 		ticks:                 timer.NewTimer(migrationCheckInterval),
 		// Gracefully return an error if any caller tries to execute
 		// a query before the executor has been fully opened.
@@ -3848,6 +3851,7 @@ func (e *Executor) gcArtifacts(ctx context.Context) error {
 			if err == nil {
 				// artifact was renamed away and is gone. There' no need to list it in `artifacts` column.
 				e.clearSingleArtifact(ctx, uuid, artifactTable)
+				e.requestGCChecksFunc()
 			} else {
 				return vterrors.Wrapf(err, "in gcArtifacts() for %s", artifactTable)
 			}
@@ -4416,6 +4420,7 @@ func (e *Executor) CleanupMigration(ctx context.Context, uuid string) (result *s
 		return nil, err
 	}
 	log.Infof("CleanupMigration: migration %s marked as ready to clean up", uuid)
+	defer e.triggerNextCheckInterval()
 	return rs, nil
 }
 

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -51,7 +51,8 @@ const (
 var (
 	checkInterval                 = 1 * time.Hour
 	purgeReentranceInterval       = 1 * time.Minute
-	checkTablesReentryMinInterval = 5 * time.Second
+	checkTablesReentryMinInterval = 10 * time.Second
+	NextChecksIntervals           = []time.Duration{time.Second, checkTablesReentryMinInterval + 5*time.Second}
 	gcLifecycle                   = "hold,purge,evac,drop"
 )
 
@@ -236,7 +237,7 @@ func (collector *TableGC) Close() {
 // _know_ that changes have been made, and now have a way to tell TableGC: "please take a look asap rather
 // than in the next hour".
 func (collector *TableGC) RequestChecks() {
-	for _, d := range []time.Duration{time.Second, checkTablesReentryMinInterval + 5*time.Second} {
+	for _, d := range NextChecksIntervals {
 		time.AfterFunc(d, func() { collector.checkRequestChan <- true })
 	}
 }

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -51,6 +51,7 @@ const (
 var (
 	checkInterval                 = 1 * time.Hour
 	purgeReentranceInterval       = 1 * time.Minute
+	nextPurgeReentry              = 1 * time.Second
 	checkTablesReentryMinInterval = 10 * time.Second
 	NextChecksIntervals           = []time.Duration{time.Second, checkTablesReentryMinInterval + 5*time.Second}
 	gcLifecycle                   = "hold,purge,evac,drop"
@@ -300,7 +301,7 @@ func (collector *TableGC) operate(ctx context.Context) {
 				collector.removePurgingTable(tableName)
 				// Chances are, there's more tables waiting to be purged. Let's speed things by
 				// requesting another purge, instead of waiting a full purgeReentranceInterval cycle
-				purgeReentranceTicker.TickAfter(time.Second)
+				purgeReentranceTicker.TickAfter(nextPurgeReentry)
 			}()
 		case dropTable := <-dropTablesChan:
 			log.Infof("TableGC: found %v in dropTablesChan", dropTable.tableName)

--- a/go/vt/vttablet/tabletserver/gc/tablegc_test.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc_test.go
@@ -60,7 +60,8 @@ func TestNextTableToPurge(t *testing.T) {
 	}
 	for _, ts := range tt {
 		collector := &TableGC{
-			purgingTables: make(map[string]bool),
+			purgingTables:    make(map[string]bool),
+			checkRequestChan: make(chan bool),
 		}
 		for _, table := range ts.tables {
 			collector.purgingTables[table] = true
@@ -256,8 +257,9 @@ func TestShouldTransitionTable(t *testing.T) {
 
 func TestCheckTables(t *testing.T) {
 	collector := &TableGC{
-		isOpen:        0,
-		purgingTables: map[string]bool{},
+		isOpen:           0,
+		purgingTables:    map[string]bool{},
+		checkRequestChan: make(chan bool),
 	}
 	var err error
 	collector.lifecycleStates, err = schema.ParseGCLifecycle("hold,purge,evac,drop")

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -187,8 +187,8 @@ func NewTabletServer(ctx context.Context, name string, config *tabletenv.TabletC
 	tsv.te = NewTxEngine(tsv)
 	tsv.messager = messager.NewEngine(tsv, tsv.se, tsv.vstreamer)
 
-	tsv.onlineDDLExecutor = onlineddl.NewExecutor(tsv, alias, topoServer, tsv.lagThrottler, tabletTypeFunc, tsv.onlineDDLExecutorToggleTableBuffer)
 	tsv.tableGC = gc.NewTableGC(tsv, topoServer, tsv.lagThrottler)
+	tsv.onlineDDLExecutor = onlineddl.NewExecutor(tsv, alias, topoServer, tsv.lagThrottler, tabletTypeFunc, tsv.onlineDDLExecutorToggleTableBuffer, tsv.tableGC.RequestChecks)
 
 	tsv.sm = &stateManager{
 		statelessql: tsv.statelessql,


### PR DESCRIPTION
## Description

Normally, the TableGC mechanism checks for GC table statuses once per hour. It will transition tables to their next state, potentially dealing with that new state yet only one hour _later_. There's incentive to speed up the process. But instead of reducing the interval (causing more load on the `PRIMARY`), we choose to intelligently kick new _check_ routines whenever there's a plausible reason -- or an explicit request.

Any time a table changes state, calls for a new cycle that takes place within seconds. A public function, `RequestChecks()`, makes it possible to "inform" the GC mechanism of recent changes that can benefit from GC.
To combat load, the _check_ function is non-reentrant, and discards recurring or flooding calls made within a period of 10 seconds (ie. the function only agrees to run once per 10 seconds _at most_).

This is in turn used by Online DDL's state machine: right after a `ALTER VITESS_MIGRATION ... CLEANUP` (or similar command) is invoked, and assuming an actual artifact is affected, Online DDL calls GC's `RequestChecks()` to speed up the destruction and cleanup of said artifact tables.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14427

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
