### PR TITLE
Throttler: refactor global configuration setting as throttler member

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/config/config.go
+++ b/go/vt/vttablet/tabletserver/throttle/config/config.go
@@ -41,12 +41,9 @@ limitations under the License.
 
 package config
 
-// Instance is the one configuration for the throttler
-var Instance = &ConfigurationSettings{}
-
-// Settings returns the settings of the global instance of Configuration
-func Settings() *ConfigurationSettings {
-	return Instance
+// NewConfigurationSettings creates new throttler configuration settings.
+func NewConfigurationSettings() *ConfigurationSettings {
+	return &ConfigurationSettings{}
 }
 
 // ConfigurationSettings models a set of configurable values, that can be

--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -100,12 +100,12 @@ func (w FakeHeartbeatWriter) RequestHeartbeats() {
 
 func newTestThrottler() *Throttler {
 	metricsQuery := "select 1"
-	config.Settings().Stores.MySQL.Clusters = map[string]*config.MySQLClusterConfigurationSettings{
+	configSettings := config.NewConfigurationSettings()
+	configSettings.Stores.MySQL.Clusters = map[string]*config.MySQLClusterConfigurationSettings{
 		selfStoreName:  {},
 		shardStoreName: {},
 	}
-	clusters := config.Settings().Stores.MySQL.Clusters
-	for _, s := range clusters {
+	for _, s := range configSettings.Stores.MySQL.Clusters {
 		s.MetricQuery = metricsQuery
 		s.ThrottleThreshold = &atomic.Uint64{}
 		s.ThrottleThreshold.Store(1)
@@ -121,6 +121,7 @@ func newTestThrottler() *Throttler {
 		tabletTypeFunc:         func() topodatapb.TabletType { return topodatapb.TabletType_PRIMARY },
 		overrideTmClient:       &fakeTMClient{},
 	}
+	throttler.configSettings = configSettings
 	throttler.mysqlThrottleMetricChan = make(chan *mysql.MySQLThrottleMetric)
 	throttler.mysqlInventoryChan = make(chan *mysql.Inventory, 1)
 	throttler.mysqlClusterProbesChan = make(chan *mysql.ClusterProbes)
@@ -222,17 +223,18 @@ func TestIsAppExempted(t *testing.T) {
 // `PRIMARY` tablet, probes other tablets). On the leader, the list is expected to be non-empty.
 func TestRefreshMySQLInventory(t *testing.T) {
 	metricsQuery := "select 1"
-	config.Settings().Stores.MySQL.Clusters = map[string]*config.MySQLClusterConfigurationSettings{
+	configSettings := config.NewConfigurationSettings()
+	clusters := map[string]*config.MySQLClusterConfigurationSettings{
 		selfStoreName: {},
 		"ks1":         {},
 		"ks2":         {},
 	}
-	clusters := config.Settings().Stores.MySQL.Clusters
 	for _, s := range clusters {
 		s.MetricQuery = metricsQuery
 		s.ThrottleThreshold = &atomic.Uint64{}
 		s.ThrottleThreshold.Store(1)
 	}
+	configSettings.Stores.MySQL.Clusters = clusters
 
 	throttler := &Throttler{
 		mysqlClusterProbesChan: make(chan *mysql.ClusterProbes),
@@ -240,6 +242,7 @@ func TestRefreshMySQLInventory(t *testing.T) {
 		ts:                     &FakeTopoServer{},
 		mysqlInventory:         mysql.NewInventory(),
 	}
+	throttler.configSettings = configSettings
 	throttler.metricsQuery.Store(metricsQuery)
 	throttler.initThrottleTabletTypes()
 


### PR DESCRIPTION
## Description

Following recurring race condition failures, e.g. https://github.com/vitessio/vitess/actions/runs/7299836104/job/19894003119?pr=14851, this PR removes the global throttler configuration Instance, and makes it a member of the throttler struct. Each throttler has its own dedicated config settings now.

This eliminates race conditions in the unit tests, and generally plays nicer with unit testing.

## Related Issue(s)

Closes https://github.com/vitessio/vitess/issues/14852

Fixes: https://github.com/vitessio/vitess/issues/14776


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
