### PR TITLE
Support `fast_analyze_table` variable, introduced in public MySQL fork

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -528,6 +528,9 @@ const (
 	sqlShowVariablesLikePreserveForeignKey = "show global variables like 'rename_table_preserve_foreign_key'"
 	sqlEnablePreserveForeignKey            = "set @@rename_table_preserve_foreign_key = 1"
 	sqlDisablePreserveForeignKey           = "set @@rename_table_preserve_foreign_key = 0"
+	sqlShowVariablesLikeFastAnalyzeTable   = "show global variables like 'fast_analyze_table'"
+	sqlEnableFastAnalyzeTable              = "set @@fast_analyze_table = 1"
+	sqlDisableFastAnalyzeTable             = "set @@fast_analyze_table = 0"
 	sqlGetAutoIncrement                    = `
 		SELECT
 			AUTO_INCREMENT


### PR DESCRIPTION
## Description

This PR follows up on https://github.com/vitessio/vitess/pull/13352. It utilizes `fast_analyze_table` (global/session variable), introduced in https://github.com/planetscale/mysql-server/commit/c8a9d93686358dabfba8f3dc5cc0621e3149fe78 as part of https://github.com/planetscale/mysql-server/releases/tag/8.0.34-ps1.

In this PR, and when `--analyze-table` DDL strategy flag is provided, the Online DDL executor checks for existence of this variable. If the variable exists, then the executor will set it to `1` prior to running `ANALYZE TABLE ...`.

This introduced code is safe to run on MySQL versions that do not support the variable, as the initial probing query is 
```sql
show global variables like 'fast_analyze_table'
```
which is always safe to run. The query returns 0 rows on unsupporting servers.

With `fast_analyze_table`, an `ANALYZE TABLE` only updates stats for the clustering index (normally the `PRIMARY KEY`).

		 

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/13437
- #13352

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
