### PR TITLE
schemadiff: granular foreign key reference errors

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -286,6 +286,26 @@ func (e *ForeignKeyDependencyUnresolvedError) Error() string {
 		sqlescape.EscapeID(e.Table))
 }
 
+type ForeignKeyNonexistentReferencedTableError struct {
+	Table           string
+	ReferencedTable string
+}
+
+func (e *ForeignKeyNonexistentReferencedTableError) Error() string {
+	return fmt.Sprintf("table %s foreign key references nonexistent table %s",
+		sqlescape.EscapeID(e.Table), sqlescape.EscapeID(e.ReferencedTable))
+}
+
+type ForeignKeyReferencesViewError struct {
+	Table          string
+	ReferencedView string
+}
+
+func (e *ForeignKeyReferencesViewError) Error() string {
+	return fmt.Sprintf("table %s foreign key references view %s",
+		sqlescape.EscapeID(e.Table), sqlescape.EscapeID(e.ReferencedView))
+}
+
 type InvalidColumnInForeignKeyConstraintError struct {
 	Table      string
 	Constraint string

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -239,6 +239,14 @@ func (s *Schema) normalize() error {
 				if referencedTableName != name {
 					nonSelfReferenceNames = append(nonSelfReferenceNames, referencedTableName)
 				}
+				referencedEntity, ok := s.named[referencedTableName]
+				if !ok {
+					return &ForeignKeyNonexistentReferencedTableError{Table: name, ReferencedTable: referencedTableName}
+				}
+				if _, ok := referencedEntity.(*CreateViewEntity); ok {
+					return &ForeignKeyReferencesViewError{Table: name, ReferencedView: referencedTableName}
+				}
+
 				fkParents[referencedTableName] = true
 			}
 			if allNamesFoundInLowerLevel(nonSelfReferenceNames, iterationLevel) {

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -331,7 +331,15 @@ func TestInvalidSchema(t *testing.T) {
 			expectErr: &ForeignKeyColumnCountMismatchError{Table: "t11", Constraint: "f11", ColumnCount: 2, ReferencedTable: "t11", ReferencedColumnCount: 1},
 		},
 		{
-			schema:    "create table t11 (id int primary key, i int, constraint f12 foreign key (i) references t12(id) on delete restrict)",
+			schema:    "create table t11 (id int primary key, i int, constraint f12 foreign key (i) references t12 (id) on delete restrict)",
+			expectErr: &ForeignKeyNonexistentReferencedTableError{Table: "t11", ReferencedTable: "t12"},
+		},
+		{
+			schema:    "create view v as select 1 as id from dual; create table t11 (id int primary key, i int, constraint fv foreign key (i) references v (id) on delete restrict)",
+			expectErr: &ForeignKeyReferencesViewError{Table: "t11", ReferencedView: "v"},
+		},
+		{
+			schema:    "create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict)",
 			expectErr: &ForeignKeyDependencyUnresolvedError{Table: "t11"},
 		},
 		{

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -401,7 +401,7 @@ func TestInvalidTableForeignKeyReference(t *testing.T) {
 		}
 		_, err := NewSchemaFromQueries(fkQueries)
 		assert.Error(t, err)
-		assert.EqualError(t, err, (&ForeignKeyDependencyUnresolvedError{Table: "t11"}).Error())
+		assert.EqualError(t, err, (&ForeignKeyNonexistentReferencedTableError{Table: "t11", ReferencedTable: "t12"}).Error())
 	}
 	{
 		fkQueries := []string{


### PR DESCRIPTION

## Description

`schemadiff` now has improved granularity for FK reference errors. It now makes a distinction between:

- A referenced table does not exist.
- The referenced table is in fact a `VIEW`.
- There are cyclic (circle > 1) references.

## Related Issue(s)

- #11975 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
