### PR TITLE
vtgate: Allow additional errors in warnings test

### DIFF
--- a/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
+++ b/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
@@ -140,10 +140,17 @@ func TestScatterErrsAsWarns(t *testing.T) {
 			utils.Exec(t, mode.conn, "use @replica")
 			utils.Exec(t, mode.conn, fmt.Sprintf("set workload = %s", mode.m))
 
+			expectedWarnings := []string{
+				"operation not allowed in state NOT_SERVING",
+				"operation not allowed in state SHUTTING_DOWN",
+				"no valid tablet",
+				"no healthy tablet",
+				"mysql.sock: connect: no such file or directory",
+			}
 			utils.AssertMatches(t, mode.conn, query1, `[[INT64(4)]]`)
-			assertContainsOneOf(t, mode.conn, showQ, "operation not allowed in state SHUTTING_DOWN", "no valid tablet", "no healthy tablet", "mysql.sock: connect: no such file or directory")
+			assertContainsOneOf(t, mode.conn, showQ, expectedWarnings...)
 			utils.AssertMatches(t, mode.conn, query2, `[[INT64(4)]]`)
-			assertContainsOneOf(t, mode.conn, showQ, "operation not allowed in state SHUTTING_DOWN", "no valid tablet", "no healthy tablet", "mysql.sock: connect: no such file or directory")
+			assertContainsOneOf(t, mode.conn, showQ, expectedWarnings...)
 
 			// invalid_field should throw error and not warning
 			_, err = mode.conn.ExecuteFetch("SELECT /*vt+ PLANNER=Gen4 SCATTER_ERRORS_AS_WARNINGS */ invalid_field from t1;", 1, false)


### PR DESCRIPTION
There's an additional error that we can see in this errors as warnings check.

It refactors it slightly to have one list instead that isn't on a huge single line.

## Related Issue(s)

Follow up to #14421

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required