### PR TITLE
go/vt/wrangler: fix nilness issues and unused variable

### DIFF
--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -318,13 +318,11 @@ func (wr *Wrangler) MoveTables(ctx context.Context, workflow, sourceKeyspace, ta
 				return err
 			}
 		}
-		if vschema != nil {
-			// We added to the vschema.
-			if err := wr.ts.SaveVSchema(ctx, targetKeyspace, vschema); err != nil {
-				return err
-			}
-		}
 
+		// We added to the vschema.
+		if err := wr.ts.SaveVSchema(ctx, targetKeyspace, vschema); err != nil {
+			return err
+		}
 	}
 	if err := wr.ts.RebuildSrvVSchema(ctx, nil); err != nil {
 		return err

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1920,9 +1920,6 @@ func (ts *trafficSwitcher) addParticipatingTablesToKeyspace(ctx context.Context,
 		if err := json2.Unmarshal([]byte(wrap), ks); err != nil {
 			return err
 		}
-		if err != nil {
-			return err
-		}
 		for table, vtab := range ks.Tables {
 			vschema.Tables[table] = vtab
 		}

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -661,9 +661,6 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row sqltype
 	workflowSubType, _ = row.ToInt32("workflow_sub_type")
 	deferSecondaryKeys, _ = row.ToBool("defer_secondary_keys")
 	rowsCopied = row.AsInt64("rows_copied", 0)
-	if err != nil {
-		return nil, "", err
-	}
 
 	status := &ReplicationStatus{
 		Shard:                primary.Shard,
@@ -701,8 +698,8 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 	var rsr ReplicationStatusResult
 	rsr.ShardStatuses = make(map[string]*ShardReplicationStatus)
 	rsr.Workflow = workflow
-	var results map[*topo.TabletInfo]*querypb.QueryResult
-	query := `select 
+
+	const query = `select
 		id,
 		source,
 		pos,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Fixes:

```
✔ ~/src/github.com/vitessio/vitess/go/vt/wrangler [main|✔] 
16:02 $ nilness ./...
/home/matt/src/github.com/vitessio/vitess/go/vt/wrangler/materializer.go:321:14: tautological condition: non-nil != nil
/home/matt/src/github.com/vitessio/vitess/go/vt/wrangler/traffic_switcher.go:1923:10: impossible condition: nil != nil
/home/matt/src/github.com/vitessio/vitess/go/vt/wrangler/vexec.go:664:9: impossible condition: nil != nil
```

The results map I've removed was immediately shadowed on old line 725. I marked the query string as const as well just to add a bit more safety.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Updates https://github.com/vitessio/vitess/issues/14684.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

n/a

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
