### PR TITLE
bugfix: don't panic when missing schema information

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4256,5 +4256,28 @@
         "user.user",
         "user.user_extra"
       ]
-    }  }
+    }
+  },
+  {
+    "comment": "unexpanded columns are fine if we can push down into single route",
+    "query": "select x from (select t.*, 1 as x from unsharded t union select t.*, 1 as x from unsharded t) as x",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select x from (select t.*, 1 as x from unsharded t union select t.*, 1 as x from unsharded t) as x",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select x from (select t.*, 1 as x from unsharded as t where 1 != 1 union select t.*, 1 as x from unsharded as t where 1 != 1) as x where 1 != 1",
+        "Query": "select x from (select t.*, 1 as x from unsharded as t union select t.*, 1 as x from unsharded as t) as x",
+        "Table": "unsharded"
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -383,5 +383,10 @@
     "comment": "correlated subqueries in select expressions are unsupported",
     "query": "SELECT (SELECT sum(user.name) FROM music LIMIT 1) FROM user",
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
+  },
+  {
+    "comment": "We need schema tracking to allow unexpanded columns inside UNION",
+    "query": "select x from (select users.*, 0 as x from main.users union select user_merchants.*, 1 as x from main.user_merchants) AS T",
+    "plan": "VT09015: schema tracking required"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -386,7 +386,7 @@
   },
   {
     "comment": "We need schema tracking to allow unexpanded columns inside UNION",
-    "query": "select x from (select users.*, 0 as x from main.users union select user_merchants.*, 1 as x from main.user_merchants) AS T",
+    "query": "select x from (select t.*, 0 as x from user t union select t.*, 1 as x from user_extra t) AS t",
     "plan": "VT09015: schema tracking required"
   }
 ]

--- a/go/vt/vtgate/semantics/derived_table.go
+++ b/go/vt/vtgate/semantics/derived_table.go
@@ -107,6 +107,10 @@ func (dt *DerivedTable) dependencies(colName string, org originable) (dependenci
 		if !strings.EqualFold(name, colName) {
 			continue
 		}
+		if len(dt.recursive) == 0 {
+			// we have unexpanded columns and can't figure this out
+			return nil, ShardedError{Inner: vterrors.VT09015()}
+		}
 		recursiveDeps, qt := dt.recursive[i], dt.types[i]
 
 		return createCertain(directDeps, recursiveDeps, qt), nil


### PR DESCRIPTION
## Description
When schema tracking is not enabled, column information can be missing for unexpanded derived tables, which leads to the planner not being able to figure out types and dependencies.

Before this change, the semantic analyser would panic on these queries. This change makes it return an error instead.

## Related Issue(s)
Fixes #14788
