### PR TITLE
VDiff: "show all" should only report vdiffs for the specified keyspace and workflow

### DIFF
--- a/go/test/endtoend/vreplication/vdiff_multiple_movetables_test.go
+++ b/go/test/endtoend/vreplication/vdiff_multiple_movetables_test.go
@@ -1,0 +1,123 @@
+package vreplication
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/log"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+func TestMultipleConcurrentVDiffs(t *testing.T) {
+	cellName := "zone"
+	cells := []string{cellName}
+	vc = NewVitessCluster(t, t.Name(), cells, mainClusterConfig)
+
+	require.NotNil(t, vc)
+	allCellNames = cellName
+	defaultCellName := cellName
+	defaultCell = vc.Cells[defaultCellName]
+	sourceKeyspace := "product"
+	shardName := "0"
+
+	defer vc.TearDown(t)
+
+	cell := vc.Cells[cellName]
+	vc.AddKeyspace(t, []*Cell{cell}, sourceKeyspace, shardName, initialProductVSchema, initialProductSchema, 0, 0, 100, sourceKsOpts)
+
+	vtgate = cell.Vtgates[0]
+	require.NotNil(t, vtgate)
+	err := cluster.WaitForHealthyShard(vc.VtctldClient, sourceKeyspace, shardName)
+	require.NoError(t, err)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", sourceKeyspace, shardName), 1, 30*time.Second)
+
+	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	defer vtgateConn.Close()
+	verifyClusterHealth(t, vc)
+
+	insertInitialData(t)
+	targetTabletId := 200
+	targetKeyspace := "customer"
+	vc.AddKeyspace(t, []*Cell{cell}, targetKeyspace, shardName, initialProductVSchema, initialProductSchema, 0, 0, targetTabletId, sourceKsOpts)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", targetKeyspace, shardName), 1, 30*time.Second)
+
+	index := 1000
+	var loadCtx context.Context
+	var loadCancel context.CancelFunc
+	loadCtx, loadCancel = context.WithCancel(context.Background())
+	load := func(tableName string) {
+		query := "insert into %s(cid, name) values(%d, 'customer-%d')"
+		for {
+			select {
+			case <-loadCtx.Done():
+				log.Infof("load cancelled")
+				return
+			default:
+				index += 1
+				vtgateConn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+				q := fmt.Sprintf(query, tableName, index, index)
+				_, err := vtgateConn.ExecuteFetch(q, 1000, false)
+				if err != nil {
+					t.Fatalf("failed to insert data: %s: %v", q, err)
+				}
+				//log.Infof("inserted data: %s", q)
+				vtgateConn.Close()
+			}
+		}
+	}
+	time.Sleep(5 * time.Minute)
+	workflowName1 := "wf1"
+	ksWorkflow1 := fmt.Sprintf("%s.%s", targetKeyspace, workflowName1)
+	mt1 := newMoveTables(vc, &moveTables{
+		workflowName:   workflowName1,
+		targetKeyspace: targetKeyspace,
+		sourceKeyspace: sourceKeyspace,
+		tables:         "customer",
+	}, moveTablesFlavorVtctld)
+	mt1.Create()
+	waitForWorkflowState(t, vc, ksWorkflow1, binlogdatapb.VReplicationWorkflowState_Running.String())
+	targetKs := vc.Cells[cellName].Keyspaces[targetKeyspace]
+	targetTab := targetKs.Shards["0"].Tablets[fmt.Sprintf("%s-%d", cellName, targetTabletId)].Vttablet
+	require.NotNil(t, targetTab)
+	catchup(t, targetTab, workflowName1, "MoveTables")
+
+	workflowName2 := "wf2"
+	ksWorkflow2 := fmt.Sprintf("%s.%s", targetKeyspace, workflowName2)
+	mt2 := newMoveTables(vc, &moveTables{
+		workflowName:   workflowName2,
+		targetKeyspace: targetKeyspace,
+		sourceKeyspace: sourceKeyspace,
+		tables:         "customer2",
+	}, moveTablesFlavorVtctld)
+	mt2.Create()
+	waitForWorkflowState(t, vc, ksWorkflow2, binlogdatapb.VReplicationWorkflowState_Running.String())
+	catchup(t, targetTab, workflowName2, "MoveTables")
+
+	go load("customer")
+	go load("customer2")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	doVdiff := func(workflowName, table string) {
+		defer wg.Done()
+		vdiff(t, targetKeyspace, workflowName, cellName, true, false, nil)
+		vtgateConn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+		defer vtgateConn.Close()
+		qr, err := vtgateConn.ExecuteFetch(fmt.Sprintf("select count(*) from %s", table), 1000, false)
+		if err != nil {
+			t.Fatalf("failed to get count of table %s: %v", table, err)
+		}
+		log.Infof("count of table %s: %v", table, qr.Rows[0][0])
+	}
+	go doVdiff(workflowName1, "customer")
+	go doVdiff(workflowName2, "customer2")
+	wg.Wait()
+	loadCancel()
+}

--- a/go/test/endtoend/vreplication/vdiff_multiple_movetables_test.go
+++ b/go/test/endtoend/vreplication/vdiff_multiple_movetables_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vreplication
 
 import (

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1781,7 +1781,7 @@ func (s *Server) VDiffShow(ctx context.Context, req *vtctldatapb.VDiffShowReques
 		log.Errorf("Error executing vdiff show action: %v", output.err)
 		return nil, output.err
 	}
-
+	log.Infof("999999999 VDiffShow: %v", output.responses)
 	return &vtctldatapb.VDiffShowResponse{
 		TabletResponses: output.responses,
 	}, nil

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1781,7 +1781,6 @@ func (s *Server) VDiffShow(ctx context.Context, req *vtctldatapb.VDiffShowReques
 		log.Errorf("Error executing vdiff show action: %v", output.err)
 		return nil, output.err
 	}
-	log.Infof("999999999 VDiffShow: %v", output.responses)
 	return &vtctldatapb.VDiffShowResponse{
 		TabletResponses: output.responses,
 	}, nil

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -48,7 +48,7 @@ const (
 	AllActionArg              = "all"
 	LastActionArg             = "last"
 
-	allVDiffsCount = 100
+	maxVDiffsToReport = 100
 )
 
 var (
@@ -327,7 +327,7 @@ func (vde *Engine) handleShowAction(ctx context.Context, dbClient binlogplayer.D
 		query, err := sqlparser.ParseAndBind(sqlGetMostRecentVDiffByKeyspaceWorkflow,
 			sqltypes.StringBindVariable(req.Keyspace),
 			sqltypes.StringBindVariable(req.Workflow),
-			sqltypes.Int64BindVariable(allVDiffsCount),
+			sqltypes.Int64BindVariable(maxVDiffsToReport),
 		)
 		if err != nil {
 			return err

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/log"
+
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -311,6 +313,7 @@ func (vde *Engine) handleShowAction(ctx context.Context, dbClient binlogplayer.D
 			row := qr.Named().Row()
 			vdiffID, _ := row["id"].ToInt64()
 			summary, err := vde.getVDiffSummary(vdiffID, dbClient)
+			log.Infof("9999999999999 summary: %v", summary.Rows)
 			resp.Output = summary
 			if err != nil {
 				return err

--- a/go/vt/vttablet/tabletmanager/vdiff/action_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action_test.go
@@ -176,6 +176,22 @@ func TestPerformVDiffAction(t *testing.T) {
 			},
 		},
 		{
+			name: "show last",
+			req: &tabletmanagerdatapb.VDiffRequest{
+				Action:    string(ShowAction),
+				ActionArg: "last",
+				Keyspace:  keyspace,
+				Workflow:  workflow,
+			},
+			expectQueries: []queryAndResult{
+				{
+					query: fmt.Sprintf("select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit %d",
+						encodeString(keyspace), encodeString(workflow), 1),
+					result: noResults,
+				},
+			},
+		},
+		{
 			name: "show all",
 			req: &tabletmanagerdatapb.VDiffRequest{
 				Action:    string(ShowAction),

--- a/go/vt/vttablet/tabletmanager/vdiff/action_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action_test.go
@@ -175,6 +175,22 @@ func TestPerformVDiffAction(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "show all",
+			req: &tabletmanagerdatapb.VDiffRequest{
+				Action:    string(ShowAction),
+				ActionArg: "all",
+				Keyspace:  keyspace,
+				Workflow:  workflow,
+			},
+			expectQueries: []queryAndResult{
+				{
+					query: fmt.Sprintf("select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit %d",
+						encodeString(keyspace), encodeString(workflow), maxVDiffsToReport),
+					result: noResults,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vdiff/schema.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/schema.go
@@ -24,10 +24,10 @@ const (
 					and vdt.state in ('completed', 'stopped')`
 	sqlRetryVDiff = `update _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) set vd.state = 'pending',
 					vd.last_error = '', vdt.state = 'pending' where vd.id = %a and (vd.state = 'error' or vdt.state = 'error')`
-	sqlGetVDiffByKeyspaceWorkflowUUID = "select * from _vt.vdiff where keyspace = %a and workflow = %a and vdiff_uuid = %a"
-	sqlGetMostRecentVDiff             = "select * from _vt.vdiff where keyspace = %a and workflow = %a order by id desc limit 1"
-	sqlGetVDiffByID                   = "select * from _vt.vdiff where id = %a"
-	sqlDeleteVDiffs                   = `delete from vd, vdt, vdl using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
+	sqlGetVDiffByKeyspaceWorkflowUUID       = "select * from _vt.vdiff where keyspace = %a and workflow = %a and vdiff_uuid = %a"
+	sqlGetMostRecentVDiffByKeyspaceWorkflow = "select * from _vt.vdiff where keyspace = %a and workflow = %a order by id desc limit %a"
+	sqlGetVDiffByID                         = "select * from _vt.vdiff where id = %a"
+	sqlDeleteVDiffs                         = `delete from vd, vdt, vdl using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 										left join _vt.vdiff_log as vdl on (vd.id = vdl.vdiff_id)
 										where vd.keyspace = %a and vd.workflow = %a`
 	sqlDeleteVDiffByUUID = `delete from vd, vdt using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
@@ -48,7 +48,6 @@ const (
 	sqlGetVDiffsToRetry              = "select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true'"
 	sqlGetVDiffID                    = "select id as id from _vt.vdiff where vdiff_uuid = %a"
 	sqlGetVDiffIDsByKeyspaceWorkflow = "select id as id from _vt.vdiff where keyspace = %a and workflow = %a"
-	sqlGetAllVDiffs                  = "select * from _vt.vdiff order by id desc"
 	sqlGetTableRows                  = "select table_rows as table_rows from INFORMATION_SCHEMA.TABLES where table_schema = %a and table_name = %a"
 	sqlGetAllTableRows               = "select table_name as table_name, table_rows as table_rows from INFORMATION_SCHEMA.TABLES where table_schema = %s and table_name in (%s)"
 

--- a/test/config.json
+++ b/test/config.json
@@ -1049,6 +1049,15 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"vdiff_multiple_movetables_test.go": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestMultipleConcurrentVDiffs"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vreplication_partial_movetables_basic",
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"vreplication_movetables_buffering": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestMoveTablesBuffering"],


### PR DESCRIPTION
## Description

This PR fixes a bug where the specified keyspace and workflow were ignored in the "show all" action.

There was no candidate e2e test that could be extended for this. So a new test has been added which has multiple concurrent workflows.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14443

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
