### PR TITLE
Flakes: Shutdown vttablet before mysqld in backup tests

### DIFF
--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -300,11 +300,12 @@ func resetTabletDirectory(t *testing.T, tablet cluster.Vttablet, initMysql bool)
 	extraArgs := []string{"--db-credentials-file", dbCredentialFile}
 	tablet.MysqlctlProcess.ExtraArgs = extraArgs
 
-	// Shutdown Mysql
-	err := tablet.MysqlctlProcess.Stop()
-	require.Nil(t, err)
 	// Teardown Tablet
-	err = tablet.VttabletProcess.TearDown()
+	err := tablet.VttabletProcess.TearDown()
+	require.Nil(t, err)
+
+	// Shutdown Mysql
+	err = tablet.MysqlctlProcess.Stop()
 	require.Nil(t, err)
 
 	// Clear out the previous data
@@ -335,13 +336,7 @@ func tearDown(t *testing.T, initMysql bool) {
 		require.Nil(t, err)
 	}
 
-	// TODO: Ideally we should not be resetting the mysql.
-	// So in below code we will have to uncomment the commented code and remove resetTabletDirectory
 	for _, tablet := range []cluster.Vttablet{*primary, *replica1, *replica2} {
-		//Tear down Tablet
-		//err := tablet.VttabletProcess.TearDown()
-		//require.Nil(t, err)
-
 		resetTabletDirectory(t, tablet, initMysql)
 		// DeleteTablet on a primary will cause tablet to shutdown, so should only call it after tablet is already shut down
 		err := localCluster.VtctlclientProcess.ExecuteCommand("DeleteTablet", "--", "--allow_primary", tablet.Alias)


### PR DESCRIPTION
## Description

In general, it's best to shutdown a tablet before its mysqld instance. This ensures that the tablet can perform any shutdown related steps that may affect its mysqld instance.

The existing backup tests were NOT doing that, and the re-use of the MySQL instances could cause some unpredictable behavior.

This PR simply reverses the order of process termination in these tests.

> Note: this is a "temporary" fix as these tests need to be rewritten soon as they rely on long deprecated things that will be removed such as InitTablet and InitShardPrimary (not to mention the odd sharing of processes and state between tests).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required