### PR TITLE
vindexes: fix pooled collator buffer memory leak

### DIFF
--- a/go/vt/vtgate/vindexes/unicode.go
+++ b/go/vt/vtgate/vindexes/unicode.go
@@ -33,7 +33,10 @@ import (
 
 func unicodeHash(hashFunc func([]byte) []byte, key sqltypes.Value) ([]byte, error) {
 	collator := collatorPool.Get().(*pooledCollator)
-	defer collatorPool.Put(collator)
+	defer func() {
+		collator.buf.Reset()
+		collatorPool.Put(collator)
+	}()
 
 	keyBytes, err := key.ToBytes()
 	if err != nil {


### PR DESCRIPTION
## Description

Fixes a memory leak in `unicode_loose_*` vindexes by resetting the buffer before returning the collator to the pool.

This issue impacts v18 and below so I think it should be backported to v17 and v16 as well. As noted in the linked issue, the problem does not exist on `main`.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14587

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

n/a