### PR TITLE
Use one canonical style for unlimited queries

### DIFF
--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -19,7 +19,6 @@ package onlineddl
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"testing"
 	"time"
@@ -57,7 +56,7 @@ func VtgateExecQuery(t *testing.T, vtParams *mysql.ConnParams, query string, exp
 	require.Nil(t, err)
 	defer conn.Close()
 
-	qr, err := conn.ExecuteFetch(query, math.MaxInt, true)
+	qr, err := conn.ExecuteFetch(query, -1, true)
 	if expectError == "" {
 		require.NoError(t, err)
 	} else {

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"reflect"
 	"strings"
@@ -913,7 +912,7 @@ func TestShowTablesWithSizes(t *testing.T) {
 		"show_tables_with_sizes_employees": {"BASE TABLE", ""},
 	}
 
-	rs, err := conn.ExecuteFetch(conn.BaseShowTablesWithSizes(), math.MaxInt, false)
+	rs, err := conn.ExecuteFetch(conn.BaseShowTablesWithSizes(), -1, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, rs.Rows)
 

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"path"
 	"strconv"
@@ -291,7 +290,7 @@ func (e *Executor) executeQuery(ctx context.Context, query string) (result *sqlt
 	}
 	defer conn.Recycle()
 
-	return conn.Conn.Exec(ctx, query, math.MaxInt32, true)
+	return conn.Conn.Exec(ctx, query, -1, true)
 }
 
 func (e *Executor) executeQueryWithSidecarDBReplacement(ctx context.Context, query string) (result *sqltypes.Result, err error) {
@@ -308,7 +307,7 @@ func (e *Executor) executeQueryWithSidecarDBReplacement(ctx context.Context, que
 	if err != nil {
 		return nil, err
 	}
-	return conn.Conn.Exec(ctx, uq, math.MaxInt32, true)
+	return conn.Conn.Exec(ctx, uq, -1, true)
 }
 
 // TabletAliasString returns tablet alias as string (duh)

--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 
@@ -185,7 +184,7 @@ func (v *VRepl) readAutoIncrement(ctx context.Context, conn *dbconnpool.DBConnec
 		return 0, err
 	}
 
-	rs, err := conn.ExecuteFetch(query, math.MaxInt, true)
+	rs, err := conn.ExecuteFetch(query, -1, true)
 	if err != nil {
 		return 0, err
 	}
@@ -199,7 +198,7 @@ func (v *VRepl) readAutoIncrement(ctx context.Context, conn *dbconnpool.DBConnec
 // readTableColumns reads column list from given table
 func (v *VRepl) readTableColumns(ctx context.Context, conn *dbconnpool.DBConnection, tableName string) (columns *vrepl.ColumnList, virtualColumns *vrepl.ColumnList, pkColumns *vrepl.ColumnList, err error) {
 	parsed := sqlparser.BuildParsedQuery(sqlShowColumnsFrom, tableName)
-	rs, err := conn.ExecuteFetch(parsed.Query, math.MaxInt, true)
+	rs, err := conn.ExecuteFetch(parsed.Query, -1, true)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -237,7 +236,7 @@ func (v *VRepl) readTableUniqueKeys(ctx context.Context, conn *dbconnpool.DBConn
 	if err != nil {
 		return nil, err
 	}
-	rs, err := conn.ExecuteFetch(query, math.MaxInt, true)
+	rs, err := conn.ExecuteFetch(query, -1, true)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +259,7 @@ func (v *VRepl) readTableUniqueKeys(ctx context.Context, conn *dbconnpool.DBConn
 // When `fast_analyze_table=1`, an `ANALYZE TABLE` command only analyzes the clustering index (normally the `PRIMARY KEY`).
 // This is useful when you want to get a better estimate of the number of table rows, as fast as possible.
 func (v *VRepl) isFastAnalyzeTableSupported(ctx context.Context, conn *dbconnpool.DBConnection) (isSupported bool, err error) {
-	rs, err := conn.ExecuteFetch(sqlShowVariablesLikeFastAnalyzeTable, math.MaxInt, true)
+	rs, err := conn.ExecuteFetch(sqlShowVariablesLikeFastAnalyzeTable, -1, true)
 	if err != nil {
 		return false, err
 	}
@@ -295,7 +294,7 @@ func (v *VRepl) executeAnalyzeTable(ctx context.Context, conn *dbconnpool.DBConn
 // readTableStatus reads table status information
 func (v *VRepl) readTableStatus(ctx context.Context, conn *dbconnpool.DBConnection, tableName string) (tableRows int64, err error) {
 	parsed := sqlparser.BuildParsedQuery(sqlShowTableStatus, tableName)
-	rs, err := conn.ExecuteFetch(parsed.Query, math.MaxInt, true)
+	rs, err := conn.ExecuteFetch(parsed.Query, -1, true)
 	if err != nil {
 		return 0, err
 	}
@@ -316,7 +315,7 @@ func (v *VRepl) applyColumnTypes(ctx context.Context, conn *dbconnpool.DBConnect
 	if err != nil {
 		return err
 	}
-	rs, err := conn.ExecuteFetch(query, math.MaxInt, true)
+	rs, err := conn.ExecuteFetch(query, -1, true)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -19,7 +19,6 @@ package gc
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -420,7 +419,7 @@ func (collector *TableGC) readTables(ctx context.Context) (gcTables []*gcTable, 
 	}
 	defer conn.Recycle()
 
-	res, err := conn.Conn.Exec(ctx, sqlShowVtTables, math.MaxInt32, true)
+	res, err := conn.Conn.Exec(ctx, sqlShowVtTables, -1, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -19,7 +19,6 @@ package vstreamer
 import (
 	"context"
 	"fmt"
-	"math"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -255,7 +254,7 @@ func (conn *snapshotConn) startSnapshotAllTables(ctx context.Context) (gtid stri
 			return "", err
 		}
 		// get list of all tables
-		rs, err := conn.ExecuteFetch("show full tables", math.MaxInt32, true)
+		rs, err := conn.ExecuteFetch("show full tables", -1, true)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
We use both `-1` and `MaxInt` style constants for unknown / unlimited result sets.

Let's standardize on `-1` which is by far most commonly use at the moment. Also avoids some imports as a nice little bonus.

Realized this after doing some consistency fixes in #14854. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required