### PR TITLE
Fix type coercion in cascading non-literal updates

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -880,6 +880,13 @@ func TestFkQueries(t *testing.T) {
 				"insert into fk_multicol_t16 (id, cola, colb) values (1,1,1),(2,2,2)",
 				"update fk_multicol_t15 set cola = 3, colb = (id * 2) - 2",
 			},
+		}, {
+			name: "Update that sets to 0 and -0 values",
+			queries: []string{
+				"insert into fk_t15 (id, col) values (1,'-0'), (2, '0'), (3, '5'), (4, '-5')",
+				"insert into fk_t16 (id, col) values (1,'-0'), (2, '0'), (3, '5'), (4, '-5')",
+				"update fk_t15 set col = col * (col - (col))",
+			},
 		},
 	}
 

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -290,7 +290,7 @@ func (cached *FkChild) CachedSize(alloc bool) int64 {
 	}
 	// field NonLiteralInfo []vitess.io/vitess/go/vt/vtgate/engine.NonLiteralUpdateInfo
 	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.NonLiteralInfo)) * int64(32))
+		size += hack.RuntimeAllocSize(int64(cap(cached.NonLiteralInfo)) * int64(40))
 		for _, elem := range cached.NonLiteralInfo {
 			size += elem.CachedSize(false)
 		}
@@ -625,7 +625,7 @@ func (cached *NonLiteralUpdateInfo) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(32)
+		size += int64(48)
 	}
 	// field UpdateExprBvName string
 	size += hack.RuntimeAllocSize(int64(len(cached.UpdateExprBvName)))

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -193,12 +193,12 @@ func (fkc *FkCascade) executeNonLiteralExprFkChild(ctx context.Context, vcursor 
 			// the column being updated is a varchar column, then if we don't coerce the value of -0 to
 			// varchar, MySQL ends up setting it to '0' instead of '-0'.
 			finalVal := row[info.UpdateExprCol]
-			var err error
 			if !finalVal.IsNull() {
+				var err error
 				finalVal, err = evalengine.CoerceTo(finalVal, selectionRes.Fields[info.ExprCol].Type)
-			}
-			if err != nil {
-				return err
+				if err != nil {
+					return err
+				}
 			}
 			bindVars[info.UpdateExprBvName] = sqltypes.ValueBindVariable(finalVal)
 		}

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -25,6 +25,7 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 // FkChild contains the Child Primitive to be executed collecting the values from the Selection Primitive using the column indexes.
@@ -40,14 +41,16 @@ type FkChild struct {
 }
 
 // NonLiteralUpdateInfo stores the information required to process non-literal update queries.
-// It stores 3 information-
-// 1. UpdateExprCol- The index of the updated expression in the select query.
-// 2. UpdateExprBvName- The bind variable name to store the updated expression into.
-// 3. CompExprCol- The index of the comparison expression in the select query to know if the row value is actually being changed or not.
+// It stores 4 information-
+// 1. ExprCol- The index of the column being updated in the select query.
+// 2. CompExprCol- The index of the comparison expression in the select query to know if the row value is actually being changed or not.
+// 3. UpdateExprCol- The index of the updated expression in the select query.
+// 4. UpdateExprBvName- The bind variable name to store the updated expression into.
 type NonLiteralUpdateInfo struct {
+	ExprCol          int
+	CompExprCol      int
 	UpdateExprCol    int
 	UpdateExprBvName string
-	CompExprCol      int
 }
 
 // FkCascade is a primitive that implements foreign key cascading using Selection as values required to execute the FkChild Primitives.
@@ -185,7 +188,15 @@ func (fkc *FkCascade) executeNonLiteralExprFkChild(ctx context.Context, vcursor 
 
 		// Next, we need to copy the updated expressions value into the bind variables map.
 		for _, info := range child.NonLiteralInfo {
-			bindVars[info.UpdateExprBvName] = sqltypes.ValueBindVariable(row[info.UpdateExprCol])
+			// Type case the value to that of the column that we are updating.
+			// This is required for example when we receive an updated float value of -0, but
+			// the column being updated is a varchar column, then if we don't coerce the value of -0 to
+			// varchar, MySQL ends up setting it to '0' instead of '-0'.
+			finalVal, err := evalengine.CoerceTo(row[info.UpdateExprCol], selectionRes.Fields[info.ExprCol].Type)
+			if err != nil {
+				return err
+			}
+			bindVars[info.UpdateExprBvName] = sqltypes.ValueBindVariable(finalVal)
 		}
 		_, err := vcursor.ExecutePrimitive(ctx, child.Exec, bindVars, wantfields)
 		if err != nil {

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -192,7 +192,11 @@ func (fkc *FkCascade) executeNonLiteralExprFkChild(ctx context.Context, vcursor 
 			// This is required for example when we receive an updated float value of -0, but
 			// the column being updated is a varchar column, then if we don't coerce the value of -0 to
 			// varchar, MySQL ends up setting it to '0' instead of '-0'.
-			finalVal, err := evalengine.CoerceTo(row[info.UpdateExprCol], selectionRes.Fields[info.ExprCol].Type)
+			finalVal := row[info.UpdateExprCol]
+			var err error
+			if !finalVal.IsNull() {
+				finalVal, err = evalengine.CoerceTo(finalVal, selectionRes.Fields[info.ExprCol].Type)
+			}
 			if err != nil {
 				return err
 			}

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -334,6 +334,7 @@ func addNonLiteralUpdExprToSelect(ctx *plancontext.PlanningContext, updExpr *sql
 	info := engine.NonLiteralUpdateInfo{
 		CompExprCol:   -1,
 		UpdateExprCol: -1,
+		ExprCol:       -1,
 	}
 	// Add the expressions to the select expressions. We make sure to reuse the offset if it has already been added once.
 	for idx, selectExpr := range exprs {
@@ -342,6 +343,9 @@ func addNonLiteralUpdExprToSelect(ctx *plancontext.PlanningContext, updExpr *sql
 		}
 		if ctx.SemTable.EqualsExpr(selectExpr.(*sqlparser.AliasedExpr).Expr, updExpr.Expr) {
 			info.UpdateExprCol = idx
+		}
+		if ctx.SemTable.EqualsExpr(selectExpr.(*sqlparser.AliasedExpr).Expr, updExpr.Name) {
+			info.ExprCol = idx
 		}
 	}
 	// If the expression doesn't exist, then we add the expression and store the offset.
@@ -352,6 +356,10 @@ func addNonLiteralUpdExprToSelect(ctx *plancontext.PlanningContext, updExpr *sql
 	if info.UpdateExprCol == -1 {
 		info.UpdateExprCol = len(exprs)
 		exprs = append(exprs, aeWrap(updExpr.Expr))
+	}
+	if info.ExprCol == -1 {
+		info.ExprCol = len(exprs)
+		exprs = append(exprs, aeWrap(updExpr.Name))
 	}
 	return info, exprs
 }

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -840,9 +840,10 @@
                 ],
                 "NonLiteralUpdateInfo": [
                   {
+                    "ExprCol": 0,
+                    "CompExprCol": 1,
                     "UpdateExprCol": 2,
-                    "UpdateExprBvName": "fkc_upd",
-                    "CompExprCol": 1
+                    "UpdateExprBvName": "fkc_upd"
                   }
                 ],
                 "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (:fkc_upd is null or (u_tbl3.col3) not in ((:fkc_upd)))",
@@ -901,9 +902,10 @@
             ],
             "NonLiteralUpdateInfo": [
               {
+                "ExprCol": 0,
+                "CompExprCol": 1,
                 "UpdateExprCol": 2,
-                "UpdateExprBvName": "fkc_upd",
-                "CompExprCol": 1
+                "UpdateExprBvName": "fkc_upd"
               }
             ],
             "Inputs": [
@@ -958,9 +960,10 @@
             ],
             "NonLiteralUpdateInfo": [
               {
+                "ExprCol": 0,
+                "CompExprCol": 1,
                 "UpdateExprCol": 2,
-                "UpdateExprBvName": "fkc_upd1",
-                "CompExprCol": 1
+                "UpdateExprBvName": "fkc_upd1"
               }
             ],
             "Inputs": [
@@ -1998,9 +2001,10 @@
             ],
             "NonLiteralUpdateInfo": [
               {
+                "ExprCol": 0,
+                "CompExprCol": 1,
                 "UpdateExprCol": 2,
-                "UpdateExprBvName": "fkc_upd",
-                "CompExprCol": 1
+                "UpdateExprBvName": "fkc_upd"
               }
             ],
             "Inputs": [
@@ -2095,9 +2099,10 @@
             ],
             "NonLiteralUpdateInfo": [
               {
+                "ExprCol": 0,
+                "CompExprCol": 2,
                 "UpdateExprCol": 3,
-                "UpdateExprBvName": "fkc_upd",
-                "CompExprCol": 2
+                "UpdateExprBvName": "fkc_upd"
               }
             ],
             "Inputs": [
@@ -2223,14 +2228,16 @@
                 ],
                 "NonLiteralUpdateInfo": [
                   {
+                    "ExprCol": 0,
+                    "CompExprCol": 2,
                     "UpdateExprCol": 3,
-                    "UpdateExprBvName": "fkc_upd",
-                    "CompExprCol": 2
+                    "UpdateExprBvName": "fkc_upd"
                   },
                   {
+                    "ExprCol": 1,
+                    "CompExprCol": 4,
                     "UpdateExprCol": 5,
-                    "UpdateExprBvName": "fkc_upd1",
-                    "CompExprCol": 4
+                    "UpdateExprBvName": "fkc_upd1"
                   }
                 ],
                 "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = :fkc_upd, colb = :fkc_upd1 where (cola, colb) in ::fkc_vals",


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue described in https://github.com/vitessio/vitess/issues/14523.

I looked at the plan and followed along with what Vitess should have done. The first thing we do is run a SELECT query and that works as intended -
```sql
mysql [localhost:8032] {msandbox} (foreign_key_rfc) > select col, col <=> col * (col - col), col * (col - col) from fk_t15 for update;
+------+---------------------------+-------------------+
| col  | col <=> col * (col - col) | col * (col - col) |
+------+---------------------------+-------------------+
| -0   |                         1 |                -0 |
| -5   |                         0 |                -0 |
| 0    |                         1 |                 0 |
| 5    |                         0 |                 0 |
+------+---------------------------+-------------------+
4 rows in set (0.00 sec)
```

This gives us the correct value of `-0` as we expect it to. However, the value is a float-type value.
Next, we end up executing the query - 
```sql
update /*+ SET_VAR(foreign_key_checks=OFF) */ fk_t16 set col = -0 where col in (('-5')) 
```
This query is intended to cascade the update on the child. Notice that we are setting col to `-0` and not `'-0'` because the value we received from the select was a float-type value.

This query is where the problem is. When we run this query on MySQL, col is actually set to `0` and not `-0`. 

The proposed fix is to first typecast the value we receive from the SELECT query into the type of the column, and then send it down to MySQL.

Post the changes, the query looks like 
```sql
update /*+ SET_VAR(foreign_key_checks=OFF) */ fk_t16 set col = '-0' where col in (('-5')) 
```
and this resolves the issue.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #14523 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
