### PR TITLE
[16.0] bug fix: stop all kinds of expressions from cnf-exploding

### DIFF
--- a/go/vt/sqlparser/predicate_rewriting.go
+++ b/go/vt/sqlparser/predicate_rewriting.go
@@ -16,32 +16,14 @@ limitations under the License.
 
 package sqlparser
 
-import (
-	"vitess.io/vitess/go/vt/log"
-)
-
-// This is the number of OR expressions in a predicate that will disable the CNF
-// rewrite because we don't want to send large queries to MySQL
-const CNFOrLimit = 5
-
 // RewritePredicate walks the input AST and rewrites any boolean logic into a simpler form
 // This simpler form is CNF plus logic for extracting predicates from OR, plus logic for turning ORs into IN
-// Note: In order to re-plan, we need to empty the accumulated metadata in the AST,
-// so ColName.Metadata will be nil:ed out as part of this rewrite
 func RewritePredicate(ast SQLNode) SQLNode {
-	count := 0
-	_ = Walk(func(node SQLNode) (bool, error) {
-		if _, isExpr := node.(*OrExpr); isExpr {
-			count++
-		}
+	original := CloneSQLNode(ast)
 
-		return true, nil
-	}, ast)
-
-	allowCNF := count < CNFOrLimit
-
-	for {
-		printExpr(ast)
+	// Beware: converting to CNF in this loop might cause exponential formula growth.
+	// We bail out early to prevent going overboard.
+	for loop := 0; loop < 15; loop++ {
 		exprChanged := false
 		stopOnChange := func(SQLNode, SQLNode) bool {
 			return !exprChanged
@@ -52,9 +34,8 @@ func RewritePredicate(ast SQLNode) SQLNode {
 				return true
 			}
 
-			rewritten, state := simplifyExpression(e, allowCNF)
-			if ch, isChange := state.(changed); isChange {
-				printRule(ch.rule, ch.exprMatched)
+			rewritten, changed := simplifyExpression(e)
+			if changed {
 				exprChanged = true
 				cursor.Replace(rewritten)
 			}
@@ -69,35 +50,162 @@ func RewritePredicate(ast SQLNode) SQLNode {
 			return ast
 		}
 	}
+
+	return original
 }
 
-func simplifyExpression(expr Expr, allowCNF bool) (Expr, rewriteState) {
+func simplifyExpression(expr Expr) (Expr, bool) {
 	switch expr := expr.(type) {
 	case *NotExpr:
 		return simplifyNot(expr)
 	case *OrExpr:
-		return simplifyOr(expr, allowCNF)
+		return simplifyOr(expr)
 	case *XorExpr:
 		return simplifyXor(expr)
 	case *AndExpr:
 		return simplifyAnd(expr)
 	}
-	return expr, noChange{}
+	return expr, false
 }
 
-func simplifyNot(expr *NotExpr) (Expr, rewriteState) {
+func simplifyNot(expr *NotExpr) (Expr, bool) {
 	switch child := expr.Expr.(type) {
 	case *NotExpr:
-		return child.Expr,
-			newChange("NOT NOT A => A", f(expr))
+		return child.Expr, true
 	case *OrExpr:
-		return &AndExpr{Right: &NotExpr{Expr: child.Right}, Left: &NotExpr{Expr: child.Left}},
-			newChange("NOT (A OR B) => NOT A AND NOT B", f(expr))
+		// not(or(a,b)) => and(not(a),not(b))
+		return &AndExpr{Right: &NotExpr{Expr: child.Right}, Left: &NotExpr{Expr: child.Left}}, true
 	case *AndExpr:
-		return &OrExpr{Right: &NotExpr{Expr: child.Right}, Left: &NotExpr{Expr: child.Left}},
-			newChange("NOT (A AND B) => NOT A OR NOT B", f(expr))
+		// not(and(a,b)) => or(not(a), not(b))
+		return &OrExpr{Right: &NotExpr{Expr: child.Right}, Left: &NotExpr{Expr: child.Left}}, true
 	}
-	return expr, noChange{}
+	return expr, false
+}
+
+func simplifyOr(expr *OrExpr) (Expr, bool) {
+	res, rewritten := distinctOr(expr)
+	if rewritten {
+		return res, true
+	}
+
+	or := expr
+
+	// first we search for ANDs and see how they can be simplified
+	land, lok := or.Left.(*AndExpr)
+	rand, rok := or.Right.(*AndExpr)
+
+	if lok && rok {
+		// (<> AND <>) OR (<> AND <>)
+		// or(and(T1,T2), and(T2, T3)) => and(T1, or(T2, T2))
+		var a, b, c Expr
+		switch {
+		case Equals.Expr(land.Left, rand.Left):
+			a, b, c = land.Left, land.Right, rand.Right
+			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, true
+		case Equals.Expr(land.Left, rand.Right):
+			a, b, c = land.Left, land.Right, rand.Left
+			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, true
+		case Equals.Expr(land.Right, rand.Left):
+			a, b, c = land.Right, land.Left, rand.Right
+			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, true
+		case Equals.Expr(land.Right, rand.Right):
+			a, b, c = land.Right, land.Left, rand.Left
+			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, true
+		}
+	}
+
+	// (<> AND <>) OR <>
+	if lok {
+		// Simplification
+		if Equals.Expr(or.Right, land.Left) || Equals.Expr(or.Right, land.Right) {
+			// or(and(a,b), c) => c   where c=a or c=b
+			return or.Right, true
+		}
+
+		// Distribution Law
+		//  or(c, and(a,b)) => and(or(c,a), or(c,b))
+		return &AndExpr{
+			Left: &OrExpr{
+				Left:  land.Left,
+				Right: or.Right,
+			},
+			Right: &OrExpr{
+				Left:  land.Right,
+				Right: or.Right,
+			},
+		}, true
+	}
+
+	// <> OR (<> AND <>)
+	if rok {
+		// Simplification
+		if Equals.Expr(or.Left, rand.Left) || Equals.Expr(or.Left, rand.Right) {
+			// or(a,and(b,c)) => a
+			return or.Left, true
+		}
+
+		// Distribution Law
+		//  or(and(a,b), c) => and(or(c,a), or(c,b))
+		return &AndExpr{
+			Left:  &OrExpr{Left: or.Left, Right: rand.Left},
+			Right: &OrExpr{Left: or.Left, Right: rand.Right},
+		}, true
+	}
+
+	// next, we want to try to turn multiple ORs into an IN when possible
+	lftCmp, lok := or.Left.(*ComparisonExpr)
+	rgtCmp, rok := or.Right.(*ComparisonExpr)
+	if lok && rok {
+		newExpr, rewritten := tryTurningOrIntoIn(lftCmp, rgtCmp)
+		if rewritten {
+			// or(a=x,a=y) => in(a,[x,y])
+			return newExpr, true
+		}
+	}
+
+	// Try to make distinct
+	result, changed := distinctOr(expr)
+	if changed {
+		return result, true
+	}
+	return result, false
+}
+
+func simplifyXor(expr *XorExpr) (Expr, bool) {
+	// xor(a,b) => and(or(a,b), not(and(a,b))
+	return &AndExpr{
+		Left:  &OrExpr{Left: expr.Left, Right: expr.Right},
+		Right: &NotExpr{Expr: &AndExpr{Left: expr.Left, Right: expr.Right}},
+	}, true
+}
+
+func simplifyAnd(expr *AndExpr) (Expr, bool) {
+	res, rewritten := distinctAnd(expr)
+	if rewritten {
+		return res, true
+	}
+	and := expr
+	if or, ok := and.Left.(*OrExpr); ok {
+		// Simplification
+		// and(or(a,b),c) => c when c=a or c=b
+		if Equals.Expr(or.Left, and.Right) {
+			return and.Right, true
+		}
+		if Equals.Expr(or.Right, and.Right) {
+			return and.Right, true
+		}
+	}
+	if or, ok := and.Right.(*OrExpr); ok {
+		// Simplification
+		if Equals.Expr(or.Left, and.Left) {
+			return and.Left, true
+		}
+		if Equals.Expr(or.Right, and.Left) {
+			return and.Left, true
+		}
+	}
+
+	return expr, false
 }
 
 // ExtractINFromOR will add additional predicated to an OR.
@@ -122,8 +230,8 @@ func ExtractINFromOR(expr *OrExpr) []Expr {
 			if !ok {
 				continue
 			}
-			in, state := tryTurningOrIntoIn(l, r)
-			if state.changed() {
+			in, changed := tryTurningOrIntoIn(l, r)
+			if changed {
 				ins = append(ins, in)
 			}
 		}
@@ -132,130 +240,48 @@ func ExtractINFromOR(expr *OrExpr) []Expr {
 	return uniquefy(ins)
 }
 
-func simplifyOr(expr *OrExpr, allowCNF bool) (Expr, rewriteState) {
-	or := expr
-
-	// first we search for ANDs and see how they can be simplified
-	land, lok := or.Left.(*AndExpr)
-	rand, rok := or.Right.(*AndExpr)
-
-	if lok && rok {
-		// (<> AND <>) OR (<> AND <>)
-		var a, b, c Expr
-		var change changed
-		switch {
-		case Equals.Expr(land.Left, rand.Left):
-			change = newChange("(A and B) or (A and C) => A AND (B OR C)", f(expr))
-			a, b, c = land.Left, land.Right, rand.Right
-			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, change
-		case Equals.Expr(land.Left, rand.Right):
-			change = newChange("(A and B) or (C and A) => A AND (B OR C)", f(expr))
-			a, b, c = land.Left, land.Right, rand.Left
-			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, change
-		case Equals.Expr(land.Right, rand.Left):
-			change = newChange("(B and A) or (A and C) => A AND (B OR C)", f(expr))
-			a, b, c = land.Right, land.Left, rand.Right
-			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, change
-		case Equals.Expr(land.Right, rand.Right):
-			change = newChange("(B and A) or (C and A) => A AND (B OR C)", f(expr))
-			a, b, c = land.Right, land.Left, rand.Left
-			return &AndExpr{Left: a, Right: &OrExpr{Left: b, Right: c}}, change
-		}
-	}
-
-	// (<> AND <>) OR <>
-	if lok {
-		// Simplification
-		if Equals.Expr(or.Right, land.Left) || Equals.Expr(or.Right, land.Right) {
-			return or.Right, newChange("(A AND B) OR A => A", f(expr))
-		}
-
-		if allowCNF {
-			// Distribution Law
-			return &AndExpr{Left: &OrExpr{Left: land.Left, Right: or.Right}, Right: &OrExpr{Left: land.Right, Right: or.Right}},
-				newChange("(A AND B) OR C => (A OR C) AND (B OR C)", f(expr))
-		}
-	}
-
-	// <> OR (<> AND <>)
-	if rok {
-		// Simplification
-		if Equals.Expr(or.Left, rand.Left) || Equals.Expr(or.Left, rand.Right) {
-			return or.Left, newChange("A OR (A AND B) => A", f(expr))
-		}
-
-		if allowCNF {
-			// Distribution Law
-			return &AndExpr{
-					Left:  &OrExpr{Left: or.Left, Right: rand.Left},
-					Right: &OrExpr{Left: or.Left, Right: rand.Right},
-				},
-				newChange("C OR (A AND B) => (C OR A) AND (C OR B)", f(expr))
-		}
-	}
-
-	// next, we want to try to turn multiple ORs into an IN when possible
-	lftCmp, lok := or.Left.(*ComparisonExpr)
-	rgtCmp, rok := or.Right.(*ComparisonExpr)
-	if lok && rok {
-		newExpr, rewritten := tryTurningOrIntoIn(lftCmp, rgtCmp)
-		if rewritten.changed() {
-			return newExpr, rewritten
-		}
-	}
-
-	// Try to make distinct
-	return distinctOr(expr)
-}
-
-func tryTurningOrIntoIn(l, r *ComparisonExpr) (Expr, rewriteState) {
+func tryTurningOrIntoIn(l, r *ComparisonExpr) (Expr, bool) {
 	// looks for A = X OR A = Y and turns them into A IN (X, Y)
 	col, ok := l.Left.(*ColName)
 	if !ok || !Equals.Expr(col, r.Left) {
-		return nil, noChange{}
+		return nil, false
 	}
 
 	var tuple ValTuple
-	var ruleStr string
+
 	switch l.Operator {
 	case EqualOp:
 		tuple = ValTuple{l.Right}
-		ruleStr = "A = <>"
 	case InOp:
 		lft, ok := l.Right.(ValTuple)
 		if !ok {
-			return nil, noChange{}
+			return nil, false
 		}
 		tuple = lft
-		ruleStr = "A IN (<>, <>)"
 	default:
-		return nil, noChange{}
+		return nil, false
 	}
-
-	ruleStr += " OR "
 
 	switch r.Operator {
 	case EqualOp:
 		tuple = append(tuple, r.Right)
-		ruleStr += "A = <>"
+
 	case InOp:
 		lft, ok := r.Right.(ValTuple)
 		if !ok {
-			return nil, noChange{}
+			return nil, false
 		}
 		tuple = append(tuple, lft...)
-		ruleStr += "A IN (<>, <>)"
-	default:
-		return nil, noChange{}
-	}
 
-	ruleStr += " => A IN (<>, <>)"
+	default:
+		return nil, false
+	}
 
 	return &ComparisonExpr{
 		Operator: InOp,
 		Left:     col,
 		Right:    uniquefy(tuple),
-	}, newChange(ruleStr, f(&OrExpr{Left: l, Right: r}))
+	}, true
 }
 
 func uniquefy(tuple ValTuple) (output ValTuple) {
@@ -271,44 +297,7 @@ outer:
 	return
 }
 
-func simplifyXor(expr *XorExpr) (Expr, rewriteState) {
-	// DeMorgan Rewriter
-	return &AndExpr{
-		Left:  &OrExpr{Left: expr.Left, Right: expr.Right},
-		Right: &NotExpr{Expr: &AndExpr{Left: expr.Left, Right: expr.Right}},
-	}, newChange("(A XOR B) => (A OR B) AND NOT (A AND B)", f(expr))
-}
-
-func simplifyAnd(expr *AndExpr) (Expr, rewriteState) {
-	res, rewritten := distinctAnd(expr)
-	if rewritten.changed() {
-		return res, rewritten
-	}
-	and := expr
-	if or, ok := and.Left.(*OrExpr); ok {
-		// Simplification
-		if Equals.Expr(or.Left, and.Right) {
-			return and.Right, newChange("(A OR B) AND A => A", f(expr))
-		}
-		if Equals.Expr(or.Right, and.Right) {
-			return and.Right, newChange("(A OR B) AND B => B", f(expr))
-		}
-	}
-	if or, ok := and.Right.(*OrExpr); ok {
-		// Simplification
-		if Equals.Expr(or.Left, and.Left) {
-			return and.Left, newChange("A AND (A OR B) => A", f(expr))
-		}
-		if Equals.Expr(or.Right, and.Left) {
-			return and.Left, newChange("A AND (B OR A) => A", f(expr))
-		}
-	}
-
-	return expr, noChange{}
-}
-
-func distinctOr(in *OrExpr) (Expr, rewriteState) {
-	var skipped []*OrExpr
+func distinctOr(in *OrExpr) (result Expr, changed bool) {
 	todo := []*OrExpr{in}
 	var leaves []Expr
 	for len(todo) > 0 {
@@ -325,27 +314,23 @@ func distinctOr(in *OrExpr) (Expr, rewriteState) {
 		addAnd(curr.Left)
 		addAnd(curr.Right)
 	}
-	original := len(leaves)
+
 	var predicates []Expr
 
 outer1:
-	for len(leaves) > 0 {
-		curr := leaves[0]
-		leaves = leaves[1:]
+	for _, curr := range leaves {
 		for _, alreadyIn := range predicates {
 			if Equals.Expr(alreadyIn, curr) {
-				if log.V(0) {
-					skipped = append(skipped, &OrExpr{Left: alreadyIn, Right: curr})
-				}
+				changed = true
 				continue outer1
 			}
 		}
 		predicates = append(predicates, curr)
 	}
-	if original == len(predicates) {
-		return in, noChange{}
+	if !changed {
+		return in, false
 	}
-	var result Expr
+
 	for i, curr := range predicates {
 		if i == 0 {
 			result = curr
@@ -354,25 +339,10 @@ outer1:
 		result = &OrExpr{Left: result, Right: curr}
 	}
 
-	return result, newChange("A OR A => A", func() Expr {
-		var result Expr
-		for _, orExpr := range skipped {
-			if result == nil {
-				result = orExpr
-				continue
-			}
-
-			result = &OrExpr{
-				Left:  result,
-				Right: orExpr,
-			}
-		}
-		return result
-	})
+	return
 }
 
-func distinctAnd(in *AndExpr) (Expr, rewriteState) {
-	var skipped []*AndExpr
+func distinctAnd(in *AndExpr) (result Expr, changed bool) {
 	todo := []*AndExpr{in}
 	var leaves []Expr
 	for len(todo) > 0 {
@@ -388,25 +358,23 @@ func distinctAnd(in *AndExpr) (Expr, rewriteState) {
 		addExpr(curr.Left)
 		addExpr(curr.Right)
 	}
-	original := len(leaves)
 	var predicates []Expr
 
 outer1:
 	for _, curr := range leaves {
 		for _, alreadyIn := range predicates {
 			if Equals.Expr(alreadyIn, curr) {
-				if log.V(0) {
-					skipped = append(skipped, &AndExpr{Left: alreadyIn, Right: curr})
-				}
+				changed = true
 				continue outer1
 			}
 		}
 		predicates = append(predicates, curr)
 	}
-	if original == len(predicates) {
-		return in, noChange{}
+
+	if !changed {
+		return in, false
 	}
-	var result Expr
+
 	for i, curr := range predicates {
 		if i == 0 {
 			result = curr
@@ -414,62 +382,5 @@ outer1:
 		}
 		result = &AndExpr{Left: result, Right: curr}
 	}
-	return AndExpressions(leaves...), newChange("A AND A => A", func() Expr {
-		var result Expr
-		for _, andExpr := range skipped {
-			if result == nil {
-				result = andExpr
-				continue
-			}
-
-			result = &AndExpr{
-				Left:  result,
-				Right: andExpr,
-			}
-		}
-		return result
-	})
-}
-
-type (
-	rewriteState interface {
-		changed() bool
-	}
-	noChange struct{}
-
-	// changed makes it possible to make sure we have a rule string for each change we do in the expression tree
-	changed struct {
-		rule string
-
-		// ExprMatched is a function here so building of this expression can be paid only when we are debug logging
-		exprMatched func() Expr
-	}
-)
-
-func (noChange) changed() bool { return false }
-func (changed) changed() bool  { return true }
-
-// f returns a function that returns the expression. It's short by design, so it interferes minimally
-// used for logging
-func f(e Expr) func() Expr {
-	return func() Expr { return e }
-}
-
-func printRule(rule string, expr func() Expr) {
-	if log.V(10) {
-		log.Infof("Rule: %s   ON   %s", rule, String(expr()))
-	}
-}
-
-func printExpr(expr SQLNode) {
-	if log.V(10) {
-		log.Infof("Current: %s", String(expr))
-	}
-}
-
-func newChange(rule string, exprMatched func() Expr) changed {
-	return changed{
-		rule:        rule,
-		exprMatched: exprMatched,
-	}
+	return AndExpressions(leaves...), true
 }


### PR DESCRIPTION
## Description
In a recent change (#14560) we fixed a bug in the CNF rewriter that stopped it from rewriting a lot of cases.
Unfortunately, we succeeded too well, and the newly rewritten expressions are timing out in expression fuzzing on CI. This is because CNF rewriting in some situations result in huge outputs (see [Wikipedia](https://en.wikipedia.org/wiki/Conjunctive_normal_form#Conversion_into_CNF))

This PR stops the rewriting once the produced expression has grown to 10 times the size of the original expression. 

## Related Issue(s)
Fixes #14569
Backport of #14585

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required