### PR TITLE
Subquery inside aggregration function

### DIFF
--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -165,6 +165,7 @@ func TestSubqueryInReference(t *testing.T) {
 
 // TestSubqueryInAggregation validates that subquery work inside aggregation functions.
 func TestSubqueryInAggregation(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -162,3 +162,19 @@ func TestSubqueryInReference(t *testing.T) {
 	mcmp.AssertMatches(`select (select id1 from t1 where id2 = 30)`, `[[INT64(3)]]`)
 	mcmp.AssertMatches(`select (select id1 from t1 where id2 = 9)`, `[[NULL]]`)
 }
+
+// TestSubqueryInAggregation validates that subquery work inside aggregation functions.
+func TestSubqueryInAggregation(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into t1(id1, id2) values(0,0),(1,1)")
+	mcmp.Exec("insert into t2(id3, id4) values(1,2),(5,7)")
+	mcmp.Exec(`SELECT max((select min(id2) from t1)) FROM t2`)
+	mcmp.Exec(`SELECT max((select group_concat(id1, id2) from t1 where id1 = 1)) FROM t1 where id1 = 1`)
+	mcmp.Exec(`SELECT max((select min(id2) from t1 where id2 = 1)) FROM dual`)
+	mcmp.Exec(`SELECT max((select min(id2) from t1)) FROM t2 where id4 = 7`)
+
+	// This fails as the planner adds `weight_string` method which make the query fail on MySQL.
+	// mcmp.Exec(`SELECT max((select min(id2) from t1 where t1.id1 = t.id1)) FROM t1 t`)
+}

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -107,6 +107,10 @@ func pushAggregationThroughSubquery(
 
 	src.Outer = pushedAggr
 
+	for _, aggregation := range pushedAggr.Aggregations {
+		aggregation.Original.Expr = rewriteColNameToArgument(ctx, aggregation.Original.Expr, aggregation.SubQueryExpression, src.Inner...)
+	}
+
 	if !rootAggr.Original {
 		return src, Rewrote("push Aggregation under subquery - keep original")
 	}

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -95,6 +95,13 @@ func settleSubqueries(ctx *plancontext.PlanningContext, op Operator) Operator {
 			for _, setExpr := range op.Assignments {
 				mergeSubqueryExpr(ctx, setExpr.Expr)
 			}
+		case *Aggregator:
+			for _, aggr := range op.Aggregations {
+				newExpr, rewritten := rewriteMergedSubqueryExpr(ctx, aggr.SubQueryExpression, aggr.Original.Expr)
+				if rewritten {
+					aggr.Original.Expr = newExpr
+				}
+			}
 		}
 		return op, NoRewrite
 	}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6562,5 +6562,288 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "select max((select min(col) from user where id = 1))",
+    "query": "select max((select min(col) from user where id = 1))",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select max((select min(col) from user where id = 1))",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select max((select min(col) from `user` where 1 != 1)) from dual where 1 != 1",
+        "Query": "select max((select min(col) from `user` where id = 1)) from dual",
+        "Table": "dual",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "select max((select min(col) from unsharded)) from user where id = 1",
+    "query": "select max((select min(col) from unsharded)) from user where id = 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select max((select min(col) from unsharded)) from user where id = 1",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "max(0|1) AS max((select min(col) from unsharded))",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutValue",
+            "PulloutVars": [
+              "__sq1"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select min(col) from unsharded where 1 != 1",
+                "Query": "select min(col) from unsharded",
+                "Table": "unsharded"
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select max(:__sq1), weight_string(:__sq1) from `user` where 1 != 1 group by weight_string(:__sq1)",
+                "Query": "select max(:__sq1), weight_string(:__sq1) from `user` where id = 1 group by weight_string(:__sq1)",
+                "Table": "`user`",
+                "Values": [
+                  "1"
+                ],
+                "Vindex": "user_index"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "select max((select min(col) from user where id = 1)) from user where id = 2",
+    "query": "select max((select min(col) from user where id = 1)) from user where id = 2",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select max((select min(col) from user where id = 1)) from user where id = 2",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "max(0|1) AS max((select min(col) from `user` where id = 1))",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutValue",
+            "PulloutVars": [
+              "__sq1"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select min(col) from `user` where 1 != 1",
+                "Query": "select min(col) from `user` where id = 1",
+                "Table": "`user`",
+                "Values": [
+                  "1"
+                ],
+                "Vindex": "user_index"
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select max(:__sq1), weight_string(:__sq1) from `user` where 1 != 1 group by weight_string(:__sq1)",
+                "Query": "select max(:__sq1), weight_string(:__sq1) from `user` where id = 2 group by weight_string(:__sq1)",
+                "Table": "`user`",
+                "Values": [
+                  "2"
+                ],
+                "Vindex": "user_index"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "select max((select group_concat(col1, col2) from user where id = 1))",
+    "query": "select max((select group_concat(col1, col2) from user where id = 1))",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select max((select group_concat(col1, col2) from user where id = 1))",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select max((select group_concat(col1, col2) from `user` where 1 != 1)) from dual where 1 != 1",
+        "Query": "select max((select group_concat(col1, col2) from `user` where id = 1)) from dual",
+        "Table": "dual",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user where id = 1",
+    "query": "select max((select group_concat(col1, col2) from user where id = 1)) from user where id = 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select max((select group_concat(col1, col2) from user where id = 1)) from user where id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select max((select group_concat(col1, col2) from `user` where 1 != 1)) from `user` where 1 != 1",
+        "Query": "select max((select group_concat(col1, col2) from `user` where id = 1)) from `user` where id = 1",
+        "Table": "`user`",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
+    "query": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "max(0|1) AS max((select group_concat(col1, col2) from `user` where id = 1))",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutValue",
+            "PulloutVars": [
+              "__sq1"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select group_concat(col1, col2) from `user` where 1 != 1",
+                "Query": "select group_concat(col1, col2) from `user` where id = 1",
+                "Table": "`user`",
+                "Values": [
+                  "1"
+                ],
+                "Vindex": "user_index"
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select max(:__sq1), weight_string(:__sq1) from `user` where 1 != 1 group by weight_string(:__sq1)",
+                "Query": "select max(:__sq1), weight_string(:__sq1) from `user` group by weight_string(:__sq1)",
+                "Table": "`user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
+    "query": "select max((select max(col2) from user u1 where u1.id = u2.id)) from user u2",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select max((select max(col2) from user u1 where u1.id = u2.id)) from user u2",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "max(0|1) AS max((select max(col2) from `user` as u1 where u1.id = u2.id))",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select max((select max(col2) from `user` as u1 where 1 != 1)), weight_string((select max(col2) from `user` as u1 where 1 != 1)) from `user` as u2 where 1 != 1 group by weight_string((select max(col2) from `user` as u1 where 1 != 1))",
+            "Query": "select max((select max(col2) from `user` as u1 where u1.id = u2.id)), weight_string((select max(col2) from `user` as u1 where u1.id = u2.id)) from `user` as u2 group by weight_string((select max(col2) from `user` as u1 where u1.id = u2.id))",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -413,5 +413,10 @@
     "comment": "reference table delete with join",
     "query": "delete r from user u join ref_with_source r on u.col = r.col",
     "plan": "VT12001: unsupported: DELETE on reference table with join"
+  },
+  {
+    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
+    "query": "select group_concat(col1, col2) from user",
+    "plan": "VT03001: aggregate functions take a single argument 'group_concat(col1, col2)'"
   }
 ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

When the subquery operator was introduced it missed the case for handling the subquery inside an aggregation function.
This PR adds support for it.

As per the issue `group_concat` does not accept more than one argument when evaluated at vtgate. That is still unsupported and is not the cause of regression. The queries reported in the issue would work now.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/14843

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [X] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
