### PR TITLE
mysqlctl: Error out on stale socket

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -467,7 +467,7 @@ func cleanupLockfile(socket string, ts string) error {
 	if !errors.Is(err, os.ErrProcessDone) {
 		// Any errors except for the process being done
 		// is unexpected here.
-		log.Errorf("%v: error checking process %v: %v", p, ts, err)
+		log.Errorf("%v: error checking process %v: %v", ts, p, err)
 		return err
 	}
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -461,13 +461,13 @@ func cleanupLockfile(socket string, ts string) error {
 	if err == nil {
 		// If the process still exists, it's not safe to
 		// remove the lock file, so we have to keep it around.
-		log.Warningf("%v: not removing socket lock file: %v", ts, lockPath)
-		return nil
+		log.Errorf("%v: not removing socket lock file: %v with pid %v", ts, lockPath, p)
+		return fmt.Errorf("process %v is still running", p)
 	}
 	if !errors.Is(err, os.ErrProcessDone) {
 		// Any errors except for the process being done
 		// is unexpected here.
-		log.Errorf("%v: error checking process: %v", ts, err)
+		log.Errorf("%v: error checking process %v: %v", p, ts, err)
 		return err
 	}
 

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -195,6 +195,6 @@ func TestCleanupLockfile(t *testing.T) {
 
 	// If the lockfile exists, and the process is found, we don't clean it up.
 	os.WriteFile("mysql.sock.lock", []byte(strconv.Itoa(os.Getpid())), 0o600)
-	assert.NoError(t, cleanupLockfile("mysql.sock", ts))
+	assert.Error(t, cleanupLockfile("mysql.sock", ts))
 	assert.FileExists(t, "mysql.sock.lock")
 }


### PR DESCRIPTION
When we see a stale socket file, it's not useful to try and start MySQL since we're going to fail to start it anyway.

In that case it's better to error out immediately and either a human or computer operator can try to fix the situation and retry instead of waiting for `wait_time` which is useless at this point.

## Related Issue(s)

This is a follow up to #14553 & #14600 to better handle #14552

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required