### PR TITLE
add foreign key as part of set statement when reserved connection is needed

### DIFF
--- a/go/vt/sysvars/sysvars.go
+++ b/go/vt/sysvars/sysvars.go
@@ -40,6 +40,8 @@ type SystemVariable struct {
 
 	SupportSetVar bool
 
+	IncludeInSet bool
+
 	Case StorageCase
 }
 
@@ -71,7 +73,7 @@ var (
 	TxReadOnly                  = SystemVariable{Name: "tx_read_only", IsBoolean: true, Default: off}
 	Workload                    = SystemVariable{Name: "workload", IdentifierAsString: true}
 	QueryTimeout                = SystemVariable{Name: "query_timeout"}
-	ForeignKeyChecks            = SystemVariable{Name: "foreign_key_checks", IsBoolean: true, SupportSetVar: true}
+	ForeignKeyChecks            = SystemVariable{Name: "foreign_key_checks", IsBoolean: true, SupportSetVar: true, IncludeInSet: true}
 
 	// Online DDL
 	DDLStrategy      = SystemVariable{Name: "ddl_strategy", IdentifierAsString: true}
@@ -295,6 +297,9 @@ func IsVitessAware(sysv string) bool {
 	vitessAwareInit.Do(func() {
 		vitessAwareVariableNames = make(map[string]struct{}, len(VitessAware))
 		for _, v := range VitessAware {
+			if v.IncludeInSet {
+				continue
+			}
 			vitessAwareVariableNames[v.Name] = struct{}{}
 		}
 	})


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
