### PR TITLE
MaxReplicationLagModule.recalculateRate no longer fills the log

### DIFF
--- a/go/vt/throttler/max_replication_lag_module.go
+++ b/go/vt/throttler/max_replication_lag_module.go
@@ -382,7 +382,6 @@ logResult:
 		r.Reason += clearReason
 	}
 
-	log.Infof("%v", r)
 	m.results.add(r)
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This  PR removes logging from `MaxReplicationLagModule` to reduce the noise.
Ideally, this would still be logged in debug mode, but as it turns out, the vitess log [does not have](https://github.com/vitessio/vitess/blob/ef28c1315287309ecaf5e7d70f0bdf5c16f934fb/go/vt/log/log.go#L36-L76) a debug mode ¯\_(ツ)_/¯ 

No need to backport this, though it's so easy that might as well.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/14874

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes
N/A.
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
