### PR TITLE
Allow for building 32 bit libraries for subparts

### DIFF
--- a/go/mysql/binlog/rbr_test.go
+++ b/go/mysql/binlog/rbr_test.go
@@ -78,7 +78,7 @@ func TestCellLengthAndData(t *testing.T) {
 		styp: querypb.Type_UINT32,
 		data: []byte{0x84, 0x83, 0x82, 0x81},
 		out: sqltypes.MakeTrusted(querypb.Type_UINT32,
-			[]byte(fmt.Sprintf("%v", 0x81828384))),
+			[]byte(fmt.Sprintf("%v", uint32(0x81828384)))),
 	}, {
 		typ:  TypeLong,
 		styp: querypb.Type_INT32,

--- a/go/mysql/collations/colldata/mysqlucadata.go
+++ b/go/mysql/collations/colldata/mysqlucadata.go
@@ -20,7 +20,7 @@ package colldata
 
 import (
 	_ "embed"
-	unsafe "unsafe"
+	"unsafe"
 )
 
 var weightTable_uca900_page000 = weightsUCA_embed(0, 2560)
@@ -1417,5 +1417,5 @@ var weightTable_uca520 = []*[]uint16{
 var weightsUCA_embed_data string
 
 func weightsUCA_embed(pos, length int) []uint16 {
-	return (*[0x7fff0000]uint16)(unsafe.Pointer(unsafe.StringData(weightsUCA_embed_data)))[pos : pos+length]
+	return (*[0x3fffffff]uint16)(unsafe.Pointer(unsafe.StringData(weightsUCA_embed_data)))[pos : pos+length]
 }

--- a/go/mysql/datetime/interval.go
+++ b/go/mysql/datetime/interval.go
@@ -258,13 +258,13 @@ func (itv *Interval) inRange() bool {
 	if itv.day > maxDay {
 		return false
 	}
-	if itv.hour > maxDay*24 {
+	if itv.hour/24 > maxDay {
 		return false
 	}
-	if itv.min > maxDay*24*60 {
+	if itv.min/24/60 > maxDay {
 		return false
 	}
-	if itv.sec > maxDay*24*60*60 {
+	if itv.sec/24/60/60 > maxDay {
 		return false
 	}
 	return true

--- a/go/mysql/decimal/scan.go
+++ b/go/mysql/decimal/scan.go
@@ -311,17 +311,12 @@ func pow(x big.Word, n int) (p big.Word) {
 }
 
 func parseLargeDecimal(integral, fractional []byte) (*big.Int, error) {
-	const (
-		b1 = big.Word(10)
-		bn = big.Word(1e19)
-		n  = 19
-	)
 	var (
 		di = big.Word(0) // 0 <= di < b1**i < bn
 		i  = 0           // 0 <= i < n
-		// 5 is the largest possible size for a MySQL decimal; anything
-		// that doesn't fit in 5 words won't make it to this func
-		z = make([]big.Word, 0, 5)
+		// s is the largest possible size for a MySQL decimal; anything
+		// that doesn't fit in s words won't make it to this func
+		z = make([]big.Word, 0, s)
 	)
 
 	parseChunk := func(partial []byte) error {

--- a/go/mysql/decimal/scan_32.go
+++ b/go/mysql/decimal/scan_32.go
@@ -1,0 +1,12 @@
+//go:build 386 || arm || mips || mipsle
+
+package decimal
+
+import "math/big"
+
+const (
+	b1 = big.Word(10)
+	bn = big.Word(1e9)
+	n  = 9
+	s  = 10
+)

--- a/go/mysql/decimal/scan_32.go
+++ b/go/mysql/decimal/scan_32.go
@@ -1,5 +1,21 @@
 //go:build 386 || arm || mips || mipsle
 
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package decimal
 
 import "math/big"

--- a/go/mysql/decimal/scan_64.go
+++ b/go/mysql/decimal/scan_64.go
@@ -1,0 +1,12 @@
+//go:build !386 && !arm && !mips && !mipsle
+
+package decimal
+
+import "math/big"
+
+const (
+	b1 = big.Word(10)
+	bn = big.Word(1e19)
+	n  = 19
+	s  = 5
+)

--- a/go/mysql/decimal/scan_64.go
+++ b/go/mysql/decimal/scan_64.go
@@ -1,5 +1,21 @@
 //go:build !386 && !arm && !mips && !mipsle
 
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package decimal
 
 import "math/big"

--- a/go/mysql/icuregex/compiler.go
+++ b/go/mysql/icuregex/compiler.go
@@ -2698,7 +2698,7 @@ func (c *compiler) compileInterval(init opcode, loop opcode) {
 	//   Goes at end of the block being looped over, so just append to the code so far.
 	c.appendOp(loop, topOfBlock)
 
-	if (c.intervalLow&0xff000000) != 0 || (c.intervalUpper > 0 && (c.intervalUpper&0xff000000) != 0) {
+	if c.intervalLow > 0x00ffffff || (c.intervalUpper > 0 && c.intervalUpper > 0x00ffffff) {
 		c.error(NumberTooBig)
 	}
 
@@ -3195,7 +3195,7 @@ func (c *compiler) maxMatchLength(start, end int) int32 {
 			}
 
 			blockLen := c.maxMatchLength(loc+4, loopEndLoc-1) // Recursive call.
-			updatedLen := int(currentLen) + int(blockLen)*maxLoopCount
+			updatedLen := int64(currentLen) + int64(blockLen)*int64(maxLoopCount)
 			if updatedLen >= math.MaxInt32 {
 				currentLen = math.MaxInt32
 				break

--- a/go/sqltypes/testing.go
+++ b/go/sqltypes/testing.go
@@ -229,7 +229,7 @@ var RandomGenerators = map[Type]RandomGenerator{
 		return NewFloat64(rand.ExpFloat64())
 	},
 	Decimal: func() Value {
-		dec := fmt.Sprintf("%d.%d", rand.Intn(9999999999), rand.Intn(9999999999))
+		dec := fmt.Sprintf("%d.%d", rand.Intn(999999999), rand.Intn(999999999))
 		if rand.Int()&0x1 == 1 {
 			dec = "-" + dec
 		}


### PR DESCRIPTION
To allow using the sqlparser and go/mysql package as a library, we also want to allow it to build on 32 bits with the simplest change possible. The changes here are small and not problematic to carry.

## Related Issue(s)

Part of #14717 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required