### PR TITLE
TabletServer: Handle nil targets properly everywhere

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -39,13 +39,9 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 var (
-	// messageManager only runs on primary tablets.
-	queryTarget = &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-
 	// MessageStats tracks stats for messages.
 	MessageStats = stats.NewGaugesWithMultiLabels(
 		"Messages",
@@ -639,7 +635,7 @@ func (mm *messageManager) postpone(ctx context.Context, tsv TabletService, ackWa
 	defer mm.postponeSema.Release(1)
 	ctx, cancel := context.WithTimeout(tabletenv.LocalContext(), ackWaitTime)
 	defer cancel()
-	if _, err := tsv.PostponeMessages(ctx, queryTarget, mm, ids); err != nil {
+	if _, err := tsv.PostponeMessages(ctx, nil, mm, ids); err != nil {
 		// This can happen during spikes. Record the incident for monitoring.
 		MessageStats.Add([]string{mm.name.String(), "PostponeFailed"}, 1)
 	}
@@ -837,7 +833,7 @@ func (mm *messageManager) runPurge() {
 			cancel()
 		}()
 		for {
-			count, err := mm.tsv.PurgeMessages(ctx, queryTarget, mm, time.Now().Add(-mm.purgeAfter).UnixNano())
+			count, err := mm.tsv.PurgeMessages(ctx, nil, mm, time.Now().Add(-mm.purgeAfter).UnixNano())
 			if err != nil {
 				MessageStats.Add([]string{mm.name.String(), "PurgeFailed"}, 1)
 				log.Errorf("Unable to delete messages: %v", err)

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -66,6 +66,8 @@ func (state servingState) String() string {
 var transitionRetryInterval = 1 * time.Second
 var logInitTime sync.Once
 
+var ErrNoTarget = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "No target")
+
 // stateManager manages state transition for all the TabletServer
 // subcomponents.
 type stateManager struct {
@@ -433,7 +435,7 @@ func (sm *stateManager) verifyTargetLocked(ctx context.Context, target *querypb.
 		}
 	} else {
 		if !tabletenv.IsLocalContext(ctx) {
-			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "No target")
+			return ErrNoTarget
 		}
 	}
 	return nil

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -610,7 +610,7 @@ func (tsv *TabletServer) Commit(ctx context.Context, target *querypb.Target, tra
 			// handlePanicAndSendLogStats doesn't log the no-op.
 			if commitSQL != "" {
 				tsv.stats.QueryTimings.Record("COMMIT", startTime)
-				// With a tabletenv.LocalContext() the target is nil.
+				// With a tabletenv.LocalContext() the target can be nil.
 				if target != nil {
 					tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), startTime)
 				}
@@ -631,7 +631,7 @@ func (tsv *TabletServer) Rollback(ctx context.Context, target *querypb.Target, t
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("ROLLBACK", time.Now())
-			// With a tabletenv.LocalContext() the target is nil.
+			// With a tabletenv.LocalContext() the target can be nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1249,7 +1249,7 @@ func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *queryp
 		target, options, false, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			// With a tabletenv.LocalContext() the target is nil.
+			// With a tabletenv.LocalContext() the target can be nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1298,7 +1298,7 @@ func (tsv *TabletServer) ReserveBeginStreamExecute(
 		target, options, false, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			// With a tabletenv.LocalContext() the target is nil.
+			// With a tabletenv.LocalContext() the target can be nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1355,7 +1355,7 @@ func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Tar
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			// With a tabletenv.LocalContext() the target is nil.
+			// With a tabletenv.LocalContext() the target can be nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1409,7 +1409,7 @@ func (tsv *TabletServer) ReserveStreamExecute(
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			// With a tabletenv.LocalContext() the target is nil.
+			// With a tabletenv.LocalContext() the target can be nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1442,7 +1442,7 @@ func (tsv *TabletServer) Release(ctx context.Context, target *querypb.Target, tr
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RELEASE", time.Now())
-			// With a tabletenv.LocalContext() the target is nil.
+			// With a tabletenv.LocalContext() the target can be nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1529,7 +1529,7 @@ func (tsv *TabletServer) execRequest(
 		span.Annotate("workload_name", options.WorkloadName)
 	}
 	trace.AnnotateSQL(span, sqlparser.Preview(sql))
-	// With a tabletenv.LocalContext() the target is nil.
+	// With a tabletenv.LocalContext() the target can be nil.
 	if target != nil {
 		span.Annotate("cell", target.Cell)
 		span.Annotate("shard", target.Shard)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -551,6 +551,7 @@ func (tsv *TabletServer) begin(ctx context.Context, target *querypb.Target, save
 			logStats.OriginalSQL = beginSQL
 			if beginSQL != "" {
 				tsv.stats.QueryTimings.Record("BEGIN", startTime)
+				// With a tabletenv.LocalContext() the target can be nil.
 				if target != nil {
 					tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), startTime)
 				}
@@ -609,6 +610,7 @@ func (tsv *TabletServer) Commit(ctx context.Context, target *querypb.Target, tra
 			// handlePanicAndSendLogStats doesn't log the no-op.
 			if commitSQL != "" {
 				tsv.stats.QueryTimings.Record("COMMIT", startTime)
+				// With a tabletenv.LocalContext() the target is nil.
 				if target != nil {
 					tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), startTime)
 				}
@@ -629,6 +631,7 @@ func (tsv *TabletServer) Rollback(ctx context.Context, target *querypb.Target, t
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("ROLLBACK", time.Now())
+			// With a tabletenv.LocalContext() the target is nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1246,6 +1249,7 @@ func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *queryp
 		target, options, false, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
+			// With a tabletenv.LocalContext() the target is nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1294,6 +1298,7 @@ func (tsv *TabletServer) ReserveBeginStreamExecute(
 		target, options, false, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
+			// With a tabletenv.LocalContext() the target is nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1350,6 +1355,7 @@ func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Tar
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
+			// With a tabletenv.LocalContext() the target is nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1403,6 +1409,7 @@ func (tsv *TabletServer) ReserveStreamExecute(
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
+			// With a tabletenv.LocalContext() the target is nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1435,6 +1442,7 @@ func (tsv *TabletServer) Release(ctx context.Context, target *querypb.Target, tr
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RELEASE", time.Now())
+			// With a tabletenv.LocalContext() the target is nil.
 			if target != nil {
 				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
 			}
@@ -1521,6 +1529,7 @@ func (tsv *TabletServer) execRequest(
 		span.Annotate("workload_name", options.WorkloadName)
 	}
 	trace.AnnotateSQL(span, sqlparser.Preview(sql))
+	// With a tabletenv.LocalContext() the target is nil.
 	if target != nil {
 		span.Annotate("cell", target.Cell)
 		span.Annotate("shard", target.Shard)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -602,7 +602,7 @@ func (tsv *TabletServer) resolveTargetType(ctx context.Context, target *querypb.
 		return topodatapb.TabletType_UNKNOWN, ErrNoTarget
 	}
 	if tsv.sm.Target() == nil {
-		return topodatapb.TabletType_UNKNOWN, nil // This is true, and does not block the request.
+		return topodatapb.TabletType_UNKNOWN, nil // This is true, and does not block the request
 	}
 	return tsv.sm.Target().TabletType, nil
 }
@@ -1471,7 +1471,6 @@ func (tsv *TabletServer) Release(ctx context.Context, target *querypb.Target, tr
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RELEASE", time.Now())
-
 			targetType, err := tsv.resolveTargetType(ctx, target)
 			if err != nil {
 				return err

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -166,7 +166,7 @@ func NewTabletServer(ctx context.Context, name string, config *tabletenv.TabletC
 	tsOnce.Do(func() { srvTopoServer = srvtopo.NewResilientServer(ctx, topoServer, "TabletSrvTopo") })
 
 	tabletTypeFunc := func() topodatapb.TabletType {
-		if tsv.sm == nil {
+		if tsv.sm == nil || tsv.sm.Target() == nil {
 			return topodatapb.TabletType_UNKNOWN
 		}
 		return tsv.sm.Target().TabletType

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -551,7 +551,9 @@ func (tsv *TabletServer) begin(ctx context.Context, target *querypb.Target, save
 			logStats.OriginalSQL = beginSQL
 			if beginSQL != "" {
 				tsv.stats.QueryTimings.Record("BEGIN", startTime)
-				tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), startTime)
+				if target != nil {
+					tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), startTime)
+				}
 			} else {
 				logStats.Method = ""
 			}
@@ -607,7 +609,9 @@ func (tsv *TabletServer) Commit(ctx context.Context, target *querypb.Target, tra
 			// handlePanicAndSendLogStats doesn't log the no-op.
 			if commitSQL != "" {
 				tsv.stats.QueryTimings.Record("COMMIT", startTime)
-				tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), startTime)
+				if target != nil {
+					tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), startTime)
+				}
 			} else {
 				logStats.Method = ""
 			}
@@ -625,7 +629,9 @@ func (tsv *TabletServer) Rollback(ctx context.Context, target *querypb.Target, t
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("ROLLBACK", time.Now())
-			defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			if target != nil {
+				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			}
 			logStats.TransactionID = transactionID
 			newReservedID, err = tsv.te.Rollback(ctx, transactionID)
 			if newReservedID > 0 {
@@ -1240,7 +1246,9 @@ func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *queryp
 		target, options, false, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			if target != nil {
+				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			}
 			connID, sessionStateChanges, err = tsv.te.ReserveBegin(ctx, options, preQueries, postBeginQueries)
 			if err != nil {
 				return err
@@ -1286,7 +1294,9 @@ func (tsv *TabletServer) ReserveBeginStreamExecute(
 		target, options, false, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			if target != nil {
+				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			}
 			connID, sessionStateChanges, err = tsv.te.ReserveBegin(ctx, options, preQueries, postBeginQueries)
 			if err != nil {
 				return err
@@ -1340,7 +1350,9 @@ func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Tar
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			if target != nil {
+				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			}
 			state.ReservedID, err = tsv.te.Reserve(ctx, options, transactionID, preQueries)
 			if err != nil {
 				return err
@@ -1391,7 +1403,9 @@ func (tsv *TabletServer) ReserveStreamExecute(
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			if target != nil {
+				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			}
 			state.ReservedID, err = tsv.te.Reserve(ctx, options, transactionID, preQueries)
 			if err != nil {
 				return err
@@ -1421,7 +1435,9 @@ func (tsv *TabletServer) Release(ctx context.Context, target *querypb.Target, tr
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RELEASE", time.Now())
-			defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			if target != nil {
+				defer tsv.stats.QueryTimingsByTabletType.Record(target.TabletType.String(), time.Now())
+			}
 			logStats.TransactionID = transactionID
 			logStats.ReservedID = reservedID
 			if reservedID != 0 {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -602,7 +602,7 @@ func (tsv *TabletServer) resolveTargetType(ctx context.Context, target *querypb.
 		return topodatapb.TabletType_UNKNOWN, ErrNoTarget
 	}
 	if tsv.sm.Target() == nil {
-		return topodatapb.TabletType_UNKNOWN, ErrNoTarget
+		return topodatapb.TabletType_UNKNOWN, nil // This is true, and does not block the request.
 	}
 	return tsv.sm.Target().TabletType, nil
 }

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -566,12 +566,28 @@ func TestTabletServerCommitPrepared(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestTabletServerWithNilTarget confirms that a nil target is
+// handled correctly. This means that when a local context is
+// used, the target type is inferred from the local tablet's
+// latest target type.
+// And if it's not a local context then we return an error.
 func TestTabletServerWithNilTarget(t *testing.T) {
 	// A non-nil target is required when not using a local context.
 	ctx := tabletenv.LocalContext()
 	db, tsv := setupTabletServerTest(t, ctx, "")
 	defer tsv.StopService()
 	defer db.Close()
+
+	// With a nil target, the local tablet's latest target type is
+	// what should be used as the inferred target type for our local
+	// calls.
+	target := (*querypb.Target)(nil)
+	localTargetType := topodatapb.TabletType_RDONLY // Use a non-default type
+	err := tsv.SetServingType(localTargetType, time.Now(), true, "test")
+	require.NoError(t, err)
+
+	baseKey := "TabletServerTest" // Our TabletServer's name
+	fullKey := fmt.Sprintf("%s.%s", baseKey, localTargetType.String())
 
 	executeSQL := "select * from test_table limit 1000"
 	executeSQLResult := &sqltypes.Result{
@@ -582,15 +598,44 @@ func TestTabletServerWithNilTarget(t *testing.T) {
 			{sqltypes.NewVarBinary("row01")},
 		},
 	}
+	// BEGIN gets transmuted to this since it's a RDONLY tablet.
+	db.AddQuery("start transaction read only", &sqltypes.Result{})
 	db.AddQuery(executeSQL, executeSQLResult)
 
-	target := (*querypb.Target)(nil)
+	expectedCount := tsv.stats.QueryTimingsByTabletType.Counts()[fullKey]
+
 	state, err := tsv.Begin(ctx, target, nil)
 	require.NoError(t, err)
+	expectedCount++
+	require.Equal(t, expectedCount, tsv.stats.QueryTimingsByTabletType.Counts()[fullKey])
+
 	_, err = tsv.Execute(ctx, target, executeSQL, nil, state.TransactionID, 0, nil)
 	require.NoError(t, err)
+	expectedCount++
+	require.Equal(t, expectedCount, tsv.stats.QueryTimingsByTabletType.Counts()[fullKey])
+
 	_, err = tsv.Rollback(ctx, target, state.TransactionID)
 	require.NoError(t, err)
+	expectedCount++
+	require.Equal(t, expectedCount, tsv.stats.QueryTimingsByTabletType.Counts()[fullKey])
+
+	state, err = tsv.Begin(ctx, target, nil)
+	require.NoError(t, err)
+	expectedCount++
+	require.Equal(t, expectedCount, tsv.stats.QueryTimingsByTabletType.Counts()[fullKey])
+
+	_, err = tsv.Commit(ctx, target, state.TransactionID)
+	require.NoError(t, err)
+	expectedCount++
+	require.Equal(t, expectedCount, tsv.stats.QueryTimingsByTabletType.Counts()[fullKey])
+
+	// Finally be sure that we return an error now as expected when NOT
+	// using a local context but passing a nil target.
+	nonLocalCtx := context.Background()
+	_, err = tsv.Begin(nonLocalCtx, target, nil)
+	require.True(t, errors.Is(err, ErrNoTarget))
+	_, err = tsv.resolveTargetType(nonLocalCtx, target)
+	require.True(t, errors.Is(err, ErrNoTarget))
 }
 
 func TestSmallerTimeout(t *testing.T) {


### PR DESCRIPTION
## Description

When executing queries locally using the local TabletServer, you use a `tabletenv.LocalContext`: https://github.com/vitessio/vitess/blob/main/go/vt/vttablet/tabletserver/tabletenv/local_context.go

And when using this the target tablet is `nil` (or at least it can be) — otherwise an error is returned. For example: https://github.com/vitessio/vitess/blob/08b2c8bcb3f2cb91831ce0927ce9fdf95da7df16/go/vt/vttablet/tabletserver/state_manager.go#L419-L440

You can see all checks for it here: https://github.com/search?q=repo%3Avitessio%2Fvitess%20IsLocalContext&type=code

And you can see the uses of it here (all the locations impacted by the bug): https://github.com/search?q=repo%3Avitessio%2Fvitess%20tabletenv.LocalContext&type=code

This means that in the TabletServer code we can never assume that the target is not nil and we need to check for it. We added some new places where we use that variable in https://github.com/vitessio/vitess/pull/13521 for stats, but we didn't add a nil check. So this PR adds that along with a unit test.

The new unit test fails on `main`:
```
❯ go test -timeout 30s -run ^TestTabletServerWithNilTarget$ vitess.io/vitess/go/vt/vttablet/tabletserver
E1208 11:31:06.168089   61524 server.go:438] Query not found: set @@session.sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
E1208 11:31:06.196732   61524 throttler.go:477] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: keyspaces/SrvKeyspace
E1208 11:31:06.200858   61524 server.go:438] Query not found: show full tables like '\_vt\_%'
E1208 11:31:06.200922   61524 tablegc.go:281] TableGC: error while reading tables: unknown error: fakesqldb:: query: 'show full tables like '\_vt\_%'' is not supported on fakesqldb (errno 1105) (sqlstate HY000) during query: show full tables like '\_vt\_%'
E1208 11:31:06.202038   61524 tabletserver.go:1560] Uncaught panic for Sql: "begin", BindVars: {}:
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:261 (0x104ba71bb)
	panicmem: panic(memoryError)
/usr/local/go/src/runtime/signal_unix.go

...
```

## Related Issue(s)
 
  - Follow-up to: https://github.com/vitessio/vitess/pull/13521
  - Fixes: https://github.com/vitessio/vitess/issues/14730

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required