### PR TITLE
MysqlCtl: implement missing `ReadBinlogFilesTimestamps` function

### DIFF
--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -28,6 +28,7 @@ import (
 
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/vt/mysqlctl/mysqlctlclient"
+	"vitess.io/vitess/go/vt/proto/mysqlctl"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 )
@@ -168,4 +169,11 @@ func TestVersionString(t *testing.T) {
 	version, err := client.VersionString(context.Background())
 	require.NoError(t, err)
 	require.NotEmpty(t, version)
+}
+
+func TestReadBinlogFilesTimestamps(t *testing.T) {
+	client, err := mysqlctlclient.New("unix", primaryTablet.MysqlctldProcess.SocketFile)
+	require.NoError(t, err)
+	_, err = client.ReadBinlogFilesTimestamps(context.Background(), &mysqlctl.ReadBinlogFilesTimestampsRequest{})
+	require.ErrorContains(t, err, "empty binlog list in ReadBinlogFilesTimestampsRequest")
 }

--- a/go/vt/mysqlctl/grpcmysqlctlserver/server.go
+++ b/go/vt/mysqlctl/grpcmysqlctlserver/server.go
@@ -56,6 +56,11 @@ func (s *server) ApplyBinlogFile(ctx context.Context, request *mysqlctlpb.ApplyB
 	return &mysqlctlpb.ApplyBinlogFileResponse{}, s.mysqld.ApplyBinlogFile(ctx, request)
 }
 
+// ReadBinlogFilesTimestamps implements the server side of the MysqlctlClient interface.
+func (s *server) ReadBinlogFilesTimestamps(ctx context.Context, request *mysqlctlpb.ReadBinlogFilesTimestampsRequest) (*mysqlctlpb.ReadBinlogFilesTimestampsResponse, error) {
+	return s.mysqld.ReadBinlogFilesTimestamps(ctx, request)
+}
+
 // ReinitConfig implements the server side of the MysqlctlClient interface.
 func (s *server) ReinitConfig(ctx context.Context, request *mysqlctlpb.ReinitConfigRequest) (*mysqlctlpb.ReinitConfigResponse, error) {
 	return &mysqlctlpb.ReinitConfigResponse{}, s.mysqld.ReinitConfig(ctx, s.cnf)


### PR DESCRIPTION

## Description

As per https://github.com/vitessio/vitess/issues/14506, calls to `ReadBinlogFilesTimestamps` failed with `rpc error: code = Unimplemented desc = method ReadBinlogFilesTimestamps not implemented`.

This affects users of `mysqlctld`, but was not detected in `endtoend` tests, which were not using the same.

The function is added and now tested.

A `release-18.0` backport is needed, but also requires a backwards-compatibility fix to `17.0`, because the function `ReadBinlogFilesTimestamps` is new to `v18`. A special PR for 18 release to follow.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
