### PR TITLE
Enhance PR template + CI workflow for backport labels.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,9 +18,10 @@
 
 ## Checklist
 
--   [ ] "Backport to:" labels have been added if this change should be back-ported
+-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
+-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
 -   [ ] Tests were added or are not required
--   [ ] Did the new or modified tests pass consistently locally and on the CI
+-   [ ] Did the new or modified tests pass consistently locally and on CI?
 -   [ ] Documentation was added or is not required
 
 ## Deployment Notes

--- a/.github/workflows/check_label.yml
+++ b/.github/workflows/check_label.yml
@@ -68,6 +68,10 @@ jobs:
             echo "Expecting PR to not have the NeedsIssue label; please create a linked issue and remove the label."
             exit 1
           fi
+          if cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'NeedsBackportReason' ; then
+            echo "Expecting PR to not have the NeedsBackportReason label; please add your justification to the PR description and remove the label."
+            exit 1
+          fi
           
 
       - name: Do Not Merge label

--- a/.github/workflows/check_label.yml
+++ b/.github/workflows/check_label.yml
@@ -69,8 +69,10 @@ jobs:
             exit 1
           fi
           if cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'NeedsBackportReason' ; then
-            echo "Expecting PR to not have the NeedsBackportReason label; please add your justification to the PR description and remove the label."
-            exit 1
+            if cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'Backport to:'; then
+              echo "Expecting PR to not have the NeedsBackportReason label; please add your justification to the PR description and remove the label."
+              exit 1
+            fi
           fi
           
 


### PR DESCRIPTION
## Description
A new label `NeedsBackportReason` has been added that can be used when a PR is marked for back ports to require a reason/justification.
This label is only checked if at least one `Backport to:` label is set.
For now, this label is expected to be applied manually by reviewers. If necessary we can think about applying it automatically whenever a PR is created.
The PR template has also been enhanced to add an additional check box.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Testing:
Tested that this works as intended by adding and removing labels on this PR after it was created.

## Related Issue(s)
#14738 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
