### PR TITLE
viper: register dynamic config with both disk and live

### DIFF
--- a/go/viperutil/internal/sync/sync.go
+++ b/go/viperutil/internal/sync/sync.go
@@ -289,10 +289,29 @@ func (v *Viper) loadFromDisk() {
 
 // begin implementation of registry.Bindable for sync.Viper
 
-func (v *Viper) BindEnv(vars ...string) error                 { return v.disk.BindEnv(vars...) }
-func (v *Viper) BindPFlag(key string, flag *pflag.Flag) error { return v.disk.BindPFlag(key, flag) }
-func (v *Viper) RegisterAlias(alias string, key string)       { v.disk.RegisterAlias(alias, key) }
-func (v *Viper) SetDefault(key string, value any)             { v.disk.SetDefault(key, value) }
+func (v *Viper) BindEnv(vars ...string) error {
+	if err := v.disk.BindEnv(vars...); err != nil {
+		return err
+	}
+	return v.live.BindEnv(vars...)
+}
+
+func (v *Viper) BindPFlag(key string, flag *pflag.Flag) error {
+	if err := v.disk.BindPFlag(key, flag); err != nil {
+		return err
+	}
+	return v.live.BindPFlag(key, flag)
+}
+
+func (v *Viper) RegisterAlias(alias string, key string) {
+	v.disk.RegisterAlias(alias, key)
+	v.live.RegisterAlias(alias, key)
+}
+
+func (v *Viper) SetDefault(key string, value any) {
+	v.disk.SetDefault(key, value)
+	v.live.SetDefault(key, value)
+}
 
 // end implementation of registry.Bindable for sync.Viper
 

--- a/go/viperutil/internal/sync/sync_test.go
+++ b/go/viperutil/internal/sync/sync_test.go
@@ -93,7 +93,10 @@ func TestWatchConfig(t *testing.T) {
 
 	sv := vipersync.New()
 	A := viperutil.Configure("a", viperutil.Options[int]{Dynamic: true})
-	B := viperutil.Configure("b", viperutil.Options[int]{Dynamic: true})
+	B := viperutil.Configure("b", viperutil.Options[int]{FlagName: "b", Dynamic: true, Default: 5})
+
+	// Check that default values are actually used
+	require.Equal(t, B.Get(), B.Default())
 
 	A.(*value.Dynamic[int]).Base.BoundGetFunc = vipersync.AdaptGetter("a", func(v *viper.Viper) func(key string) int {
 		return v.GetInt


### PR DESCRIPTION
## Description
The way we have setup viper in vitess, it has two distinct instances of viper - one for disk config and one for live config.
Dynamic config needs to be bound to both instances. We were binding them only to disk, but getting them from live, which meant that neither flag values nor default values were actually respected.
This PR fixes that by duplicating the lines of code that do the binding so that both internal instances know of dynamic configs.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
#14452 
We should mark this as fixed only after back ports are merged.
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
