### PR TITLE
go/vt/topo: fix nilness issues and unused variables

### DIFF
--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -137,7 +137,7 @@ func (ts *Server) GetShardServingCells(ctx context.Context, si *ShardInfo) (serv
 	var mu sync.Mutex
 	for _, cell := range cells {
 		wg.Add(1)
-		go func(cell, keyspace string) {
+		go func(cell string) {
 			defer wg.Done()
 			srvKeyspace, err := ts.GetSrvKeyspace(ctx, cell, si.keyspace)
 			switch {
@@ -166,7 +166,7 @@ func (ts *Server) GetShardServingCells(ctx context.Context, si *ShardInfo) (serv
 				rec.RecordError(err)
 				return
 			}
-		}(cell, si.Keyspace())
+		}(cell)
 	}
 	wg.Wait()
 	if rec.HasErrors() {
@@ -188,7 +188,7 @@ func (ts *Server) GetShardServingTypes(ctx context.Context, si *ShardInfo) (serv
 	var mu sync.Mutex
 	for _, cell := range cells {
 		wg.Add(1)
-		go func(cell, keyspace string) {
+		go func(cell string) {
 			defer wg.Done()
 			srvKeyspace, err := ts.GetSrvKeyspace(ctx, cell, si.keyspace)
 			switch {
@@ -223,7 +223,7 @@ func (ts *Server) GetShardServingTypes(ctx context.Context, si *ShardInfo) (serv
 				rec.RecordError(err)
 				return
 			}
-		}(cell, si.Keyspace())
+		}(cell)
 	}
 	wg.Wait()
 	if rec.HasErrors() {
@@ -613,10 +613,8 @@ func (ts *Server) MigrateServedType(ctx context.Context, keyspace string, shards
 			case IsErrType(err, NoNode):
 				// Assuming this cell is not active, nothing to do.
 			default:
-				if err != nil {
-					rec.RecordError(err)
-					return
-				}
+				rec.RecordError(err)
+				return
 			}
 		}(cell, keyspace)
 	}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -443,21 +443,20 @@ func (ts *Server) CreateTablet(ctx context.Context, tablet *topodatapb.Tablet) e
 		return err
 	}
 	tabletPath := path.Join(TabletsPath, topoproto.TabletAliasString(tablet.Alias), TabletFile)
-	if _, err = conn.Create(ctx, tabletPath, data); err != nil {
+	if _, err := conn.Create(ctx, tabletPath, data); err != nil {
 		return err
 	}
 
-	if updateErr := UpdateTabletReplicationData(ctx, ts, tablet); updateErr != nil {
-		return updateErr
+	if err := UpdateTabletReplicationData(ctx, ts, tablet); err != nil {
+		return err
 	}
 
-	if err == nil {
-		event.Dispatch(&events.TabletChange{
-			Tablet: tablet,
-			Status: "created",
-		})
-	}
-	return err
+	event.Dispatch(&events.TabletChange{
+		Tablet: tablet,
+		Status: "created",
+	})
+
+	return nil
 }
 
 // DeleteTablet wraps the underlying conn.Delete

--- a/go/vt/topo/test/trylock.go
+++ b/go/vt/topo/test/trylock.go
@@ -138,7 +138,7 @@ func checkTryLockTimeout(ctx context.Context, t *testing.T, conn topo.Conn) {
 
 	// test we can't unlock again
 	if err := lockDescriptor.Unlock(ctx); err == nil {
-		require.Fail(t, "Unlock failed", err.Error())
+		require.Fail(t, "Unlock succeeded but should not have")
 	}
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

More nilness cleanup, along with tightening error scopes to fix a scoping issue that presented itself as a nilness violation. Remove unused goroutine variables while here.

```
✔ ~/src/github.com/vitessio/vitess/go/vt/topo [main|✔] 
15:39 $ nilness ./...
/home/matt/src/github.com/vitessio/vitess/go/vt/topo/srv_keyspace.go:616:12: tautological condition: non-nil != nil
/home/matt/src/github.com/vitessio/vitess/go/vt/topo/tablet.go:454:9: tautological condition: nil == nil
/home/matt/src/github.com/vitessio/vitess/go/vt/topo/test/trylock.go:141:45: nil dereference in dynamic method call
```

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Updates https://github.com/vitessio/vitess/issues/14684.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

n/a

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
