### PR TITLE
Replication: Have the DB flavor process waiting for a pos

### DIFF
--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -146,11 +146,9 @@ type flavor interface {
 	// with parsed executed position.
 	primaryStatus(c *Conn) (replication.PrimaryStatus, error)
 
-	// waitUntilPositionCommand returns the SQL command to issue
-	// to wait until the given position, until the context
-	// expires.  The command returns -1 if it times out. It
-	// returns NULL if GTIDs are not enabled.
-	waitUntilPositionCommand(ctx context.Context, pos replication.Position) (string, error)
+	// waitUntilPosition waits until the given position is reached or
+	// until the context expires and returns an error if we did not succeed.
+	waitUntilPosition(ctx context.Context, c *Conn, pos replication.Position) error
 
 	baseShowTables() string
 	baseShowTablesWithSizes() string
@@ -166,7 +164,8 @@ type CapableOf func(capability FlavorCapability) (bool, error)
 var flavors = make(map[string]func() flavor)
 
 // ServerVersionAtLeast returns true if current server is at least given value.
-// Example: if input is []int{8, 0, 23}... the function returns 'true' if we're on MySQL 8.0.23, 8.0.24, ...
+// Example: if input is []int{8, 0, 23}... the function returns 'true' if we're
+// on MySQL 8.0.23, 8.0.24, ...
 func ServerVersionAtLeast(serverVersion string, parts ...int) (bool, error) {
 	versionPrefix := strings.Split(serverVersion, "-")[0]
 	versionTokens := strings.Split(versionPrefix, ".")
@@ -448,21 +447,18 @@ func (c *Conn) ShowPrimaryStatus() (replication.PrimaryStatus, error) {
 	return c.flavor.primaryStatus(c)
 }
 
-// WaitUntilPositionCommand returns the SQL command to issue
-// to wait until the given position, until the context
-// expires.  The command returns -1 if it times out. It
-// returns NULL if GTIDs are not enabled.
-func (c *Conn) WaitUntilPositionCommand(ctx context.Context, pos replication.Position) (string, error) {
-	return c.flavor.waitUntilPositionCommand(ctx, pos)
+// WaitUntilPosition waits until the given position is reached or until the
+// context expires. It returns an error if we did not succeed.
+func (c *Conn) WaitUntilPosition(ctx context.Context, pos replication.Position) error {
+	return c.flavor.waitUntilPosition(ctx, c, pos)
 }
 
-// WaitUntilFilePositionCommand returns the SQL command to issue
-// to wait until the given position, until the context
-// expires for the file position flavor.  The command returns -1 if it times out. It
-// returns NULL if GTIDs are not enabled.
-func (c *Conn) WaitUntilFilePositionCommand(ctx context.Context, pos replication.Position) (string, error) {
+// WaitUntilFilePosition waits until the given position is reached or until
+// the context expires for the file position flavor. It returns an error if
+// we did not succeed.
+func (c *Conn) WaitUntilFilePosition(ctx context.Context, pos replication.Position) error {
 	filePosFlavor := filePosFlavor{}
-	return filePosFlavor.waitUntilPositionCommand(ctx, pos)
+	return filePosFlavor.waitUntilPosition(ctx, c, pos)
 }
 
 // BaseShowTables returns a query that shows tables

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -147,7 +147,8 @@ type flavor interface {
 	primaryStatus(c *Conn) (replication.PrimaryStatus, error)
 
 	// waitUntilPosition waits until the given position is reached or
-	// until the context expires and returns an error if we did not succeed.
+	// until the context expires. It returns an error if we did not
+	// succeed.
 	waitUntilPosition(ctx context.Context, c *Conn, pos replication.Position) error
 
 	baseShowTables() string

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -33,6 +33,7 @@ import (
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/hook"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 type ResetSuperReadOnlyFunc func() error
@@ -333,7 +334,7 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.P
 		// position is most likely reached. So, check the position first.
 		mpos, err := conn.Conn.PrimaryFilePosition()
 		if err != nil {
-			return fmt.Errorf("WaitSourcePos: PrimaryFilePosition failed: %v", err)
+			return vterrors.Wrapf(err, "WaitSourcePos: PrimaryFilePosition failed")
 		}
 		if mpos.AtLeast(targetPos) {
 			return nil
@@ -343,7 +344,7 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.P
 		// position is most likely reached. So, check the position first.
 		mpos, err := conn.Conn.PrimaryPosition()
 		if err != nil {
-			return fmt.Errorf("WaitSourcePos: PrimaryPosition failed: %v", err)
+			return vterrors.Wrapf(err, "WaitSourcePos: PrimaryPosition failed")
 		}
 		if mpos.AtLeast(targetPos) {
 			return nil
@@ -351,7 +352,7 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.P
 	}
 
 	if err := conn.Conn.WaitUntilPosition(ctx, targetPos); err != nil {
-		return fmt.Errorf("WaitSourcePos failed: %v", err)
+		return vterrors.Wrapf(err, "WaitSourcePos failed")
 	}
 	return nil
 }

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -315,7 +315,8 @@ func (mysqld *Mysqld) SetSuperReadOnly(on bool) (ResetSuperReadOnlyFunc, error) 
 	return resetFunc, nil
 }
 
-// WaitSourcePos lets replicas wait to given replication position
+// WaitSourcePos lets replicas wait for the given replication position to
+// be reached.
 func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.Position) error {
 	// Get a connection.
 	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
@@ -324,14 +325,12 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.P
 	}
 	defer conn.Recycle()
 
-	// First check if filePos flavored Position was passed in. If so, we can't defer to the flavor in the connection,
-	// unless that flavor is also filePos.
-	waitCommandName := "WaitUntilPositionCommand"
-	var query string
+	// First check if filePos flavored Position was passed in. If so, we
+	// can't defer to the flavor in the connection, unless that flavor is
+	// also filePos.
 	if targetPos.MatchesFlavor(replication.FilePosFlavorID) {
-		// If we are the primary, WaitUntilFilePositionCommand will fail.
-		// But position is most likely reached. So, check the position
-		// first.
+		// If we are the primary, WaitUntilFilePosition will fail. But
+		// position is most likely reached. So, check the position first.
 		mpos, err := conn.Conn.PrimaryFilePosition()
 		if err != nil {
 			return fmt.Errorf("WaitSourcePos: PrimaryFilePosition failed: %v", err)
@@ -339,17 +338,9 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.P
 		if mpos.AtLeast(targetPos) {
 			return nil
 		}
-
-		// Find the query to run, run it.
-		query, err = conn.Conn.WaitUntilFilePositionCommand(ctx, targetPos)
-		if err != nil {
-			return err
-		}
-		waitCommandName = "WaitUntilFilePositionCommand"
 	} else {
-		// If we are the primary, WaitUntilPositionCommand will fail.
-		// But position is most likely reached. So, check the position
-		// first.
+		// If we are the primary, WaitUntilPosition will fail. But
+		// position is most likely reached. So, check the position first.
 		mpos, err := conn.Conn.PrimaryPosition()
 		if err != nil {
 			return fmt.Errorf("WaitSourcePos: PrimaryPosition failed: %v", err)
@@ -357,28 +348,10 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos replication.P
 		if mpos.AtLeast(targetPos) {
 			return nil
 		}
-
-		// Find the query to run, run it.
-		query, err = conn.Conn.WaitUntilPositionCommand(ctx, targetPos)
-		if err != nil {
-			return err
-		}
 	}
 
-	qr, err := mysqld.FetchSuperQuery(ctx, query)
-	if err != nil {
-		return fmt.Errorf("%v(%v) failed: %v", waitCommandName, query, err)
-	}
-
-	if len(qr.Rows) != 1 || len(qr.Rows[0]) != 1 {
-		return fmt.Errorf("unexpected result format from %v(%v): %#v", waitCommandName, query, qr)
-	}
-	result := qr.Rows[0][0]
-	if result.IsNull() {
-		return fmt.Errorf("%v(%v) failed: replication is probably stopped", waitCommandName, query)
-	}
-	if result.ToString() == "-1" {
-		return fmt.Errorf("timed out waiting for position %v", targetPos)
+	if err := conn.Conn.WaitUntilPosition(ctx, targetPos); err != nil {
+		return fmt.Errorf("WaitSourcePos failed: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

The different database flavors use different SQL functions in order to perform the generic "wait for the replica to reach this position" functionality — and each function has different semantics for what it returns and what those return values mean.

We have previously only asked the flavor interface to provide the *command*/*query* (which leveraged the flavor's specific SQL function) to use and then executed the provided query and processed the results at a higher level such as the `mysqlctl` package — where the specifics of the flavor implementation's SQL function were not known. Prior to moving to the newer `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS()` SQL function for GTID based MySQL replication in https://github.com/vitessio/vitess/issues/14611, the differences were not significant enough that they caused known problems using this method.

After that change in https://github.com/vitessio/vitess/issues/14611, however, it proved problematic to try and process the results outside of the flavor implementation given the semantic differences. This PR moves the handling/processing of the `WaitForPos` functionality down into the flavor interface (as much of the other functionality is, e.g. `status`).

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/14611
  - Fixes: https://github.com/vitessio/vitess/issues/14738

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required