### PR TITLE
Vindexes: Pass context in consistent lookup handleDup

### DIFF
--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -383,8 +383,7 @@ func (lu *clCommon) handleDup(ctx context.Context, vcursor VCursor, values []sql
 			return err
 		}
 		// Lock the target row using normal transaction priority.
-		// TODO: context needs to be passed on.
-		qr, err = vcursor.ExecuteKeyspaceID(context.Background(), lu.keyspace, existingksid, lu.lockOwnerQuery, bindVars, false /* rollbackOnError */, false /* autocommit */)
+		qr, err = vcursor.ExecuteKeyspaceID(ctx, lu.keyspace, existingksid, lu.lockOwnerQuery, bindVars, false /* rollbackOnError */, false /* autocommit */)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Context handling was refactored in  https://github.com/vitessio/vitess/commit/c43a162ea567f47a89b8d4a506d2995740737b79 which included [this TODO](https://github.com/vitessio/vitess/commit/c43a162ea567f47a89b8d4a506d2995740737b79#diff-0e06131de7d1c872b547136ccc5fa2318a7b6b99f5c3ba78c8d0ab2f6757980eR302-R303)
```go
// TODO: context needs to be passed on.
qr, err = vcursor.ExecuteKeyspaceID(context.Background(), lu.keyspace, existingksid, lu.lockOwnerQuery, bindVars, false /* rollbackOnError */, false /* autocommit */)
```

This causes consistent lookup duplicate row handling to fail when tablets are using strict table ACL enforcement because there is no caller id in the context.

It looks like the TODO and `context.Background()` was left behind inadvertently, so this PR simply passes the existing context through. cc @harshit-gangal in case there was a reason for it.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14652

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

n/a