### PR TITLE
go/vt/topo: add error value to GetTablet logs

### DIFF
--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -229,7 +229,7 @@ func NewTabletInfo(tablet *topodatapb.Tablet, version Version) *TabletInfo {
 func (ts *Server) GetTablet(ctx context.Context, alias *topodatapb.TabletAlias) (*TabletInfo, error) {
 	conn, err := ts.ConnForCell(ctx, alias.Cell)
 	if err != nil {
-		log.Errorf("Unable to get connection for cell %s", alias.Cell)
+		log.Errorf("unable to get connection for cell %q: %v", alias.Cell, err)
 		return nil, err
 	}
 
@@ -240,7 +240,7 @@ func (ts *Server) GetTablet(ctx context.Context, alias *topodatapb.TabletAlias) 
 	tabletPath := path.Join(TabletsPath, topoproto.TabletAliasString(alias), TabletFile)
 	data, version, err := conn.Get(ctx, tabletPath)
 	if err != nil {
-		log.Errorf("unable to connect to tablet %s: %s", alias, err)
+		log.Errorf("unable to connect to tablet %q: %v", alias, err)
 		return nil, err
 	}
 	tablet := &topodatapb.Tablet{}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

We're seeing this error message a lot in logs and there is an `err` variable in scope, but it's not actually shown. Display it. Quote the cell name and tablet aliases for clarity as well.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

n/a, trivial cleanup.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required