### PR TITLE
tabletserver: Skip wait for DBA grants for external tablets

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -234,7 +234,9 @@ func NewTabletServer(ctx context.Context, name string, config *tabletenv.TabletC
 
 // WaitForDBAGrants waits for DBA user to have the required privileges to function properly.
 func WaitForDBAGrants(config *tabletenv.TabletConfig, waitTime time.Duration) error {
-	if waitTime == 0 {
+	// We don't wait for grants if the tablet is externally managed. Permissions
+	// are then the responsibility of the DBA.
+	if config.DB.HasGlobalSettings() || waitTime == 0 {
 		return nil
 	}
 	timer := time.NewTimer(waitTime)


### PR DESCRIPTION
In case of externally managed tablets, we don't want to enforce the DBA grants check.

The check was added in https://github.com/vitessio/vitess/pull/14565

## Related Issue(s)

Fixes #14628 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
