### PR TITLE
Fail correlated subquery in planning phase instead of a runtime error

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -108,23 +108,24 @@ func findTablesContained(ctx *plancontext.PlanningContext, node sqlparser.SQLNod
 	return
 }
 
-func rewriteRemainingColumns(
+func checkForCorrelatedSubqueries(
 	ctx *plancontext.PlanningContext,
 	stmt sqlparser.SelectStatement,
 	subqID semantics.TableSet,
-) sqlparser.SelectStatement {
-	return sqlparser.CopyOnRewrite(stmt, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
-		colname, isColname := cursor.Node().(*sqlparser.ColName)
+) (correlated bool) {
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		colname, isColname := node.(*sqlparser.ColName)
 		if !isColname {
-			return
+			return true, nil
 		}
 		deps := ctx.SemTable.RecursiveDeps(colname)
 		if deps.IsSolvedBy(subqID) {
-			return
+			return true, nil
 		}
-		rsv := ctx.GetReservedArgumentFor(colname)
-		cursor.Replace(sqlparser.NewArgument(rsv))
-	}, nil).(sqlparser.SelectStatement)
+		correlated = true
+		return false, nil
+	}, stmt)
+	return correlated
 }
 
 // joinPredicateCollector is used to inspect the predicates inside the subquery, looking for any

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -169,12 +169,9 @@ func createSubquery(
 	sqc := &SubQueryBuilder{totalID: totalID, subqID: subqID, outerID: outerID}
 
 	predicates, joinCols := sqc.inspectStatement(ctx, subq.Select)
-	stmt := rewriteRemainingColumns(ctx, subq.Select, subqID)
+	correlated := checkForCorrelatedSubqueries(ctx, subq.Select, subqID)
 
-	// TODO: this should not be needed. We are using CopyOnRewrite above, but somehow this is not getting copied
-	ctx.SemTable.CopySemanticInfo(subq.Select, stmt)
-
-	opInner := translateQueryToOp(ctx, stmt)
+	opInner := translateQueryToOp(ctx, subq.Select)
 
 	opInner = sqc.getRootOperator(opInner, nil)
 	return &SubQuery{
@@ -187,6 +184,7 @@ func createSubquery(
 		IsProjection:     isProjection,
 		TopLevel:         topLevel,
 		JoinColumns:      joinCols,
+		correlated:       correlated,
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1037,10 +1037,10 @@
   },
   {
     "comment": "merge even one side have schema name in subquery",
-    "query": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `COLUMN_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
+    "query": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `COLUMN_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
+      "Original": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
       "Instructions": {
         "OperatorType": "UncorrelatedSubquery",
         "Variant": "PulloutIn",
@@ -1066,8 +1066,8 @@
                       "Name": "main",
                       "Sharded": false
                     },
-                    "FieldQuery": "select :COLUMN_NAME from information_schema.`tables` as t where 1 != 1",
-                    "Query": "select distinct :COLUMN_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
+                    "FieldQuery": "select TABLE_NAME from information_schema.`tables` as t where 1 != 1",
+                    "Query": "select distinct TABLE_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
                     "SysTableTableSchema": "['a']",
                     "Table": "information_schema.`tables`"
                   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1102,10 +1102,10 @@
   },
   {
     "comment": "merge even one side have schema name in subquery",
-    "query": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `COLUMN_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
+    "query": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `COLUMN_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
+      "Original": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
       "Instructions": {
         "OperatorType": "UncorrelatedSubquery",
         "Variant": "PulloutIn",
@@ -1131,8 +1131,8 @@
                       "Name": "main",
                       "Sharded": false
                     },
-                    "FieldQuery": "select :COLUMN_NAME from information_schema.`tables` as t where 1 != 1",
-                    "Query": "select distinct :COLUMN_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
+                    "FieldQuery": "select TABLE_NAME from information_schema.`tables` as t where 1 != 1",
+                    "Query": "select distinct TABLE_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
                     "SysTableTableSchema": "['a']",
                     "Table": "information_schema.`tables`"
                   },

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -378,5 +378,10 @@
     "comment": "Alias cannot clash with base tables",
     "query": "WITH user AS (SELECT col FROM user) SELECT * FROM user",
     "plan": "VT12001: unsupported: do not support CTE that use the CTE alias inside the CTE query"
+  },
+  {
+    "comment": "correlated subqueries in select expressions are unsupported",
+    "query": "SELECT (SELECT sum(user.name) FROM music LIMIT 1) FROM user",
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   }
 ]


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
As described in the bug https://github.com/vitessio/vitess/issues/14700, the query given in it fails on runtime. This PR fixes the planner to find these cases at plan-time itself and fail the planning if we are unable to merge the subquery into a route.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/14700

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
