### PR TITLE
Reduce flakiness in TestShardReplicationPositions

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -10837,7 +10837,7 @@ func TestShardReplicationPositions(t *testing.T) {
 			},
 			tmc: &testutil.TabletManagerClient{
 				PrimaryPositionDelays: map[string]time.Duration{
-					"zone1-0000000100": time.Millisecond * 200,
+					"zone1-0000000100": time.Second * 2,
 				},
 				PrimaryPositionResults: map[string]struct {
 					Position string
@@ -10848,7 +10848,7 @@ func TestShardReplicationPositions(t *testing.T) {
 					},
 				},
 				ReplicationStatusDelays: map[string]time.Duration{
-					"zone1-0000000101": time.Millisecond * 200,
+					"zone1-0000000101": time.Second * 2,
 				},
 				ReplicationStatusResults: map[string]struct {
 					Position *replicationdatapb.Status
@@ -10861,7 +10861,7 @@ func TestShardReplicationPositions(t *testing.T) {
 					},
 				},
 			},
-			ctxTimeout: time.Millisecond * 100,
+			ctxTimeout: time.Second,
 			req: &vtctldatapb.ShardReplicationPositionsRequest{
 				Keyspace: "testkeyspace",
 				Shard:    "-",


### PR DESCRIPTION
## Description

In CI, sometimes 10ms is exhausted simply in context switching, so we end up timing out the request before calling `GetTabletMapByShard`, rather than in the tabletmanager RPCs we are trying to have timeout.

Bumping the timeout by 10x to try to reduce flakiness.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14707.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
