### PR TITLE
[servenv] optional pprof endpoints

### DIFF
--- a/go/flags/endtoend/mysqlctl.txt
+++ b/go/flags/endtoend/mysqlctl.txt
@@ -81,6 +81,7 @@ Flags:
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/go/flags/endtoend/mysqlctld.txt
+++ b/go/flags/endtoend/mysqlctld.txt
@@ -106,6 +106,7 @@ Flags:
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/go/flags/endtoend/topo2topo.txt
+++ b/go/flags/endtoend/topo2topo.txt
@@ -33,6 +33,7 @@ Flags:
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)

--- a/go/flags/endtoend/vtaclcheck.txt
+++ b/go/flags/endtoend/vtaclcheck.txt
@@ -21,6 +21,7 @@ Flags:
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --static-auth-file string                                     The path of the auth_server_static JSON file to check

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -182,6 +182,7 @@ Flags:
       --opentsdb_uri string                                         URI of opentsdb /api/put method
       --port int                                                    port for the server
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --restart_before_backup                                       Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.

--- a/go/flags/endtoend/vtbench.txt
+++ b/go/flags/endtoend/vtbench.txt
@@ -72,6 +72,7 @@ Flags:
       --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
       --port int                                                    VTGate port
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --protocol string                                             Client protocol, either mysql (default), grpc-vtgate, or grpc-vttablet (default "mysql")
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/go/flags/endtoend/vtclient.txt
+++ b/go/flags/endtoend/vtclient.txt
@@ -38,6 +38,7 @@ Flags:
       --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
       --parallel int                                                DMLs only: Number of threads executing the same query in parallel. Useful for simple load testing. (default 1)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --qps int                                                     queries per second to throttle each thread at.
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -256,6 +256,7 @@ Flags:
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proto_topo vttest.TopoData                                       vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them

--- a/go/flags/endtoend/vtctlclient.txt
+++ b/go/flags/endtoend/vtctlclient.txt
@@ -30,6 +30,7 @@ Usage of vtctlclient:
       --logbuflevel int                                             Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --server string                                               server to use for connection

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -100,6 +100,7 @@ Flags:
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -64,6 +64,7 @@ Flags:
       --output-mode string                                          Output in human-friendly text or json (default "text")
       --planner-version string                                      Sets the default planner to use. Valid values are: Gen4, Gen4Greedy, Gen4Left2Right
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication-mode string                                     The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW")
       --schema string                                               The SQL table schema

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -163,6 +163,7 @@ Flags:
       --planner-version string                                           Sets the default planner to use when the session has not changed it. Valid values are: Gen4, Gen4Greedy, Gen4Left2Right
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --query-timeout int                                                Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)

--- a/go/flags/endtoend/vtgateclienttest.txt
+++ b/go/flags/endtoend/vtgateclienttest.txt
@@ -56,6 +56,7 @@ Flags:
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -61,6 +61,7 @@ Flags:
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                    port for the server
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --prevent-cross-cell-failover                                 Prevent VTOrc from promoting a primary in a different cell than the current primary in case of a failover
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --reasonable-replication-lag duration                         Maximum replication lag on replicas which is deemed to be acceptable (default 10s)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -254,6 +254,7 @@ Flags:
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --pt-osc-path string                                               override default pt-online-schema-change binary full path
       --publish_retry_interval duration                                  how long vttablet waits to retry publishing the tablet record (default 30s)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -99,6 +99,7 @@ Flags:
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         Port to use for vtcombo. If this is 0, a random port will be chosen.
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proto_topo string                                                Define the fake cluster topology as a compact text format encoded vttest proto. See vttest.proto for more information.
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --queryserver-config-transaction-timeout float                     query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value

--- a/go/flags/endtoend/zkctl.txt
+++ b/go/flags/endtoend/zkctl.txt
@@ -28,6 +28,7 @@ Flags:
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/go/vt/servenv/http.go
+++ b/go/vt/servenv/http.go
@@ -46,6 +46,10 @@ func HTTPServe(l net.Listener) error {
 
 // HTTPRegisterProfile registers the default pprof HTTP endpoints with the internal servenv mux.
 func HTTPRegisterProfile() {
+	if !httpPprof {
+		return
+	}
+
 	HTTPHandleFunc("/debug/pprof/", pprof.Index)
 	HTTPHandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	HTTPHandleFunc("/debug/pprof/profile", pprof.Profile)

--- a/go/vt/servenv/http.go
+++ b/go/vt/servenv/http.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"net/http/pprof"
 
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv/internal/mux"
 )
 
@@ -48,6 +51,10 @@ func HTTPServe(l net.Listener) error {
 func HTTPRegisterProfile() {
 	if !httpPprof {
 		return
+	}
+
+	if !pflag.Lookup("pprof-http").Changed {
+		log.Warning("Beginning in vitess version 20, pprof-http will default to `false`; to continue enabling pprof endpoints, please manually set this flag before upgrading.")
 	}
 
 	HTTPHandleFunc("/debug/pprof/", pprof.Index)

--- a/go/vt/servenv/http.go
+++ b/go/vt/servenv/http.go
@@ -54,7 +54,7 @@ func HTTPRegisterProfile() {
 	}
 
 	if !pflag.Lookup("pprof-http").Changed {
-		log.Warning("Beginning in vitess version 20, pprof-http will default to `false`; to continue enabling pprof endpoints, please manually set this flag before upgrading.")
+		log.Warning("Beginning in v20, pprof-http will default to `false`; to continue enabling pprof endpoints, please manually set this flag before upgrading.")
 	}
 
 	HTTPHandleFunc("/debug/pprof/", pprof.Index)

--- a/go/vt/servenv/pprof.go
+++ b/go/vt/servenv/pprof.go
@@ -35,6 +35,7 @@ import (
 
 var (
 	pprofFlag []string
+	httpPprof bool
 )
 
 type profmode string
@@ -298,6 +299,7 @@ func (prof *profile) init() (start func(), stop func()) {
 
 func init() {
 	OnParse(func(fs *pflag.FlagSet) {
+		fs.BoolVar(&httpPprof, "pprof-http", httpPprof, "enable pprof http endpoints")
 		fs.StringSliceVar(&pprofFlag, "pprof", pprofFlag, "enable profiling")
 	})
 	OnInit(pprofInit)

--- a/go/vt/servenv/pprof.go
+++ b/go/vt/servenv/pprof.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	pprofFlag []string
-	httpPprof bool
+	httpPprof = true
 )
 
 type profmode string


### PR DESCRIPTION
## Description

this PR adds a flag to allow users to deploy vitess components without including the `/debug/pprof` endpoints. we will begin by defaulting to opted-in to avoid changing behavior when upgrading to v19, but in v20 we will switch to disabled by default.

Demos!

```
➜  local git:(andrew/optional-pprof-endpoints) ✗ grep "false" vtdataroot/tmp/vttablet.WARNING 
W1216 12:57:36.270569   46724 http.go:56] Beginning in vitess version 20, pprof-http will default to `false`; to continue enabling pprof endpoints, please manually set this flag before upgrading.
```

```
  local git:(andrew/optional-pprof-endpoints) ✗ curl http://localhost:15000/debug/pprof/
404 page not found
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
