### PR TITLE
go/vt/topo: enable concurrency for FindAllShardsInKeyspace

### DIFF
--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -284,8 +284,8 @@ type FindAllShardsInKeyspaceOptions struct {
 // FindAllShardsInKeyspace reads and returns all the existing shards in a
 // keyspace. It doesn't take any lock.
 //
-// If cfg is non-nil, it is used to configure the method's behavior. Otherwise,
-// a default configuration is used.
+// If opt is non-nil, it is used to configure the method's behavior. Otherwise,
+// the default options are used.
 func (ts *Server) FindAllShardsInKeyspace(ctx context.Context, keyspace string, opt *FindAllShardsInKeyspaceOptions) (map[string]*ShardInfo, error) {
 	// Apply any necessary defaults.
 	if opt == nil {

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -307,9 +307,9 @@ func (ts *Server) FindAllShardsInKeyspace(ctx context.Context, keyspace string, 
 	// records which resulted in overwhelming topo server instances:
 	// https://github.com/vitessio/vitess/pull/5436.
 	//
-	// However, removing the concurrency all together can cause large operations
-	// to fail all together due to timeout. The caller chooses the appropriate
-	// concurrency level so that certain paths can be optimized (such as vtctld
+	// However, removing the concurrency altogether can cause large operations
+	// to fail due to timeout. The caller chooses the appropriate concurrency
+	// level so that certain paths can be optimized (such as vtctld
 	// RebuildKeyspace calls, which do not run on every vttablet).
 	var (
 		mu     sync.Mutex

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -273,11 +273,11 @@ func (ts *Server) UpdateKeyspace(ctx context.Context, ki *KeyspaceInfo) error {
 	return nil
 }
 
-// FindAllShardsInKeyspaceConfig controls the behavior of
+// FindAllShardsInKeyspaceOptions controls the behavior of
 // Server.FindAllShardsInKeyspace.
-type FindAllShardsInKeyspaceConfig struct {
+type FindAllShardsInKeyspaceOptions struct {
 	// Concurrency controls the maximum number of concurrent calls to GetShard.
-	// If unspecified, Concurrency is set to 1.
+	// If <= 0, Concurrency is set to 1.
 	Concurrency int
 }
 
@@ -286,13 +286,13 @@ type FindAllShardsInKeyspaceConfig struct {
 //
 // If cfg is non-nil, it is used to configure the method's behavior. Otherwise,
 // a default configuration is used.
-func (ts *Server) FindAllShardsInKeyspace(ctx context.Context, keyspace string, cfg *FindAllShardsInKeyspaceConfig) (map[string]*ShardInfo, error) {
+func (ts *Server) FindAllShardsInKeyspace(ctx context.Context, keyspace string, opt *FindAllShardsInKeyspaceOptions) (map[string]*ShardInfo, error) {
 	// Apply any necessary defaults.
-	if cfg == nil {
-		cfg = &FindAllShardsInKeyspaceConfig{}
+	if opt == nil {
+		opt = &FindAllShardsInKeyspaceOptions{}
 	}
-	if cfg.Concurrency == 0 {
-		cfg.Concurrency = 1
+	if opt.Concurrency <= 0 {
+		opt.Concurrency = 1
 	}
 
 	shards, err := ts.GetShardNames(ctx, keyspace)
@@ -317,7 +317,7 @@ func (ts *Server) FindAllShardsInKeyspace(ctx context.Context, keyspace string, 
 	)
 
 	eg, ctx := errgroup.WithContext(ctx)
-	eg.SetLimit(cfg.Concurrency)
+	eg.SetLimit(opt.Concurrency)
 
 	for _, shard := range shards {
 		shard := shard

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -287,9 +287,12 @@ type FindAllShardsInKeyspaceConfig struct {
 // If cfg is non-nil, it is used to configure the method's behavior. Otherwise,
 // a default configuration is used.
 func (ts *Server) FindAllShardsInKeyspace(ctx context.Context, keyspace string, cfg *FindAllShardsInKeyspaceConfig) (map[string]*ShardInfo, error) {
-	if cfg == nil || cfg.Concurrency == 0 {
-		// Apply defaults.
-		cfg = &FindAllShardsInKeyspaceConfig{Concurrency: 1}
+	// Apply any necessary defaults.
+	if cfg == nil {
+		cfg = &FindAllShardsInKeyspaceConfig{}
+	}
+	if cfg.Concurrency == 0 {
+		cfg.Concurrency = 1
 	}
 
 	shards, err := ts.GetShardNames(ctx, keyspace)

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -32,24 +32,24 @@ func TestServerFindAllShardsInKeyspace(t *testing.T) {
 	tests := []struct {
 		name   string
 		shards int
-		cfg    *topo.FindAllShardsInKeyspaceOptions
+		opt    *topo.FindAllShardsInKeyspaceOptions
 	}{
 		{
 			name:   "negative concurrency",
 			shards: 1,
 			// Ensure this doesn't panic.
-			cfg: &topo.FindAllShardsInKeyspaceOptions{Concurrency: -1},
+			opt: &topo.FindAllShardsInKeyspaceOptions{Concurrency: -1},
 		},
 		{
 			name:   "unsharded",
 			shards: 1,
 			// Make sure the defaults apply as expected.
-			cfg: nil,
+			opt: nil,
 		},
 		{
 			name:   "sharded",
 			shards: 32,
-			cfg:    &topo.FindAllShardsInKeyspaceOptions{Concurrency: 8},
+			opt:    &topo.FindAllShardsInKeyspaceOptions{Concurrency: 8},
 		},
 	}
 
@@ -75,7 +75,7 @@ func TestServerFindAllShardsInKeyspace(t *testing.T) {
 
 			// Verify that we return a complete list of shards and that each
 			// key range is present in the output.
-			out, err := ts.FindAllShardsInKeyspace(ctx, keyspace, tt.cfg)
+			out, err := ts.FindAllShardsInKeyspace(ctx, keyspace, tt.opt)
 			require.NoError(t, err)
 			require.Len(t, out, tt.shards)
 

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -32,8 +32,14 @@ func TestServerFindAllShardsInKeyspace(t *testing.T) {
 	tests := []struct {
 		name   string
 		shards int
-		cfg    *topo.FindAllShardsInKeyspaceConfig
+		cfg    *topo.FindAllShardsInKeyspaceOptions
 	}{
+		{
+			name:   "negative concurrency",
+			shards: 1,
+			// Ensure this doesn't panic.
+			cfg: &topo.FindAllShardsInKeyspaceOptions{Concurrency: -1},
+		},
 		{
 			name:   "unsharded",
 			shards: 1,
@@ -43,7 +49,7 @@ func TestServerFindAllShardsInKeyspace(t *testing.T) {
 		{
 			name:   "sharded",
 			shards: 32,
-			cfg:    &topo.FindAllShardsInKeyspaceConfig{Concurrency: 8},
+			cfg:    &topo.FindAllShardsInKeyspaceOptions{Concurrency: 8},
 		},
 	}
 

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/key"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+)
+
+func TestServerFindAllShardsInKeyspace(t *testing.T) {
+	tests := []struct {
+		name   string
+		shards int
+		cfg    *topo.FindAllShardsInKeyspaceConfig
+	}{
+		{
+			name:   "unsharded",
+			shards: 1,
+			// Make sure the defaults apply as expected.
+			cfg: nil,
+		},
+		{
+			name:   "sharded",
+			shards: 32,
+			cfg:    &topo.FindAllShardsInKeyspaceConfig{Concurrency: 8},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ts := memorytopo.NewServer(ctx)
+			defer ts.Close()
+
+			// Create an ephemeral keyspace and generate shard records within
+			// the keyspace to fetch later.
+			const keyspace = "keyspace"
+			require.NoError(t, ts.CreateKeyspace(ctx, keyspace, &topodatapb.Keyspace{}))
+
+			shards, err := key.GenerateShardRanges(tt.shards)
+			require.NoError(t, err)
+
+			for _, s := range shards {
+				require.NoError(t, ts.CreateShard(ctx, keyspace, s))
+			}
+
+			// Verify that we return a complete list of shards and that each
+			// key range is present in the output.
+			out, err := ts.FindAllShardsInKeyspace(ctx, keyspace, tt.cfg)
+			require.NoError(t, err)
+			require.Len(t, out, tt.shards)
+
+			for _, s := range shards {
+				if _, ok := out[s]; !ok {
+					t.Errorf("shard %q was not found", s)
+				}
+			}
+		})
+	}
+}

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -314,7 +314,7 @@ func (ts *Server) CreateShard(ctx context.Context, keyspace, shard string) (err 
 	// Set primary as serving only if its keyrange doesn't overlap
 	// with other shards. This applies to unsharded keyspaces also
 	value.IsPrimaryServing = true
-	sis, err := ts.FindAllShardsInKeyspace(ctx, keyspace, &FindAllShardsInKeyspaceConfig{
+	sis, err := ts.FindAllShardsInKeyspace(ctx, keyspace, &FindAllShardsInKeyspaceOptions{
 		// Assume that CreateShard may be called by many vttablets concurrently
 		// in a large, sharded keyspace. Do not apply concurrency to avoid
 		// overwhelming the toposerver.

--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -30,16 +30,14 @@ import (
 )
 
 // RebuildKeyspace rebuilds the serving graph data while locking out other changes.
-func RebuildKeyspace(ctx context.Context, _ logutil.Logger, ts *topo.Server, keyspace string, cells []string, allowPartial bool) (err error) {
-	// TODO: logutil.Logger is unused, clean up call sites.
-
+func RebuildKeyspace(ctx context.Context, log logutil.Logger, ts *topo.Server, keyspace string, cells []string, allowPartial bool) (err error) {
 	ctx, unlock, lockErr := ts.LockKeyspace(ctx, keyspace, "RebuildKeyspace")
 	if lockErr != nil {
 		return lockErr
 	}
 	defer unlock(&err)
 
-	return RebuildKeyspaceLocked(ctx, ts, keyspace, cells, allowPartial)
+	return RebuildKeyspaceLocked(ctx, log, ts, keyspace, cells, allowPartial)
 }
 
 // RebuildKeyspaceLocked should only be used with an action lock on the keyspace
@@ -48,7 +46,7 @@ func RebuildKeyspace(ctx context.Context, _ logutil.Logger, ts *topo.Server, key
 //
 // Take data from the global keyspace and rebuild the local serving
 // copies in each cell.
-func RebuildKeyspaceLocked(ctx context.Context, ts *topo.Server, keyspace string, cells []string, allowPartial bool) error {
+func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Server, keyspace string, cells []string, allowPartial bool) error {
 	if err := topo.CheckKeyspaceLocked(ctx, keyspace); err != nil {
 		return err
 	}

--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -66,7 +66,7 @@ func RebuildKeyspaceLocked(ctx context.Context, ts *topo.Server, keyspace string
 		}
 	}
 
-	shards, err := ts.FindAllShardsInKeyspace(ctx, keyspace, &topo.FindAllShardsInKeyspaceConfig{
+	shards, err := ts.FindAllShardsInKeyspace(ctx, keyspace, &topo.FindAllShardsInKeyspaceOptions{
 		// Fetch shard records concurrently to speed up the rebuild process.
 		// This call is invoked by the first tablet in a given keyspace or
 		// manually via vtctld, so there is little risk of a thundering herd.

--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -64,7 +64,8 @@ func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Ser
 		}
 	}
 
-	shards, err := ts.FindAllShardsInKeyspace(ctx, keyspace)
+	// TODO(mdlayher): apply concurrency.
+	shards, err := ts.FindAllShardsInKeyspace(ctx, keyspace, nil)
 	if err != nil {
 		return err
 	}

--- a/go/vt/topotools/split.go
+++ b/go/vt/topotools/split.go
@@ -17,11 +17,10 @@ limitations under the License.
 package topotools
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -119,7 +118,7 @@ func OverlappingShardsForShard(os []*OverlappingShards, shardName string) *Overl
 // will return an error).
 // If shards don't perfectly overlap, they are not returned.
 func FindOverlappingShards(ctx context.Context, ts *topo.Server, keyspace string) ([]*OverlappingShards, error) {
-	shardMap, err := ts.FindAllShardsInKeyspace(ctx, keyspace)
+	shardMap, err := ts.FindAllShardsInKeyspace(ctx, keyspace, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -1243,7 +1243,7 @@ func (s *VtctldServer) FindAllShardsInKeyspace(ctx context.Context, req *vtctlda
 
 	span.Annotate("keyspace", req.Keyspace)
 
-	result, err := s.ts.FindAllShardsInKeyspace(ctx, req.Keyspace)
+	result, err := s.ts.FindAllShardsInKeyspace(ctx, req.Keyspace, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -86,7 +86,7 @@ func getTablesInKeyspace(ctx context.Context, ts *topo.Server, tmc tmclient.Tabl
 // validateNewWorkflow ensures that the specified workflow doesn't already exist
 // in the keyspace.
 func validateNewWorkflow(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManagerClient, keyspace, workflow string) error {
-	allshards, err := ts.FindAllShardsInKeyspace(ctx, keyspace)
+	allshards, err := ts.FindAllShardsInKeyspace(ctx, keyspace, nil)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -124,7 +124,8 @@ func refreshKeyspaceHelper(ctx context.Context, keyspaceName string) error {
 
 // refreshAllShards refreshes all the shard records in the given keyspace.
 func refreshAllShards(ctx context.Context, keyspaceName string) error {
-	shardInfos, err := ts.FindAllShardsInKeyspace(ctx, keyspaceName)
+	// TODO(mdlayher): apply concurrency.
+	shardInfos, err := ts.FindAllShardsInKeyspace(ctx, keyspaceName, nil)
 	if err != nil {
 		log.Error(err)
 		return err

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -124,8 +124,12 @@ func refreshKeyspaceHelper(ctx context.Context, keyspaceName string) error {
 
 // refreshAllShards refreshes all the shard records in the given keyspace.
 func refreshAllShards(ctx context.Context, keyspaceName string) error {
-	// TODO(mdlayher): apply concurrency.
-	shardInfos, err := ts.FindAllShardsInKeyspace(ctx, keyspaceName, nil)
+	shardInfos, err := ts.FindAllShardsInKeyspace(ctx, keyspaceName, &topo.FindAllShardsInKeyspaceConfig{
+		// Fetch shard records concurrently to speed up discovery. A typical
+		// Vitess cluster will have 1-3 vtorc instances deployed, so there is
+		// little risk of a thundering herd.
+		Concurrency: 8,
+	})
 	if err != nil {
 		log.Error(err)
 		return err

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -124,7 +124,7 @@ func refreshKeyspaceHelper(ctx context.Context, keyspaceName string) error {
 
 // refreshAllShards refreshes all the shard records in the given keyspace.
 func refreshAllShards(ctx context.Context, keyspaceName string) error {
-	shardInfos, err := ts.FindAllShardsInKeyspace(ctx, keyspaceName, &topo.FindAllShardsInKeyspaceConfig{
+	shardInfos, err := ts.FindAllShardsInKeyspace(ctx, keyspaceName, &topo.FindAllShardsInKeyspaceOptions{
 		// Fetch shard records concurrently to speed up discovery. A typical
 		// Vitess cluster will have 1-3 vtorc instances deployed, so there is
 		// little risk of a thundering herd.

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -44,7 +44,7 @@ const (
 // validateNewWorkflow ensures that the specified workflow doesn't already exist
 // in the keyspace.
 func (wr *Wrangler) validateNewWorkflow(ctx context.Context, keyspace, workflow string) error {
-	allshards, err := wr.ts.FindAllShardsInKeyspace(ctx, keyspace)
+	allshards, err := wr.ts.FindAllShardsInKeyspace(ctx, keyspace, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Speed up `FindAllShardsInKeyspace` by employing caller-controlled concurrency to avoid 30+ second runtimes for this call.

I've added a new struct for configuration here since certain cases such as `CreateShard` should not make concurrent calls in order to avoid a thundering herd on the topo.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14669.

Introduces some limited concurrency rather than the unbounded concurrency which was removed in https://github.com/vitessio/vitess/pull/5436.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

n/a

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
