### PR TITLE
Improve err extraction logic

### DIFF
--- a/go/mysql/sqlerror/sql_error.go
+++ b/go/mysql/sqlerror/sql_error.go
@@ -77,7 +77,7 @@ func (se *SQLError) SQLState() string {
 	return se.State
 }
 
-var errExtract = regexp.MustCompile(`.*\(errno ([0-9]*)\) \(sqlstate ([0-9a-zA-Z]{5})\).*`)
+var errExtract = regexp.MustCompile(`\(errno ([0-9]*)\) \(sqlstate ([0-9a-zA-Z]{5})\)`)
 
 // NewSQLErrorFromError returns a *SQLError from the provided error.
 // If it's not the right type, it still tries to get it from a regexp.


### PR DESCRIPTION
The previous regexp had superfluous wildcard matching at the beginning and end. This results in eagerly matching the whole string and subsequently matches the last occurance of the match.

Instead we don't want to use the wildcard so the default left to right matching is used and we get the first occurence.

## Related Issue(s)

Fixes #14866

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
