### PR TITLE
Remove some logs that are logging excessively on large clusters

### DIFF
--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -216,7 +216,6 @@ func (svi *SysVarIgnore) VariableName() string {
 
 // Execute implements the SetOp interface method.
 func (svi *SysVarIgnore) Execute(context.Context, VCursor, *evalengine.ExpressionEnv) error {
-	log.Infof("Ignored inapplicable SET %v = %v", svi.Name, svi.Expr)
 	return nil
 }
 
@@ -249,16 +248,13 @@ func (svci *SysVarCheckAndIgnore) Execute(ctx context.Context, vcursor VCursor, 
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Unexpected error, DestinationKeyspaceID mapping to multiple shards: %v", svci.TargetDestination)
 	}
 	checkSysVarQuery := fmt.Sprintf("select 1 from dual where @@%s = %s", svci.Name, svci.Expr)
-	result, err := execShard(ctx, nil, vcursor, checkSysVarQuery, env.BindVars, rss[0], false /* rollbackOnError */, false /* canAutocommit */)
+	_, err = execShard(ctx, nil, vcursor, checkSysVarQuery, env.BindVars, rss[0], false /* rollbackOnError */, false /* canAutocommit */)
 	if err != nil {
 		// Rather than returning the error, we will just log the error
 		// as the intention for executing the query it to validate the current setting and eventually ignore it anyways.
 		// There is no benefit of returning the error back to client.
 		log.Warningf("unable to validate the current settings for '%s': %s", svci.Name, err.Error())
 		return nil
-	}
-	if len(result.Rows) == 0 {
-		log.Infof("Ignored inapplicable SET %v = %v", svci.Name, svci.Expr)
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -276,7 +276,6 @@ func (collector *TableGC) operate(ctx context.Context) {
 			// find something new to do.
 			go tableCheckTicker.TickNow()
 		case <-tableCheckTicker.C:
-			log.Info("TableGC: tableCheckTicker")
 			if err := collector.readAndCheckTables(ctx, dropTablesChan, transitionRequestsChan); err != nil {
 				log.Error(err)
 			}
@@ -415,8 +414,6 @@ func (collector *TableGC) readAndCheckTables(
 
 // readTables reads the list of _vt_% tables from the database
 func (collector *TableGC) readTables(ctx context.Context) (gcTables []*gcTable, err error) {
-	log.Infof("TableGC: read tables")
-
 	conn, err := collector.pool.Get(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -441,8 +438,6 @@ func (collector *TableGC) readTables(ctx context.Context) (gcTables []*gcTable, 
 // It lists _vt_% tables, then filters through those which are due-date.
 // It then applies the necessary operation per table.
 func (collector *TableGC) checkTables(ctx context.Context, gcTables []*gcTable, dropTablesChan chan<- *gcTable, transitionRequestsChan chan<- *transitionRequest) error {
-	log.Infof("TableGC: check tables")
-
 	for i := range gcTables {
 		table := gcTables[i] // we capture as local variable as we will later use this in a goroutine
 		shouldTransition, state, uuid, err := collector.shouldTransitionTable(table.tableName)

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -355,7 +355,6 @@ func (throttler *Throttler) normalizeThrottlerConfig(throttlerConfig *topodatapb
 }
 
 func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspace, err error) bool {
-	log.Infof("Throttler: WatchSrvKeyspaceCallback called with: %+v", srvks)
 	if err != nil {
 		log.Errorf("WatchSrvKeyspaceCallback error: %v", err)
 		return false
@@ -366,7 +365,6 @@ func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspa
 		// Throttler is enabled and we should apply the config change
 		// through Operate() or else we get into race conditions.
 		go func() {
-			log.Infof("Throttler: submitting a throttler config apply message with: %+v", throttlerConfig)
 			throttler.throttlerConfigChan <- throttlerConfig
 		}()
 	} else {


### PR DESCRIPTION
## Description

Removes logs for "Ignored inapplicable SET" system variables and some throttler logs which generate excessive logs for clusters with large number of shards.

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
