### PR TITLE
Ensure hexval and int don't share BindVar after Normalization

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -46,7 +46,7 @@ func Normalize(stmt Statement, reserved *ReservedVars, bindVars map[string]*quer
 type normalizer struct {
 	bindVars  map[string]*querypb.BindVariable
 	reserved  *ReservedVars
-	vals      map[string]string
+	vals      map[Literal]string
 	err       error
 	inDerived bool
 }
@@ -55,7 +55,7 @@ func newNormalizer(reserved *ReservedVars, bindVars map[string]*querypb.BindVari
 	return &normalizer{
 		bindVars: bindVars,
 		reserved: reserved,
-		vals:     make(map[string]string),
+		vals:     make(map[Literal]string),
 	}
 }
 
@@ -198,28 +198,16 @@ func (nz *normalizer) convertLiteralDedup(node *Literal, cursor *Cursor) {
 	}
 
 	// Check if there's a bindvar for that value already.
-	key := keyFor(bval, node)
-	bvname, ok := nz.vals[key]
+	bvname, ok := nz.vals[*node]
 	if !ok {
 		// If there's no such bindvar, make a new one.
 		bvname = nz.reserved.nextUnusedVar()
-		nz.vals[key] = bvname
+		nz.vals[*node] = bvname
 		nz.bindVars[bvname] = bval
 	}
 
 	// Modify the AST node to a bindvar.
 	cursor.Replace(NewTypedArgument(bvname, node.SQLType()))
-}
-
-func keyFor(bval *querypb.BindVariable, lit *Literal) string {
-	if bval.Type != sqltypes.VarBinary && bval.Type != sqltypes.VarChar {
-		return lit.Val
-	}
-
-	// Prefixing strings with "'" ensures that a string
-	// and number that have the same representation don't
-	// collide.
-	return "'" + lit.Val
 }
 
 // convertLiteral converts an Literal without the dedup.
@@ -279,15 +267,14 @@ func (nz *normalizer) parameterize(left, right Expr) Expr {
 	if bval == nil {
 		return nil
 	}
-	key := keyFor(bval, lit)
-	bvname := nz.decideBindVarName(key, lit, col, bval)
+	bvname := nz.decideBindVarName(lit, col, bval)
 	return NewTypedArgument(bvname, lit.SQLType())
 }
 
-func (nz *normalizer) decideBindVarName(key string, lit *Literal, col *ColName, bval *querypb.BindVariable) string {
+func (nz *normalizer) decideBindVarName(lit *Literal, col *ColName, bval *querypb.BindVariable) string {
 	if len(lit.Val) <= 256 {
 		// first we check if we already have a bindvar for this value. if we do, we re-use that bindvar name
-		bvname, ok := nz.vals[key]
+		bvname, ok := nz.vals[*lit]
 		if ok {
 			return bvname
 		}
@@ -297,7 +284,7 @@ func (nz *normalizer) decideBindVarName(key string, lit *Literal, col *ColName, 
 	// Big values are most likely not for vindexes.
 	// We save a lot of CPU because we avoid building
 	bvname := nz.reserved.ReserveColName(col)
-	nz.vals[key] = bvname
+	nz.vals[*lit] = bvname
 	nz.bindVars[bvname] = bval
 
 	return bvname

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -371,6 +371,14 @@ func TestNormalize(t *testing.T) {
 		in:      `select * from (select 12) as t`,
 		outstmt: `select * from (select 12 from dual) as t`,
 		outbv:   map[string]*querypb.BindVariable{},
+	}, {
+		// HexVal and Int should not share a bindvar just because they have the same value
+		in:      `select * from t where v1 = x'31' and v2 = 31`,
+		outstmt: `select * from t where v1 = :v1 /* HEXVAL */ and v2 = :v2 /* INT64 */`,
+		outbv: map[string]*querypb.BindVariable{
+			"v1": sqltypes.HexValBindVariable([]byte("x'31'")),
+			"v2": sqltypes.Int64BindVariable(31),
+		},
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.in, func(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR relates to https://github.com/vitessio/vitess/issues/14450, adding a test and attempting to resolve what appears to be an incorrect sharing of a bind var between a HexVal e.g. `x'31'` and an Int e.g. `31`. This occurs because the type is not considered as part of the key for the BindVar map.

There was some existing code that attempted to disambiguate literal values as map keys by prefixing a single quote. Since this proved to not be correctly handling all situations, I thought it appropriate to key by the `Literal` itself. This ensures that a literal's `Type` is also considered first class in disambiguation.
    
I chose to use the `Literal` rather than `*Literal` because literals with the same type and value are intended to share a `BindVar`.
    
There's now slightly more data in the key since it is a struct with a `Type` field of size `Int`, but since the key previously was an arbitrary length string, the difference should be negligible. Running the benchmarks didn't seem to indicate anything of concern. I ran them using `go test -bench="BenchmarkNormalize" -run="^#" ./go/vt/sqlparser/.`

That said, it's totally possible (likely even) that I don't have the full picture here. I just kind of stumbled across this yesterday and have no other experience with vitess so...take it all with a grain of salt! I'm also not at all opposed to doing another approach like the existing single-quote prefix. It just seemed like more edge cases waiting to happen.

I have no opinions on backporting because I'm not an operator and don't know anything about vitess' processes.

## Related Issue(s)

Fixes #14450

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
