### PR TITLE
TxThrottler: dont throttle unless lag

### DIFF
--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -234,7 +234,7 @@ func (t *Throttler) LastMaxLagNotIgnoredForTabletType(tabletType topodata.Tablet
 	var maxLag uint32
 	cacheEntries := cache.entries
 
-	for key, _ := range cacheEntries {
+	for key := range cacheEntries {
 		if cache.isIgnored(key) {
 			continue
 		}

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -32,6 +32,7 @@ import (
 	"math"
 	"sync"
 	"time"
+	"vitess.io/vitess/go/vt/proto/topodata"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -32,7 +32,6 @@ import (
 	"math"
 	"sync"
 	"time"
-	"vitess.io/vitess/go/vt/proto/topodata"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -35,6 +35,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/proto/topodata"
 
 	throttlerdatapb "vitess.io/vitess/go/vt/proto/throttlerdata"
 )
@@ -222,6 +223,28 @@ func (t *Throttler) Throttle(threadID int) time.Duration {
 		panic(fmt.Sprintf("BUG: thread with ID: %v already finished", threadID))
 	}
 	return t.threadThrottlers[threadID].throttle(t.nowFunc())
+}
+
+// LastMaxLagNotIgnoredForTabletType returns the max of all the last replication lag values seen across all tablets of
+// the provided type, excluding ignored tablets.
+func (t *Throttler) LastMaxLagNotIgnoredForTabletType(tabletType topodata.TabletType) uint32 {
+	cache := t.maxReplicationLagModule.lagCacheByType(tabletType)
+
+	var maxLag uint32
+	cacheEntries := cache.entries
+
+	for key, _ := range cacheEntries {
+		if cache.isIgnored(key) {
+			continue
+		}
+
+		lag := cache.latest(key).Stats.ReplicationLagSeconds
+		if lag > maxLag {
+			maxLag = lag
+		}
+	}
+
+	return maxLag
 }
 
 // ThreadFinished marks threadID as finished and redistributes the thread's

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -227,7 +227,7 @@ func (t *Throttler) Throttle(threadID int) time.Duration {
 
 // LastMaxLagNotIgnoredForTabletType returns the max of all the last replication lag values seen across all tablets of
 // the provided type, excluding ignored tablets.
-func (t *Throttler) LastMaxLagNotIgnoredForTabletType(tabletType topodata.TabletType) uint32 {
+func (t *Throttler) MaxLag(tabletType topodata.TabletType) uint32 {
 	cache := t.maxReplicationLagModule.lagCacheByType(tabletType)
 
 	var maxLag uint32

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -225,7 +225,7 @@ func (t *Throttler) Throttle(threadID int) time.Duration {
 	return t.threadThrottlers[threadID].throttle(t.nowFunc())
 }
 
-// LastMaxLagNotIgnoredForTabletType returns the max of all the last replication lag values seen across all tablets of
+// MaxLag returns the max of all the last replication lag values seen across all tablets of
 // the provided type, excluding ignored tablets.
 func (t *Throttler) MaxLag(tabletType topodata.TabletType) uint32 {
 	cache := t.maxReplicationLagModule.lagCacheByType(tabletType)

--- a/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
@@ -12,6 +12,7 @@ import (
 
 	discovery "vitess.io/vitess/go/vt/discovery"
 	throttlerdata "vitess.io/vitess/go/vt/proto/throttlerdata"
+	topodata "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 // MockThrottlerInterface is a mock of ThrottlerInterface interface.
@@ -61,6 +62,20 @@ func (m *MockThrottlerInterface) GetConfiguration() *throttlerdata.Configuration
 func (mr *MockThrottlerInterfaceMockRecorder) GetConfiguration() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguration", reflect.TypeOf((*MockThrottlerInterface)(nil).GetConfiguration))
+}
+
+// LastMaxLagNotIgnoredForTabletType mocks base method.
+func (m *MockThrottlerInterface) LastMaxLagNotIgnoredForTabletType(tabletType topodata.TabletType) uint32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastMaxLagNotIgnoredForTabletType", tabletType)
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+// LastMaxLagNotIgnoredForTabletType indicates an expected call of LastMaxLagNotIgnoredForTabletType.
+func (mr *MockThrottlerInterfaceMockRecorder) LastMaxLagNotIgnoredForTabletType(tabletType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastMaxLagNotIgnoredForTabletType", reflect.TypeOf((*MockThrottlerInterface)(nil).LastMaxLagNotIgnoredForTabletType), tabletType)
 }
 
 // MaxRate mocks base method.

--- a/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
@@ -65,9 +65,9 @@ func (mr *MockThrottlerInterfaceMockRecorder) GetConfiguration() *gomock.Call {
 }
 
 // LastMaxLagNotIgnoredForTabletType mocks base method.
-func (m *MockThrottlerInterface) LastMaxLagNotIgnoredForTabletType(tabletType topodata.TabletType) uint32 {
+func (m *MockThrottlerInterface) MaxLag(tabletType topodata.TabletType) uint32 {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LastMaxLagNotIgnoredForTabletType", tabletType)
+	ret := m.ctrl.Call(m, "MaxLag", tabletType)
 	ret0, _ := ret[0].(uint32)
 	return ret0
 }
@@ -75,7 +75,7 @@ func (m *MockThrottlerInterface) LastMaxLagNotIgnoredForTabletType(tabletType to
 // LastMaxLagNotIgnoredForTabletType indicates an expected call of LastMaxLagNotIgnoredForTabletType.
 func (mr *MockThrottlerInterfaceMockRecorder) LastMaxLagNotIgnoredForTabletType(tabletType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastMaxLagNotIgnoredForTabletType", reflect.TypeOf((*MockThrottlerInterface)(nil).LastMaxLagNotIgnoredForTabletType), tabletType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxLag", reflect.TypeOf((*MockThrottlerInterface)(nil).MaxLag), tabletType)
 }
 
 // MaxRate mocks base method.

--- a/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
@@ -64,7 +64,7 @@ func (mr *MockThrottlerInterfaceMockRecorder) GetConfiguration() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguration", reflect.TypeOf((*MockThrottlerInterface)(nil).GetConfiguration))
 }
 
-// LastMaxLagNotIgnoredForTabletType mocks base method.
+// MaxLag mocks base method.
 func (m *MockThrottlerInterface) MaxLag(tabletType topodata.TabletType) uint32 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaxLag", tabletType)
@@ -72,8 +72,8 @@ func (m *MockThrottlerInterface) MaxLag(tabletType topodata.TabletType) uint32 {
 	return ret0
 }
 
-// LastMaxLagNotIgnoredForTabletType indicates an expected call of LastMaxLagNotIgnoredForTabletType.
-func (mr *MockThrottlerInterfaceMockRecorder) LastMaxLagNotIgnoredForTabletType(tabletType interface{}) *gomock.Call {
+// MaxLag indicates an expected call of LastMaxLagNotIgnoredForTabletType.
+func (mr *MockThrottlerInterfaceMockRecorder) MaxLag(tabletType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxLag", reflect.TypeOf((*MockThrottlerInterface)(nil).MaxLag), tabletType)
 }

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -360,7 +360,7 @@ func (ts *txThrottlerStateImpl) throttle() bool {
 
 	var maxLag uint32
 
-	for tabletType, _ := range ts.tabletTypes {
+	for tabletType := range ts.tabletTypes {
 		maxLagPerTabletType := ts.throttler.LastMaxLagNotIgnoredForTabletType(tabletType)
 		if maxLagPerTabletType > maxLag {
 			maxLag = maxLagPerTabletType

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -170,7 +170,7 @@ type txThrottlerStateImpl struct {
 	// tabletTypes stores the tablet types for throttling
 	tabletTypes map[topodatapb.TabletType]bool
 
-	shardMaxLag        int64
+	maxLag             int64
 	done               chan bool
 	waitForTermination sync.WaitGroup
 }
@@ -366,7 +366,7 @@ func (ts *txThrottlerStateImpl) throttle() bool {
 	ts.throttleMu.Lock()
 	defer ts.throttleMu.Unlock()
 
-	maxLag := atomic.LoadInt64(&ts.shardMaxLag)
+	maxLag := atomic.LoadInt64(&ts.maxLag)
 
 	return maxLag > ts.config.TxThrottlerConfig.TargetReplicationLagSec &&
 		ts.throttler.Throttle(0 /* threadId */) > 0
@@ -389,7 +389,7 @@ outerloop:
 					maxLag = maxLagPerTabletType
 				}
 			}
-			atomic.StoreInt64(&ts.shardMaxLag, int64(maxLag))
+			atomic.StoreInt64(&ts.maxLag, int64(maxLag))
 		case <-ts.done:
 			break outerloop
 		}

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -79,28 +79,59 @@ func TestEnabledThrottler(t *testing.T) {
 		return mockThrottler, nil
 	}
 
-	call0 := mockThrottler.EXPECT().UpdateConfiguration(gomock.Any(), true /* copyZeroValues */)
-	call1 := mockThrottler.EXPECT().Throttle(0)
-	call1.Return(0 * time.Second)
+	var calls []*gomock.Call
+
+	call := mockThrottler.EXPECT().UpdateConfiguration(gomock.Any(), true /* copyZeroValues */)
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
+	call.Return(uint32(20))
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().Throttle(0)
+	call.Return(0 * time.Second)
+	calls = append(calls, call)
+
 	tabletStats := &discovery.TabletHealth{
 		Target: &querypb.Target{
 			Cell:       "cell1",
 			TabletType: topodatapb.TabletType_REPLICA,
 		},
 	}
-	call2 := mockThrottler.EXPECT().RecordReplicationLag(gomock.Any(), tabletStats)
-	call3 := mockThrottler.EXPECT().Throttle(0)
-	call3.Return(1 * time.Second)
 
-	call4 := mockThrottler.EXPECT().Throttle(0)
-	call4.Return(1 * time.Second)
-	calllast := mockThrottler.EXPECT().Close()
+	call = mockThrottler.EXPECT().RecordReplicationLag(gomock.Any(), tabletStats)
+	calls = append(calls, call)
 
-	call1.After(call0)
-	call2.After(call1)
-	call3.After(call2)
-	call4.After(call3)
-	calllast.After(call4)
+	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
+	call.Return(uint32(20))
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().Throttle(0)
+	call.Return(1 * time.Second)
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
+	call.Return(uint32(20))
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().Throttle(0)
+	call.Return(1 * time.Second)
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
+	call.Return(uint32(1))
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().Throttle(0)
+	call.Return(1 * time.Second)
+	calls = append(calls, call)
+
+	call = mockThrottler.EXPECT().Close()
+	calls = append(calls, call)
+
+	for i := 1; i < len(calls); i++ {
+		calls[i].After(calls[i-1])
+	}
 
 	config := tabletenv.NewDefaultConfig()
 	config.EnableTxThrottler = true
@@ -149,6 +180,17 @@ func TestEnabledThrottler(t *testing.T) {
 	assert.Equal(t, int64(3), throttlerImpl.requestsTotal.Counts()["some_workload"])
 	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some_workload"])
 	throttlerImpl.Close()
+	assert.Zero(t, throttlerImpl.throttlerRunning.Get())
+	assert.False(t, throttler.Throttle(0, "some-workload"))
+	assert.Equal(t, int64(3), throttlerImpl.requestsTotal.Counts()["some-workload"])
+	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some-workload"])
+
+	// This call should not throttle despite priority. Check that's the case and counters agree.
+	assert.False(t, throttler.Throttle(100, "some-workload"))
+	assert.Equal(t, int64(4), throttlerImpl.requestsTotal.Counts()["some-workload"])
+	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some-workload"])
+
+	throttler.Close()
 	assert.Zero(t, throttlerImpl.throttlerRunning.Get())
 }
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -142,7 +142,7 @@ func TestEnabledThrottler(t *testing.T) {
 
 	// Stop the go routine that keeps updating the cached  shard's max lag to prevent it from changing the value in a
 	// way that will interfere with how we manipulate that value in our tests to evaluate different cases:
-	throttlerStateImpl.endChannel <- true
+	throttlerStateImpl.done <- true
 
 	// 1 should not throttle due to return value of underlying Throttle(), despite high lag
 	atomic.StoreInt64(&throttlerStateImpl.shardMaxLag, 20)

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -145,7 +145,7 @@ func TestEnabledThrottler(t *testing.T) {
 	throttlerStateImpl.done <- true
 
 	// 1 should not throttle due to return value of underlying Throttle(), despite high lag
-	atomic.StoreInt64(&throttlerStateImpl.shardMaxLag, 20)
+	atomic.StoreInt64(&throttlerStateImpl.maxLag, 20)
 	assert.False(t, throttlerImpl.Throttle(100, "some-workload"))
 	assert.Equal(t, int64(1), throttlerImpl.requestsTotal.Counts()["some-workload"])
 	assert.Zero(t, throttlerImpl.requestsThrottled.Counts()["some-workload"])
@@ -175,7 +175,7 @@ func TestEnabledThrottler(t *testing.T) {
 	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some-workload"])
 
 	// 4 should not throttle despite return value of underlying Throttle() and priority = 100, due to low lag
-	atomic.StoreInt64(&throttlerStateImpl.shardMaxLag, 1)
+	atomic.StoreInt64(&throttlerStateImpl.maxLag, 1)
 	assert.False(t, throttler.Throttle(100, "some-workload"))
 	assert.Equal(t, int64(4), throttlerImpl.requestsTotal.Counts()["some-workload"])
 	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some-workload"])

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -106,14 +106,12 @@ func TestEnabledThrottler(t *testing.T) {
 	calls = append(calls, call)
 
 	// 3
-	call = mockThrottler.EXPECT().Throttle(0)
-	call.Return(1 * time.Second)
-	calls = append(calls, call)
+	// Nothing gets mocked here because the order of evaluation in txThrottler.Throttle() evaluates first
+	// whether the priority allows for throttling or not, so no need to mock calls in mockThrottler.Throttle()
 
 	// 4
-	call = mockThrottler.EXPECT().Throttle(0)
-	call.Return(1 * time.Second)
-	calls = append(calls, call)
+	// Nothing gets mocked here because the order of evaluation in txThrottlerStateImpl.Throttle() evaluates first
+	// whether there is lag or not, so no call to the underlying mockThrottler is issued.
 
 	call = mockThrottler.EXPECT().Close()
 	calls = append(calls, call)

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -22,6 +22,7 @@ package txthrottler
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -84,10 +85,7 @@ func TestEnabledThrottler(t *testing.T) {
 	call := mockThrottler.EXPECT().UpdateConfiguration(gomock.Any(), true /* copyZeroValues */)
 	calls = append(calls, call)
 
-	// No underlying throttling & lag present
-	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
-	call.Return(uint32(20))
-	calls = append(calls, call)
+	// 1
 	call = mockThrottler.EXPECT().Throttle(0)
 	call.Return(0 * time.Second)
 	calls = append(calls, call)
@@ -102,26 +100,17 @@ func TestEnabledThrottler(t *testing.T) {
 	call = mockThrottler.EXPECT().RecordReplicationLag(gomock.Any(), tabletStats)
 	calls = append(calls, call)
 
-	// Underlying throttling & lag present
-	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
-	call.Return(uint32(20))
-	calls = append(calls, call)
+	// 2
 	call = mockThrottler.EXPECT().Throttle(0)
 	call.Return(1 * time.Second)
 	calls = append(calls, call)
 
-	// Underlying throttling & lag present
-	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
-	call.Return(uint32(20))
-	calls = append(calls, call)
+	// 3
 	call = mockThrottler.EXPECT().Throttle(0)
 	call.Return(1 * time.Second)
 	calls = append(calls, call)
 
-	// Underlying throttling & no lag present
-	call = mockThrottler.EXPECT().LastMaxLagNotIgnoredForTabletType(topodatapb.TabletType_REPLICA)
-	call.Return(uint32(1))
-	calls = append(calls, call)
+	// 4
 	call = mockThrottler.EXPECT().Throttle(0)
 	call.Return(1 * time.Second)
 	calls = append(calls, call)
@@ -148,11 +137,17 @@ func TestEnabledThrottler(t *testing.T) {
 	})
 
 	assert.Nil(t, throttlerImpl.Open())
-	throttlerStateImpl := throttlerImpl.state.(*txThrottlerStateImpl)
+	throttlerStateImpl, ok := throttlerImpl.state.(*txThrottlerStateImpl)
+	assert.True(t, ok)
 	assert.Equal(t, map[topodatapb.TabletType]bool{topodatapb.TabletType_REPLICA: true}, throttlerStateImpl.tabletTypes)
 	assert.Equal(t, int64(1), throttlerImpl.throttlerRunning.Get())
 
-	// No underlying throttling & lag present - Don't throttle despite priority
+	// Stop the go routine that keeps updating the cached  shard's max lag to prevent it from changing the value in a
+	// way that will interfere with how we manipulate that value in our tests to evaluate different cases:
+	throttlerStateImpl.endChannel <- true
+
+	// 1 should not throttle due to return value of underlying Throttle(), despite high lag
+	atomic.StoreInt64(&throttlerStateImpl.shardMaxLag, 20)
 	assert.False(t, throttlerImpl.Throttle(100, "some-workload"))
 	assert.Equal(t, int64(1), throttlerImpl.requestsTotal.Counts()["some-workload"])
 	assert.Zero(t, throttlerImpl.requestsThrottled.Counts()["some-workload"])
@@ -171,17 +166,18 @@ func TestEnabledThrottler(t *testing.T) {
 	assert.Equal(t, map[string]int64{"cell1.REPLICA": 1, "cell2.RDONLY": 1}, throttlerImpl.healthChecksReadTotal.Counts())
 	assert.Equal(t, map[string]int64{"cell1.REPLICA": 1}, throttlerImpl.healthChecksRecordedTotal.Counts())
 
-	// Underlying throttling & lag present - Throttle due to priority
+	// 2 should throttle due to return value of underlying Throttle(), high lag & priority = 100
 	assert.True(t, throttlerImpl.Throttle(100, "some-workload"))
 	assert.Equal(t, int64(2), throttlerImpl.requestsTotal.Counts()["some-workload"])
 	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some-workload"])
 
-	// Underlying throttling & lag present - Do not throttle due to priority
+	// 3 should not throttle despite return value of underlying Throttle() and high lag, due to priority = 0
 	assert.False(t, throttlerImpl.Throttle(0, "some-workload"))
 	assert.Equal(t, int64(3), throttlerImpl.requestsTotal.Counts()["some-workload"])
 	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some-workload"])
 
-	// Underlying throttling & no lag present - Do no throttle despite priority
+	// 4 should not throttle despite return value of underlying Throttle() and priority = 100, due to low lag
+	atomic.StoreInt64(&throttlerStateImpl.shardMaxLag, 1)
 	assert.False(t, throttler.Throttle(100, "some-workload"))
 	assert.Equal(t, int64(4), throttlerImpl.requestsTotal.Counts()["some-workload"])
 	assert.Equal(t, int64(1), throttlerImpl.requestsThrottled.Counts()["some-workload"])


### PR DESCRIPTION
## Description

This PR addresses issue https://github.com/vitessio/vitess/issues/14768. It does so by ensuring that the transaction throttler checks for current lag in the shard before deciding whether to throttle the request or not.

The issue mentioned above is a bug causing artificially high throttling when the `TxThrottler` is enabled. Backporting of this is desirable as it will correct that undesirable behaviour in previous versions, not only in the next one. However, it seems I cannot add the _backport to_ label to the PR.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/14768

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A