### PR TITLE
Provide subset of shards for certain VReplication Commands

### DIFF
--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -657,11 +657,8 @@ func areTabletsAvailableToStreamFrom(ctx context.Context, req *vtctldatapb.Workf
 // New callers should instead use the new BuildTargets function.
 //
 // It returns ErrNoStreams if there are no targets found for the workflow.
-func LegacyBuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManagerClient, targetKeyspace string, workflow string) (*TargetInfo, error) {
-	targetShards, err := ts.GetShardNames(ctx, targetKeyspace)
-	if err != nil {
-		return nil, err
-	}
+func LegacyBuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManagerClient, targetKeyspace string, workflow string,
+	targetShards []string) (*TargetInfo, error) {
 
 	var (
 		frozen          bool

--- a/go/vt/wrangler/testdata/show-80dash.json
+++ b/go/vt/wrangler/testdata/show-80dash.json
@@ -1,0 +1,71 @@
+{
+  "Workflow": "wrWorkflow",
+  "SourceLocation": {
+    "Keyspace": "source",
+    "Shards": [
+      "0"
+    ]
+  },
+  "TargetLocation": {
+    "Keyspace": "target",
+    "Shards": [
+      "80-"
+    ]
+  },
+  "MaxVReplicationLag": 0,
+  "MaxVReplicationTransactionLag": 0,
+  "Frozen": false,
+  "ShardStatuses": {
+    "80-/zone1-0000000210": {
+      "PrimaryReplicationStatuses": [
+        {
+          "Shard": "80-",
+          "Tablet": "zone1-0000000210",
+          "ID": 1,
+          "Bls": {
+            "keyspace": "source",
+            "shard": "0",
+            "filter": {
+              "rules": [
+                {
+                  "match": "t1"
+                },
+                {
+                  "match": "t2"
+                }
+              ]
+            }
+          },
+          "Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
+          "StopPos": "",
+          "State": "Copying",
+          "DBName": "vt_target",
+          "TransactionTimestamp": 0,
+          "TimeUpdated": 1234,
+          "TimeHeartbeat": 1234,
+          "TimeThrottled": 0,
+          "ComponentThrottled": "",
+          "Message": "",
+          "Tags": "",
+          "WorkflowType": "Materialize",
+          "WorkflowSubType": "None",
+          "CopyState": [
+            {
+              "Table": "t1",
+              "LastPK": "pk1"
+            },
+            {
+              "Table": "t2",
+              "LastPK": "pk2"
+            }
+          ],
+          "RowsCopied": 1000
+        }
+      ],
+      "TabletControls": null,
+      "PrimaryIsServing": true
+    }
+  },
+  "SourceTimeZone": "",
+  "TargetTimeZone": ""
+}

--- a/go/vt/wrangler/testdata/show-all-shards.json
+++ b/go/vt/wrangler/testdata/show-all-shards.json
@@ -1,0 +1,121 @@
+{
+  "Workflow": "wrWorkflow",
+  "SourceLocation": {
+    "Keyspace": "source",
+    "Shards": [
+      "0"
+    ]
+  },
+  "TargetLocation": {
+    "Keyspace": "target",
+    "Shards": [
+      "-80",
+      "80-"
+    ]
+  },
+  "MaxVReplicationLag": 0,
+  "MaxVReplicationTransactionLag": 0,
+  "Frozen": false,
+  "ShardStatuses": {
+    "-80/zone1-0000000200": {
+      "PrimaryReplicationStatuses": [
+        {
+          "Shard": "-80",
+          "Tablet": "zone1-0000000200",
+          "ID": 1,
+          "Bls": {
+            "keyspace": "source",
+            "shard": "0",
+            "filter": {
+              "rules": [
+                {
+                  "match": "t1"
+                },
+                {
+                  "match": "t2"
+                }
+              ]
+            }
+          },
+          "Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
+          "StopPos": "",
+          "State": "Copying",
+          "DBName": "vt_target",
+          "TransactionTimestamp": 0,
+          "TimeUpdated": 1234,
+          "TimeHeartbeat": 1234,
+          "TimeThrottled": 0,
+          "ComponentThrottled": "",
+          "Message": "",
+          "Tags": "",
+          "WorkflowType": "Materialize",
+          "WorkflowSubType": "None",
+          "CopyState": [
+            {
+              "Table": "t1",
+              "LastPK": "pk1"
+            },
+            {
+              "Table": "t2",
+              "LastPK": "pk2"
+            }
+          ],
+          "RowsCopied": 1000
+        }
+      ],
+      "TabletControls": null,
+      "PrimaryIsServing": true
+    },
+    "80-/zone1-0000000210": {
+      "PrimaryReplicationStatuses": [
+        {
+          "Shard": "80-",
+          "Tablet": "zone1-0000000210",
+          "ID": 1,
+          "Bls": {
+            "keyspace": "source",
+            "shard": "0",
+            "filter": {
+              "rules": [
+                {
+                  "match": "t1"
+                },
+                {
+                  "match": "t2"
+                }
+              ]
+            }
+          },
+          "Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
+          "StopPos": "",
+          "State": "Copying",
+          "DBName": "vt_target",
+          "TransactionTimestamp": 0,
+          "TimeUpdated": 1234,
+          "TimeHeartbeat": 1234,
+          "TimeThrottled": 0,
+          "ComponentThrottled": "",
+          "Message": "",
+          "Tags": "",
+          "WorkflowType": "Materialize",
+          "WorkflowSubType": "None",
+          "CopyState": [
+            {
+              "Table": "t1",
+              "LastPK": "pk1"
+            },
+            {
+              "Table": "t2",
+              "LastPK": "pk2"
+            }
+          ],
+          "RowsCopied": 1000
+        }
+      ],
+      "TabletControls": null,
+      "PrimaryIsServing": true
+    }
+  },
+  "SourceTimeZone": "",
+  "TargetTimeZone": ""
+}

--- a/go/vt/wrangler/testdata/show-dash80.json
+++ b/go/vt/wrangler/testdata/show-dash80.json
@@ -1,0 +1,71 @@
+{
+  "Workflow": "wrWorkflow",
+  "SourceLocation": {
+    "Keyspace": "source",
+    "Shards": [
+      "0"
+    ]
+  },
+  "TargetLocation": {
+    "Keyspace": "target",
+    "Shards": [
+      "-80"
+    ]
+  },
+  "MaxVReplicationLag": 0,
+  "MaxVReplicationTransactionLag": 0,
+  "Frozen": false,
+  "ShardStatuses": {
+    "-80/zone1-0000000200": {
+      "PrimaryReplicationStatuses": [
+        {
+          "Shard": "-80",
+          "Tablet": "zone1-0000000200",
+          "ID": 1,
+          "Bls": {
+            "keyspace": "source",
+            "shard": "0",
+            "filter": {
+              "rules": [
+                {
+                  "match": "t1"
+                },
+                {
+                  "match": "t2"
+                }
+              ]
+            }
+          },
+          "Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
+          "StopPos": "",
+          "State": "Copying",
+          "DBName": "vt_target",
+          "TransactionTimestamp": 0,
+          "TimeUpdated": 1234,
+          "TimeHeartbeat": 1234,
+          "TimeThrottled": 0,
+          "ComponentThrottled": "",
+          "Message": "",
+          "Tags": "",
+          "WorkflowType": "Materialize",
+          "WorkflowSubType": "None",
+          "CopyState": [
+            {
+              "Table": "t1",
+              "LastPK": "pk1"
+            },
+            {
+              "Table": "t2",
+              "LastPK": "pk2"
+            }
+          ],
+          "RowsCopied": 1000
+        }
+      ],
+      "TabletControls": null,
+      "PrimaryIsServing": true
+    }
+  },
+  "SourceTimeZone": "",
+  "TargetTimeZone": ""
+}

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -159,7 +159,7 @@ func (wr *Wrangler) VExec(ctx context.Context, workflow, keyspace, query string,
 	if wr.VExecFunc != nil {
 		return wr.VExecFunc(ctx, workflow, keyspace, query, dryRun)
 	}
-	results, err := wr.runVexec(ctx, workflow, keyspace, query, nil, dryRun)
+	results, err := wr.runVexec(ctx, workflow, keyspace, query, nil, dryRun, nil)
 	retResults := make(map[*topo.TabletInfo]*sqltypes.Result)
 	for tablet, result := range results {
 		retResults[tablet] = sqltypes.Proto3ToResult(result)
@@ -168,10 +168,13 @@ func (wr *Wrangler) VExec(ctx context.Context, workflow, keyspace, query string,
 }
 
 // runVexec is the main function that runs a dry or wet execution of 'query' on backend shards.
-func (wr *Wrangler) runVexec(ctx context.Context, workflow, keyspace, query string, callback func(context.Context, *topo.TabletInfo) (*querypb.QueryResult, error), dryRun bool) (map[*topo.TabletInfo]*querypb.QueryResult, error) {
+func (wr *Wrangler) runVexec(ctx context.Context, workflow, keyspace, query string,
+	callback func(context.Context, *topo.TabletInfo) (*querypb.QueryResult, error),
+	dryRun bool, shards []string) (map[*topo.TabletInfo]*querypb.QueryResult, error) {
+
 	vx := newVExec(ctx, workflow, keyspace, query, wr)
 
-	if err := vx.getPrimaries(); err != nil {
+	if err := vx.getPrimaries(shards); err != nil {
 		return nil, err
 	}
 	if callback == nil { // Using legacy SQL query path
@@ -286,15 +289,13 @@ func (vx *vexec) parseQuery() (err error) {
 }
 
 // getPrimaries identifies primary tablet for all shards relevant to our keyspace
-func (vx *vexec) getPrimaries() error {
+func (vx *vexec) getPrimaries(shards []string) error {
 	var err error
-	shards, err := vx.wr.ts.GetShardNames(vx.ctx, vx.keyspace)
+	shards, err = vx.wr.getShardSubset(vx.ctx, vx.keyspace, shards)
 	if err != nil {
 		return err
 	}
-	if len(shards) == 0 {
-		return fmt.Errorf("no shards found in keyspace %s", vx.keyspace)
-	}
+
 	var allPrimaries []*topo.TabletInfo
 	var primary *topo.TabletInfo
 	for _, shard := range shards {
@@ -341,10 +342,11 @@ func (wr *Wrangler) convertQueryResultToSQLTypesResult(results map[*topo.TabletI
 // rpcReq is an optional argument for any actions that use the new RPC path. Today
 // that is only the update action. When using the SQL interface this is ignored and
 // you can pass nil.
-func (wr *Wrangler) WorkflowAction(ctx context.Context, workflow, keyspace, action string, dryRun bool, rpcReq any) (map[*topo.TabletInfo]*sqltypes.Result, error) {
+func (wr *Wrangler) WorkflowAction(ctx context.Context, workflow, keyspace, action string, dryRun bool, rpcReq any,
+	shards []string) (map[*topo.TabletInfo]*sqltypes.Result, error) {
 	switch action {
 	case "show":
-		replStatus, err := wr.ShowWorkflow(ctx, workflow, keyspace)
+		replStatus, err := wr.ShowWorkflow(ctx, workflow, keyspace, shards)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +361,7 @@ func (wr *Wrangler) WorkflowAction(ctx context.Context, workflow, keyspace, acti
 		return nil, err
 	default:
 	}
-	results, err := wr.execWorkflowAction(ctx, workflow, keyspace, action, dryRun, rpcReq)
+	results, err := wr.execWorkflowAction(ctx, workflow, keyspace, action, dryRun, rpcReq, shards)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +393,7 @@ func (wr *Wrangler) getWorkflowActionQuery(action string) (string, error) {
 // canRestartWorkflow validates that, for an atomic copy workflow, none of the streams are still in the copy phase.
 // Since we copy all tables in a single snapshot, we cannot restart a workflow which broke before all tables were copied.
 func (wr *Wrangler) canRestartWorkflow(ctx context.Context, workflow, keyspace string) error {
-	res, err := wr.ShowWorkflow(ctx, workflow, keyspace)
+	res, err := wr.ShowWorkflow(ctx, workflow, keyspace, nil)
 	if err != nil {
 		return err
 	}
@@ -410,7 +412,8 @@ func (wr *Wrangler) canRestartWorkflow(ctx context.Context, workflow, keyspace s
 	return nil
 }
 
-func (wr *Wrangler) execWorkflowAction(ctx context.Context, workflow, keyspace, action string, dryRun bool, rpcReq any) (map[*topo.TabletInfo]*querypb.QueryResult, error) {
+func (wr *Wrangler) execWorkflowAction(ctx context.Context, workflow, keyspace, action string, dryRun bool, rpcReq any,
+	shards []string) (map[*topo.TabletInfo]*querypb.QueryResult, error) {
 	var callback func(context.Context, *topo.TabletInfo) (*querypb.QueryResult, error) = nil
 	query, err := wr.getWorkflowActionQuery(action)
 	if err != nil {
@@ -453,7 +456,7 @@ func (wr *Wrangler) execWorkflowAction(ctx context.Context, workflow, keyspace, 
 			wr.Logger().Printf("On the following tablets in the %s keyspace for workflow %s:\n",
 				keyspace, workflow)
 			vx := newVExec(ctx, workflow, keyspace, "", wr)
-			if err := vx.getPrimaries(); err != nil {
+			if err := vx.getPrimaries(shards); err != nil {
 				return nil, err
 			}
 			tablets := vx.primaries
@@ -476,7 +479,7 @@ func (wr *Wrangler) execWorkflowAction(ctx context.Context, workflow, keyspace, 
 		}
 	}
 
-	return wr.runVexec(ctx, workflow, keyspace, query, callback, dryRun)
+	return wr.runVexec(ctx, workflow, keyspace, query, callback, dryRun, shards)
 }
 
 // WorkflowTagAction sets or clears the tags for a workflow in a keyspace.
@@ -484,7 +487,7 @@ func (wr *Wrangler) WorkflowTagAction(ctx context.Context, keyspace string, work
 	// A WHERE clause with the correct workflow name is automatically added
 	// to the query later on in vexec.addDefaultWheres().
 	query := fmt.Sprintf("update _vt.vreplication set tags = %s", encodeString(tags))
-	results, err := wr.runVexec(ctx, workflow, keyspace, query, nil, false)
+	results, err := wr.runVexec(ctx, workflow, keyspace, query, nil, false, nil)
 	return wr.convertQueryResultToSQLTypesResult(results), err
 }
 
@@ -694,7 +697,7 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row sqltype
 	return status, bls.Keyspace, nil
 }
 
-func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (*ReplicationStatusResult, error) {
+func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string, shards []string) (*ReplicationStatusResult, error) {
 	var rsr ReplicationStatusResult
 	rsr.ShardStatuses = make(map[string]*ShardReplicationStatus)
 	rsr.Workflow = workflow
@@ -719,7 +722,7 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 		defer_secondary_keys,
 		rows_copied
 	from _vt.vreplication`
-	results, err := wr.runVexec(ctx, workflow, keyspace, query, nil, false)
+	results, err := wr.runVexec(ctx, workflow, keyspace, query, nil, false, shards)
 	if err != nil {
 		return nil, err
 	}
@@ -877,8 +880,8 @@ func (wr *Wrangler) ListAllWorkflows(ctx context.Context, keyspace string, activ
 }
 
 // ShowWorkflow will return all of the relevant replication related information for the given workflow.
-func (wr *Wrangler) ShowWorkflow(ctx context.Context, workflow, keyspace string) (*ReplicationStatusResult, error) {
-	replStatus, err := wr.getStreams(ctx, workflow, keyspace)
+func (wr *Wrangler) ShowWorkflow(ctx context.Context, workflow, keyspace string, shards []string) (*ReplicationStatusResult, error) {
+	replStatus, err := wr.getStreams(ctx, workflow, keyspace, shards)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/wrangler/vexec_plan.go
+++ b/go/vt/wrangler/vexec_plan.go
@@ -84,7 +84,7 @@ func (p vreplicationPlanner) exec(
 	return qr, nil
 }
 func (p vreplicationPlanner) dryRun(ctx context.Context) error {
-	rsr, err := p.vx.wr.getStreams(p.vx.ctx, p.vx.workflow, p.vx.keyspace)
+	rsr, err := p.vx.wr.getStreams(p.vx.ctx, p.vx.workflow, p.vx.keyspace, nil)
 	if err != nil {
 		return err
 	}

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -18,6 +18,7 @@ package wrangler
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"regexp"
 	"sort"
@@ -37,6 +38,15 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
+var (
+	//go:embed testdata/show-all-shards.json
+	want_show_all_shards string
+	//go:embed testdata/show-dash80.json
+	want_show_dash_80 string
+	//go:embed testdata/show-80dash.json
+	want_show_80_dash string
+)
+
 func TestVExec(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -49,7 +59,7 @@ func TestVExec(t *testing.T) {
 	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
 
 	vx := newVExec(ctx, workflow, keyspace, query, wr)
-	err := vx.getPrimaries()
+	err := vx.getPrimaries(nil)
 	require.Nil(t, err)
 	primaries := vx.primaries
 	require.NotNil(t, primaries)
@@ -80,7 +90,7 @@ func TestVExec(t *testing.T) {
 	vx.plannedQuery = plan.parsedQuery.Query
 	vx.exec()
 
-	res, err := wr.getStreams(ctx, workflow, keyspace)
+	res, err := wr.getStreams(ctx, workflow, keyspace, nil)
 	require.NoError(t, err)
 	require.Less(t, res.MaxVReplicationLag, int64(3 /*seconds*/)) // lag should be very small
 
@@ -195,149 +205,47 @@ func TestWorkflowListStreams(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
 
-	_, err := wr.WorkflowAction(ctx, workflow, keyspace, "listall", false, nil)
+	_, err := wr.WorkflowAction(ctx, workflow, keyspace, "listall", false, nil, nil)
 	require.NoError(t, err)
 
-	_, err = wr.WorkflowAction(ctx, workflow, "badks", "show", false, nil)
+	_, err = wr.WorkflowAction(ctx, workflow, "badks", "show", false, nil, nil)
 	require.Errorf(t, err, "node doesn't exist: keyspaces/badks/shards")
 
-	_, err = wr.WorkflowAction(ctx, "badwf", keyspace, "show", false, nil)
+	_, err = wr.WorkflowAction(ctx, "badwf", keyspace, "show", false, nil, nil)
 	require.Errorf(t, err, "no streams found for workflow badwf in keyspace target")
 	logger.Clear()
-	_, err = wr.WorkflowAction(ctx, workflow, keyspace, "show", false, nil)
-	require.NoError(t, err)
-	want := `{
-	"Workflow": "wrWorkflow",
-	"SourceLocation": {
-		"Keyspace": "source",
-		"Shards": [
-			"0"
-		]
-	},
-	"TargetLocation": {
-		"Keyspace": "target",
-		"Shards": [
-			"-80",
-			"80-"
-		]
-	},
-	"MaxVReplicationLag": 0,
-	"MaxVReplicationTransactionLag": 0,
-	"Frozen": false,
-	"ShardStatuses": {
-		"-80/zone1-0000000200": {
-			"PrimaryReplicationStatuses": [
-				{
-					"Shard": "-80",
-					"Tablet": "zone1-0000000200",
-					"ID": 1,
-					"Bls": {
-						"keyspace": "source",
-						"shard": "0",
-						"filter": {
-							"rules": [
-								{
-									"match": "t1"
-								},
-								{
-									"match": "t2"
-								}
-							]
-						}
-					},
-					"Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
-					"StopPos": "",
-					"State": "Copying",
-					"DBName": "vt_target",
-					"TransactionTimestamp": 0,
-					"TimeUpdated": 1234,
-					"TimeHeartbeat": 1234,
-					"TimeThrottled": 0,
-					"ComponentThrottled": "",
-					"Message": "",
-					"Tags": "",
-					"WorkflowType": "Materialize",
-					"WorkflowSubType": "None",
-					"CopyState": [
-						{
-							"Table": "t1",
-							"LastPK": "pk1"
-						},
-						{
-							"Table": "t2",
-							"LastPK": "pk2"
-						}
-					],
-					"RowsCopied": 1000
-				}
-			],
-			"TabletControls": null,
-			"PrimaryIsServing": true
-		},
-		"80-/zone1-0000000210": {
-			"PrimaryReplicationStatuses": [
-				{
-					"Shard": "80-",
-					"Tablet": "zone1-0000000210",
-					"ID": 1,
-					"Bls": {
-						"keyspace": "source",
-						"shard": "0",
-						"filter": {
-							"rules": [
-								{
-									"match": "t1"
-								},
-								{
-									"match": "t2"
-								}
-							]
-						}
-					},
-					"Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
-					"StopPos": "",
-					"State": "Copying",
-					"DBName": "vt_target",
-					"TransactionTimestamp": 0,
-					"TimeUpdated": 1234,
-					"TimeHeartbeat": 1234,
-					"TimeThrottled": 0,
-					"ComponentThrottled": "",
-					"Message": "",
-					"Tags": "",
-					"WorkflowType": "Materialize",
-					"WorkflowSubType": "None",
-					"CopyState": [
-						{
-							"Table": "t1",
-							"LastPK": "pk1"
-						},
-						{
-							"Table": "t2",
-							"LastPK": "pk2"
-						}
-					],
-					"RowsCopied": 1000
-				}
-			],
-			"TabletControls": null,
-			"PrimaryIsServing": true
-		}
-	},
-	"SourceTimeZone": "",
-	"TargetTimeZone": ""
-}
+	var testCases = []struct {
+		shards []string
+		want   string
+	}{
+		{[]string{"-80", "80-"}, want_show_all_shards},
+		{[]string{"-80"}, want_show_dash_80},
+		{[]string{"80-"}, want_show_80_dash},
+	}
+	scrub := func(s string) string {
+		s = strings.ReplaceAll(s, "\t", "")
+		s = strings.ReplaceAll(s, "\n", "")
+		s = strings.ReplaceAll(s, " ", "")
+		return s
+	}
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v", testCase.shards), func(t *testing.T) {
+			want := scrub(testCase.want)
+			_, err = wr.WorkflowAction(ctx, workflow, keyspace, "show", false, nil, testCase.shards)
+			require.NoError(t, err)
+			got := scrub(logger.String())
+			// MaxVReplicationLag needs to be reset. This can't be determinable in this kind of a test because
+			// time.Now() is constantly shifting.
+			re := regexp.MustCompile(`"MaxVReplicationLag":\d+`)
+			got = re.ReplaceAllLiteralString(got, `"MaxVReplicationLag":0`)
+			re = regexp.MustCompile(`"MaxVReplicationTransactionLag":\d+`)
+			got = re.ReplaceAllLiteralString(got, `"MaxVReplicationTransactionLag":0`)
+			require.Equal(t, want, got)
+			logger.Clear()
+		})
+	}
 
-`
-	got := logger.String()
-	// MaxVReplicationLag needs to be reset. This can't be determinable in this kind of a test because time.Now() is constantly shifting.
-	re := regexp.MustCompile(`"MaxVReplicationLag": \d+`)
-	got = re.ReplaceAllLiteralString(got, `"MaxVReplicationLag": 0`)
-	re = regexp.MustCompile(`"MaxVReplicationTransactionLag": \d+`)
-	got = re.ReplaceAllLiteralString(got, `"MaxVReplicationTransactionLag": 0`)
-	require.Equal(t, want, got)
-
-	results, err := wr.execWorkflowAction(ctx, workflow, keyspace, "stop", false, nil)
+	results, err := wr.execWorkflowAction(ctx, workflow, keyspace, "stop", false, nil, nil)
 	require.Nil(t, err)
 
 	// convert map to list and sort it for comparison
@@ -351,7 +259,7 @@ func TestWorkflowListStreams(t *testing.T) {
 	require.ElementsMatch(t, wantResults, gotResults)
 
 	logger.Clear()
-	results, err = wr.execWorkflowAction(ctx, workflow, keyspace, "stop", true, nil)
+	results, err = wr.execWorkflowAction(ctx, workflow, keyspace, "stop", true, nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, "map[]", fmt.Sprintf("%v", results))
 	dryRunResult := `Query: update _vt.vreplication set state = 'Stopped' where db_name = 'vt_target' and workflow = 'wrWorkflow'
@@ -548,7 +456,7 @@ func TestWorkflowUpdate(t *testing.T) {
 				OnDdl:       tcase.onDDL,
 			}
 
-			_, err := wr.WorkflowAction(ctx, workflow, keyspace, "update", true, rpcReq)
+			_, err := wr.WorkflowAction(ctx, workflow, keyspace, "update", true, rpcReq, nil)
 			if tcase.wantErr != "" {
 				require.Error(t, err)
 				require.Equal(t, err.Error(), tcase.wantErr)

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -77,6 +77,11 @@ type VReplicationWorkflowParams struct {
 
 	// MoveTables only
 	NoRoutingRules bool
+
+	// Only these shards will be expected to participate in the workflow. Expects user to know what they are doing
+	// and provide the correct set of shards associated with the workflow. This is for reducing latency for workflows
+	// that only use a small set of shards in a keyspace with a large number of shards.
+	ShardSubset []string
 }
 
 // VReplicationWorkflow stores various internal objects for a workflow
@@ -101,6 +106,7 @@ func (vrw *VReplicationWorkflow) String() string {
 func (wr *Wrangler) NewVReplicationWorkflow(ctx context.Context, workflowType VReplicationWorkflowType,
 	params *VReplicationWorkflowParams) (*VReplicationWorkflow, error) {
 
+	wr.WorkflowParams = params
 	log.Infof("NewVReplicationWorkflow with params %+v", params)
 	vrw := &VReplicationWorkflow{wr: wr, ctx: ctx, params: params, workflowType: workflowType}
 	ts, ws, err := wr.getWorkflowState(ctx, params.TargetKeyspace, params.Workflow)
@@ -253,12 +259,16 @@ func NewWorkflowError(tablet string, id int32, description string) *WorkflowErro
 	return wfErr
 }
 
+func (vrw *VReplicationWorkflow) IsPartialMigration() bool {
+	return vrw.ws.IsPartialMigration
+}
+
 // GetStreamCount returns a count of total streams and of streams that have started processing
 func (vrw *VReplicationWorkflow) GetStreamCount() (int64, int64, []*WorkflowError, error) {
 	var err error
 	var workflowErrors []*WorkflowError
 	var total, started int64
-	res, err := vrw.wr.ShowWorkflow(vrw.ctx, vrw.params.Workflow, vrw.params.TargetKeyspace)
+	res, err := vrw.wr.ShowWorkflow(vrw.ctx, vrw.params.Workflow, vrw.params.TargetKeyspace, nil)
 	if err != nil {
 		return 0, 0, nil, err
 	}
@@ -525,7 +535,11 @@ func (vrw *VReplicationWorkflow) canSwitch(keyspace, workflowName string) (reaso
 		return "", nil
 	}
 	log.Infof("state:%s, direction %d, switched %t", vrw.CachedState(), vrw.params.Direction, ws.WritesSwitched)
-	result, err := vrw.wr.getStreams(vrw.ctx, workflowName, keyspace)
+	var shards []string
+	if vrw.params.ShardSubset != nil {
+		shards = vrw.params.ShardSubset
+	}
+	result, err := vrw.wr.getStreams(vrw.ctx, workflowName, keyspace, shards)
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -378,6 +378,90 @@ func TestPartialMoveTables(t *testing.T) {
 	require.Equal(t, WorkflowStateNotSwitched, wf.CurrentState())
 }
 
+// TestPartialMoveTablesSpecifiedShards is a version of TestPartialMoveTables which uses the --shards option.
+func TestPartialMoveTablesShardOffset(t *testing.T) {
+	ctx := context.Background()
+	shards := []string{"-80", "80-"}
+	shardToMove := shards[0:1]
+	otherShard := shards[1:]
+	p := &VReplicationWorkflowParams{
+		Workflow:                        "test",
+		WorkflowType:                    MoveTablesWorkflow,
+		SourceKeyspace:                  "ks1",
+		SourceShards:                    shardToMove, // shard by shard
+		TargetShards:                    shardToMove, // shard by shard
+		TargetKeyspace:                  "ks2",
+		Tables:                          "t1,t2",
+		Cells:                           "cell1,cell2",
+		TabletTypes:                     "REPLICA,RDONLY,PRIMARY",
+		Timeout:                         DefaultActionTimeout,
+		MaxAllowedTransactionLagSeconds: defaultMaxAllowedTransactionLagSeconds,
+		OnDDL:                           binlogdatapb.OnDDLAction_STOP.String(),
+	}
+	tme := newTestTablePartialMigrater(ctx, t, shards, shards[0:1], "select * %s")
+	defer tme.stopTablets(t)
+
+	// Save some unrelated shard routing rules to be sure that
+	// they don't interfere in any way.
+	srr, err := tme.ts.GetShardRoutingRules(ctx)
+	require.NoError(t, err)
+	srr.Rules = append(srr.Rules, []*vschema.ShardRoutingRule{
+		{
+			FromKeyspace: "wut",
+			Shard:        "40-80",
+			ToKeyspace:   "bloop",
+		},
+		{
+			FromKeyspace: "haylo",
+			Shard:        "-80",
+			ToKeyspace:   "blarg",
+		},
+	}...)
+	err = tme.ts.SaveShardRoutingRules(ctx, srr)
+	require.NoError(t, err)
+
+	// Providing an incorrect shard should result in the workflow not being found.
+	p.ShardSubset = otherShard
+	wf, err := tme.wr.NewVReplicationWorkflow(ctx, MoveTablesWorkflow, p)
+	require.NoError(t, err)
+	require.Nil(t, wf.ts)
+
+	p.ShardSubset = shardToMove
+	wf, err = tme.wr.NewVReplicationWorkflow(ctx, MoveTablesWorkflow, p)
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+	require.Equal(t, WorkflowStateNotSwitched, wf.CurrentState())
+	require.True(t, wf.ts.isPartialMigration, "expected partial shard migration")
+
+	// The default shard routing rule for the keyspace's other shard would
+	// normally be put in place, but the unit test does not execute the
+	// wrangler.MoveTables function which adds all of the default shard
+	// routing rules in the topo for the keyspace when the first workflow
+	// is run against it. So we simulate it here.
+	srr, err = tme.ts.GetShardRoutingRules(ctx)
+	require.NoError(t, err)
+	srr.Rules = append(srr.Rules, &vschema.ShardRoutingRule{
+		FromKeyspace: "ks2",
+		Shard:        "80-",
+		ToKeyspace:   "ks1",
+	})
+	err = tme.ts.SaveShardRoutingRules(ctx, srr)
+	require.NoError(t, err)
+
+	tme.expectNoPreviousJournals()
+	expectMoveTablesQueries(t, tme, p)
+	tme.expectNoPreviousJournals()
+	wf.params.ShardSubset = shardToMove
+	require.NoError(t, testSwitchForward(t, wf))
+	require.Equal(t, "Reads partially switched, for shards: -80. Writes partially switched, for shards: -80", wf.CurrentState())
+	require.NoError(t, err)
+
+	tme.expectNoPreviousJournals()
+	tme.expectNoPreviousReverseJournals()
+	require.NoError(t, testReverse(t, wf))
+	require.Equal(t, WorkflowStateNotSwitched, wf.CurrentState())
+}
+
 func validateRoutingRuleCount(ctx context.Context, t *testing.T, ts *topo.Server, cnt int) {
 	rr, err := ts.GetRoutingRules(ctx)
 	require.NoError(t, err)

--- a/go/vt/wrangler/wrangler.go
+++ b/go/vt/wrangler/wrangler.go
@@ -58,10 +58,10 @@ type Wrangler struct {
 	// DO NOT USE in production code.
 	VExecFunc func(ctx context.Context, workflow, keyspace, query string, dryRun bool) (map[*topo.TabletInfo]*sqltypes.Result, error)
 	// Limt the number of concurrent background goroutines if needed.
-	sem *semaphore.Weighted
-
-	collationEnv *collations.Environment
-	parser       *sqlparser.Parser
+	sem            *semaphore.Weighted
+	collationEnv   *collations.Environment
+	parser         *sqlparser.Parser
+	WorkflowParams *VReplicationWorkflowParams
 }
 
 // New creates a new Wrangler object.


### PR DESCRIPTION
## Description

For clusters with large number of shards, when there are workflows which only have a few participating shards, like Partial MoveTables for example, there is a huge overhead when commands contact all primaries in a keyspace with most returning no results.

This PR adds a `--shards` option to vtctlclient for
* the `Workflow` command so that `Show`, `Stop`, `Start` and `Delete` only operate on the specified shards. 
* the `MoveTables` command (only for partial move tables) for all sub-commands except `Create`. 

Note that we expect the user to know what they are doing since we don't validate that the specified workflows are not present on other shards and hence can result in only a few streams being updated and potentially cause data loss and cluster inconsistencies if this is done for `SwitchTraffic` for example.

### Examples
Examples are run after stopping the end to end test `TestPartialMoveTablesBasic` after one partial `MoveTables` is created and before `SwitchTraffic`.

<details>
<summary>v Workflow -- --shards 80- customer2.partial80Dash show</summary>
<code>
{
	"Workflow": "partial80Dash",
	"SourceLocation": {
		"Keyspace": "customer",
		"Shards": [
			"80-"
		]
	},
	"TargetLocation": {
		"Keyspace": "customer2",
		"Shards": [
			"80-"
		]
	},
	"MaxVReplicationLag": 1,
	"MaxVReplicationTransactionLag": 2,
	"Frozen": false,
	"ShardStatuses": {
		"80-/zone1-0000001300": {
			"PrimaryReplicationStatuses": [
				{
					"Shard": "80-",
					"Tablet": "zone1-0000001300",
					"ID": 3,
					"Bls": {
						"keyspace": "customer",
						"shard": "80-",
						"filter": {
							"rules": [
								{
									"match": "customer",
									"filter": "select * from customer"
								}
							]
						}
					},
					"Pos": "90d40b5e-906f-11ee-bbf0-74b94734325d:1-1617",
					"StopPos": "",
					"State": "Running",
					"DBName": "vt_customer2",
					"TransactionTimestamp": 1701452322,
					"TimeUpdated": 1701452323,
					"TimeHeartbeat": 0,
					"TimeThrottled": 0,
					"ComponentThrottled": "",
					"Message": "",
					"Tags": "",
					"WorkflowType": "MoveTables",
					"WorkflowSubType": "Partial",
					"CopyState": null,
					"RowsCopied": 2
				}
			],
			"TabletControls": null,
			"PrimaryIsServing": true
		}
	},
	"SourceTimeZone": "",
	"TargetTimeZone": "",
	"DeferSecondaryKeys": true
}
</code>
</details>

<details>
<summary>v Workflow -- --shards -80 customer2.partial80Dash show</summary>
<code>
Workflow Error: rpc error: code = Unknown desc = no streams found for workflow partial80Dash in keyspace customer2
E1201 18:38:21.738289   24125 main.go:105] remote error: rpc error: code = Unknown desc = no streams found for workflow partial80Dash in keyspace customer2
</code>
</details>
<details>
<summary>v MoveTables -- --shards 80- show customer2.partial80Dash</summary >
<code>
The following vreplication streams exist for workflow customer2.partial80Dash:

id=3 on 80-/zone1-0000001300: Status: Running. VStream Lag: -1s. Tx time: Fri Dec  1 18:39:44 2023.
</code>
</details>

<details>
<summary>v MoveTables -- --shards 80- SwitchTraffic customer2.partial80Dash</summary>
<code>
SwitchTraffic was successful for workflow customer2.partial80Dash
Start State: Reads Not Switched. Writes Not Switched
Current State: Reads partially switched, for shards: 80-. Writes partially switched, for shards: 80-
</code>
</details>

<details>
<summary>v MoveTables -- --shards 80- ReverseTraffic customer2.partial80Dash</summary>
<code>
ReverseTraffic was successful for workflow customer.partial80Dash_reverse
Start State: Reads partially switched, for shards: 80-. Writes partially switched, for shards: 80-
Current State: Reads Not Switched. Writes Not Switched
</code>
</details>

<details>
<summary>v MoveTables -- --shards 80- cancel customer2.partial80Dash</summary>
<code>
cancel was successful for workflow customer2.partial80Dash
Start State: Reads Not Switched. Writes Not Switched
Current State: Workflow Not Found
</code>
</details>


## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/14204

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required
