### PR TITLE
Add a retry to remove the vttablet directory during upgrade/downgrade backup tests

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -82,6 +82,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_backups_manual.yml'
+            - 'examples/**'
 
     - name: Set up Go
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -85,6 +85,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml'
+            - 'examples/**'
 
     - name: Set up Go
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/examples/backups/stop_tablets.sh
+++ b/examples/backups/stop_tablets.sh
@@ -34,19 +34,19 @@ for tablet in 100 200 300; do
       for ((i=0; i<30; i++)); do
           # Redirect stderr to a temporary file
           temp_file=$(mktemp)
-          rm -Rf $VTDATAROOT/vt_0000000$uid 2>$temp_file
+          rm -Rf $VTDATAROOT/vt_0000000$uid 2>"$temp_file"
 
-          if grep -q 'Directory not empty' $temp_file; then
+          if grep -q 'Directory not empty' "$temp_file"; then
               echo "Directory not empty, retrying..."
-          elif [ ! -s $temp_file ]; then
+          elif [ ! -s "$temp_file" ]; then
               echo "Deletion succeeded."
-              rm -f $temp_file
+              rm -f "$temp_file"
               break
           else
               echo "An error occurred."
-              cat $temp_file
+              cat "$temp_file"
           fi
-          rm -f $temp_file
+          rm -f "$temp_file"
           sleep 1
       done
     done

--- a/examples/backups/stop_tablets.sh
+++ b/examples/backups/stop_tablets.sh
@@ -30,7 +30,25 @@ for tablet in 100 200 300; do
       CELL=zone1 TABLET_UID=$uid ../common/scripts/mysqlctl-down.sh
       echo "Removing tablet directory zone1-$uid"
       vtctldclient DeleteTablets --allow-primary zone1-$uid
-      rm -Rf $VTDATAROOT/vt_0000000$uid
+
+      for ((i=0; i<30; i++)); do
+          # Redirect stderr to a temporary file
+          temp_file=$(mktemp)
+          rm -Rf $VTDATAROOT/vt_0000000$uid 2>$temp_file
+
+          if grep -q 'Directory not empty' $temp_file; then
+              echo "Directory not empty, retrying..."
+          elif [ ! -s $temp_file ]; then
+              echo "Deletion succeeded."
+              rm -f $temp_file
+              break
+          else
+              echo "An error occurred."
+              cat $temp_file
+          fi
+          rm -f $temp_file
+          sleep 1
+      done
     done
   fi
 done


### PR DESCRIPTION
## Description

This PR fixes a small issue during the manual upgrade/downgrade backup tests. The issue happens when for some reason the deletion of the VTTablet directory fails due to used files, leading to an error code `39` from `rm -Rf`. This issue can be seen as follows in the logs of the `Stop tablets` step:

```
Shutting down tablet zone1-301
Stopping vttablet...
Shutting down mysql zone1-301
Shutting down MySQL for tablet zone1-0000000301...
Removing tablet directory zone1-301
Successfully deleted 1 tablets
rm: cannot remove '/tmp//vt_0000000301': Directory not empty
```

This silent error leads to the failure of step `Start new tablet and restore`. Since the VTTablet's directory was partially removed, VTTablet thinks it has to start from an existing data dir (which is not what we want). And because the VTTablet directory has been mostly emptied already, the `my.cnf` file does not exist, leading to a fatal error (also visible in the logs):

```
Starting MySQL for tablet zone1-0000000301...
Resuming from existing vttablet dir:
    /tmp//vt_0000000301
E1208 15:33:57.111914   44151 mysqlctl.go:276] failed to find mysql config: couldn't read my.cnf file: open /tmp/vt_0000000301/my.cnf: no such file or directory
```

After some local tests, it seems like adding a sleep before the `rm -Rf` is sufficient. I then decided to add a 30 second-long retry loop where we attempt to remove the VTTablet directory every second.

Moreover, the list of files to watch in the backups manual workflows have changed to include the `examples/**` path as we use it in our tests.
