### PR TITLE
evalengine: Fix week overflow

### DIFF
--- a/go/mysql/datetime/datetime.go
+++ b/go/mysql/datetime/datetime.go
@@ -315,12 +315,16 @@ func (d Date) Week(mode int) int {
 		year, week := d.SundayWeek()
 		if year < d.Year() {
 			return 0
+		} else if year > d.Year() {
+			return 53
 		}
 		return week
 	case 1:
 		year, week := d.ISOWeek()
 		if year < d.Year() {
 			return 0
+		} else if year > d.Year() {
+			return 53
 		}
 		return week
 	case 2:
@@ -333,12 +337,16 @@ func (d Date) Week(mode int) int {
 		year, week := d.Sunday4DayWeek()
 		if year < d.Year() {
 			return 0
+		} else if year > d.Year() {
+			return 53
 		}
 		return week
 	case 5:
 		year, week := d.MondayWeek()
 		if year < d.Year() {
 			return 0
+		} else if year > d.Year() {
+			return 53
 		}
 		return week
 	case 6:

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -574,6 +574,22 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `DAYOFMONTH(0)`,
 			result:     `INT64(0)`,
 		},
+		{
+			expression: `week('2023-12-31', 4)`,
+			result:     `INT64(53)`,
+		},
+		{
+			expression: `week('2023-12-31', 2)`,
+			result:     `INT64(53)`,
+		},
+		{
+			expression: `week('2024-12-31', 1)`,
+			result:     `INT64(53)`,
+		},
+		{
+			expression: `week('2024-12-31', 5)`,
+			result:     `INT64(53)`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")


### PR DESCRIPTION
Some of the last days in the year can fall in the first week of the next year. If that happens, there are various modes when we should return 53 as the week number and not week 1 for the next year.

This can always be 53. There are weeks which already contain 53 weeks, but it can never be 54 in those cases as in years with 53 weeks, there's never a last day of the year that falls in the first week of next year. It then always falls in week 53 already.

## Related Issue(s)

Fixes #14858 

Backporting as this is a straight bug in the calculation and it's trivially easy to fix. There's no risk to this fix either.  It also can trigger CI instability if we don't fix it which is a useful reason as well. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required