### PR TITLE
txserializer: change log message based on dry run

### DIFF
--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -273,15 +273,18 @@ func (txs *TxSerializer) unlockLocked(key string, returnSlot bool) {
 		delete(txs.queues, key)
 
 		if q.max > 1 {
+			var formattedKey = key
 			var logMsg string
+
 			if txs.env.Config().SanitizeLogMessages {
-				logMsg = fmt.Sprintf("%v simultaneous transactions (%v in total) for the same row range (%v) would have been queued.", q.max, q.count, txs.sanitizeKey(key))
-			} else {
-				logMsg = fmt.Sprintf("%v simultaneous transactions (%v in total) for the same row range (%v) would have been queued.", q.max, q.count, key)
+				formattedKey = txs.sanitizeKey(key)
 			}
+
 			if txs.dryRun {
+				logMsg = fmt.Sprintf("%v simultaneous transactions (%v in total) for the same row range (%v) would have been queued.", q.max, q.count, formattedKey)
 				txs.logDryRun.Infof(logMsg)
 			} else {
+				logMsg = fmt.Sprintf("%v simultaneous transactions (%v in total) for the same row range (%v) have been queued.", q.max, q.count, formattedKey)
 				txs.log.Infof(logMsg)
 			}
 		}


### PR DESCRIPTION
## Description

Change the hot row protection log message to describe whether or not transactions have been queued based on the dry run status.

### Before 

_`TestTxSerializer_ConcurrentTransactions`_

```
3 simultaneous transactions (3 in total) for the same row range (t1 where1) would have been queued.
```
❌ The transactions are [actually queued](https://github.com/vitessio/vitess/blob/main/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go#L223).

_`TestTxSerializerDryRun`_

```
3 simultaneous transactions (3 in total) for the same row range (t1 where1) would have been queued.
```
✅ The transactions are not actually queued.

---

### After

_`TestTxSerializer_ConcurrentTransactions`_

```
3 simultaneous transactions (3 in total) for the same row range (t1 where1) have been queued.
```
✅ The transactions are actually queued.

_`TestTxSerializerDryRun`_

```
3 simultaneous transactions (3 in total) for the same row range (t1 where1) would have been queued.
```
✅ The transactions are not actually queued.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/14673

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

N/A