### PR TITLE
Online DDL: edit CONSTRAINT names in CREATE TABLE

### DIFF
--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -55,6 +55,7 @@ const (
 	MySQLUpgradeInServerFlavorCapability
 	DynamicRedoLogCapacityFlavorCapability // supported in MySQL 8.0.30 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html
 	DisableRedoLogFlavorCapability         // supported in MySQL 8.0.21 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-21.html
+	CheckConstraintsCapability             // supported in MySQL 8.0.16 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-16.html
 )
 
 const (

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -397,6 +397,8 @@ func (mysqlFlavor80) supportsCapability(serverVersion string, capability FlavorC
 		return ServerVersionAtLeast(serverVersion, 8, 0, 30)
 	case DisableRedoLogFlavorCapability:
 		return ServerVersionAtLeast(serverVersion, 8, 0, 21)
+	case CheckConstraintsCapability:
+		return ServerVersionAtLeast(serverVersion, 8, 0, 16)
 	default:
 		return false, nil
 	}

--- a/go/mysql/flavor_test.go
+++ b/go/mysql/flavor_test.go
@@ -160,6 +160,16 @@ func TestGetFlavor(t *testing.T) {
 			capability: DisableRedoLogFlavorCapability,
 			isCapable:  false,
 		},
+		{
+			version:    "8.0.15",
+			capability: CheckConstraintsCapability,
+			isCapable:  false,
+		},
+		{
+			version:    "8.0.20",
+			capability: CheckConstraintsCapability,
+			isCapable:  true,
+		},
 	}
 	for _, tc := range testcases {
 		name := fmt.Sprintf("%s %v", tc.version, tc.capability)

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -428,7 +428,20 @@ func testRevertible(t *testing.T) {
 					droppedNoDefaultColumnNames := row.AsString("dropped_no_default_column_names", "")
 					expandedColumnNames := row.AsString("expanded_column_names", "")
 
-					assert.Equal(t, testcase.removedForeignKeyNames, removeBackticks(removedForeignKeyNames))
+					// Online DDL renames constraint names, and keeps the original name as a prefix.
+					// The name of e.g. "some_fk_2_" might turn into "some_fk_2_518ubnm034rel35l1m0u1dc7m"
+					expectRemovedForeignKeyNames := strings.Split(testcase.removedForeignKeyNames, ",")
+					actualRemovedForeignKeyNames := strings.Split(removeBackticks(removedForeignKeyNames), ",")
+					assert.Equal(t, len(expectRemovedForeignKeyNames), len(actualRemovedForeignKeyNames))
+					for _, actualRemovedForeignKeyName := range actualRemovedForeignKeyNames {
+						found := false
+						for _, expectRemovedForeignKeyName := range expectRemovedForeignKeyNames {
+							if strings.HasPrefix(actualRemovedForeignKeyName, expectRemovedForeignKeyName) {
+								found = true
+							}
+						}
+						assert.Truef(t, found, "unexpected FK name", "%s", actualRemovedForeignKeyName)
+					}
 					assert.Equal(t, testcase.removedUniqueKeyNames, removeBackticks(removedUniqueKeyNames))
 					assert.Equal(t, testcase.droppedNoDefaultColumnNames, removeBackticks(droppedNoDefaultColumnNames))
 					assert.Equal(t, testcase.expandedColumnNames, removeBackticks(expandedColumnNames))

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -466,7 +466,8 @@ func testRevertible(t *testing.T) {
 				droppedNoDefaultColumnNames := row.AsString("dropped_no_default_column_names", "")
 				expandedColumnNames := row.AsString("expanded_column_names", "")
 
-				assert.Equal(t, "some_fk_2", removeBackticks(removedForeignKeyNames))
+				// Online DDL renames constraint names, and keeps the original name as a prefix. The name will be e.g. some_fk_2_518ubnm034rel35l1m0u1dc7m
+				assert.Contains(t, removeBackticks(removedForeignKeyNames), "some_fk_2")
 				assert.Equal(t, "", removeBackticks(removedUniqueKeyNames))
 				assert.Equal(t, "", removeBackticks(droppedNoDefaultColumnNames))
 				assert.Equal(t, "", removeBackticks(expandedColumnNames))


### PR DESCRIPTION

## Description

Followup to https://github.com/vitessio/vitess/pull/10638 and https://github.com/vitessio/vitess/pull/14385, this PR edits a `CREATE TABLE` statement, to remove the table-name prefix from existing constraint names. This is so as to make the constraint name a non-generated one. The reasoning is to avoid https://bugs.mysql.com/bug.php?id=107772

e.g. if some issues:

```sh
vtctldclient ApplySchema --ddl_strategy="vitess" --sql "create table mytable (id int primary key, check ((id >= 0)))" commerce
```
Then MySQL auto generates a constraint name, and the `CREATE TABLE` statement becomes:
```sql
CREATE TABLE `mytable` (
  `id` int NOT NULL,
  PRIMARY KEY (`id`),
  CONSTRAINT `mytable_chk_1` CHECK ((`id` >= 0))
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```

However, Online DDL intercepts the name `mytable_chk_1`, identifies that it begins with `mytable_chk_`, and converts it to something like `chk_crq6muar52qehxxi5wmd4fj5y`.

## Related Issue(s)

https://bugs.mysql.com/bug.php?id=107772

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
