### PR TITLE
mysqld: check for correct return value from WAIT_FOR_EXECUTED_GTID_SET

### DIFF
--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -377,7 +377,7 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.P
 	if result.IsNull() {
 		return fmt.Errorf("%v(%v) failed: replication is probably stopped", waitCommandName, query)
 	}
-	if result.ToString() == "-1" {
+	if result.ToString() == "1" {
 		return fmt.Errorf("timed out waiting for position %v", targetPos)
 	}
 	return nil


### PR DESCRIPTION
## Description
In #14612, we changed how we wait for a primary candidate to catch up to a specific replication position. Specifically for the mysql flavor, instead of using `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` we now use `WAIT_FOR_EXECUTED_GTID_SET`.
However, the two functions return different values on timeout. The old one returns -1, whereas the new one returns 1.
This was causing us to assume that `WaitForSourcePos` was successful when in fact it had timed out, leading to the situation described in #14738.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

I have ignored the MariaDB flavor since we dropped support in v16. In any case, that flavor is executing this command with no timeout specified, which means it will wait indefinitely and return 0.

Right now the only "affected" version is main. However, because #14612 was back ported to all release branches, ~this fix also needs to be back ported and needs to go into the next v18 patch release~ we plan to revert it in all the release branches. Luckily, we haven't actually made any new patch releases after #14612 was merged.

I spent some time trying to come up with a way to unit test this, but ran into the old problem of the complexity of mocking a real mysql. I'll probably spend more time on that later on, but right now we need to get this fixed ASAP.

Proof of the correctness of this change (MySQL only):

```
mysql> SELECT WAIT_FOR_EXECUTED_GTID_SET('b68c0b3c-964e-11ee-812c-32b90e164722:1-42,b95c3986-964e-11ee-a897-d342cf47f4f4:1-66', 4);
+----------------------------------------------------------------------------------------------------------------------+
| WAIT_FOR_EXECUTED_GTID_SET('b68c0b3c-964e-11ee-812c-32b90e164722:1-42,b95c3986-964e-11ee-a897-d342cf47f4f4:1-66', 4) |
+----------------------------------------------------------------------------------------------------------------------+
|                                                                                                                    1 |
+----------------------------------------------------------------------------------------------------------------------+
1 row in set (4.01 sec)

mysql> SELECT WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS('b68c0b3c-964e-11ee-812c-32b90e164722:1-42,b95c3986-964e-11ee-a897-d342cf47f4f4:1-66', 1);
+-----------------------------------------------------------------------------------------------------------------------------+
| WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS('b68c0b3c-964e-11ee-812c-32b90e164722:1-42,b95c3986-964e-11ee-a897-d342cf47f4f4:1-66', 1) |
+-----------------------------------------------------------------------------------------------------------------------------+
|                                                                                                                          -1 |
+-----------------------------------------------------------------------------------------------------------------------------+
1 row in set, 1 warning (1.01 sec)
```

## Related Issue(s)
  - Fixes: #14738 
  - Fixes: #14611

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
EDIT: instead of back porting this PR, we are reverting the original PR on all release branches. That gives us time to debate the code changes and get them right on main for v19.