### PR TITLE
Use GetTabletsByCell in healthcheck

### DIFF
--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -62,7 +62,7 @@ func (c *counters) set(name string, value int64) {
 func (c *counters) reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.counts = make(map[string]int64)
+	clear(c.counts)
 }
 
 // ZeroAll zeroes out all values
@@ -70,7 +70,9 @@ func (c *counters) ZeroAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	clear(c.counts)
+	for k := range c.counts {
+		c.counts[k] = 0
+	}
 }
 
 // Counts returns a copy of the Counters' map.

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -25,7 +25,7 @@ limitations under the License.
 // Alternatively, use a Watcher implementation which will constantly watch
 // a source (e.g. the topology) and add and remove tablets as they are
 // added or removed from the source.
-// For a Watcher example have a look at NewCellTabletsWatcher().
+// For a Watcher example have a look at NewTopologyWatcher().
 //
 // Internally, the HealthCheck module is connected to each tablet and has a
 // streaming RPC (StreamHealth) open to receive periodic health infos.
@@ -88,7 +88,7 @@ var (
 	refreshKnownTablets = true
 
 	// topoReadConcurrency tells us how many topo reads are allowed in parallel.
-	topoReadConcurrency = 32
+	topoReadConcurrency int64 = 32
 
 	// How much to sleep between each check.
 	waitAvailableTabletInterval = 100 * time.Millisecond
@@ -176,7 +176,7 @@ func registerWebUIFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&TabletURLTemplateString, "tablet_url_template", "http://{{.GetTabletHostPort}}", "Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this.")
 	fs.DurationVar(&refreshInterval, "tablet_refresh_interval", 1*time.Minute, "Tablet refresh interval.")
 	fs.BoolVar(&refreshKnownTablets, "tablet_refresh_known_tablets", true, "Whether to reload the tablet's address/port map from topo in case they change.")
-	fs.IntVar(&topoReadConcurrency, "topo_read_concurrency", 32, "Concurrency of topo reads.")
+	fs.Int64Var(&topoReadConcurrency, "topo_read_concurrency", 32, "Concurrency of topo reads.")
 	ParseTabletURLTemplateFromFlag()
 }
 
@@ -362,7 +362,7 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 		} else if len(KeyspacesToWatch) > 0 {
 			filter = NewFilterByKeyspace(KeyspacesToWatch)
 		}
-		topoWatchers = append(topoWatchers, NewCellTabletsWatcher(ctx, topoServer, hc, filter, c, refreshInterval, refreshKnownTablets, topoReadConcurrency))
+		topoWatchers = append(topoWatchers, NewTopologyWatcher(ctx, topoServer, hc, filter, c, refreshInterval, refreshKnownTablets, topoReadConcurrency))
 	}
 
 	hc.topoWatchers = topoWatchers

--- a/go/vt/discovery/tablet_picker.go
+++ b/go/vt/discovery/tablet_picker.go
@@ -428,7 +428,7 @@ func (tp *TabletPicker) GetMatchingTablets(ctx context.Context) []*topo.TabletIn
 
 	shortCtx, cancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer cancel()
-	tabletMap, err := tp.ts.GetTabletMap(shortCtx, aliases)
+	tabletMap, err := tp.ts.GetTabletMap(shortCtx, aliases, nil)
 	if err != nil {
 		log.Warningf("Error fetching tablets from topo: %v", err)
 		// If we get a partial result we can still use it, otherwise return.

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -147,7 +147,7 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 		t.Fatalf("CreateTablet failed: %v", err)
 	}
 	tw.loadTablets()
-	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 1, "AddTablet": 1})
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
 	checkChecksum(t, tw, 3238442862)
 
 	// Check the tablet is returned by GetAllTablets().
@@ -178,9 +178,9 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 	// If refreshKnownTablets is disabled, only the new tablet is read
 	// from the topo
 	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 2, "AddTablet": 1})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
 	} else {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 1, "AddTablet": 1})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
 	}
 	checkChecksum(t, tw, 2762153755)
 
@@ -195,7 +195,7 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 	// only the list is read from the topo and the checksum doesn't change
 	tw.loadTablets()
 	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 2})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0})
 	} else {
 		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1})
 	}
@@ -221,7 +221,7 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 	key = TabletToMapKey(tablet)
 
 	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 2, "ReplaceTablet": 1})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "ReplaceTablet": 1})
 
 		if _, ok := allTablets[key]; !ok || len(allTablets) != 2 || !proto.Equal(allTablets[key], tablet) {
 			t.Errorf("fhc.GetAllTablets() = %+v; want %+v", allTablets, tablet)
@@ -264,7 +264,7 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 			t.Fatalf("UpdateTabletFields failed: %v", err)
 		}
 		tw.loadTablets()
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 2, "ReplaceTablet": 2})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "ReplaceTablet": 2})
 		allTablets = fhc.GetAllTablets()
 		key2 := TabletToMapKey(tablet2)
 		if _, ok := allTablets[key2]; !ok {
@@ -288,7 +288,7 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 			t.Fatalf("UpdateTabletFields failed: %v", err)
 		}
 		tw.loadTablets()
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 2, "ReplaceTablet": 2})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "ReplaceTablet": 2})
 	}
 
 	// Remove the tablet and check that it is detected as being gone.
@@ -300,7 +300,7 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 	}
 	tw.loadTablets()
 	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 1, "RemoveTablet": 1})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "RemoveTablet": 1})
 	} else {
 		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "RemoveTablet": 1})
 	}
@@ -551,7 +551,7 @@ func TestFilterByKeypsaceSkipsIgnoredTablets(t *testing.T) {
 	require.NoError(t, ts.CreateTablet(context.Background(), tablet))
 
 	tw.loadTablets()
-	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 1, "AddTablet": 1})
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
 	checkChecksum(t, tw, 3238442862)
 
 	// Check tablet is reported by HealthCheck
@@ -576,7 +576,7 @@ func TestFilterByKeypsaceSkipsIgnoredTablets(t *testing.T) {
 	require.NoError(t, ts.CreateTablet(context.Background(), tablet2))
 
 	tw.loadTablets()
-	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 1})
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0})
 	checkChecksum(t, tw, 2762153755)
 
 	// Check the new tablet is NOT reported by HealthCheck.

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -102,9 +102,8 @@ func TestStartAndCloseTopoWatcher(t *testing.T) {
 	done <- true
 
 	_, ok := <-result
-	if !ok {
-		t.Fatal("timed out")
-	}
+	require.True(t, ok, "timed out")
+
 }
 
 func TestCellTabletsWatcher(t *testing.T) {
@@ -143,19 +142,18 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 		Keyspace: "keyspace",
 		Shard:    "shard",
 	}
-	if err := ts.CreateTablet(context.Background(), tablet); err != nil {
-		t.Fatalf("CreateTablet failed: %v", err)
-	}
+	require.NoError(t, ts.CreateTablet(context.Background(), tablet), "CreateTablet failed for %v", tablet.Alias)
+
 	tw.loadTablets()
-	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "AddTablet": 1})
 	checkChecksum(t, tw, 3238442862)
 
 	// Check the tablet is returned by GetAllTablets().
 	allTablets := fhc.GetAllTablets()
 	key := TabletToMapKey(tablet)
-	if _, ok := allTablets[key]; !ok || len(allTablets) != 1 || !proto.Equal(allTablets[key], tablet) {
-		t.Errorf("fhc.GetAllTablets() = %+v; want %+v", allTablets, tablet)
-	}
+	assert.Len(t, allTablets, 1)
+	assert.Contains(t, allTablets, key)
+	assert.True(t, proto.Equal(tablet, allTablets[key]))
 
 	// Add a second tablet to the topology.
 	tablet2 := &topodatapb.Tablet{
@@ -170,75 +168,51 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 		Keyspace: "keyspace",
 		Shard:    "shard",
 	}
-	if err := ts.CreateTablet(context.Background(), tablet2); err != nil {
-		t.Fatalf("CreateTablet failed: %v", err)
-	}
+	require.NoError(t, ts.CreateTablet(context.Background(), tablet2), "CreateTablet failed for %v", tablet2.Alias)
 	tw.loadTablets()
 
-	// If refreshKnownTablets is disabled, only the new tablet is read
-	// from the topo
-	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
-	} else {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
-	}
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "AddTablet": 1})
 	checkChecksum(t, tw, 2762153755)
 
 	// Check the new tablet is returned by GetAllTablets().
 	allTablets = fhc.GetAllTablets()
 	key = TabletToMapKey(tablet2)
-	if _, ok := allTablets[key]; !ok || len(allTablets) != 2 || !proto.Equal(allTablets[key], tablet2) {
-		t.Errorf("fhc.GetAllTablets() = %+v; want %+v", allTablets, tablet2)
-	}
-
-	// Load the tablets again to show that when refreshKnownTablets is disabled,
-	// only the list is read from the topo and the checksum doesn't change
-	tw.loadTablets()
-	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0})
-	} else {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1})
-	}
-	checkChecksum(t, tw, 2762153755)
+	assert.Len(t, allTablets, 2)
+	assert.Contains(t, allTablets, key)
+	assert.True(t, proto.Equal(tablet2, allTablets[key]))
 
 	// same tablet, different port, should update (previous
 	// one should go away, new one be added)
 	//
 	// if refreshKnownTablets is disabled, this case is *not*
-	// detected and the tablet remains in the topo using the
+	// detected and the tablet remains in the healthcheck using the
 	// old key
 	origTablet := tablet.CloneVT()
 	origKey := TabletToMapKey(tablet)
 	tablet.PortMap["vt"] = 456
-	if _, err := ts.UpdateTabletFields(context.Background(), tablet.Alias, func(t *topodatapb.Tablet) error {
+	_, err := ts.UpdateTabletFields(context.Background(), tablet.Alias, func(t *topodatapb.Tablet) error {
 		t.PortMap["vt"] = 456
 		return nil
-	}); err != nil {
-		t.Fatalf("UpdateTabletFields failed: %v", err)
-	}
+	})
+	require.Nil(t, err, "UpdateTabletFields failed")
+
 	tw.loadTablets()
 	allTablets = fhc.GetAllTablets()
 	key = TabletToMapKey(tablet)
 
 	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "ReplaceTablet": 1})
-
-		if _, ok := allTablets[key]; !ok || len(allTablets) != 2 || !proto.Equal(allTablets[key], tablet) {
-			t.Errorf("fhc.GetAllTablets() = %+v; want %+v", allTablets, tablet)
-		}
-		if _, ok := allTablets[origKey]; ok {
-			t.Errorf("fhc.GetAllTablets() = %+v; don't want %v", allTablets, origKey)
-		}
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "ReplaceTablet": 1})
+		assert.Len(t, allTablets, 2)
+		assert.Contains(t, allTablets, key)
+		assert.True(t, proto.Equal(tablet, allTablets[key]))
+		assert.NotContains(t, allTablets, origKey)
 		checkChecksum(t, tw, 2762153755)
 	} else {
 		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1})
-
-		if _, ok := allTablets[origKey]; !ok || len(allTablets) != 2 || !proto.Equal(allTablets[origKey], origTablet) {
-			t.Errorf("fhc.GetAllTablets() = %+v; want %+v", allTablets, origTablet)
-		}
-		if _, ok := allTablets[key]; ok {
-			t.Errorf("fhc.GetAllTablets() = %+v; don't want %v", allTablets, key)
-		}
+		assert.Len(t, allTablets, 2)
+		assert.Contains(t, allTablets, origKey)
+		assert.True(t, proto.Equal(origTablet, allTablets[origKey]))
+		assert.NotContains(t, allTablets, key)
 		checkChecksum(t, tw, 2762153755)
 	}
 
@@ -248,94 +222,77 @@ func checkWatcher(t *testing.T, refreshKnownTablets bool) {
 	if refreshKnownTablets {
 		origTablet := tablet.CloneVT()
 		origTablet2 := tablet2.CloneVT()
-		if _, err := ts.UpdateTabletFields(context.Background(), tablet2.Alias, func(t *topodatapb.Tablet) error {
+		_, err := ts.UpdateTabletFields(context.Background(), tablet2.Alias, func(t *topodatapb.Tablet) error {
 			t.Hostname = tablet.Hostname
 			t.PortMap = tablet.PortMap
 			tablet2 = t
 			return nil
-		}); err != nil {
-			t.Fatalf("UpdateTabletFields failed: %v", err)
-		}
-		if _, err := ts.UpdateTabletFields(context.Background(), tablet.Alias, func(t *topodatapb.Tablet) error {
+		})
+		require.Nil(t, err, "UpdateTabletFields failed")
+		_, err = ts.UpdateTabletFields(context.Background(), tablet.Alias, func(t *topodatapb.Tablet) error {
 			t.Hostname = "host3"
 			tablet = t
 			return nil
-		}); err != nil {
-			t.Fatalf("UpdateTabletFields failed: %v", err)
-		}
+		})
+		require.Nil(t, err, "UpdateTabletFields failed")
 		tw.loadTablets()
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "ReplaceTablet": 2})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "ReplaceTablet": 2})
 		allTablets = fhc.GetAllTablets()
 		key2 := TabletToMapKey(tablet2)
-		if _, ok := allTablets[key2]; !ok {
-			t.Fatalf("tablet was lost because it's reusing an address recently used by another tablet: %v", key2)
-		}
+		assert.Contains(t, allTablets, key2, "tablet was lost because it's reusing an address recently used by another tablet: %v", key2)
 
 		// Change tablets back to avoid altering later tests.
-		if _, err := ts.UpdateTabletFields(context.Background(), tablet2.Alias, func(t *topodatapb.Tablet) error {
+		_, err = ts.UpdateTabletFields(context.Background(), tablet2.Alias, func(t *topodatapb.Tablet) error {
 			t.Hostname = origTablet2.Hostname
 			t.PortMap = origTablet2.PortMap
 			tablet2 = t
 			return nil
-		}); err != nil {
-			t.Fatalf("UpdateTabletFields failed: %v", err)
-		}
-		if _, err := ts.UpdateTabletFields(context.Background(), tablet.Alias, func(t *topodatapb.Tablet) error {
+		})
+		require.Nil(t, err, "UpdateTabletFields failed")
+
+		_, err = ts.UpdateTabletFields(context.Background(), tablet.Alias, func(t *topodatapb.Tablet) error {
 			t.Hostname = origTablet.Hostname
 			tablet = t
 			return nil
-		}); err != nil {
-			t.Fatalf("UpdateTabletFields failed: %v", err)
-		}
+		})
+		require.Nil(t, err, "UpdateTabletFields failed")
+
 		tw.loadTablets()
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "ReplaceTablet": 2})
+		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "ReplaceTablet": 2})
 	}
 
 	// Remove the tablet and check that it is detected as being gone.
-	if err := ts.DeleteTablet(context.Background(), tablet.Alias); err != nil {
-		t.Fatalf("DeleteTablet failed: %v", err)
-	}
-	if _, err := topo.FixShardReplication(context.Background(), ts, logger, "aa", "keyspace", "shard"); err != nil {
-		t.Fatalf("FixShardReplication failed: %v", err)
-	}
+	require.NoError(t, ts.DeleteTablet(context.Background(), tablet.Alias))
+
+	_, err = topo.FixShardReplication(context.Background(), ts, logger, "aa", "keyspace", "shard")
+	require.Nil(t, err, "FixShardReplication failed")
 	tw.loadTablets()
-	if refreshKnownTablets {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "RemoveTablet": 1})
-	} else {
-		counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "RemoveTablet": 1})
-	}
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "RemoveTablet": 1})
 	checkChecksum(t, tw, 789108290)
 
 	allTablets = fhc.GetAllTablets()
+	assert.Len(t, allTablets, 1)
 	key = TabletToMapKey(tablet)
-	if _, ok := allTablets[key]; ok || len(allTablets) != 1 {
-		t.Errorf("fhc.GetAllTablets() = %+v; don't want %v", allTablets, key)
-	}
+	assert.NotContains(t, allTablets, key)
+
 	key = TabletToMapKey(tablet2)
-	if _, ok := allTablets[key]; !ok || len(allTablets) != 1 || !proto.Equal(allTablets[key], tablet2) {
-		t.Errorf("fhc.GetAllTablets() = %+v; want %+v", allTablets, tablet2)
-	}
+	assert.Contains(t, allTablets, key)
+	assert.True(t, proto.Equal(tablet2, allTablets[key]))
 
 	// Remove the other and check that it is detected as being gone.
-	if err := ts.DeleteTablet(context.Background(), tablet2.Alias); err != nil {
-		t.Fatalf("DeleteTablet failed: %v", err)
-	}
-	if _, err := topo.FixShardReplication(context.Background(), ts, logger, "aa", "keyspace", "shard"); err != nil {
-		t.Fatalf("FixShardReplication failed: %v", err)
-	}
+	require.NoError(t, ts.DeleteTablet(context.Background(), tablet2.Alias))
+	_, err = topo.FixShardReplication(context.Background(), ts, logger, "aa", "keyspace", "shard")
+	require.Nil(t, err, "FixShardReplication failed")
 	tw.loadTablets()
-	checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "RemoveTablet": 1})
+	checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "RemoveTablet": 1})
 	checkChecksum(t, tw, 0)
 
 	allTablets = fhc.GetAllTablets()
+	assert.Len(t, allTablets, 0)
 	key = TabletToMapKey(tablet)
-	if _, ok := allTablets[key]; ok || len(allTablets) != 0 {
-		t.Errorf("fhc.GetAllTablets() = %+v; don't want %v", allTablets, key)
-	}
+	assert.NotContains(t, allTablets, key)
 	key = TabletToMapKey(tablet2)
-	if _, ok := allTablets[key]; ok || len(allTablets) != 0 {
-		t.Errorf("fhc.GetAllTablets() = %+v; don't want %v", allTablets, key)
-	}
+	assert.NotContains(t, allTablets, key)
 
 	tw.Stop()
 }
@@ -402,19 +359,13 @@ func TestFilterByShard(t *testing.T) {
 
 	for _, tc := range testcases {
 		fbs, err := NewFilterByShard(tc.filters)
-		if err != nil {
-			t.Errorf("cannot create FilterByShard for filters %v: %v", tc.filters, err)
-		}
+		require.Nil(t, err, "cannot create FilterByShard for filters %v", tc.filters)
 
 		tablet := &topodatapb.Tablet{
 			Keyspace: tc.keyspace,
 			Shard:    tc.shard,
 		}
-
-		got := fbs.IsIncluded(tablet)
-		if got != tc.included {
-			t.Errorf("isIncluded(%v,%v) for filters %v returned %v but expected %v", tc.keyspace, tc.shard, tc.filters, got, tc.included)
-		}
+		require.Equal(t, tc.included, fbs.IsIncluded(tablet))
 	}
 }
 
@@ -462,22 +413,21 @@ func TestFilterByKeyspace(t *testing.T) {
 			Shard:    testShard,
 		}
 
-		got := f.IsIncluded(tablet)
-		if got != test.expected {
-			t.Errorf("isIncluded(%v) for keyspace %v returned %v but expected %v", test.keyspace, test.keyspace, got, test.expected)
-		}
+		assert.Equal(t, test.expected, f.IsIncluded(tablet))
 
-		if err := ts.CreateTablet(context.Background(), tablet); err != nil {
-			t.Errorf("CreateTablet failed: %v", err)
-		}
+		// Make this fatal because there is no point continuing if CreateTablet fails
+		require.NoError(t, ts.CreateTablet(context.Background(), tablet))
 
 		tw.loadTablets()
 		key := TabletToMapKey(tablet)
 		allTablets := hc.GetAllTablets()
 
-		if _, ok := allTablets[key]; ok != test.expected && proto.Equal(allTablets[key], tablet) != test.expected {
-			t.Errorf("Error adding tablet - got %v; want %v", ok, test.expected)
+		if test.expected {
+			assert.Contains(t, allTablets, key)
+		} else {
+			assert.NotContains(t, allTablets, key)
 		}
+		assert.Equal(t, test.expected, proto.Equal(tablet, allTablets[key]))
 
 		// Replace the tablet we added above
 		tabletReplacement := &topodatapb.Tablet{
@@ -492,26 +442,22 @@ func TestFilterByKeyspace(t *testing.T) {
 			Keyspace: test.keyspace,
 			Shard:    testShard,
 		}
-		got = f.IsIncluded(tabletReplacement)
-		if got != test.expected {
-			t.Errorf("isIncluded(%v) for keyspace %v returned %v but expected %v", test.keyspace, test.keyspace, got, test.expected)
-		}
-		if err := ts.CreateTablet(context.Background(), tabletReplacement); err != nil {
-			t.Errorf("CreateTablet failed: %v", err)
-		}
+		assert.Equal(t, test.expected, f.IsIncluded(tabletReplacement))
+		require.NoError(t, ts.CreateTablet(context.Background(), tabletReplacement))
 
 		tw.loadTablets()
 		key = TabletToMapKey(tabletReplacement)
 		allTablets = hc.GetAllTablets()
 
-		if _, ok := allTablets[key]; ok != test.expected && proto.Equal(allTablets[key], tabletReplacement) != test.expected {
-			t.Errorf("Error replacing tablet - got %v; want %v", ok, test.expected)
+		if test.expected {
+			assert.Contains(t, allTablets, key)
+		} else {
+			assert.NotContains(t, allTablets, key)
 		}
+		assert.Equal(t, test.expected, proto.Equal(tabletReplacement, allTablets[key]))
 
 		// Delete the tablet
-		if err := ts.DeleteTablet(context.Background(), tabletReplacement.Alias); err != nil {
-			t.Fatalf("DeleteTablet failed: %v", err)
-		}
+		require.NoError(t, ts.DeleteTablet(context.Background(), tabletReplacement.Alias))
 	}
 }
 
@@ -551,7 +497,7 @@ func TestFilterByKeypsaceSkipsIgnoredTablets(t *testing.T) {
 	require.NoError(t, ts.CreateTablet(context.Background(), tablet))
 
 	tw.loadTablets()
-	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0, "AddTablet": 1})
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "AddTablet": 1})
 	checkChecksum(t, tw, 3238442862)
 
 	// Check tablet is reported by HealthCheck
@@ -576,7 +522,7 @@ func TestFilterByKeypsaceSkipsIgnoredTablets(t *testing.T) {
 	require.NoError(t, ts.CreateTablet(context.Background(), tablet2))
 
 	tw.loadTablets()
-	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "GetTablet": 0})
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1})
 	checkChecksum(t, tw, 2762153755)
 
 	// Check the new tablet is NOT reported by HealthCheck.

--- a/go/vt/topo/consultopo/error.go
+++ b/go/vt/topo/consultopo/error.go
@@ -40,15 +40,16 @@ var (
 // are either application-level errors, or context errors.
 func convertError(err error, nodePath string) error {
 	// Unwrap errors from the Go HTTP client.
-	if urlErr, ok := err.(*url.Error); ok {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
 		err = urlErr.Err
 	}
 
 	// Convert specific sentinel values.
-	switch err {
-	case context.Canceled:
+	switch {
+	case errors.Is(err, context.Canceled):
 		return topo.NewError(topo.Interrupted, nodePath)
-	case context.DeadlineExceeded:
+	case errors.Is(err, context.DeadlineExceeded):
 		return topo.NewError(topo.Timeout, nodePath)
 	}
 

--- a/go/vt/topo/errors.go
+++ b/go/vt/topo/errors.go
@@ -36,6 +36,7 @@ const (
 	NoUpdateNeeded
 	NoImplementation
 	NoReadOnlyImplementation
+	ResourceExhausted
 )
 
 // Error represents a topo error.
@@ -68,6 +69,8 @@ func NewError(code ErrorCode, node string) error {
 		message = fmt.Sprintf("no such topology implementation %s", node)
 	case NoReadOnlyImplementation:
 		message = fmt.Sprintf("no read-only topology implementation %s", node)
+	case ResourceExhausted:
+		message = fmt.Sprintf("server resource exhausted: %s", node)
 	default:
 		message = fmt.Sprintf("unknown code: %s", node)
 	}

--- a/go/vt/topo/memorytopo/file.go
+++ b/go/vt/topo/memorytopo/file.go
@@ -187,6 +187,9 @@ func (c *Conn) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, 
 	if c.factory.err != nil {
 		return nil, c.factory.err
 	}
+	if c.factory.listErr != nil {
+		return nil, c.factory.listErr
+	}
 
 	dir, file := path.Split(filePathPrefix)
 	// Get the node to list.

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -70,6 +70,9 @@ type Factory struct {
 	// err is used for testing purposes to force queries / watches
 	// to return the given error
 	err error
+	// listErr is used for testing purposed to fake errors from
+	// calls to List.
+	listErr error
 }
 
 // HasGlobalReadOnlyCell is part of the topo.Factory interface.
@@ -347,4 +350,11 @@ func (f *Factory) recursiveDelete(n *node) {
 	if len(parent.children) == 0 {
 		f.recursiveDelete(parent)
 	}
+}
+
+func (f *Factory) SetListError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.listErr = err
 }

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -666,7 +666,7 @@ func (ts *Server) GetTabletMapForShardByCell(ctx context.Context, keyspace, shar
 
 	// get the tablets for the cells we were able to reach, forward
 	// ErrPartialResult from FindAllTabletAliasesInShard
-	result, gerr := ts.GetTabletMap(ctx, aliases)
+	result, gerr := ts.GetTabletMap(ctx, aliases, nil)
 	if gerr == nil && err != nil {
 		gerr = err
 	}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -303,7 +303,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string, opt *G
 	}
 	listResults, err := cellConn.List(ctx, TabletsPath)
 	if err != nil || len(listResults) == 0 {
-		// Currently the ZooKeeper and Memory topo implementations do not support scans
+		// Currently the ZooKeeper implementation does not support scans
 		// so we fall back to the more costly method of fetching the tablets one by one.
 		// In the etcd case, it is possible that the response is too large. We also fall
 		// back to fetching the tablets one by one in that case.

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -305,7 +305,9 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string, opt *G
 	if err != nil || len(listResults) == 0 {
 		// Currently the ZooKeeper and Memory topo implementations do not support scans
 		// so we fall back to the more costly method of fetching the tablets one by one.
-		if IsErrType(err, NoImplementation) {
+		// In the etcd case, it is possible that the response is too large. We also fall
+		// back to fetching the tablets one by one in that case.
+		if IsErrType(err, NoImplementation) || IsErrType(err, ResourceExhausted) {
 			return ts.GetTabletsIndividuallyByCell(ctx, cellAlias, opt)
 		}
 		if IsErrType(err, NoNode) {

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+)
+
+func TestServerGetTabletsByCell(t *testing.T) {
+	tests := []struct {
+		name    string
+		tablets int
+		opt     *topo.GetTabletsByCellOptions
+	}{
+		{
+			name:    "negative concurrency",
+			tablets: 1,
+			// Ensure this doesn't panic.
+			opt: &topo.GetTabletsByCellOptions{Concurrency: -1},
+		},
+		{
+			name:    "unsharded",
+			tablets: 1,
+			// Make sure the defaults apply as expected.
+			opt: nil,
+		},
+		{
+			name:    "sharded",
+			tablets: 32,
+			opt:     &topo.GetTabletsByCellOptions{Concurrency: 8},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			const cell = "zone1"
+			ts := memorytopo.NewServer(ctx, cell)
+			defer ts.Close()
+
+			// Create an ephemeral keyspace and generate shard records within
+			// the keyspace to fetch later.
+			const keyspace = "keyspace"
+			require.NoError(t, ts.CreateKeyspace(ctx, keyspace, &topodatapb.Keyspace{}))
+
+			const shard = "shard"
+			require.NoError(t, ts.CreateShard(ctx, keyspace, shard))
+
+			tablets := make([]*topo.TabletInfo, tt.tablets)
+
+			for i := 0; i < tt.tablets; i++ {
+				tablet := &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(i),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(i),
+					},
+					Keyspace: "keyspace",
+					Shard:    "shard",
+				}
+				tInfo := &topo.TabletInfo{Tablet: tablet}
+				tablets[i] = tInfo
+				require.NoError(t, ts.CreateTablet(ctx, tablet))
+			}
+
+			// Verify that we return a complete list of shards and that each
+			// key range is present in the output.
+			out, err := ts.GetTabletsByCell(ctx, cell, tt.opt)
+			require.NoError(t, err)
+			require.Len(t, out, tt.tablets)
+
+			for i, tab := range tablets {
+				require.Equal(t, tab.Tablet, tablets[i].Tablet)
+			}
+		})
+	}
+}

--- a/go/vt/topo/zk2topo/error.go
+++ b/go/vt/topo/zk2topo/error.go
@@ -18,6 +18,7 @@ package zk2topo
 
 import (
 	"context"
+	"errors"
 
 	"github.com/z-division/go-zookeeper/zk"
 
@@ -26,20 +27,20 @@ import (
 
 // Error codes returned by the zookeeper Go client:
 func convertError(err error, node string) error {
-	switch err {
-	case zk.ErrBadVersion:
+	switch {
+	case errors.Is(err, zk.ErrBadVersion):
 		return topo.NewError(topo.BadVersion, node)
-	case zk.ErrNoNode:
+	case errors.Is(err, zk.ErrNoNode):
 		return topo.NewError(topo.NoNode, node)
-	case zk.ErrNodeExists:
+	case errors.Is(err, zk.ErrNodeExists):
 		return topo.NewError(topo.NodeExists, node)
-	case zk.ErrNotEmpty:
+	case errors.Is(err, zk.ErrNotEmpty):
 		return topo.NewError(topo.NodeNotEmpty, node)
-	case zk.ErrSessionExpired:
+	case errors.Is(err, zk.ErrSessionExpired):
 		return topo.NewError(topo.Timeout, node)
-	case context.Canceled:
+	case errors.Is(err, context.Canceled):
 		return topo.NewError(topo.Interrupted, node)
-	case context.DeadlineExceeded:
+	case errors.Is(err, context.DeadlineExceeded):
 		return topo.NewError(topo.Timeout, node)
 	}
 	return err

--- a/go/vt/topotools/tablet.go
+++ b/go/vt/topotools/tablet.go
@@ -127,7 +127,7 @@ func DoCellsHaveRdonlyTablets(ctx context.Context, ts *topo.Server, cells []stri
 	}
 
 	for _, cell := range cells {
-		tablets, err := ts.GetTabletsByCell(ctx, cell)
+		tablets, err := ts.GetTabletsByCell(ctx, cell, nil)
 		if err != nil {
 			return false, err
 		}

--- a/go/vt/topotools/utils.go
+++ b/go/vt/topotools/utils.go
@@ -43,7 +43,7 @@ func GetTabletMapForCell(ctx context.Context, ts *topo.Server, cell string) (map
 	if err != nil {
 		return nil, err
 	}
-	tabletMap, err := ts.GetTabletMap(ctx, aliases)
+	tabletMap, err := ts.GetTabletMap(ctx, aliases, nil)
 	if err != nil {
 		// we got another error than topo.ErrNoNode
 		return nil, err
@@ -65,7 +65,7 @@ func GetAllTabletsAcrossCells(ctx context.Context, ts *topo.Server) ([]*topo.Tab
 	wg.Add(len(cells))
 	for i, cell := range cells {
 		go func(i int, cell string) {
-			results[i], errors[i] = ts.GetTabletsByCell(ctx, cell)
+			results[i], errors[i] = ts.GetTabletsByCell(ctx, cell, nil)
 			wg.Done()
 		}(i, cell)
 	}

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -1982,7 +1982,7 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 	case len(req.TabletAliases) > 0:
 		span.Annotate("tablet_aliases", strings.Join(topoproto.TabletAliasList(req.TabletAliases).ToStringSlice(), ","))
 
-		tabletMap, err = s.ts.GetTabletMap(ctx, req.TabletAliases)
+		tabletMap, err = s.ts.GetTabletMap(ctx, req.TabletAliases, nil)
 		if err != nil {
 			err = fmt.Errorf("GetTabletMap(%v) failed: %w", req.TabletAliases, err)
 		}
@@ -2058,7 +2058,7 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 		go func(cell string) {
 			defer wg.Done()
 
-			tablets, err := s.ts.GetTabletsByCell(ctx, cell)
+			tablets, err := s.ts.GetTabletsByCell(ctx, cell, nil)
 			if err != nil {
 				if req.Strict {
 					log.Infof("GetTablets got an error from cell %s: %s. Running in strict mode, so canceling other cell RPCs", cell, err)
@@ -4432,7 +4432,7 @@ func (s *VtctldServer) ValidateShard(ctx context.Context, req *vtctldatapb.Valid
 
 	getTabletMapCtx, getTabletMapCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer getTabletMapCancel()
-	tabletMap, _ := s.ts.GetTabletMap(getTabletMapCtx, aliases)
+	tabletMap, _ := s.ts.GetTabletMap(getTabletMapCtx, aliases, nil)
 
 	var primaryAlias *topodatapb.TabletAlias
 	for _, alias := range aliases {

--- a/go/vt/vtctl/grpcvtctldserver/topo.go
+++ b/go/vt/vtctl/grpcvtctldserver/topo.go
@@ -161,7 +161,7 @@ func deleteShardCell(ctx context.Context, ts *topo.Server, keyspace string, shar
 	// Get all the tablet records for the aliases we've collected. Note that
 	// GetTabletMap ignores ErrNoNode, which is convenient for our purpose; it
 	// means a tablet was deleted but is still referenced.
-	tabletMap, err := ts.GetTabletMap(ctx, aliases)
+	tabletMap, err := ts.GetTabletMap(ctx, aliases, nil)
 	if err != nil {
 		return fmt.Errorf("GetTabletMap() failed: %w", err)
 	}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2707,7 +2707,7 @@ func (s *Server) DeleteShard(ctx context.Context, keyspace, shard string, recurs
 		// GetTabletMap ignores ErrNoNode, and it's good for
 		// our purpose, it means a tablet was deleted but is
 		// still referenced.
-		tabletMap, err := s.ts.GetTabletMap(ctx, aliases)
+		tabletMap, err := s.ts.GetTabletMap(ctx, aliases, nil)
 		if err != nil {
 			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "GetTabletMap() failed: %v", err)
 		}

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -83,14 +83,6 @@ type ThrottlerInterface interface {
 	ResetConfiguration()
 }
 
-// TopologyWatcherInterface defines the public interface that is implemented by
-// discovery.LegacyTopologyWatcher. It is only used here to allow mocking out
-// go/vt/discovery.LegacyTopologyWatcher.
-type TopologyWatcherInterface interface {
-	Start()
-	Stop()
-}
-
 // TxThrottlerName is the name the wrapped go/vt/throttler object will be registered with
 // go/vt/throttler.GlobalManager.
 const TxThrottlerName = "TransactionThrottler"

--- a/go/vt/wrangler/shard.go
+++ b/go/vt/wrangler/shard.go
@@ -113,7 +113,7 @@ func (wr *Wrangler) DeleteShard(ctx context.Context, keyspace, shard string, rec
 		// GetTabletMap ignores ErrNoNode, and it's good for
 		// our purpose, it means a tablet was deleted but is
 		// still referenced.
-		tabletMap, err := wr.ts.GetTabletMap(ctx, aliases)
+		tabletMap, err := wr.ts.GetTabletMap(ctx, aliases, nil)
 		if err != nil {
 			return fmt.Errorf("GetTabletMap() failed: %v", err)
 		}

--- a/go/vt/wrangler/split.go
+++ b/go/vt/wrangler/split.go
@@ -40,7 +40,7 @@ const (
 // on a Shard.
 func (wr *Wrangler) SetSourceShards(ctx context.Context, keyspace, shard string, sources []*topodatapb.TabletAlias, tables []string) error {
 	// Read the source tablets.
-	sourceTablets, err := wr.ts.GetTabletMap(ctx, sources)
+	sourceTablets, err := wr.ts.GetTabletMap(ctx, sources, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
VTGate's healthcheck module currently calls GetTablet for each tablet alias that it discovers in a cell. Instead we can use GetTabletsForCell to fetch all tablets for a cell at once.

This PR does a few more things:
- GetTabletsForCell now handles the case where the response size violates gRPC limits by falling back to one tablet at a time in case of error.
- Previously, the one tablet at a time method had unlimited concurrency. In this PR we introduce a configuration option for concurrency.
- We pass `topoReadConcurrency` from healthcheck into GetTabletsForCell.
- The behavior of `--refresh_known_tablets` flag is different now. Previously we would not read those tablets at all, now we do read them, but ignore any changes if they are already known.

The basic fix has already been tried in production and shown to reduce the number of `Get` calls from vtgate -> topo from O(n) to O(1).

We can consider deprecating and deleting `--refresh_known_tablets` in a future release. The concerns that originally motivated adding that flag in #3965 are alleviated by fetching all tablets in one call to the topo.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #14277 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
