### PR TITLE
Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET`

### DIFF
--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -234,7 +234,7 @@ func (mysqlFlavor) waitUntilPositionCommand(ctx context.Context, pos replication
 		}
 	}
 
-	return fmt.Sprintf("SELECT WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS('%s', %v)", pos, timeoutSeconds), nil
+	return fmt.Sprintf("SELECT WAIT_FOR_EXECUTED_GTID_SET('%s', %v)", pos, timeoutSeconds), nil
 }
 
 // readBinlogEvent is part of the Flavor interface.


### PR DESCRIPTION

## Description

See https://github.com/vitessio/vitess/issues/14611 for details. In `8.2.0` the function `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` is removed, and we must therefore use `WAIT_FOR_EXECUTED_GTID_SET` instead.

The two functions have the same signature assuming no channel argument is used -- which isn't in our case. Therefore I've made no changes to any tests: everything should continue to work in the exact same way, and we expect all existing tests to pass.

## Related Issue(s)

Closes https://github.com/vitessio/vitess/issues/14611

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
