### PR TITLE
VDiff: Fix vtctldclient limit bug

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -271,16 +271,16 @@ func commandCreate(cmd *cobra.Command, args []string) error {
 		TabletTypes:                 createOptions.TabletTypes,
 		TabletSelectionPreference:   tsp,
 		Tables:                      createOptions.Tables,
-		Limit:                       int64(createOptions.Limit),
+		Limit:                       createOptions.Limit,
 		FilteredReplicationWaitTime: protoutil.DurationToProto(createOptions.FilteredReplicationWaitTime),
 		DebugQuery:                  createOptions.DebugQuery,
 		OnlyPKs:                     createOptions.OnlyPKs,
 		UpdateTableStats:            createOptions.UpdateTableStats,
-		MaxExtraRowsToCompare:       int64(createOptions.MaxExtraRowsToCompare),
+		MaxExtraRowsToCompare:       createOptions.MaxExtraRowsToCompare,
 		Wait:                        createOptions.Wait,
 		WaitUpdateInterval:          protoutil.DurationToProto(createOptions.WaitUpdateInterval),
 		AutoRetry:                   createOptions.AutoRetry,
-		MaxReportSampleRows:         int64(createOptions.MaxReportSampleRows),
+		MaxReportSampleRows:         createOptions.MaxReportSampleRows,
 	})
 
 	if err != nil {

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -113,9 +113,9 @@ var (
 				createOptions.Tables[i] = strings.TrimSpace(table)
 			}
 		}
-		// Enforce non-negative values for limits and max values.
+		// Enforce non-negative values for limits and max options.
 		if createOptions.Limit < 1 {
-			return fmt.Errorf("--limit must be a positive value of at least 1")
+			return fmt.Errorf("--limit must be a positive value")
 		}
 		if createOptions.MaxReportSampleRows < 0 {
 			return fmt.Errorf("--max-report-sample-rows must not be a negative value")

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -57,13 +57,13 @@ var (
 		TargetCells                 []string
 		TabletTypes                 []topodatapb.TabletType
 		Tables                      []string
-		Limit                       uint32 // We only accept positive values but pass on an int64
+		Limit                       int64
 		FilteredReplicationWaitTime time.Duration
 		DebugQuery                  bool
-		MaxReportSampleRows         uint32 // We only accept positive values but pass on an int64
+		MaxReportSampleRows         int64
 		OnlyPKs                     bool
 		UpdateTableStats            bool
-		MaxExtraRowsToCompare       uint32 // We only accept positive values but pass on an int64
+		MaxExtraRowsToCompare       int64
 		Wait                        bool
 		WaitUpdateInterval          time.Duration
 		AutoRetry                   bool
@@ -863,12 +863,12 @@ func registerCommands(root *cobra.Command) {
 	create.Flags().Var((*topoprotopb.TabletTypeListFlag)(&createOptions.TabletTypes), "tablet-types", "Tablet types to use on the source and target.")
 	create.Flags().BoolVar(&common.CreateOptions.TabletTypesInPreferenceOrder, "tablet-types-in-preference-order", true, "When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag.")
 	create.Flags().DurationVar(&createOptions.FilteredReplicationWaitTime, "filtered-replication-wait-time", 30*time.Second, "Specifies the maximum time to wait, in seconds, for replication to catch up when syncing tablet streams.")
-	create.Flags().Uint32Var(&createOptions.Limit, "limit", math.MaxUint32, "Max rows to stop comparing after.")
+	create.Flags().Int64Var(&createOptions.Limit, "limit", math.MaxInt64, "Max rows to stop comparing after.")
 	create.Flags().BoolVar(&createOptions.DebugQuery, "debug-query", false, "Adds a mysql query to the report that can be used for further debugging.")
-	create.Flags().Uint32Var(&createOptions.MaxReportSampleRows, "max-report-sample-rows", 10, "Maximum number of row differences to report (0 for all differences). NOTE: when increasing this value it is highly recommended to also specify --only-pks")
+	create.Flags().Int64Var(&createOptions.MaxReportSampleRows, "max-report-sample-rows", 10, "Maximum number of row differences to report (0 for all differences). NOTE: when increasing this value it is highly recommended to also specify --only-pks")
 	create.Flags().BoolVar(&createOptions.OnlyPKs, "only-pks", false, "When reporting missing rows, only show primary keys in the report.")
 	create.Flags().StringSliceVar(&createOptions.Tables, "tables", nil, "Only run vdiff for these tables in the workflow.")
-	create.Flags().Uint32Var(&createOptions.MaxExtraRowsToCompare, "max-extra-rows-to-compare", 1000, "If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation.")
+	create.Flags().Int64Var(&createOptions.MaxExtraRowsToCompare, "max-extra-rows-to-compare", 1000, "If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation.")
 	create.Flags().BoolVar(&createOptions.Wait, "wait", false, "When creating or resuming a vdiff, wait for it to finish before exiting.")
 	create.Flags().DurationVar(&createOptions.WaitUpdateInterval, "wait-update-interval", time.Duration(1*time.Minute), "When waiting on a vdiff to finish, check and display the current status this often.")
 	create.Flags().BoolVar(&createOptions.AutoRetry, "auto-retry", true, "Should this vdiff automatically retry and continue in case of recoverable errors.")

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -118,10 +118,10 @@ var (
 			return fmt.Errorf("--limit must be a positive value greater than 1")
 		}
 		if createOptions.MaxReportSampleRows < 0 {
-			return fmt.Errorf("--max-report-sample-rows must be a positive value")
+			return fmt.Errorf("--max-report-sample-rows must not be a negative value")
 		}
 		if createOptions.MaxExtraRowsToCompare < 0 {
-			return fmt.Errorf("--max-extra-rows-to-compare must be a positive value")
+			return fmt.Errorf("--max-extra-rows-to-compare must not be a negative value")
 		}
 		return nil
 	}

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -113,6 +113,16 @@ var (
 				createOptions.Tables[i] = strings.TrimSpace(table)
 			}
 		}
+		// Enforce positive values for limits and max values.
+		if createOptions.Limit < 1 {
+			return fmt.Errorf("--limit must be a positive value greater than 1")
+		}
+		if createOptions.MaxReportSampleRows < 0 {
+			return fmt.Errorf("--max-report-sample-rows must be a positive value")
+		}
+		if createOptions.MaxExtraRowsToCompare < 0 {
+			return fmt.Errorf("--max-extra-rows-to-compare must be a positive value")
+		}
 		return nil
 	}
 

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -115,7 +115,7 @@ var (
 		}
 		// Enforce non-negative values for limits and max values.
 		if createOptions.Limit < 1 {
-			return fmt.Errorf("--limit must be a positive value greater than 1")
+			return fmt.Errorf("--limit must be a positive value of at least 1")
 		}
 		if createOptions.MaxReportSampleRows < 0 {
 			return fmt.Errorf("--max-report-sample-rows must not be a negative value")

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -113,7 +113,7 @@ var (
 				createOptions.Tables[i] = strings.TrimSpace(table)
 			}
 		}
-		// Enforce positive values for limits and max values.
+		// Enforce non-negative values for limits and max values.
 		if createOptions.Limit < 1 {
 			return fmt.Errorf("--limit must be a positive value greater than 1")
 		}

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -261,8 +261,8 @@ func testCLIFlagHandling(t *testing.T, targetKs, workflowName string, cell *Cell
 		"timeout_seconds":           "60",
 	}
 	pickerOpts := map[string]string{
-		"source_cell":  "zone1,zone2,zone3,zonefoo",
-		"target_cell":  "zone1,zone2,zone3,zonefoo",
+		"source_cell":  "zone1,zone2,zone3,zonefoosource",
+		"target_cell":  "zone1,zone2,zone3,zonefootarget",
 		"tablet_types": "replica,primary,rdonly",
 	}
 	reportOpts := map[string]string{

--- a/go/vt/vtctl/grpcvtctldclient/client_gen.go
+++ b/go/vt/vtctl/grpcvtctldclient/client_gen.go
@@ -128,15 +128,6 @@ func (client *gRPCVtctldClient) CleanupSchemaMigration(ctx context.Context, in *
 	return client.c.CleanupSchemaMigration(ctx, in, opts...)
 }
 
-// ForceCutOverSchemaMigration is part of the vtctlservicepb.VtctldClient interface.
-func (client *gRPCVtctldClient) ForceCutOverSchemaMigration(ctx context.Context, in *vtctldatapb.ForceCutOverSchemaMigrationRequest, opts ...grpc.CallOption) (*vtctldatapb.ForceCutOverSchemaMigrationResponse, error) {
-	if client.c == nil {
-		return nil, status.Error(codes.Unavailable, connClosedMsg)
-	}
-
-	return client.c.ForceCutOverSchemaMigration(ctx, in, opts...)
-}
-
 // CompleteSchemaMigration is part of the vtctlservicepb.VtctldClient interface.
 func (client *gRPCVtctldClient) CompleteSchemaMigration(ctx context.Context, in *vtctldatapb.CompleteSchemaMigrationRequest, opts ...grpc.CallOption) (*vtctldatapb.CompleteSchemaMigrationResponse, error) {
 	if client.c == nil {
@@ -261,6 +252,15 @@ func (client *gRPCVtctldClient) FindAllShardsInKeyspace(ctx context.Context, in 
 	}
 
 	return client.c.FindAllShardsInKeyspace(ctx, in, opts...)
+}
+
+// ForceCutOverSchemaMigration is part of the vtctlservicepb.VtctldClient interface.
+func (client *gRPCVtctldClient) ForceCutOverSchemaMigration(ctx context.Context, in *vtctldatapb.ForceCutOverSchemaMigrationRequest, opts ...grpc.CallOption) (*vtctldatapb.ForceCutOverSchemaMigrationResponse, error) {
+	if client.c == nil {
+		return nil, status.Error(codes.Unavailable, connClosedMsg)
+	}
+
+	return client.c.ForceCutOverSchemaMigration(ctx, in, opts...)
 }
 
 // GetBackups is part of the vtctlservicepb.VtctldClient interface.

--- a/go/vt/vtctl/localvtctldclient/client_gen.go
+++ b/go/vt/vtctl/localvtctldclient/client_gen.go
@@ -176,11 +176,6 @@ func (client *localVtctldClient) CleanupSchemaMigration(ctx context.Context, in 
 	return client.s.CleanupSchemaMigration(ctx, in)
 }
 
-// ForceCutOverSchemaMigration is part of the vtctlservicepb.VtctldClient interface.
-func (client *localVtctldClient) ForceCutOverSchemaMigration(ctx context.Context, in *vtctldatapb.ForceCutOverSchemaMigrationRequest, opts ...grpc.CallOption) (*vtctldatapb.ForceCutOverSchemaMigrationResponse, error) {
-	return client.s.ForceCutOverSchemaMigration(ctx, in)
-}
-
 // CompleteSchemaMigration is part of the vtctlservicepb.VtctldClient interface.
 func (client *localVtctldClient) CompleteSchemaMigration(ctx context.Context, in *vtctldatapb.CompleteSchemaMigrationRequest, opts ...grpc.CallOption) (*vtctldatapb.CompleteSchemaMigrationResponse, error) {
 	return client.s.CompleteSchemaMigration(ctx, in)
@@ -249,6 +244,11 @@ func (client *localVtctldClient) ExecuteHook(ctx context.Context, in *vtctldatap
 // FindAllShardsInKeyspace is part of the vtctlservicepb.VtctldClient interface.
 func (client *localVtctldClient) FindAllShardsInKeyspace(ctx context.Context, in *vtctldatapb.FindAllShardsInKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.FindAllShardsInKeyspaceResponse, error) {
 	return client.s.FindAllShardsInKeyspace(ctx, in)
+}
+
+// ForceCutOverSchemaMigration is part of the vtctlservicepb.VtctldClient interface.
+func (client *localVtctldClient) ForceCutOverSchemaMigration(ctx context.Context, in *vtctldatapb.ForceCutOverSchemaMigrationRequest, opts ...grpc.CallOption) (*vtctldatapb.ForceCutOverSchemaMigrationResponse, error) {
+	return client.s.ForceCutOverSchemaMigration(ctx, in)
 }
 
 // GetBackups is part of the vtctlservicepb.VtctldClient interface.

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1632,7 +1632,7 @@ func (s *Server) VDiffCreate(ctx context.Context, req *vtctldatapb.VDiffCreateRe
 		CoreOptions: &tabletmanagerdatapb.VDiffCoreOptions{
 			Tables:                strings.Join(req.Tables, ","),
 			AutoRetry:             req.AutoRetry,
-			MaxRows:               req.MaxExtraRowsToCompare,
+			MaxRows:               req.Limit,
 			TimeoutSeconds:        req.FilteredReplicationWaitTime.Seconds,
 			MaxExtraRowsToCompare: req.MaxExtraRowsToCompare,
 			UpdateTableStats:      req.UpdateTableStats,


### PR DESCRIPTION
## Description

This fixes the bug described in https://github.com/vitessio/vitess/issues/14777. I also adjusted the other max related flag values as I noticed a difference from the `vtctlclient` implementation in that we were limiting the accepted values to 4,294,967,295 in `vtctldclient` vs 9,223,372,036,854,775,807 in `vtctlclient`.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/14777

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
    - Backporting to v18 as this is safe, the bug can cause errant/unexpected results, and the vtctldclient implementation is brand new in v18 
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
    -  The vtctldclient docs will be updated automatically