### PR TITLE
Add summary changes to indicate MySQL 5.7 is EOL and Vitess is dropping support for it in v19

### DIFF
--- a/changelog/19.0/19.0.0/summary.md
+++ b/changelog/19.0/19.0.0/summary.md
@@ -3,6 +3,7 @@
 ### Table of Contents
 
 - **[Major Changes](#major-changes)**
+  - **[Dropping Support for MySQL 5.7](#drop-support-mysql57)**
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
     - [VTTablet Flags](#vttablet-flags)
   - **[Docker](#docker)**
@@ -13,6 +14,13 @@
     - [`SHOW VSCHEMA KEYSPACES` Query](#show-vschema-keyspaces)
 
 ## <a id="major-changes"/>Major Changes
+
+### <a id="drop-support-mysql57"/>Dropping Support for MySQL 5.7
+
+Oracle has marked MySQL 5.7 end of life as of October 2023. Vitess is also dropping support for MySQL 5.7 from v19 onwards. Users are advised to upgrade to MySQL 8.0 while on v18 version of Vitess before
+upgrading to v19.
+
+Vitess will however, continue to support importing from MySQL 5.7 into Vitess even in v19.
 
 ### <a id="deprecations-and-deletions"/>Deprecations and Deletions
 


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds the summary changes to indicate MySQL 5.7 is EOL and Vitess is dropping support for it in v19. This is in response to the discussion that was prompted from the review comment https://github.com/vitessio/vitess/pull/14598#discussion_r1406623904

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
