### PR TITLE
Fix typo for `--cells` flag help description in `ApplyRoutingRules`

### DIFF
--- a/go/cmd/vtctldclient/command/routing_rules.go
+++ b/go/cmd/vtctldclient/command/routing_rules.go
@@ -148,7 +148,7 @@ func commandGetRoutingRules(cmd *cobra.Command, args []string) error {
 func init() {
 	ApplyRoutingRules.Flags().StringVarP(&applyRoutingRulesOptions.Rules, "rules", "r", "", "Routing rules, specified as a string.")
 	ApplyRoutingRules.Flags().StringVarP(&applyRoutingRulesOptions.RulesFilePath, "rules-file", "f", "", "Path to a file containing routing rules specified as JSON.")
-	ApplyRoutingRules.Flags().StringSliceVarP(&applyRoutingRulesOptions.Cells, "cells", "c", nil, "Limit the VSchema graph rebuildingg to the specified cells. Ignored if --skip-rebuild is specified.")
+	ApplyRoutingRules.Flags().StringSliceVarP(&applyRoutingRulesOptions.Cells, "cells", "c", nil, "Limit the VSchema graph rebuilding to the specified cells. Ignored if --skip-rebuild is specified.")
 	ApplyRoutingRules.Flags().BoolVar(&applyRoutingRulesOptions.SkipRebuild, "skip-rebuild", false, "Skip rebuilding the SrvVSchema objects.")
 	ApplyRoutingRules.Flags().BoolVarP(&applyRoutingRulesOptions.DryRun, "dry-run", "d", false, "Load the specified routing rules as a validation step, but do not actually apply the rules to the topo.")
 	Root.AddCommand(ApplyRoutingRules)


### PR DESCRIPTION
## Description
While reading through the documentation for `ApplyRoutingRules`, I noticed this typo in the flag. This pull request fixes that.


## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

N/A