### PR TITLE
evalengine: Fix the min / max calculation for decimals

### DIFF
--- a/go/vt/vtgate/evalengine/api_aggregation.go
+++ b/go/vt/vtgate/evalengine/api_aggregation.go
@@ -389,6 +389,7 @@ func (s *aggregationDecimal) Min(value sqltypes.Value) error {
 	}
 	if !s.dec.IsInitialized() || dec.Cmp(s.dec) < 0 {
 		s.dec = dec
+		s.prec = -dec.Exponent()
 	}
 	return nil
 }
@@ -403,6 +404,7 @@ func (s *aggregationDecimal) Max(value sqltypes.Value) error {
 	}
 	if !s.dec.IsInitialized() || dec.Cmp(s.dec) > 0 {
 		s.dec = dec
+		s.prec = -dec.Exponent()
 	}
 	return nil
 }

--- a/go/vt/vtgate/evalengine/api_aggregation_test.go
+++ b/go/vt/vtgate/evalengine/api_aggregation_test.go
@@ -73,6 +73,12 @@ func TestMinMax(t *testing.T) {
 			max:    sqltypes.NewVarBinary("b"),
 		},
 		{
+			type_:  sqltypes.Decimal,
+			values: []sqltypes.Value{sqltypes.NewDecimal("1.001"), sqltypes.NewDecimal("2.1")},
+			min:    sqltypes.NewDecimal("1.001"),
+			max:    sqltypes.NewDecimal("2.1"),
+		},
+		{
 			// accent insensitive
 			type_: sqltypes.VarChar,
 			coll:  getCollationID("utf8mb4_0900_as_ci"),


### PR DESCRIPTION
We were not storing the precision for the decimal here, resulting in accidentally rounding it.

## Related Issue(s)

Fixes #14608

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required