### PR TITLE
Refactor operator code

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/hash_join.go
+++ b/go/vt/vtgate/planbuilder/operators/hash_join.go
@@ -119,10 +119,18 @@ func (hj *HashJoin) planOffsets(ctx *plancontext.PlanningContext) ops.Operator {
 		hj.RHSKeys = append(hj.RHSKeys, rOffset)
 	}
 
+	needsProj := false
 	eexprs := slice.Map(hj.columns, func(in sqlparser.Expr) *ProjExpr {
-		return hj.addColumn(ctx, in)
+		column, pureOffset := hj.addColumn(ctx, in)
+		if !pureOffset {
+			needsProj = true
+		}
+		return column
 	})
 
+	if !needsProj {
+		return nil
+	}
 	proj := newAliasedProjection(hj)
 	_, err := proj.addProjExpr(eexprs...)
 	if err != nil {
@@ -156,7 +164,8 @@ func (hj *HashJoin) ShortDescription() string {
 	cmp := strings.Join(comparisons, " AND ")
 
 	if len(hj.columns) > 0 {
-		return fmt.Sprintf("%s columns %v", cmp, hj.columns)
+		exprs := sqlparser.String(sqlparser.Exprs(hj.columns))
+		return fmt.Sprintf("%s columns [%v]", cmp, exprs)
 	}
 
 	return cmp
@@ -230,7 +239,7 @@ func (c Comparison) String() string {
 	return sqlparser.String(c.LHS) + " = " + sqlparser.String(c.RHS)
 }
 
-func (hj *HashJoin) addColumn(ctx *plancontext.PlanningContext, in sqlparser.Expr) *ProjExpr {
+func (hj *HashJoin) addColumn(ctx *plancontext.PlanningContext, in sqlparser.Expr) (*ProjExpr, bool) {
 	lId, rId := TableID(hj.LHS), TableID(hj.RHS)
 	var replaceExpr sqlparser.Expr // this is the expression we will put in instead of whatever we find there
 	pre := func(node, parent sqlparser.SQLNode) bool {
@@ -307,12 +316,14 @@ func (hj *HashJoin) addColumn(ctx *plancontext.PlanningContext, in sqlparser.Exp
 		panic(err)
 	}
 
+	_, isPureOffset := rewrittenExpr.(*sqlparser.Offset)
+
 	return &ProjExpr{
 		Original: aeWrap(in),
 		EvalExpr: rewrittenExpr,
 		ColExpr:  rewrittenExpr,
 		Info:     &EvalEngine{EExpr: eexpr},
-	}
+	}, isPureOffset
 }
 
 // JoinPredicate produces an AST representation of the join condition this join has

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4058,19 +4058,28 @@
       "QueryType": "SELECT",
       "Original": "select id from user left join (select col from user_extra limit 10) ue on user.col = ue.col",
       "Instructions": {
-        "OperatorType": "Projection",
-        "Expressions": [
-          "id as id"
-        ],
+        "OperatorType": "Join",
+        "Variant": "HashLeftJoin",
+        "Collation": "binary",
+        "ComparisonType": "INT16",
+        "JoinColumnIndexes": "-2",
+        "Predicate": "`user`.col = ue.col",
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "HashLeftJoin",
-            "Collation": "binary",
-            "ComparisonType": "INT16",
-            "JoinColumnIndexes": "-2",
-            "Predicate": "`user`.col = ue.col",
-            "TableName": "`user`_user_extra",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `user`.col, id from `user` where 1 != 1",
+            "Query": "select `user`.col, id from `user`",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Limit",
+            "Count": "10",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -4079,26 +4088,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select `user`.col, id from `user` where 1 != 1",
-                "Query": "select `user`.col, id from `user`",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Limit",
-                "Count": "10",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select col from (select col from user_extra where 1 != 1) as ue where 1 != 1",
-                    "Query": "select col from (select col from user_extra) as ue limit :__upper_limit",
-                    "Table": "user_extra"
-                  }
-                ]
+                "FieldQuery": "select col from (select col from user_extra where 1 != 1) as ue where 1 != 1",
+                "Query": "select col from (select col from user_extra) as ue limit :__upper_limit",
+                "Table": "user_extra"
               }
             ]
           }
@@ -4117,54 +4109,45 @@
       "QueryType": "SELECT",
       "Original": "select id, user_id from (select id, col from user limit 10) u join (select col, user_id from user_extra limit 10) ue on u.col = ue.col",
       "Instructions": {
-        "OperatorType": "Projection",
-        "Expressions": [
-          "id as id",
-          "user_id as user_id"
-        ],
+        "OperatorType": "Join",
+        "Variant": "HashJoin",
+        "Collation": "binary",
+        "ComparisonType": "INT16",
+        "JoinColumnIndexes": "-1,2",
+        "Predicate": "u.col = ue.col",
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "HashJoin",
-            "Collation": "binary",
-            "ComparisonType": "INT16",
-            "JoinColumnIndexes": "-1,2",
-            "Predicate": "u.col = ue.col",
-            "TableName": "`user`_user_extra",
+            "OperatorType": "Limit",
+            "Count": "10",
             "Inputs": [
               {
-                "OperatorType": "Limit",
-                "Count": "10",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select id, col from (select id, col from `user` where 1 != 1) as u where 1 != 1",
-                    "Query": "select id, col from (select id, col from `user`) as u limit :__upper_limit",
-                    "Table": "`user`"
-                  }
-                ]
-              },
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select id, col from (select id, col from `user` where 1 != 1) as u where 1 != 1",
+                "Query": "select id, col from (select id, col from `user`) as u limit :__upper_limit",
+                "Table": "`user`"
+              }
+            ]
+          },
+          {
+            "OperatorType": "Limit",
+            "Count": "10",
+            "Inputs": [
               {
-                "OperatorType": "Limit",
-                "Count": "10",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select col, user_id from (select col, user_id from user_extra where 1 != 1) as ue where 1 != 1",
-                    "Query": "select col, user_id from (select col, user_id from user_extra) as ue limit :__upper_limit",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select col, user_id from (select col, user_id from user_extra where 1 != 1) as ue where 1 != 1",
+                "Query": "select col, user_id from (select col, user_id from user_extra) as ue limit :__upper_limit",
+                "Table": "user_extra"
               }
             ]
           }


### PR DESCRIPTION
## Description
Pure refactoring of the operator code:
1. Collapse the packages. We had `operators`, `ops` and `rewrite`. They have now been collapsed to only `operators`
2. Remove AliasedExpression from GroupBy where it was not required

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
