### PR TITLE
go/cache: fix nilness issues and unsued code

### DIFF
--- a/go/cache/theine/store.go
+++ b/go/cache/theine/store.go
@@ -44,17 +44,17 @@ const (
 )
 
 type Shard[K cachekey, V any] struct {
-	hashmap   map[K]*Entry[K, V]
-	dookeeper *bf.Bloomfilter
-	deque     *deque.Deque[*Entry[K, V]]
-	group     *Group[K, V]
-	qsize     uint
-	qlen      int
-	counter   uint
-	mu        sync.RWMutex
+	hashmap    map[K]*Entry[K, V]
+	doorkeeper *bf.Bloomfilter
+	deque      *deque.Deque[*Entry[K, V]]
+	group      *Group[K, V]
+	qsize      uint
+	qlen       int
+	counter    uint
+	mu         sync.RWMutex
 }
 
-func NewShard[K cachekey, V any](size uint, qsize uint, doorkeeper bool) *Shard[K, V] {
+func NewShard[K cachekey, V any](qsize uint, doorkeeper bool) *Shard[K, V] {
 	s := &Shard[K, V]{
 		hashmap: make(map[K]*Entry[K, V]),
 		qsize:   qsize,
@@ -62,17 +62,17 @@ func NewShard[K cachekey, V any](size uint, qsize uint, doorkeeper bool) *Shard[
 		group:   NewGroup[K, V](),
 	}
 	if doorkeeper {
-		s.dookeeper = bf.New(0.01)
+		s.doorkeeper = bf.New(0.01)
 	}
 	return s
 }
 
 func (s *Shard[K, V]) set(key K, entry *Entry[K, V]) {
 	s.hashmap[key] = entry
-	if s.dookeeper != nil {
+	if s.doorkeeper != nil {
 		ds := 20 * len(s.hashmap)
-		if ds > s.dookeeper.Capacity {
-			s.dookeeper.EnsureCapacity(ds)
+		if ds > s.doorkeeper.Capacity {
+			s.doorkeeper.EnsureCapacity(ds)
 		}
 	}
 }
@@ -195,10 +195,6 @@ func NewStore[K cachekey, V cacheval](maxsize int64, doorkeeper bool) *Store[K, 
 		shardCount = 128
 	}
 	dequeSize := int(maxsize) / 100 / shardCount
-	shardSize := int(maxsize) / shardCount
-	if shardSize < 50 {
-		shardSize = 50
-	}
 	policySize := int(maxsize) - (dequeSize * shardCount)
 
 	s := &Store[K, V]{
@@ -213,7 +209,7 @@ func NewStore[K cachekey, V cacheval](maxsize int64, doorkeeper bool) *Store[K, 
 	}
 	s.shards = make([]*Shard[K, V], 0, s.shardCount)
 	for i := 0; i < int(s.shardCount); i++ {
-		s.shards = append(s.shards, NewShard[K, V](uint(shardSize), uint(dequeSize), doorkeeper))
+		s.shards = append(s.shards, NewShard[K, V](uint(dequeSize), doorkeeper))
 	}
 
 	go s.maintenance()
@@ -329,11 +325,11 @@ func (s *Store[K, V]) setInternal(key K, value V, cost int64, epoch uint32) (*Sh
 		return shard, exist, true
 	}
 	if s.doorkeeper {
-		if shard.counter > uint(shard.dookeeper.Capacity) {
-			shard.dookeeper.Reset()
+		if shard.counter > uint(shard.doorkeeper.Capacity) {
+			shard.doorkeeper.Reset()
 			shard.counter = 0
 		}
-		hit := shard.dookeeper.Insert(h)
+		hit := shard.doorkeeper.Insert(h)
 		if !hit {
 			shard.counter += 1
 			shard.mu.Unlock()
@@ -373,7 +369,6 @@ func (s *Store[K, V]) processDeque(shard *Shard[K, V], epoch uint32) {
 		return
 	}
 	var evictedkv []dequeKV[K, V]
-	var expiredkv []dequeKV[K, V]
 
 	// send to slru
 	send := make([]*Entry[K, V], 0, 2)
@@ -421,9 +416,6 @@ func (s *Store[K, V]) processDeque(shard *Shard[K, V], epoch uint32) {
 	if s.OnRemoval != nil {
 		for _, kv := range evictedkv {
 			s.OnRemoval(kv.k, kv.v, EVICTED)
-		}
-		for _, kv := range expiredkv {
-			s.OnRemoval(kv.k, kv.v, EXPIRED)
 		}
 	}
 }

--- a/go/cache/theine/store_test.go
+++ b/go/cache/theine/store_test.go
@@ -74,9 +74,9 @@ func TestProcessDeque(t *testing.T) {
 func TestDoorKeeperDynamicSize(t *testing.T) {
 	store := NewStore[keyint, cachedint](200000, true)
 	shard := store.shards[0]
-	require.True(t, shard.dookeeper.Capacity == 512)
+	require.True(t, shard.doorkeeper.Capacity == 512)
 	for i := keyint(0); i < 5000; i++ {
 		shard.set(i, &Entry[keyint, cachedint]{})
 	}
-	require.True(t, shard.dookeeper.Capacity > 100000)
+	require.True(t, shard.doorkeeper.Capacity > 100000)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

- Typo: *doorkeeper
- NewShard size parameter is entirely unused
- expiredkv is entirely unused and was triggering a niless issue:

```
/home/matt/src/github.com/planetscale/vitess/go/cache/theine/store.go:425:22: nil dereference in index operation
```

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Updates https://github.com/vitessio/vitess/issues/14684.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

n/a

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
