### PR TITLE
[release-16.0] tabletserver: do not consolidate streams on primary tablet when consolidator mode is `notOnPrimary` (#14332)

### DIFF
--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -116,64 +116,88 @@ func TestDisableConsolidator(t *testing.T) {
 }
 
 func TestConsolidatorReplicasOnly(t *testing.T) {
-	totalConsolidationsTag := "Waits/Histograms/Consolidations/Count"
-	initial := framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
-		wg.Done()
-	}()
-	go func() {
-		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
-		wg.Done()
-	}()
-	wg.Wait()
-	afterOne := framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
-	assert.Equal(t, initial+1, afterOne, "expected one consolidation")
+	type executeFn func(
+		query string, bindvars map[string]*querypb.BindVariable,
+	) (*sqltypes.Result, error)
 
-	revert := changeVar(t, "Consolidator", tabletenv.NotOnPrimary)
-	defer revert()
+	testCases := []struct {
+		name                   string
+		getExecuteFn           func(qc *framework.QueryClient) executeFn
+		totalConsolidationsTag string
+	}{
+		{
+			name:                   "Execute",
+			getExecuteFn:           func(qc *framework.QueryClient) executeFn { return qc.Execute },
+			totalConsolidationsTag: "Waits/Histograms/Consolidations/Count",
+		},
+		{
+			name:                   "StreamExecute",
+			getExecuteFn:           func(qc *framework.QueryClient) executeFn { return qc.StreamExecute },
+			totalConsolidationsTag: "Waits/Histograms/StreamConsolidations/Count",
+		},
+	}
 
-	// primary should not do query consolidation
-	var wg2 sync.WaitGroup
-	wg2.Add(2)
-	go func() {
-		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
-		wg2.Done()
-	}()
-	go func() {
-		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
-		wg2.Done()
-	}()
-	wg2.Wait()
-	noNewConsolidations := framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
-	assert.Equal(t, afterOne, noNewConsolidations, "expected no new consolidations")
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			initial := framework.FetchInt(framework.DebugVars(), testCase.totalConsolidationsTag)
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				testCase.getExecuteFn(framework.NewClient())("select sleep(0.5) from dual", nil)
+				wg.Done()
+			}()
+			go func() {
+				testCase.getExecuteFn(framework.NewClient())("select sleep(0.5) from dual", nil)
+				wg.Done()
+			}()
+			wg.Wait()
+			afterOne := framework.FetchInt(framework.DebugVars(), testCase.totalConsolidationsTag)
+			assert.Equal(t, initial+1, afterOne, "expected one consolidation")
 
-	// become a replica, where query consolidation should happen
-	client := framework.NewClientWithTabletType(topodatapb.TabletType_REPLICA)
+			revert := changeVar(t, "Consolidator", tabletenv.NotOnPrimary)
+			defer revert()
 
-	err := client.SetServingType(topodatapb.TabletType_REPLICA)
-	require.NoError(t, err)
-	defer func() {
-		err = client.SetServingType(topodatapb.TabletType_PRIMARY)
-		require.NoError(t, err)
-	}()
+			// primary should not do query consolidation
+			var wg2 sync.WaitGroup
+			wg2.Add(2)
+			go func() {
+				testCase.getExecuteFn(framework.NewClient())("select sleep(0.5) from dual", nil)
+				wg2.Done()
+			}()
+			go func() {
+				testCase.getExecuteFn(framework.NewClient())("select sleep(0.5) from dual", nil)
+				wg2.Done()
+			}()
+			wg2.Wait()
+			noNewConsolidations := framework.FetchInt(framework.DebugVars(), testCase.totalConsolidationsTag)
+			assert.Equal(t, afterOne, noNewConsolidations, "expected no new consolidations")
 
-	initial = framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
-	var wg3 sync.WaitGroup
-	wg3.Add(2)
-	go func() {
-		client.Execute("select sleep(0.5) from dual", nil)
-		wg3.Done()
-	}()
-	go func() {
-		client.Execute("select sleep(0.5) from dual", nil)
-		wg3.Done()
-	}()
-	wg3.Wait()
-	afterOne = framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
-	assert.Equal(t, initial+1, afterOne, "expected another consolidation")
+			// become a replica, where query consolidation should happen
+			client := framework.NewClientWithTabletType(topodatapb.TabletType_REPLICA)
+
+			err := client.SetServingType(topodatapb.TabletType_REPLICA)
+			require.NoError(t, err)
+			defer func() {
+				err = client.SetServingType(topodatapb.TabletType_PRIMARY)
+				require.NoError(t, err)
+			}()
+
+			initial = framework.FetchInt(framework.DebugVars(), testCase.totalConsolidationsTag)
+			var wg3 sync.WaitGroup
+			wg3.Add(2)
+			go func() {
+				testCase.getExecuteFn(client)("select sleep(0.5) from dual", nil)
+				wg3.Done()
+			}()
+			go func() {
+				testCase.getExecuteFn(client)("select sleep(0.5) from dual", nil)
+				wg3.Done()
+			}()
+			wg3.Wait()
+			afterOne = framework.FetchInt(framework.DebugVars(), testCase.totalConsolidationsTag)
+			assert.Equal(t, initial+1, afterOne, "expected another consolidation")
+		})
+	}
 }
 
 func TestQueryPlanCache(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -436,7 +436,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 
 	if consolidator := qre.tsv.qe.streamConsolidator; consolidator != nil {
 		if qre.connID == 0 && qre.plan.PlanID == p.PlanSelectStream && qre.shouldConsolidate() {
-			return consolidator.Consolidate(qre.logStats, sqlWithoutComments, callback,
+			return consolidator.Consolidate(qre.tsv.stats.WaitTimings, qre.logStats, sqlWithoutComments, callback,
 				func(callback StreamCallback) error {
 					dbConn, err := qre.getStreamConn()
 					if err != nil {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -886,6 +886,7 @@ func (tsv *TabletServer) streamExecute(ctx context.Context, target *querypb.Targ
 				ctx:            ctx,
 				logStats:       logStats,
 				tsv:            tsv,
+				tabletType:     target.GetTabletType(),
 				setting:        connSetting,
 			}
 			return qre.Stream(callback)


### PR DESCRIPTION
## Description
This is a backport of #14332

I accidentally closed the PR when I accidentally deleted the branch when I meant to force-push 😢 