### PR TITLE
Revert "[release-16.0] Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET` (#14612)"

### DIFF
--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -275,7 +275,7 @@ func (mysqlFlavor) waitUntilPositionCommand(ctx context.Context, pos Position) (
 		}
 	}
 
-	return fmt.Sprintf("SELECT WAIT_FOR_EXECUTED_GTID_SET('%s', %v)", pos, timeoutSeconds), nil
+	return fmt.Sprintf("SELECT WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS('%s', %v)", pos, timeoutSeconds), nil
 }
 
 // readBinlogEvent is part of the Flavor interface.


### PR DESCRIPTION
Reverts vitessio/vitess#14620

because it causes #14738 