### PR TITLE
bug fix: stop all kinds of expressions from cnf-exploding

### DIFF
--- a/go/vt/sqlparser/predicate_rewriting.go
+++ b/go/vt/sqlparser/predicate_rewriting.go
@@ -21,8 +21,8 @@ package sqlparser
 func RewritePredicate(ast SQLNode) SQLNode {
 	original := CloneSQLNode(ast)
 
-	// This loop can in some cases of this conversion to CNF can lead to an exponential explosion of the formula,
-	// so we stop it before it goes too crazy
+	// Beware: converting to CNF in this loop might cause exponential formula growth.
+	// We bail out early to prevent going overboard.
 	for loop := 0; loop < 15; loop++ {
 		exprChanged := false
 		stopOnChange := func(SQLNode, SQLNode) bool {

--- a/go/vt/sqlparser/predicate_rewriting_test.go
+++ b/go/vt/sqlparser/predicate_rewriting_test.go
@@ -91,7 +91,13 @@ func TestSimplifyExpression(in *testing.T) {
 			expr, err := ParseExpr(tc.in)
 			require.NoError(t, err)
 
-			expr, didRewrite := simplifyExpression(expr)
+			r := &rewriter{
+				// setting these number so it never stops rewriting for these tests
+				initialSize: 1000000000,
+				currentSize: 1,
+			}
+
+			expr, didRewrite := r.simplifyExpression(expr)
 			assert.True(t, didRewrite)
 			assert.Equal(t, tc.expected, String(expr))
 		})

--- a/go/vt/sqlparser/predicate_rewriting_test.go
+++ b/go/vt/sqlparser/predicate_rewriting_test.go
@@ -92,7 +92,7 @@ func TestSimplifyExpression(in *testing.T) {
 			require.NoError(t, err)
 
 			expr, didRewrite := simplifyExpression(expr)
-			assert.True(t, didRewrite.changed())
+			assert.True(t, didRewrite)
 			assert.Equal(t, tc.expected, String(expr))
 		})
 	}

--- a/go/vt/sqlparser/predicate_rewriting_test.go
+++ b/go/vt/sqlparser/predicate_rewriting_test.go
@@ -91,14 +91,8 @@ func TestSimplifyExpression(in *testing.T) {
 			expr, err := ParseExpr(tc.in)
 			require.NoError(t, err)
 
-			r := &rewriter{
-				// setting these number so it never stops rewriting for these tests
-				initialSize: 1000000000,
-				currentSize: 1,
-			}
-
-			expr, didRewrite := r.simplifyExpression(expr)
-			assert.True(t, didRewrite)
+			expr, changed := simplifyExpression(expr)
+			assert.True(t, changed)
 			assert.Equal(t, tc.expected, String(expr))
 		})
 	}

--- a/go/vt/sqlparser/predicate_rewriting_test.go
+++ b/go/vt/sqlparser/predicate_rewriting_test.go
@@ -91,7 +91,7 @@ func TestSimplifyExpression(in *testing.T) {
 			expr, err := ParseExpr(tc.in)
 			require.NoError(t, err)
 
-			expr, didRewrite := simplifyExpression(expr, true)
+			expr, didRewrite := simplifyExpression(expr)
 			assert.True(t, didRewrite.changed())
 			assert.Equal(t, tc.expected, String(expr))
 		})
@@ -137,9 +137,12 @@ func TestRewritePredicate(in *testing.T) {
 		in:       "(a = 1 and b = 41) or (a = 2 and b = 42) or (a = 3 and b = 43)",
 		expected: "a in (1, 2, 3) and (a in (1, 2) or b = 43) and ((a = 1 or b = 42 or a = 3) and (a = 1 or b = 42 or b = 43)) and ((b = 41 or a = 2 or a = 3) and (b = 41 or a = 2 or b = 43) and ((b in (41, 42) or a = 3) and b in (41, 42, 43)))",
 	}, {
-		// this has too many OR expressions in it, so we don't even try the CNF rewriting
+		// the following two tests show some pathological cases that would grow too much, and so we abort the rewriting
 		in:       "a = 1 and b = 41 or a = 2 and b = 42 or a = 3 and b = 43 or a = 4 and b = 44 or a = 5 and b = 45 or a = 6 and b = 46",
 		expected: "a = 1 and b = 41 or a = 2 and b = 42 or a = 3 and b = 43 or a = 4 and b = 44 or a = 5 and b = 45 or a = 6 and b = 46",
+	}, {
+		in:       "not n0 xor not (n2 and n3) xor (not n2 and (n1 xor n1) xor (n0 xor n0 xor n2))",
+		expected: "not n0 xor not (n2 and n3) xor (not n2 and (n1 xor n1) xor (n0 xor n0 xor n2))",
 	}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Description
In a recent change (#14560) we fixed a bug in the CNF rewriter that stopped it from rewriting a lot of cases.
Unfortunately, we succeeded too well, and the newly rewritten expressions are timing out in expression fuzzing on CI. This is because CNF rewriting in some situations result in huge outputs (see [Wikipedia](https://en.wikipedia.org/wiki/Conjunctive_normal_form#Conversion_into_CNF))

This PR stops the rewriting once the produced expression has grown to 10 times the size of the original expression. 

## Related Issue(s)
Fixes #14569

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required