### PR TITLE
Added support for group_concat and count distinct with multiple expressions

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -628,7 +628,7 @@ func TestDistinctAggregation(t *testing.T) {
 	}, {
 		query: `SELECT a.value, SUM(DISTINCT b.t1_id), min(DISTINCT a.t1_id) FROM t1 a, t1 b group by a.value`,
 	}, {
-		query: `SELECT distinct count(*) from t1, (select distinct count(*) from t1) as t2`,
+		query: `SELECT count(distinct name, shardkey) from t1`,
 	}}
 
 	for _, tc := range tcases {

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -574,6 +574,8 @@ func TestGroupConcatAggregation(t *testing.T) {
 	compareRow(t, mQr, vtQr, nil, []int{0})
 	mQr, vtQr = mcmp.ExecNoCompare(`SELECT group_concat(value), t1.name FROM t1, t2 group by t1.name`)
 	compareRow(t, mQr, vtQr, []int{1}, []int{0})
+	mQr, vtQr = mcmp.ExecNoCompare(`SELECT group_concat(name, value) FROM t1`)
+	compareRow(t, mQr, vtQr, nil, []int{0})
 }
 
 func compareRow(t *testing.T, mRes *sqltypes.Result, vtRes *sqltypes.Result, grpCols []int, fCols []int) {

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -574,6 +574,10 @@ func TestGroupConcatAggregation(t *testing.T) {
 	compareRow(t, mQr, vtQr, nil, []int{0})
 	mQr, vtQr = mcmp.ExecNoCompare(`SELECT group_concat(value), t1.name FROM t1, t2 group by t1.name`)
 	compareRow(t, mQr, vtQr, []int{1}, []int{0})
+	if versionMet := utils.BinaryIsAtLeastAtVersion(19, "vtgate"); !versionMet {
+		// skipping
+		return
+	}
 	mQr, vtQr = mcmp.ExecNoCompare(`SELECT group_concat(name, value) FROM t1`)
 	compareRow(t, mQr, vtQr, nil, []int{0})
 }
@@ -615,6 +619,7 @@ func TestDistinctAggregation(t *testing.T) {
 	tcases := []struct {
 		query       string
 		expectedErr string
+		minVersion  int
 	}{{
 		query:       `SELECT COUNT(DISTINCT value), SUM(DISTINCT shardkey) FROM t1`,
 		expectedErr: "VT12001: unsupported: only one DISTINCT aggregation is allowed in a SELECT: sum(distinct shardkey) (errno 1235) (sqlstate 42000)",
@@ -628,10 +633,15 @@ func TestDistinctAggregation(t *testing.T) {
 	}, {
 		query: `SELECT a.value, SUM(DISTINCT b.t1_id), min(DISTINCT a.t1_id) FROM t1 a, t1 b group by a.value`,
 	}, {
-		query: `SELECT count(distinct name, shardkey) from t1`,
+		minVersion: 19,
+		query:      `SELECT count(distinct name, shardkey) from t1`,
 	}}
 
 	for _, tc := range tcases {
+		if versionMet := utils.BinaryIsAtLeastAtVersion(tc.minVersion, "vtgate"); !versionMet {
+			// skipping
+			continue
+		}
 		mcmp.Run(tc.query, func(mcmp *utils.MySQLCompare) {
 			_, err := mcmp.ExecAllowError(tc.query)
 			if tc.expectedErr == "" {

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -165,6 +165,7 @@ func TestSubqueryInReference(t *testing.T) {
 
 // TestSubqueryInAggregation validates that subquery work inside aggregation functions.
 func TestSubqueryInAggregation(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -165,7 +165,6 @@ func TestSubqueryInReference(t *testing.T) {
 
 // TestSubqueryInAggregation validates that subquery work inside aggregation functions.
 func TestSubqueryInAggregation(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -204,7 +204,7 @@ func checkIfWeCanPush(ctx *plancontext.PlanningContext, aggregator *Aggregator) 
 			continue
 		}
 
-		innerExpr := aggr.Func.GetArg()
+		innerExpr := aggr.getPushColumn()
 		if !exprHasUniqueVindex(ctx, innerExpr) {
 			canPush = false
 		}

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -27,6 +27,13 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 )
 
+func errDistinctAggrWithMultiExpr(f sqlparser.AggrFunc) {
+	if f == nil {
+		panic(vterrors.VT12001("distinct aggregation function with multiple expressions"))
+	}
+	panic(vterrors.VT12001(fmt.Sprintf("distinct aggregation function with multiple expressions '%s'", sqlparser.String(f))))
+}
+
 func tryPushAggregator(ctx *plancontext.PlanningContext, aggregator *Aggregator) (output Operator, applyResult *ApplyResult) {
 	if aggregator.Pushed {
 		return aggregator, NoRewrite
@@ -162,7 +169,7 @@ func pushAggregationThroughRoute(
 
 // pushAggregations splits aggregations between the original aggregator and the one we are pushing down
 func pushAggregations(ctx *plancontext.PlanningContext, aggregator *Aggregator, aggrBelowRoute *Aggregator) {
-	canPushDistinctAggr, distinctExpr := checkIfWeCanPush(ctx, aggregator)
+	canPushDistinctAggr, distinctExprs := checkIfWeCanPush(ctx, aggregator)
 
 	distinctAggrGroupByAdded := false
 
@@ -173,16 +180,20 @@ func pushAggregations(ctx *plancontext.PlanningContext, aggregator *Aggregator, 
 			continue
 		}
 
+		if len(distinctExprs) != 1 {
+			errDistinctAggrWithMultiExpr(aggr.Func)
+		}
+
 		// We handle a distinct aggregation by turning it into a group by and
 		// doing the aggregating on the vtgate level instead
-		aeDistinctExpr := aeWrap(distinctExpr)
+		aeDistinctExpr := aeWrap(distinctExprs[0])
 		aggrBelowRoute.Columns[aggr.ColOffset] = aeDistinctExpr
 
 		// We handle a distinct aggregation by turning it into a group by and
 		// doing the aggregating on the vtgate level instead
 		// Adding to group by can be done only once even though there are multiple distinct aggregation with same expression.
 		if !distinctAggrGroupByAdded {
-			groupBy := NewGroupBy(distinctExpr, distinctExpr)
+			groupBy := NewGroupBy(distinctExprs[0], distinctExprs[0])
 			groupBy.ColOffset = aggr.ColOffset
 			aggrBelowRoute.Grouping = append(aggrBelowRoute.Grouping, groupBy)
 			distinctAggrGroupByAdded = true
@@ -190,13 +201,13 @@ func pushAggregations(ctx *plancontext.PlanningContext, aggregator *Aggregator, 
 	}
 
 	if !canPushDistinctAggr {
-		aggregator.DistinctExpr = distinctExpr
+		aggregator.DistinctExpr = distinctExprs[0]
 	}
 }
 
-func checkIfWeCanPush(ctx *plancontext.PlanningContext, aggregator *Aggregator) (bool, sqlparser.Expr) {
+func checkIfWeCanPush(ctx *plancontext.PlanningContext, aggregator *Aggregator) (bool, sqlparser.Exprs) {
 	canPush := true
-	var distinctExpr sqlparser.Expr
+	var distinctExprs sqlparser.Exprs
 	var differentExpr *sqlparser.AliasedExpr
 
 	for _, aggr := range aggregator.Aggregations {
@@ -204,15 +215,25 @@ func checkIfWeCanPush(ctx *plancontext.PlanningContext, aggregator *Aggregator) 
 			continue
 		}
 
-		innerExpr := aggr.getPushColumn()
-		if !exprHasUniqueVindex(ctx, innerExpr) {
+		args := aggr.Func.GetArgs()
+		hasUniqVindex := false
+		for _, arg := range args {
+			if exprHasUniqueVindex(ctx, arg) {
+				hasUniqVindex = true
+				break
+			}
+		}
+		if !hasUniqVindex {
 			canPush = false
 		}
-		if distinctExpr == nil {
-			distinctExpr = innerExpr
+		if len(distinctExprs) == 0 {
+			distinctExprs = args
 		}
-		if !ctx.SemTable.EqualsExpr(distinctExpr, innerExpr) {
-			differentExpr = aggr.Original
+		for idx, expr := range distinctExprs {
+			if !ctx.SemTable.EqualsExpr(expr, args[idx]) {
+				differentExpr = aggr.Original
+				break
+			}
 		}
 	}
 
@@ -220,7 +241,7 @@ func checkIfWeCanPush(ctx *plancontext.PlanningContext, aggregator *Aggregator) 
 		panic(vterrors.VT12001(fmt.Sprintf("only one DISTINCT aggregation is allowed in a SELECT: %s", sqlparser.String(differentExpr))))
 	}
 
-	return canPush, distinctExpr
+	return canPush, distinctExprs
 }
 
 func pushAggregationThroughFilter(
@@ -530,12 +551,15 @@ func splitAggrColumnsToLeftAndRight(
 		outerJoin:   leftJoin,
 	}
 
-	canPushDistinctAggr, distinctExpr := checkIfWeCanPush(ctx, aggregator)
+	canPushDistinctAggr, distinctExprs := checkIfWeCanPush(ctx, aggregator)
 
 	// Distinct aggregation cannot be pushed down in the join.
 	// We keep node of the distinct aggregation expression to be used later for ordering.
 	if !canPushDistinctAggr {
-		aggregator.DistinctExpr = distinctExpr
+		if len(distinctExprs) != 1 {
+			errDistinctAggrWithMultiExpr(nil)
+		}
+		aggregator.DistinctExpr = distinctExprs[0]
 		return nil, errAbortAggrPushing
 	}
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6564,7 +6564,7 @@
     }
   },
   {
-    "comment": "select max((select min(col) from user where id = 1))",
+    "comment": "sharded subquery inside aggregation function on a dual table",
     "query": "select max((select min(col) from user where id = 1))",
     "plan": {
       "QueryType": "SELECT",
@@ -6591,7 +6591,7 @@
     }
   },
   {
-    "comment": "select max((select min(col) from unsharded)) from user where id = 1",
+    "comment": "unsharded subquery inside aggregation function on a sharded table",
     "query": "select max((select min(col) from unsharded)) from user where id = 1",
     "plan": {
       "QueryType": "SELECT",
@@ -6648,7 +6648,7 @@
     }
   },
   {
-    "comment": "select max((select min(col) from user where id = 1)) from user where id = 2",
+    "comment": "sharded subquery inside aggregation function on a sharded table on different vindex value",
     "query": "select max((select min(col) from user where id = 1)) from user where id = 2",
     "plan": {
       "QueryType": "SELECT",
@@ -6708,7 +6708,7 @@
     }
   },
   {
-    "comment": "select max((select group_concat(col1, col2) from user where id = 1))",
+    "comment": "sharded subquery inside group_concat multi-column aggregation function on a dual table",
     "query": "select max((select group_concat(col1, col2) from user where id = 1))",
     "plan": {
       "QueryType": "SELECT",
@@ -6735,7 +6735,7 @@
     }
   },
   {
-    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user where id = 1",
+    "comment": "sharded subquery inside group_concat multi-column aggregation function on a sharded table on same vindex value",
     "query": "select max((select group_concat(col1, col2) from user where id = 1)) from user where id = 1",
     "plan": {
       "QueryType": "SELECT",
@@ -6761,7 +6761,7 @@
     }
   },
   {
-    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
+    "comment": "sharded subquery inside group_concat multi-column aggregation function on a sharded table",
     "query": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
     "plan": {
       "QueryType": "SELECT",
@@ -6817,7 +6817,7 @@
     }
   },
   {
-    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
+    "comment": "sharded correlated subquery inside aggregation function on a sharded table on same vindex",
     "query": "select max((select max(col2) from user u1 where u1.id = u2.id)) from user u2",
     "plan": {
       "QueryType": "SELECT",
@@ -6837,6 +6837,69 @@
             },
             "FieldQuery": "select max((select max(col2) from `user` as u1 where 1 != 1)), weight_string((select max(col2) from `user` as u1 where 1 != 1)) from `user` as u2 where 1 != 1 group by weight_string((select max(col2) from `user` as u1 where 1 != 1))",
             "Query": "select max((select max(col2) from `user` as u1 where u1.id = u2.id)), weight_string((select max(col2) from `user` as u1 where u1.id = u2.id)) from `user` as u2 group by weight_string((select max(col2) from `user` as u1 where u1.id = u2.id))",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "count aggregation function having multiple column",
+    "query": "select count(distinct user_id, name) from user",
+    "plan": "VT03001: aggregate functions take a single argument 'count(distinct user_id, `name`)'"
+  },
+  {
+    "comment": "Multi-value aggregates pushed as function without splitting",
+    "query": "select count(a,b) from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(a,b) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum_count(0) AS count(a, b)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select count(a, b) from `user` where 1 != 1",
+            "Query": "select count(a, b) from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "group_concat with multi column - pushed without splitting",
+    "query": "select group_concat(col1, col2) from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select group_concat(col1, col2) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "group_concat(0) AS group_concat(col1, col2)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select group_concat(col1, col2) from `user` where 1 != 1",
+            "Query": "select group_concat(col1, col2) from `user`",
             "Table": "`user`"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -2844,11 +2844,6 @@
     }
   },
   {
-    "comment": "select count(distinct user_id, name) from user",
-    "query": "select count(distinct user_id, name) from user",
-    "plan": "VT03001: aggregate functions take a single argument 'count(distinct user_id, `name`)'"
-  },
-  {
     "comment": "select sum(col) from (select user.col as col, 32 from user join user_extra) t",
     "query": "select sum(col) from (select user.col as col, 32 from user join user_extra) t",
     "plan": {
@@ -6847,11 +6842,6 @@
     }
   },
   {
-    "comment": "count aggregation function having multiple column",
-    "query": "select count(distinct user_id, name) from user",
-    "plan": "VT03001: aggregate functions take a single argument 'count(distinct user_id, `name`)'"
-  },
-  {
     "comment": "Multi-value aggregates pushed as function without splitting",
     "query": "select count(a,b) from user",
     "plan": {
@@ -6900,6 +6890,35 @@
             },
             "FieldQuery": "select group_concat(col1, col2) from `user` where 1 != 1",
             "Query": "select group_concat(col1, col2) from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "",
+    "query": "select count(distinct name, id) from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(distinct name, id) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum_count_distinct(0) AS count(distinct `name`, id)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select count(distinct `name`, id) from `user` where 1 != 1",
+            "Query": "select count(distinct `name`, id) from `user`",
             "Table": "`user`"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -413,5 +413,15 @@
     "comment": "group_concat unsupported when needs full evaluation at vtgate with more than 1 column",
     "query": "select group_concat(user.col1, music.col2) x from user join music on user.col = music.col order by x",
     "plan": "VT12001: unsupported: group_concat with more than 1 column"
+  },
+  {
+    "comment": "count aggregation function having multiple column",
+    "query": "select count(distinct user_id, name) from user",
+    "plan": "VT12001: unsupported: distinct aggregation function with multiple expressions 'count(distinct user_id, `name`)'"
+  },
+  {
+    "comment": "count and sum distinct on different columns",
+    "query": "SELECT COUNT(DISTINCT col), SUM(DISTINCT id) FROM user",
+    "plan": "VT12001: unsupported: only one DISTINCT aggregation is allowed in a SELECT: sum(distinct id)"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -15,11 +15,6 @@
     "plan": "VT12001: unsupported: natural right join"
   },
   {
-    "comment": "Multi-value aggregates not supported",
-    "query": "select count(a,b) from user",
-    "plan": "VT03001: aggregate functions take a single argument 'count(a, b)'"
-  },
-  {
     "comment": "subqueries not supported in group by",
     "query": "select id from user group by id, (select id from user_extra)",
     "plan": "VT12001: unsupported: subqueries in GROUP BY"
@@ -415,8 +410,8 @@
     "plan": "VT12001: unsupported: DELETE on reference table with join"
   },
   {
-    "comment": "select max((select group_concat(col1, col2) from user where id = 1)) from user",
-    "query": "select group_concat(col1, col2) from user",
-    "plan": "VT03001: aggregate functions take a single argument 'group_concat(col1, col2)'"
+    "comment": "group_concat unsupported when needs full evaluation at vtgate with more than 1 column",
+    "query": "select group_concat(user.col1, music.col2) x from user join music on user.col = music.col order by x",
+    "plan": "VT12001: unsupported: group_concat with more than 1 column"
   }
 ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR allows aggregation functions with multiple expressions when the aggregation function can be pushed to underlying MySQL for execution.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
