### PR TITLE
Automatically update the Golang dependencies using a CRON

### DIFF
--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -30,9 +30,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Detect new version and update codebase
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Upgrade the Golang Dependencies
         id: detect-and-update
         run: |
           go get -u ./...

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -1,7 +1,6 @@
 name: Update Golang Dependencies
 
 on:
-  pull_request:
   schedule:
     - cron: "0 0 * * *" # Runs every day at midnight UTC
   workflow_dispatch:
@@ -9,8 +8,8 @@ on:
 permissions: read-all
 
 jobs:
-  update_golang_version:
-#    if: github.repository == 'vitessio/vitess'
+  update_golang_deps:
+    if: github.repository == 'vitessio/vitess'
     permissions:
       contents: write
       pull-requests: write
@@ -39,6 +38,8 @@ jobs:
           if [ -z "${output}" ]; then
             exit 0
           fi
+
+          go mod tidy
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -13,9 +13,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    strategy:
-      matrix:
-        branch: [ main, release-18.0, release-17.0, release-16.0 ]
     name: Update Golang Dependencies
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          ref: ${{ matrix.branch }}
+          ref: main
 
       - name: Upgrade the Golang Dependencies
         id: detect-and-update
@@ -44,14 +41,14 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          branch: "upgrade-go-deps-on-${{ matrix.branch }}"
+          branch: "upgrade-go-deps-on-main"
           commit-message: "upgrade go deps"
           signoff: true
           delete-branch: true
-          title: "[${{ matrix.branch }}] Upgrade the Golang Dependencies"
+          title: "Upgrade the Golang Dependencies"
           body: |
             This Pull Request updates all the Goland dependencies to their latest version using `go get -u ./...`.
-          base: ${{ matrix.branch }}
+          base: main
           labels: |
             go
             dependencies

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -1,0 +1,60 @@
+name: Update Golang Dependencies
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *" # Runs every day at midnight UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update_golang_version:
+#    if: github.repository == 'vitessio/vitess'
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      matrix:
+        branch: [ main, release-18.0, release-17.0, release-16.0 ]
+    name: Update Golang Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.5
+
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Detect new version and update codebase
+        env:
+          GH_TOKEN: ${{ github.token }}
+        id: detect-and-update
+        run: |
+          go get -u ./...
+
+          output=$(git status -s)
+          if [ -z "${output}" ]; then
+            exit 0
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: "upgrade-go-deps-on-${{ matrix.branch }}"
+          commit-message: "upgrade go deps"
+          signoff: true
+          delete-branch: true
+          title: "[${{ matrix.branch }}] Upgrade the Golang Dependencies"
+          body: |
+            This Pull Request updates all the Goland dependencies to their latest version using `go get -u ./...`.
+          base: ${{ matrix.branch }}
+          labels: |
+            go
+            dependencies
+            Component: General
+            Type: Internal Cleanup

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   update_golang_version:
-#    if: github.repository == 'vitessio/vitess'
+    if: github.repository == 'vitessio/vitess'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   update_golang_version:
-    if: github.repository == 'vitessio/vitess'
+#    if: github.repository == 'vitessio/vitess'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Description

This PR adds a new workflow that runs either on manual trigger or on a weekly CRON. The workflow will attempt to upgrade all the Golang dependencies to a newer version using `go get -u ./...` followed by `go mod tidy`. It will run `main`. This avoid having to manually upgrade the dependencies or even to forget about upgrading them.

@dbussink recently did a PR that manually does this (https://github.com/vitessio/vitess/pull/14888), this new workflow will ensure this work is done consistently. 

[I ran some tests](https://github.com/frouioui/vitess/actions/runs/7415911638/job/20179944616?pr=220) on my fork here where automation created the PR:
- https://github.com/frouioui/vitess/pull/221

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/14890

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
