### PR TITLE
VReplication TableStreamer: Only stream tables in tablestreamer (ignore views)

### DIFF
--- a/go/test/endtoend/vreplication/fk_config_test.go
+++ b/go/test/endtoend/vreplication/fk_config_test.go
@@ -20,6 +20,7 @@ var (
 	initialFKSchema = `
 create table parent(id int, name varchar(128), primary key(id)) engine=innodb;
 create table child(id int, parent_id int, name varchar(128), primary key(id), foreign key(parent_id) references parent(id) on delete cascade) engine=innodb;
+create view vparent as select * from parent;
 `
 	initialFKData = `
 insert into parent values(1, 'parent1'), (2, 'parent2');

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"vitess.io/vitess/go/vt/vttablet"
-
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
+	"vitess.io/vitess/go/vt/vttablet"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -124,7 +124,7 @@ func (ts *tableStreamer) Stream() error {
 	for _, row := range rs.Rows {
 		tableName := row[0].ToString()
 		tableType := row[1].ToString()
-		if tableType != "BASE TABLE" {
+		if tableType != tmutils.TableBaseTable {
 			continue
 		}
 		if schema2.IsInternalOperationTableName(tableName) {

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
@@ -117,12 +117,16 @@ func (ts *tableStreamer) Stream() error {
 		return err
 	}
 
-	rs, err := conn.ExecuteFetch("show tables", -1, true)
+	rs, err := conn.ExecuteFetch("show full tables", -1, true)
 	if err != nil {
 		return err
 	}
 	for _, row := range rs.Rows {
 		tableName := row[0].ToString()
+		tableType := row[1].ToString()
+		if tableType != "BASE TABLE" {
+			continue
+		}
 		if schema2.IsInternalOperationTableName(tableName) {
 			log.Infof("Skipping internal table %s", tableName)
 			continue


### PR DESCRIPTION
## Description

When we do an atomic copy the `tablestreamer` streams all tables. The corresponding `MoveTables` gets its own list of tables, for which it adds filters for each table as part of the vreplication stream's `binlogsource`. For non-atomic copy workflows, we stream each table in the `binlogsource` list of tables. On the target vreplication creates one table plan for each of these tables.

However we get a full list of tables again after we have taken a snapshot (after locking all tables) for atomic copy and stream those tables.

There was a bug where we were not excluding views from this list. Hence the target was seeing a stream from the view resulting in the target stream erroring out since it doesn't have this view in its list of table plans.

This PR fixes that bug. It also adds a view to the e2e test: that test fails without the fix in the PR.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14648

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

