### PR TITLE
tx_throttler: delete topo watcher metric instead of deprecating

### DIFF
--- a/changelog/19.0/19.0.0/summary.md
+++ b/changelog/19.0/19.0.0/summary.md
@@ -12,7 +12,6 @@
 ### <a id="deprecations-and-deletions"/>Deprecations and Deletions
 
 - The `MYSQL_FLAVOR` environment variable is now removed from all Docker Images.
-- VTTablet metrics for TxThrottler's topology watchers have been deprecated. They will be deleted in the next release.
 
 ### <a id="docker"/>Docker
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -144,9 +144,7 @@ type txThrottler struct {
 	topoServer *topo.Server
 
 	// stats
-	throttlerRunning *stats.Gauge
-	// TODO(deepthi): deprecated, should be deleted in v20
-	topoWatchers              *stats.GaugesWithSingleLabel
+	throttlerRunning          *stats.Gauge
 	healthChecksReadTotal     *stats.CountersWithMultiLabels
 	healthChecksRecordedTotal *stats.CountersWithMultiLabels
 	requestsTotal             *stats.CountersWithSingleLabel
@@ -199,7 +197,6 @@ func NewTxThrottler(env tabletenv.Env, topoServer *topo.Server) TxThrottler {
 		config:           config,
 		topoServer:       topoServer,
 		throttlerRunning: env.Exporter().NewGauge(TxThrottlerName+"Running", "transaction throttler running state"),
-		topoWatchers:     env.Exporter().NewGaugesWithSingleLabel(TxThrottlerName+"TopoWatchers", "DEPRECATED: transaction throttler topology watchers", "cell"),
 		healthChecksReadTotal: env.Exporter().NewCountersWithMultiLabels(TxThrottlerName+"HealthchecksRead", "transaction throttler healthchecks read",
 			[]string{"cell", "DbType"}),
 		healthChecksRecordedTotal: env.Exporter().NewCountersWithMultiLabels(TxThrottlerName+"HealthchecksRecorded", "transaction throttler healthchecks recorded",


### PR DESCRIPTION
## Description
Delete the topo watcher metric instead of deprecating. See #14444 for a detailed explanation.

## Related Issue(s)
#14412 #14444 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
