### PR TITLE
Type Cast all update expressions in verify queries

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -905,6 +905,15 @@ func TestFkQueries(t *testing.T) {
 				"update fk_t11 set col = id where id in (1, 5)",
 			},
 		},
+		{
+			name: "Update on child to 0 when parent has -0",
+			queries: []string{
+				"insert into fk_t15 (id, col) values (2, '-0')",
+				"insert /*+ SET_VAR(foreign_key_checks=0) */ into fk_t16 (id, col) values (3, '5'), (4, '-5')",
+				"update fk_t16 set col = col * (col - (col)) where id = 3",
+				"update fk_t16 set col = col * (col - (col)) where id = 4",
+			},
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -290,7 +290,7 @@ func (cached *FkChild) CachedSize(alloc bool) int64 {
 	}
 	// field NonLiteralInfo []vitess.io/vitess/go/vt/vtgate/engine.NonLiteralUpdateInfo
 	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.NonLiteralInfo)) * int64(40))
+		size += hack.RuntimeAllocSize(int64(cap(cached.NonLiteralInfo)) * int64(32))
 		for _, elem := range cached.NonLiteralInfo {
 			size += elem.CachedSize(false)
 		}
@@ -625,7 +625,7 @@ func (cached *NonLiteralUpdateInfo) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(48)
+		size += int64(32)
 	}
 	// field UpdateExprBvName string
 	size += hack.RuntimeAllocSize(int64(len(cached.UpdateExprBvName)))

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -25,7 +25,6 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 // FkChild contains the Child Primitive to be executed collecting the values from the Selection Primitive using the column indexes.
@@ -42,12 +41,10 @@ type FkChild struct {
 
 // NonLiteralUpdateInfo stores the information required to process non-literal update queries.
 // It stores 4 information-
-// 1. ExprCol- The index of the column being updated in the select query.
-// 2. CompExprCol- The index of the comparison expression in the select query to know if the row value is actually being changed or not.
-// 3. UpdateExprCol- The index of the updated expression in the select query.
-// 4. UpdateExprBvName- The bind variable name to store the updated expression into.
+// 1. CompExprCol- The index of the comparison expression in the select query to know if the row value is actually being changed or not.
+// 2. UpdateExprCol- The index of the updated expression in the select query.
+// 3. UpdateExprBvName- The bind variable name to store the updated expression into.
 type NonLiteralUpdateInfo struct {
-	ExprCol          int
 	CompExprCol      int
 	UpdateExprCol    int
 	UpdateExprBvName string
@@ -188,19 +185,7 @@ func (fkc *FkCascade) executeNonLiteralExprFkChild(ctx context.Context, vcursor 
 
 		// Next, we need to copy the updated expressions value into the bind variables map.
 		for _, info := range child.NonLiteralInfo {
-			// Type case the value to that of the column that we are updating.
-			// This is required for example when we receive an updated float value of -0, but
-			// the column being updated is a varchar column, then if we don't coerce the value of -0 to
-			// varchar, MySQL ends up setting it to '0' instead of '-0'.
-			finalVal := row[info.UpdateExprCol]
-			if !finalVal.IsNull() {
-				var err error
-				finalVal, err = evalengine.CoerceTo(finalVal, selectionRes.Fields[info.ExprCol].Type)
-				if err != nil {
-					return err
-				}
-			}
-			bindVars[info.UpdateExprBvName] = sqltypes.ValueBindVariable(finalVal)
+			bindVars[info.UpdateExprBvName] = sqltypes.ValueBindVariable(row[info.UpdateExprCol])
 		}
 		_, err := vcursor.ExecutePrimitive(ctx, child.Exec, bindVars, wantfields)
 		if err != nil {

--- a/go/vt/vtgate/planbuilder/operators/update_test.go
+++ b/go/vt/vtgate/planbuilder/operators/update_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+// TestGetCastTypeForColumn tests that we get the correct string value to use in a CAST function based on the type of the column.
+func TestGetCastTypeForColumn(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  querypb.Type
+		want string
+	}{
+		{
+			name: "VARCHAR column",
+			typ:  querypb.Type_VARCHAR,
+			want: "CHAR",
+		},
+		{
+			name: "CHAR column",
+			typ:  querypb.Type_CHAR,
+			want: "CHAR",
+		},
+		{
+			name: "VARBINARY column",
+			typ:  querypb.Type_VARBINARY,
+			want: "BINARY",
+		},
+		{
+			name: "BINARY column",
+			typ:  querypb.Type_BINARY,
+			want: "BINARY",
+		},
+		{
+			name: "UINT16 column",
+			typ:  querypb.Type_UINT16,
+			want: "UNSIGNED",
+		},
+		{
+			name: "UINT24 column",
+			typ:  querypb.Type_UINT24,
+			want: "UNSIGNED",
+		},
+		{
+			name: "UINT32 column",
+			typ:  querypb.Type_UINT32,
+			want: "UNSIGNED",
+		},
+		{
+			name: "UINT64 column",
+			typ:  querypb.Type_UINT64,
+			want: "UNSIGNED",
+		},
+		{
+			name: "INT16 column",
+			typ:  querypb.Type_INT16,
+			want: "SIGNED",
+		},
+		{
+			name: "INT24 column",
+			typ:  querypb.Type_INT24,
+			want: "SIGNED",
+		},
+		{
+			name: "INT32 column",
+			typ:  querypb.Type_INT32,
+			want: "SIGNED",
+		},
+		{
+			name: "INT64 column",
+			typ:  querypb.Type_INT64,
+			want: "SIGNED",
+		},
+		{
+			name: "FLOAT32 column",
+			typ:  querypb.Type_FLOAT32,
+			want: "FLOAT",
+		},
+		{
+			name: "FLOAT64 column",
+			typ:  querypb.Type_FLOAT64,
+			want: "FLOAT",
+		},
+		{
+			name: "DECIMAL column",
+			typ:  querypb.Type_DECIMAL,
+			want: "DECIMAL",
+		},
+		{
+			name: "DATETIME column",
+			typ:  querypb.Type_DATETIME,
+			want: "DATETIME",
+		},
+		{
+			name: "NULL column",
+			typ:  querypb.Type_NULL_TYPE,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updExpr := &sqlparser.UpdateExpr{
+				Name: sqlparser.NewColName("col"),
+			}
+			updatedTable := &vindexes.Table{
+				Columns: []vindexes.Column{
+					{
+						Name: sqlparser.NewIdentifierCI("col"),
+						Type: tt.typ,
+					},
+				},
+			}
+			tyStr := getCastTypeForColumn(updatedTable, updExpr)
+			require.EqualValues(t, tt.want, tyStr)
+		})
+	}
+}

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -328,7 +328,7 @@
             "Cols": [
               0
             ],
-            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in (('bar'))",
+            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))",
             "Table": "u_tbl3"
           },
           {
@@ -693,7 +693,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in (('foo'))",
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))",
                 "Table": "u_tbl3"
               },
               {
@@ -727,7 +727,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
-                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in (('foo')) for update nowait",
+                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait",
                 "Table": "u_tbl9"
               },
               {
@@ -755,7 +755,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in (('foo'))",
+                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))",
                 "Table": "u_tbl9"
               }
             ]
@@ -805,8 +805,8 @@
               "Name": "unsharded_fk_allow",
               "Sharded": false
             },
-            "FieldQuery": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = u_tbl2.col1 + 'bar' where 1 != 1",
-            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = u_tbl2.col1 + 'bar' where u_tbl2.col1 + 'bar' is not null and not (u_tbl2.col2) <=> (u_tbl2.col1 + 'bar') and u_tbl2.id = 1 and u_tbl1.col1 is null limit 1 for share nowait",
+            "FieldQuery": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where 1 != 1",
+            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where cast(u_tbl2.col1 + 'bar' as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.col1 + 'bar' as CHAR)) and u_tbl2.id = 1 and u_tbl1.col1 is null limit 1 for share nowait",
             "Table": "u_tbl1, u_tbl2"
           },
           {
@@ -821,8 +821,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select col2, col2 <=> col1 + 'bar', col1 + 'bar' from u_tbl2 where 1 != 1",
-                "Query": "select col2, col2 <=> col1 + 'bar', col1 + 'bar' from u_tbl2 where id = 1 for update nowait",
+                "FieldQuery": "select col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where 1 != 1",
+                "Query": "select col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where id = 1 for update nowait",
                 "Table": "u_tbl2"
               },
               {
@@ -840,7 +840,6 @@
                 ],
                 "NonLiteralUpdateInfo": [
                   {
-                    "ExprCol": 0,
                     "CompExprCol": 1,
                     "UpdateExprCol": 2,
                     "UpdateExprBvName": "fkc_upd"
@@ -889,8 +888,8 @@
               "Name": "unsharded_fk_allow",
               "Sharded": false
             },
-            "FieldQuery": "select col1, col1 <=> x + 'bar', x + 'bar' from u_tbl1 where 1 != 1",
-            "Query": "select col1, col1 <=> x + 'bar', x + 'bar' from u_tbl1 where id = 1 for update nowait",
+            "FieldQuery": "select col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where 1 != 1",
+            "Query": "select col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where id = 1 for update nowait",
             "Table": "u_tbl1"
           },
           {
@@ -902,7 +901,6 @@
             ],
             "NonLiteralUpdateInfo": [
               {
-                "ExprCol": 0,
                 "CompExprCol": 1,
                 "UpdateExprCol": 2,
                 "UpdateExprBvName": "fkc_upd"
@@ -934,7 +932,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (:fkc_upd is null or (col3) not in ((:fkc_upd)))",
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:fkc_upd as CHAR) is null or (col3) not in ((cast(:fkc_upd as CHAR))))",
                 "Table": "u_tbl3"
               },
               {
@@ -960,7 +958,6 @@
             ],
             "NonLiteralUpdateInfo": [
               {
-                "ExprCol": 0,
                 "CompExprCol": 1,
                 "UpdateExprCol": 2,
                 "UpdateExprBvName": "fkc_upd1"
@@ -1066,7 +1063,7 @@
             "Cols": [
               0
             ],
-            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((2))",
+            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast(2 as CHAR)))",
             "Table": "u_tbl3"
           },
           {
@@ -1143,7 +1140,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((2))",
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(2 as CHAR)))",
                 "Table": "u_tbl3"
               },
               {
@@ -1177,7 +1174,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
-                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((2)) for update nowait",
+                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR))) for update nowait",
                 "Table": "u_tbl9"
               },
               {
@@ -1205,7 +1202,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((2))",
+                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR)))",
                 "Table": "u_tbl9"
               }
             ]
@@ -1443,8 +1440,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = 'foo' where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = 'foo' where not (u_tbl8.col8) <=> ('foo') and (u_tbl8.col8) in ::fkc_vals and u_tbl9.col9 is null limit 1 for share nowait",
+                "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals and u_tbl9.col9 is null limit 1 for share nowait",
                 "Table": "u_tbl8, u_tbl9"
               },
               {
@@ -1519,8 +1516,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = 'foo' where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = 'foo' where not (u_tbl4.col4) <=> ('foo') and (u_tbl4.col4) in ::fkc_vals and u_tbl3.col3 is null limit 1 for share nowait",
+                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where 1 != 1",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals and u_tbl3.col3 is null limit 1 for share nowait",
                 "Table": "u_tbl3, u_tbl4"
               },
               {
@@ -1532,7 +1529,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (u_tbl9.col9) not in (('foo')) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
+                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (u_tbl9.col9) not in ((cast('foo' as CHAR))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
                 "Table": "u_tbl4, u_tbl9"
               },
               {
@@ -1608,8 +1605,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = :v1 where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = :v1 where not (u_tbl4.col4) <=> (:v1) and (u_tbl4.col4) in ::fkc_vals and :v1 is not null and u_tbl3.col3 is null limit 1 for share nowait",
+                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where 1 != 1",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where not (u_tbl4.col4) <=> (cast(:v1 as CHAR)) and (u_tbl4.col4) in ::fkc_vals and cast(:v1 as CHAR) is not null and u_tbl3.col3 is null limit 1 for share nowait",
                 "Table": "u_tbl3, u_tbl4"
               },
               {
@@ -1621,7 +1618,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (:v1 is null or (u_tbl9.col9) not in ((:v1))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
+                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (cast(:v1 as CHAR) is null or (u_tbl9.col9) not in ((cast(:v1 as CHAR)))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
                 "Table": "u_tbl4, u_tbl9"
               },
               {
@@ -2092,8 +2089,8 @@
               "Name": "unsharded_fk_allow",
               "Sharded": false
             },
-            "FieldQuery": "select col7, col7 <=> baz + 1 + col7, baz + 1 + col7 from u_tbl7 where 1 != 1",
-            "Query": "select col7, col7 <=> baz + 1 + col7, baz + 1 + col7 from u_tbl7 where bar = 42 for update nowait",
+            "FieldQuery": "select col7, col7 <=> cast(baz + 1 + col7 as CHAR), cast(baz + 1 + col7 as CHAR) from u_tbl7 where 1 != 1",
+            "Query": "select col7, col7 <=> cast(baz + 1 + col7 as CHAR), cast(baz + 1 + col7 as CHAR) from u_tbl7 where bar = 42 for update nowait",
             "Table": "u_tbl7"
           },
           {
@@ -2105,7 +2102,6 @@
             ],
             "NonLiteralUpdateInfo": [
               {
-                "ExprCol": 0,
                 "CompExprCol": 1,
                 "UpdateExprCol": 2,
                 "UpdateExprBvName": "fkc_upd"
@@ -2120,8 +2116,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = :fkc_upd where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = :fkc_upd where not (u_tbl4.col4) <=> (:fkc_upd) and (u_tbl4.col4) in ::fkc_vals and :fkc_upd is not null and u_tbl3.col3 is null limit 1 for share nowait",
+                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:fkc_upd as CHAR) where 1 != 1",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:fkc_upd as CHAR) where not (u_tbl4.col4) <=> (cast(:fkc_upd as CHAR)) and (u_tbl4.col4) in ::fkc_vals and cast(:fkc_upd as CHAR) is not null and u_tbl3.col3 is null limit 1 for share nowait",
                 "Table": "u_tbl3, u_tbl4"
               },
               {
@@ -2133,7 +2129,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (:fkc_upd is null or (u_tbl9.col9) not in ((:fkc_upd))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
+                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (cast(:fkc_upd as CHAR) is null or (u_tbl9.col9) not in ((cast(:fkc_upd as CHAR)))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
                 "Table": "u_tbl4, u_tbl9"
               },
               {
@@ -2203,7 +2199,6 @@
             ],
             "NonLiteralUpdateInfo": [
               {
-                "ExprCol": 0,
                 "CompExprCol": 2,
                 "UpdateExprCol": 3,
                 "UpdateExprBvName": "fkc_upd"
@@ -2332,13 +2327,11 @@
                 ],
                 "NonLiteralUpdateInfo": [
                   {
-                    "ExprCol": 0,
                     "CompExprCol": 2,
                     "UpdateExprCol": 3,
                     "UpdateExprBvName": "fkc_upd"
                   },
                   {
-                    "ExprCol": 1,
                     "CompExprCol": 4,
                     "UpdateExprCol": 5,
                     "UpdateExprBvName": "fkc_upd1"

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
@@ -328,7 +328,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in (('bar'))",
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))",
             "Table": "u_tbl3"
           },
           {
@@ -693,7 +693,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in (('foo'))",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))",
                 "Table": "u_tbl3"
               },
               {
@@ -727,7 +727,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
-                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in (('foo')) for update nowait",
+                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait",
                 "Table": "u_tbl9"
               },
               {
@@ -755,7 +755,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in (('foo'))",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))",
                 "Table": "u_tbl9"
               }
             ]
@@ -805,8 +805,8 @@
               "Name": "unsharded_fk_allow",
               "Sharded": false
             },
-            "FieldQuery": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = u_tbl2.col1 + 'bar' where 1 != 1",
-            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = u_tbl2.col1 + 'bar' where u_tbl2.col1 + 'bar' is not null and not (u_tbl2.col2) <=> (u_tbl2.col1 + 'bar') and u_tbl2.id = 1 and u_tbl1.col1 is null limit 1 for share nowait",
+            "FieldQuery": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where 1 != 1",
+            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where cast(u_tbl2.col1 + 'bar' as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.col1 + 'bar' as CHAR)) and u_tbl2.id = 1 and u_tbl1.col1 is null limit 1 for share nowait",
             "Table": "u_tbl1, u_tbl2"
           },
           {
@@ -821,8 +821,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select col2, col2 <=> col1 + 'bar', col1 + 'bar' from u_tbl2 where 1 != 1",
-                "Query": "select col2, col2 <=> col1 + 'bar', col1 + 'bar' from u_tbl2 where id = 1 for update nowait",
+                "FieldQuery": "select col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where 1 != 1",
+                "Query": "select col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where id = 1 for update nowait",
                 "Table": "u_tbl2"
               },
               {
@@ -840,7 +840,6 @@
                 ],
                 "NonLiteralUpdateInfo": [
                   {
-                    "ExprCol": 0,
                     "CompExprCol": 1,
                     "UpdateExprCol": 2,
                     "UpdateExprBvName": "fkc_upd"
@@ -889,8 +888,8 @@
               "Name": "unsharded_fk_allow",
               "Sharded": false
             },
-            "FieldQuery": "select col1, col1 <=> x + 'bar', x + 'bar' from u_tbl1 where 1 != 1",
-            "Query": "select col1, col1 <=> x + 'bar', x + 'bar' from u_tbl1 where id = 1 for update nowait",
+            "FieldQuery": "select col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where 1 != 1",
+            "Query": "select col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where id = 1 for update nowait",
             "Table": "u_tbl1"
           },
           {
@@ -902,7 +901,6 @@
             ],
             "NonLiteralUpdateInfo": [
               {
-                "ExprCol": 0,
                 "CompExprCol": 1,
                 "UpdateExprCol": 2,
                 "UpdateExprBvName": "fkc_upd"
@@ -934,7 +932,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (:fkc_upd is null or (col3) not in ((:fkc_upd)))",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:fkc_upd as CHAR) is null or (col3) not in ((cast(:fkc_upd as CHAR))))",
                 "Table": "u_tbl3"
               },
               {
@@ -960,7 +958,6 @@
             ],
             "NonLiteralUpdateInfo": [
               {
-                "ExprCol": 0,
                 "CompExprCol": 1,
                 "UpdateExprCol": 2,
                 "UpdateExprBvName": "fkc_upd1"
@@ -1066,7 +1063,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((2))",
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast(2 as CHAR)))",
             "Table": "u_tbl3"
           },
           {
@@ -1143,7 +1140,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((2))",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(2 as CHAR)))",
                 "Table": "u_tbl3"
               },
               {
@@ -1177,7 +1174,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select col9 from u_tbl9 where 1 != 1",
-                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((2)) for update nowait",
+                "Query": "select col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR))) for update nowait",
                 "Table": "u_tbl9"
               },
               {
@@ -1205,7 +1202,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((2))",
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR)))",
                 "Table": "u_tbl9"
               }
             ]
@@ -1443,8 +1440,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = 'foo' where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = 'foo' where not (u_tbl8.col8) <=> ('foo') and (u_tbl8.col8) in ::fkc_vals and u_tbl9.col9 is null limit 1 for share nowait",
+                "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals and u_tbl9.col9 is null limit 1 for share nowait",
                 "Table": "u_tbl8, u_tbl9"
               },
               {
@@ -1519,8 +1516,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = 'foo' where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = 'foo' where not (u_tbl4.col4) <=> ('foo') and (u_tbl4.col4) in ::fkc_vals and u_tbl3.col3 is null limit 1 for share nowait",
+                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where 1 != 1",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals and u_tbl3.col3 is null limit 1 for share nowait",
                 "Table": "u_tbl3, u_tbl4"
               },
               {
@@ -1532,7 +1529,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (u_tbl9.col9) not in (('foo')) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
+                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (u_tbl9.col9) not in ((cast('foo' as CHAR))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
                 "Table": "u_tbl4, u_tbl9"
               },
               {
@@ -1608,8 +1605,8 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = :v1 where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = :v1 where not (u_tbl4.col4) <=> (:v1) and (u_tbl4.col4) in ::fkc_vals and :v1 is not null and u_tbl3.col3 is null limit 1 for share nowait",
+                "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where 1 != 1",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where not (u_tbl4.col4) <=> (cast(:v1 as CHAR)) and (u_tbl4.col4) in ::fkc_vals and cast(:v1 as CHAR) is not null and u_tbl3.col3 is null limit 1 for share nowait",
                 "Table": "u_tbl3, u_tbl4"
               },
               {
@@ -1621,7 +1618,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (:v1 is null or (u_tbl9.col9) not in ((:v1))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
+                "Query": "select 1 from u_tbl4, u_tbl9 where (u_tbl4.col4) in ::fkc_vals and (cast(:v1 as CHAR) is null or (u_tbl9.col9) not in ((cast(:v1 as CHAR)))) and u_tbl4.col4 = u_tbl9.col9 limit 1 for share nowait",
                 "Table": "u_tbl4, u_tbl9"
               },
               {

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -752,16 +752,84 @@
     "unsharded_fk_allow": {
       "foreignKeyMode": "managed",
       "tables": {
-        "u_tbl1": {},
-        "u_tbl2": {},
-        "u_tbl3": {},
-        "u_tbl4": {},
-        "u_tbl5": {},
-        "u_tbl6": {},
-        "u_tbl7": {},
-        "u_tbl8": {},
+        "u_tbl1": {
+          "columns": [
+            {
+              "name": "col1",
+              "type": "VARCHAR"
+            },
+            {
+              "name": "col14",
+              "type": "INT16"
+            }
+          ]
+        },
+        "u_tbl2": {
+          "columns": [
+            {
+              "name": "col2",
+              "type": "VARCHAR"
+            }
+          ]
+        },
+        "u_tbl3": {
+          "columns": [
+            {
+              "name": "col3",
+              "type": "VARCHAR"
+            }
+          ]
+        },
+        "u_tbl4": {
+          "columns": [
+            {
+              "name": "col41",
+              "type": "INT16"
+            },
+            {
+              "name": "col4",
+              "type": "VARCHAR"
+            }
+          ]
+        },
+        "u_tbl5": {
+          "columns": [
+            {
+              "name": "col5",
+              "type": "VARCHAR"
+            }
+          ]
+        },
+        "u_tbl6": {
+          "columns": [
+            {
+              "name": "col6",
+              "type": "VARCHAR"
+            }
+          ]
+        },
+        "u_tbl7": {
+          "columns": [
+            {
+              "name": "col7",
+              "type": "VARCHAR"
+            }
+          ]
+        },
+        "u_tbl8": {
+          "columns": [
+            {
+              "name": "col8",
+              "type": "VARCHAR"
+            }
+          ]
+        },
         "u_tbl9": {
           "columns": [
+            {
+              "name": "col9",
+              "type": "VARCHAR"
+            },
             {"name": "foo"},
             {"name": "bar", "default": "1"}
           ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the bug described in https://github.com/vitessio/vitess/issues/14589. 

Since `fk_t16` has child tables and this is a non-literal update, Vitess has to cascade the changes and then update the `fk_t16` table with foreign key checks turned off. This requires Vitess to verify that the updated values are present in the parent table i.e. `fk_t15`.

Previously Vitess was using a query like `select 1 from fk_t16 left join fk_t15 on fk_t15.col = fk_t16.col * (fk_t16.col - fk_t16.col) where fk_t16.col * (fk_t16.col - fk_t16.col) is not null and not (fk_t16.col) <=> (fk_t16.col * (fk_t16.col - fk_t16.col)) and fk_t16.id = 3 and fk_t15.col is null limit 1 for share nowait`.

The problem is that `fk_t16.col * (fk_t16.col - fk_t16.col)` evaluates to `-0` but of type float. When compared to `fk_t15.col` of type varchar `0`, MySQL ends up doing the comparison in float space and concludes that -0 and 0 are the same values. This makes Vitess infer that the verification is successful and it is safe to proceed with the update. 

The final value however is set in Varchar since the column is of varchar type. This leads to Vitess ending up in a broken state and allowing an update that otherwise should have been rejected.

The way adopted to fix this problem has been to CAST the update expression to the type of the column before using it for comparison. i.e. the verification query now looks like `select 1 from fk_t16 left join fk_t15 on fk_t15.col = cast(fk_t16.col * (fk_t16.col - fk_t16.col) as CHAR) where cast(fk_t16.col * (fk_t16.col - fk_t16.col) as CHAR) is not null and not (fk_t16.col) <=> (cast(fk_t16.col * (fk_t16.col - fk_t16.col) as CHAR)) and fk_t16.id = 3 and fk_t15.col is null limit 1 for share nowait`

The overall plan looks like - 
```json
{
  "OperatorType": "FKVerify",
  "Inputs": [
    {
      "InputName": "VerifyParent-1",
      "OperatorType": "Route",
      "Variant": "Unsharded",
      "Keyspace": {
        "Name": "uks",
        "Sharded": false
      },
      "FieldQuery": "select 1 from fk_t16 left join fk_t15 on fk_t15.col = cast(fk_t16.col * (fk_t16.col - fk_t16.col) as CHAR) where 1 != 1",
      "Query": "select 1 from fk_t16 left join fk_t15 on fk_t15.col = cast(fk_t16.col * (fk_t16.col - fk_t16.col) as CHAR) where cast(fk_t16.col * (fk_t16.col - fk_t16.col) as CHAR) is not null and not (fk_t16.col) <=> (cast(fk_t16.col * (fk_t16.col - fk_t16.col) as CHAR)) and fk_t16.id = 3 and fk_t15.col is null limit 1 for share nowait",
      "Table": "fk_t15, fk_t16"
    },
    {
      "InputName": "PostVerify",
      "OperatorType": "FkCascade",
      "Inputs": [
        {
          "InputName": "Selection",
          "OperatorType": "Route",
          "Variant": "Unsharded",
          "Keyspace": {
            "Name": "uks",
            "Sharded": false
          },
          "FieldQuery": "select col, col <=> cast(col * (col - col) as CHAR), cast(col * (col - col) as CHAR) from fk_t16 where 1 != 1",
          "Query": "select col, col <=> cast(col * (col - col) as CHAR), cast(col * (col - col) as CHAR) from fk_t16 where id = 3 for update nowait",
          "Table": "fk_t16"
        },
        {
          "InputName": "CascadeChild-1",
          "OperatorType": "FkCascade",
          "BvName": "fkc_vals",
          "Cols": [
            0
          ],
          "NonLiteralUpdateInfo": [
            {
              "CompExprCol": 1,
              "UpdateExprCol": 2,
              "UpdateExprBvName": "fkc_upd"
            }
          ],
          "Inputs": [
            {
              "InputName": "Selection",
              "OperatorType": "Route",
              "Variant": "Unsharded",
              "Keyspace": {
                "Name": "uks",
                "Sharded": false
              },
              "FieldQuery": "select col from fk_t17 where 1 != 1",
              "Query": "select col from fk_t17 where (col) in ::fkc_vals and (:fkc_upd is null or (col) not in ((:fkc_upd))) for update nowait",
              "Table": "fk_t17"
            },
            {
              "InputName": "CascadeChild-1",
              "OperatorType": "Update",
              "Variant": "Unsharded",
              "Keyspace": {
                "Name": "uks",
                "Sharded": false
              },
              "TargetTabletType": "PRIMARY",
              "BvName": "fkc_vals1",
              "Cols": [
                0
              ],
              "Query": "update fk_t19 set col = null where (col) in ::fkc_vals1",
              "Table": "fk_t19"
            },
            {
              "InputName": "CascadeChild-2",
              "OperatorType": "Update",
              "Variant": "Unsharded",
              "Keyspace": {
                "Name": "uks",
                "Sharded": false
              },
              "TargetTabletType": "PRIMARY",
              "BvName": "fkc_vals2",
              "Cols": [
                0
              ],
              "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ fk_t18 set col = null where (col) in ::fkc_vals2",
              "Table": "fk_t18"
            },
            {
              "InputName": "Parent",
              "OperatorType": "Update",
              "Variant": "Unsharded",
              "Keyspace": {
                "Name": "uks",
                "Sharded": false
              },
              "TargetTabletType": "PRIMARY",
              "Query": "update fk_t17 set col = null where (col) in ::fkc_vals and (:fkc_upd is null or (col) not in ((:fkc_upd)))",
              "Table": "fk_t17"
            }
          ]
        },
        {
          "InputName": "Parent",
          "OperatorType": "Update",
          "Variant": "Unsharded",
          "Keyspace": {
            "Name": "uks",
            "Sharded": false
          },
          "TargetTabletType": "PRIMARY",
          "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ fk_t16 set col = col * (col - col) where id = 3",
          "Table": "fk_t16"
        }
      ]
    }
  ]
}
```

This works as intended.

Since we are now type-casting the expressions using the `CAST` function, we get the correctly typed expressions in SELECT and the changes introduced in https://github.com/vitessio/vitess/pull/14524 are no longer required. They have now been reverted.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/14589

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
