### PR TITLE
Run Go deps upgrade every week

### DIFF
--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -2,7 +2,7 @@ name: Update Golang Dependencies
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Runs every day at midnight UTC
+    - cron: "0 0 * * 0" # Runs every week at midnight UTC
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
Small fix, in #14891 we set the cron schedule to automatically upgrade the golang deps to every day instead of every week.