### PR TITLE
schemadiff: allow char->varchar FK reference type matching

### DIFF
--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -357,6 +357,9 @@ func (s *Schema) normalize() error {
 		if child.Type == "char" && parent.Type == "varchar" {
 			return true
 		}
+		if child.Type == "varchar" && parent.Type == "char" {
+			return true
+		}
 		return false
 	}
 	colTypeEqualForForeignKey := func(child, parent *sqlparser.ColumnType) bool {

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -383,13 +383,12 @@ func TestInvalidSchema(t *testing.T) {
 			schema: "create table t10(id varchar(50) charset utf8mb4 collate utf8mb4_0900_ai_ci primary key); create table t11 (id int primary key, i varchar(100) charset utf8mb4 collate utf8mb4_0900_ai_ci, key ix(i), constraint f10 foreign key (i) references t10(id) on delete restrict)",
 		},
 		{
-			// weirdly allowed: varchar->char
+			// allowed: varchar->char
 			schema: "create table t10(id varchar(50) charset utf8mb4 collate utf8mb4_0900_ai_ci primary key); create table t11 (id int primary key, i char(100) charset utf8mb4 collate utf8mb4_0900_ai_ci, key ix(i), constraint f10 foreign key (i) references t10(id) on delete restrict)",
 		},
 		{
-			// but weirdly not allowed: char->varchar
-			schema:    "create table t10(id char(50) charset utf8mb4 collate utf8mb4_0900_ai_ci primary key); create table t11 (id int primary key, i varchar(50) charset utf8mb4 collate utf8mb4_0900_ai_ci, key ix(i), constraint f10 foreign key (i) references t10(id) on delete restrict)",
-			expectErr: &ForeignKeyColumnTypeMismatchError{Table: "t11", Constraint: "f10", Column: "i", ReferencedTable: "t10", ReferencedColumn: "id"},
+			// allowed: char->varchar
+			schema: "create table t10(id char(50) charset utf8mb4 collate utf8mb4_0900_ai_ci primary key); create table t11 (id int primary key, i varchar(50) charset utf8mb4 collate utf8mb4_0900_ai_ci, key ix(i), constraint f10 foreign key (i) references t10(id) on delete restrict)",
 		},
 		{
 			schema:    "create table t10(id varchar(50) charset utf8mb3 primary key); create table t11 (id int primary key, i varchar(100) charset utf8mb4, key ix(i), constraint f10 foreign key (i) references t10(id) on delete restrict)",


### PR DESCRIPTION

## Description

Followup and adjustment to https://github.com/vitessio/vitess/pull/14751. Per https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html:

> The length of string types need not be the same. For nonbinary (character) string columns, the character set and collation must be the same.

This allows parent(char)->child(varchar) types.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/11975
- 
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
