### PR TITLE
planbuilder: push down ordering through filter

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -541,6 +541,8 @@ func tryPushOrdering(ctx *plancontext.PlanningContext, in *Ordering) (ops.Operat
 	switch src := in.Source.(type) {
 	case *Route:
 		return rewrite.Swap(in, src, "push ordering under route")
+	case *Filter:
+		return rewrite.Swap(in, src, "push ordering under filter")
 	case *ApplyJoin:
 		if canPushLeft(ctx, src, in.Order) {
 			// ApplyJoin is stable in regard to the columns coming from the LHS,

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -2021,54 +2021,47 @@
       "QueryType": "SELECT",
       "Original": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
       "Instructions": {
-        "OperatorType": "Sort",
-        "Variant": "Memory",
-        "OrderBy": "(0|2) ASC",
+        "OperatorType": "Filter",
+        "Predicate": "repeat(a.tcol1, min(a.id)) like 'A\\%B'",
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Filter",
-            "Predicate": "repeat(a.tcol1, min(a.id)) like 'A\\%B'",
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "min(1|3) AS min(a.id)",
+            "GroupBy": "(0|2)",
             "Inputs": [
               {
-                "OperatorType": "Aggregate",
-                "Variant": "Ordered",
-                "Aggregates": "min(1|3) AS min(a.id)",
-                "GroupBy": "(0|2)",
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:1,L:0,L:2,L:3",
+                "JoinVars": {
+                  "a_tcol1": 1
+                },
+                "TableName": "`user`_music",
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "L:1,L:0,L:2,L:3",
-                    "JoinVars": {
-                      "a_tcol1": 1
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
                     },
-                    "TableName": "`user`_music",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1), weight_string(a.id)",
-                        "OrderBy": "(1|2) ASC",
-                        "Query": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a group by a.tcol1, weight_string(a.tcol1), weight_string(a.id) order by a.tcol1 asc",
-                        "Table": "`user`"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select 1 from music as b where 1 != 1 group by .0",
-                        "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by .0",
-                        "Table": "music"
-                      }
-                    ]
+                    "FieldQuery": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1), weight_string(a.id)",
+                    "OrderBy": "(1|2) ASC",
+                    "Query": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a group by a.tcol1, weight_string(a.tcol1), weight_string(a.id) order by a.tcol1 asc",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1 from music as b where 1 != 1 group by .0",
+                    "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by .0",
+                    "Table": "music"
                   }
                 ]
               }


### PR DESCRIPTION
## Description
When decided what should be pushed under what, we made a mistake. 
The thinking was that if we need to filter and order the results, we should filter first so we have less to order. For that reason we didn't push ordering under filtering.

Unfortunately, this means that we forced the sorting to happen on the vtgate side, which means that we have to have the full result set before we can sort it, and that can easily lead to OOMs.

Here we are allowing the ordering to be pushed down under the route, which means that MySQL is producing ordered results. These can be merged together one chunk at a time, thanks to the pre-sorting.


## Related Issue(s)


## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
