### PR TITLE
go/cache: use generics and remove unused API

### DIFF
--- a/go/cache/lru_cache.go
+++ b/go/cache/lru_cache.go
@@ -33,13 +33,12 @@ import (
 // reaches the capacity, the least recently used item is deleted from
 // the cache. Note the capacity is not the number of items, but the
 // total sum of the CachedSize() of each item.
-type LRUCache struct {
+type LRUCache[T any] struct {
 	mu sync.Mutex
 
 	// list & table contain *entry objects.
 	list  *list.List
 	table map[string]*list.Element
-	cost  func(any) int64
 
 	size      int64
 	capacity  int64
@@ -49,46 +48,44 @@ type LRUCache struct {
 }
 
 // Item is what is stored in the cache
-type Item struct {
+type Item[T any] struct {
 	Key   string
-	Value any
+	Value T
 }
 
-type entry struct {
+type entry[T any] struct {
 	key          string
-	value        any
-	size         int64
+	value        T
 	timeAccessed time.Time
 }
 
 // NewLRUCache creates a new empty cache with the given capacity.
-func NewLRUCache(capacity int64, cost func(any) int64) *LRUCache {
-	return &LRUCache{
+func NewLRUCache[T any](capacity int64) *LRUCache[T] {
+	return &LRUCache[T]{
 		list:     list.New(),
 		table:    make(map[string]*list.Element),
 		capacity: capacity,
-		cost:     cost,
 	}
 }
 
 // Get returns a value from the cache, and marks the entry as most
 // recently used.
-func (lru *LRUCache) Get(key string) (v any, ok bool) {
+func (lru *LRUCache[T]) Get(key string) (v T, ok bool) {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
 	element := lru.table[key]
 	if element == nil {
 		lru.misses++
-		return nil, false
+		return *new(T), false
 	}
 	lru.moveToFront(element)
 	lru.hits++
-	return element.Value.(*entry).value, true
+	return element.Value.(*entry[T]).value, true
 }
 
 // Set sets a value in the cache.
-func (lru *LRUCache) Set(key string, value any) bool {
+func (lru *LRUCache[T]) Set(key string, value T) bool {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
@@ -102,7 +99,7 @@ func (lru *LRUCache) Set(key string, value any) bool {
 }
 
 // Delete removes an entry from the cache, and returns if the entry existed.
-func (lru *LRUCache) delete(key string) bool {
+func (lru *LRUCache[T]) delete(key string) bool {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
@@ -113,27 +110,17 @@ func (lru *LRUCache) delete(key string) bool {
 
 	lru.list.Remove(element)
 	delete(lru.table, key)
-	lru.size -= element.Value.(*entry).size
+	lru.size--
 	return true
 }
 
 // Delete removes an entry from the cache
-func (lru *LRUCache) Delete(key string) {
+func (lru *LRUCache[T]) Delete(key string) {
 	lru.delete(key)
 }
 
-// Clear will clear the entire cache.
-func (lru *LRUCache) Clear() {
-	lru.mu.Lock()
-	defer lru.mu.Unlock()
-
-	lru.list.Init()
-	lru.table = make(map[string]*list.Element)
-	lru.size = 0
-}
-
 // Len returns the size of the cache (in entries)
-func (lru *LRUCache) Len() int {
+func (lru *LRUCache[T]) Len() int {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 	return lru.list.Len()
@@ -142,7 +129,7 @@ func (lru *LRUCache) Len() int {
 // SetCapacity will set the capacity of the cache. If the capacity is
 // smaller, and the current cache size exceed that capacity, the cache
 // will be shrank.
-func (lru *LRUCache) SetCapacity(capacity int64) {
+func (lru *LRUCache[T]) SetCapacity(capacity int64) {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
@@ -150,105 +137,80 @@ func (lru *LRUCache) SetCapacity(capacity int64) {
 	lru.checkCapacity()
 }
 
-// Wait is a no-op in the LRU cache
-func (lru *LRUCache) Wait() {}
-
 // UsedCapacity returns the size of the cache (in bytes)
-func (lru *LRUCache) UsedCapacity() int64 {
+func (lru *LRUCache[T]) UsedCapacity() int64 {
 	return lru.size
 }
 
 // MaxCapacity returns the cache maximum capacity.
-func (lru *LRUCache) MaxCapacity() int64 {
+func (lru *LRUCache[T]) MaxCapacity() int64 {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 	return lru.capacity
 }
 
 // Evictions returns the number of evictions
-func (lru *LRUCache) Evictions() int64 {
+func (lru *LRUCache[T]) Evictions() int64 {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 	return lru.evictions
 }
 
 // Hits returns number of cache hits since creation
-func (lru *LRUCache) Hits() int64 {
+func (lru *LRUCache[T]) Hits() int64 {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 	return lru.hits
 }
 
 // Misses returns number of cache misses since creation
-func (lru *LRUCache) Misses() int64 {
+func (lru *LRUCache[T]) Misses() int64 {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 	return lru.misses
 }
 
-// ForEach yields all the values for the cache, ordered from most recently
-// used to least recently used.
-func (lru *LRUCache) ForEach(callback func(value any) bool) {
-	lru.mu.Lock()
-	defer lru.mu.Unlock()
-
-	for e := lru.list.Front(); e != nil; e = e.Next() {
-		v := e.Value.(*entry)
-		if !callback(v.value) {
-			break
-		}
-	}
-}
-
 // Items returns all the values for the cache, ordered from most recently
 // used to least recently used.
-func (lru *LRUCache) Items() []Item {
+func (lru *LRUCache[T]) Items() []Item[T] {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
-	items := make([]Item, 0, lru.list.Len())
+	items := make([]Item[T], 0, lru.list.Len())
 	for e := lru.list.Front(); e != nil; e = e.Next() {
-		v := e.Value.(*entry)
-		items = append(items, Item{Key: v.key, Value: v.value})
+		v := e.Value.(*entry[T])
+		items = append(items, Item[T]{Key: v.key, Value: v.value})
 	}
 	return items
 }
 
-func (lru *LRUCache) updateInplace(element *list.Element, value any) {
-	valueSize := lru.cost(value)
-	sizeDiff := valueSize - element.Value.(*entry).size
-	element.Value.(*entry).value = value
-	element.Value.(*entry).size = valueSize
-	lru.size += sizeDiff
+func (lru *LRUCache[T]) updateInplace(element *list.Element, value T) {
+	element.Value.(*entry[T]).value = value
 	lru.moveToFront(element)
 	lru.checkCapacity()
 }
 
-func (lru *LRUCache) moveToFront(element *list.Element) {
+func (lru *LRUCache[T]) moveToFront(element *list.Element) {
 	lru.list.MoveToFront(element)
-	element.Value.(*entry).timeAccessed = time.Now()
+	element.Value.(*entry[T]).timeAccessed = time.Now()
 }
 
-func (lru *LRUCache) addNew(key string, value any) {
-	newEntry := &entry{key, value, lru.cost(value), time.Now()}
+func (lru *LRUCache[T]) addNew(key string, value T) {
+	newEntry := &entry[T]{key, value, time.Now()}
 	element := lru.list.PushFront(newEntry)
 	lru.table[key] = element
-	lru.size += newEntry.size
+	lru.size++
 	lru.checkCapacity()
 }
 
-func (lru *LRUCache) checkCapacity() {
+func (lru *LRUCache[T]) checkCapacity() {
 	// Partially duplicated from Delete
 	for lru.size > lru.capacity {
 		delElem := lru.list.Back()
-		delValue := delElem.Value.(*entry)
+		delValue := delElem.Value.(*entry[T])
 		lru.list.Remove(delElem)
 		delete(lru.table, delValue.key)
-		lru.size -= delValue.size
+		lru.size--
 		lru.evictions++
 	}
-}
-
-func (lru *LRUCache) Close() {
-	lru.Clear()
 }

--- a/go/cache/lru_cache.go
+++ b/go/cache/lru_cache.go
@@ -31,8 +31,7 @@ import (
 
 // LRUCache is a typical LRU cache implementation.  If the cache
 // reaches the capacity, the least recently used item is deleted from
-// the cache. Note the capacity is not the number of items, but the
-// total sum of the CachedSize() of each item.
+// the cache.
 type LRUCache[T any] struct {
 	mu sync.Mutex
 

--- a/go/cache/lru_cache_test.go
+++ b/go/cache/lru_cache_test.go
@@ -24,12 +24,8 @@ type CacheValue struct {
 	size int64
 }
 
-func cacheValueSize(val any) int64 {
-	return val.(*CacheValue).size
-}
-
 func TestInitialState(t *testing.T) {
-	cache := NewLRUCache(5, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](5)
 	l, sz, c, e, h, m := cache.Len(), cache.UsedCapacity(), cache.MaxCapacity(), cache.Evictions(), cache.Hits(), cache.Misses()
 	if l != 0 {
 		t.Errorf("length = %v, want 0", l)
@@ -52,13 +48,13 @@ func TestInitialState(t *testing.T) {
 }
 
 func TestSetInsertsValue(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](100)
 	data := &CacheValue{0}
 	key := "key"
 	cache.Set(key, data)
 
 	v, ok := cache.Get(key)
-	if !ok || v.(*CacheValue) != data {
+	if !ok || v != data {
 		t.Errorf("Cache has incorrect value: %v != %v", data, v)
 	}
 
@@ -69,40 +65,24 @@ func TestSetInsertsValue(t *testing.T) {
 }
 
 func TestGetValueWithMultipleTypes(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](100)
 	data := &CacheValue{0}
 	key := "key"
 	cache.Set(key, data)
 
 	v, ok := cache.Get("key")
-	if !ok || v.(*CacheValue) != data {
+	if !ok || v != data {
 		t.Errorf("Cache has incorrect value for \"key\": %v != %v", data, v)
 	}
 
 	v, ok = cache.Get(string([]byte{'k', 'e', 'y'}))
-	if !ok || v.(*CacheValue) != data {
+	if !ok || v != data {
 		t.Errorf("Cache has incorrect value for []byte {'k','e','y'}: %v != %v", data, v)
 	}
 }
 
-func TestSetUpdatesSize(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
-	emptyValue := &CacheValue{0}
-	key := "key1"
-	cache.Set(key, emptyValue)
-	if sz := cache.UsedCapacity(); sz != 0 {
-		t.Errorf("cache.UsedCapacity() = %v, expected 0", sz)
-	}
-	someValue := &CacheValue{20}
-	key = "key2"
-	cache.Set(key, someValue)
-	if sz := cache.UsedCapacity(); sz != 20 {
-		t.Errorf("cache.UsedCapacity() = %v, expected 20", sz)
-	}
-}
-
 func TestSetWithOldKeyUpdatesValue(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](100)
 	emptyValue := &CacheValue{0}
 	key := "key1"
 	cache.Set(key, emptyValue)
@@ -110,31 +90,13 @@ func TestSetWithOldKeyUpdatesValue(t *testing.T) {
 	cache.Set(key, someValue)
 
 	v, ok := cache.Get(key)
-	if !ok || v.(*CacheValue) != someValue {
+	if !ok || v != someValue {
 		t.Errorf("Cache has incorrect value: %v != %v", someValue, v)
 	}
 }
 
-func TestSetWithOldKeyUpdatesSize(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
-	emptyValue := &CacheValue{0}
-	key := "key1"
-	cache.Set(key, emptyValue)
-
-	if sz := cache.UsedCapacity(); sz != 0 {
-		t.Errorf("cache.UsedCapacity() = %v, expected %v", sz, 0)
-	}
-
-	someValue := &CacheValue{20}
-	cache.Set(key, someValue)
-	expected := int64(someValue.size)
-	if sz := cache.UsedCapacity(); sz != expected {
-		t.Errorf("cache.UsedCapacity() = %v, expected %v", sz, expected)
-	}
-}
-
 func TestGetNonExistent(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](100)
 
 	if _, ok := cache.Get("notthere"); ok {
 		t.Error("Cache returned a notthere value after no inserts.")
@@ -142,7 +104,7 @@ func TestGetNonExistent(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](100)
 	value := &CacheValue{1}
 	key := "key"
 
@@ -159,22 +121,9 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-func TestClear(t *testing.T) {
-	cache := NewLRUCache(100, cacheValueSize)
-	value := &CacheValue{1}
-	key := "key"
-
-	cache.Set(key, value)
-	cache.Clear()
-
-	if sz := cache.UsedCapacity(); sz != 0 {
-		t.Errorf("cache.UsedCapacity() = %v, expected 0 after Clear()", sz)
-	}
-}
-
 func TestCapacityIsObeyed(t *testing.T) {
 	size := int64(3)
-	cache := NewLRUCache(100, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](100)
 	cache.SetCapacity(size)
 	value := &CacheValue{1}
 
@@ -215,7 +164,7 @@ func TestCapacityIsObeyed(t *testing.T) {
 
 func TestLRUIsEvicted(t *testing.T) {
 	size := int64(3)
-	cache := NewLRUCache(size, cacheValueSize)
+	cache := NewLRUCache[*CacheValue](size)
 
 	cache.Set("key1", &CacheValue{1})
 	cache.Set("key2", &CacheValue{1})

--- a/go/pools/numbered.go
+++ b/go/pools/numbered.go
@@ -30,7 +30,7 @@ type Numbered struct {
 	mu                   sync.Mutex
 	empty                *sync.Cond // Broadcast when pool becomes empty
 	resources            map[int64]*numberedWrapper
-	recentlyUnregistered *cache.LRUCache
+	recentlyUnregistered *cache.LRUCache[*unregistered]
 }
 
 type numberedWrapper struct {
@@ -47,10 +47,8 @@ type unregistered struct {
 // NewNumbered creates a new numbered
 func NewNumbered() *Numbered {
 	n := &Numbered{
-		resources: make(map[int64]*numberedWrapper),
-		recentlyUnregistered: cache.NewLRUCache(1000, func(_ any) int64 {
-			return 1
-		}),
+		resources:            make(map[int64]*numberedWrapper),
+		recentlyUnregistered: cache.NewLRUCache[*unregistered](1000),
 	}
 	n.empty = sync.NewCond(&n.mu)
 	return n
@@ -107,8 +105,7 @@ func (nu *Numbered) Get(id int64, purpose string) (val any, err error) {
 	defer nu.mu.Unlock()
 	nw, ok := nu.resources[id]
 	if !ok {
-		if val, ok := nu.recentlyUnregistered.Get(fmt.Sprintf("%v", id)); ok {
-			unreg := val.(*unregistered)
+		if unreg, ok := nu.recentlyUnregistered.Get(fmt.Sprintf("%v", id)); ok {
 			return nil, fmt.Errorf("ended at %v (%v)", unreg.timeUnregistered.Format("2006-01-02 15:04:05.000 MST"), unreg.reason)
 		}
 		return nil, fmt.Errorf("not found")

--- a/go/sync2/consolidator.go
+++ b/go/sync2/consolidator.go
@@ -127,21 +127,19 @@ func (rs *pendingResult) Wait() {
 // It is also used by the txserializer package to count how often transactions
 // have been queued and had to wait because they targeted the same row (range).
 type ConsolidatorCache struct {
-	*cache.LRUCache
+	*cache.LRUCache[*ccount]
 }
 
 // NewConsolidatorCache creates a new cache with the given capacity.
 func NewConsolidatorCache(capacity int64) *ConsolidatorCache {
-	return &ConsolidatorCache{cache.NewLRUCache(capacity, func(_ any) int64 {
-		return 1
-	})}
+	return &ConsolidatorCache{cache.NewLRUCache[*ccount](capacity)}
 }
 
 // Record increments the count for "query" by 1.
 // If it's not in the cache yet, it will be added.
 func (cc *ConsolidatorCache) Record(query string) {
-	if v, ok := cc.Get(query); ok {
-		v.(*ccount).add(1)
+	if c, ok := cc.Get(query); ok {
+		c.add(1)
 	} else {
 		c := ccount(1)
 		cc.Set(query, &c)
@@ -159,7 +157,7 @@ func (cc *ConsolidatorCache) Items() []ConsolidatorCacheItem {
 	items := cc.LRUCache.Items()
 	ret := make([]ConsolidatorCacheItem, len(items))
 	for i, v := range items {
-		ret[i] = ConsolidatorCacheItem{Query: v.Key, Count: v.Value.(*ccount).get()}
+		ret[i] = ConsolidatorCacheItem{Query: v.Key, Count: v.Value.get()}
 	}
 	return ret
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

The two remaining uses of the old cache API use a fixed cost of 1 and can still benefit from adding a type-safe generic interface.

Remove a couple of entirely unused methods. There are several methods at this point regarding hit/miss/eviction that are otherwise unused outside of tests but I've left them at this point for the sake of coverage.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

n/a, cleanup.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

n/a

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
