### PR TITLE
Flakes: Fix flaky vtctl unit test TestMoveTables

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2338,7 +2338,7 @@ func commandVReplicationWorkflow(ctx context.Context, wr *wrangler.Wrangler, sub
 			sort.Strings(tables)
 			s := ""
 			var progress wrangler.TableCopyProgress
-			for table := range *copyProgress {
+			for _, table := range tables {
 				var rowCountPct, tableSizePct int64
 				progress = *(*copyProgress)[table]
 				if progress.SourceRowCount > 0 {


### PR DESCRIPTION
## Description

A second table was added to the vtctl `TestMoveTables` unit test which surfaced a flakiness in the test caused by the intrinsic lack of ordering of map keys. Fixed by sorting the keys so that we get a stable output.

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
