### PR TITLE
VTGate/foreign keys stress test: add tests for 'standard' replica

### DIFF
--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -215,8 +215,10 @@ func testRevertible(t *testing.T) {
 	fkOnlineDDLPossible := false
 	t.Run("check 'rename_table_preserve_foreign_key' variable", func(t *testing.T) {
 		// Online DDL is not possible on vanilla MySQL 8.0 for reasons described in https://vitess.io/blog/2021-06-15-online-ddl-why-no-fk/.
-		// However, Online DDL is made possible in via these changes: https://github.com/planetscale/mysql-server/commit/bb777e3e86387571c044fb4a2beb4f8c60462ced
-		// as part of https://github.com/planetscale/mysql-server/releases/tag/8.0.34-ps1.
+		// However, Online DDL is made possible in via these changes:
+		// - https://github.com/planetscale/mysql-server/commit/bb777e3e86387571c044fb4a2beb4f8c60462ced
+		// - https://github.com/planetscale/mysql-server/commit/c2f1344a6863518d749f2eb01a4c74ca08a5b889
+		// as part of https://github.com/planetscale/mysql-server/releases/tag/8.0.34-ps3.
 		// Said changes introduce a new global/session boolean variable named 'rename_table_preserve_foreign_key'. It defaults 'false'/0 for backwards compatibility.
 		// When enabled, a `RENAME TABLE` to a FK parent "pins" the children's foreign keys to the table name rather than the table pointer. Which means after the RENAME,
 		// the children will point to the newly instated table rather than the original, renamed table.

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -2157,8 +2157,10 @@ func testForeignKeys(t *testing.T) {
 	fkOnlineDDLPossible := false
 	t.Run("check 'rename_table_preserve_foreign_key' variable", func(t *testing.T) {
 		// Online DDL is not possible on vanilla MySQL 8.0 for reasons described in https://vitess.io/blog/2021-06-15-online-ddl-why-no-fk/.
-		// However, Online DDL is made possible in via these changes: https://github.com/planetscale/mysql-server/commit/bb777e3e86387571c044fb4a2beb4f8c60462ced
-		// as part of https://github.com/planetscale/mysql-server/releases/tag/8.0.34-ps1.
+		// However, Online DDL is made possible in via these changes:
+		// - https://github.com/planetscale/mysql-server/commit/bb777e3e86387571c044fb4a2beb4f8c60462ced
+		// - https://github.com/planetscale/mysql-server/commit/c2f1344a6863518d749f2eb01a4c74ca08a5b889
+		// as part of https://github.com/planetscale/mysql-server/releases/tag/8.0.34-ps3.
 		// Said changes introduce a new global/session boolean variable named 'rename_table_preserve_foreign_key'. It defaults 'false'/0 for backwards compatibility.
 		// When enabled, a `RENAME TABLE` to a FK parent "pins" the children's foreign keys to the table name rather than the table pointer. Which means after the RENAME,
 		// the children will point to the newly instated table rather than the original, renamed table.

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -526,8 +526,6 @@ const (
 	sqlAnalyzeTable                        = "ANALYZE NO_WRITE_TO_BINLOG TABLE `%a`"
 	sqlShowCreateTable                     = "SHOW CREATE TABLE `%a`"
 	sqlShowVariablesLikePreserveForeignKey = "show global variables like 'rename_table_preserve_foreign_key'"
-	sqlEnablePreserveForeignKey            = "set @@rename_table_preserve_foreign_key = 1"
-	sqlDisablePreserveForeignKey           = "set @@rename_table_preserve_foreign_key = 0"
 	sqlShowVariablesLikeFastAnalyzeTable   = "show global variables like 'fast_analyze_table'"
 	sqlEnableFastAnalyzeTable              = "set @@fast_analyze_table = 1"
 	sqlDisableFastAnalyzeTable             = "set @@fast_analyze_table = 0"


### PR DESCRIPTION
## Description

https://github.com/vitessio/vitess/pull/13799 introduced VTGate stress tests for foreign keys, and https://github.com/vitessio/vitess/pull/14098 further improved them. Among the techniques used, we set up a primary with foreign key tables, and a replica where we stripped out the foreign key constraints. This setup validated that VTGate's cascading of foreign key rules works correctly, by comparing data on primary and replica.

This PR adds an additional replica, this time a standard, "faithful" one. The objective with this replica is to validate that the schema on primary and replica are consistent after Online DDL. This is something we can't do with the already existing replica as we intentionally diverged the schema on that replica in the first place.

The test compares the new, "faithful" replica with the primary, expected identical schema, explicitly makes sure that foreign key referenced tables are pinned to the correct primaries (validating the effects of `rename_table_preserve_foreign_key`) and of course also validates that the data is identical.

We are modifying the behavior of `rename_table_preserve_foreign_key` in our public fork. The tests are expected to ~~fail right away and to pass once we've updated the forked MySQL image~~ pass as we're not yet using the forked MySQL image in this repo's CI.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/11975

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
