### PR TITLE
go/vt/vtadmin: fix nilness issues

### DIFF
--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -78,9 +78,7 @@ func TestCreateKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.CreateKeyspace(ctx, &vtadminpb.CreateKeyspaceRequest{
 			ClusterId: "test",
@@ -97,9 +95,7 @@ func TestCreateKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.CreateKeyspace(ctx, &vtadminpb.CreateKeyspaceRequest{
 			ClusterId: "test",
@@ -147,9 +143,7 @@ func TestCreateShard(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.CreateShard(ctx, &vtadminpb.CreateShardRequest{
 			ClusterId: "test",
@@ -167,9 +161,7 @@ func TestCreateShard(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.CreateShard(ctx, &vtadminpb.CreateShardRequest{
 			ClusterId: "test",
@@ -218,9 +210,7 @@ func TestDeleteKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.DeleteKeyspace(ctx, &vtadminpb.DeleteKeyspaceRequest{
 			ClusterId: "test",
@@ -237,9 +227,7 @@ func TestDeleteKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.DeleteKeyspace(ctx, &vtadminpb.DeleteKeyspaceRequest{
 			ClusterId: "test",
@@ -287,9 +275,7 @@ func TestDeleteShards(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.DeleteShards(ctx, &vtadminpb.DeleteShardsRequest{
 			ClusterId: "test",
@@ -311,9 +297,7 @@ func TestDeleteShards(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.DeleteShards(ctx, &vtadminpb.DeleteShardsRequest{
 			ClusterId: "test",
@@ -366,9 +350,7 @@ func TestDeleteTablet(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.DeleteTablet(ctx, &vtadminpb.DeleteTabletRequest{
 			ClusterIds: []string{"test"},
@@ -386,9 +368,7 @@ func TestDeleteTablet(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.DeleteTablet(ctx, &vtadminpb.DeleteTabletRequest{
 			ClusterIds: []string{"test"},
@@ -437,9 +417,7 @@ func TestEmergencyFailoverShard(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.EmergencyFailoverShard(ctx, &vtadminpb.EmergencyFailoverShardRequest{
 			ClusterId: "test",
@@ -457,9 +435,7 @@ func TestEmergencyFailoverShard(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.EmergencyFailoverShard(ctx, &vtadminpb.EmergencyFailoverShardRequest{
 			ClusterId: "test",
@@ -514,9 +490,7 @@ func TestFindSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
 			Table: "t1",
@@ -537,9 +511,7 @@ func TestFindSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
 			Table: "t1",
@@ -559,9 +531,7 @@ func TestFindSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
 			Table: "t1",
@@ -613,9 +583,7 @@ func TestGetBackups(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
 		assert.NoError(t, err)
@@ -627,9 +595,7 @@ func TestGetBackups(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
 		assert.NotEmpty(t, resp.Backups, "actor %+v should be permitted to GetBackups", actor)
@@ -641,9 +607,7 @@ func TestGetBackups(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
 		assert.NotEmpty(t, resp.Backups, "actor %+v should be permitted to GetBackups", actor)
@@ -692,9 +656,7 @@ func TestGetCellInfos(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetCellInfos(ctx, &vtadminpb.GetCellInfosRequest{
 			NamesOnly: true,
@@ -708,9 +670,7 @@ func TestGetCellInfos(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetCellInfos(ctx, &vtadminpb.GetCellInfosRequest{
 			NamesOnly: true,
@@ -724,9 +684,7 @@ func TestGetCellInfos(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetCellInfos(ctx, &vtadminpb.GetCellInfosRequest{
 			NamesOnly: true,
@@ -777,9 +735,7 @@ func TestGetCellsAliases(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetCellsAliases(ctx, &vtadminpb.GetCellsAliasesRequest{})
 		assert.NoError(t, err)
@@ -791,9 +747,7 @@ func TestGetCellsAliases(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetCellsAliases(ctx, &vtadminpb.GetCellsAliasesRequest{})
 		assert.NotEmpty(t, resp.Aliases, "actor %+v should be permitted to GetCellsAliases", actor)
@@ -805,9 +759,7 @@ func TestGetCellsAliases(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetCellsAliases(ctx, &vtadminpb.GetCellsAliasesRequest{})
 		assert.NotEmpty(t, resp.Aliases, "actor %+v should be permitted to GetCellsAliases", actor)
@@ -850,9 +802,7 @@ func TestGetClusters(t *testing.T) {
 
 		var actor *rbac.Actor
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetClusters(ctx, &vtadminpb.GetClustersRequest{})
 		assert.Empty(t, resp.Clusters, "actor %+v should not be permitted to GetClusters", actor)
@@ -863,9 +813,7 @@ func TestGetClusters(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetClusters(ctx, &vtadminpb.GetClustersRequest{})
 		assert.Empty(t, resp.Clusters, "actor %+v should not be permitted to GetClusters", actor)
@@ -876,9 +824,7 @@ func TestGetClusters(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetClusters(ctx, &vtadminpb.GetClustersRequest{})
 		require.NoError(t, err)
@@ -927,9 +873,7 @@ func TestGetGates(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetGates(ctx, &vtadminpb.GetGatesRequest{})
 		assert.NoError(t, err)
@@ -948,9 +892,7 @@ func TestGetGates(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetGates(ctx, &vtadminpb.GetGatesRequest{})
 		assert.NotEmpty(t, resp.Gates, "actor %+v should be permitted to GetGates", actor)
@@ -970,9 +912,7 @@ func TestGetGates(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetGates(ctx, &vtadminpb.GetGatesRequest{})
 		assert.NotEmpty(t, resp.Gates, "actor %+v should be permitted to GetGates", actor)
@@ -1016,9 +956,7 @@ func TestGetKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetKeyspace(ctx, &vtadminpb.GetKeyspaceRequest{
 			ClusterId: "test",
@@ -1033,9 +971,7 @@ func TestGetKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetKeyspace(ctx, &vtadminpb.GetKeyspaceRequest{
 			ClusterId: "test",
@@ -1087,9 +1023,7 @@ func TestGetKeyspaces(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetKeyspaces(ctx, &vtadminpb.GetKeyspacesRequest{})
 		assert.NoError(t, err)
@@ -1101,9 +1035,7 @@ func TestGetKeyspaces(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetKeyspaces(ctx, &vtadminpb.GetKeyspacesRequest{})
 		assert.NotEmpty(t, resp.Keyspaces, "actor %+v should be permitted to GetKeyspaces", actor)
@@ -1122,9 +1054,7 @@ func TestGetKeyspaces(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetKeyspaces(ctx, &vtadminpb.GetKeyspacesRequest{})
 		assert.NotEmpty(t, resp.Keyspaces, "actor %+v should be permitted to GetKeyspaces", actor)
@@ -1174,9 +1104,7 @@ func TestGetSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetSchema(ctx, &vtadminpb.GetSchemaRequest{
 			ClusterId: "test",
@@ -1199,9 +1127,7 @@ func TestGetSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetSchema(ctx, &vtadminpb.GetSchemaRequest{
 			ClusterId: "test",
@@ -1254,9 +1180,7 @@ func TestGetSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetSchemas(ctx, &vtadminpb.GetSchemasRequest{})
 		assert.NoError(t, err)
@@ -1275,9 +1199,7 @@ func TestGetSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetSchemas(ctx, &vtadminpb.GetSchemasRequest{})
 		assert.NotEmpty(t, resp.Schemas, "actor %+v should be permitted to GetSchemas", actor)
@@ -1303,9 +1225,7 @@ func TestGetSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetSchemas(ctx, &vtadminpb.GetSchemasRequest{})
 		assert.NotEmpty(t, resp.Schemas, "actor %+v should be permitted to GetSchemas", actor)
@@ -1361,9 +1281,7 @@ func TestGetShardReplicationPositions(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetShardReplicationPositions(ctx, &vtadminpb.GetShardReplicationPositionsRequest{})
 		assert.NoError(t, err)
@@ -1375,9 +1293,7 @@ func TestGetShardReplicationPositions(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetShardReplicationPositions(ctx, &vtadminpb.GetShardReplicationPositionsRequest{})
 		assert.NotEmpty(t, resp.ReplicationPositions, "actor %+v should be permitted to GetShardReplicationPositions", actor)
@@ -1396,9 +1312,7 @@ func TestGetShardReplicationPositions(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetShardReplicationPositions(ctx, &vtadminpb.GetShardReplicationPositionsRequest{})
 		assert.NotEmpty(t, resp.ReplicationPositions, "actor %+v should be permitted to GetShardReplicationPositions", actor)
@@ -1448,9 +1362,7 @@ func TestGetSrvVSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetSrvVSchema(ctx, &vtadminpb.GetSrvVSchemaRequest{
 			ClusterId: "test",
@@ -1465,9 +1377,7 @@ func TestGetSrvVSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetSrvVSchema(ctx, &vtadminpb.GetSrvVSchemaRequest{
 			ClusterId: "test",
@@ -1519,9 +1429,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetSrvVSchemas(ctx, &vtadminpb.GetSrvVSchemasRequest{})
 		require.NoError(t, err)
@@ -1533,9 +1441,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetSrvVSchemas(ctx, &vtadminpb.GetSrvVSchemasRequest{})
 		assert.NotEmpty(t, resp.SrvVSchemas, "actor %+v should be permitted to GetSrvVSchemas", actor)
@@ -1554,9 +1460,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetSrvVSchemas(ctx, &vtadminpb.GetSrvVSchemasRequest{})
 		assert.NotEmpty(t, resp.SrvVSchemas, "actor %+v should be permitted to GetSrvVSchemas", actor)
@@ -1606,9 +1510,7 @@ func TestGetTablet(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetTablet(ctx, &vtadminpb.GetTabletRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -1625,9 +1527,7 @@ func TestGetTablet(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetTablet(ctx, &vtadminpb.GetTabletRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -1681,9 +1581,7 @@ func TestGetTablets(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetTablets(ctx, &vtadminpb.GetTabletsRequest{})
 		require.NoError(t, err)
@@ -1695,9 +1593,7 @@ func TestGetTablets(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetTablets(ctx, &vtadminpb.GetTabletsRequest{})
 		assert.NotEmpty(t, resp.Tablets, "actor %+v should be permitted to GetTablets", actor)
@@ -1716,9 +1612,7 @@ func TestGetTablets(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetTablets(ctx, &vtadminpb.GetTabletsRequest{})
 		assert.NotEmpty(t, resp.Tablets, "actor %+v should be permitted to GetTablets", actor)
@@ -1768,9 +1662,7 @@ func TestGetVSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetVSchema(ctx, &vtadminpb.GetVSchemaRequest{
 			ClusterId: "test",
@@ -1785,9 +1677,7 @@ func TestGetVSchema(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetVSchema(ctx, &vtadminpb.GetVSchemaRequest{
 			ClusterId: "test",
@@ -1839,9 +1729,7 @@ func TestGetVSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetVSchemas(ctx, &vtadminpb.GetVSchemasRequest{})
 		require.NoError(t, err)
@@ -1853,9 +1741,7 @@ func TestGetVSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetVSchemas(ctx, &vtadminpb.GetVSchemasRequest{})
 		assert.NotEmpty(t, resp.VSchemas, "actor %+v should be permitted to GetVSchemas", actor)
@@ -1874,9 +1760,7 @@ func TestGetVSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetVSchemas(ctx, &vtadminpb.GetVSchemasRequest{})
 		assert.NotEmpty(t, resp.VSchemas, "actor %+v should be permitted to GetVSchemas", actor)
@@ -1932,9 +1816,7 @@ func TestGetVtctlds(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetVtctlds(ctx, &vtadminpb.GetVtctldsRequest{})
 		assert.NoError(t, err)
@@ -1953,9 +1835,7 @@ func TestGetVtctlds(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetVtctlds(ctx, &vtadminpb.GetVtctldsRequest{})
 		assert.NotEmpty(t, resp.Vtctlds, "actor %+v should be permitted to GetVtctlds", actor)
@@ -1975,9 +1855,7 @@ func TestGetVtctlds(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetVtctlds(ctx, &vtadminpb.GetVtctldsRequest{})
 		assert.NotEmpty(t, resp.Vtctlds, "actor %+v should be permitted to GetVtctlds", actor)
@@ -2021,9 +1899,7 @@ func TestGetWorkflow(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetWorkflow(ctx, &vtadminpb.GetWorkflowRequest{
 			ClusterId: "test",
@@ -2039,9 +1915,7 @@ func TestGetWorkflow(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetWorkflow(ctx, &vtadminpb.GetWorkflowRequest{
 			ClusterId: "test",
@@ -2094,9 +1968,7 @@ func TestGetWorkflows(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.GetWorkflows(ctx, &vtadminpb.GetWorkflowsRequest{})
 		require.NoError(t, err)
@@ -2108,9 +1980,7 @@ func TestGetWorkflows(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetWorkflows(ctx, &vtadminpb.GetWorkflowsRequest{})
 		assert.NotEmpty(t, resp.WorkflowsByCluster, "actor %+v should be permitted to GetWorkflows", actor)
@@ -2122,9 +1992,7 @@ func TestGetWorkflows(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.GetWorkflows(ctx, &vtadminpb.GetWorkflowsRequest{})
 		assert.NotEmpty(t, resp.WorkflowsByCluster, "actor %+v should be permitted to GetWorkflows", actor)
@@ -2167,9 +2035,7 @@ func TestPingTablet(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.PingTablet(ctx, &vtadminpb.PingTabletRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2186,9 +2052,7 @@ func TestPingTablet(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.PingTablet(ctx, &vtadminpb.PingTabletRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2236,9 +2100,7 @@ func TestPlannedFailoverShard(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.PlannedFailoverShard(ctx, &vtadminpb.PlannedFailoverShardRequest{
 			ClusterId: "test",
@@ -2256,9 +2118,7 @@ func TestPlannedFailoverShard(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.PlannedFailoverShard(ctx, &vtadminpb.PlannedFailoverShardRequest{
 			ClusterId: "test",
@@ -2307,9 +2167,7 @@ func TestRefreshState(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.RefreshState(ctx, &vtadminpb.RefreshStateRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2326,9 +2184,7 @@ func TestRefreshState(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.RefreshState(ctx, &vtadminpb.RefreshStateRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2376,9 +2232,7 @@ func TestRefreshTabletReplicationSource(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.RefreshTabletReplicationSource(ctx, &vtadminpb.RefreshTabletReplicationSourceRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2395,9 +2249,7 @@ func TestRefreshTabletReplicationSource(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.RefreshTabletReplicationSource(ctx, &vtadminpb.RefreshTabletReplicationSourceRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2451,9 +2303,7 @@ func TestReloadSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.ReloadSchemas(ctx, &vtadminpb.ReloadSchemasRequest{
 			Keyspaces: []string{
@@ -2470,9 +2320,7 @@ func TestReloadSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.ReloadSchemas(ctx, &vtadminpb.ReloadSchemasRequest{
 			Keyspaces: []string{
@@ -2488,9 +2336,7 @@ func TestReloadSchemas(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, _ := api.ReloadSchemas(ctx, &vtadminpb.ReloadSchemasRequest{
 			Keyspaces: []string{
@@ -2537,9 +2383,7 @@ func TestRunHealthCheck(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.RunHealthCheck(ctx, &vtadminpb.RunHealthCheckRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2556,9 +2400,7 @@ func TestRunHealthCheck(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.RunHealthCheck(ctx, &vtadminpb.RunHealthCheckRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2606,9 +2448,7 @@ func TestSetReadOnly(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.SetReadOnly(ctx, &vtadminpb.SetReadOnlyRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2625,9 +2465,7 @@ func TestSetReadOnly(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.SetReadOnly(ctx, &vtadminpb.SetReadOnlyRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2675,9 +2513,7 @@ func TestSetReadWrite(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.SetReadWrite(ctx, &vtadminpb.SetReadWriteRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2694,9 +2530,7 @@ func TestSetReadWrite(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.SetReadWrite(ctx, &vtadminpb.SetReadWriteRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2744,9 +2578,7 @@ func TestStartReplication(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.StartReplication(ctx, &vtadminpb.StartReplicationRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2763,9 +2595,7 @@ func TestStartReplication(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.StartReplication(ctx, &vtadminpb.StartReplicationRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2813,9 +2643,7 @@ func TestStopReplication(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.StopReplication(ctx, &vtadminpb.StopReplicationRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2832,9 +2660,7 @@ func TestStopReplication(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.StopReplication(ctx, &vtadminpb.StopReplicationRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2882,9 +2708,7 @@ func TestTabletExternallyPromoted(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.TabletExternallyPromoted(ctx, &vtadminpb.TabletExternallyPromotedRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2901,9 +2725,7 @@ func TestTabletExternallyPromoted(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.TabletExternallyPromoted(ctx, &vtadminpb.TabletExternallyPromotedRequest{
 			Alias: &topodatapb.TabletAlias{
@@ -2951,9 +2773,7 @@ func TestVTExplain(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.VTExplain(ctx, &vtadminpb.VTExplainRequest{
 			Cluster:  "test",
@@ -2975,9 +2795,7 @@ func TestVTExplain(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.VTExplain(ctx, &vtadminpb.VTExplainRequest{
 			Cluster:  "test",
@@ -3023,9 +2841,7 @@ func TestValidateKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.ValidateKeyspace(ctx, &vtadminpb.ValidateKeyspaceRequest{
 			ClusterId: "test",
@@ -3040,9 +2856,7 @@ func TestValidateKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.ValidateKeyspace(ctx, &vtadminpb.ValidateKeyspaceRequest{
 			ClusterId: "test",
@@ -3088,9 +2902,7 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.ValidateSchemaKeyspace(ctx, &vtadminpb.ValidateSchemaKeyspaceRequest{
 			ClusterId: "test",
@@ -3105,9 +2917,7 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.ValidateSchemaKeyspace(ctx, &vtadminpb.ValidateSchemaKeyspaceRequest{
 			ClusterId: "test",
@@ -3153,9 +2963,7 @@ func TestValidateVersionKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.ValidateVersionKeyspace(ctx, &vtadminpb.ValidateVersionKeyspaceRequest{
 			ClusterId: "test",
@@ -3170,9 +2978,7 @@ func TestValidateVersionKeyspace(t *testing.T) {
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
 
 		resp, err := api.ValidateVersionKeyspace(ctx, &vtadminpb.ValidateVersionKeyspaceRequest{
 			ClusterId: "test",

--- a/go/vt/vtadmin/rbac/authentication.go
+++ b/go/vt/vtadmin/rbac/authentication.go
@@ -99,7 +99,13 @@ type actorkey struct{}
 // NewContext returns a context with the given actor stored in it. This is used
 // to pass actor information from the authentication middleware and interceptors
 // to the actual vtadmin api methods.
+//
+// If actor is nil, the context is returned with no actor attached.
 func NewContext(ctx context.Context, actor *Actor) context.Context {
+	if actor == nil {
+		return ctx
+	}
+
 	return context.WithValue(ctx, actorkey{}, actor)
 }
 

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -111,9 +111,8 @@ func Test{{ .Method }}(t *testing.T) {
 
 		{{ getActor .Actor }}
 		ctx := context.Background()
-		if actor != nil {
-			ctx = rbac.NewContext(ctx, actor)
-		}
+		ctx = rbac.NewContext(ctx, actor)
+
 		{{ if .IncludeErrorVar }}
 		resp, err := api.{{ $test.Method }}(ctx, {{ $test.Request }})
 		{{ else }}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

All of the nilness issues here arise from the code generator inserting a conditional block. It would appear the existing test coverage also passes but to be explicit, I've made it so that `rbac.NewContext` simply returns the input given a nil actor. This is a bit more friendly for callers regardless.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Updates https://github.com/vitessio/vitess/issues/14684.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
