### PR TITLE
Refactor: use NonEmpty() instead of !IsEmpty()

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/materialize/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/materialize/create.go
@@ -167,7 +167,7 @@ func (ts *tableSettings) Set(v string) error {
 		err = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 			switch node := node.(type) {
 			case sqlparser.TableName:
-				if node.Name.NonEmpty() {
+				if node.Name.NotEmpty() {
 					if seenSourceTables[node.Name.String()] {
 						return false, fmt.Errorf("multiple source_expression queries use the same table: %q", node.Name.String())
 					}

--- a/go/cmd/vtctldclient/command/vreplication/materialize/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/materialize/create.go
@@ -167,7 +167,7 @@ func (ts *tableSettings) Set(v string) error {
 		err = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 			switch node := node.(type) {
 			case sqlparser.TableName:
-				if !node.Name.IsEmpty() {
+				if node.Name.NonEmpty() {
 					if seenSourceTables[node.Name.String()] {
 						return false, fmt.Errorf("multiple source_expression queries use the same table: %q", node.Name.String())
 					}

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -831,7 +831,7 @@ func (idx *IndexDefinition) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (ii *IndexInfo) Format(buf *TrackedBuffer) {
-	if ii.ConstraintName.NonEmpty() {
+	if ii.ConstraintName.NotEmpty() {
 		buf.astPrintf(ii, "constraint %v ", ii.ConstraintName)
 	}
 	switch ii.Type {
@@ -847,7 +847,7 @@ func (ii *IndexInfo) Format(buf *TrackedBuffer) {
 	case IndexTypeFullText:
 		buf.astPrintf(ii, "%s %s", keywordStrings[FULLTEXT], keywordStrings[KEY])
 	}
-	if ii.Name.NonEmpty() {
+	if ii.Name.NotEmpty() {
 		buf.astPrintf(ii, " %v", ii.Name)
 	}
 }
@@ -883,7 +883,7 @@ func (node VindexParam) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (c *ConstraintDefinition) Format(buf *TrackedBuffer) {
-	if c.Name.NonEmpty() {
+	if c.Name.NotEmpty() {
 		buf.astPrintf(c, "constraint %v ", c.Name)
 	}
 	c.Details.Format(buf)
@@ -1114,7 +1114,7 @@ func (node *StarExpr) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *AliasedExpr) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "%v", node.Expr)
-	if node.As.NonEmpty() {
+	if node.As.NotEmpty() {
 		buf.astPrintf(node, " as %v", node.As)
 	}
 }
@@ -1163,7 +1163,7 @@ func (node TableExprs) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *AliasedTableExpr) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "%v%v", node.Expr, node.Partitions)
-	if node.As.NonEmpty() {
+	if node.As.NotEmpty() {
 		buf.astPrintf(node, " as %v", node.As)
 		if len(node.Columns) != 0 {
 			buf.astPrintf(node, "%v", node.Columns)
@@ -1189,7 +1189,7 @@ func (node TableName) Format(buf *TrackedBuffer) {
 	if node.IsEmpty() {
 		return
 	}
-	if node.Qualifier.NonEmpty() {
+	if node.Qualifier.NotEmpty() {
 		buf.astPrintf(node, "%v.", node.Qualifier)
 	}
 	buf.astPrintf(node, "%v", node.Name)
@@ -1544,7 +1544,7 @@ func (node *CollateExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *FuncExpr) Format(buf *TrackedBuffer) {
-	if node.Qualifier.NonEmpty() {
+	if node.Qualifier.NotEmpty() {
 		buf.astPrintf(node, "%v.", node.Qualifier)
 	}
 	// Function names should not be back-quoted even
@@ -1598,7 +1598,7 @@ func (node *JSONStorageSizeExpr) Format(buf *TrackedBuffer) {
 // Format formats the node
 func (node *OverClause) Format(buf *TrackedBuffer) {
 	buf.WriteString("over")
-	if node.WindowName.NonEmpty() {
+	if node.WindowName.NotEmpty() {
 		buf.astPrintf(node, " %v", node.WindowName)
 	}
 	if node.WindowSpec != nil {
@@ -1608,7 +1608,7 @@ func (node *OverClause) Format(buf *TrackedBuffer) {
 
 // Format formats the node
 func (node *WindowSpecification) Format(buf *TrackedBuffer) {
-	if node.Name.NonEmpty() {
+	if node.Name.NotEmpty() {
 		buf.astPrintf(node, " %v", node.Name)
 	}
 	if node.PartitionClause != nil {
@@ -2020,7 +2020,7 @@ func (node *ShowBasic) Format(buf *TrackedBuffer) {
 	if !node.Tbl.IsEmpty() {
 		buf.astPrintf(node, " from %v", node.Tbl)
 	}
-	if node.DbName.NonEmpty() {
+	if node.DbName.NotEmpty() {
 		buf.astPrintf(node, " from %v", node.DbName)
 	}
 	buf.astPrintf(node, "%v", node.Filter)
@@ -2070,7 +2070,7 @@ func (node *CreateDatabase) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *AlterDatabase) Format(buf *TrackedBuffer) {
 	buf.literal("alter database")
-	if node.DBName.NonEmpty() {
+	if node.DBName.NotEmpty() {
 		buf.astPrintf(node, " %v", node.DBName)
 	}
 	if node.UpdateDataDirectory {
@@ -2354,7 +2354,7 @@ func (node *DropColumn) Format(buf *TrackedBuffer) {
 // Format formats the node
 func (node *DropKey) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "drop %s", node.Type.ToString())
-	if node.Name.NonEmpty() {
+	if node.Name.NotEmpty() {
 		buf.astPrintf(node, " %v", node.Name)
 	}
 }

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -831,7 +831,7 @@ func (idx *IndexDefinition) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (ii *IndexInfo) Format(buf *TrackedBuffer) {
-	if !ii.ConstraintName.IsEmpty() {
+	if ii.ConstraintName.NonEmpty() {
 		buf.astPrintf(ii, "constraint %v ", ii.ConstraintName)
 	}
 	switch ii.Type {
@@ -847,7 +847,7 @@ func (ii *IndexInfo) Format(buf *TrackedBuffer) {
 	case IndexTypeFullText:
 		buf.astPrintf(ii, "%s %s", keywordStrings[FULLTEXT], keywordStrings[KEY])
 	}
-	if !ii.Name.IsEmpty() {
+	if ii.Name.NonEmpty() {
 		buf.astPrintf(ii, " %v", ii.Name)
 	}
 }
@@ -883,7 +883,7 @@ func (node VindexParam) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (c *ConstraintDefinition) Format(buf *TrackedBuffer) {
-	if !c.Name.IsEmpty() {
+	if c.Name.NonEmpty() {
 		buf.astPrintf(c, "constraint %v ", c.Name)
 	}
 	c.Details.Format(buf)
@@ -1114,7 +1114,7 @@ func (node *StarExpr) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *AliasedExpr) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "%v", node.Expr)
-	if !node.As.IsEmpty() {
+	if node.As.NonEmpty() {
 		buf.astPrintf(node, " as %v", node.As)
 	}
 }
@@ -1598,7 +1598,7 @@ func (node *JSONStorageSizeExpr) Format(buf *TrackedBuffer) {
 // Format formats the node
 func (node *OverClause) Format(buf *TrackedBuffer) {
 	buf.WriteString("over")
-	if !node.WindowName.IsEmpty() {
+	if node.WindowName.NonEmpty() {
 		buf.astPrintf(node, " %v", node.WindowName)
 	}
 	if node.WindowSpec != nil {
@@ -1608,7 +1608,7 @@ func (node *OverClause) Format(buf *TrackedBuffer) {
 
 // Format formats the node
 func (node *WindowSpecification) Format(buf *TrackedBuffer) {
-	if !node.Name.IsEmpty() {
+	if node.Name.NonEmpty() {
 		buf.astPrintf(node, " %v", node.Name)
 	}
 	if node.PartitionClause != nil {
@@ -2354,7 +2354,7 @@ func (node *DropColumn) Format(buf *TrackedBuffer) {
 // Format formats the node
 func (node *DropKey) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "drop %s", node.Type.ToString())
-	if !node.Name.IsEmpty() {
+	if node.Name.NonEmpty() {
 		buf.astPrintf(node, " %v", node.Name)
 	}
 }

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1163,7 +1163,7 @@ func (node TableExprs) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *AliasedTableExpr) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "%v%v", node.Expr, node.Partitions)
-	if !node.As.IsEmpty() {
+	if node.As.NonEmpty() {
 		buf.astPrintf(node, " as %v", node.As)
 		if len(node.Columns) != 0 {
 			buf.astPrintf(node, "%v", node.Columns)
@@ -1189,7 +1189,7 @@ func (node TableName) Format(buf *TrackedBuffer) {
 	if node.IsEmpty() {
 		return
 	}
-	if !node.Qualifier.IsEmpty() {
+	if node.Qualifier.NonEmpty() {
 		buf.astPrintf(node, "%v.", node.Qualifier)
 	}
 	buf.astPrintf(node, "%v", node.Name)
@@ -1544,7 +1544,7 @@ func (node *CollateExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *FuncExpr) Format(buf *TrackedBuffer) {
-	if !node.Qualifier.IsEmpty() {
+	if node.Qualifier.NonEmpty() {
 		buf.astPrintf(node, "%v.", node.Qualifier)
 	}
 	// Function names should not be back-quoted even
@@ -2020,7 +2020,7 @@ func (node *ShowBasic) Format(buf *TrackedBuffer) {
 	if !node.Tbl.IsEmpty() {
 		buf.astPrintf(node, " from %v", node.Tbl)
 	}
-	if !node.DbName.IsEmpty() {
+	if node.DbName.NonEmpty() {
 		buf.astPrintf(node, " from %v", node.DbName)
 	}
 	buf.astPrintf(node, "%v", node.Filter)
@@ -2070,7 +2070,7 @@ func (node *CreateDatabase) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *AlterDatabase) Format(buf *TrackedBuffer) {
 	buf.literal("alter database")
-	if !node.DBName.IsEmpty() {
+	if node.DBName.NonEmpty() {
 		buf.astPrintf(node, " %v", node.DBName)
 	}
 	if node.UpdateDataDirectory {

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1530,7 +1530,7 @@ func (node TableExprs) FormatFast(buf *TrackedBuffer) {
 func (node *AliasedTableExpr) FormatFast(buf *TrackedBuffer) {
 	node.Expr.FormatFast(buf)
 	node.Partitions.FormatFast(buf)
-	if !node.As.IsEmpty() {
+	if node.As.NonEmpty() {
 		buf.WriteString(" as ")
 		node.As.FormatFast(buf)
 		if len(node.Columns) != 0 {
@@ -1558,7 +1558,7 @@ func (node TableName) FormatFast(buf *TrackedBuffer) {
 	if node.IsEmpty() {
 		return
 	}
-	if !node.Qualifier.IsEmpty() {
+	if node.Qualifier.NonEmpty() {
 		node.Qualifier.FormatFast(buf)
 		buf.WriteByte('.')
 	}
@@ -2064,7 +2064,7 @@ func (node *CollateExpr) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (node *FuncExpr) FormatFast(buf *TrackedBuffer) {
-	if !node.Qualifier.IsEmpty() {
+	if node.Qualifier.NonEmpty() {
 		node.Qualifier.FormatFast(buf)
 		buf.WriteByte('.')
 	}
@@ -2690,7 +2690,7 @@ func (node *ShowBasic) FormatFast(buf *TrackedBuffer) {
 		buf.WriteString(" from ")
 		node.Tbl.FormatFast(buf)
 	}
-	if !node.DbName.IsEmpty() {
+	if node.DbName.NonEmpty() {
 		buf.WriteString(" from ")
 		node.DbName.FormatFast(buf)
 	}
@@ -2751,7 +2751,7 @@ func (node *CreateDatabase) FormatFast(buf *TrackedBuffer) {
 // FormatFast formats the node.
 func (node *AlterDatabase) FormatFast(buf *TrackedBuffer) {
 	buf.WriteString("alter database")
-	if !node.DBName.IsEmpty() {
+	if node.DBName.NonEmpty() {
 		buf.WriteByte(' ')
 		node.DBName.FormatFast(buf)
 	}

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1128,7 +1128,7 @@ func (idx *IndexDefinition) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (ii *IndexInfo) FormatFast(buf *TrackedBuffer) {
-	if !ii.ConstraintName.IsEmpty() {
+	if ii.ConstraintName.NonEmpty() {
 		buf.WriteString("constraint ")
 		ii.ConstraintName.FormatFast(buf)
 		buf.WriteByte(' ')
@@ -1154,7 +1154,7 @@ func (ii *IndexInfo) FormatFast(buf *TrackedBuffer) {
 		buf.WriteByte(' ')
 		buf.WriteString(keywordStrings[KEY])
 	}
-	if !ii.Name.IsEmpty() {
+	if ii.Name.NonEmpty() {
 		buf.WriteByte(' ')
 		ii.Name.FormatFast(buf)
 	}
@@ -1196,7 +1196,7 @@ func (node VindexParam) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (c *ConstraintDefinition) FormatFast(buf *TrackedBuffer) {
-	if !c.Name.IsEmpty() {
+	if c.Name.NonEmpty() {
 		buf.WriteString("constraint ")
 		c.Name.FormatFast(buf)
 		buf.WriteByte(' ')
@@ -1474,7 +1474,7 @@ func (node *StarExpr) FormatFast(buf *TrackedBuffer) {
 // FormatFast formats the node.
 func (node *AliasedExpr) FormatFast(buf *TrackedBuffer) {
 	node.Expr.FormatFast(buf)
-	if !node.As.IsEmpty() {
+	if node.As.NonEmpty() {
 		buf.WriteString(" as ")
 		node.As.FormatFast(buf)
 	}
@@ -2138,7 +2138,7 @@ func (node *JSONStorageSizeExpr) FormatFast(buf *TrackedBuffer) {
 // FormatFast formats the node
 func (node *OverClause) FormatFast(buf *TrackedBuffer) {
 	buf.WriteString("over")
-	if !node.WindowName.IsEmpty() {
+	if node.WindowName.NonEmpty() {
 		buf.WriteByte(' ')
 		node.WindowName.FormatFast(buf)
 	}
@@ -2151,7 +2151,7 @@ func (node *OverClause) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node
 func (node *WindowSpecification) FormatFast(buf *TrackedBuffer) {
-	if !node.Name.IsEmpty() {
+	if node.Name.NonEmpty() {
 		buf.WriteByte(' ')
 		node.Name.FormatFast(buf)
 	}
@@ -3118,7 +3118,7 @@ func (node *DropColumn) FormatFast(buf *TrackedBuffer) {
 func (node *DropKey) FormatFast(buf *TrackedBuffer) {
 	buf.WriteString("drop ")
 	buf.WriteString(node.Type.ToString())
-	if !node.Name.IsEmpty() {
+	if node.Name.NonEmpty() {
 		buf.WriteByte(' ')
 		node.Name.FormatFast(buf)
 	}

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1128,7 +1128,7 @@ func (idx *IndexDefinition) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (ii *IndexInfo) FormatFast(buf *TrackedBuffer) {
-	if ii.ConstraintName.NonEmpty() {
+	if ii.ConstraintName.NotEmpty() {
 		buf.WriteString("constraint ")
 		ii.ConstraintName.FormatFast(buf)
 		buf.WriteByte(' ')
@@ -1154,7 +1154,7 @@ func (ii *IndexInfo) FormatFast(buf *TrackedBuffer) {
 		buf.WriteByte(' ')
 		buf.WriteString(keywordStrings[KEY])
 	}
-	if ii.Name.NonEmpty() {
+	if ii.Name.NotEmpty() {
 		buf.WriteByte(' ')
 		ii.Name.FormatFast(buf)
 	}
@@ -1196,7 +1196,7 @@ func (node VindexParam) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (c *ConstraintDefinition) FormatFast(buf *TrackedBuffer) {
-	if c.Name.NonEmpty() {
+	if c.Name.NotEmpty() {
 		buf.WriteString("constraint ")
 		c.Name.FormatFast(buf)
 		buf.WriteByte(' ')
@@ -1474,7 +1474,7 @@ func (node *StarExpr) FormatFast(buf *TrackedBuffer) {
 // FormatFast formats the node.
 func (node *AliasedExpr) FormatFast(buf *TrackedBuffer) {
 	node.Expr.FormatFast(buf)
-	if node.As.NonEmpty() {
+	if node.As.NotEmpty() {
 		buf.WriteString(" as ")
 		node.As.FormatFast(buf)
 	}
@@ -1530,7 +1530,7 @@ func (node TableExprs) FormatFast(buf *TrackedBuffer) {
 func (node *AliasedTableExpr) FormatFast(buf *TrackedBuffer) {
 	node.Expr.FormatFast(buf)
 	node.Partitions.FormatFast(buf)
-	if node.As.NonEmpty() {
+	if node.As.NotEmpty() {
 		buf.WriteString(" as ")
 		node.As.FormatFast(buf)
 		if len(node.Columns) != 0 {
@@ -1558,7 +1558,7 @@ func (node TableName) FormatFast(buf *TrackedBuffer) {
 	if node.IsEmpty() {
 		return
 	}
-	if node.Qualifier.NonEmpty() {
+	if node.Qualifier.NotEmpty() {
 		node.Qualifier.FormatFast(buf)
 		buf.WriteByte('.')
 	}
@@ -2064,7 +2064,7 @@ func (node *CollateExpr) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (node *FuncExpr) FormatFast(buf *TrackedBuffer) {
-	if node.Qualifier.NonEmpty() {
+	if node.Qualifier.NotEmpty() {
 		node.Qualifier.FormatFast(buf)
 		buf.WriteByte('.')
 	}
@@ -2138,7 +2138,7 @@ func (node *JSONStorageSizeExpr) FormatFast(buf *TrackedBuffer) {
 // FormatFast formats the node
 func (node *OverClause) FormatFast(buf *TrackedBuffer) {
 	buf.WriteString("over")
-	if node.WindowName.NonEmpty() {
+	if node.WindowName.NotEmpty() {
 		buf.WriteByte(' ')
 		node.WindowName.FormatFast(buf)
 	}
@@ -2151,7 +2151,7 @@ func (node *OverClause) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node
 func (node *WindowSpecification) FormatFast(buf *TrackedBuffer) {
-	if node.Name.NonEmpty() {
+	if node.Name.NotEmpty() {
 		buf.WriteByte(' ')
 		node.Name.FormatFast(buf)
 	}
@@ -2690,7 +2690,7 @@ func (node *ShowBasic) FormatFast(buf *TrackedBuffer) {
 		buf.WriteString(" from ")
 		node.Tbl.FormatFast(buf)
 	}
-	if node.DbName.NonEmpty() {
+	if node.DbName.NotEmpty() {
 		buf.WriteString(" from ")
 		node.DbName.FormatFast(buf)
 	}
@@ -2751,7 +2751,7 @@ func (node *CreateDatabase) FormatFast(buf *TrackedBuffer) {
 // FormatFast formats the node.
 func (node *AlterDatabase) FormatFast(buf *TrackedBuffer) {
 	buf.WriteString("alter database")
-	if node.DBName.NonEmpty() {
+	if node.DBName.NotEmpty() {
 		buf.WriteByte(' ')
 		node.DBName.FormatFast(buf)
 	}
@@ -3118,7 +3118,7 @@ func (node *DropColumn) FormatFast(buf *TrackedBuffer) {
 func (node *DropKey) FormatFast(buf *TrackedBuffer) {
 	buf.WriteString("drop ")
 	buf.WriteString(node.Type.ToString())
-	if node.Name.NonEmpty() {
+	if node.Name.NotEmpty() {
 		buf.WriteByte(' ')
 		node.Name.FormatFast(buf)
 	}

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -400,7 +400,7 @@ func (node *AliasedTableExpr) RemoveHints() *AliasedTableExpr {
 
 // TableName returns a TableName pointing to this table expr
 func (node *AliasedTableExpr) TableName() (TableName, error) {
-	if !node.As.IsEmpty() {
+	if node.As.NonEmpty() {
 		return TableName{Name: node.As}, nil
 	}
 
@@ -938,6 +938,11 @@ func NewIdentifierCS(str string) IdentifierCS {
 // IsEmpty returns true if TabIdent is empty.
 func (node IdentifierCS) IsEmpty() bool {
 	return node.v == ""
+}
+
+// NonEmpty returns true if TabIdent is not empty.
+func (node IdentifierCS) NonEmpty() bool {
+	return !node.IsEmpty()
 }
 
 // String returns the unescaped table name. It must
@@ -2136,7 +2141,7 @@ func RemoveKeyspace(in SQLNode) {
 	_ = Walk(func(node SQLNode) (kontinue bool, err error) {
 		switch col := node.(type) {
 		case *ColName:
-			if !col.Qualifier.Qualifier.IsEmpty() {
+			if col.Qualifier.Qualifier.NonEmpty() {
 				col.Qualifier.Qualifier = NewIdentifierCS("")
 			}
 		}

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -400,7 +400,7 @@ func (node *AliasedTableExpr) RemoveHints() *AliasedTableExpr {
 
 // TableName returns a TableName pointing to this table expr
 func (node *AliasedTableExpr) TableName() (TableName, error) {
-	if node.As.NonEmpty() {
+	if node.As.NotEmpty() {
 		return TableName{Name: node.As}, nil
 	}
 
@@ -869,7 +869,7 @@ func (node IdentifierCI) IsEmpty() bool {
 }
 
 // NonEmpty returns true if the name is not empty.
-func (node IdentifierCI) NonEmpty() bool {
+func (node IdentifierCI) NotEmpty() bool {
 	return !node.IsEmpty()
 }
 
@@ -941,7 +941,7 @@ func (node IdentifierCS) IsEmpty() bool {
 }
 
 // NonEmpty returns true if TabIdent is not empty.
-func (node IdentifierCS) NonEmpty() bool {
+func (node IdentifierCS) NotEmpty() bool {
 	return !node.IsEmpty()
 }
 
@@ -2109,7 +2109,7 @@ func GetAllSelects(selStmt SelectStatement) []*Select {
 
 // ColumnName returns the alias if one was provided, otherwise prints the AST
 func (ae *AliasedExpr) ColumnName() string {
-	if ae.As.NonEmpty() {
+	if ae.As.NotEmpty() {
 		return ae.As.String()
 	}
 
@@ -2141,7 +2141,7 @@ func RemoveKeyspace(in SQLNode) {
 	_ = Walk(func(node SQLNode) (kontinue bool, err error) {
 		switch col := node.(type) {
 		case *ColName:
-			if col.Qualifier.Qualifier.NonEmpty() {
+			if col.Qualifier.Qualifier.NotEmpty() {
 				col.Qualifier.Qualifier = NewIdentifierCS("")
 			}
 		}

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -868,6 +868,11 @@ func (node IdentifierCI) IsEmpty() bool {
 	return node.val == ""
 }
 
+// NonEmpty returns true if the name is not empty.
+func (node IdentifierCI) NonEmpty() bool {
+	return !node.IsEmpty()
+}
+
 // String returns the unescaped column name. It must
 // not be used for SQL generation. Use sqlparser.String
 // instead. The Stringer conformance is for usage
@@ -2099,7 +2104,7 @@ func GetAllSelects(selStmt SelectStatement) []*Select {
 
 // ColumnName returns the alias if one was provided, otherwise prints the AST
 func (ae *AliasedExpr) ColumnName() string {
-	if !ae.As.IsEmpty() {
+	if ae.As.NonEmpty() {
 		return ae.As.String()
 	}
 

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -307,7 +307,7 @@ func (er *astRewriter) visitSelect(node *Select) {
 		}
 
 		aliasedExpr, ok := col.(*AliasedExpr)
-		if !ok || !aliasedExpr.As.IsEmpty() {
+		if !ok || aliasedExpr.As.NonEmpty() {
 			continue
 		}
 		buf := NewTrackedBuffer(nil)

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -307,7 +307,7 @@ func (er *astRewriter) visitSelect(node *Select) {
 		}
 
 		aliasedExpr, ok := col.(*AliasedExpr)
-		if !ok || aliasedExpr.As.NonEmpty() {
+		if !ok || aliasedExpr.As.NotEmpty() {
 			continue
 		}
 		buf := NewTrackedBuffer(nil)

--- a/go/vt/sqlparser/utils.go
+++ b/go/vt/sqlparser/utils.go
@@ -135,14 +135,14 @@ func ReplaceTableQualifiers(query, olddb, newdb string) (string, error) {
 	upd := Rewrite(in, func(cursor *Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case TableName:
-			if !node.Qualifier.IsEmpty() &&
+			if node.Qualifier.NonEmpty() &&
 				node.Qualifier.String() == oldQualifier.String() {
 				node.Qualifier = newQualifier
 				cursor.Replace(node)
 				modified = true
 			}
 		case *ShowBasic: // for things like 'show tables from _vt'
-			if !node.DbName.IsEmpty() &&
+			if node.DbName.NonEmpty() &&
 				node.DbName.String() == oldQualifier.String() {
 				node.DbName = newQualifier
 				cursor.Replace(node)

--- a/go/vt/sqlparser/utils.go
+++ b/go/vt/sqlparser/utils.go
@@ -135,14 +135,14 @@ func ReplaceTableQualifiers(query, olddb, newdb string) (string, error) {
 	upd := Rewrite(in, func(cursor *Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case TableName:
-			if node.Qualifier.NonEmpty() &&
+			if node.Qualifier.NotEmpty() &&
 				node.Qualifier.String() == oldQualifier.String() {
 				node.Qualifier = newQualifier
 				cursor.Replace(node)
 				modified = true
 			}
 		case *ShowBasic: // for things like 'show tables from _vt'
-			if node.DbName.NonEmpty() &&
+			if node.DbName.NotEmpty() &&
 				node.DbName.String() == oldQualifier.String() {
 				node.DbName = newQualifier
 				cursor.Replace(node)

--- a/go/vt/topotools/vschema_ddl.go
+++ b/go/vt/topotools/vschema_ddl.go
@@ -124,7 +124,7 @@ func ApplyVSchemaDDL(ksName string, ks *vschemapb.Keyspace, alterVschema *sqlpar
 		//    already exists.
 		spec := alterVschema.VindexSpec
 		name := spec.Name.String()
-		if !spec.Type.IsEmpty() {
+		if spec.Type.NonEmpty() {
 			owner, params := spec.ParseParams()
 			if vindex, ok := ks.Vindexes[name]; ok {
 				if vindex.Type != spec.Type.String() {

--- a/go/vt/topotools/vschema_ddl.go
+++ b/go/vt/topotools/vschema_ddl.go
@@ -124,7 +124,7 @@ func ApplyVSchemaDDL(ksName string, ks *vschemapb.Keyspace, alterVschema *sqlpar
 		//    already exists.
 		spec := alterVschema.VindexSpec
 		name := spec.Name.String()
-		if spec.Type.NonEmpty() {
+		if spec.Type.NotEmpty() {
 			owner, params := spec.ParseParams()
 			if vindex, ok := ks.Vindexes[name]; ok {
 				if vindex.Type != spec.Type.String() {

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -246,7 +246,7 @@ func buildAnalyzePlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vsche
 	var err error
 	dest := key.Destination(key.DestinationAllShards{})
 
-	if !analyzeStmt.Table.Qualifier.IsEmpty() && sqlparser.SystemSchema(analyzeStmt.Table.Qualifier.String()) {
+	if analyzeStmt.Table.Qualifier.NonEmpty() && sqlparser.SystemSchema(analyzeStmt.Table.Qualifier.String()) {
 		ks, err = vschema.AnyKeyspace()
 		if err != nil {
 			return nil, err

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -246,7 +246,7 @@ func buildAnalyzePlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vsche
 	var err error
 	dest := key.Destination(key.DestinationAllShards{})
 
-	if analyzeStmt.Table.Qualifier.NonEmpty() && sqlparser.SystemSchema(analyzeStmt.Table.Qualifier.String()) {
+	if analyzeStmt.Table.Qualifier.NotEmpty() && sqlparser.SystemSchema(analyzeStmt.Table.Qualifier.String()) {
 		ks, err = vschema.AnyKeyspace()
 		if err != nil {
 			return nil, err

--- a/go/vt/vtgate/planbuilder/call_proc.go
+++ b/go/vt/vtgate/planbuilder/call_proc.go
@@ -25,7 +25,7 @@ import (
 
 func buildCallProcPlan(stmt *sqlparser.CallProc, vschema plancontext.VSchema) (*planResult, error) {
 	var ks string
-	if stmt.Name.Qualifier.NonEmpty() {
+	if stmt.Name.Qualifier.NotEmpty() {
 		ks = stmt.Name.Qualifier.String()
 	}
 

--- a/go/vt/vtgate/planbuilder/call_proc.go
+++ b/go/vt/vtgate/planbuilder/call_proc.go
@@ -25,7 +25,7 @@ import (
 
 func buildCallProcPlan(stmt *sqlparser.CallProc, vschema plancontext.VSchema) (*planResult, error) {
 	var ks string
-	if !stmt.Name.Qualifier.IsEmpty() {
+	if stmt.Name.Qualifier.NonEmpty() {
 		ks = stmt.Name.Qualifier.String()
 	}
 

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -95,7 +95,7 @@ func rewriteSingleTbl(del *sqlparser.Delete) (*sqlparser.Delete, error) {
 	if !ok {
 		return del, nil
 	}
-	if !atExpr.As.IsEmpty() && !sqlparser.Equals.IdentifierCS(del.Targets[0].Name, atExpr.As) {
+	if atExpr.As.NonEmpty() && !sqlparser.Equals.IdentifierCS(del.Targets[0].Name, atExpr.As) {
 		// Unknown table in MULTI DELETE
 		return nil, vterrors.VT03003(del.Targets[0].Name.String())
 	}

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -95,7 +95,7 @@ func rewriteSingleTbl(del *sqlparser.Delete) (*sqlparser.Delete, error) {
 	if !ok {
 		return del, nil
 	}
-	if atExpr.As.NonEmpty() && !sqlparser.Equals.IdentifierCS(del.Targets[0].Name, atExpr.As) {
+	if atExpr.As.NotEmpty() && !sqlparser.Equals.IdentifierCS(del.Targets[0].Name, atExpr.As) {
 		// Unknown table in MULTI DELETE
 		return nil, vterrors.VT03003(del.Targets[0].Name.String())
 	}

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -166,7 +166,7 @@ func (ap AliasedProjections) AddColumn(col *sqlparser.AliasedExpr) (ProjCols, in
 
 func (pe *ProjExpr) String() string {
 	var alias, expr, info string
-	if !pe.Original.As.IsEmpty() {
+	if pe.Original.As.NonEmpty() {
 		alias = " AS " + pe.Original.As.String()
 	}
 	if sqlparser.Equals.Expr(pe.EvalExpr, pe.ColExpr) {
@@ -399,7 +399,7 @@ func (p *Projection) GetSelectExprs(*plancontext.PlanningContext) sqlparser.Sele
 		var output sqlparser.SelectExprs
 		for _, pe := range cols {
 			ae := &sqlparser.AliasedExpr{Expr: pe.EvalExpr}
-			if !pe.Original.As.IsEmpty() {
+			if pe.Original.As.NonEmpty() {
 				ae.As = pe.Original.As
 			} else if !sqlparser.Equals.Expr(ae.Expr, pe.Original.Expr) {
 				ae.As = sqlparser.NewIdentifierCI(pe.Original.ColumnName())

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -166,7 +166,7 @@ func (ap AliasedProjections) AddColumn(col *sqlparser.AliasedExpr) (ProjCols, in
 
 func (pe *ProjExpr) String() string {
 	var alias, expr, info string
-	if pe.Original.As.NonEmpty() {
+	if pe.Original.As.NotEmpty() {
 		alias = " AS " + pe.Original.As.String()
 	}
 	if sqlparser.Equals.Expr(pe.EvalExpr, pe.ColExpr) {
@@ -399,7 +399,7 @@ func (p *Projection) GetSelectExprs(*plancontext.PlanningContext) sqlparser.Sele
 		var output sqlparser.SelectExprs
 		for _, pe := range cols {
 			ae := &sqlparser.AliasedExpr{Expr: pe.EvalExpr}
-			if pe.Original.As.NonEmpty() {
+			if pe.Original.As.NotEmpty() {
 				ae.As = pe.Original.As
 			} else if !sqlparser.Equals.Expr(ae.Expr, pe.Original.Expr) {
 				ae.As = sqlparser.NewIdentifierCI(pe.Original.ColumnName())

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -515,7 +515,7 @@ func (qp *QueryProjection) GetSimplifiedExpr(ctx *plancontext.PlanningContext, e
 		if !ok {
 			continue
 		}
-		aliased := !ae.As.IsEmpty()
+		aliased := ae.As.NonEmpty()
 		if aliased {
 			if in.Name.Equal(ae.As) {
 				err = check(ae.Expr)
@@ -818,7 +818,7 @@ func (qp *QueryProjection) FindSelectExprIndexForExpr(ctx *plancontext.PlanningC
 			continue
 		}
 		if isCol {
-			isAliasExpr := !aliasedExpr.As.IsEmpty()
+			isAliasExpr := aliasedExpr.As.NonEmpty()
 			if isAliasExpr && colExpr.Name.Equal(aliasedExpr.As) {
 				return &idx, aliasedExpr
 			}

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -515,7 +515,7 @@ func (qp *QueryProjection) GetSimplifiedExpr(ctx *plancontext.PlanningContext, e
 		if !ok {
 			continue
 		}
-		aliased := ae.As.NonEmpty()
+		aliased := ae.As.NotEmpty()
 		if aliased {
 			if in.Name.Equal(ae.As) {
 				err = check(ae.Expr)
@@ -818,7 +818,7 @@ func (qp *QueryProjection) FindSelectExprIndexForExpr(ctx *plancontext.PlanningC
 			continue
 		}
 		if isCol {
-			isAliasExpr := aliasedExpr.As.NonEmpty()
+			isAliasExpr := aliasedExpr.As.NotEmpty()
 			if isAliasExpr && colExpr.Name.Equal(aliasedExpr.As) {
 				return &idx, aliasedExpr
 			}

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -130,7 +130,7 @@ func addColumn(ctx *plancontext.PlanningContext, op ColNameColumns, e sqlparser.
 func (to *Table) ShortDescription() string {
 	tbl := to.VTable.String()
 	var alias, where string
-	if !to.QTable.Alias.As.IsEmpty() {
+	if to.QTable.Alias.As.NonEmpty() {
 		alias = " AS " + to.QTable.Alias.As.String()
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -130,7 +130,7 @@ func addColumn(ctx *plancontext.PlanningContext, op ColNameColumns, e sqlparser.
 func (to *Table) ShortDescription() string {
 	tbl := to.VTable.String()
 	var alias, where string
-	if to.QTable.Alias.As.NonEmpty() {
+	if to.QTable.Alias.As.NotEmpty() {
 		alias = " AS " + to.QTable.Alias.As.String()
 	}
 

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -164,7 +164,7 @@ func buildVariablePlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (
 }
 
 func buildShowTblPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (engine.Primitive, error) {
-	if show.DbName.NonEmpty() {
+	if show.DbName.NotEmpty() {
 		show.Tbl.Qualifier = sqlparser.NewIdentifierCS(show.DbName.String())
 		// Remove Database Name from the query.
 		show.DbName = sqlparser.NewIdentifierCS("")
@@ -174,7 +174,7 @@ func buildShowTblPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (e
 	var ks *vindexes.Keyspace
 	var err error
 
-	if show.Tbl.Qualifier.NonEmpty() && sqlparser.SystemSchema(show.Tbl.Qualifier.String()) {
+	if show.Tbl.Qualifier.NotEmpty() && sqlparser.SystemSchema(show.Tbl.Qualifier.String()) {
 		ks, err = vschema.AnyKeyspace()
 		if err != nil {
 			return nil, err
@@ -486,7 +486,7 @@ func buildCreateTblPlan(show *sqlparser.ShowCreate, vschema plancontext.VSchema)
 	var ks *vindexes.Keyspace
 	var err error
 
-	if show.Op.Qualifier.NonEmpty() && sqlparser.SystemSchema(show.Op.Qualifier.String()) {
+	if show.Op.Qualifier.NotEmpty() && sqlparser.SystemSchema(show.Op.Qualifier.String()) {
 		ks, err = vschema.AnyKeyspace()
 		if err != nil {
 			return nil, err
@@ -519,7 +519,7 @@ func buildCreateTblPlan(show *sqlparser.ShowCreate, vschema plancontext.VSchema)
 
 func buildCreatePlan(show *sqlparser.ShowCreate, vschema plancontext.VSchema) (engine.Primitive, error) {
 	dbName := ""
-	if show.Op.Qualifier.NonEmpty() {
+	if show.Op.Qualifier.NotEmpty() {
 		dbName = show.Op.Qualifier.String()
 	}
 
@@ -567,7 +567,7 @@ func buildShowVGtidPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) 
 
 func buildShowGtidPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (engine.Primitive, error) {
 	dbName := ""
-	if show.DbName.NonEmpty() {
+	if show.DbName.NotEmpty() {
 		dbName = show.DbName.String()
 	}
 	dest, ks, _, err := vschema.TargetDestination(dbName)

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -164,7 +164,7 @@ func buildVariablePlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (
 }
 
 func buildShowTblPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (engine.Primitive, error) {
-	if !show.DbName.IsEmpty() {
+	if show.DbName.NonEmpty() {
 		show.Tbl.Qualifier = sqlparser.NewIdentifierCS(show.DbName.String())
 		// Remove Database Name from the query.
 		show.DbName = sqlparser.NewIdentifierCS("")
@@ -174,7 +174,7 @@ func buildShowTblPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (e
 	var ks *vindexes.Keyspace
 	var err error
 
-	if !show.Tbl.Qualifier.IsEmpty() && sqlparser.SystemSchema(show.Tbl.Qualifier.String()) {
+	if show.Tbl.Qualifier.NonEmpty() && sqlparser.SystemSchema(show.Tbl.Qualifier.String()) {
 		ks, err = vschema.AnyKeyspace()
 		if err != nil {
 			return nil, err
@@ -486,7 +486,7 @@ func buildCreateTblPlan(show *sqlparser.ShowCreate, vschema plancontext.VSchema)
 	var ks *vindexes.Keyspace
 	var err error
 
-	if !show.Op.Qualifier.IsEmpty() && sqlparser.SystemSchema(show.Op.Qualifier.String()) {
+	if show.Op.Qualifier.NonEmpty() && sqlparser.SystemSchema(show.Op.Qualifier.String()) {
 		ks, err = vschema.AnyKeyspace()
 		if err != nil {
 			return nil, err
@@ -519,7 +519,7 @@ func buildCreateTblPlan(show *sqlparser.ShowCreate, vschema plancontext.VSchema)
 
 func buildCreatePlan(show *sqlparser.ShowCreate, vschema plancontext.VSchema) (engine.Primitive, error) {
 	dbName := ""
-	if !show.Op.Qualifier.IsEmpty() {
+	if show.Op.Qualifier.NonEmpty() {
 		dbName = show.Op.Qualifier.String()
 	}
 
@@ -567,7 +567,7 @@ func buildShowVGtidPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) 
 
 func buildShowGtidPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) (engine.Primitive, error) {
 	dbName := ""
-	if !show.DbName.IsEmpty() {
+	if show.DbName.NonEmpty() {
 		dbName = show.DbName.String()
 	}
 	dest, ks, _, err := vschema.TargetDestination(dbName)

--- a/go/vt/vtgate/semantics/derived_table.go
+++ b/go/vt/vtgate/semantics/derived_table.go
@@ -77,7 +77,7 @@ func handleAliasedExpr(vTbl *DerivedTable, expr *sqlparser.AliasedExpr, cols sql
 		return
 	}
 
-	if expr.As.NonEmpty() {
+	if expr.As.NotEmpty() {
 		vTbl.columnNames = append(vTbl.columnNames, expr.As.String())
 		return
 	}
@@ -161,7 +161,7 @@ func (dt *DerivedTable) getColumns() []ColumnInfo {
 }
 
 func (dt *DerivedTable) hasStar() bool {
-	return dt.tables.NonEmpty()
+	return dt.tables.NotEmpty()
 }
 
 // GetTables implements the TableInfo interface

--- a/go/vt/vtgate/semantics/derived_table.go
+++ b/go/vt/vtgate/semantics/derived_table.go
@@ -77,7 +77,7 @@ func handleAliasedExpr(vTbl *DerivedTable, expr *sqlparser.AliasedExpr, cols sql
 		return
 	}
 
-	if !expr.As.IsEmpty() {
+	if expr.As.NonEmpty() {
 		vTbl.columnNames = append(vTbl.columnNames, expr.As.String())
 		return
 	}

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -67,7 +67,7 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 
 func (r *earlyRewriter) handleAliasedTable(node *sqlparser.AliasedTableExpr) error {
 	tbl, ok := node.Expr.(sqlparser.TableName)
-	if !ok || !tbl.Qualifier.IsEmpty() {
+	if !ok || tbl.Qualifier.NonEmpty() {
 		return nil
 	}
 	scope := r.scoper.currentScope()

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -348,7 +348,7 @@ func (r *earlyRewriter) rewriteOrderByExpr(node *sqlparser.Literal) (sqlparser.E
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "don't know how to handle %s", sqlparser.String(node))
 	}
 
-	if !aliasedExpr.As.IsEmpty() {
+	if aliasedExpr.As.NonEmpty() {
 		return sqlparser.NewColName(aliasedExpr.As.String()), nil
 	}
 

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -67,7 +67,7 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 
 func (r *earlyRewriter) handleAliasedTable(node *sqlparser.AliasedTableExpr) error {
 	tbl, ok := node.Expr.(sqlparser.TableName)
-	if !ok || tbl.Qualifier.NonEmpty() {
+	if !ok || tbl.Qualifier.NotEmpty() {
 		return nil
 	}
 	scope := r.scoper.currentScope()
@@ -348,7 +348,7 @@ func (r *earlyRewriter) rewriteOrderByExpr(node *sqlparser.Literal) (sqlparser.E
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "don't know how to handle %s", sqlparser.String(node))
 	}
 
-	if aliasedExpr.As.NonEmpty() {
+	if aliasedExpr.As.NotEmpty() {
 		return sqlparser.NewColName(aliasedExpr.As.String()), nil
 	}
 

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -320,7 +320,7 @@ func checkForInvalidAliasUse(cte *sqlparser.CommonTableExpr, name string) (err e
 	// TODO I'm sure there is a better. way, but we need to do this to stop infinite loops from occurring
 	down := func(node sqlparser.SQLNode, parent sqlparser.SQLNode) bool {
 		tbl, ok := node.(sqlparser.TableName)
-		if !ok || !tbl.Qualifier.IsEmpty() {
+		if !ok || tbl.Qualifier.NonEmpty() {
 			return err == nil
 		}
 		if tbl.Name.String() == name {

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -320,7 +320,7 @@ func checkForInvalidAliasUse(cte *sqlparser.CommonTableExpr, name string) (err e
 	// TODO I'm sure there is a better. way, but we need to do this to stop infinite loops from occurring
 	down := func(node sqlparser.SQLNode, parent sqlparser.SQLNode) bool {
 		tbl, ok := node.(sqlparser.TableName)
-		if !ok || tbl.Qualifier.NonEmpty() {
+		if !ok || tbl.Qualifier.NotEmpty() {
 			return err == nil
 		}
 		if tbl.Name.String() == name {

--- a/go/vt/vtgate/semantics/table_set.go
+++ b/go/vt/vtgate/semantics/table_set.go
@@ -57,7 +57,7 @@ func (ts TableSet) NumberOfTables() int {
 }
 
 // NonEmpty returns true if there are tables in the tableset
-func (ts TableSet) NonEmpty() bool {
+func (ts TableSet) NotEmpty() bool {
 	return !ts.IsEmpty()
 }
 

--- a/go/vt/vtgate/semantics/vtable.go
+++ b/go/vt/vtgate/semantics/vtable.go
@@ -94,7 +94,7 @@ func (v *vTableInfo) getColumns() []ColumnInfo {
 }
 
 func (v *vTableInfo) hasStar() bool {
-	return v.tables.NonEmpty()
+	return v.tables.NotEmpty()
 }
 
 // GetTables implements the TableInfo interface

--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -263,7 +263,7 @@ func MustReloadSchemaOnDDL(sql string, dbname string) bool {
 			if table.IsEmpty() {
 				continue
 			}
-			if table.Qualifier.NonEmpty() && table.Qualifier.String() != dbname {
+			if table.Qualifier.NotEmpty() && table.Qualifier.String() != dbname {
 				continue
 			}
 			tableName := table.Name.String()

--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -263,7 +263,7 @@ func MustReloadSchemaOnDDL(sql string, dbname string) bool {
 			if table.IsEmpty() {
 				continue
 			}
-			if !table.Qualifier.IsEmpty() && table.Qualifier.String() != dbname {
+			if table.Qualifier.NonEmpty() && table.Qualifier.String() != dbname {
 				continue
 			}
 			tableName := table.Name.String()

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -338,7 +338,7 @@ func ruleMatches(tableName string, filter *binlogdatapb.Filter) bool {
 
 // tableMatches is similar to buildPlan below and MatchTable in vreplication/table_plan_builder.go.
 func tableMatches(table sqlparser.TableName, dbname string, filter *binlogdatapb.Filter) bool {
-	if table.Qualifier.NonEmpty() && table.Qualifier.String() != dbname {
+	if table.Qualifier.NotEmpty() && table.Qualifier.String() != dbname {
 		return false
 	}
 	return ruleMatches(table.Name.String(), filter)

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -338,7 +338,7 @@ func ruleMatches(tableName string, filter *binlogdatapb.Filter) bool {
 
 // tableMatches is similar to buildPlan below and MatchTable in vreplication/table_plan_builder.go.
 func tableMatches(table sqlparser.TableName, dbname string, filter *binlogdatapb.Filter) bool {
-	if !table.Qualifier.IsEmpty() && table.Qualifier.String() != dbname {
+	if table.Qualifier.NonEmpty() && table.Qualifier.String() != dbname {
 		return false
 	}
 	return ruleMatches(table.Name.String(), filter)
@@ -528,7 +528,7 @@ func (plan *Plan) analyzeWhere(vschema *localVSchema, where *sqlparser.Where) er
 			if !ok {
 				return fmt.Errorf("unexpected: %v", sqlparser.String(expr))
 			}
-			//StrVal is varbinary, we do not support varchar since we would have to implement all collation types
+			// StrVal is varbinary, we do not support varchar since we would have to implement all collation types
 			if val.Type != sqlparser.IntVal && val.Type != sqlparser.StrVal {
 				return fmt.Errorf("unexpected: %v", sqlparser.String(expr))
 			}
@@ -702,7 +702,7 @@ func (plan *Plan) analyzeExpr(vschema *localVSchema, selExpr sqlparser.SelectExp
 			return ColExpr{}, fmt.Errorf("unsupported function: %v", sqlparser.String(inner))
 		}
 	case *sqlparser.Literal:
-		//allow only intval 1
+		// allow only intval 1
 		if inner.Type != sqlparser.IntVal {
 			return ColExpr{}, fmt.Errorf("only integer literals are supported")
 		}

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -672,14 +672,14 @@ func (df *vdiff) buildTablePlan(table *tabletmanagerdatapb.TableDefinition, quer
 			}
 		case *sqlparser.AliasedExpr:
 			var targetCol *sqlparser.ColName
-			if !selExpr.As.IsEmpty() {
-				targetCol = &sqlparser.ColName{Name: selExpr.As}
-			} else {
+			if selExpr.As.IsEmpty() {
 				if colAs, ok := selExpr.Expr.(*sqlparser.ColName); ok {
 					targetCol = colAs
 				} else {
 					return nil, fmt.Errorf("expression needs an alias: %v", sqlparser.String(selExpr))
 				}
+			} else {
+				targetCol = &sqlparser.ColName{Name: selExpr.As}
 			}
 			// If the input was "select a as b", then source will use "a" and target will use "b".
 			sourceSelect.SelectExprs = append(sourceSelect.SelectExprs, selExpr)


### PR DESCRIPTION
## Description
This is not super important, but it does take it's toll. Whenever reading an `if` statement that is using an identifier, and we are checking that it's not empty, we write something like this:

```golang
if !to.QTable.Alias.As.IsEmpty() { ... }
```

The distance between the `!` and the `IsEmpty()` is quite a few characters apart, and that forces me to do an extra mental step when reading code. I much prefer using `NotEmpty` for this:

```golang
if to.QTable.Alias.As.NotEmpty() { ... }
```

This makes the code slightly more readable, and we can use all the readability we can get.
