### PR TITLE
servenv: Remove double close() logic

### DIFF
--- a/go/cmd/mysqlctld/cli/mysqlctld.go
+++ b/go/cmd/mysqlctld/cli/mysqlctld.go
@@ -54,7 +54,6 @@ var (
 		Long: "`mysqlctld` is a gRPC server that can be used instead of the `mysqlctl` client tool.\n" +
 			"If the target directories are empty when it is invoked, it automatically performs initialization operations to bootstrap the `mysqld` instance before starting it.\n" +
 			"The `mysqlctld` process can subsequently receive gRPC commands from a `vttablet` to perform housekeeping operations like shutting down and restarting the `mysqld` instance as needed.\n\n" +
-
 			"{{< warning >}}\n" +
 			"`mysqld_safe` is not used so the `mysqld` process will not be automatically restarted in case of a failure.\n" +
 			"{{</ warning>}}\n\n" +
@@ -151,7 +150,6 @@ func run(cmd *cobra.Command, args []string) error {
 	cancel()
 
 	servenv.Init()
-	defer servenv.Close()
 
 	// Take mysqld down with us on SIGTERM before entering lame duck.
 	servenv.OnTermSync(func() {

--- a/go/cmd/vtaclcheck/cli/vtactlcheck.go
+++ b/go/cmd/vtaclcheck/cli/vtactlcheck.go
@@ -44,7 +44,6 @@ var (
 
 func run(cmd *cobra.Command, args []string) error {
 	servenv.Init()
-	defer servenv.Close()
 
 	opts := &vtaclcheck.Options{
 		ACLFile:        aclFile,

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -217,7 +217,6 @@ func init() {
 
 func run(_ *cobra.Command, args []string) error {
 	servenv.Init()
-	defer servenv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	servenv.OnClose(func() {

--- a/go/cmd/vtbench/cli/vtbench.go
+++ b/go/cmd/vtbench/cli/vtbench.go
@@ -162,7 +162,6 @@ func run(cmd *cobra.Command, args []string) error {
 	_ = cmd.Flags().Set("logtostderr", "true")
 
 	servenv.Init()
-	defer servenv.Close()
 
 	var clientProto vtbench.ClientProtocol
 	switch protocol {

--- a/go/cmd/vtctld/cli/cli.go
+++ b/go/cmd/vtctld/cli/cli.go
@@ -55,7 +55,6 @@ This is demonstrated in the example usage below.`,
 
 func run(cmd *cobra.Command, args []string) error {
 	servenv.Init()
-	defer servenv.Close()
 
 	ts = topo.Open()
 	defer ts.Close()

--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -134,7 +134,6 @@ func run(cmd *cobra.Command, args []string) error {
 	defer exit.Recover()
 
 	servenv.Init()
-	defer servenv.Close()
 
 	ts := topo.Open()
 	defer ts.Close()

--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -104,7 +104,6 @@ vttablet \
 
 func run(cmd *cobra.Command, args []string) error {
 	servenv.Init()
-	defer servenv.Close()
 
 	tabletAlias, err := topoproto.ParseTabletAlias(tabletPath)
 	if err != nil {

--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -18,7 +18,6 @@ package servenv
 
 import (
 	"net"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -74,12 +73,6 @@ func Run(bindAddress string, port int) {
 
 	log.Info("Shutting down gracefully")
 	fireOnCloseHooks(onCloseTimeout)
-}
-
-// Close runs any registered exit hooks in parallel.
-func Close() {
-	onCloseHooks.Fire()
-	ListeningURL = url.URL{}
 }
 
 // OnClose registers f to be run at the end of the app lifecycle.

--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -18,6 +18,7 @@ package servenv
 
 import (
 	"net"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -73,6 +74,7 @@ func Run(bindAddress string, port int) {
 
 	log.Info("Shutting down gracefully")
 	fireOnCloseHooks(onCloseTimeout)
+	ListeningURL = url.URL{}
 }
 
 // OnClose registers f to be run at the end of the app lifecycle.


### PR DESCRIPTION
The servenv.Run function already runs the close hooks once it finishes. This means there's no use for deferring a `.Close()` since it double executes all close hooks.

In fact, it leads to panics. For example, vttablet always panics on each shutdown because the connection to the topo is already closed.

## Related Issue(s)
Fixes #14458 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required
