### PR TITLE
Fix hearbeatWriter Close being stuck if waiting for a semi-sync ACK

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -419,7 +419,11 @@ func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.R
 		if pat.expr.MatchString(query) {
 			userCallback, ok := db.queryPatternUserCallback[pat.expr]
 			if ok {
+				// Since the user call back can be indefinitely stuck, we shouldn't hold the lock indefinitely.
+				// This is only test code, so no actual cause for concern.
+				db.mu.Unlock()
 				userCallback(query)
+				db.mu.Lock()
 			}
 			if pat.err != "" {
 				return fmt.Errorf(pat.err)

--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -59,6 +59,7 @@ type heartbeatWriter struct {
 	appPool      *dbconnpool.ConnectionPool
 	allPrivsPool *dbconnpool.ConnectionPool
 	ticks        *timer.Timer
+	writeConnID  atomic.Int64
 
 	onDemandDuration            time.Duration
 	onDemandMu                  sync.Mutex
@@ -90,6 +91,7 @@ func newHeartbeatWriter(env tabletenv.Env, alias *topodatapb.TabletAlias) *heart
 		appPool:      dbconnpool.NewConnectionPool("HeartbeatWriteAppPool", env.Exporter(), 2, mysqlctl.DbaIdleTimeout, 0, mysqlctl.PoolDynamicHostnameResolution),
 		allPrivsPool: dbconnpool.NewConnectionPool("HeartbeatWriteAllPrivsPool", env.Exporter(), 2, mysqlctl.DbaIdleTimeout, 0, mysqlctl.PoolDynamicHostnameResolution),
 	}
+	w.writeConnID.Store(-1)
 	if w.onDemandDuration > 0 {
 		// see RequestHeartbeats() for use of onDemandRequestTicks
 		// it's basically a mechanism to rate limit operation RequestHeartbeats().
@@ -192,11 +194,6 @@ func (w *heartbeatWriter) write() error {
 	defer w.env.LogError()
 	ctx, cancel := context.WithDeadline(context.Background(), w.now().Add(w.interval))
 	defer cancel()
-	allPrivsConn, err := w.allPrivsPool.Get(ctx)
-	if err != nil {
-		return err
-	}
-	defer allPrivsConn.Recycle()
 
 	upsert, err := w.bindHeartbeatVars(sqlUpsertHeartbeat)
 	if err != nil {
@@ -207,6 +204,8 @@ func (w *heartbeatWriter) write() error {
 		return err
 	}
 	defer appConn.Recycle()
+	w.writeConnID.Store(appConn.Conn.ID())
+	defer w.writeConnID.Store(-1)
 	_, err = appConn.Conn.ExecuteFetch(upsert, 1, false)
 	if err != nil {
 		return err
@@ -215,6 +214,9 @@ func (w *heartbeatWriter) write() error {
 }
 
 func (w *heartbeatWriter) recordError(err error) {
+	if err == nil {
+		return
+	}
 	w.errorLog.Errorf("%v", err)
 	writeErrors.Add(1)
 }
@@ -238,12 +240,61 @@ func (w *heartbeatWriter) enableWrites(enable bool) {
 			w.ticks.Start(w.writeHeartbeat)
 		}()
 	case false:
-		w.ticks.Stop()
+		// We stop the ticks in a separate go routine because it can block if the write is stuck on semi-sync ACKs.
+		// At the same time we try and kill the write that is in progress. We use the context and its cancellation
+		// for coordination between the two go-routines. In the end we will have guaranteed that the ticks have stopped
+		// and no write is in progress.
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			w.ticks.Stop()
+			cancel()
+		}()
+		w.killWritesUntilStopped(ctx)
+
 		if w.onDemandDuration > 0 {
 			// Let the next RequestHeartbeats() go through
 			w.allowNextHeartbeatRequest()
 		}
 	}
+}
+
+// killWritesUntilStopped tries to kill the write in progress until the ticks have stopped.
+func (w *heartbeatWriter) killWritesUntilStopped(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			// If the context has been cancelled, then we know that the ticks have stopped.
+			// This guarantees that there are no writes in progress, so there is nothing to kill.
+			return
+		default:
+		}
+		// Actually try to kill the query.
+		err := w.killWrite()
+		w.recordError(err)
+		// We sleep for 100 millisecond, to prevent killing the query over and over very quickly.
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// killWrite kills the write in progress (if any).
+func (w *heartbeatWriter) killWrite() error {
+	defer w.env.LogError()
+	writeId := w.writeConnID.Load()
+	if writeId == -1 {
+		return nil
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), w.now().Add(w.interval))
+	defer cancel()
+	killConn, err := w.allPrivsPool.Get(ctx)
+	if err != nil {
+		log.Errorf("Kill conn didn't get connection :(")
+		return err
+	}
+	defer killConn.Recycle()
+
+	_, err = killConn.Conn.ExecuteFetch(fmt.Sprintf("kill %d", writeId), 1, false)
+	return err
 }
 
 // allowNextHeartbeatRequest ensures that the next call to RequestHeartbeats() passes through and

--- a/go/vt/vttablet/tabletserver/repltracker/writer_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer_test.go
@@ -86,7 +86,7 @@ func TestCloseWhileStuckWriting(t *testing.T) {
 	})
 
 	// When we receive a kill query, we want to finish running the wait group to unblock the upsert query.
-	db.AddQueryPatternWithCallback("kill", &sqltypes.Result{}, func(s string) {
+	db.AddQueryPatternWithCallback("kill.*", &sqltypes.Result{}, func(s string) {
 		killWg.Done()
 	})
 
@@ -104,7 +104,7 @@ func TestCloseWhileStuckWriting(t *testing.T) {
 	select {
 	case <-ctx.Done():
 		db.Close()
-	case <-time.After(10 * time.Second):
+	case <-time.After(1000 * time.Second):
 		t.Fatalf("Timed out waiting for heartbeat writer to close")
 	}
 }

--- a/go/vt/vttablet/tabletserver/repltracker/writer_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package repltracker
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -63,6 +65,48 @@ func TestWriteHeartbeatError(t *testing.T) {
 	tw.writeHeartbeat()
 	assert.Equal(t, int64(0), writes.Get())
 	assert.Equal(t, int64(1), writeErrors.Get())
+}
+
+// TestCloseWhileStuckWriting tests that Close shouldn't get stuck even if the heartbeat writer is stuck waiting for a semi-sync ACK.
+func TestCloseWhileStuckWriting(t *testing.T) {
+	db := fakesqldb.New(t)
+	tw := newTestWriter(db, nil)
+	tw.isOpen = true
+
+	killWg := sync.WaitGroup{}
+	killWg.Add(1)
+	startedWaitWg := sync.WaitGroup{}
+	startedWaitWg.Add(1)
+
+	// Insert a query pattern that causes the upsert to block indefinitely until it has been killed.
+	// This simulates a stuck primary write due to a semi-sync ACK requirement.
+	db.AddQueryPatternWithCallback(`INSERT INTO .*heartbeat \(ts, tabletUid, keyspaceShard\).*`, &sqltypes.Result{}, func(s string) {
+		startedWaitWg.Done()
+		killWg.Wait()
+	})
+
+	// When we receive a kill query, we want to finish running the wait group to unblock the upsert query.
+	db.AddQueryPatternWithCallback("kill", &sqltypes.Result{}, func(s string) {
+		killWg.Done()
+	})
+
+	// Now we enable writes, but the first write will get blocked.
+	tw.enableWrites(true)
+	// We wait until the write has blocked to ensure we only call Close after we are stuck writing.
+	startedWaitWg.Wait()
+	// Even if the write is blocked, we should be able to disable writes without waiting indefinitely.
+	// This is what we call, when we try to Close the heartbeat writer.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		tw.enableWrites(false)
+		cancel()
+	}()
+	select {
+	case <-ctx.Done():
+		db.Close()
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Timed out waiting for heartbeat writer to close")
+	}
 }
 
 func newTestWriter(db *fakesqldb.DB, frozenTime *time.Time) *heartbeatWriter {


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue pointed out in #14637. On investigating the issue, it was found that if the heartbeat writer is stuck while writing due to the requirement of semi-sync ACKs, it will also block `Close()` call to itself. This causes a problem since we aren't able to end the primary term, causing the cluster to see 2 primary tablets. VTOrc is unable to repair this failure either, because the problem is in the hearbeat writer of vttablet, and no external RPC can unblock it.

The proposed fix in this PR, is to do what we do for the user queries i.e., when we try to close the heartbeat writer, we try and kill the ongoing write. This ensures that we aren't indefinitely stuck. The code has been written with correctness in mind, and it is still blocking the `Close()` call from finishing, until we have guaranteed that no write is in progress. This is essential to prevent errant GTIDs from happening.

The heartbeat writer already had a connection pool with all the privileges. Earlier it was being used to run `DDL` queries in the `withDDL` struct that we had, but all of that was cleaned up with sidecardb related changes. However, the pool was left even though it wasn't being used. In this PR we have repurposed that pool and use it for `kill` queries that we need to run.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/14637

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
