### PR TITLE
port release notes of v18.0.2, v17.0.5 and v16.0.7 to main

### DIFF
--- a/changelog/16.0/16.0.7/changelog.md
+++ b/changelog/16.0/16.0.7/changelog.md
@@ -1,0 +1,42 @@
+# Changelog of Vitess v16.0.7
+
+### Bug fixes 
+#### Build/CI
+ * [release-16.0] Update create_release.sh (#14492) [#14514](https://github.com/vitessio/vitess/pull/14514) 
+#### Cluster management
+ * [release-16.0] Fix Panic in PRS due to a missing nil check (#14656) [#14674](https://github.com/vitessio/vitess/pull/14674) 
+#### Query Serving
+ * [release-16.0] expression rewriting: enable more rewrites and limit CNF rewrites (#14560) [#14574](https://github.com/vitessio/vitess/pull/14574)
+ * [release-16.0] fix concurrency on stream execute engine primitives (#14586) [#14590](https://github.com/vitessio/vitess/pull/14590)
+ * [16.0] bug fix: stop all kinds of expressions from cnf-exploding [#14595](https://github.com/vitessio/vitess/pull/14595)
+ * [release-16.0] tabletserver: do not consolidate streams on primary tablet when consolidator mode is `notOnPrimary` (#14332) [#14683](https://github.com/vitessio/vitess/pull/14683) 
+#### VReplication
+ * Revert "[release-16.0] Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET` (#14612)" [#14743](https://github.com/vitessio/vitess/pull/14743)
+ * [release-16.0] VReplication: Update singular workflow in traffic switcher (#14826) [#14827](https://github.com/vitessio/vitess/pull/14827)
+### CI/Build 
+#### Build/CI
+ * [release-16.0] Update MySQL apt package and GPG signature (#14785) [#14790](https://github.com/vitessio/vitess/pull/14790) 
+#### Docker
+ * [release-16.0] Build and push Docker Images from GitHub Actions [#14513](https://github.com/vitessio/vitess/pull/14513) 
+#### General
+ * [release-16.0] Upgrade the Golang version to `go1.20.12` [#14691](https://github.com/vitessio/vitess/pull/14691)
+### Dependabot 
+#### General
+ * [release-16.0] build(deps): bump golang.org/x/crypto from 0.16.0 to 0.17.0 (#14814) [#14818](https://github.com/vitessio/vitess/pull/14818)
+### Enhancement 
+#### Build/CI
+ * [release-16.0] Add step to static check to ensure consistency of GHA workflows (#14724) [#14725](https://github.com/vitessio/vitess/pull/14725)
+### Internal Cleanup 
+#### TabletManager
+ * [release-16.0] Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET` (#14612) [#14620](https://github.com/vitessio/vitess/pull/14620)
+### Performance 
+#### Query Serving
+ * [release-16.0] vindexes: fix pooled collator buffer memory leak (#14621) [#14622](https://github.com/vitessio/vitess/pull/14622)
+### Release 
+#### General
+ * [release-16.0] Code Freeze for `v16.0.7` [#14808](https://github.com/vitessio/vitess/pull/14808)
+### Testing 
+#### Backup and Restore
+ * [release-16.0] Add a retry to remove the vttablet directory during upgrade/downgrade backup tests (#14753) [#14756](https://github.com/vitessio/vitess/pull/14756)
+ * [release-16.0] Backup flaky test [#14819](https://github.com/vitessio/vitess/pull/14819)
+

--- a/changelog/16.0/16.0.7/release_notes.md
+++ b/changelog/16.0/16.0.7/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v16.0.7
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/16.0/16.0.7/changelog.md).
+
+The release includes 18 merged Pull Requests.
+
+Thanks to all our contributors: @GuptaManan100, @app/github-actions, @app/vitess-bot, @deepthi, @frouioui, @harshit-gangal, @maxenglander, @shlomi-noach, @systay
+

--- a/changelog/16.0/README.md
+++ b/changelog/16.0/README.md
@@ -1,5 +1,9 @@
 ## v16.0
 The dedicated team for this release can be found [here](team.md).
+* **[16.0.7](16.0.7)**
+	* [Changelog](16.0.7/changelog.md)
+	* [Release Notes](16.0.7/release_notes.md)
+
 * **[16.0.6](16.0.6)**
 	* [Changelog](16.0.6/changelog.md)
 	* [Release Notes](16.0.6/release_notes.md)

--- a/changelog/17.0/17.0.5/changelog.md
+++ b/changelog/17.0/17.0.5/changelog.md
@@ -1,0 +1,49 @@
+# Changelog of Vitess v17.0.5
+
+### Bug fixes 
+#### Build/CI
+ * [release-17.0] Update create_release.sh (#14492) [#14515](https://github.com/vitessio/vitess/pull/14515) 
+#### Cluster management
+ * [release-17.0] Fix Panic in PRS due to a missing nil check (#14656) [#14675](https://github.com/vitessio/vitess/pull/14675)
+ * Revert "[release-17.0] Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET` (#14612)" [#14744](https://github.com/vitessio/vitess/pull/14744) 
+#### Evalengine
+ * [release-17.0] Fix nullability checks in evalengine (#14556) [#14563](https://github.com/vitessio/vitess/pull/14563) 
+#### Query Serving
+ * [release-17.0] expression rewriting: enable more rewrites and limit CNF rewrites (#14560) [#14575](https://github.com/vitessio/vitess/pull/14575)
+ * [release-17.0] fix concurrency on stream execute engine primitives (#14586) [#14591](https://github.com/vitessio/vitess/pull/14591)
+ * [17.0] bug fix: stop all kinds of expressions from cnf-exploding [#14594](https://github.com/vitessio/vitess/pull/14594)
+ * [release-17.0] tabletserver: do not consolidate streams on primary tablet when consolidator mode is `notOnPrimary` (#14332) [#14678](https://github.com/vitessio/vitess/pull/14678)
+ * Fix accepting bind variables in time related function calls. [#14763](https://github.com/vitessio/vitess/pull/14763) 
+#### VReplication
+ * [release-17.0] VReplication: Update singular workflow in traffic switcher (#14826) [#14828](https://github.com/vitessio/vitess/pull/14828)
+### CI/Build 
+#### Build/CI
+ * [release-17.0] Update MySQL apt package and GPG signature (#14785) [#14791](https://github.com/vitessio/vitess/pull/14791) 
+#### Docker
+ * [release-17.0] Build and push Docker Images from GitHub Actions [#14512](https://github.com/vitessio/vitess/pull/14512) 
+#### General
+ * [release-17.0] Upgrade the Golang version to `go1.20.11` [#14489](https://github.com/vitessio/vitess/pull/14489)
+ * [release-17.0] Upgrade the Golang version to `go1.20.12` [#14692](https://github.com/vitessio/vitess/pull/14692)
+### Dependabot 
+#### General
+ * [release-17.0] build(deps): bump golang.org/x/crypto from 0.16.0 to 0.17.0 (#14814) [#14816](https://github.com/vitessio/vitess/pull/14816) 
+#### VTAdmin
+ * [release-17.0] Bump @adobe/css-tools from 4.3.1 to 4.3.2 in /web/vtadmin (#14654) [#14667](https://github.com/vitessio/vitess/pull/14667)
+### Enhancement 
+#### Build/CI
+ * [release-17.0] Add step to static check to ensure consistency of GHA workflows (#14724) [#14726](https://github.com/vitessio/vitess/pull/14726)
+### Internal Cleanup 
+#### TabletManager
+ * [release-17.0] Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET` (#14612) [#14619](https://github.com/vitessio/vitess/pull/14619) 
+#### vtctldclient
+ * [release-17.0] Fix typo for `--cells` flag help description in `ApplyRoutingRules` (#14721) [#14722](https://github.com/vitessio/vitess/pull/14722)
+### Performance 
+#### Query Serving
+ * [release-17.0] vindexes: fix pooled collator buffer memory leak (#14621) [#14623](https://github.com/vitessio/vitess/pull/14623)
+### Release 
+#### General
+ * [release-17.0] Code Freeze for `v17.0.5` [#14806](https://github.com/vitessio/vitess/pull/14806)
+### Testing 
+#### Backup and Restore
+ * [release-17.0] Add a retry to remove the vttablet directory during upgrade/downgrade backup tests (#14753) [#14757](https://github.com/vitessio/vitess/pull/14757)
+

--- a/changelog/17.0/17.0.5/release_notes.md
+++ b/changelog/17.0/17.0.5/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v17.0.5
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/17.0/17.0.5/changelog.md).
+
+The release includes 22 merged Pull Requests.
+
+Thanks to all our contributors: @GuptaManan100, @app/github-actions, @app/vitess-bot, @deepthi, @frouioui, @harshit-gangal, @shlomi-noach, @systay
+

--- a/changelog/17.0/README.md
+++ b/changelog/17.0/README.md
@@ -1,4 +1,8 @@
 ## v17.0
+* **[17.0.5](17.0.5)**
+	* [Changelog](17.0.5/changelog.md)
+	* [Release Notes](17.0.5/release_notes.md)
+
 * **[17.0.4](17.0.4)**
 	* [Changelog](17.0.4/changelog.md)
 	* [Release Notes](17.0.4/release_notes.md)

--- a/changelog/18.0/18.0.2/changelog.md
+++ b/changelog/18.0/18.0.2/changelog.md
@@ -1,0 +1,56 @@
+# Changelog of Vitess v18.0.2
+
+### Bug fixes 
+#### Cluster management
+ * [release-18.0] Fix Panic in PRS due to a missing nil check (#14656) [#14676](https://github.com/vitessio/vitess/pull/14676)
+ * Revert "[release-18.0] Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET` (#14612)" [#14742](https://github.com/vitessio/vitess/pull/14742) 
+#### Evalengine
+ * [release-18.0] evalengine: Fix the min / max calculation for decimals (#14614) [#14616](https://github.com/vitessio/vitess/pull/14616) 
+#### Query Serving
+ * [release-18.0] fix concurrency on stream execute engine primitives (#14586) [#14592](https://github.com/vitessio/vitess/pull/14592)
+ * [18.0] bug fix: stop all kinds of expressions from cnf-exploding [#14593](https://github.com/vitessio/vitess/pull/14593)
+ * [release-18.0] bugfix: do not rewrite an expression twice (#14641) [#14643](https://github.com/vitessio/vitess/pull/14643)
+ * [release-18.0] tabletserver: do not consolidate streams on primary tablet when consolidator mode is `notOnPrimary` (#14332) [#14679](https://github.com/vitessio/vitess/pull/14679)
+ * [release-18.0] TabletServer: Handle nil targets properly everywhere (#14734) [#14741](https://github.com/vitessio/vitess/pull/14741) 
+#### VReplication
+ * [release-18.0] VReplication TableStreamer: Only stream tables in tablestreamer (ignore views) (#14646) [#14649](https://github.com/vitessio/vitess/pull/14649)
+ * [release-18.0] VDiff: Fix vtctldclient limit bug (#14778) [#14780](https://github.com/vitessio/vitess/pull/14780)
+ * [release-18.0] Backport: VReplication SwitchWrites: Properly return errors in SwitchWrites #14800 [#14824](https://github.com/vitessio/vitess/pull/14824)
+ * [release-18.0] VReplication: Update singular workflow in traffic switcher (#14826) [#14829](https://github.com/vitessio/vitess/pull/14829)
+### CI/Build 
+#### Build/CI
+ * [release-18.0] Update MySQL apt package and GPG signature (#14785) [#14792](https://github.com/vitessio/vitess/pull/14792) 
+#### General
+ * [release-18.0] Upgrade the Golang version to `go1.21.5` [#14690](https://github.com/vitessio/vitess/pull/14690)
+### Dependabot 
+#### General
+ * [release-18.0] build(deps): bump golang.org/x/crypto from 0.16.0 to 0.17.0 (#14814) [#14817](https://github.com/vitessio/vitess/pull/14817) 
+#### VTAdmin
+ * [release-18.0] Bump @adobe/css-tools from 4.3.1 to 4.3.2 in /web/vtadmin (#14654) [#14668](https://github.com/vitessio/vitess/pull/14668)
+### Enhancement 
+#### Backup and Restore
+ * [release-18.0] increase vtctlclient backupShard command success rate (#14604) [#14639](https://github.com/vitessio/vitess/pull/14639) 
+#### Build/CI
+ * [release-18.0] Add step to static check to ensure consistency of GHA workflows (#14724) [#14727](https://github.com/vitessio/vitess/pull/14727) 
+#### Query Serving
+ * [release-18.0] planbuilder: push down ordering through filter (#14583) [#14584](https://github.com/vitessio/vitess/pull/14584)
+### Internal Cleanup 
+#### TabletManager
+ * [release-18.0] Replace use of `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS` with `WAIT_FOR_EXECUTED_GTID_SET` (#14612) [#14617](https://github.com/vitessio/vitess/pull/14617) 
+#### vtctldclient
+ * [release-18.0] Fix typo for `--cells` flag help description in `ApplyRoutingRules` (#14721) [#14723](https://github.com/vitessio/vitess/pull/14723)
+### Performance 
+#### Query Serving
+ * vindexes: fix pooled collator buffer memory leak [#14621](https://github.com/vitessio/vitess/pull/14621)
+### Regression 
+#### Query Serving
+ * [release-18.0] plabuilder: use OR for not in comparisons (#14607) [#14615](https://github.com/vitessio/vitess/pull/14615)
+ * [release-18.0] fix: insert on duplicate key update missing BindVars (#14728) [#14755](https://github.com/vitessio/vitess/pull/14755)
+### Release 
+#### General
+ * Back to dev mode after v18.0.1 [#14580](https://github.com/vitessio/vitess/pull/14580)
+ * [release-18.0] Code Freeze for `v18.0.2` [#14804](https://github.com/vitessio/vitess/pull/14804)
+### Testing 
+#### Backup and Restore
+ * [release-18.0] Add a retry to remove the vttablet directory during upgrade/downgrade backup tests (#14753) [#14758](https://github.com/vitessio/vitess/pull/14758)
+

--- a/changelog/18.0/18.0.2/release_notes.md
+++ b/changelog/18.0/18.0.2/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v18.0.2
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/18.0/18.0.2/changelog.md).
+
+The release includes 27 merged Pull Requests.
+
+Thanks to all our contributors: @app/github-actions, @app/vitess-bot, @brendar, @deepthi, @harshit-gangal, @rohit-nayak-ps, @systay
+

--- a/changelog/18.0/README.md
+++ b/changelog/18.0/README.md
@@ -1,4 +1,8 @@
 ## v18.0
+* **[18.0.2](18.0.2)**
+	* [Changelog](18.0.2/changelog.md)
+	* [Release Notes](18.0.2/release_notes.md)
+
 * **[18.0.1](18.0.1)**
 	* [Changelog](18.0.1/changelog.md)
 	* [Release Notes](18.0.1/release_notes.md)


### PR DESCRIPTION
This PR moves the release notes of the v18.0.2, v17.0.5 and v16.0.7 patches to main