### PR TITLE
Tests: Fix vdiff test breakage from concurrent merge

### DIFF
--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -172,6 +172,8 @@ func TestVDiff2(t *testing.T) {
 }
 
 func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, tks *Keyspace, cells []*Cell) {
+	vtgateConn := vc.GetVTGateConn(t)
+	defer vtgateConn.Close()
 	arrTargetShards := strings.Split(tc.targetShards, ",")
 	if tc.typ == "Reshard" {
 		require.NoError(t, vc.AddShards(t, cells, tks, tc.targetShards, 0, 0, tc.tabletBaseID, targetKsOpts))


### PR DESCRIPTION
## Description

We merged these two PRs concurrently and thus ended up with a test breakage:
  - https://github.com/vitessio/vitess/pull/14735
  - https://github.com/vitessio/vitess/pull/14786

```
❯ golangci-lint run go/... --timeout 10m
go/test/endtoend/vreplication/vreplication_test_env.go:1: : # vitess.io/vitess/go/test/endtoend/vreplication [vitess.io/vitess/go/test/endtoend/vreplication.test]
go/test/endtoend/vreplication/vdiff2_test.go:239:14: undefined: vtgateConn (typecheck)
/*
```

This PR addresses that issue by using a locally scoped vtgate connection according to the newly established model.

## Related Issue(s)

  - Internal follow-up to:
      - https://github.com/vitessio/vitess/pull/14735
      - https://github.com/vitessio/vitess/pull/14786

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required