### PR TITLE
CI: Adjust FOSSA API secret name

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   test:
     name: Code Coverage
-    runs-on: ubuntu-22.04
+    runs-on: gh-hosted-runners-4cores-1
 
     steps:
     - name: Check out code
@@ -32,7 +32,7 @@ jobs:
       if: steps.changes.outputs.changed_files == 'true'
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21.5
+        go-version: 1.21.6
 
     - name: Set up python
       if: steps.changes.outputs.changed_files == 'true'

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: fossa-contrib/fossa-action@v2
         with:
-          fossa-api-key: ${{secrets.fossaApiKey}}
+          fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
 
       - name: Check for changes in Go files
         if: steps.skip-workflow.outputs.skip-workflow == 'false'


### PR DESCRIPTION
## Description

This is a follow-up to: https://github.com/vitessio/vitess/pull/14333

You can see that the run on the merge to `main` failed: https://github.com/vitessio/vitess/actions/runs/7466472041/job/20317903610

The FOSSA part of the workflow only runs on main so there's no other way to test it than to merge: https://github.com/vitessio/vitess/blob/9df71e0698febc8fae7de03f11eb449fc2e5ee84/.github/workflows/static_checks_etc.yml#L36-L45

We have an open discussion with CNCF to get a push-only API token so that we can enable the scan for pull-requests as well using that: https://github.com/fossa-contrib/fossa-action#push-only-api-token

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/14333

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required