### PR TITLE
Fix Upgrade downgrade reparent tests in release-17.0

### DIFF
--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -162,7 +162,11 @@ func TestReparentAvoid(t *testing.T) {
 	utils.StopTablet(t, tablets[0], true)
 	out, err := utils.PrsAvoid(t, clusterInstance, tablets[1])
 	require.Error(t, err)
-	assert.Contains(t, out, "cannot find a tablet to reparent to in the same cell as the current primary")
+	if clusterInstance.VtctlMajorVersion <= 17 {
+		assert.Contains(t, out, "cannot find a tablet to reparent to in the same cell as the current primary")
+	} else {
+		assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc = latest balancer error")
+	}
 	utils.ValidateTopology(t, clusterInstance, false)
 	utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
 }

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -123,9 +123,16 @@ func TestReparentReplicaOffline(t *testing.T) {
 	// Perform a graceful reparent operation.
 	out, err := utils.PrsWithTimeout(t, clusterInstance, tablets[1], false, "", "31s")
 	require.Error(t, err)
-	assert.True(t, utils.SetReplicationSourceFailed(tablets[3], out))
 
-	utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
+	// Assert that PRS failed
+	if clusterInstance.VtctlMajorVersion <= 17 {
+		assert.True(t, utils.SetReplicationSourceFailed(tablets[3], out))
+		utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
+	} else {
+		assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc")
+		utils.CheckPrimaryTablet(t, clusterInstance, tablets[0])
+	}
+
 }
 
 func TestReparentAvoid(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

It looks like the changes made in https://github.com/vitessio/vitess/pull/13623 broke the upgrade downgrade tests in release-17.0.

This PR copies over changes from that PR related to the changes in the test files so that upgrade tests work.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
