### PR TITLE
Debug vars: Expose build version in `/debug/vars`

### DIFF
--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -121,6 +121,7 @@ func init() {
 	stats.NewString("BuildHost").Set(AppVersion.buildHost)
 	stats.NewString("BuildUser").Set(AppVersion.buildUser)
 	stats.NewGauge("BuildTimestamp", "build timestamp").Set(AppVersion.buildTime)
+	stats.NewString("BuildVersion").Set(AppVersion.version)
 	stats.NewString("BuildGitRev").Set(AppVersion.buildGitRev)
 	stats.NewString("BuildGitBranch").Set(AppVersion.buildGitBranch)
 	stats.NewGauge("BuildNumber", "build number").Set(AppVersion.jenkinsBuildNumber)
@@ -128,11 +129,12 @@ func init() {
 	stats.NewString("GoOS").Set(AppVersion.goOS)
 	stats.NewString("GoArch").Set(AppVersion.goArch)
 
-	buildLabels := []string{"BuildHost", "BuildUser", "BuildTimestamp", "BuildGitRev", "BuildGitBranch", "BuildNumber"}
+	buildLabels := []string{"BuildHost", "BuildUser", "BuildTimestamp", "BuildVersion", "BuildGitRev", "BuildGitBranch", "BuildNumber"}
 	buildValues := []string{
 		AppVersion.buildHost,
 		AppVersion.buildUser,
 		fmt.Sprintf("%v", AppVersion.buildTime),
+		AppVersion.version,
 		AppVersion.buildGitRev,
 		AppVersion.buildGitBranch,
 		fmt.Sprintf("%v", AppVersion.jenkinsBuildNumber),

--- a/web/vtadmin/src/util/tabletDebugVars.ts
+++ b/web/vtadmin/src/util/tabletDebugVars.ts
@@ -33,6 +33,7 @@ export type TabletDebugVars = Partial<{
     BuildNumber: string;
     BuildTimestamp: string;
     BuildUser: string;
+    BuildVersion: string;
 
     QPS: { [k: string]: number[] };
 


### PR DESCRIPTION
## Description

Expose `BuildVersion` (as defined in [`go/vt/servenv/version.go`
](https://github.com/vitessio/vitess/blob/main/go/vt/servenv/version.go)) via `/debug/vars`. Allows programmatic access to the build version.

## Related Issue(s)

Needs Issue

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

N/A