### PR TITLE
Online DDL: use shorter artifact table name in vitess migrations

### DIFF
--- a/go/vt/schema/name_test.go
+++ b/go/vt/schema/name_test.go
@@ -36,6 +36,8 @@ func TestNameIsGCTableName(t *testing.T) {
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_ghc",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_del",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_new",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrepl",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrp",
 		"_table_old",
 		"__table_old",
 	}
@@ -63,6 +65,8 @@ func TestIsInternalOperationTableName(t *testing.T) {
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_ghc",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_del",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_new",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrepl",
+		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_vrp",
 		"_table_old",
 		"__table_old",
 		"_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",

--- a/go/vt/schema/online_ddl.go
+++ b/go/vt/schema/online_ddl.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	onlineDdlUUIDRegexp               = regexp.MustCompile(`^[0-f]{8}_[0-f]{4}_[0-f]{4}_[0-f]{4}_[0-f]{12}$`)
-	onlineDDLGeneratedTableNameRegexp = regexp.MustCompile(`^_[0-f]{8}_[0-f]{4}_[0-f]{4}_[0-f]{4}_[0-f]{12}_([0-9]{14})_(gho|ghc|del|new|vrepl)$`)
+	onlineDDLGeneratedTableNameRegexp = regexp.MustCompile(`^_[0-f]{8}_[0-f]{4}_[0-f]{4}_[0-f]{4}_[0-f]{12}_([0-9]{14})_(gho|ghc|del|new|vrepl|vrp)$`)
 	ptOSCGeneratedTableNameRegexp     = regexp.MustCompile(`^_.*_old$`)
 	migrationContextValidatorRegexp   = regexp.MustCompile(`^[\w:-]*$`)
 )

--- a/go/vt/schema/online_ddl_test.go
+++ b/go/vt/schema/online_ddl_test.go
@@ -107,6 +107,7 @@ func TestIsOnlineDDLTableName(t *testing.T) {
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114014_del",
 		"_4e5dcf80_354b_11eb_82cd_f875a4d24e90_20201203114013_new",
 		"_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrepl",
+		"_84371a37_6153_11eb_9917_f875a4d24e90_20210128122816_vrp",
 		"_table_old",
 		"__table_old",
 	}
@@ -121,6 +122,7 @@ func TestIsOnlineDDLTableName(t *testing.T) {
 		"_table_ghc",
 		"_table_del",
 		"_table_vrepl",
+		"_table_vrp",
 		"table_old",
 	}
 	for _, tableName := range irrelevantNames {

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1337,7 +1337,7 @@ func (e *Executor) initVreplicationOriginalMigration(ctx context.Context, online
 		return v, err
 	}
 
-	vreplTableName := fmt.Sprintf("_%s_%s_vrepl", onlineDDL.UUID, ReadableTimestamp())
+	vreplTableName := fmt.Sprintf("_%s_%s_vrp", onlineDDL.UUID, ReadableTimestamp())
 	if err := e.updateArtifacts(ctx, onlineDDL.UUID, vreplTableName); err != nil {
 		return v, err
 	}


### PR DESCRIPTION
## Description

Fixes https://github.com/vitessio/vitess/issues/14570
Follows up (and extends) on https://github.com/vitessio/vitess/pull/14571

`vitess` migrations now use a shorter (by `2` characters) form of artifact table name. Instead of `_*_vrepl` it's `_*_vrp`. The change is minimal and everything should just continue to work as it was, with existing tests.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/14570

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
