### PR TITLE
Typo fix and remove unsupported branch for go version upgrade matrix

### DIFF
--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -47,7 +47,7 @@ jobs:
           delete-branch: true
           title: "Upgrade the Golang Dependencies"
           body: |
-            This Pull Request updates all the Goland dependencies to their latest version using `go get -u ./...`.
+            This Pull Request updates all the Golang dependencies to their latest version using `go get -u ./...`.
           base: main
           labels: |
             go

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-18.0, release-17.0, release-16.0, release-15.0 ]
+        branch: [ main, release-18.0, release-17.0, release-16.0 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Little fix to the new golang deps upgrade workflow and remove the `release-15.0` branch from the golang version upgrade matrix.