### PR TITLE
fix: flush tables with read lock to run only with reserved connection

### DIFF
--- a/go/vt/vttablet/endtoend/reserve_test.go
+++ b/go/vt/vttablet/endtoend/reserve_test.go
@@ -28,8 +28,6 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"
 )
 
-//TODO: Add Counter checks in all the tests.
-
 func TestMultipleReserveHaveDifferentConnection(t *testing.T) {
 	framework.Server.Config().EnableSettingsPool = false
 	defer func() {
@@ -1186,6 +1184,19 @@ func TestReserveQueryTimeout(t *testing.T) {
 		client.Release())
 
 	_, err = client.ReserveStreamExecute("select sleep(19)", []string{"set sql_mode = ''"}, nil)
+	assert.NoError(t, err)
+	assert.NoError(t,
+		client.Release())
+}
+
+// TestReserveFlushTables checks that `flush table with read lock` works only with reserve api.
+func TestReserveFlushTables(t *testing.T) {
+	client := framework.NewClient()
+
+	_, err := client.Execute("flush tables with read lock", nil)
+	assert.ErrorContains(t, err, "Flush not allowed without reserved connection")
+
+	_, err = client.ReserveExecute("flush tables with read lock", nil, nil)
 	assert.NoError(t, err)
 	assert.NoError(t,
 		client.Release())

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -246,7 +246,7 @@ func Build(statement sqlparser.Statement, tables map[string]*schema.Table, dbNam
 	case *sqlparser.Load:
 		plan, err = &Plan{PlanID: PlanLoad}, nil
 	case *sqlparser.Flush:
-		plan, err = &Plan{PlanID: PlanFlush, FullQuery: GenerateFullQuery(stmt)}, nil
+		plan, err = analyzeFlush(stmt, tables)
 	case *sqlparser.CallProc:
 		plan, err = &Plan{PlanID: PlanCallProc, FullQuery: GenerateFullQuery(stmt)}, nil
 	default:

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -939,6 +939,25 @@ options:PassthroughDMLs
   "FullQuery": "flush tables a, b"
 }
 
+# flush statement with read lock
+"flush tables a,b with read lock"
+{
+  "PlanID": "Flush",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    },
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "flush tables a, b with read lock",
+  "NeedsReservedConn": true
+}
+
 # call proc
 "call getAllTheThings()"
 {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -109,7 +109,7 @@ func (ep *TabletPlan) IsValid(hasReservedCon, hasSysSettings bool) error {
 
 func isValid(planType planbuilder.PlanType, hasReservedCon bool, hasSysSettings bool) error {
 	switch planType {
-	case planbuilder.PlanSelectLockFunc, planbuilder.PlanDDL:
+	case planbuilder.PlanSelectLockFunc, planbuilder.PlanDDL, planbuilder.PlanFlush:
 		if hasReservedCon {
 			return nil
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR makes `Flush Tables With Read Lock` to run with a dedicated connection so that VTGate session can track the connection and use it to execute `Unlock Tables` on it or if the VTGate session is closed, the connection can be closed as well. This prevents other sessions from being stuck forever for the `unlock` of tables.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/14719

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
