### PR TITLE
tx_throttler: remove topo watchers metric

### DIFF
--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -131,7 +131,6 @@ func TestEnabledThrottler(t *testing.T) {
 	throttlerStateImpl := throttlerImpl.state.(*txThrottlerStateImpl)
 	assert.Equal(t, map[topodatapb.TabletType]bool{topodatapb.TabletType_REPLICA: true}, throttlerStateImpl.tabletTypes)
 	assert.Equal(t, int64(1), throttlerImpl.throttlerRunning.Get())
-	assert.Equal(t, map[string]int64{"cell1": 1, "cell2": 1}, throttlerImpl.topoWatchers.Counts())
 
 	assert.False(t, throttlerImpl.Throttle(100, "some_workload"))
 	assert.Equal(t, int64(1), throttlerImpl.requestsTotal.Counts()["some_workload"])
@@ -162,7 +161,6 @@ func TestEnabledThrottler(t *testing.T) {
 	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some_workload"])
 	throttlerImpl.Close()
 	assert.Zero(t, throttlerImpl.throttlerRunning.Get())
-	assert.Equal(t, map[string]int64{"cell1": 0, "cell2": 0}, throttlerImpl.topoWatchers.Counts())
 }
 
 func TestFetchKnownCells(t *testing.T) {


### PR DESCRIPTION
## Description
A number of txThrottler related metrics were added in v18 in #13153. One of them counts the number of active topology watchers created by the txThrottler. As it happens, these watchers are never actually started or used, so in v19 they have been removed from the txThrottler struct. As part of that, the related metric will need to be deprecated in v19 and deleted in v20.

Since this metric was only introduced in v18 (which is not GA yet), a simpler route is to delete the metric from v18 before anyone uses it instead of trying to release/deprecate/delete over 3 releases.

Q: Why did I choose to do this PR on release-18.0 and not on main? 
A: Removing this metric on `main` will be building on #14412 and cannot be cherry-picked cleanly on to the release branch.

Q: Why not delete topology watchers from the throttler code altogether? I.e. why not backport #14412 onto the release branch before GA?
A: That is a somewhat bigger change than this isolated change. If reviewers feel strongly that we should do that, we can. If we decide to go that route, we need to backport both #14412 and #14445. That will of course take a bit more time to do, and there isn't much time left before the release.

## Related Issue(s)
#14412 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
