### PR TITLE
increase vtctlclient backupShard command success rate

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -464,6 +464,8 @@ func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream v
 				tablets = append(tablets, shardTablet)
 			}
 		}
+	} else {
+		tablets = shardTablets
 	}
 
 	var (

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -442,7 +442,7 @@ func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream v
 	if err != nil {
 		nilStatIndex, errorCount := 0, 0
 		for i, stat := range stats {
-			if stat == nil {
+			if stat != nil {
 				// Possible of multiple errors but only catch the last error index in stats
 				nilStatIndex = i
 				errorCount++

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -442,14 +442,18 @@ func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream v
 	if err != nil {
 		nilStatIndex, errorCount := 0, 0
 		for i, stat := range stats {
-			if stat != nil {
+			// Skip Primary
+			if stat != nil && stat.Position != "" {
+				continue
+			}
+			if stat == nil {
 				// Possible of multiple errors but only catch the last error index in stats
 				nilStatIndex = i
 				errorCount++
 			}
 		}
-		// Only return err when errors on all vttablets
-		if errorCount == len(stats) {
+		// Only return err when all Non-Primary have errors
+		if errorCount == len(stats)-1 {
 			return err
 		}
 		for i, shardTablet := range shardTablets {

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -438,9 +438,9 @@ func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream v
 	})
 
 	var tablets []*topo.TabletInfo
+	nilStatIndex, errorCount := 0, 0
 	// Instead of return on err directly, count total errors and compare with len(stats)
 	if err != nil {
-		nilStatIndex, errorCount := 0, 0
 		for i, stat := range stats {
 			// Skip Primary
 			if stat != nil && stat.Position != "" {
@@ -456,6 +456,9 @@ func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream v
 		if errorCount == len(stats)-1 {
 			return err
 		}
+	}
+
+	if errorCount != 0 {
 		for i, shardTablet := range shardTablets {
 			if i != nilStatIndex {
 				tablets = append(tablets, shardTablet)

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -436,13 +436,18 @@ func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream v
 	// Instead of return on err directly, only return when no healthy tablets at all
 	if err != nil {
 		for i, stat := range stats {
+			// Always include TabletType_PRIMARY
+			if shardTablets[i].Type == topodatapb.TabletType_PRIMARY {
+				tablets = append(tablets, shardTablets[i])
+				continue
+			}
 			// shardTablets[i] and stats[i] is 1:1 mapping
 			// Healthy shardTablets[i] will be added to tablets
 			if stat != nil {
 				tablets = append(tablets, shardTablets[i])
 			}
 		}
-		// Only return err when all tablets have errors
+		// Only return err when no usable tablet
 		if len(tablets) == 0 {
 			return err
 		}

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -347,14 +347,9 @@ func waitForCatchUp(
 // GetBackupCandidates is used to get a list of healthy tablets for backup
 func GetBackupCandidates(tablets []*topo.TabletInfo, stats []*replicationdatapb.Status) (res []*topo.TabletInfo) {
 	for i, stat := range stats {
-		// Always include TabletType_PRIMARY
-		if tablets[i].Type == topodatapb.TabletType_PRIMARY {
-			res = append(res, tablets[i])
-			continue
-		}
 		// shardTablets[i] and stats[i] is 1:1 mapping
-		// Healthy shardTablets[i] will be added to tablets
-		if stat != nil {
+		// Always include TabletType_PRIMARY. Healthy shardTablets[i] will be added to tablets
+		if tablets[i].Type == topodatapb.TabletType_PRIMARY || stat != nil {
 			res = append(res, tablets[i])
 		}
 	}

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -343,3 +343,20 @@ func waitForCatchUp(
 	}
 	return nil
 }
+
+// GetBackupCandidates is used to get a list of healthy tablets for backup
+func GetBackupCandidates(tablets []*topo.TabletInfo, stats []*replicationdatapb.Status) (res []*topo.TabletInfo) {
+	for i, stat := range stats {
+		// Always include TabletType_PRIMARY
+		if tablets[i].Type == topodatapb.TabletType_PRIMARY {
+			res = append(tablets, tablets[i])
+			continue
+		}
+		// shardTablets[i] and stats[i] is 1:1 mapping
+		// Healthy shardTablets[i] will be added to tablets
+		if stat != nil {
+			res = append(tablets, tablets[i])
+		}
+	}
+	return res
+}

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -349,13 +349,13 @@ func GetBackupCandidates(tablets []*topo.TabletInfo, stats []*replicationdatapb.
 	for i, stat := range stats {
 		// Always include TabletType_PRIMARY
 		if tablets[i].Type == topodatapb.TabletType_PRIMARY {
-			res = append(tablets, tablets[i])
+			res = append(res, tablets[i])
 			continue
 		}
 		// shardTablets[i] and stats[i] is 1:1 mapping
 		// Healthy shardTablets[i] will be added to tablets
 		if stat != nil {
-			res = append(tablets, tablets[i])
+			res = append(res, tablets[i])
 		}
 	}
 	return res

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -346,16 +346,6 @@ func waitForCatchUp(
 
 // GetBackupCandidates is used to get a list of healthy tablets for backup
 func GetBackupCandidates(tablets []*topo.TabletInfo, stats []*replicationdatapb.Status) (res []*topo.TabletInfo) {
-	// In case of all tablets has nil stats, return TabletType_PRIMARY
-	if len(stats) == 0 {
-		for _, tablet := range tablets {
-			if tablet.Type == topodatapb.TabletType_PRIMARY {
-				res = append(res, tablet)
-				break
-			}
-		}
-		return res
-	}
 	for i, stat := range stats {
 		// Always include TabletType_PRIMARY
 		if tablets[i].Type == topodatapb.TabletType_PRIMARY {

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -346,6 +346,16 @@ func waitForCatchUp(
 
 // GetBackupCandidates is used to get a list of healthy tablets for backup
 func GetBackupCandidates(tablets []*topo.TabletInfo, stats []*replicationdatapb.Status) (res []*topo.TabletInfo) {
+	// In case of all tablets has nil stats, return TabletType_PRIMARY
+	if len(stats) == 0 {
+		for _, tablet := range tablets {
+			if tablet.Type == topodatapb.TabletType_PRIMARY {
+				res = append(res, tablet)
+				break
+			}
+		}
+		return res
+	}
 	for i, stat := range stats {
 		// Always include TabletType_PRIMARY
 		if tablets[i].Type == topodatapb.TabletType_PRIMARY {

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -1218,3 +1218,105 @@ func Test_getTabletsWithPromotionRules(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetBackupCandidates(t *testing.T) {
+	var (
+		primaryTablet = &topo.TabletInfo{
+			Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  1,
+				},
+				Type: topodatapb.TabletType_PRIMARY,
+			},
+		}
+		replicaTablet = &topo.TabletInfo{
+			Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  2,
+				},
+				Type: topodatapb.TabletType_REPLICA,
+			},
+		}
+		rdonlyTablet = &topo.TabletInfo{
+			Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  3,
+				},
+				Type: topodatapb.TabletType_RDONLY,
+			},
+		}
+		spareTablet = &topo.TabletInfo{
+			Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  4,
+				},
+				Type: topodatapb.TabletType_SPARE,
+			},
+		}
+	)
+	tests := []struct {
+		name     string
+		in       []*topo.TabletInfo
+		expected []*topo.TabletInfo
+		status   []*replicationdatapb.Status
+	}{
+		{
+			name:     "one primary tablet with status",
+			in:       []*topo.TabletInfo{primaryTablet},
+			expected: []*topo.TabletInfo{primaryTablet},
+			status:   []*replicationdatapb.Status{{}},
+		},
+		{
+			name:     "one primary tablet with no status",
+			in:       []*topo.TabletInfo{primaryTablet},
+			expected: []*topo.TabletInfo{primaryTablet},
+			status:   []*replicationdatapb.Status{nil},
+		},
+		{
+			name:     "4 tablets with no status",
+			in:       []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			expected: []*topo.TabletInfo{primaryTablet},
+			status:   []*replicationdatapb.Status{nil, nil, nil, nil},
+		},
+		{
+			name:     "4 tablets with full status",
+			in:       []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			expected: []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			status:   []*replicationdatapb.Status{{}, {}, {}, {}},
+		},
+		{
+			name:     "4 tablets with no primaryTablet status",
+			in:       []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			expected: []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			status:   []*replicationdatapb.Status{nil, {}, {}, {}},
+		},
+		{
+			name:     "4 tablets with no replicaTablet status",
+			in:       []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			expected: []*topo.TabletInfo{primaryTablet, rdonlyTablet, spareTablet},
+			status:   []*replicationdatapb.Status{{}, nil, {}, {}},
+		},
+		{
+			name:     "4 tablets with no rdonlyTablet status",
+			in:       []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			expected: []*topo.TabletInfo{primaryTablet, replicaTablet, spareTablet},
+			status:   []*replicationdatapb.Status{{}, {}, nil, {}},
+		},
+		{
+			name:     "4 tablets with no spareTablet status",
+			in:       []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet, spareTablet},
+			expected: []*topo.TabletInfo{primaryTablet, replicaTablet, rdonlyTablet},
+			status:   []*replicationdatapb.Status{{}, {}, {}, nil},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := GetBackupCandidates(tt.in, tt.status)
+			require.EqualValues(t, tt.expected, res)
+		})
+	}
+}

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -1219,7 +1219,7 @@ func Test_getTabletsWithPromotionRules(t *testing.T) {
 	}
 }
 
-func Test_GetBackupCandidates(t *testing.T) {
+func TestGetBackupCandidates(t *testing.T) {
 	var (
 		primaryTablet = &topo.TabletInfo{
 			Tablet: &topodatapb.Tablet{


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
In the case of at least one tablet being healthy, this PR would increase the chance of successful backup, by only returning Primary + healthy tablets.

In the case of all Non-Primary tablets having errors, vtctlclient should fail in the same way.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
https://github.com/vitessio/vitess/issues/14602
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->