### PR TITLE
mysqlctl: Fix cleaning up the stale lock file

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -438,14 +438,16 @@ func cleanupLockfile(socket string, ts string) error {
 	lockPath := fmt.Sprintf("%s.lock", socket)
 	pid, err := os.ReadFile(lockPath)
 	if errors.Is(err, os.ErrNotExist) {
+		log.Infof("%v: no stale lock file at %s", ts, lockPath)
 		// If there's no lock file, we can early return here, nothing
 		// to clean up then.
 		return nil
 	} else if err != nil {
+		log.Errorf("%v: error checking if lock file exists: %v", ts, err)
 		// Any other errors here are unexpected.
 		return err
 	}
-	p, err := strconv.Atoi(string(pid))
+	p, err := strconv.Atoi(string(bytes.TrimSpace(pid)))
 	if err != nil {
 		log.Errorf("%v: error parsing pid from lock file: %v", ts, err)
 		return err

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -188,6 +188,11 @@ func TestCleanupLockfile(t *testing.T) {
 	assert.NoError(t, cleanupLockfile("mysql.sock", ts))
 	assert.NoFileExists(t, "mysql.sock.lock")
 
+	// If lockfile exists, but the process is not found, we clean it up.
+	os.WriteFile("mysql.sock.lock", []byte("123456789\n"), 0o600)
+	assert.NoError(t, cleanupLockfile("mysql.sock", ts))
+	assert.NoFileExists(t, "mysql.sock.lock")
+
 	// If the lockfile exists, and the process is found, we don't clean it up.
 	os.WriteFile("mysql.sock.lock", []byte(strconv.Itoa(os.Getpid())), 0o600)
 	assert.NoError(t, cleanupLockfile("mysql.sock", ts))


### PR DESCRIPTION
The lock file can have a newline, so we need to trim any space like characters before we try to parse the PID.

## Related Issue(s)

Fixes #14552 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required