### PR TITLE
examples: fix flag syntax for zkctl

### DIFF
--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: gh-hosted-runners-16cores-1
     strategy:
       matrix:
-        topo: [consul,etcd,k8s]
+        topo: [consul,etcd,zk2]
 
     steps:
     - name: Skip CI

--- a/examples/common/scripts/zk-down.sh
+++ b/examples/common/scripts/zk-down.sh
@@ -21,6 +21,6 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 # Stop ZooKeeper servers.
 echo "Stopping zk servers..."
 for zkid in $zkids; do
-  zkctl -zk.myid $zkid -zk.cfg $zkcfg -log_dir $VTDATAROOT/tmp shutdown
+  zkctl --zk.myid $zkid --zk.cfg $zkcfg --log_dir $VTDATAROOT/tmp shutdown
 done
 

--- a/examples/common/scripts/zk-up.sh
+++ b/examples/common/scripts/zk-up.sh
@@ -19,7 +19,6 @@
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
 cell=${CELL:-'test'}
-
 # Start ZooKeeper servers.
 # The "zkctl init" command won't return until the server is able to contact its
 # peers, so we need to start them all in the background and then wait for them.
@@ -32,7 +31,7 @@ for zkid in $zkids; do
     echo "    $VTDATAROOT/$zkdir"
     action='start'
   fi
-  zkctl -zk.myid $zkid -zk.cfg $zkcfg -log_dir $VTDATAROOT/tmp $action \
+  zkctl --zk.myid $zkid --zk.cfg $zkcfg --log_dir $VTDATAROOT/tmp $action \
     > $VTDATAROOT/tmp/zkctl_$zkid.out 2>&1 &
   pids[$zkid]=$!
 done


### PR DESCRIPTION
## Description
Running the local example with `TOPO=zk2` fails with an error from zkctl startup.
This is because we changed flags to use `--` instead of `-` back in v16.
This was broken at least on main, most likely on 17, and probably on v16 as well.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #14471 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
