### PR TITLE
 Set minimal tokens for auto_approve_pr

### DIFF
--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -3,14 +3,20 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   auto_approve:
     name: Auto Approve Pull Request
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write  # only given on local PRs, forks run with `read` access
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
       - name: Auto Approve Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This is a follow-up to #12718 and #12996. `auto_approve_pr.yml` was publishes a few weeks ago with full permissions (when running on a local branch). This PR ensures it runs with minimal permissions.

## Related Issue(s)

#12717

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
