### PR TITLE
[release 18.0]: `ReadBinlogFilesTimestamps` backwards compatibility

### DIFF
--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -28,6 +28,7 @@ import (
 
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/vt/mysqlctl/mysqlctlclient"
+	"vitess.io/vitess/go/vt/proto/mysqlctl"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 )
@@ -168,4 +169,11 @@ func TestVersionString(t *testing.T) {
 	version, err := client.VersionString(context.Background())
 	require.NoError(t, err)
 	require.NotEmpty(t, version)
+}
+
+func TestReadBinlogFilesTimestamps(t *testing.T) {
+	client, err := mysqlctlclient.New("unix", primaryTablet.MysqlctldProcess.SocketFile)
+	require.NoError(t, err)
+	_, err = client.ReadBinlogFilesTimestamps(context.Background(), &mysqlctl.ReadBinlogFilesTimestampsRequest{})
+	require.ErrorContains(t, err, "empty binlog list in ReadBinlogFilesTimestampsRequest")
 }

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/utils"
@@ -41,6 +42,12 @@ import (
 	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
 )
+
+func TestFormatRFC3339(t *testing.T) {
+	var tm time.Time
+	res := FormatRFC3339(tm)
+	assert.Equal(t, "0001-01-01T00:00:00Z", res)
+}
 
 // TestBackupExecutesBackupWithScopedParams tests that Backup passes
 // a Scope()-ed stats to backupengine ExecuteBackup.

--- a/go/vt/mysqlctl/grpcmysqlctlserver/server.go
+++ b/go/vt/mysqlctl/grpcmysqlctlserver/server.go
@@ -56,6 +56,11 @@ func (s *server) ApplyBinlogFile(ctx context.Context, request *mysqlctlpb.ApplyB
 	return &mysqlctlpb.ApplyBinlogFileResponse{}, s.mysqld.ApplyBinlogFile(ctx, request)
 }
 
+// ReadBinlogFilesTimestamps implements the server side of the MysqlctlClient interface.
+func (s *server) ReadBinlogFilesTimestamps(ctx context.Context, request *mysqlctlpb.ReadBinlogFilesTimestampsRequest) (*mysqlctlpb.ReadBinlogFilesTimestampsResponse, error) {
+	return s.mysqld.ReadBinlogFilesTimestamps(ctx, request)
+}
+
 // ReinitConfig implements the server side of the MysqlctlClient interface.
 func (s *server) ReinitConfig(ctx context.Context, request *mysqlctlpb.ReinitConfigRequest) (*mysqlctlpb.ReinitConfigResponse, error) {
 	return &mysqlctlpb.ReinitConfigResponse{}, s.mysqld.ReinitConfig(ctx, s.cnf)


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/14506

This PR contains two fixes:

1. Similarly to https://github.com/vitessio/vitess/pull/14525, implements `ReadBinlogFilesTimestamps`.
2. Adds backwards compatibility to `ReadBinlogFilesTimestamps` invocation. `ReadBinlogFilesTimestamps` was introduced in `v18`. If a `v18` `vtctldclient` calls a `v17` `mysqlctld` daemon, then that daemon does not implement said function. The solution here is to check the returned error, and ignore accordingly. It's a bit ugly, and it's a workaround to something we should not have introduced in a single step.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/14506

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
