### PR TITLE
VReplication SwitchWrites: Properly return errors in SwitchWrites

### DIFF
--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -487,11 +487,11 @@ func (wr *Wrangler) SwitchWrites(ctx context.Context, targetKeyspace, workflowNa
 	ts, ws, err := wr.getWorkflowState(ctx, targetKeyspace, workflowName)
 	_ = ws
 	if err != nil {
-		handleError("failed to get the current workflow state", err)
+		return handleError("failed to get the current workflow state", err)
 	}
 	if ts == nil {
 		errorMsg := fmt.Sprintf("workflow %s not found in keyspace %s", workflowName, targetKeyspace)
-		handleError("failed to get the current workflow state", fmt.Errorf(errorMsg))
+		return handleError("failed to get the current workflow state", fmt.Errorf(errorMsg))
 	}
 
 	var sw iswitcher
@@ -508,7 +508,7 @@ func (wr *Wrangler) SwitchWrites(ctx context.Context, targetKeyspace, workflowNa
 
 	ts.Logger().Infof("Built switching metadata: %+v", ts)
 	if err := ts.validate(ctx); err != nil {
-		handleError("workflow validation failed", err)
+		return handleError("workflow validation failed", err)
 	}
 
 	if reverseReplication {
@@ -655,7 +655,7 @@ func (wr *Wrangler) SwitchWrites(ctx context.Context, targetKeyspace, workflowNa
 		return handleError("failed to update the routing rules", err)
 	}
 	if err := sw.streamMigraterfinalize(ctx, ts, sourceWorkflows); err != nil {
-		handleError("failed to finalize the traffic switch", err)
+		return handleError("failed to finalize the traffic switch", err)
 	}
 	if reverseReplication {
 		if err := sw.startReverseVReplication(ctx); err != nil {


### PR DESCRIPTION
## Description

During a refactor there was a regression where some errors were just being logged and not returned. This PR correctly returns them to the caller.

Original commit where this was introduced: https://github.com/vitessio/vitess/pull/13656/commits/89295b59d80a6f5ef57b06c5ff19cbf06651699d#diff-a071a972abd45af831ed93cc6447a87b83cee112f1c7d3bb0bdd592979d80c91
 
## Related Issue(s)

https://github.com/vitessio/vitess/pull/13656

Fixes: https://github.com/vitessio/vitess/issues/14801

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

