### PR TITLE
Online DDL: recognize shorter vitess artifact table name

### DIFF
--- a/go/vt/schema/name_test.go
+++ b/go/vt/schema/name_test.go
@@ -36,6 +36,8 @@ func TestNameIsGCTableName(t *testing.T) {
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_ghc",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_del",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_new",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrepl",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrp",
 		"_table_old",
 		"__table_old",
 	}
@@ -63,6 +65,8 @@ func TestIsInternalOperationTableName(t *testing.T) {
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_ghc",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_del",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_new",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrepl",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrp",
 		"_table_old",
 		"__table_old",
 		"_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",

--- a/go/vt/schema/online_ddl.go
+++ b/go/vt/schema/online_ddl.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	onlineDdlUUIDRegexp               = regexp.MustCompile(`^[0-f]{8}_[0-f]{4}_[0-f]{4}_[0-f]{4}_[0-f]{12}$`)
-	onlineDDLGeneratedTableNameRegexp = regexp.MustCompile(`^_[0-f]{8}_[0-f]{4}_[0-f]{4}_[0-f]{4}_[0-f]{12}_([0-9]{14})_(gho|ghc|del|new|vrepl)$`)
+	onlineDDLGeneratedTableNameRegexp = regexp.MustCompile(`^_[0-f]{8}_[0-f]{4}_[0-f]{4}_[0-f]{4}_[0-f]{12}_([0-9]{14})_(gho|ghc|del|new|vrepl|vrp)$`)
 	ptOSCGeneratedTableNameRegexp     = regexp.MustCompile(`^_.*_old$`)
 	migrationContextValidatorRegexp   = regexp.MustCompile(`^[\w:-]*$`)
 )

--- a/go/vt/schema/online_ddl_test.go
+++ b/go/vt/schema/online_ddl_test.go
@@ -107,6 +107,7 @@ func TestIsOnlineDDLTableName(t *testing.T) {
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_del",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_new",
 		"_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrepl",
+		"_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp",
 		"_table_old",
 		"__table_old",
 	}
@@ -121,6 +122,7 @@ func TestIsOnlineDDLTableName(t *testing.T) {
 		"_table_ghc",
 		"_table_del",
 		"_table_vrepl",
+		"_table_vrp",
 		"table_old",
 	}
 	for _, tableName := range irrelevantNames {


### PR DESCRIPTION

## Description

Initial support for https://github.com/vitessio/vitess/issues/14570. This PR merely recognizes this new shorter naming scheme as an OnlineDDL table name, .e.g `_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrp`.

This name is two characters shorter than the current scheme (e.g. `_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrepl`). It allows default constraint names with one or two digits. For example:

```sql
mysql> create table _84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp(id int primary key, pid int, foreign key (pid) references p(id));
Query OK, 0 rows affected (0.06 sec)

mysql> show create table _84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp\G
*************************** 1. row ***************************
       Table: _84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp
Create Table: CREATE TABLE `_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp` (
  `id` int NOT NULL,
  `pid` int DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `pid` (`pid`),
  CONSTRAINT `_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp_ibfk_1` FOREIGN KEY (`pid`) REFERENCES `p` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```

The name `_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp_ibfk_1` is `63` characters long, and thus we can support up to `_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp_ibfk_99` with this naming scheme.

This PR only _accepts_ this new naming scheme. A followup PR will actually use it.
## Related Issue(s)

https://github.com/vitessio/vitess/issues/14570

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
