### PR TITLE
fix: insert on duplicate key update missing BindVars

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -31,9 +31,9 @@ func TestInsertOnDuplicateKey(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()
 
-	utils.Exec(t, conn, "insert into t10(id, sharding_key, col1, col2, col3) values(1, 2, 'a', 1, 2)")
-	utils.Exec(t, conn, "insert into t10(id, sharding_key, col1, col2, col3) values(1, 2, 'a', 1, 2) on duplicate key update id=10;")
-	utils.AssertMatches(t, conn, "select id, sharding_key from t10 where id=10", "[[INT64(10) INT64(2)] ")
+	utils.Exec(t, conn, "insert into t11(id, sharding_key, col1, col2, col3) values(1, 2, 'a', 1, 2)")
+	utils.Exec(t, conn, "insert into t11(id, sharding_key, col1, col2, col3) values(1, 2, 'a', 1, 2) on duplicate key update id=10;")
+	utils.AssertMatches(t, conn, "select id, sharding_key from t11 where id=10", "[[INT64(10) INT64(2)]]")
 
 }
 

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -27,6 +27,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInsertOnDuplicateKey(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	utils.Exec(t, conn, "insert into t10(id, sharding_key, col1, col2, col3) values(1, 2, 'a', 1, 2)")
+	utils.Exec(t, conn, "insert into t10(id, sharding_key, col1, col2, col3) values(1, 2, 'a', 1, 2) on duplicate key update id=10;")
+	utils.AssertMatches(t, conn, "select id, sharding_key from t10 where id=10", "[[INT64(10) INT64(2)] ")
+
+}
+
 func TestInsertNeg(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/schema.sql
+++ b/go/test/endtoend/vtgate/schema.sql
@@ -155,3 +155,13 @@ create table t10_id_to_keyspace_id_idx
     keyspace_id varbinary(10),
     primary key (id)
 ) Engine = InnoDB;
+
+create table t11
+(
+    id           bigint,
+    sharding_key bigint,
+    col1 varchar(50),
+    col2 int,
+    col3 int,
+    primary key (id)
+) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/vschema.json
+++ b/go/test/endtoend/vtgate/vschema.json
@@ -1,11 +1,10 @@
-
 {
   "sharded": true,
   "vindexes": {
-    "unicode_loose_xxhash" : {
+    "unicode_loose_xxhash": {
       "type": "unicode_loose_xxhash"
     },
-    "unicode_loose_md5" : {
+    "unicode_loose_md5": {
       "type": "unicode_loose_md5"
     },
     "hash": {
@@ -159,7 +158,10 @@
           "name": "hash"
         },
         {
-          "columns": ["id2", "id1"],
+          "columns": [
+            "id2",
+            "id1"
+          ],
           "name": "t4_id2_vdx"
         }
       ]
@@ -179,7 +181,10 @@
           "name": "hash"
         },
         {
-          "columns": ["id2", "id1"],
+          "columns": [
+            "id2",
+            "id1"
+          ],
           "name": "t6_id2_vdx"
         }
       ]
@@ -298,6 +303,14 @@
       "column_vindexes": [
         {
           "column": "id",
+          "name": "hash"
+        }
+      ]
+    },
+    "t11": {
+      "column_vindexes": [
+        {
+          "column": "sharding_key",
           "name": "hash"
         }
       ]

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -386,7 +386,7 @@ func (cached *Insert) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(192)
+		size += int64(208)
 	}
 	// field InsertCommon vitess.io/vitess/go/vt/vtgate/engine.InsertCommon
 	size += cached.InsertCommon.CachedSize(false)
@@ -433,7 +433,7 @@ func (cached *InsertCommon) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(128)
+		size += int64(144)
 	}
 	// field Keyspace *vitess.io/vitess/go/vt/vtgate/vindexes.Keyspace
 	size += cached.Keyspace.CachedSize(true)
@@ -450,8 +450,13 @@ func (cached *InsertCommon) CachedSize(alloc bool) int64 {
 	}
 	// field Prefix string
 	size += hack.RuntimeAllocSize(int64(len(cached.Prefix)))
-	// field Suffix string
-	size += hack.RuntimeAllocSize(int64(len(cached.Suffix)))
+	// field Suffix vitess.io/vitess/go/vt/sqlparser.OnDup
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Suffix)) * int64(8))
+		for _, elem := range cached.Suffix {
+			size += elem.CachedSize(true)
+		}
+	}
 	return size
 }
 func (cached *InsertSelect) CachedSize(alloc bool) int64 {

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"vitess.io/vitess/go/vt/sqlparser"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -73,7 +75,7 @@ type (
 
 		// Prefix, Suffix are for sharded insert plans.
 		Prefix string
-		Suffix string
+		Suffix sqlparser.OnDup
 
 		// Insert needs tx handling
 		txNeeded

--- a/go/vt/vtgate/engine/insert_select.go
+++ b/go/vt/vtgate/engine/insert_select.go
@@ -56,7 +56,7 @@ func newInsertSelect(
 	keyspace *vindexes.Keyspace,
 	table *vindexes.Table,
 	prefix string,
-	suffix string,
+	suffix sqlparser.OnDup,
 	vv [][]int,
 	input Primitive,
 ) *InsertSelect {
@@ -172,7 +172,7 @@ func (ins *InsertSelect) getInsertUnshardedQuery(rows []sqltypes.Row, bindVars m
 		}
 		mids = append(mids, row)
 	}
-	return ins.Prefix + sqlparser.String(mids) + ins.Suffix
+	return ins.Prefix + sqlparser.String(mids) + sqlparser.String(ins.Suffix)
 }
 
 func (ins *InsertSelect) insertIntoShardedTable(
@@ -270,7 +270,7 @@ func (ins *InsertSelect) getInsertShardedQueries(
 				mids = append(mids, row)
 			}
 		}
-		rewritten := ins.Prefix + sqlparser.String(mids) + ins.Suffix
+		rewritten := ins.Prefix + sqlparser.String(mids) + sqlparser.String(ins.Suffix)
 		queries[i] = &querypb.BoundQuery{
 			Sql:           rewritten,
 			BindVariables: bvs,

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -213,9 +213,7 @@ func TestInsertShardedSimple(t *testing.T) {
 		sqlparser.Values{
 			{&sqlparser.Argument{Name: "_id_0", Type: sqltypes.Int64}},
 		},
-		/*sqlparser.OnDup{
-			&sqlparser.UpdateExpr{Name: sqlparser.NewColName(" suffix"), Expr: &sqlparser.NullVal{}},
-		}*/nil,
+		nil,
 	)
 	vc := newDMLTestVCursor("-20", "20-")
 	vc.shardForKsid = []string{"20-", "-20", "20-"}
@@ -254,9 +252,6 @@ func TestInsertShardedSimple(t *testing.T) {
 			{&sqlparser.Argument{Name: "_id_1", Type: sqltypes.Int64}},
 			{&sqlparser.Argument{Name: "_id_2", Type: sqltypes.Int64}},
 		},
-		/*sqlparser.OnDup{
-			&sqlparser.UpdateExpr{Name: sqlparser.NewColName(" suffix"), Expr: &sqlparser.NullVal{}},
-		}*/
 		nil,
 	)
 	vc = newDMLTestVCursor("-20", "20-")
@@ -298,9 +293,6 @@ func TestInsertShardedSimple(t *testing.T) {
 			{&sqlparser.Argument{Name: "_id_1", Type: sqltypes.Int64}},
 			{&sqlparser.Argument{Name: "_id_2", Type: sqltypes.Int64}},
 		},
-		/*sqlparser.OnDup{
-			&sqlparser.UpdateExpr{Name: sqlparser.NewColName(" suffix"), Expr: &sqlparser.NullVal{}},
-		}*/
 		nil,
 	)
 	ins.MultiShardAutocommit = true

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -590,7 +590,7 @@ func autoIncGenerate(gen *operators.Generate) *engine.Generate {
 	}
 }
 
-func generateInsertShardedQuery(ins *sqlparser.Insert) (prefix string, mids sqlparser.Values, suffix string) {
+func generateInsertShardedQuery(ins *sqlparser.Insert) (prefix string, mids sqlparser.Values, suffix sqlparser.OnDup) {
 	mids, isValues := ins.Rows.(sqlparser.Values)
 	prefixFormat := "insert %v%sinto %v%v "
 	if isValues {
@@ -605,9 +605,7 @@ func generateInsertShardedQuery(ins *sqlparser.Insert) (prefix string, mids sqlp
 		ins.Table, ins.Columns)
 	prefix = prefixBuf.String()
 
-	suffixBuf := sqlparser.NewTrackedBuffer(dmlFormatter)
-	suffixBuf.Myprintf("%v", ins.OnDup)
-	suffix = suffixBuf.String()
+	suffix = ins.OnDup
 	return
 }
 

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -605,7 +605,13 @@ func generateInsertShardedQuery(ins *sqlparser.Insert) (prefix string, mids sqlp
 		ins.Table, ins.Columns)
 	prefix = prefixBuf.String()
 
-	suffix = ins.OnDup
+	suffix = sqlparser.CopyOnRewrite(ins.OnDup, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
+		if tblName, ok := cursor.Node().(sqlparser.TableName); ok {
+			if tblName.Qualifier != sqlparser.NewIdentifierCS("") {
+				cursor.Replace(sqlparser.NewTableName(tblName.Name.String()))
+			}
+		}
+	}, nil).(sqlparser.OnDup)
 	return
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -4899,5 +4899,33 @@
     "comment": "insert row values greater than number of columns",
     "query": "insert into user(one, two, three) values (1, 2, 3, 4)",
     "plan": "VT03006: column count does not match value count at row 1"
+  },
+  {
+    "comment": "insert on duplicate key update with database qualifier",
+    "query": "insert into user.music(id, user_id, col) values (1, 2, 3) on duplicate key update user.music.col = 5",
+    "plan": {
+      "QueryType": "INSERT",
+      "Original": "insert into user.music(id, user_id, col) values (1, 2, 3) on duplicate key update user.music.col = 5",
+      "Instructions": {
+        "OperatorType": "Insert",
+        "Variant": "Sharded",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "TargetTabletType": "PRIMARY",
+        "InsertIgnore": true,
+        "Query": "insert into music(id, user_id, col) values (:_id_0, :_user_id_0, 3) on duplicate key update music.col = 5",
+        "TableName": "music",
+        "VindexValues": {
+          "music_user_map": "1",
+          "user_index": "2"
+        }
+      },
+      "TablesUsed": [
+        "user.music"
+      ]
+    }
   }
+
 ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
"In V18, the addition of trimming bound variables during insert needs to be included for each shard in this pull request: https://github.com/vitessio/vitess/pull/14064.  However, the scenario of 'insert on duplicate key' has been overlooked, and the bound variables added are not included for 'on duplicate key' variables."


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/14729

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
