### PR TITLE
Refactor out more usage of servenv for mysql version

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -139,10 +139,11 @@ func run(cmd *cobra.Command, args []string) {
 		log.Warningf("no cache-refresh-key set; forcing cache refreshes will not be possible")
 	}
 	cache.SetCacheRefreshKey(cacheRefreshKey)
-	collationEnv := collations.NewEnvironment(servenv.MySQLServerVersion())
+	mysqlServerVersion := servenv.MySQLServerVersion()
+	collationEnv := collations.NewEnvironment(mysqlServerVersion)
 
 	parser, err := sqlparser.New(sqlparser.Options{
-		MySQLServerVersion: servenv.MySQLServerVersion(),
+		MySQLServerVersion: mysqlServerVersion,
 		TruncateUILen:      servenv.TruncateUILen,
 		TruncateErrLen:     servenv.TruncateErrLen,
 	})
@@ -154,7 +155,7 @@ func run(cmd *cobra.Command, args []string) {
 		HTTPOpts:              httpOpts,
 		RBAC:                  rbacConfig,
 		EnableDynamicClusters: enableDynamicClusters,
-	}, collationEnv, parser)
+	}, collationEnv, parser, mysqlServerVersion)
 	bootSpan.Finish()
 
 	if err := s.ListenAndServe(); err != nil {

--- a/go/cmd/vtcombo/cli/plugin_grpcvtctldserver.go
+++ b/go/cmd/vtcombo/cli/plugin_grpcvtctldserver.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	servenv.OnRun(func() {
 		if servenv.GRPCCheckServiceMap("vtctld") {
-			grpcvtctldserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser)
+			grpcvtctldserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser, mysqlVersion)
 		}
 	})
 }

--- a/go/cmd/vtcombo/cli/plugin_grpcvtctlserver.go
+++ b/go/cmd/vtcombo/cli/plugin_grpcvtctlserver.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	servenv.OnRun(func() {
 		if servenv.GRPCCheckServiceMap("vtctl") {
-			grpcvtctlserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser)
+			grpcvtctlserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser, mysqlVersion)
 		}
 	})
 }

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -131,10 +131,11 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), waitTime)
 	installSignalHandlers(cancel)
 
-	collationEnv := collations.NewEnvironment(servenv.MySQLServerVersion())
+	mysqlVersion := servenv.MySQLServerVersion()
+	collationEnv := collations.NewEnvironment(mysqlVersion)
 
 	parser, err := sqlparser.New(sqlparser.Options{
-		MySQLServerVersion: servenv.MySQLServerVersion(),
+		MySQLServerVersion: mysqlVersion,
 		TruncateUILen:      servenv.TruncateUILen,
 		TruncateErrLen:     servenv.TruncateErrLen,
 	})
@@ -166,7 +167,7 @@ func main() {
 		// New behavior. Strip off the prefix, and set things up to run through
 		// the vtctldclient command tree, using the localvtctldclient (in-process)
 		// client.
-		vtctld := grpcvtctldserver.NewVtctldServer(ts, collationEnv, parser)
+		vtctld := grpcvtctldserver.NewVtctldServer(ts, collationEnv, parser, mysqlVersion)
 		localvtctldclient.SetServer(vtctld)
 		command.VtctldClientProtocol = "local"
 
@@ -182,7 +183,7 @@ func main() {
 		fallthrough
 	default:
 		log.Warningf("WARNING: vtctl should only be used for VDiff v1 workflows. Please use VDiff v2 and consider using vtctldclient for all other commands.")
-		wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collationEnv, parser)
+		wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collationEnv, parser, mysqlVersion)
 
 		if args[0] == "--" {
 			vtctl.PrintDoubleDashDeprecationNotice(wr)

--- a/go/cmd/vtctld/cli/cli.go
+++ b/go/cmd/vtctld/cli/cli.go
@@ -32,6 +32,7 @@ var (
 	ts           *topo.Server
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	mysqlVersion string
 	Main         = &cobra.Command{
 		Use:   "vtctld",
 		Short: "The Vitess cluster management daemon.",
@@ -65,9 +66,10 @@ func run(cmd *cobra.Command, args []string) error {
 	defer ts.Close()
 
 	var err error
-	collationEnv = collations.NewEnvironment(servenv.MySQLServerVersion())
+	mysqlVersion = servenv.MySQLServerVersion()
+	collationEnv = collations.NewEnvironment(mysqlVersion)
 	parser, err = sqlparser.New(sqlparser.Options{
-		MySQLServerVersion: servenv.MySQLServerVersion(),
+		MySQLServerVersion: mysqlVersion,
 		TruncateUILen:      servenv.TruncateUILen,
 		TruncateErrLen:     servenv.TruncateErrLen,
 	})
@@ -75,7 +77,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	// Init the vtctld core
-	if err := vtctld.InitVtctld(ts, collationEnv, parser); err != nil {
+	if err := vtctld.InitVtctld(ts, collationEnv, parser, mysqlVersion); err != nil {
 		return err
 	}
 

--- a/go/cmd/vtctld/cli/plugin_grpcvtctldserver.go
+++ b/go/cmd/vtctld/cli/plugin_grpcvtctldserver.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	servenv.OnRun(func() {
 		if servenv.GRPCCheckServiceMap("vtctld") {
-			grpcvtctldserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser)
+			grpcvtctldserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser, mysqlVersion)
 		}
 	})
 }

--- a/go/cmd/vtctld/cli/plugin_grpcvtctlserver.go
+++ b/go/cmd/vtctld/cli/plugin_grpcvtctlserver.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	servenv.OnRun(func() {
 		if servenv.GRPCCheckServiceMap("vtctl") {
-			grpcvtctlserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser)
+			grpcvtctlserver.StartServer(servenv.GRPCServer, ts, collationEnv, parser, mysqlVersion)
 		}
 	})
 }

--- a/go/cmd/vtctld/cli/schema.go
+++ b/go/cmd/vtctld/cli/schema.go
@@ -71,7 +71,7 @@ func initSchema() {
 				return
 			}
 			ctx := context.Background()
-			wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collationEnv, parser)
+			wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collationEnv, parser, mysqlVersion)
 			_, err = schemamanager.Run(
 				ctx,
 				controller,

--- a/go/cmd/vtctldclient/command/root.go
+++ b/go/cmd/vtctldclient/command/root.go
@@ -85,6 +85,7 @@ var (
 
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	mysqlVersion string
 
 	topoOptions = struct {
 		implementation        string
@@ -214,7 +215,7 @@ func getClientForCommand(cmd *cobra.Command) (vtctldclient.VtctldClient, error) 
 				return nil
 			})
 		})
-		vtctld := grpcvtctldserver.NewVtctldServer(ts, collationEnv, parser)
+		vtctld := grpcvtctldserver.NewVtctldServer(ts, collationEnv, parser, mysqlVersion)
 		localvtctldclient.SetServer(vtctld)
 		VtctldClientProtocol = "local"
 		server = ""
@@ -232,10 +233,11 @@ func init() {
 	Root.PersistentFlags().StringVar(&topoOptions.globalRoot, "topo-global-root", topoOptions.globalRoot, "the path of the global topology data in the global topology server")
 	vreplcommon.RegisterCommands(Root)
 
-	collationEnv = collations.NewEnvironment(servenv.MySQLServerVersion())
+	mysqlVersion = servenv.MySQLServerVersion()
+	collationEnv = collations.NewEnvironment(mysqlVersion)
 	var err error
 	parser, err = sqlparser.New(sqlparser.Options{
-		MySQLServerVersion: servenv.MySQLServerVersion(),
+		MySQLServerVersion: mysqlVersion,
 		TruncateUILen:      servenv.TruncateUILen,
 		TruncateErrLen:     servenv.TruncateErrLen,
 	})

--- a/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/cmd/vtctldclient/command"
 	"vitess.io/vitess/go/cmd/vtctldclient/command/vreplication/common"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -146,7 +147,7 @@ func SetupLocalVtctldClient(t *testing.T, ctx context.Context, cells ...string) 
 	tmclient.RegisterTabletManagerClientFactory("grpc", func() tmclient.TabletManagerClient {
 		return nil
 	})
-	vtctld := grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+	vtctld := grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	localvtctldclient.SetServer(vtctld)
 	command.VtctldClientProtocol = "local"
 	client, err := vtctldclient.New(command.VtctldClientProtocol, "")

--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff_env_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff_env_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -85,7 +86,7 @@ func newTestVDiffEnv(t testing.TB, ctx context.Context, sourceShards, targetShar
 		tabletType:     topodatapb.TabletType_REPLICA,
 		tmc:            newTestVDiffTMClient(),
 	}
-	env.ws = workflow.NewServer(env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	env.ws = workflow.NewServer(env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	env.tmc.testEnv = env
 
 	// Generate a unique dialer name.

--- a/go/cmd/vtexplain/cli/vtexplain.go
+++ b/go/cmd/vtexplain/cli/vtexplain.go
@@ -175,16 +175,17 @@ func parseAndRun() error {
 		Target:          dbName,
 	}
 
-	collationEnv := collations.NewEnvironment(servenv.MySQLServerVersion())
+	mysqlServerVersion := servenv.MySQLServerVersion()
+	collationEnv := collations.NewEnvironment(mysqlServerVersion)
 	parser, err := sqlparser.New(sqlparser.Options{
-		MySQLServerVersion: servenv.MySQLServerVersion(),
+		MySQLServerVersion: mysqlServerVersion,
 		TruncateUILen:      servenv.TruncateUILen,
 		TruncateErrLen:     servenv.TruncateErrLen,
 	})
 	if err != nil {
 		return err
 	}
-	vte, err := vtexplain.Init(context.Background(), vschema, schema, ksShardMap, opts, collationEnv, parser)
+	vte, err := vtexplain.Init(context.Background(), vschema, schema, ksShardMap, opts, collationEnv, parser, mysqlServerVersion)
 	if err != nil {
 		return err
 	}

--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -158,11 +158,12 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cells_to_watch validation failed: %v", err)
 	}
 
+	mysqlVersion := servenv.MySQLServerVersion()
 	plannerVersion, _ := plancontext.PlannerNameToVersion(plannerName)
-	collationEnv := collations.NewEnvironment(servenv.MySQLServerVersion())
+	collationEnv := collations.NewEnvironment(mysqlVersion)
 
 	// pass nil for HealthCheck and it will be created
-	vtg := vtgate.Init(context.Background(), nil, resilientServer, cell, tabletTypes, plannerVersion, collationEnv)
+	vtg := vtgate.Init(context.Background(), nil, resilientServer, cell, tabletTypes, plannerVersion, collationEnv, mysqlVersion)
 
 	servenv.OnRun(func() {
 		// Flags are parsed now. Parse the template using the actual flag value and overwrite the current template.

--- a/go/test/fuzzing/tabletserver_schema_fuzzer.go
+++ b/go/test/fuzzing/tabletserver_schema_fuzzer.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -68,7 +69,7 @@ func newTestLoadTable(tableName, comment string, db *fakesqldb.DB) (*schema.Tabl
 		IdleTimeout: 10 * time.Second,
 	}
 
-	connPool := connpool.NewPool(tabletenv.NewEnv(nil, "SchemaTest", collations.MySQL8(), sqlparser.NewTestParser()), "", cfg)
+	connPool := connpool.NewPool(tabletenv.NewEnv(nil, "SchemaTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), "", cfg)
 	connPool.Open(appParams, dbaParams, appParams)
 	conn, err := connPool.Get(ctx, nil)
 	if err != nil {

--- a/go/test/fuzzing/vtctl_fuzzer.go
+++ b/go/test/fuzzing/vtctl_fuzzer.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
@@ -182,7 +183,7 @@ func Fuzz(data []byte) int {
 		// Add params to the command
 		commandSlice = append(commandSlice, args...)
 
-		_ = vtctl.RunCommand(ctx, wrangler.New(logger, topo, tmc, collations.MySQL8(), sqlparser.NewTestParser()), commandSlice)
+		_ = vtctl.RunCommand(ctx, wrangler.New(logger, topo, tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), commandSlice)
 		command++
 	}
 

--- a/go/test/vschemawrapper/vschema_wrapper.go
+++ b/go/test/vschemawrapper/vschema_wrapper.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -49,6 +50,7 @@ type VSchemaWrapper struct {
 	Version               plancontext.PlannerVersion
 	EnableViews           bool
 	TestBuilder           func(query string, vschema plancontext.VSchema, keyspace string) (*engine.Plan, error)
+	MySQLServerVersion    string
 }
 
 func (vw *VSchemaWrapper) GetPrepareData(stmtName string) *vtgatepb.PrepareData {
@@ -132,6 +134,13 @@ func (vw *VSchemaWrapper) CollationEnv() *collations.Environment {
 
 func (vw *VSchemaWrapper) SQLParser() *sqlparser.Parser {
 	return sqlparser.NewTestParser()
+}
+
+func (vw *VSchemaWrapper) MySQLVersion() string {
+	if vw.MySQLServerVersion == "" {
+		return config.DefaultMySQLVersion
+	}
+	return vw.MySQLServerVersion
 }
 
 func (vw *VSchemaWrapper) PlannerWarning(_ string) {

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -294,7 +294,7 @@ func TestDiffTables(t *testing.T) {
 			hints: &DiffHints{
 				TableCharsetCollateStrategy: TableCharsetCollateIgnoreAlways,
 			},
-			env: NewEnv(collations.NewEnvironment("5.7.9"), collations.CollationUtf8mb3ID, sqlparser.NewTestParser()),
+			env: NewEnv(collations.NewEnvironment("5.7.9"), collations.CollationUtf8mb3ID, sqlparser.NewTestParser(), "5.7.9"),
 		},
 	}
 	env := NewTestEnv()

--- a/go/vt/schemadiff/env.go
+++ b/go/vt/schemadiff/env.go
@@ -2,6 +2,7 @@ package schemadiff
 
 import (
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -9,6 +10,7 @@ type Environment struct {
 	CollationEnv *collations.Environment
 	DefaultColl  collations.ID
 	Parser       *sqlparser.Parser
+	MySQLVersion string
 }
 
 func NewTestEnv() *Environment {
@@ -16,13 +18,15 @@ func NewTestEnv() *Environment {
 		CollationEnv: collations.MySQL8(),
 		DefaultColl:  collations.MySQL8().DefaultConnectionCharset(),
 		Parser:       sqlparser.NewTestParser(),
+		MySQLVersion: config.DefaultMySQLVersion,
 	}
 }
 
-func NewEnv(collEnv *collations.Environment, defaultColl collations.ID, parser *sqlparser.Parser) *Environment {
+func NewEnv(collEnv *collations.Environment, defaultColl collations.ID, parser *sqlparser.Parser, mysqlVersion string) *Environment {
 	return &Environment{
 		CollationEnv: collEnv,
 		DefaultColl:  defaultColl,
 		Parser:       parser,
+		MySQLVersion: mysqlVersion,
 	}
 }

--- a/go/vt/schemadiff/semantics.go
+++ b/go/vt/schemadiff/semantics.go
@@ -18,6 +18,7 @@ package schemadiff
 
 import (
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -60,6 +61,10 @@ func (si *declarativeSchemaInformation) ConnCollation() collations.ID {
 
 func (si *declarativeSchemaInformation) CollationEnv() *collations.Environment {
 	return si.env.CollationEnv
+}
+
+func (si *declarativeSchemaInformation) MySQLVersion() string {
+	return config.DefaultMySQLVersion
 }
 
 func (si *declarativeSchemaInformation) ForeignKeyMode(keyspace string) (vschemapb.Keyspace_ForeignKeyMode, error) {

--- a/go/vt/servenv/mysql.go
+++ b/go/vt/servenv/mysql.go
@@ -40,14 +40,6 @@ func MySQLServerVersion() string {
 	return mySQLServerVersion
 }
 
-// SetMySQLServerVersionForTest sets the value of the `--mysql_server_version`
-// flag. It is intended for use in tests that require a specific MySQL server
-// version (for example, collations) that cannot specify that via the command
-// line.
-func SetMySQLServerVersionForTest(version string) {
-	mySQLServerVersion = version
-}
-
 func init() {
 	for _, cmd := range []string{
 		"mysqlctl",

--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -33,6 +33,7 @@ import (
 	"vitess.io/vitess/go/stats"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 )
@@ -89,7 +90,7 @@ func TestInitErrors(t *testing.T) {
 	}
 
 	require.Equal(t, int64(0), getDDLCount())
-	err = Init(ctx, exec, collEnv, parser)
+	err = Init(ctx, exec, collEnv, parser, config.DefaultMySQLVersion)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(sidecarTables)-len(schemaErrors)), getDDLCount())
 	require.Equal(t, int64(len(schemaErrors)), getDDLErrorCount())
@@ -161,7 +162,7 @@ func TestMiscSidecarDB(t *testing.T) {
 	ddlErrorCount.Set(0)
 	ddlCount.Set(0)
 	require.Equal(t, int64(0), getDDLCount())
-	err = Init(ctx, exec, collEnv, parser)
+	err = Init(ctx, exec, collEnv, parser, config.DefaultMySQLVersion)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(sidecarTables)), getDDLCount())
 
@@ -170,16 +171,17 @@ func TestMiscSidecarDB(t *testing.T) {
 	AddSchemaInitQueries(db, true, parser)
 
 	// tests init on already inited db
-	err = Init(ctx, exec, collEnv, parser)
+	err = Init(ctx, exec, collEnv, parser, config.DefaultMySQLVersion)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(sidecarTables)), getDDLCount())
 
 	// tests misc paths not covered above
 	si := &schemaInit{
-		ctx:     ctx,
-		exec:    exec,
-		collEnv: collations.MySQL8(),
-		parser:  parser,
+		ctx:          ctx,
+		exec:         exec,
+		collEnv:      collations.MySQL8(),
+		parser:       parser,
+		mysqlVersion: config.DefaultMySQLVersion,
 	}
 
 	err = si.setCurrentDatabase(sidecar.GetIdentifier())
@@ -230,8 +232,9 @@ func TestAlterTableAlgorithm(t *testing.T) {
 		{"modify column", "t1", "create table if not exists _vt.t1(i int)", "create table if not exists _vt.t(i float)"},
 	}
 	si := &schemaInit{
-		collEnv: collations.MySQL8(),
-		parser:  sqlparser.NewTestParser(),
+		collEnv:      collations.MySQL8(),
+		parser:       sqlparser.NewTestParser(),
+		mysqlVersion: config.DefaultMySQLVersion,
 	}
 	copyAlgo := sqlparser.AlgorithmValue("COPY")
 	for _, tc := range testCases {

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtadmin"
@@ -68,7 +69,7 @@ func TestCreateKeyspace(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -133,7 +134,7 @@ func TestCreateShard(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -200,7 +201,7 @@ func TestDeleteKeyspace(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -265,7 +266,7 @@ func TestDeleteShards(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -340,7 +341,7 @@ func TestDeleteTablet(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -407,7 +408,7 @@ func TestEmergencyFailoverShard(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -483,7 +484,7 @@ func TestFindSchema(t *testing.T) {
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -504,7 +505,7 @@ func TestFindSchema(t *testing.T) {
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -524,7 +525,7 @@ func TestFindSchema(t *testing.T) {
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -573,7 +574,7 @@ func TestGetBackups(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -646,7 +647,7 @@ func TestGetCellInfos(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -725,7 +726,7 @@ func TestGetCellsAliases(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -792,7 +793,7 @@ func TestGetClusters(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -866,7 +867,7 @@ func TestGetGates(t *testing.T) {
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -885,7 +886,7 @@ func TestGetGates(t *testing.T) {
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -905,7 +906,7 @@ func TestGetGates(t *testing.T) {
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -946,7 +947,7 @@ func TestGetKeyspace(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1013,7 +1014,7 @@ func TestGetKeyspaces(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1097,7 +1098,7 @@ func TestGetSchema(t *testing.T) {
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1120,7 +1121,7 @@ func TestGetSchema(t *testing.T) {
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1173,7 +1174,7 @@ func TestGetSchemas(t *testing.T) {
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1192,7 +1193,7 @@ func TestGetSchemas(t *testing.T) {
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1218,7 +1219,7 @@ func TestGetSchemas(t *testing.T) {
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1271,7 +1272,7 @@ func TestGetShardReplicationPositions(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1352,7 +1353,7 @@ func TestGetSrvVSchema(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1419,7 +1420,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1500,7 +1501,7 @@ func TestGetTablet(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1571,7 +1572,7 @@ func TestGetTablets(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1652,7 +1653,7 @@ func TestGetVSchema(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1719,7 +1720,7 @@ func TestGetVSchemas(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1809,7 +1810,7 @@ func TestGetVtctlds(t *testing.T) {
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1828,7 +1829,7 @@ func TestGetVtctlds(t *testing.T) {
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1848,7 +1849,7 @@ func TestGetVtctlds(t *testing.T) {
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -1889,7 +1890,7 @@ func TestGetWorkflow(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -1958,7 +1959,7 @@ func TestGetWorkflows(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2025,7 +2026,7 @@ func TestPingTablet(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2090,7 +2091,7 @@ func TestPlannedFailoverShard(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2157,7 +2158,7 @@ func TestRefreshState(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2222,7 +2223,7 @@ func TestRefreshTabletReplicationSource(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2293,7 +2294,7 @@ func TestReloadSchemas(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2373,7 +2374,7 @@ func TestRunHealthCheck(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2438,7 +2439,7 @@ func TestSetReadOnly(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2503,7 +2504,7 @@ func TestSetReadWrite(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2568,7 +2569,7 @@ func TestStartReplication(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2633,7 +2634,7 @@ func TestStopReplication(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2698,7 +2699,7 @@ func TestTabletExternallyPromoted(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2766,7 +2767,7 @@ func TestVTExplain(t *testing.T) {
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -2788,7 +2789,7 @@ func TestVTExplain(t *testing.T) {
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
 
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())
@@ -2831,7 +2832,7 @@ func TestValidateKeyspace(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2892,7 +2893,7 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -2953,7 +2954,7 @@ func TestValidateVersionKeyspace(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -35,6 +35,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	_flag "vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/test/utils"
@@ -559,7 +560,7 @@ func TestFindSchema(t *testing.T) {
 				clusters[i] = vtadmintestutil.BuildCluster(t, cfg)
 			}
 
-			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			defer api.Close()
 
 			resp, err := api.FindSchema(ctx, tt.req)
@@ -769,7 +770,7 @@ func TestFindSchema(t *testing.T) {
 		},
 		)
 
-		api := NewAPI([]*cluster.Cluster{c1, c2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+		api := NewAPI([]*cluster.Cluster{c1, c2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		defer api.Close()
 
 		schema, err := api.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
@@ -869,7 +870,7 @@ func TestGetClusters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			api := NewAPI(tt.clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(tt.clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			resp, err := api.GetClusters(ctx, &vtadminpb.GetClustersRequest{})
 			assert.NoError(t, err)
@@ -947,7 +948,7 @@ func TestGetGates(t *testing.T) {
 		},
 	}
 
-	api := NewAPI([]*cluster.Cluster{cluster1, cluster2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+	api := NewAPI([]*cluster.Cluster{cluster1, cluster2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	ctx := context.Background()
 
 	resp, err := api.GetGates(ctx, &vtadminpb.GetGatesRequest{})
@@ -1069,7 +1070,7 @@ func TestGetKeyspace(t *testing.T) {
 				testutil.AddShards(ctx, t, ts, shards...)
 				topos[i] = ts
 				vtctlds[i] = testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				})
 			}
 
@@ -1085,7 +1086,7 @@ func TestGetKeyspace(t *testing.T) {
 					})
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				ks, err := api.GetKeyspace(ctx, tt.req)
 				if tt.shouldErr {
 					assert.Error(t, err)
@@ -1313,10 +1314,10 @@ func TestGetKeyspaces(t *testing.T) {
 
 			servers := []vtctlservicepb.VtctldServer{
 				testutil.NewVtctldServerWithTabletManagerClient(t, topos[0], nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				}),
 				testutil.NewVtctldServerWithTabletManagerClient(t, topos[1], nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				}),
 			}
 
@@ -1338,7 +1339,7 @@ func TestGetKeyspaces(t *testing.T) {
 					}),
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				resp, err := api.GetKeyspaces(ctx, tt.req)
 				require.NoError(t, err)
 
@@ -1548,7 +1549,7 @@ func TestGetSchema(t *testing.T) {
 			defer cancel()
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddTablets(ctx, t, tt.ts, nil, vtadmintestutil.TopodataTabletsFromVTAdminTablets(tt.tablets)...)
@@ -1562,7 +1563,7 @@ func TestGetSchema(t *testing.T) {
 					VtctldClient: client,
 					Tablets:      tt.tablets,
 				})
-				api := NewAPI([]*cluster.Cluster{c}, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI([]*cluster.Cluster{c}, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				defer api.Close()
 
 				resp, err := api.GetSchema(ctx, tt.req)
@@ -1692,7 +1693,7 @@ func TestGetSchema(t *testing.T) {
 		},
 		)
 
-		api := NewAPI([]*cluster.Cluster{c1, c2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+		api := NewAPI([]*cluster.Cluster{c1, c2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		defer api.Close()
 
 		schema, err := api.GetSchema(ctx, &vtadminpb.GetSchemaRequest{
@@ -2202,10 +2203,10 @@ func TestGetSchemas(t *testing.T) {
 
 			vtctlds := []vtctlservicepb.VtctldServer{
 				testutil.NewVtctldServerWithTabletManagerClient(t, topos[0], &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				}),
 				testutil.NewVtctldServerWithTabletManagerClient(t, topos[1], &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+					return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				}),
 			}
 
@@ -2246,7 +2247,7 @@ func TestGetSchemas(t *testing.T) {
 					})
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				defer api.Close()
 
 				resp, err := api.GetSchemas(ctx, tt.req)
@@ -2467,7 +2468,7 @@ func TestGetSchemas(t *testing.T) {
 		},
 		)
 
-		api := NewAPI([]*cluster.Cluster{c1, c2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+		api := NewAPI([]*cluster.Cluster{c1, c2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		defer api.Close()
 
 		resp, err := api.GetSchemas(context.Background(), &vtadminpb.GetSchemasRequest{
@@ -2641,7 +2642,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 			toposerver := memorytopo.NewServer(ctx, tt.cells...)
 
 			vtctldserver := testutil.NewVtctldServerWithTabletManagerClient(t, toposerver, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.WithTestServer(t, vtctldserver, func(t *testing.T, vtctldClient vtctldclient.VtctldClient) {
@@ -2660,7 +2661,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 					}),
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				resp, err := api.GetSrvKeyspace(ctx, tt.req)
 
 				if tt.shouldErr {
@@ -2805,7 +2806,7 @@ func TestGetSrvKeyspaces(t *testing.T) {
 			}
 
 			vtctldserver := testutil.NewVtctldServerWithTabletManagerClient(t, toposerver, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.WithTestServer(t, vtctldserver, func(t *testing.T, vtctldClient vtctldclient.VtctldClient) {
@@ -2826,7 +2827,7 @@ func TestGetSrvKeyspaces(t *testing.T) {
 					}),
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				resp, err := api.GetSrvKeyspaces(ctx, tt.req)
 
 				if tt.shouldErr {
@@ -2970,7 +2971,7 @@ func TestGetSrvVSchema(t *testing.T) {
 			toposerver := memorytopo.NewServer(ctx, tt.cells...)
 
 			vtctldserver := testutil.NewVtctldServerWithTabletManagerClient(t, toposerver, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.WithTestServer(t, vtctldserver, func(t *testing.T, vtctldClient vtctldclient.VtctldClient) {
@@ -2989,7 +2990,7 @@ func TestGetSrvVSchema(t *testing.T) {
 					}),
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				resp, err := api.GetSrvVSchema(ctx, tt.req)
 
 				if tt.shouldErr {
@@ -3264,7 +3265,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 			toposerver := memorytopo.NewServer(ctx, tt.cells...)
 
 			vtctldserver := testutil.NewVtctldServerWithTabletManagerClient(t, toposerver, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.WithTestServer(t, vtctldserver, func(t *testing.T, vtctldClient vtctldclient.VtctldClient) {
@@ -3283,7 +3284,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 					}),
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				resp, err := api.GetSrvVSchemas(ctx, tt.req)
 
 				if tt.shouldErr {
@@ -3554,7 +3555,7 @@ func TestGetTablet(t *testing.T) {
 				})
 			}
 
-			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			resp, err := api.GetTablet(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)
@@ -3749,7 +3750,7 @@ func TestGetTablets(t *testing.T) {
 				})
 			}
 
-			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			resp, err := api.GetTablets(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)
@@ -3880,7 +3881,7 @@ func TestGetVSchema(t *testing.T) {
 			t.Parallel()
 
 			clusters := []*cluster.Cluster{vtadmintestutil.BuildCluster(t, tt.clusterCfg)}
-			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			resp, err := api.GetVSchema(ctx, tt.req)
 			if tt.shouldErr {
@@ -4210,7 +4211,7 @@ func TestGetVSchemas(t *testing.T) {
 			}
 
 			clusters := vtadmintestutil.BuildClusters(t, tt.clusterCfgs...)
-			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			resp, err := api.GetVSchemas(ctx, tt.req)
 			if tt.shouldErr {
@@ -4294,7 +4295,7 @@ func TestGetVtctlds(t *testing.T) {
 		},
 	}
 
-	api := NewAPI([]*cluster.Cluster{cluster1, cluster2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+	api := NewAPI([]*cluster.Cluster{cluster1, cluster2}, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	ctx := context.Background()
 
 	resp, err := api.GetVtctlds(ctx, &vtadminpb.GetVtctldsRequest{})
@@ -4426,7 +4427,7 @@ func TestGetWorkflow(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			api := NewAPI(vtadmintestutil.BuildClusters(t, tt.cfgs...), Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(vtadmintestutil.BuildClusters(t, tt.cfgs...), Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			resp, err := api.GetWorkflow(ctx, tt.req)
 			if tt.shouldErr {
@@ -4865,7 +4866,7 @@ func TestGetWorkflows(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			api := NewAPI(vtadmintestutil.BuildClusters(t, tt.cfgs...), Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(vtadmintestutil.BuildClusters(t, tt.cfgs...), Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			resp, err := api.GetWorkflows(ctx, tt.req)
 			if tt.shouldErr {
@@ -5116,7 +5117,7 @@ func TestVTExplain(t *testing.T) {
 			}
 
 			vtctldserver := testutil.NewVtctldServerWithTabletManagerClient(t, toposerver, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.WithTestServer(t, vtctldserver, func(t *testing.T, vtctldClient vtctldclient.VtctldClient) {
@@ -5155,7 +5156,7 @@ func TestVTExplain(t *testing.T) {
 					}),
 				}
 
-				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser())
+				api := NewAPI(clusters, Options{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 				resp, err := api.VTExplain(ctx, tt.req)
 
 				if tt.expectedError != nil {
@@ -5357,7 +5358,7 @@ func TestServeHTTP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			api := NewAPI(tt.clusters, Options{EnableDynamicClusters: tt.enableDynamicClusters}, collations.MySQL8(), sqlparser.NewTestParser())
+			api := NewAPI(tt.clusters, Options{EnableDynamicClusters: tt.enableDynamicClusters}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			// Copy the Cookie over to a new Request
 			req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -46,6 +46,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtadmin"
@@ -90,7 +91,7 @@ func Test{{ .Method }}(t *testing.T) {
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
 	{{ if not .SerializeCases }}
-	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+	api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	t.Cleanup(func() {
 		if err := api.Close(); err != nil {
 			t.Logf("api did not close cleanly: %s", err.Error())
@@ -103,7 +104,7 @@ func Test{{ .Method }}(t *testing.T) {
 	t.Run("{{ .Name }}", func(t *testing.T) {
 		t.Parallel()
 		{{ if $test.SerializeCases }}
-		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser())
+		api := vtadmin.NewAPI(testClusters(t), opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		t.Cleanup(func() {
 			if err := api.Close(); err != nil {
 				t.Logf("api did not close cleanly: %s", err.Error())

--- a/go/vt/vtadmin/testutil/cluster.go
+++ b/go/vt/vtadmin/testutil/cluster.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -172,7 +173,7 @@ func BuildIntegrationTestCluster(t testing.TB, ctx context.Context, c *vtadminpb
 
 	ts, factory := memorytopo.NewServerAndFactory(ctx, cells...)
 	vtctld := grpcvtctldtestutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	localclient := localvtctldclient.New(vtctld)

--- a/go/vt/vtctl/endtoend/get_schema_test.go
+++ b/go/vt/vtctl/endtoend/get_schema_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/sqlparser"
 
@@ -163,7 +164,7 @@ func TestGetSchema(t *testing.T) {
 
 	logger := logutil.NewMemoryLogger()
 
-	err := vtctl.RunCommand(ctx, wrangler.New(logger, topo, &tmc, collations.MySQL8(), sqlparser.NewTestParser()), []string{
+	err := vtctl.RunCommand(ctx, wrangler.New(logger, topo, &tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), []string{
 		"GetSchema",
 		topoproto.TabletAliasString(tablet.Alias),
 	})
@@ -203,7 +204,7 @@ func TestGetSchema(t *testing.T) {
 		},
 	}
 
-	err = vtctl.RunCommand(ctx, wrangler.New(logger, topo, &tmc, collations.MySQL8(), sqlparser.NewTestParser()), []string{
+	err = vtctl.RunCommand(ctx, wrangler.New(logger, topo, &tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), []string{
 		"GetSchema",
 		"--table_sizes_only",
 		topoproto.TabletAliasString(tablet.Alias),

--- a/go/vt/vtctl/endtoend/onlineddl_show_test.go
+++ b/go/vt/vtctl/endtoend/onlineddl_show_test.go
@@ -12,6 +12,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -123,7 +124,7 @@ func onlineDDLTest(t *testing.T, args []string, expectedQuery string) {
 	tmclienttest.SetProtocol("go.vt.vtctl.endtoend", t.Name())
 
 	logger := logutil.NewMemoryLogger()
-	wr := wrangler.New(logger, fakeTopo, &tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logger, fakeTopo, &tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	err := vtctl.RunCommand(ctx, wr, args)
 	assert.Error(t, err)

--- a/go/vt/vtctl/grpcvtctlclient/client_test.go
+++ b/go/vt/vtctl/grpcvtctlclient/client_test.go
@@ -28,12 +28,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"vitess.io/vitess/go/vt/sqlparser"
-
 	"vitess.io/vitess/go/mysql/collations"
-
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctlserver"
 	"vitess.io/vitess/go/vt/vtctl/vtctlclienttest"
 
@@ -56,7 +55,7 @@ func TestVtctlServer(t *testing.T) {
 
 	// Create a gRPC server and listen on the port
 	server := grpc.NewServer()
-	vtctlservicepb.RegisterVtctlServer(server, grpcvtctlserver.NewVtctlServer(ts, collations.MySQL8(), sqlparser.NewTestParser()))
+	vtctlservicepb.RegisterVtctlServer(server, grpcvtctlserver.NewVtctlServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	go server.Serve(listener)
 
 	// Create a VtctlClient gRPC client to talk to the fake server
@@ -90,7 +89,7 @@ func TestVtctlAuthClient(t *testing.T) {
 	opts = append(opts, grpc.UnaryInterceptor(servenv.FakeAuthUnaryInterceptor))
 	server := grpc.NewServer(opts...)
 
-	vtctlservicepb.RegisterVtctlServer(server, grpcvtctlserver.NewVtctlServer(ts, collations.MySQL8(), sqlparser.NewTestParser()))
+	vtctlservicepb.RegisterVtctlServer(server, grpcvtctlserver.NewVtctlServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	go server.Serve(listener)
 
 	authJSON := `{

--- a/go/vt/vtctl/grpcvtctldclient/client_test.go
+++ b/go/vt/vtctl/grpcvtctldclient/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
@@ -43,7 +44,7 @@ func TestFindAllShardsInKeyspace(t *testing.T) {
 	ts := memorytopo.NewServer(ctx, "cell1")
 	defer ts.Close()
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	testutil.WithTestServer(t, vtctld, func(t *testing.T, client vtctldclient.VtctldClient) {
@@ -90,7 +91,7 @@ func TestGetKeyspace(t *testing.T) {
 	ts := memorytopo.NewServer(ctx, "cell1")
 	defer ts.Close()
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	testutil.WithTestServer(t, vtctld, func(t *testing.T, client vtctldclient.VtctldClient) {
@@ -119,7 +120,7 @@ func TestGetKeyspaces(t *testing.T) {
 	ts := memorytopo.NewServer(ctx, "cell1")
 	defer ts.Close()
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	testutil.WithTestServer(t, vtctld, func(t *testing.T, client vtctldclient.VtctldClient) {

--- a/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -48,7 +49,7 @@ func TestInitShardPrimary(t *testing.T) {
 	ts := memorytopo.NewServer(ctx, "cell1")
 	tmc := tmclient.NewTabletManagerClient()
 	defer tmc.Close()
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	primaryDb := fakesqldb.New(t)
 	defer primaryDb.Close()
@@ -95,7 +96,7 @@ func TestInitShardPrimary(t *testing.T) {
 		tablet.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 	}
 
-	vtctld := grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+	vtctld := grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	resp, err := vtctld.InitShardPrimary(context.Background(), &vtctldatapb.InitShardPrimaryRequest{
 		Keyspace:                tablet1.Tablet.Keyspace,
 		Shard:                   tablet1.Tablet.Shard,
@@ -111,7 +112,7 @@ func TestInitShardPrimaryNoFormerPrimary(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
 	tmc := tmclient.NewTabletManagerClient()
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	primaryDb := fakesqldb.New(t)
 	defer primaryDb.Close()
@@ -150,7 +151,7 @@ func TestInitShardPrimaryNoFormerPrimary(t *testing.T) {
 		tablet.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 	}
 
-	vtctld := grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+	vtctld := grpcvtctldserver.NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	_, err := vtctld.InitShardPrimary(context.Background(), &vtctldatapb.InitShardPrimaryRequest{
 		Keyspace:                tablet1.Tablet.Keyspace,
 		Shard:                   tablet1.Tablet.Shard,

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -35,6 +35,7 @@ import (
 
 	"vitess.io/vitess/go/event"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sets"
@@ -93,13 +94,13 @@ type VtctldServer struct {
 }
 
 // NewVtctldServer returns a new VtctldServer for the given topo server.
-func NewVtctldServer(ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser) *VtctldServer {
+func NewVtctldServer(ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *VtctldServer {
 	tmc := tmclient.NewTabletManagerClient()
 
 	return &VtctldServer{
 		ts:  ts,
 		tmc: tmc,
-		ws:  workflow.NewServer(ts, tmc, collationEnv, parser),
+		ws:  workflow.NewServer(ts, tmc, collationEnv, parser, mysqlVersion),
 	}
 }
 
@@ -109,7 +110,7 @@ func NewTestVtctldServer(ts *topo.Server, tmc tmclient.TabletManagerClient) *Vtc
 	return &VtctldServer{
 		ts:  ts,
 		tmc: tmc,
-		ws:  workflow.NewServer(ts, tmc, collations.MySQL8(), sqlparser.NewTestParser()),
+		ws:  workflow.NewServer(ts, tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 }
 
@@ -4990,8 +4991,8 @@ func (s *VtctldServer) WorkflowUpdate(ctx context.Context, req *vtctldatapb.Work
 }
 
 // StartServer registers a VtctldServer for RPCs on the given gRPC server.
-func StartServer(s *grpc.Server, ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser) {
-	vtctlservicepb.RegisterVtctldServer(s, NewVtctldServer(ts, collationEnv, parser))
+func StartServer(s *grpc.Server, ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) {
+	vtctlservicepb.RegisterVtctldServer(s, NewVtctldServer(ts, collationEnv, parser, mysqlVersion))
 }
 
 // getTopologyCell is a helper method that returns a topology cell given its path.

--- a/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/replication"
 
 	"vitess.io/vitess/go/mysql"
@@ -313,7 +314,7 @@ func TestEmergencyReparentShardSlow(t *testing.T) {
 			}, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.EmergencyReparentShard(ctx, tt.req)
 
@@ -611,7 +612,7 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 			}, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.PlannedReparentShard(ctx, tt.req)
 
@@ -741,7 +742,7 @@ func TestSleepTablet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			start := time.Now()

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -35,6 +35,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
@@ -87,7 +88,7 @@ func TestPanicHandler(t *testing.T) {
 	}()
 
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, nil, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	_, err := vtctld.AddCellInfo(context.Background(), nil)
@@ -143,7 +144,7 @@ func TestAddCellInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.AddCellInfo(ctx, tt.req)
 			if tt.shouldErr {
@@ -216,7 +217,7 @@ func TestAddCellsAlias(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.AddCellsAlias(ctx, tt.req)
 			if tt.shouldErr {
@@ -328,7 +329,7 @@ func TestApplyRoutingRules(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.ApplyRoutingRules(ctx, tt.req)
 			if tt.shouldErr {
@@ -596,7 +597,7 @@ func TestApplyVSchema(t *testing.T) {
 			defer cancel()
 			ts := memorytopo.NewServer(ctx, "zone1")
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddKeyspace(ctx, t, ts, &vtctldatapb.Keyspace{
@@ -879,7 +880,7 @@ func TestBackup(t *testing.T) {
 				testutil.AddTablet(ctx, t, tt.ts, tt.tablet, nil)
 			}
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			client := localvtctldclient.New(vtctld)
 			stream, err := client.Backup(ctx, tt.req)
@@ -1219,7 +1220,7 @@ func TestBackupShard(t *testing.T) {
 				}, tt.tablets...,
 			)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			client := localvtctldclient.New(vtctld)
 			stream, err := client.BackupShard(ctx, tt.req)
@@ -1439,7 +1440,7 @@ func TestCancelSchemaMigration(t *testing.T) {
 			}, test.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, test.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			resp, err := vtctld.CancelSchemaMigration(ctx, test.req)
@@ -1672,7 +1673,7 @@ func TestChangeTabletType(t *testing.T) {
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &testutil.TabletManagerClient{
 				TopoServer: ts,
 			}, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{
@@ -1720,7 +1721,7 @@ func TestChangeTabletType(t *testing.T) {
 		vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &testutil.TabletManagerClient{
 			TopoServer: nil,
 		}, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		})
 
 		testutil.AddTablet(ctx, t, ts, &topodatapb.Tablet{
@@ -1942,7 +1943,7 @@ func TestCleanupSchemaMigration(t *testing.T) {
 			}, test.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, test.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			resp, err := vtctld.CleanupSchemaMigration(ctx, test.req)
@@ -2144,7 +2145,7 @@ func TestForceCutOverSchemaMigration(t *testing.T) {
 			}, test.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, test.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			resp, err := vtctld.ForceCutOverSchemaMigration(ctx, test.req)
@@ -2348,7 +2349,7 @@ func TestCompleteSchemaMigration(t *testing.T) {
 			}, test.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, test.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			resp, err := vtctld.CompleteSchemaMigration(ctx, test.req)
@@ -2604,7 +2605,7 @@ func TestCreateKeyspace(t *testing.T) {
 			defer cancel()
 			ts := memorytopo.NewServer(ctx, cells...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			for name, ks := range tt.topo {
@@ -2882,7 +2883,7 @@ func TestCreateShard(t *testing.T) {
 			defer cancel()
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, "zone1")
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			for _, ks := range tt.keyspaces {
@@ -2937,7 +2938,7 @@ func TestDeleteCellInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.DeleteCellInfo(ctx, tt.req)
 			if tt.shouldErr {
@@ -2998,7 +2999,7 @@ func TestDeleteCellsAlias(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.DeleteCellsAlias(ctx, tt.req)
 			if tt.shouldErr {
@@ -3230,7 +3231,7 @@ func TestDeleteKeyspace(t *testing.T) {
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, cells...)
 			defer ts.Close()
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddKeyspaces(ctx, t, ts, tt.keyspaces...)
@@ -3744,7 +3745,7 @@ func TestDeleteShards(t *testing.T) {
 
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, cells...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddShards(ctx, t, ts, tt.shards...)
@@ -3887,7 +3888,7 @@ func TestDeleteSrvKeyspace(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.DeleteSrvVSchema(ctx, tt.req)
 			if tt.shouldErr {
@@ -4348,7 +4349,7 @@ func TestDeleteTablets(t *testing.T) {
 			defer cancel()
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, "zone1")
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			// Setup tablets and shards
@@ -4577,7 +4578,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 			}, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.EmergencyReparentShard(ctx, tt.req)
 
@@ -4719,7 +4720,7 @@ func TestExecuteFetchAsApp(t *testing.T) {
 			testutil.AddTablet(ctx, t, ts, tt.tablet, nil)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.ExecuteFetchAsApp(ctx, tt.req)
 			if tt.shouldErr {
@@ -4846,7 +4847,7 @@ func TestExecuteFetchAsDBA(t *testing.T) {
 			testutil.AddTablet(ctx, t, ts, tt.tablet, nil)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.ExecuteFetchAsDBA(ctx, tt.req)
 			if tt.shouldErr {
@@ -5031,7 +5032,7 @@ func TestExecuteHook(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testutil.AddTablets(ctx, t, tt.ts, nil, tt.tablets...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			_, err := vtctld.ExecuteHook(ctx, tt.req)
@@ -5052,7 +5053,7 @@ func TestFindAllShardsInKeyspace(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	ks := &vtctldatapb.Keyspace{
@@ -5094,7 +5095,7 @@ func TestGetBackups(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx)
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	testutil.BackupStorage.Backups = map[string][]string{
@@ -5202,7 +5203,7 @@ func TestGetKeyspace(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	expected := &vtctldatapb.GetKeyspaceResponse{
@@ -5228,7 +5229,7 @@ func TestGetCellInfoNames(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2", "cell3")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	resp, err := vtctld.GetCellInfoNames(ctx, &vtctldatapb.GetCellInfoNamesRequest{})
@@ -5237,7 +5238,7 @@ func TestGetCellInfoNames(t *testing.T) {
 
 	ts = memorytopo.NewServer(ctx)
 	vtctld = testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	resp, err = vtctld.GetCellInfoNames(ctx, &vtctldatapb.GetCellInfoNamesRequest{})
@@ -5246,7 +5247,7 @@ func TestGetCellInfoNames(t *testing.T) {
 
 	ts, topofactory := memorytopo.NewServerAndFactory(ctx, "cell1")
 	vtctld = testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	topofactory.SetError(assert.AnError)
@@ -5261,7 +5262,7 @@ func TestGetCellInfo(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx)
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	expected := &topodatapb.CellInfo{
@@ -5289,7 +5290,7 @@ func TestGetCellsAliases(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "c11", "c12", "c13", "c21", "c22")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	alias1 := &topodatapb.CellsAlias{
@@ -5316,7 +5317,7 @@ func TestGetCellsAliases(t *testing.T) {
 
 	ts, topofactory := memorytopo.NewServerAndFactory(ctx)
 	vtctld = testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	topofactory.SetError(assert.AnError)
@@ -5397,7 +5398,7 @@ func TestGetFullStatus(t *testing.T) {
 					ServerUuid: tt.serverUUID,
 				},
 			}, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{
@@ -5423,7 +5424,7 @@ func TestGetKeyspaces(t *testing.T) {
 	defer cancel()
 	ts, topofactory := memorytopo.NewServerAndFactory(ctx, "cell1")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	resp, err := vtctld.GetKeyspaces(ctx, &vtctldatapb.GetKeyspacesRequest{})
@@ -5591,7 +5592,7 @@ func TestGetPermissions(t *testing.T) {
 			testutil.AddTablets(ctx, t, ts, nil, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.GetPermissions(ctx, tt.req)
 			if tt.shouldErr {
@@ -5667,7 +5668,7 @@ func TestGetRoutingRules(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.GetRoutingRules(ctx, &vtctldatapb.GetRoutingRulesRequest{})
 			if tt.shouldErr {
@@ -5692,7 +5693,7 @@ func TestGetSchema(t *testing.T) {
 		}{},
 	}
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	validAlias := &topodatapb.TabletAlias{
@@ -6057,7 +6058,7 @@ func TestGetSchemaMigrations(t *testing.T) {
 			ts, factory := memorytopo.NewServerAndFactory(ctx, cells...)
 			testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{AlsoSetShardPrimary: true}, test.tablets...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			if test.failTopo {
@@ -6148,7 +6149,7 @@ func TestGetShard(t *testing.T) {
 			defer cancel()
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, cells...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddShards(ctx, t, ts, tt.topo...)
@@ -6285,7 +6286,7 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.GetSrvKeyspaceNames(ctx, tt.req)
 			if tt.shouldErr {
@@ -6442,7 +6443,7 @@ func TestGetSrvKeyspaces(t *testing.T) {
 
 			testutil.AddSrvKeyspaces(t, ts, tt.srvKeyspaces...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			if tt.topoErr != nil {
@@ -6469,7 +6470,7 @@ func TestGetSrvVSchema(t *testing.T) {
 	defer cancel()
 	ts, topofactory := memorytopo.NewServerAndFactory(ctx, "zone1", "zone2")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	zone1SrvVSchema := &vschemapb.SrvVSchema{
@@ -6680,7 +6681,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 			defer cancel()
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, "zone1", "zone2", "zone3")
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			zone1SrvVSchema := &vschemapb.SrvVSchema{
@@ -6740,7 +6741,7 @@ func TestGetTablet(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	tablet := &topodatapb.Tablet{
@@ -7363,7 +7364,7 @@ func TestGetTablets(t *testing.T) {
 			defer cancel()
 			ts := memorytopo.NewServer(ctx, tt.cells...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddTablets(ctx, t, ts, nil, tt.tablets...)
@@ -7387,7 +7388,7 @@ func TestGetTopologyPath(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2", "cell3")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	err := ts.CreateKeyspace(ctx, "keyspace1", &topodatapb.Keyspace{})
@@ -7476,7 +7477,7 @@ func TestGetVSchema(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "zone1")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	t.Run("found", func(t *testing.T) {
@@ -7707,7 +7708,7 @@ func TestLaunchSchemaMigration(t *testing.T) {
 			}, test.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, test.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			resp, err := vtctld.LaunchSchemaMigration(ctx, test.req)
@@ -7794,7 +7795,7 @@ func TestPingTablet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			resp, err := vtctld.PingTablet(ctx, tt.req)
@@ -8042,7 +8043,7 @@ func TestPlannedReparentShard(t *testing.T) {
 			}, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.PlannedReparentShard(ctx, tt.req)
 
@@ -8085,7 +8086,7 @@ func TestRebuildKeyspaceGraph(t *testing.T) {
 			Name: "testkeyspace",
 		})
 		vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		})
 
 		_, err := vtctld.RebuildKeyspaceGraph(ctx, &vtctldatapb.RebuildKeyspaceGraphRequest{
@@ -8102,7 +8103,7 @@ func TestRebuildKeyspaceGraph(t *testing.T) {
 
 		ts := memorytopo.NewServer(ctx, "zone1")
 		vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		})
 
 		_, err := vtctld.RebuildKeyspaceGraph(context.Background(), &vtctldatapb.RebuildKeyspaceGraphRequest{
@@ -8122,7 +8123,7 @@ func TestRebuildKeyspaceGraph(t *testing.T) {
 			Name: "testkeyspace",
 		})
 		vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		})
 		factory.SetError(assert.AnError)
 
@@ -8143,7 +8144,7 @@ func TestRebuildKeyspaceGraph(t *testing.T) {
 			Name: "testkeyspace",
 		})
 		vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+			return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 		})
 
 		lctx, unlock, lerr := ts.LockKeyspace(context.Background(), "testkeyspace", "test lock")
@@ -8192,7 +8193,7 @@ func TestRebuildVSchemaGraph(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.RebuildVSchemaGraph(ctx, req)
 			if tt.shouldErr {
@@ -8291,7 +8292,7 @@ func TestRefreshState(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.RefreshState(ctx, tt.req)
 			if tt.shouldErr {
@@ -8476,7 +8477,7 @@ func TestRefreshStateByShard(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.RefreshStateByShard(ctx, tt.req)
 			if tt.shouldErr {
@@ -8580,7 +8581,7 @@ func TestReloadSchema(t *testing.T) {
 			testutil.AddTablets(ctx, t, ts, nil, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.ReloadSchema(ctx, tt.req)
 			if tt.shouldErr {
@@ -8678,7 +8679,7 @@ func TestReloadSchemaKeyspace(t *testing.T) {
 			}, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.ReloadSchemaKeyspace(ctx, tt.req)
 			if tt.shouldErr {
@@ -8836,7 +8837,7 @@ func TestReloadSchemaShard(t *testing.T) {
 			}, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.ReloadSchemaShard(ctx, tt.req)
 			if tt.shouldErr {
@@ -8855,7 +8856,7 @@ func TestRemoveBackup(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx)
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	setup := func() {
@@ -9046,7 +9047,7 @@ func TestRemoveKeyspaceCell(t *testing.T) {
 			defer cancel()
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, cells...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			// Setup topo
@@ -9335,7 +9336,7 @@ func TestRemoveShardCell(t *testing.T) {
 			defer cancel()
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, cells...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			// Setup shard topos and replication graphs.
@@ -9945,7 +9946,7 @@ func TestReparentTablet(t *testing.T) {
 			defer cancel()
 			ts, topofactory := memorytopo.NewServerAndFactory(ctx, cells...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{
@@ -10078,7 +10079,7 @@ func TestRestoreFromBackup(t *testing.T) {
 				}, tt.tablets...,
 			)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			client := localvtctldclient.New(vtctld)
 			stream, err := client.RestoreFromBackup(ctx, tt.req)
@@ -10296,7 +10297,7 @@ func TestRetrySchemaMigration(t *testing.T) {
 			}, test.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, test.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			resp, err := vtctld.RetrySchemaMigration(ctx, test.req)
@@ -10403,7 +10404,7 @@ func TestRunHealthCheck(t *testing.T) {
 			testutil.AddTablets(ctx, t, ts, nil, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			_, err := vtctld.RunHealthCheck(ctx, tt.req)
 			if tt.shouldErr {
@@ -10483,7 +10484,7 @@ func TestSetKeyspaceDurabilityPolicy(t *testing.T) {
 			testutil.AddKeyspaces(ctx, t, ts, tt.keyspaces...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.SetKeyspaceDurabilityPolicy(ctx, tt.req)
 			if tt.expectedErr != "" {
@@ -10580,7 +10581,7 @@ func TestSetShardIsPrimaryServing(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.SetShardIsPrimaryServing(tt.ctx, tt.req)
 			if tt.shouldErr {
@@ -10830,7 +10831,7 @@ func TestSetShardTabletControl(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.SetShardTabletControl(tt.ctx, tt.req)
 			if tt.shouldErr {
@@ -11034,7 +11035,7 @@ func TestSetWritable(t *testing.T) {
 
 			testutil.AddTablets(ctx, t, ts, nil, tt.tablets...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			_, err := vtctld.SetWritable(ctx, tt.req)
@@ -11055,7 +11056,7 @@ func TestShardReplicationAdd(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "zone1")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	tablets := []*topodatapb.Tablet{
@@ -11350,7 +11351,7 @@ func TestShardReplicationPositions(t *testing.T) {
 			}, tt.tablets...)
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			requestCtx := ctx
@@ -11381,7 +11382,7 @@ func TestShardReplicationRemove(t *testing.T) {
 
 	ts := memorytopo.NewServer(ctx, "zone1")
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	tablets := []*topodatapb.Tablet{
@@ -11541,7 +11542,7 @@ func TestSourceShardAdd(t *testing.T) {
 			defer cancel()
 			ts := memorytopo.NewServer(ctx, "zone1")
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddShards(ctx, t, ts, tt.shards...)
@@ -11676,7 +11677,7 @@ func TestSourceShardDelete(t *testing.T) {
 			defer cancel()
 			ts := memorytopo.NewServer(ctx, "zone1")
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			testutil.AddShards(ctx, t, ts, tt.shards...)
@@ -11868,7 +11869,7 @@ func TestStartReplication(t *testing.T) {
 				AlsoSetShardPrimary: true,
 			}, tt.tablets...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			_, err := vtctld.StartReplication(ctx, tt.req)
@@ -12005,7 +12006,7 @@ func TestStopReplication(t *testing.T) {
 
 			testutil.AddTablets(ctx, t, ts, nil, tt.tablets...)
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			_, err := vtctld.StopReplication(ctx, tt.req)
@@ -12392,7 +12393,7 @@ func TestTabletExternallyReparented(t *testing.T) {
 				TopoServer: ts,
 			}
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 
 			if tt.tmcHasNoTopo {
@@ -12577,7 +12578,7 @@ func TestUpdateCellInfo(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.UpdateCellInfo(ctx, tt.req)
 			if tt.shouldErr {
@@ -12727,7 +12728,7 @@ func TestUpdateCellsAlias(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.UpdateCellsAlias(ctx, tt.req)
 			if tt.shouldErr {
@@ -12835,7 +12836,7 @@ func TestValidate(t *testing.T) {
 		SkipShardCreation:    false,
 	}, tablets...)
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	resp, err := vtctld.Validate(ctx, &vtctldatapb.ValidateRequest{
@@ -12952,7 +12953,7 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 	}, tablets...)
 
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	schema1 := &tabletmanagerdatapb.SchemaDefinition{
@@ -13138,7 +13139,7 @@ func TestValidateVersionKeyspace(t *testing.T) {
 	}, tablets...)
 
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	tests := []*struct {
@@ -13253,7 +13254,7 @@ func TestValidateVersionShard(t *testing.T) {
 	}, tablets...)
 
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, &tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+		return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	})
 
 	tests := []*struct {
@@ -13845,7 +13846,7 @@ func TestValidateShard(t *testing.T) {
 			}
 
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser())
+				return NewVtctldServer(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			})
 			resp, err := vtctld.ValidateShard(ctx, tt.req)
 			if tt.shouldErr {

--- a/go/vt/vtctl/grpcvtctlserver/server.go
+++ b/go/vt/vtctl/grpcvtctlserver/server.go
@@ -47,11 +47,12 @@ type VtctlServer struct {
 	ts           *topo.Server
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	mysqlVersion string
 }
 
 // NewVtctlServer returns a new Vtctl Server for the topo server.
-func NewVtctlServer(ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser) *VtctlServer {
-	return &VtctlServer{ts: ts, collationEnv: collationEnv, parser: parser}
+func NewVtctlServer(ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *VtctlServer {
+	return &VtctlServer{ts: ts, collationEnv: collationEnv, parser: parser, mysqlVersion: mysqlVersion}
 }
 
 // ExecuteVtctlCommand is part of the vtctldatapb.VtctlServer interface
@@ -78,13 +79,13 @@ func (s *VtctlServer) ExecuteVtctlCommand(args *vtctldatapb.ExecuteVtctlCommandR
 	// create the wrangler
 	tmc := tmclient.NewTabletManagerClient()
 	defer tmc.Close()
-	wr := wrangler.New(logger, s.ts, tmc, s.collationEnv, s.parser)
+	wr := wrangler.New(logger, s.ts, tmc, s.collationEnv, s.parser, s.mysqlVersion)
 
 	// execute the command
 	return vtctl.RunCommand(stream.Context(), wr, args.Args)
 }
 
 // StartServer registers the VtctlServer for RPCs
-func StartServer(s *grpc.Server, ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser) {
-	vtctlservicepb.RegisterVtctlServer(s, NewVtctlServer(ts, collationEnv, parser))
+func StartServer(s *grpc.Server, ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) {
+	vtctlservicepb.RegisterVtctlServer(s, NewVtctlServer(ts, collationEnv, parser, mysqlVersion))
 }

--- a/go/vt/vtctl/workflow/materializer.go
+++ b/go/vt/vtctl/workflow/materializer.go
@@ -67,6 +67,7 @@ type materializer struct {
 
 	parser       *sqlparser.Parser
 	collationEnv *collations.Environment
+	mysqlVersion string
 }
 
 func (mz *materializer) getWorkflowSubType() (binlogdatapb.VReplicationWorkflowSubType, error) {
@@ -456,7 +457,7 @@ func (mz *materializer) deploySchema() error {
 				// We use schemadiff to normalize the schema.
 				// For now, and because this is could have wider implications, we ignore any errors in
 				// reading the source schema.
-				env := schemadiff.NewEnv(mz.collationEnv, mz.collationEnv.DefaultConnectionCharset(), mz.parser)
+				env := schemadiff.NewEnv(mz.collationEnv, mz.collationEnv.DefaultConnectionCharset(), mz.parser, mz.mysqlVersion)
 				schema, err := schemadiff.NewSchemaFromQueries(env, applyDDLs)
 				if err != nil {
 					log.Error(vterrors.Wrapf(err, "AtomicCopy: failed to normalize schema via schemadiff"))

--- a/go/vt/vtctl/workflow/materializer_env_test.go
+++ b/go/vt/vtctl/workflow/materializer_env_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -84,7 +85,7 @@ func newTestMaterializerEnv(t *testing.T, ctx context.Context, ms *vtctldatapb.M
 		tmc:      newTestMaterializerTMClient(),
 	}
 	parser := sqlparser.NewTestParser()
-	env.ws = NewServer(env.topoServ, env.tmc, collations.MySQL8(), parser)
+	env.ws = NewServer(env.topoServ, env.tmc, collations.MySQL8(), parser, config.DefaultMySQLVersion)
 	tabletID := 100
 	for _, shard := range sources {
 		_ = env.addTablet(tabletID, env.ms.SourceKeyspace, shard, topodatapb.TabletType_PRIMARY)

--- a/go/vt/vtctl/workflow/materializer_test.go
+++ b/go/vt/vtctl/workflow/materializer_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -3016,7 +3017,7 @@ func TestMaterializerNoSourcePrimary(t *testing.T) {
 		cell:     "cell",
 		tmc:      newTestMaterializerTMClient(),
 	}
-	env.ws = NewServer(env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	env.ws = NewServer(env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	defer env.close()
 
 	tabletID := 100

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -147,16 +147,18 @@ type Server struct {
 	sem          *semaphore.Weighted
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	mysqlVersion string
 }
 
 // NewServer returns a new server instance with the given topo.Server and
 // TabletManagerClient.
-func NewServer(ts *topo.Server, tmc tmclient.TabletManagerClient, collationEnv *collations.Environment, parser *sqlparser.Parser) *Server {
+func NewServer(ts *topo.Server, tmc tmclient.TabletManagerClient, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *Server {
 	return &Server{
 		ts:           ts,
 		tmc:          tmc,
 		collationEnv: collationEnv,
 		parser:       parser,
+		mysqlVersion: mysqlVersion,
 	}
 }
 
@@ -166,6 +168,10 @@ func (s *Server) SQLParser() *sqlparser.Parser {
 
 func (s *Server) CollationEnv() *collations.Environment {
 	return s.collationEnv
+}
+
+func (s *Server) MySQLVersion() string {
+	return s.mysqlVersion
 }
 
 // CheckReshardingJournalExistsOnTablet returns the journal (or an empty
@@ -1329,6 +1335,7 @@ func (s *Server) Materialize(ctx context.Context, ms *vtctldatapb.MaterializeSet
 		ms:           ms,
 		parser:       s.SQLParser(),
 		collationEnv: s.CollationEnv(),
+		mysqlVersion: s.MySQLVersion(),
 	}
 
 	err := mz.createMaterializerStreams()
@@ -1470,6 +1477,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 		workflowType: workflowType,
 		collationEnv: s.CollationEnv(),
 		parser:       s.SQLParser(),
+		mysqlVersion: s.MySQLVersion(),
 	}
 	err = mz.createMoveTablesStreams(req)
 	if err != nil {

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -145,7 +146,7 @@ func TestCheckReshardingJournalExistsOnTablet(t *testing.T) {
 				},
 			}
 
-			ws := NewServer(nil, tmc, collations.MySQL8(), sqlparser.NewTestParser())
+			ws := NewServer(nil, tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			journal, exists, err := ws.CheckReshardingJournalExistsOnTablet(ctx, tt.tablet, 1)
 			if tt.shouldErr {
 				assert.Error(t, err)

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -487,7 +487,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository) {
 
 		logstream := logutil.NewMemoryLogger()
 
-		wr := wrangler.New(logstream, ts, tmClient, actions.collationEnv, actions.parser)
+		wr := wrangler.New(logstream, ts, tmClient, actions.collationEnv, actions.parser, actions.mysqlVersion)
 		err := vtctl.RunCommand(r.Context(), wr, args)
 		if err != nil {
 			resp.Error = err.Error()
@@ -523,7 +523,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository) {
 		logger := logutil.NewCallbackLogger(func(ev *logutilpb.Event) {
 			w.Write([]byte(logutil.EventString(ev)))
 		})
-		wr := wrangler.New(logger, ts, tmClient, actions.collationEnv, actions.parser)
+		wr := wrangler.New(logger, ts, tmClient, actions.collationEnv, actions.parser, actions.mysqlVersion)
 
 		apiCallUUID, err := schema.CreateUUID()
 		if err != nil {

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	"vitess.io/vitess/go/vt/servenv/testutils"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -51,7 +52,7 @@ func TestAPI(t *testing.T) {
 	cells := []string{"cell1", "cell2"}
 	ts := memorytopo.NewServer(ctx, cells...)
 	defer ts.Close()
-	actionRepo := NewActionRepository(ts, collations.MySQL8(), sqlparser.NewTestParser())
+	actionRepo := NewActionRepository(ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	server := testutils.HTTPTestServer()
 	defer server.Close()
 

--- a/go/vt/vtctld/tablet_data_test.go
+++ b/go/vt/vtctld/tablet_data_test.go
@@ -28,6 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	"vitess.io/vitess/go/vt/logutil"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -116,7 +117,7 @@ func TestTabletData(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
 	defer ts.Close()
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	if err := ts.CreateKeyspace(context.Background(), "ks", &topodatapb.Keyspace{}); err != nil {
 		t.Fatalf("CreateKeyspace failed: %v", err)

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -52,8 +52,8 @@ func registerVtctldFlags(fs *pflag.FlagSet) {
 }
 
 // InitVtctld initializes all the vtctld functionality.
-func InitVtctld(ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser) error {
-	actionRepo := NewActionRepository(ts, collationEnv, parser)
+func InitVtctld(ts *topo.Server, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) error {
+	actionRepo := NewActionRepository(ts, collationEnv, parser, mysqlVersion)
 
 	// keyspace actions
 	actionRepo.RegisterKeyspaceAction("ValidateKeyspace",

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -149,6 +149,7 @@ type (
 
 		collationEnv *collations.Environment
 		parser       *sqlparser.Parser
+		mysqlVersion string
 	}
 )
 
@@ -184,7 +185,7 @@ type TabletActions struct {
 }
 
 // Init sets up the fake execution environment
-func Init(ctx context.Context, vSchemaStr, sqlSchema, ksShardMapStr string, opts *Options, collationEnv *collations.Environment, parser *sqlparser.Parser) (*VTExplain, error) {
+func Init(ctx context.Context, vSchemaStr, sqlSchema, ksShardMapStr string, opts *Options, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) (*VTExplain, error) {
 	// Verify options
 	if opts.ReplicationMode != "ROW" && opts.ReplicationMode != "STATEMENT" {
 		return nil, fmt.Errorf("invalid replication mode \"%s\"", opts.ReplicationMode)
@@ -206,6 +207,7 @@ func Init(ctx context.Context, vSchemaStr, sqlSchema, ksShardMapStr string, opts
 		},
 		collationEnv: collationEnv,
 		parser:       parser,
+		mysqlVersion: mysqlVersion,
 	}
 	vte.setGlobalTabletEnv(tabletEnv)
 	err = vte.initVtgateExecutor(ctx, vSchemaStr, ksShardMapStr, opts)

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	"vitess.io/vitess/go/test/utils"
 
@@ -69,7 +70,7 @@ func initTest(ctx context.Context, mode string, opts *Options, topts *testopts, 
 	}
 
 	opts.ExecutionMode = mode
-	vte, err := Init(ctx, string(vSchema), string(schema), shardmap, opts, collations.MySQL8(), sqlparser.NewTestParser())
+	vte, err := Init(ctx, string(vSchema), string(schema), shardmap, opts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	require.NoError(t, err, "vtexplain Init error\n%s", string(schema))
 	return vte
 }
@@ -348,7 +349,7 @@ func TestInit(t *testing.T) {
   }
 }`
 	schema := "create table table_missing_primary_vindex (id int primary key)"
-	_, err := Init(ctx, vschema, schema, "", defaultTestOpts(), collations.MySQL8(), sqlparser.NewTestParser())
+	_, err := Init(ctx, vschema, schema, "", defaultTestOpts(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing primary col vindex")
 }

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -75,7 +75,7 @@ func (vte *VTExplain) initVtgateExecutor(ctx context.Context, vSchemaStr, ksShar
 	var schemaTracker vtgate.SchemaInfo // no schema tracker for these tests
 	queryLogBufferSize := 10
 	plans := theine.NewStore[vtgate.PlanCacheKey, *engine.Plan](4*1024*1024, false)
-	vte.vtgateExecutor = vtgate.NewExecutor(ctx, vte.explainTopo, vtexplainCell, resolver, opts.Normalize, false, streamSize, plans, schemaTracker, false, opts.PlannerVersion, 0, vte.collationEnv, vte.parser)
+	vte.vtgateExecutor = vtgate.NewExecutor(ctx, vte.explainTopo, vtexplainCell, resolver, opts.Normalize, false, streamSize, plans, schemaTracker, false, opts.PlannerVersion, 0, vte.collationEnv, vte.parser, vte.mysqlVersion)
 	vte.vtgateExecutor.SetQueryLogger(streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize))
 
 	return nil
@@ -143,7 +143,7 @@ func (vte *VTExplain) buildTopology(ctx context.Context, opts *Options, vschemaS
 			log.Infof("registering test tablet %s for keyspace %s shard %s", hostname, ks, shard.Name)
 
 			tablet := vte.healthCheck.AddFakeTablet(vtexplainCell, hostname, 1, ks, shard.Name, topodatapb.TabletType_PRIMARY, true, 1, nil, func(t *topodatapb.Tablet) queryservice.QueryService {
-				return vte.newTablet(ctx, opts, t, vte.collationEnv, vte.parser)
+				return vte.newTablet(ctx, opts, t, vte.collationEnv, vte.parser, vte.mysqlVersion)
 			})
 			vte.explainTopo.TabletConns[hostname] = tablet.(*explainTablet)
 			vte.explainTopo.KeyspaceShards[ks][shard.Name] = shard

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -104,7 +104,7 @@ type explainTablet struct {
 
 var _ queryservice.QueryService = (*explainTablet)(nil)
 
-func (vte *VTExplain) newTablet(ctx context.Context, opts *Options, t *topodatapb.Tablet, collationEnv *collations.Environment, parser *sqlparser.Parser) *explainTablet {
+func (vte *VTExplain) newTablet(ctx context.Context, opts *Options, t *topodatapb.Tablet, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *explainTablet {
 	db := fakesqldb.New(nil)
 	sidecardb.AddSchemaInitQueries(db, true, vte.parser)
 
@@ -119,7 +119,7 @@ func (vte *VTExplain) newTablet(ctx context.Context, opts *Options, t *topodatap
 	config.EnableTableGC = false
 
 	// XXX much of this is cloned from the tabletserver tests
-	tsv := tabletserver.NewTabletServer(ctx, topoproto.TabletAliasString(t.Alias), config, memorytopo.NewServer(ctx, ""), t.Alias, collationEnv, parser)
+	tsv := tabletserver.NewTabletServer(ctx, topoproto.TabletAliasString(t.Alias), config, memorytopo.NewServer(ctx, ""), t.Alias, collationEnv, parser, mysqlVersion)
 
 	tablet := explainTablet{db: db, tsv: tsv, vte: vte, collationEnv: collationEnv}
 	db.Handler = &tablet

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 
@@ -76,7 +77,7 @@ create table t2 (
 	defer cancel()
 	collationEnv := collations.MySQL8()
 	parser := sqlparser.NewTestParser()
-	vte, err := Init(ctx, testVSchema, testSchema, "", opts, collationEnv, parser)
+	vte, err := Init(ctx, testVSchema, testSchema, "", opts, collationEnv, parser, config.DefaultMySQLVersion)
 	require.NoError(t, err)
 	defer vte.Stop()
 
@@ -142,7 +143,7 @@ create table test_partitioned (
 		Keyspace: "test_keyspace",
 		Shard:    "-80",
 		Alias:    &topodatapb.TabletAlias{},
-	}, collationEnv, parser)
+	}, collationEnv, parser, config.DefaultMySQLVersion)
 	se := tablet.tsv.SchemaEngine()
 	tables := se.GetSchema()
 

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -56,6 +56,7 @@ type noopVCursor struct {
 	inTx bool
 }
 
+// MySQLVersion implements VCursor.
 func (t *noopVCursor) Commit(ctx context.Context) error {
 	return nil
 }
@@ -140,6 +141,10 @@ func (t *noopVCursor) CollationEnv() *collations.Environment {
 // SQLParser implements VCursor
 func (t *noopVCursor) SQLParser() *sqlparser.Parser {
 	return sqlparser.NewTestParser()
+}
+
+func (*noopVCursor) MySQLVersion() string {
+	return config.DefaultMySQLVersion
 }
 
 func (t *noopVCursor) TimeZone() *time.Location {

--- a/go/vt/vtgate/engine/filter_test.go
+++ b/go/vt/vtgate/engine/filter_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 func TestFilterPass(t *testing.T) {
+	collationEnv := collations.MySQL8()
 	utf8mb4Bin := collationEnv.LookupByName("utf8mb4_bin")
 	predicate := &sqlparser.ComparisonExpr{
 		Operator: sqlparser.GreaterThanOp,
@@ -72,6 +74,7 @@ func TestFilterPass(t *testing.T) {
 				Collation:     utf8mb4Bin,
 				ResolveColumn: evalengine.FieldResolver(tc.res.Fields).Column,
 				CollationEnv:  collations.MySQL8(),
+				MySQLVersion:  config.DefaultMySQLVersion,
 			})
 			require.NoError(t, err)
 
@@ -87,6 +90,7 @@ func TestFilterPass(t *testing.T) {
 }
 
 func TestFilterStreaming(t *testing.T) {
+	collationEnv := collations.MySQL8()
 	utf8mb4Bin := collationEnv.LookupByName("utf8mb4_bin")
 	predicate := &sqlparser.ComparisonExpr{
 		Operator: sqlparser.GreaterThanOp,
@@ -129,6 +133,7 @@ func TestFilterStreaming(t *testing.T) {
 				Collation:     utf8mb4Bin,
 				ResolveColumn: evalengine.FieldResolver(tc.res[0].Fields).Column,
 				CollationEnv:  collations.MySQL8(),
+				MySQLVersion:  config.DefaultMySQLVersion,
 			})
 			require.NoError(t, err)
 

--- a/go/vt/vtgate/engine/memory_sort_test.go
+++ b/go/vt/vtgate/engine/memory_sort_test.go
@@ -26,16 +26,8 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
-
-func init() {
-	// We require MySQL 8.0 collations for the comparisons in the tests
-	mySQLVersion := "8.0.0"
-	servenv.SetMySQLServerVersionForTest(mySQLVersion)
-	collationEnv = collations.NewEnvironment(mySQLVersion)
-}
 
 func TestMemorySortExecute(t *testing.T) {
 	fields := sqltypes.MakeTestFields(

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -32,18 +32,8 @@ import (
 	"vitess.io/vitess/go/test/utils"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/servenv"
 	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
-
-var collationEnv *collations.Environment
-
-func init() {
-	// We require MySQL 8.0 collations for the comparisons in the tests
-	mySQLVersion := "8.0.0"
-	servenv.SetMySQLServerVersionForTest(mySQLVersion)
-	collationEnv = collations.NewEnvironment(mySQLVersion)
-}
 
 func TestOrderedAggregateExecute(t *testing.T) {
 	fields := sqltypes.MakeTestFields(
@@ -904,9 +894,10 @@ func TestOrderedAggregateCollate(t *testing.T) {
 		)},
 	}
 
+	collationEnv := collations.MySQL8()
 	collationID, _ := collationEnv.LookupID("utf8mb4_0900_ai_ci")
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collationEnv)},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, Type: evalengine.NewType(sqltypes.Unknown, collationID)}},
 		Input:       fp,
 	}
@@ -942,9 +933,10 @@ func TestOrderedAggregateCollateAS(t *testing.T) {
 		)},
 	}
 
+	collationEnv := collations.MySQL8()
 	collationID, _ := collationEnv.LookupID("utf8mb4_0900_as_ci")
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collationEnv)},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, Type: evalengine.NewType(sqltypes.Unknown, collationID)}},
 		Input:       fp,
 	}
@@ -982,9 +974,10 @@ func TestOrderedAggregateCollateKS(t *testing.T) {
 		)},
 	}
 
+	collationEnv := collations.MySQL8()
 	collationID, _ := collationEnv.LookupID("utf8mb4_ja_0900_as_cs_ks")
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collationEnv)},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, Type: evalengine.NewType(sqltypes.Unknown, collationID)}},
 		Input:       fp,
 	}

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -91,6 +91,7 @@ type (
 		SQLParser() *sqlparser.Parser
 		TimeZone() *time.Location
 		SQLMode() string
+		MySQLVersion() string
 
 		ExecuteLock(ctx context.Context, rs *srvtopo.ResolvedShard, query *querypb.BoundQuery, lockFuncType sqlparser.LockingFuncType) (*sqltypes.Result, error)
 

--- a/go/vt/vtgate/engine/projection_test.go
+++ b/go/vt/vtgate/engine/projection_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -41,6 +42,7 @@ func TestMultiply(t *testing.T) {
 	evalExpr, err := evalengine.Translate(expr, &evalengine.Config{
 		CollationEnv: collations.MySQL8(),
 		Collation:    collations.MySQL8().DefaultConnectionCharset(),
+		MySQLVersion: config.DefaultMySQLVersion,
 	})
 	require.NoError(t, err)
 	fp := &fakePrimitive{
@@ -84,6 +86,7 @@ func TestProjectionStreaming(t *testing.T) {
 	evalExpr, err := evalengine.Translate(expr, &evalengine.Config{
 		CollationEnv: collations.MySQL8(),
 		Collation:    collations.MySQL8().DefaultConnectionCharset(),
+		MySQLVersion: config.DefaultMySQLVersion,
 	})
 	require.NoError(t, err)
 	fp := &fakePrimitive{
@@ -130,6 +133,7 @@ func TestEmptyInput(t *testing.T) {
 	evalExpr, err := evalengine.Translate(expr, &evalengine.Config{
 		CollationEnv: collations.MySQL8(),
 		Collation:    collations.MySQL8().DefaultConnectionCharset(),
+		MySQLVersion: config.DefaultMySQLVersion,
 	})
 	require.NoError(t, err)
 	fp := &fakePrimitive{
@@ -163,6 +167,7 @@ func TestHexAndBinaryArgument(t *testing.T) {
 	hexExpr, err := evalengine.Translate(sqlparser.NewArgument("vtg1"), &evalengine.Config{
 		CollationEnv: collations.MySQL8(),
 		Collation:    collations.MySQL8().DefaultConnectionCharset(),
+		MySQLVersion: config.DefaultMySQLVersion,
 	})
 	require.NoError(t, err)
 	proj := &Projection{
@@ -210,6 +215,7 @@ func TestFields(t *testing.T) {
 			bindExpr, err := evalengine.Translate(sqlparser.NewArgument("vtg1"), &evalengine.Config{
 				CollationEnv: collations.MySQL8(),
 				Collation:    collations.MySQL8().DefaultConnectionCharset(),
+				MySQLVersion: config.DefaultMySQLVersion,
 			})
 			require.NoError(t, err)
 			proj := &Projection{

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -31,7 +31,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -45,13 +44,6 @@ var defaultSelectResult = sqltypes.MakeTestResult(
 	),
 	"1",
 )
-
-func init() {
-	// We require MySQL 8.0 collations for the comparisons in the tests
-	mySQLVersion := "8.0.0"
-	servenv.SetMySQLServerVersionForTest(mySQLVersion)
-	collationEnv = collations.NewEnvironment(mySQLVersion)
-}
 
 func TestSelectUnsharded(t *testing.T) {
 	sel := NewRoute(

--- a/go/vt/vtgate/evalengine/compiler.go
+++ b/go/vt/vtgate/evalengine/compiler.go
@@ -35,6 +35,7 @@ type compiler struct {
 	asm          assembler
 	sqlmode      SQLMode
 	collationEnv *collations.Environment
+	mysqlVersion string
 }
 
 type CompilerLog interface {

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -51,7 +51,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vthash"
 )
@@ -3369,7 +3368,7 @@ func (asm *assembler) Fn_Database() {
 func (asm *assembler) Fn_Version() {
 	asm.adjustStack(1)
 	asm.emit(func(env *ExpressionEnv) int {
-		env.vm.stack[env.vm.sp] = env.vm.arena.newEvalText([]byte(servenv.MySQLServerVersion()), collationUtf8mb3)
+		env.vm.stack[env.vm.sp] = env.vm.arena.newEvalText([]byte(env.currentVersion()), collationUtf8mb3)
 		env.vm.sp++
 		return 1
 	}, "FN VERSION")

--- a/go/vt/vtgate/evalengine/fn_info.go
+++ b/go/vt/vtgate/evalengine/fn_info.go
@@ -18,7 +18,6 @@ package evalengine
 
 import (
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/servenv"
 )
 
 type builtinUser struct {
@@ -47,7 +46,7 @@ type builtinVersion struct {
 var _ IR = (*builtinVersion)(nil)
 
 func (call *builtinVersion) eval(env *ExpressionEnv) (eval, error) {
-	return newEvalText([]byte(servenv.MySQLServerVersion()), collationUtf8mb3), nil
+	return newEvalText([]byte(env.currentVersion()), collationUtf8mb3), nil
 }
 
 func (*builtinVersion) compile(c *compiler) (ctype, error) {

--- a/go/vt/vtgate/evalengine/fn_regexp.go
+++ b/go/vt/vtgate/evalengine/fn_regexp.go
@@ -218,7 +218,7 @@ func compileConstantRegex(c *compiler, args TupleExpr, pat, mt int, cs collation
 		return nil, errNonConstantRegexp
 	}
 	var err error
-	staticEnv := EmptyExpressionEnv(c.collationEnv)
+	staticEnv := EmptyExpressionEnv(c.collationEnv, c.mysqlVersion)
 	pattern, err = simplifyExpr(staticEnv, pattern)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/evalengine/mysql_test.go
+++ b/go/vt/vtgate/evalengine/mysql_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -70,6 +71,7 @@ func convert(t *testing.T, query string, simplify bool) (Expr, error) {
 	cfg := &Config{
 		Collation:         collations.CollationUtf8mb4ID,
 		CollationEnv:      collations.MySQL8(),
+		MySQLVersion:      config.DefaultMySQLVersion,
 		NoConstantFolding: !simplify,
 	}
 
@@ -89,7 +91,7 @@ func testSingle(t *testing.T, query string) (EvalResult, error) {
 	if err != nil {
 		return EvalResult{}, err
 	}
-	return EmptyExpressionEnv(collations.MySQL8()).Evaluate(converted)
+	return EmptyExpressionEnv(collations.MySQL8(), config.DefaultMySQLVersion).Evaluate(converted)
 }
 
 func TestMySQLGolden(t *testing.T) {

--- a/go/vt/vtgate/evalengine/perf_test.go
+++ b/go/vt/vtgate/evalengine/perf_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -35,6 +36,7 @@ func BenchmarkCompilerExpressions(b *testing.B) {
 			ResolveType:   fields.Type,
 			Collation:     collations.CollationUtf8mb4ID,
 			CollationEnv:  collations.MySQL8(),
+			MySQLVersion:  config.DefaultMySQLVersion,
 		}
 
 		translated, err := evalengine.Translate(expr, cfg)

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -573,6 +573,7 @@ type Config struct {
 	NoCompilation     bool
 	SQLMode           SQLMode
 	CollationEnv      *collations.Environment
+	MySQLVersion      string
 }
 
 func Translate(e sqlparser.Expr, cfg *Config) (Expr, error) {
@@ -588,7 +589,7 @@ func Translate(e sqlparser.Expr, cfg *Config) (Expr, error) {
 	}
 
 	if !cfg.NoConstantFolding {
-		staticEnv := EmptyExpressionEnv(cfg.CollationEnv)
+		staticEnv := EmptyExpressionEnv(cfg.CollationEnv, cfg.MySQLVersion)
 		expr, err = simplifyExpr(staticEnv, expr)
 		if err != nil {
 			return nil, err
@@ -600,7 +601,7 @@ func Translate(e sqlparser.Expr, cfg *Config) (Expr, error) {
 	}
 
 	if len(ast.untyped) == 0 && !cfg.NoCompilation {
-		comp := compiler{collation: cfg.Collation, collationEnv: cfg.CollationEnv, sqlmode: cfg.SQLMode}
+		comp := compiler{collation: cfg.Collation, collationEnv: cfg.CollationEnv, sqlmode: cfg.SQLMode, mysqlVersion: cfg.MySQLVersion}
 		return comp.compile(expr)
 	}
 

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 
@@ -128,6 +129,7 @@ func TestTranslateSimplification(t *testing.T) {
 				ResolveColumn:     fields.Column,
 				Collation:         collations.MySQL8().DefaultConnectionCharset(),
 				CollationEnv:      collations.MySQL8(),
+				MySQLVersion:      config.DefaultMySQLVersion,
 				NoConstantFolding: true,
 				NoCompilation:     true,
 			}
@@ -306,6 +308,7 @@ func TestEvaluate(t *testing.T) {
 			sqltypesExpr, err := Translate(astExpr, &Config{
 				Collation:    collations.MySQL8().DefaultConnectionCharset(),
 				CollationEnv: collations.MySQL8(),
+				MySQLVersion: config.DefaultMySQLVersion,
 			})
 			require.Nil(t, err)
 			require.NotNil(t, sqltypesExpr)
@@ -316,7 +319,7 @@ func TestEvaluate(t *testing.T) {
 				"uint32_bind_variable": sqltypes.Uint32BindVariable(21),
 				"uint64_bind_variable": sqltypes.Uint64BindVariable(22),
 				"float_bind_variable":  sqltypes.Float64BindVariable(2.2),
-			}, NewEmptyVCursor(collations.MySQL8(), time.Local))
+			}, NewEmptyVCursor(collations.MySQL8(), time.Local, config.DefaultMySQLVersion))
 
 			// When
 			r, err := env.Evaluate(sqltypesExpr)
@@ -355,12 +358,13 @@ func TestEvaluateTuple(t *testing.T) {
 			sqltypesExpr, err := Translate(astExpr, &Config{
 				Collation:    collationEnv.DefaultConnectionCharset(),
 				CollationEnv: collationEnv,
+				MySQLVersion: config.DefaultMySQLVersion,
 			})
 			require.Nil(t, err)
 			require.NotNil(t, sqltypesExpr)
 
 			// When
-			r, err := EmptyExpressionEnv(collationEnv).Evaluate(sqltypesExpr)
+			r, err := EmptyExpressionEnv(collationEnv, config.DefaultMySQLVersion).Evaluate(sqltypesExpr)
 
 			// Then
 			require.NoError(t, err)
@@ -395,6 +399,7 @@ func TestTranslationFailures(t *testing.T) {
 			_, err = Translate(astExpr, &Config{
 				Collation:    collations.MySQL8().DefaultConnectionCharset(),
 				CollationEnv: collations.MySQL8(),
+				MySQLVersion: config.DefaultMySQLVersion,
 			})
 			require.EqualError(t, err, testcase.expectedErr)
 		})
@@ -434,6 +439,7 @@ func TestCardinalityWithBindVariables(t *testing.T) {
 				_, err = Translate(astExpr, &Config{
 					Collation:     collations.MySQL8().DefaultConnectionCharset(),
 					CollationEnv:  collations.MySQL8(),
+					MySQLVersion:  config.DefaultMySQLVersion,
 					NoCompilation: true,
 				})
 				return err

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -123,8 +123,9 @@ type Executor struct {
 	warmingReadsPercent int
 	warmingReadsChannel chan bool
 
-	collEnv *collations.Environment
-	parser  *sqlparser.Parser
+	collEnv      *collations.Environment
+	parser       *sqlparser.Parser
+	mysqlVersion string
 }
 
 var executorOnce sync.Once
@@ -157,6 +158,7 @@ func NewExecutor(
 	warmingReadsPercent int,
 	collationEnv *collations.Environment,
 	parser *sqlparser.Parser,
+	mysqlVersion string,
 ) *Executor {
 	e := &Executor{
 		serv:                serv,
@@ -175,6 +177,7 @@ func NewExecutor(
 		warmingReadsChannel: make(chan bool, warmingReadsConcurrency),
 		collEnv:             collationEnv,
 		parser:              parser,
+		mysqlVersion:        mysqlVersion,
 	}
 
 	vschemaacl.Init()
@@ -515,6 +518,7 @@ func (e *Executor) addNeededBindVars(vcursor *vcursorImpl, bindVarNeeds *sqlpars
 				evalExpr, err := evalengine.Translate(expr, &evalengine.Config{
 					Collation:    vcursor.collation,
 					CollationEnv: e.collEnv,
+					MySQLVersion: e.mysqlVersion,
 					SQLMode:      evalengine.ParseSQLMode(vcursor.SQLMode()),
 				})
 				if err != nil {
@@ -1560,4 +1564,8 @@ func (e *Executor) collationEnv() *collations.Environment {
 
 func (e *Executor) sqlparser() *sqlparser.Parser {
 	return e.parser
+}
+
+func (e *Executor) mysqlServerVersion() string {
+	return e.mysqlVersion
 }

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/cache/theine"
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/test/utils"
@@ -182,7 +183,7 @@ func createExecutorEnvCallback(t testing.TB, eachShard func(shard, ks string, ta
 	// one-off queries from thrashing the cache. Disable the doorkeeper in the tests to prevent flakiness.
 	plans := theine.NewStore[PlanCacheKey, *engine.Plan](queryPlanCacheMemory, false)
 
-	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser())
+	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	executor.SetQueryLogger(queryLogger)
 
 	key.AnyShardPicker = DestinationAnyShardPickerFirstShard{}
@@ -232,7 +233,7 @@ func createCustomExecutor(t testing.TB, vschema string, mysqlVersion string) (ex
 	parser, err := sqlparser.New(sqlparser.Options{MySQLServerVersion: mysqlVersion})
 	require.NoError(t, err)
 	collationEnv := collations.NewEnvironment(mysqlVersion)
-	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collationEnv, parser)
+	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collationEnv, parser, mysqlVersion)
 	executor.SetQueryLogger(queryLogger)
 
 	t.Cleanup(func() {
@@ -269,7 +270,7 @@ func createCustomExecutorSetValues(t testing.TB, vschema string, values []*sqlty
 	sbclookup = hc.AddTestTablet(cell, "0", 1, KsTestUnsharded, "0", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	queryLogger := streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize)
 	plans := DefaultPlanCache()
-	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser())
+	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	executor.SetQueryLogger(queryLogger)
 
 	t.Cleanup(func() {
@@ -294,7 +295,7 @@ func createExecutorEnvWithPrimaryReplicaConn(t testing.TB, ctx context.Context, 
 	replica = hc.AddTestTablet(cell, "0-replica", 1, KsTestUnsharded, "0", topodatapb.TabletType_REPLICA, true, 1, nil)
 
 	queryLogger := streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize)
-	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, DefaultPlanCache(), nil, false, querypb.ExecuteOptions_Gen4, warmingReadsPercent, collations.MySQL8(), sqlparser.NewTestParser())
+	executor = NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, DefaultPlanCache(), nil, false, querypb.ExecuteOptions_Gen4, warmingReadsPercent, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	executor.SetQueryLogger(queryLogger)
 
 	t.Cleanup(func() {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -28,6 +28,7 @@ import (
 
 	_flag "vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -1555,7 +1556,7 @@ func TestStreamSelectIN(t *testing.T) {
 func createExecutor(ctx context.Context, serv *sandboxTopo, cell string, resolver *Resolver) *Executor {
 	queryLogger := streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize)
 	plans := DefaultPlanCache()
-	ex := NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser())
+	ex := NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	ex.SetQueryLogger(queryLogger)
 	return ex
 }
@@ -3181,7 +3182,7 @@ func TestStreamOrderByLimitWithMultipleResults(t *testing.T) {
 	}
 	queryLogger := streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize)
 	plans := DefaultPlanCache()
-	executor := NewExecutor(ctx, serv, cell, resolver, true, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser())
+	executor := NewExecutor(ctx, serv, cell, resolver, true, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	executor.SetQueryLogger(queryLogger)
 	defer executor.Close()
 	// some sleep for all goroutines to start

--- a/go/vt/vtgate/executor_stream_test.go
+++ b/go/vt/vtgate/executor_stream_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/test/utils"
@@ -68,7 +69,7 @@ func TestStreamSQLSharded(t *testing.T) {
 	queryLogger := streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize)
 	plans := DefaultPlanCache()
 
-	executor := NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser())
+	executor := NewExecutor(ctx, serv, cell, resolver, false, false, testBufferSize, plans, nil, false, querypb.ExecuteOptions_Gen4, 0, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	executor.SetQueryLogger(queryLogger)
 
 	defer executor.Close()

--- a/go/vt/vtgate/planbuilder/expression_converter.go
+++ b/go/vt/vtgate/planbuilder/expression_converter.go
@@ -20,18 +20,18 @@ import (
 	"fmt"
 	"strings"
 
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 )
 
 type expressionConverter struct {
 	tabletExpressions []sqlparser.Expr
 	collationEnv      *collations.Environment
 	collation         collations.ID
+	mysqlVersion      string
 }
 
 func booleanValues(astExpr sqlparser.Expr) evalengine.Expr {
@@ -86,6 +86,7 @@ func (ec *expressionConverter) convert(astExpr sqlparser.Expr, boolean, identifi
 	evalExpr, err := evalengine.Translate(astExpr, &evalengine.Config{
 		Collation:    ec.collation,
 		CollationEnv: ec.collationEnv,
+		MySQLVersion: ec.mysqlVersion,
 	})
 	if err != nil {
 		if !strings.Contains(err.Error(), evalengine.ErrTranslateExprNotSupported) {

--- a/go/vt/vtgate/planbuilder/expression_converter_test.go
+++ b/go/vt/vtgate/planbuilder/expression_converter_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
@@ -53,6 +54,7 @@ func TestConversion(t *testing.T) {
 			ec := &expressionConverter{
 				collationEnv: collations.MySQL8(),
 				collation:    collations.MySQL8().DefaultConnectionCharset(),
+				mysqlVersion: config.DefaultMySQLVersion,
 			}
 			var result []evalengine.Expr
 			for _, expr := range exprs {

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -828,14 +828,15 @@ func transformLimit(ctx *plancontext.PlanningContext, op *operators.Limit) (logi
 		return nil, err
 	}
 
-	return createLimit(plan, op.AST, ctx.VSchema.CollationEnv())
+	return createLimit(plan, op.AST, ctx.VSchema.CollationEnv(), ctx.VSchema.MySQLVersion())
 }
 
-func createLimit(input logicalPlan, limit *sqlparser.Limit, collationEnv *collations.Environment) (logicalPlan, error) {
+func createLimit(input logicalPlan, limit *sqlparser.Limit, collationEnv *collations.Environment, mysqlVersion string) (logicalPlan, error) {
 	plan := newLimit(input)
 	cfg := &evalengine.Config{
 		Collation:    collationEnv.DefaultConnectionCharset(),
 		CollationEnv: collationEnv,
+		MySQLVersion: mysqlVersion,
 	}
 	pv, err := evalengine.Translate(limit.Rowcount, cfg)
 	if err != nil {

--- a/go/vt/vtgate/planbuilder/operators/dml_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/dml_planning.go
@@ -83,6 +83,7 @@ func buildChangedVindexesValues(
 					ResolveType:  ctx.SemTable.TypeForExpr,
 					Collation:    ctx.SemTable.Collation,
 					CollationEnv: ctx.VSchema.CollationEnv(),
+					MySQLVersion: ctx.VSchema.MySQLVersion(),
 				})
 				if err != nil {
 					panic(invalidUpdateExpr(assignment.Name.Name.String(), assignment.Expr.EvalExpr))

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -122,6 +122,7 @@ func (f *Filter) planOffsets(ctx *plancontext.PlanningContext) Operator {
 		ResolveType:  ctx.SemTable.TypeForExpr,
 		Collation:    ctx.SemTable.Collation,
 		CollationEnv: ctx.VSchema.CollationEnv(),
+		MySQLVersion: ctx.VSchema.MySQLVersion(),
 	}
 
 	predicate := sqlparser.AndExpressions(f.Predicates...)

--- a/go/vt/vtgate/planbuilder/operators/hash_join.go
+++ b/go/vt/vtgate/planbuilder/operators/hash_join.go
@@ -335,6 +335,7 @@ func (hj *HashJoin) addColumn(ctx *plancontext.PlanningContext, in sqlparser.Exp
 		ResolveType:  ctx.SemTable.TypeForExpr,
 		Collation:    ctx.SemTable.Collation,
 		CollationEnv: ctx.VSchema.CollationEnv(),
+		MySQLVersion: ctx.VSchema.MySQLVersion(),
 	}
 	eexpr, err := evalengine.Translate(rewrittenExpr, cfg)
 	if err != nil {

--- a/go/vt/vtgate/planbuilder/operators/insert.go
+++ b/go/vt/vtgate/planbuilder/operators/insert.go
@@ -509,6 +509,7 @@ func insertRowsPlan(ctx *plancontext.PlanningContext, insOp *Insert, ins *sqlpar
 					ResolveType:  ctx.SemTable.TypeForExpr,
 					Collation:    ctx.SemTable.Collation,
 					CollationEnv: ctx.VSchema.CollationEnv(),
+					MySQLVersion: ctx.VSchema.MySQLVersion(),
 				})
 				if err != nil {
 					panic(err)
@@ -640,6 +641,7 @@ func modifyForAutoinc(ctx *plancontext.PlanningContext, ins *sqlparser.Insert, v
 			ResolveType:  ctx.SemTable.TypeForExpr,
 			Collation:    ctx.SemTable.Collation,
 			CollationEnv: ctx.VSchema.CollationEnv(),
+			MySQLVersion: ctx.VSchema.MySQLVersion(),
 		})
 		if err != nil {
 			panic(err)

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -557,6 +557,7 @@ func (p *Projection) planOffsets(ctx *plancontext.PlanningContext) Operator {
 			ResolveType:  ctx.SemTable.TypeForExpr,
 			Collation:    ctx.SemTable.Collation,
 			CollationEnv: ctx.VSchema.CollationEnv(),
+			MySQLVersion: ctx.VSchema.MySQLVersion(),
 		})
 		if err != nil {
 			panic(err)

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -121,7 +121,7 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, expr sqlparser.Expr, r
 	}
 	nr := &NoneRouting{keyspace: ks}
 
-	if isConstantFalse(expr, ctx.VSchema.ConnCollation(), ctx.VSchema.CollationEnv()) {
+	if isConstantFalse(expr, ctx.VSchema.ConnCollation(), ctx.VSchema.CollationEnv(), ctx.VSchema.MySQLVersion()) {
 		return nr
 	}
 
@@ -165,11 +165,12 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, expr sqlparser.Expr, r
 
 // isConstantFalse checks whether this predicate can be evaluated at plan-time. If it returns `false` or `null`,
 // we know that the query will not return anything, and this can be used to produce better plans
-func isConstantFalse(expr sqlparser.Expr, collation collations.ID, collationEnv *collations.Environment) bool {
-	eenv := evalengine.EmptyExpressionEnv(collationEnv)
+func isConstantFalse(expr sqlparser.Expr, collation collations.ID, collationEnv *collations.Environment, mysqlVersion string) bool {
+	eenv := evalengine.EmptyExpressionEnv(collationEnv, mysqlVersion)
 	eexpr, err := evalengine.Translate(expr, &evalengine.Config{
 		Collation:    collation,
 		CollationEnv: collationEnv,
+		MySQLVersion: mysqlVersion,
 	})
 	if err != nil {
 		return false

--- a/go/vt/vtgate/planbuilder/operators/sharded_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/sharded_routing.go
@@ -611,6 +611,7 @@ func makeEvalEngineExpr(ctx *plancontext.PlanningContext, n sqlparser.Expr) eval
 			Collation:    ctx.SemTable.Collation,
 			ResolveType:  ctx.SemTable.TypeForExpr,
 			CollationEnv: ctx.VSchema.CollationEnv(),
+			MySQLVersion: ctx.VSchema.MySQLVersion(),
 		})
 		if ee != nil {
 			return ee

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -36,7 +36,6 @@ import (
 	"vitess.io/vitess/go/test/vschemawrapper"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sidecardb"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -233,12 +232,7 @@ func addPKs(t *testing.T, vschema *vindexes.VSchema, ks string, tbls []string) {
 
 func TestSystemTables57(t *testing.T) {
 	// first we move everything to use 5.7 logic
-	oldVer := servenv.MySQLServerVersion()
-	servenv.SetMySQLServerVersionForTest("5.7")
-	defer func() {
-		servenv.SetMySQLServerVersionForTest(oldVer)
-	}()
-	vschemaWrapper := &vschemawrapper.VSchemaWrapper{V: loadSchema(t, "vschemas/schema.json", true)}
+	vschemaWrapper := &vschemawrapper.VSchemaWrapper{V: loadSchema(t, "vschemas/schema.json", true), MySQLServerVersion: "5.7.9"}
 	testOutputTempDir := makeTestOutput(t)
 	testFile(t, "info_schema57_cases.json", testOutputTempDir, vschemaWrapper, false)
 }
@@ -333,12 +327,7 @@ func TestOneWithTPCHVSchema(t *testing.T) {
 
 func TestOneWith57Version(t *testing.T) {
 	// first we move everything to use 5.7 logic
-	oldVer := servenv.MySQLServerVersion()
-	servenv.SetMySQLServerVersionForTest("5.7")
-	defer func() {
-		servenv.SetMySQLServerVersionForTest(oldVer)
-	}()
-	vschema := &vschemawrapper.VSchemaWrapper{V: loadSchema(t, "vschemas/schema.json", true)}
+	vschema := &vschemawrapper.VSchemaWrapper{V: loadSchema(t, "vschemas/schema.json", true), MySQLServerVersion: "5.7.9"}
 
 	testFile(t, "onecase.json", "", vschema, false)
 }

--- a/go/vt/vtgate/planbuilder/plancontext/vschema.go
+++ b/go/vt/vtgate/planbuilder/plancontext/vschema.go
@@ -42,6 +42,7 @@ type VSchema interface {
 	SetPlannerVersion(pv PlannerVersion)
 	ConnCollation() collations.ID
 	CollationEnv() *collations.Environment
+	MySQLVersion() string
 
 	// ErrorIfShardedF will return an error if the keyspace is sharded,
 	// and produce a warning if the vtgate if configured to do so

--- a/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -105,17 +106,19 @@ func TestFuzzRewriting(t *testing.T) {
 			original, err := evalengine.Translate(predicate, &evalengine.Config{
 				Collation:     collations.MySQL8().DefaultConnectionCharset(),
 				CollationEnv:  collations.MySQL8(),
+				MySQLVersion:  config.DefaultMySQLVersion,
 				ResolveColumn: resolveForFuzz,
 			})
 			require.NoError(t, err)
 			simpler, err := evalengine.Translate(simplified.(sqlparser.Expr), &evalengine.Config{
 				Collation:     collations.MySQL8().DefaultConnectionCharset(),
 				CollationEnv:  collations.MySQL8(),
+				MySQLVersion:  config.DefaultMySQLVersion,
 				ResolveColumn: resolveForFuzz,
 			})
 			require.NoError(t, err)
 
-			env := evalengine.EmptyExpressionEnv(collations.MySQL8())
+			env := evalengine.EmptyExpressionEnv(collations.MySQL8(), config.DefaultMySQLVersion)
 			env.Row = make([]sqltypes.Value, tc.nodes)
 			for i := range env.Row {
 				env.Row[i] = sqltypes.NewInt32(1)

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -292,6 +292,7 @@ func handleDualSelects(sel *sqlparser.Select, vschema plancontext.VSchema) (engi
 				n, err := evalengine.Translate(lFunc.Name, &evalengine.Config{
 					Collation:    vschema.ConnCollation(),
 					CollationEnv: vschema.CollationEnv(),
+					MySQLVersion: vschema.MySQLVersion(),
 				})
 				if err != nil {
 					return nil, err
@@ -307,6 +308,7 @@ func handleDualSelects(sel *sqlparser.Select, vschema plancontext.VSchema) (engi
 		exprs[i], err = evalengine.Translate(expr.Expr, &evalengine.Config{
 			Collation:    vschema.ConnCollation(),
 			CollationEnv: vschema.CollationEnv(),
+			MySQLVersion: vschema.MySQLVersion(),
 		})
 		if err != nil {
 			return nil, nil

--- a/go/vt/vtgate/planbuilder/set.go
+++ b/go/vt/vtgate/planbuilder/set.go
@@ -58,6 +58,7 @@ func buildSetPlan(stmt *sqlparser.Set, vschema plancontext.VSchema) (*planResult
 	ec := &expressionConverter{
 		collationEnv: vschema.CollationEnv(),
 		collation:    vschema.ConnCollation(),
+		mysqlVersion: vschema.MySQLVersion(),
 	}
 
 	for _, expr := range stmt.Exprs {
@@ -83,7 +84,7 @@ func buildSetPlan(stmt *sqlparser.Set, vschema plancontext.VSchema) (*planResult
 			}
 			setOps = append(setOps, setOp)
 		case sqlparser.NextTxScope, sqlparser.SessionScope:
-			planFunc, err := sysvarPlanningFuncs.Get(expr, vschema.CollationEnv(), vschema.SQLParser())
+			planFunc, err := sysvarPlanningFuncs.Get(expr, vschema.CollationEnv(), vschema.SQLParser(), vschema.MySQLVersion())
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vtgate/planbuilder/vindex_op.go
+++ b/go/vt/vtgate/planbuilder/vindex_op.go
@@ -36,6 +36,7 @@ func transformVindexPlan(ctx *plancontext.PlanningContext, op *operators.Vindex)
 		Collation:    ctx.SemTable.Collation,
 		ResolveType:  ctx.SemTable.TypeForExpr,
 		CollationEnv: ctx.VSchema.CollationEnv(),
+		MySQLVersion: ctx.VSchema.MySQLVersion(),
 	})
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/semantics/FakeSI.go
+++ b/go/vt/vtgate/semantics/FakeSI.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -52,6 +53,10 @@ func (*FakeSI) ConnCollation() collations.ID {
 
 func (*FakeSI) CollationEnv() *collations.Environment {
 	return collations.MySQL8()
+}
+
+func (*FakeSI) MySQLVersion() string {
+	return config.DefaultMySQLVersion
 }
 
 func (s *FakeSI) ForeignKeyMode(keyspace string) (vschemapb.Keyspace_ForeignKeyMode, error) {

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -62,6 +62,7 @@ func newAnalyzer(dbName string, si SchemaInformation) *analyzer {
 		binder:          b,
 		expandedColumns: map[sqlparser.TableName][]*sqlparser.ColName{},
 		collationEnv:    si.CollationEnv(),
+		mysqlVersion:    si.MySQLVersion(),
 	}
 	s.binder = b
 	return a

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -153,6 +153,7 @@ type (
 		FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, string, topodatapb.TabletType, key.Destination, error)
 		ConnCollation() collations.ID
 		CollationEnv() *collations.Environment
+		MySQLVersion() string
 		// ForeignKeyMode returns the foreign_key flag value
 		ForeignKeyMode(keyspace string) (vschemapb.Keyspace_ForeignKeyMode, error)
 		GetForeignKeyChecksState() *bool

--- a/go/vt/vtgate/simplifier/simplifier_test.go
+++ b/go/vt/vtgate/simplifier/simplifier_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -124,11 +125,12 @@ func TestSimplifyEvalEngineExpr(t *testing.T) {
 		local, err := evalengine.Translate(expr, &evalengine.Config{
 			CollationEnv: collationEnv,
 			Collation:    collationEnv.DefaultConnectionCharset(),
+			MySQLVersion: config.DefaultMySQLVersion,
 		})
 		if err != nil {
 			return false
 		}
-		res, err := evalengine.EmptyExpressionEnv(collationEnv).Evaluate(local)
+		res, err := evalengine.EmptyExpressionEnv(collationEnv, config.DefaultMySQLVersion).Evaluate(local)
 		if err != nil {
 			return false
 		}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -86,6 +86,7 @@ type iExecute interface {
 
 	collationEnv() *collations.Environment
 	sqlparser() *sqlparser.Parser
+	mysqlServerVersion() string
 }
 
 // VSchemaOperator is an interface to Vschema Operations
@@ -212,6 +213,11 @@ func (vc *vcursorImpl) ConnCollation() collations.ID {
 // ConnCollation returns the collation of this session
 func (vc *vcursorImpl) CollationEnv() *collations.Environment {
 	return vc.executor.collationEnv()
+}
+
+// ConnCollation returns the collation of this session
+func (vc *vcursorImpl) MySQLVersion() string {
+	return vc.executor.mysqlServerVersion()
 }
 
 func (vc *vcursorImpl) SQLParser() *sqlparser.Parser {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -249,6 +249,7 @@ func Init(
 	tabletTypesToWait []topodatapb.TabletType,
 	pv plancontext.PlannerVersion,
 	collationEnv *collations.Environment,
+	mysqlServerVersion string,
 ) *VTGate {
 	// Build objects from low to high level.
 	// Start with the gateway. If we can't reach the topology service,
@@ -300,7 +301,7 @@ func Init(
 	}
 
 	parser, err := sqlparser.New(sqlparser.Options{
-		MySQLServerVersion: servenv.MySQLServerVersion(),
+		MySQLServerVersion: mysqlServerVersion,
 		TruncateUILen:      servenv.TruncateUILen,
 		TruncateErrLen:     servenv.TruncateErrLen,
 	})
@@ -333,6 +334,7 @@ func Init(
 		warmingReadsPercent,
 		collationEnv,
 		parser,
+		mysqlServerVersion,
 	)
 
 	if err := executor.defaultQueryLogger(); err != nil {

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -60,7 +61,7 @@ var (
 // StartCustomServer starts the server and initializes
 // all the global variables. This function should only be called
 // once at the beginning of the test.
-func StartCustomServer(ctx context.Context, connParams, connAppDebugParams mysql.ConnParams, dbName string, config *tabletenv.TabletConfig) error {
+func StartCustomServer(ctx context.Context, connParams, connAppDebugParams mysql.ConnParams, dbName string, cfg *tabletenv.TabletConfig) error {
 	// Setup a fake vtgate server.
 	protocol := "resolveTest"
 	vtgateconn.SetVTGateProtocol(protocol)
@@ -79,7 +80,7 @@ func StartCustomServer(ctx context.Context, connParams, connAppDebugParams mysql
 	}
 	TopoServer = memorytopo.NewServer(ctx, "")
 
-	Server = tabletserver.NewTabletServer(ctx, "", config, TopoServer, &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	Server = tabletserver.NewTabletServer(ctx, "", cfg, TopoServer, &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	Server.Register()
 	err := Server.StartService(Target, dbcfgs, nil /* mysqld */)
 	if err != nil {

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1474,7 +1474,7 @@ func (e *Executor) initVreplicationOriginalMigration(ctx context.Context, online
 		return v, err
 	}
 
-	v = NewVRepl(onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, originalShowCreateTable, vreplShowCreateTable, onlineDDL.SQL, onlineDDL.StrategySetting().IsAnalyzeTableFlag(), e.env.CollationEnv(), e.env.SQLParser())
+	v = NewVRepl(onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, originalShowCreateTable, vreplShowCreateTable, onlineDDL.SQL, onlineDDL.StrategySetting().IsAnalyzeTableFlag(), e.env.CollationEnv(), e.env.SQLParser(), e.env.MySQLVersion())
 	return v, nil
 }
 
@@ -1528,7 +1528,7 @@ func (e *Executor) initVreplicationRevertMigration(ctx context.Context, onlineDD
 	if err := e.updateArtifacts(ctx, onlineDDL.UUID, vreplTableName); err != nil {
 		return v, err
 	}
-	v = NewVRepl(onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, "", "", "", false, e.env.CollationEnv(), e.env.SQLParser())
+	v = NewVRepl(onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, "", "", "", false, e.env.CollationEnv(), e.env.SQLParser(), e.env.MySQLVersion())
 	v.pos = revertStream.pos
 	return v, nil
 }
@@ -2795,7 +2795,7 @@ func (e *Executor) evaluateDeclarativeDiff(ctx context.Context, onlineDDL *schem
 	if newShowCreateTable == "" {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unexpected: cannot find table or view even as it was just created: %v", onlineDDL.Table)
 	}
-	senv := schemadiff.NewEnv(e.env.CollationEnv(), e.env.CollationEnv().DefaultConnectionCharset(), e.env.SQLParser())
+	senv := schemadiff.NewEnv(e.env.CollationEnv(), e.env.CollationEnv().DefaultConnectionCharset(), e.env.SQLParser(), e.env.MySQLVersion())
 	hints := &schemadiff.DiffHints{AutoIncrementStrategy: schemadiff.AutoIncrementApplyHigher}
 	switch ddlStmt.(type) {
 	case *sqlparser.CreateTable:

--- a/go/vt/vttablet/onlineddl/executor_test.go
+++ b/go/vt/vttablet/onlineddl/executor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	"vitess.io/vitess/go/vt/schema"
@@ -48,7 +49,7 @@ func TestGetConstraintType(t *testing.T) {
 
 func TestValidateAndEditCreateTableStatement(t *testing.T) {
 	e := Executor{
-		env: tabletenv.NewEnv(nil, "ValidateAndEditCreateTableStatementTest", collations.MySQL8(), sqlparser.NewTestParser()),
+		env: tabletenv.NewEnv(nil, "ValidateAndEditCreateTableStatementTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 	tt := []struct {
 		name                string
@@ -192,7 +193,7 @@ func TestValidateAndEditCreateTableStatement(t *testing.T) {
 
 func TestValidateAndEditAlterTableStatement(t *testing.T) {
 	e := Executor{
-		env: tabletenv.NewEnv(nil, "TestValidateAndEditAlterTableStatementTest", collations.MySQL8(), sqlparser.NewTestParser()),
+		env: tabletenv.NewEnv(nil, "TestValidateAndEditAlterTableStatementTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 	tt := []struct {
 		alter  string
@@ -286,7 +287,7 @@ func TestValidateAndEditAlterTableStatement(t *testing.T) {
 
 func TestAddInstantAlgorithm(t *testing.T) {
 	e := Executor{
-		env: tabletenv.NewEnv(nil, "AddInstantAlgorithmTest", collations.MySQL8(), sqlparser.NewTestParser()),
+		env: tabletenv.NewEnv(nil, "AddInstantAlgorithmTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 	tt := []struct {
 		alter  string
@@ -331,7 +332,7 @@ func TestAddInstantAlgorithm(t *testing.T) {
 
 func TestDuplicateCreateTable(t *testing.T) {
 	e := Executor{
-		env: tabletenv.NewEnv(nil, "DuplicateCreateTableTest", collations.MySQL8(), sqlparser.NewTestParser()),
+		env: tabletenv.NewEnv(nil, "DuplicateCreateTableTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 	ctx := context.Background()
 	onlineDDL := &schema.OnlineDDL{UUID: "a5a563da_dc1a_11ec_a416_0a43f95f28a3", Table: "something", Strategy: "vitess", Options: "--unsafe-allow-foreign-keys"}

--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -139,6 +139,7 @@ type VRepl struct {
 
 	collationEnv *collations.Environment
 	sqlparser    *sqlparser.Parser
+	mysqlVersion string
 }
 
 // NewVRepl creates a VReplication handler for Online DDL
@@ -154,6 +155,7 @@ func NewVRepl(workflow string,
 	analyzeTable bool,
 	collationEnv *collations.Environment,
 	parser *sqlparser.Parser,
+	mysqlVersion string,
 ) *VRepl {
 	return &VRepl{
 		workflow:                workflow,
@@ -172,6 +174,7 @@ func NewVRepl(workflow string,
 		convertCharset:          map[string](*binlogdatapb.CharsetConversion){},
 		collationEnv:            collationEnv,
 		sqlparser:               parser,
+		mysqlVersion:            mysqlVersion,
 	}
 }
 
@@ -462,7 +465,7 @@ func (v *VRepl) analyzeTables(ctx context.Context, conn *dbconnpool.DBConnection
 	}
 	v.addedUniqueKeys = vrepl.AddedUniqueKeys(sourceUniqueKeys, targetUniqueKeys, v.parser.ColumnRenameMap())
 	v.removedUniqueKeys = vrepl.RemovedUniqueKeys(sourceUniqueKeys, targetUniqueKeys, v.parser.ColumnRenameMap())
-	v.removedForeignKeyNames, err = vrepl.RemovedForeignKeyNames(v.sqlparser, v.collationEnv, v.originalShowCreateTable, v.vreplShowCreateTable)
+	v.removedForeignKeyNames, err = vrepl.RemovedForeignKeyNames(v.sqlparser, v.collationEnv, v.mysqlVersion, v.originalShowCreateTable, v.vreplShowCreateTable)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/onlineddl/vrepl/foreign_key.go
+++ b/go/vt/vttablet/onlineddl/vrepl/foreign_key.go
@@ -30,13 +30,14 @@ import (
 func RemovedForeignKeyNames(
 	parser *sqlparser.Parser,
 	collEnv *collations.Environment,
+	mysqlVersion string,
 	originalCreateTable string,
 	vreplCreateTable string,
 ) (names []string, err error) {
 	if originalCreateTable == "" || vreplCreateTable == "" {
 		return nil, nil
 	}
-	env := schemadiff.NewEnv(collEnv, collEnv.DefaultConnectionCharset(), parser)
+	env := schemadiff.NewEnv(collEnv, collEnv.DefaultConnectionCharset(), parser, mysqlVersion)
 	diffHints := schemadiff.DiffHints{ConstraintNamesStrategy: schemadiff.ConstraintNamesIgnoreAll}
 	diff, err := schemadiff.DiffCreateTablesQueries(env, originalCreateTable, vreplCreateTable, &diffHints)
 	if err != nil {

--- a/go/vt/vttablet/onlineddl/vrepl/foreign_key_test.go
+++ b/go/vt/vttablet/onlineddl/vrepl/foreign_key_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -69,7 +70,7 @@ func TestRemovedForeignKeyNames(t *testing.T) {
 	}
 	for _, tcase := range tcases {
 		t.Run(tcase.before, func(t *testing.T) {
-			names, err := RemovedForeignKeyNames(sqlparser.NewTestParser(), collations.MySQL8(), tcase.before, tcase.after)
+			names, err := RemovedForeignKeyNames(sqlparser.NewTestParser(), collations.MySQL8(), config.DefaultMySQLVersion, tcase.before, tcase.after)
 			assert.NoError(t, err)
 			assert.Equal(t, tcase.names, names)
 		})

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -426,7 +426,7 @@ func (tm *TabletManager) getGTIDFromTimestamp(ctx context.Context, pos replicati
 		Port: connParams.Port,
 	}
 	dbCfgs.SetDbParams(*connParams, *connParams, *connParams)
-	vsClient := vreplication.NewReplicaConnector(connParams, tm.CollationEnv, tm.SQLParser)
+	vsClient := vreplication.NewReplicaConnector(connParams, tm.CollationEnv, tm.SQLParser, tm.MySQLVersion)
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/vttablet"
 
 	"github.com/stretchr/testify/require"
@@ -112,7 +113,7 @@ func TestCreateVReplicationWorkflow(t *testing.T) {
 	targetTablet := tenv.addTablet(t, targetTabletUID, targetKs, shard)
 	defer tenv.deleteTablet(targetTablet.tablet)
 
-	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tests := []struct {
 		name   string
@@ -269,7 +270,7 @@ func TestMoveTables(t *testing.T) {
 		},
 	})
 
-	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tenv.mysqld.Schema = defaultSchema
 	tenv.mysqld.Schema.DatabaseSchema = tenv.dbName
@@ -657,7 +658,7 @@ func TestSourceShardSelection(t *testing.T) {
 		defer tenv.deleteTablet(tt.tablet)
 	}
 
-	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tenv.ts.SaveVSchema(ctx, sourceKs, &vschemapb.Keyspace{
 		Sharded: true,
@@ -856,7 +857,7 @@ func TestFailedMoveTablesCreateCleanup(t *testing.T) {
 		sourceKs, shard, table, table)
 	tenv := newTestEnv(t, ctx, sourceKs, []string{shard})
 	defer tenv.close()
-	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	ws := workflow.NewServer(tenv.ts, tenv.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	sourceTablet := tenv.addTablet(t, sourceTabletUID, sourceKs, shard)
 	defer tenv.deleteTablet(sourceTablet.tablet)

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -158,6 +158,7 @@ type TabletManager struct {
 	VDiffEngine         *vdiff.Engine
 	CollationEnv        *collations.Environment
 	SQLParser           *sqlparser.Parser
+	MySQLVersion        string
 
 	// tmState manages the TabletManager state.
 	tmState *tmState

--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
@@ -64,14 +64,16 @@ type externalConnector struct {
 	connectors   map[string]*mysqlConnector
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	mysqlVersion string
 }
 
-func newExternalConnector(dbcfgs map[string]*dbconfigs.DBConfigs, collationEnv *collations.Environment, parser *sqlparser.Parser) *externalConnector {
+func newExternalConnector(dbcfgs map[string]*dbconfigs.DBConfigs, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *externalConnector {
 	return &externalConnector{
 		dbconfigs:    dbcfgs,
 		connectors:   make(map[string]*mysqlConnector),
 		collationEnv: collationEnv,
 		parser:       parser,
+		mysqlVersion: mysqlVersion,
 	}
 }
 
@@ -96,7 +98,7 @@ func (ec *externalConnector) Get(name string) (*mysqlConnector, error) {
 		return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "external mysqlConnector %v not found", name)
 	}
 	c := &mysqlConnector{}
-	c.env = tabletenv.NewEnv(config, name, ec.collationEnv, ec.parser)
+	c.env = tabletenv.NewEnv(config, name, ec.collationEnv, ec.parser, ec.mysqlVersion)
 	c.se = schema.NewEngine(c.env)
 	c.vstreamer = vstreamer.NewEngine(c.env, nil, c.se, nil, "")
 	c.vstreamer.InitDBConfig("", "")

--- a/go/vt/vttablet/tabletmanager/vreplication/replica_connector.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replica_connector.go
@@ -36,7 +36,7 @@ import (
 // This is used by binlog server to make vstream connection
 // using the vstream connection, it will parse the events from binglog
 // to fetch the corresponding GTID for required recovery time
-func NewReplicaConnector(connParams *mysql.ConnParams, collationEnv *collations.Environment, parser *sqlparser.Parser) *ReplicaConnector {
+func NewReplicaConnector(connParams *mysql.ConnParams, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *ReplicaConnector {
 
 	// Construct
 	config := tabletenv.NewDefaultConfig()
@@ -47,7 +47,7 @@ func NewReplicaConnector(connParams *mysql.ConnParams, collationEnv *collations.
 	dbCfg.SetDbParams(*connParams, *connParams, *connParams)
 	config.DB = dbCfg
 	c := &ReplicaConnector{conn: connParams}
-	env := tabletenv.NewEnv(config, "source", collationEnv, parser)
+	env := tabletenv.NewEnv(config, "source", collationEnv, parser, mysqlVersion)
 	c.se = schema.NewEngine(env)
 	c.se.SkipMetaCheck = true
 	c.vstreamer = vstreamer.NewEngine(env, nil, c.se, nil, "")

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/pools/smartconnpool"
@@ -333,7 +334,7 @@ func TestDBNoPoolConnKill(t *testing.T) {
 	params := dbconfigs.New(db.ConnParams())
 	connPool.Open(params, params, params)
 	defer connPool.Close()
-	dbConn, err := NewConn(context.Background(), params, connPool.dbaPool, nil, tabletenv.NewEnv(nil, "TestDBNoPoolConnKill", collations.MySQL8(), sqlparser.NewTestParser()))
+	dbConn, err := NewConn(context.Background(), params, connPool.dbaPool, nil, tabletenv.NewEnv(nil, "TestDBNoPoolConnKill", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	if dbConn != nil {
 		defer dbConn.Close()
 	}

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/pools/smartconnpool"
 	"vitess.io/vitess/go/sqltypes"
@@ -60,7 +61,7 @@ func TestConnPoolTimeout(t *testing.T) {
 	}
 	cfg.Timeout = time.Second
 	cfg.IdleTimeout = 10 * time.Second
-	connPool := NewPool(tabletenv.NewEnv(nil, "PoolTest", collations.MySQL8(), sqlparser.NewTestParser()), "TestPool", cfg)
+	connPool := NewPool(tabletenv.NewEnv(nil, "PoolTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), "TestPool", cfg)
 	params := dbconfigs.New(db.ConnParams())
 	connPool.Open(params, params, params)
 	defer connPool.Close()
@@ -337,7 +338,7 @@ func newPool() *Pool {
 }
 
 func newPoolWithCapacity(capacity int) *Pool {
-	return NewPool(tabletenv.NewEnv(nil, "PoolTest", collations.MySQL8(), sqlparser.NewTestParser()), "TestPool", tabletenv.ConnPoolConfig{
+	return NewPool(tabletenv.NewEnv(nil, "PoolTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), "TestPool", tabletenv.ConnPoolConfig{
 		Size:        capacity,
 		IdleTimeout: 10 * time.Second,
 	})

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -152,9 +153,9 @@ func TestEngineGenerate(t *testing.T) {
 }
 
 func newTestEngine() *Engine {
-	config := tabletenv.NewDefaultConfig()
+	cfg := tabletenv.NewDefaultConfig()
 	tsv := &fakeTabletServer{
-		Env: tabletenv.NewEnv(config, "MessagerTest", collations.MySQL8(), sqlparser.NewTestParser()),
+		Env: tabletenv.NewEnv(cfg, "MessagerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 	se := schema.NewEngine(tsv)
 	te := NewEngine(tsv, se, newFakeVStreamer())

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -832,9 +833,9 @@ type fakeTabletServer struct {
 }
 
 func newFakeTabletServer() *fakeTabletServer {
-	config := tabletenv.NewDefaultConfig()
+	cfg := tabletenv.NewDefaultConfig()
 	return &fakeTabletServer{
-		Env: tabletenv.NewEnv(config, "MessagerTest", collations.MySQL8(), sqlparser.NewTestParser()),
+		Env: tabletenv.NewEnv(cfg, "MessagerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -28,7 +28,7 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
-func analyzeSelect(sel *sqlparser.Select, tables map[string]*schema.Table, collationEnv *collations.Environment) (plan *Plan, err error) {
+func analyzeSelect(sel *sqlparser.Select, tables map[string]*schema.Table, collationEnv *collations.Environment, mysqlVersion string) (plan *Plan, err error) {
 	plan = &Plan{
 		PlanID:    PlanSelect,
 		FullQuery: GenerateLimitQuery(sel),
@@ -52,6 +52,7 @@ func analyzeSelect(sel *sqlparser.Select, tables map[string]*schema.Table, colla
 		v, err := evalengine.Translate(nextVal.Expr, &evalengine.Config{
 			CollationEnv: collationEnv,
 			Collation:    collationEnv.DefaultConnectionCharset(),
+			MySQLVersion: mysqlVersion,
 		})
 		if err != nil {
 			return nil, err

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -202,7 +202,7 @@ func (plan *Plan) TableNames() (names []string) {
 }
 
 // Build builds a plan based on the schema.
-func Build(statement sqlparser.Statement, tables map[string]*schema.Table, dbName string, viewsEnabled bool, collationEnv *collations.Environment) (plan *Plan, err error) {
+func Build(statement sqlparser.Statement, tables map[string]*schema.Table, dbName string, viewsEnabled bool, collationEnv *collations.Environment, mysqlVersion string) (plan *Plan, err error) {
 	switch stmt := statement.(type) {
 	case *sqlparser.Union:
 		plan, err = &Plan{
@@ -210,7 +210,7 @@ func Build(statement sqlparser.Statement, tables map[string]*schema.Table, dbNam
 			FullQuery: GenerateLimitQuery(stmt),
 		}, nil
 	case *sqlparser.Select:
-		plan, err = analyzeSelect(stmt, tables, collationEnv)
+		plan, err = analyzeSelect(stmt, tables, collationEnv, mysqlVersion)
 	case *sqlparser.Insert:
 		plan, err = analyzeInsert(stmt, tables)
 	case *sqlparser.Update:

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/tableacl"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
@@ -85,7 +86,7 @@ func testPlan(t *testing.T, fileName string) {
 			var err error
 			statement, err := parser.Parse(tcase.input)
 			if err == nil {
-				plan, err = Build(statement, testSchema, "dbName", false, collations.MySQL8())
+				plan, err = Build(statement, testSchema, "dbName", false, collations.MySQL8(), config.DefaultMySQLVersion)
 			}
 			PassthroughDMLs = false
 
@@ -123,7 +124,7 @@ func TestPlanInReservedConn(t *testing.T) {
 			var err error
 			statement, err := parser.Parse(tcase.input)
 			if err == nil {
-				plan, err = Build(statement, testSchema, "dbName", false, collations.MySQL8())
+				plan, err = Build(statement, testSchema, "dbName", false, collations.MySQL8(), config.DefaultMySQLVersion)
 			}
 			PassthroughDMLs = false
 
@@ -175,7 +176,7 @@ func TestCustom(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Got error: %v, parsing sql: %v", err.Error(), tcase.input)
 				}
-				plan, err := Build(statement, schem, "dbName", false, collations.MySQL8())
+				plan, err := Build(statement, schem, "dbName", false, collations.MySQL8(), config.DefaultMySQLVersion)
 				var out string
 				if err != nil {
 					out = err.Error()
@@ -264,7 +265,7 @@ func TestLockPlan(t *testing.T) {
 			var err error
 			statement, err := parser.Parse(tcase.input)
 			if err == nil {
-				plan, err = Build(statement, testSchema, "dbName", false, collations.MySQL8())
+				plan, err = Build(statement, testSchema, "dbName", false, collations.MySQL8(), config.DefaultMySQLVersion)
 			}
 
 			var out string

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -363,7 +363,7 @@ func (qe *QueryEngine) getPlan(curSchema *currentSchema, sql string) (*TabletPla
 	if err != nil {
 		return nil, err
 	}
-	splan, err := planbuilder.Build(statement, curSchema.tables, qe.env.Config().DB.DBName, qe.env.Config().EnableViews, qe.env.CollationEnv())
+	splan, err := planbuilder.Build(statement, curSchema.tables, qe.env.Config().DB.DBName, qe.env.Config().EnableViews, qe.env.CollationEnv(), qe.env.MySQLVersion())
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -33,6 +33,7 @@ import (
 
 	"vitess.io/vitess/go/cache/theine"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/proto/topodata"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -61,9 +62,9 @@ func TestStrictMode(t *testing.T) {
 	schematest.AddDefaultQueries(db)
 
 	// Test default behavior.
-	config := tabletenv.NewDefaultConfig()
-	config.DB = newDBConfigs(db)
-	env := tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	env := tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	se := schema.NewEngine(env)
 	qe := NewQueryEngine(env, se)
 	qe.se.InitDBConfig(newDBConfigs(db).DbaWithDB())
@@ -90,7 +91,7 @@ func TestStrictMode(t *testing.T) {
 	qe.Close()
 
 	// Test that we succeed if the enforcement flag is off.
-	config.EnforceStrictTransTables = false
+	cfg.EnforceStrictTransTables = false
 	qe = NewQueryEngine(env, se)
 	if err := qe.Open(); err != nil {
 		t.Fatal(err)
@@ -351,12 +352,12 @@ func TestStatsURL(t *testing.T) {
 }
 
 func newTestQueryEngine(idleTimeout time.Duration, strict bool, dbcfgs *dbconfigs.DBConfigs) *QueryEngine {
-	config := tabletenv.NewDefaultConfig()
-	config.DB = dbcfgs
-	config.OltpReadPool.IdleTimeout = idleTimeout
-	config.OlapReadPool.IdleTimeout = idleTimeout
-	config.TxPool.IdleTimeout = idleTimeout
-	env := tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = dbcfgs
+	cfg.OltpReadPool.IdleTimeout = idleTimeout
+	cfg.OlapReadPool.IdleTimeout = idleTimeout
+	cfg.TxPool.IdleTimeout = idleTimeout
+	env := tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	se := schema.NewEngine(env)
 	qe := NewQueryEngine(env, se)
 	// the integration tests that check cache behavior do not expect a doorkeeper; disable it
@@ -453,10 +454,10 @@ func benchmarkPlanCache(b *testing.B, db *fakesqldb.DB, par int) {
 	b.Helper()
 
 	dbcfgs := newDBConfigs(db)
-	config := tabletenv.NewDefaultConfig()
-	config.DB = dbcfgs
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = dbcfgs
 
-	env := tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	se := schema.NewEngine(env)
 	qe := NewQueryEngine(env, se)
 
@@ -510,11 +511,11 @@ func TestPlanCachePollution(t *testing.T) {
 	db.AddQueryPattern(".*", &sqltypes.Result{})
 
 	dbcfgs := newDBConfigs(db)
-	config := tabletenv.NewDefaultConfig()
-	config.DB = dbcfgs
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = dbcfgs
 	// config.LFUQueryCacheSizeBytes = 3 * 1024 * 1024
 
-	env := tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	se := schema.NewEngine(env)
 	qe := NewQueryEngine(env, se)
 
@@ -536,7 +537,7 @@ func TestPlanCachePollution(t *testing.T) {
 	go func() {
 		cacheMode := "lfu"
 
-		out, err := os.Create(path.Join(plotPath, fmt.Sprintf("cache_plot_%d_%s.dat", config.QueryCacheMemory, cacheMode)))
+		out, err := os.Create(path.Join(plotPath, fmt.Sprintf("cache_plot_%d_%s.dat", cfg.QueryCacheMemory, cacheMode)))
 		require.NoError(t, err)
 		defer out.Close()
 
@@ -827,10 +828,10 @@ func TestAddQueryStats(t *testing.T) {
 	t.Parallel()
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			config := tabletenv.NewDefaultConfig()
-			config.DB = newDBConfigs(fakesqldb.New(t))
-			config.EnablePerWorkloadTableMetrics = testcase.enablePerWorkloadTableMetrics
-			env := tabletenv.NewEnv(config, "TestAddQueryStats_"+testcase.name, collations.MySQL8(), sqlparser.NewTestParser())
+			cfg := tabletenv.NewDefaultConfig()
+			cfg.DB = newDBConfigs(fakesqldb.New(t))
+			cfg.EnablePerWorkloadTableMetrics = testcase.enablePerWorkloadTableMetrics
+			env := tabletenv.NewEnv(cfg, "TestAddQueryStats_"+testcase.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			se := schema.NewEngine(env)
 			qe := NewQueryEngine(env, se)
 			qe.AddStats(testcase.planType, testcase.tableName, testcase.workload, testcase.tabletType, testcase.queryCount, testcase.duration, testcase.mysqlTime, testcase.rowsAffected, testcase.rowsReturned, testcase.errorCount, testcase.errorCode)
@@ -871,7 +872,7 @@ func TestPlanPoolUnsafe(t *testing.T) {
 		t.Run(tcase.name, func(t *testing.T) {
 			statement, err := sqlparser.NewTestParser().Parse(tcase.query)
 			require.NoError(t, err)
-			plan, err := planbuilder.Build(statement, map[string]*schema.Table{}, "dbName", false, collations.MySQL8())
+			plan, err := planbuilder.Build(statement, map[string]*schema.Table{}, "dbName", false, collations.MySQL8(), config.DefaultMySQLVersion)
 			// Plan building will not fail, but it will mark that reserved connection is needed.
 			// checking plan is valid will fail.
 			require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -614,7 +614,7 @@ func (*QueryExecutor) BeginAgain(ctx context.Context, dc *StatefulConnection) er
 }
 
 func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
-	env := evalengine.NewExpressionEnv(qre.ctx, qre.bindVars, evalengine.NewEmptyVCursor(qre.tsv.collationEnv, time.Local))
+	env := evalengine.NewExpressionEnv(qre.ctx, qre.bindVars, evalengine.NewEmptyVCursor(qre.tsv.collationEnv, time.Local, qre.tsv.mysqlVersion))
 	result, err := env.Evaluate(qre.plan.NextCount)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -32,6 +32,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
@@ -1452,48 +1453,48 @@ const (
 
 // newTestQueryExecutor uses a package level variable testTabletServer defined in tabletserver_test.go
 func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb.DB) *TabletServer {
-	config := tabletenv.NewDefaultConfig()
-	config.OltpReadPool.Size = 100
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.OltpReadPool.Size = 100
 	if flags&smallTxPool > 0 {
-		config.TxPool.Size = 3
+		cfg.TxPool.Size = 3
 	} else {
-		config.TxPool.Size = 100
+		cfg.TxPool.Size = 100
 	}
 	if flags&enableStrictTableACL > 0 {
-		config.StrictTableACL = true
+		cfg.StrictTableACL = true
 	} else {
-		config.StrictTableACL = false
+		cfg.StrictTableACL = false
 	}
 	if flags&noTwopc > 0 {
-		config.TwoPCEnable = false
+		cfg.TwoPCEnable = false
 	} else {
-		config.TwoPCEnable = true
+		cfg.TwoPCEnable = true
 	}
 	if flags&disableOnlineDDL > 0 {
-		config.EnableOnlineDDL = false
+		cfg.EnableOnlineDDL = false
 	} else {
-		config.EnableOnlineDDL = true
+		cfg.EnableOnlineDDL = true
 	}
-	config.TwoPCCoordinatorAddress = "fake"
+	cfg.TwoPCCoordinatorAddress = "fake"
 	if flags&shortTwopcAge > 0 {
-		config.TwoPCAbandonAge = 0.5
+		cfg.TwoPCAbandonAge = 0.5
 	} else {
-		config.TwoPCAbandonAge = 10
+		cfg.TwoPCAbandonAge = 10
 	}
 	if flags&smallResultSize > 0 {
-		config.Oltp.MaxRows = 2
+		cfg.Oltp.MaxRows = 2
 	}
 	if flags&enableConsolidator > 0 {
-		config.Consolidator = tabletenv.Enable
+		cfg.Consolidator = tabletenv.Enable
 	} else {
-		config.Consolidator = tabletenv.Disable
+		cfg.Consolidator = tabletenv.Disable
 	}
 	dbconfigs := newDBConfigs(db)
-	config.DB = dbconfigs
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg.DB = dbconfigs
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 	err := tsv.StartService(target, dbconfigs, nil /* mysqld */)
-	if config.TwoPCEnable {
+	if cfg.TwoPCEnable {
 		tsv.TwoPCEngineWait()
 	}
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/repltracker/reader_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/reader_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
@@ -138,15 +139,15 @@ func TestReaderReadHeartbeatError(t *testing.T) {
 }
 
 func newReader(db *fakesqldb.DB, frozenTime *time.Time) *heartbeatReader {
-	config := tabletenv.NewDefaultConfig()
-	config.ReplicationTracker.Mode = tabletenv.Heartbeat
-	config.ReplicationTracker.HeartbeatInterval = time.Second
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.ReplicationTracker.Mode = tabletenv.Heartbeat
+	cfg.ReplicationTracker.HeartbeatInterval = time.Second
 	params := db.ConnParams()
 	cp := *params
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "")
-	config.DB = dbc
+	cfg.DB = dbc
 
-	tr := newHeartbeatReader(tabletenv.NewEnv(config, "ReaderTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	tr := newHeartbeatReader(tabletenv.NewEnv(cfg, "ReaderTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	tr.keyspaceShard = "test:0"
 
 	if frozenTime != nil {

--- a/go/vt/vttablet/tabletserver/repltracker/repltracker_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/repltracker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"
@@ -37,13 +38,13 @@ func TestReplTracker(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 
-	config := tabletenv.NewDefaultConfig()
-	config.ReplicationTracker.Mode = tabletenv.Heartbeat
-	config.ReplicationTracker.HeartbeatInterval = time.Second
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.ReplicationTracker.Mode = tabletenv.Heartbeat
+	cfg.ReplicationTracker.HeartbeatInterval = time.Second
 	params := db.ConnParams()
 	cp := *params
-	config.DB = dbconfigs.NewTestDBConfigs(cp, cp, "")
-	env := tabletenv.NewEnv(config, "ReplTrackerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	cfg.DB = dbconfigs.NewTestDBConfigs(cp, cp, "")
+	env := tabletenv.NewEnv(cfg, "ReplTrackerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	alias := &topodatapb.TabletAlias{
 		Cell: "cell",
 		Uid:  1,
@@ -80,7 +81,7 @@ func TestReplTracker(t *testing.T) {
 	assert.False(t, rt.hw.isOpen)
 	assert.False(t, rt.hr.isOpen)
 
-	config.ReplicationTracker.Mode = tabletenv.Polling
+	cfg.ReplicationTracker.Mode = tabletenv.Polling
 	rt = NewReplTracker(env, alias)
 	rt.InitDBConfig(target, mysqld)
 	assert.Equal(t, tabletenv.Polling, rt.mode)

--- a/go/vt/vttablet/tabletserver/repltracker/writer_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -110,15 +111,15 @@ func TestCloseWhileStuckWriting(t *testing.T) {
 }
 
 func newTestWriter(db *fakesqldb.DB, frozenTime *time.Time) *heartbeatWriter {
-	config := tabletenv.NewDefaultConfig()
-	config.ReplicationTracker.Mode = tabletenv.Heartbeat
-	config.ReplicationTracker.HeartbeatInterval = time.Second
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.ReplicationTracker.Mode = tabletenv.Heartbeat
+	cfg.ReplicationTracker.HeartbeatInterval = time.Second
 
 	params := db.ConnParams()
 	cp := *params
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "")
 
-	tw := newHeartbeatWriter(tabletenv.NewEnv(config, "WriterTest", collations.MySQL8(), sqlparser.NewTestParser()), &topodatapb.TabletAlias{Cell: "test", Uid: 1111})
+	tw := newHeartbeatWriter(tabletenv.NewEnv(cfg, "WriterTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), &topodatapb.TabletAlias{Cell: "test", Uid: 1111})
 	tw.keyspaceShard = "test:0"
 
 	if frozenTime != nil {

--- a/go/vt/vttablet/tabletserver/schema/db_test.go
+++ b/go/vt/vttablet/tabletserver/schema/db_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/maps2"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -98,7 +99,7 @@ func TestGenerateFullQuery(t *testing.T) {
 
 func TestGetCreateStatement(t *testing.T) {
 	db := fakesqldb.New(t)
-	env := tabletenv.NewEnv(nil, "TestGetCreateStatement", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(nil, "TestGetCreateStatement", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 	require.NoError(t, err)
 
@@ -134,7 +135,7 @@ func TestGetCreateStatement(t *testing.T) {
 
 func TestGetChangedViewNames(t *testing.T) {
 	db := fakesqldb.New(t)
-	env := tabletenv.NewEnv(nil, "TestGetChangedViewNames", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(nil, "TestGetChangedViewNames", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 	require.NoError(t, err)
 
@@ -168,7 +169,7 @@ func TestGetChangedViewNames(t *testing.T) {
 
 func TestGetViewDefinition(t *testing.T) {
 	db := fakesqldb.New(t)
-	env := tabletenv.NewEnv(nil, "TestGetViewDefinition", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(nil, "TestGetViewDefinition", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 	require.NoError(t, err)
 
@@ -341,7 +342,7 @@ func TestGetMismatchedTableNames(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			db := fakesqldb.New(t)
-			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser())
+			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 			require.NoError(t, err)
 
@@ -462,7 +463,7 @@ func TestReloadTablesInDB(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			db := fakesqldb.New(t)
-			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser())
+			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 			require.NoError(t, err)
 
@@ -595,7 +596,7 @@ func TestReloadViewsInDB(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			db := fakesqldb.New(t)
-			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser())
+			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 			require.NoError(t, err)
 
@@ -886,7 +887,7 @@ func TestReloadDataInDB(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			db := fakesqldb.New(t)
-			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser())
+			env := tabletenv.NewEnv(nil, tc.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 			require.NoError(t, err)
 

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/maps2"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/mysql/sqlerror"
 
@@ -162,7 +163,7 @@ func (se *Engine) syncSidecarDB(ctx context.Context, conn *dbconnpool.DBConnecti
 		}
 		return conn.ExecuteFetch(query, maxRows, true)
 	}
-	if err := sidecardb.Init(ctx, exec, se.env.CollationEnv(), se.env.SQLParser()); err != nil {
+	if err := sidecardb.Init(ctx, exec, se.env.CollationEnv(), se.env.SQLParser(), se.env.MySQLVersion()); err != nil {
 		log.Errorf("Error in sidecardb.Init: %+v", err)
 		if se.env.Config().DB.HasGlobalSettings() {
 			log.Warning("Ignoring sidecardb.Init error for unmanaged tablets")
@@ -828,7 +829,7 @@ func NewEngineForTests() *Engine {
 		isOpen:    true,
 		tables:    make(map[string]*Table),
 		historian: newHistorian(false, 0, nil),
-		env:       tabletenv.NewEnv(tabletenv.NewDefaultConfig(), "SchemaEngineForTests", collations.MySQL8(), sqlparser.NewTestParser()),
+		env:       tabletenv.NewEnv(tabletenv.NewDefaultConfig(), "SchemaEngineForTests", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion),
 	}
 	return se
 }
@@ -850,6 +851,10 @@ func (se *Engine) CollationEnv() *collations.Environment {
 
 func (se *Engine) SQLParser() *sqlparser.Parser {
 	return se.env.SQLParser()
+}
+
+func (se *Engine) MySQLVersion() string {
+	return se.env.MySQLVersion()
 }
 
 func extractNamesFromTablesList(tables []*Table) []string {

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -35,6 +35,7 @@ import (
 	"vitess.io/vitess/go/event/syslogger"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/mysql/sqlerror"
@@ -574,13 +575,13 @@ func TestSchemaEngineCloseTickRace(t *testing.T) {
 }
 
 func newEngine(reloadTime time.Duration, idleTimeout time.Duration, schemaMaxAgeSeconds int64, db *fakesqldb.DB) *Engine {
-	config := tabletenv.NewDefaultConfig()
-	config.SchemaReloadInterval = reloadTime
-	config.OltpReadPool.IdleTimeout = idleTimeout
-	config.OlapReadPool.IdleTimeout = idleTimeout
-	config.TxPool.IdleTimeout = idleTimeout
-	config.SchemaVersionMaxAgeSeconds = schemaMaxAgeSeconds
-	se := NewEngine(tabletenv.NewEnv(config, "SchemaTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.SchemaReloadInterval = reloadTime
+	cfg.OltpReadPool.IdleTimeout = idleTimeout
+	cfg.OlapReadPool.IdleTimeout = idleTimeout
+	cfg.TxPool.IdleTimeout = idleTimeout
+	cfg.SchemaVersionMaxAgeSeconds = schemaMaxAgeSeconds
+	se := NewEngine(tabletenv.NewEnv(cfg, "SchemaTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	se.InitDBConfig(newDBConfigs(db).DbaWithDB())
 	return se
 }
@@ -764,7 +765,7 @@ func TestEngineMysqlTime(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			se := &Engine{}
 			db := fakesqldb.New(t)
-			env := tabletenv.NewEnv(nil, tt.name, collations.MySQL8(), sqlparser.NewTestParser())
+			env := tabletenv.NewEnv(nil, tt.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 			require.NoError(t, err)
 
@@ -871,7 +872,7 @@ func TestEnginePopulatePrimaryKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := fakesqldb.New(t)
-			env := tabletenv.NewEnv(nil, tt.name, collations.MySQL8(), sqlparser.NewTestParser())
+			env := tabletenv.NewEnv(nil, tt.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 			require.NoError(t, err)
 			se := &Engine{}
@@ -933,7 +934,7 @@ func TestEngineUpdateInnoDBRowsRead(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := fakesqldb.New(t)
-			env := tabletenv.NewEnv(nil, tt.name, collations.MySQL8(), sqlparser.NewTestParser())
+			env := tabletenv.NewEnv(nil, tt.name, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 			require.NoError(t, err)
 			se := &Engine{}
@@ -961,7 +962,7 @@ func TestEngineUpdateInnoDBRowsRead(t *testing.T) {
 // TestEngineGetTableData tests the functionality of getTableData function
 func TestEngineGetTableData(t *testing.T) {
 	db := fakesqldb.New(t)
-	env := tabletenv.NewEnv(nil, "TestEngineGetTableData", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(nil, "TestEngineGetTableData", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 	require.NoError(t, err)
 
@@ -1136,7 +1137,7 @@ func TestEngineReload(t *testing.T) {
 	cfg := tabletenv.NewDefaultConfig()
 	cfg.DB = newDBConfigs(db)
 	cfg.SignalWhenSchemaChange = true
-	env := tabletenv.NewEnv(nil, "TestEngineReload", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(nil, "TestEngineReload", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	conn, err := connpool.NewConn(context.Background(), dbconfigs.New(db.ConnParams()), nil, nil, env)
 	require.NoError(t, err)
 

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/dbconfigs"
 
@@ -235,7 +236,7 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 		Size:        2,
 		IdleTimeout: 10 * time.Second,
 	}
-	connPool := connpool.NewPool(tabletenv.NewEnv(nil, "SchemaTest", collations.MySQL8(), sqlparser.NewTestParser()), "", cfg)
+	connPool := connpool.NewPool(tabletenv.NewEnv(nil, "SchemaTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), "", cfg)
 	connPool.Open(appParams, dbaParams, appParams)
 	conn, err := connPool.Get(ctx, nil)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/schema/tracker_test.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -77,9 +78,9 @@ func TestTracker(t *testing.T) {
 			},
 		}},
 	}
-	config := se.env.Config()
-	config.TrackSchemaVersions = true
-	env := tabletenv.NewEnv(config, "TrackerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := se.env.Config()
+	cfg.TrackSchemaVersions = true
+	env := tabletenv.NewEnv(cfg, "TrackerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	initial := env.Stats().ErrorCounters.Counts()["INTERNAL"]
 	tracker := NewTracker(env, vs, se)
 	tracker.Open()
@@ -121,9 +122,9 @@ func TestTrackerShouldNotInsertInitialSchema(t *testing.T) {
 			},
 		}},
 	}
-	config := se.env.Config()
-	config.TrackSchemaVersions = true
-	env := tabletenv.NewEnv(config, "TrackerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := se.env.Config()
+	cfg.TrackSchemaVersions = true
+	env := tabletenv.NewEnv(cfg, "TrackerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tracker := NewTracker(env, vs, se)
 	tracker.Open()
 	<-vs.done

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
@@ -732,9 +733,9 @@ func verifySubcomponent(t *testing.T, order int64, component any, state testStat
 
 func newTestStateManager(t *testing.T) *stateManager {
 	order.Store(0)
-	config := tabletenv.NewDefaultConfig()
-	env := tabletenv.NewEnv(config, "StateManagerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
 	parser := sqlparser.NewTestParser()
+	env := tabletenv.NewEnv(cfg, "StateManagerTest", collations.MySQL8(), parser, config.DefaultMySQLVersion)
 	sm := &stateManager{
 		statelessql: NewQueryList("stateless", parser),
 		statefulql:  NewQueryList("stateful", parser),

--- a/go/vt/vttablet/tabletserver/tabletenv/env.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/env.go
@@ -36,6 +36,7 @@ type Env interface {
 	SQLParser() *sqlparser.Parser
 	LogError()
 	CollationEnv() *collations.Environment
+	MySQLVersion() string
 }
 
 type testEnv struct {
@@ -44,11 +45,12 @@ type testEnv struct {
 	stats        *Stats
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	mysqlVersion string
 }
 
 // NewEnv creates an Env that can be used for tabletserver subcomponents
 // without an actual TabletServer.
-func NewEnv(config *TabletConfig, exporterName string, collationEnv *collations.Environment, parser *sqlparser.Parser) Env {
+func NewEnv(config *TabletConfig, exporterName string, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) Env {
 	exporter := servenv.NewExporter(exporterName, "Tablet")
 	return &testEnv{
 		config:       config,
@@ -56,6 +58,7 @@ func NewEnv(config *TabletConfig, exporterName string, collationEnv *collations.
 		stats:        NewStats(exporter),
 		collationEnv: collationEnv,
 		parser:       parser,
+		mysqlVersion: mysqlVersion,
 	}
 }
 
@@ -65,6 +68,7 @@ func (te *testEnv) Exporter() *servenv.Exporter           { return te.exporter }
 func (te *testEnv) Stats() *Stats                         { return te.stats }
 func (te *testEnv) CollationEnv() *collations.Environment { return te.collationEnv }
 func (te *testEnv) SQLParser() *sqlparser.Parser          { return te.parser }
+func (te *testEnv) MySQLVersion() string                  { return te.mysqlVersion }
 
 func (te *testEnv) LogError() {
 	if x := recover(); x != nil {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -131,10 +131,15 @@ type TabletServer struct {
 
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	mysqlVersion string
 }
 
 func (tsv *TabletServer) SQLParser() *sqlparser.Parser {
 	return tsv.parser
+}
+
+func (tsv *TabletServer) MySQLVersion() string {
+	return tsv.mysqlVersion
 }
 
 var _ queryservice.QueryService = (*TabletServer)(nil)
@@ -145,8 +150,8 @@ var _ queryservice.QueryService = (*TabletServer)(nil)
 var RegisterFunctions []func(Controller)
 
 // NewServer creates a new TabletServer based on the command line flags.
-func NewServer(ctx context.Context, name string, topoServer *topo.Server, alias *topodatapb.TabletAlias, collationEnv *collations.Environment, parser *sqlparser.Parser) *TabletServer {
-	return NewTabletServer(ctx, name, tabletenv.NewCurrentConfig(), topoServer, alias, collationEnv, parser)
+func NewServer(ctx context.Context, name string, topoServer *topo.Server, alias *topodatapb.TabletAlias, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *TabletServer {
+	return NewTabletServer(ctx, name, tabletenv.NewCurrentConfig(), topoServer, alias, collationEnv, parser, mysqlVersion)
 }
 
 var (
@@ -156,7 +161,7 @@ var (
 
 // NewTabletServer creates an instance of TabletServer. Only the first
 // instance of TabletServer will expose its state variables.
-func NewTabletServer(ctx context.Context, name string, config *tabletenv.TabletConfig, topoServer *topo.Server, alias *topodatapb.TabletAlias, collationEnv *collations.Environment, parser *sqlparser.Parser) *TabletServer {
+func NewTabletServer(ctx context.Context, name string, config *tabletenv.TabletConfig, topoServer *topo.Server, alias *topodatapb.TabletAlias, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *TabletServer {
 	exporter := servenv.NewExporter(name, "Tablet")
 	tsv := &TabletServer{
 		exporter:               exporter,
@@ -169,6 +174,7 @@ func NewTabletServer(ctx context.Context, name string, config *tabletenv.TabletC
 		alias:                  alias.CloneVT(),
 		collationEnv:           collationEnv,
 		parser:                 parser,
+		mysqlVersion:           mysqlVersion,
 	}
 	tsv.QueryTimeout.Store(config.Oltp.QueryTimeout.Nanoseconds())
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -442,9 +442,9 @@ func TestTabletServerConcludeTransaction(t *testing.T) {
 func TestTabletServerBeginFail(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TxPool.Size = 1
-	db, tsv := setupTabletServerTestCustom(t, ctx, config, "", sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TxPool.Size = 1
+	db, tsv := setupTabletServerTestCustom(t, ctx, cfg, "", sqlparser.NewTestParser())
 	defer tsv.StopService()
 	defer db.Close()
 
@@ -947,12 +947,12 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	// The actual execution looks like this:
 	// tx1 | tx3
 	// tx2
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.Mode = tabletenv.Enable
-	config.HotRowProtection.MaxConcurrency = 1
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.Mode = tabletenv.Enable
+	cfg.HotRowProtection.MaxConcurrency = 1
 	// Reduce the txpool to 2 because we should never consume more than two slots.
-	config.TxPool.Size = 2
-	db, tsv := setupTabletServerTestCustom(t, ctx, config, "", sqlparser.NewTestParser())
+	cfg.TxPool.Size = 2
+	db, tsv := setupTabletServerTestCustom(t, ctx, cfg, "", sqlparser.NewTestParser())
 	defer tsv.StopService()
 	defer db.Close()
 
@@ -1055,11 +1055,11 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 func TestDMLQueryWithoutWhereClause(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.Mode = tabletenv.Enable
-	config.HotRowProtection.MaxConcurrency = 1
-	config.TxPool.Size = 2
-	db, tsv := setupTabletServerTestCustom(t, ctx, config, "", sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.Mode = tabletenv.Enable
+	cfg.HotRowProtection.MaxConcurrency = 1
+	cfg.TxPool.Size = 2
+	db, tsv := setupTabletServerTestCustom(t, ctx, cfg, "", sqlparser.NewTestParser())
 	defer tsv.StopService()
 	defer db.Close()
 
@@ -1082,12 +1082,12 @@ func TestSerializeTransactionsSameRow_ConcurrentTransactions(t *testing.T) {
 	// Out of these three, two can run in parallel because we increased the
 	// ConcurrentTransactions limit to 2.
 	// One out of the three transaction will always get serialized though.
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.Mode = tabletenv.Enable
-	config.HotRowProtection.MaxConcurrency = 2
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.Mode = tabletenv.Enable
+	cfg.HotRowProtection.MaxConcurrency = 2
 	// Reduce the txpool to 2 because we should never consume more than two slots.
-	config.TxPool.Size = 2
-	db, tsv := setupTabletServerTestCustom(t, ctx, config, "", sqlparser.NewTestParser())
+	cfg.TxPool.Size = 2
+	db, tsv := setupTabletServerTestCustom(t, ctx, cfg, "", sqlparser.NewTestParser())
 	defer tsv.StopService()
 	defer db.Close()
 
@@ -1219,11 +1219,11 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests(t *testing.T) {
 	// serialized.
 	// Since we start to queue before the transaction pool would queue, we need
 	// to enforce an upper limit as well to protect vttablet.
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.Mode = tabletenv.Enable
-	config.HotRowProtection.MaxQueueSize = 1
-	config.HotRowProtection.MaxConcurrency = 1
-	db, tsv := setupTabletServerTestCustom(t, ctx, config, "", sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.Mode = tabletenv.Enable
+	cfg.HotRowProtection.MaxQueueSize = 1
+	cfg.HotRowProtection.MaxConcurrency = 1
+	db, tsv := setupTabletServerTestCustom(t, ctx, cfg, "", sqlparser.NewTestParser())
 	defer tsv.StopService()
 	defer db.Close()
 
@@ -1303,10 +1303,10 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 	// tx1 and tx2 run against the same row.
 	// tx2 is blocked on tx1. Eventually, tx2 is canceled and its request fails.
 	// Only after that tx1 commits and finishes.
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.Mode = tabletenv.Enable
-	config.HotRowProtection.MaxConcurrency = 1
-	db, tsv := setupTabletServerTestCustom(t, ctx, config, "", sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.Mode = tabletenv.Enable
+	cfg.HotRowProtection.MaxConcurrency = 1
+	db, tsv := setupTabletServerTestCustom(t, ctx, cfg, "", sqlparser.NewTestParser())
 	defer tsv.StopService()
 	defer db.Close()
 
@@ -1559,8 +1559,8 @@ func TestHandleExecUnknownError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	logStats := tabletenv.NewLogStats(ctx, "TestHandleExecError")
-	config := tabletenv.NewDefaultConfig()
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	defer tsv.handlePanicAndSendLogStats("select * from test_table", nil, logStats)
 	panic("unknown exec error")
 }
@@ -1681,8 +1681,8 @@ func (tl *testLogger) getLogs() []string {
 func TestHandleExecTabletError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 	err := tsv.convertAndLogError(
@@ -1704,10 +1704,10 @@ func TestHandleExecTabletError(t *testing.T) {
 func TestTerseErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TerseErrors = true
-	config.SanitizeLogMessages = false
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TerseErrors = true
+	cfg.SanitizeLogMessages = false
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 
@@ -1738,10 +1738,10 @@ func TestTerseErrors(t *testing.T) {
 func TestSanitizeLogMessages(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TerseErrors = false
-	config.SanitizeLogMessages = true
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TerseErrors = false
+	cfg.SanitizeLogMessages = true
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 
@@ -1772,9 +1772,9 @@ func TestSanitizeLogMessages(t *testing.T) {
 func TestTerseErrorsNonSQLError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TerseErrors = true
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TerseErrors = true
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 	err := tsv.convertAndLogError(
@@ -1796,10 +1796,10 @@ func TestTerseErrorsNonSQLError(t *testing.T) {
 func TestSanitizeLogMessagesNonSQLError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TerseErrors = false
-	config.SanitizeLogMessages = true
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TerseErrors = false
+	cfg.SanitizeLogMessages = true
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 	err := tsv.convertAndLogError(
@@ -1821,10 +1821,10 @@ func TestSanitizeLogMessagesNonSQLError(t *testing.T) {
 func TestSanitizeMessagesBindVars(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TerseErrors = true
-	config.SanitizeLogMessages = true
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TerseErrors = true
+	cfg.SanitizeLogMessages = true
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 
@@ -1852,10 +1852,10 @@ func TestSanitizeMessagesBindVars(t *testing.T) {
 func TestSanitizeMessagesNoBindVars(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TerseErrors = true
-	config.SanitizeLogMessages = true
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TerseErrors = true
+	cfg.SanitizeLogMessages = true
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 	err := tsv.convertAndLogError(ctx, "", nil, vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "sensitive message"), nil)
@@ -1871,9 +1871,9 @@ func TestSanitizeMessagesNoBindVars(t *testing.T) {
 func TestTruncateErrorLen(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TruncateErrorLen = 32
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TruncateErrorLen = 32
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 	err := tsv.convertAndLogError(
@@ -1904,7 +1904,7 @@ func TestTruncateMessages(t *testing.T) {
 		TruncateErrLen:     52,
 	})
 	require.NoError(t, err)
-	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), parser)
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), parser, config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 
@@ -1956,9 +1956,9 @@ func TestTruncateMessages(t *testing.T) {
 func TestTerseErrorsIgnoreFailoverInProgress(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	config := tabletenv.NewDefaultConfig()
-	config.TerseErrors = true
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TerseErrors = true
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tl := newTestLogger()
 	defer tl.Close()
 	err := tsv.convertAndLogError(ctx, "select * from test_table where id = :a",
@@ -1999,8 +1999,8 @@ func TestACLHUP(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tableacl.Register("simpleacl", &simpleacl.Factory{})
-	config := tabletenv.NewDefaultConfig()
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	f, err := os.CreateTemp("", "tableacl")
 	require.NoError(t, err)
@@ -2509,14 +2509,14 @@ func TestDatabaseNameReplaceByKeyspaceNameReserveBeginExecuteMethod(t *testing.T
 }
 
 func setupTabletServerTest(t testing.TB, ctx context.Context, keyspaceName string) (*fakesqldb.DB, *TabletServer) {
-	config := tabletenv.NewDefaultConfig()
-	return setupTabletServerTestCustom(t, ctx, config, keyspaceName, sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	return setupTabletServerTestCustom(t, ctx, cfg, keyspaceName, sqlparser.NewTestParser())
 }
 
-func setupTabletServerTestCustom(t testing.TB, ctx context.Context, config *tabletenv.TabletConfig, keyspaceName string, parser *sqlparser.Parser) (*fakesqldb.DB, *TabletServer) {
+func setupTabletServerTestCustom(t testing.TB, ctx context.Context, cfg *tabletenv.TabletConfig, keyspaceName string, parser *sqlparser.Parser) (*fakesqldb.DB, *TabletServer) {
 	db := setupFakeDB(t)
 	sidecardb.AddSchemaInitQueries(db, true, parser)
-	tsv := NewTabletServer(ctx, "TabletServerTest", config, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), parser)
+	tsv := NewTabletServer(ctx, "TabletServerTest", cfg, memorytopo.NewServer(ctx, ""), &topodatapb.TabletAlias{}, collations.MySQL8(), parser, config.DefaultMySQLVersion)
 	require.Equal(t, StateNotConnected, tsv.sm.State())
 	dbcfgs := newDBConfigs(db)
 	target := &querypb.Target{

--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	cfg "vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
@@ -110,7 +111,7 @@ func newTestThrottler() *Throttler {
 		s.ThrottleThreshold = &atomic.Uint64{}
 		s.ThrottleThreshold.Store(1)
 	}
-	env := tabletenv.NewEnv(nil, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(nil, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), cfg.DefaultMySQLVersion)
 	throttler := &Throttler{
 		mysqlClusterProbesChan: make(chan *mysql.ClusterProbes),
 		mysqlClusterThresholds: cache.New(cache.NoExpiration, 0),

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
@@ -45,12 +46,12 @@ func TestTxEngineClose(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 	ctx := context.Background()
-	config := tabletenv.NewDefaultConfig()
-	config.DB = newDBConfigs(db)
-	config.TxPool.Size = 10
-	config.Oltp.TxTimeout = 100 * time.Millisecond
-	config.GracePeriods.Shutdown = 0
-	te := NewTxEngine(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	cfg.TxPool.Size = 10
+	cfg.Oltp.TxTimeout = 100 * time.Millisecond
+	cfg.GracePeriods.Shutdown = 0
+	te := NewTxEngine(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 
 	// Normal close.
 	te.AcceptReadWrite()
@@ -151,9 +152,9 @@ func TestTxEngineBegin(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 	db.AddQueryPattern(".*", &sqltypes.Result{})
-	config := tabletenv.NewDefaultConfig()
-	config.DB = newDBConfigs(db)
-	te := NewTxEngine(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	te := NewTxEngine(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 
 	for _, exec := range []func() (int64, string, error){
 		func() (int64, string, error) {
@@ -197,9 +198,9 @@ func TestTxEngineRenewFails(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 	db.AddQueryPattern(".*", &sqltypes.Result{})
-	config := tabletenv.NewDefaultConfig()
-	config.DB = newDBConfigs(db)
-	te := NewTxEngine(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	te := NewTxEngine(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	te.AcceptReadOnly()
 	options := &querypb.ExecuteOptions{}
 	connID, _, err := te.ReserveBegin(ctx, options, nil, nil)
@@ -532,12 +533,12 @@ func TestWithInnerTests(outerT *testing.T) {
 }
 
 func setupTxEngine(db *fakesqldb.DB) *TxEngine {
-	config := tabletenv.NewDefaultConfig()
-	config.DB = newDBConfigs(db)
-	config.TxPool.Size = 10
-	config.Oltp.TxTimeout = 100 * time.Millisecond
-	config.GracePeriods.Shutdown = 0
-	te := NewTxEngine(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	cfg.TxPool.Size = 10
+	cfg.Oltp.TxTimeout = 100 * time.Millisecond
+	cfg.GracePeriods.Shutdown = 0
+	te := NewTxEngine(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	return te
 }
 
@@ -567,9 +568,9 @@ func TestTxEngineFailReserve(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 	db.AddQueryPattern(".*", &sqltypes.Result{})
-	config := tabletenv.NewDefaultConfig()
-	config.DB = newDBConfigs(db)
-	te := NewTxEngine(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(db)
+	te := NewTxEngine(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 
 	options := &querypb.ExecuteOptions{}
 	_, err := te.Reserve(ctx, options, 0, nil)

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -817,15 +818,15 @@ func newTxPoolWithEnv(env tabletenv.Env) (*TxPool, *fakeLimiter) {
 }
 
 func newEnv(exporterName string) tabletenv.Env {
-	config := tabletenv.NewDefaultConfig()
-	config.TxPool.Size = 300
-	config.Oltp.TxTimeout = 30 * time.Second
-	config.TxPool.Timeout = 40 * time.Second
-	config.TxPool.MaxWaiters = 500000
-	config.OltpReadPool.IdleTimeout = 30 * time.Second
-	config.OlapReadPool.IdleTimeout = 30 * time.Second
-	config.TxPool.IdleTimeout = 30 * time.Second
-	env := tabletenv.NewEnv(config, exporterName, collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TxPool.Size = 300
+	cfg.Oltp.TxTimeout = 30 * time.Second
+	cfg.TxPool.Timeout = 40 * time.Second
+	cfg.TxPool.MaxWaiters = 500000
+	cfg.OltpReadPool.IdleTimeout = 30 * time.Second
+	cfg.OlapReadPool.IdleTimeout = 30 * time.Second
+	cfg.TxPool.IdleTimeout = 30 * time.Second
+	env := tabletenv.NewEnv(cfg, exporterName, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	return env
 }
 

--- a/go/vt/vttablet/tabletserver/txlimiter/tx_limiter_test.go
+++ b/go/vt/vttablet/tabletserver/txlimiter/tx_limiter_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -40,16 +41,16 @@ func createCallers(username, principal, component, subcomponent string) (*queryp
 }
 
 func TestTxLimiter_DisabledAllowsAll(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.TxPool.Size = 10
-	config.TransactionLimitPerUser = 0.1
-	config.EnableTransactionLimit = false
-	config.EnableTransactionLimitDryRun = false
-	config.TransactionLimitByUsername = false
-	config.TransactionLimitByPrincipal = false
-	config.TransactionLimitByComponent = false
-	config.TransactionLimitBySubcomponent = false
-	limiter := New(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TxPool.Size = 10
+	cfg.TransactionLimitPerUser = 0.1
+	cfg.EnableTransactionLimit = false
+	cfg.EnableTransactionLimitDryRun = false
+	cfg.TransactionLimitByUsername = false
+	cfg.TransactionLimitByPrincipal = false
+	cfg.TransactionLimitByComponent = false
+	cfg.TransactionLimitBySubcomponent = false
+	limiter := New(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	im, ef := createCallers("", "", "", "")
 	for i := 0; i < 5; i++ {
 		if got, want := limiter.Get(im, ef), true; got != want {
@@ -60,18 +61,18 @@ func TestTxLimiter_DisabledAllowsAll(t *testing.T) {
 }
 
 func TestTxLimiter_LimitsOnlyOffendingUser(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.TxPool.Size = 10
-	config.TransactionLimitPerUser = 0.3
-	config.EnableTransactionLimit = true
-	config.EnableTransactionLimitDryRun = false
-	config.TransactionLimitByUsername = true
-	config.TransactionLimitByPrincipal = false
-	config.TransactionLimitByComponent = false
-	config.TransactionLimitBySubcomponent = false
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TxPool.Size = 10
+	cfg.TransactionLimitPerUser = 0.3
+	cfg.EnableTransactionLimit = true
+	cfg.EnableTransactionLimitDryRun = false
+	cfg.TransactionLimitByUsername = true
+	cfg.TransactionLimitByPrincipal = false
+	cfg.TransactionLimitByComponent = false
+	cfg.TransactionLimitBySubcomponent = false
 
 	// This should allow 3 slots to all users
-	newlimiter := New(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	newlimiter := New(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	limiter, ok := newlimiter.(*Impl)
 	if !ok {
 		t.Fatalf("New returned limiter of unexpected type: got %T, want %T", newlimiter, limiter)
@@ -126,18 +127,18 @@ func TestTxLimiter_LimitsOnlyOffendingUser(t *testing.T) {
 }
 
 func TestTxLimiterDryRun(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.TxPool.Size = 10
-	config.TransactionLimitPerUser = 0.3
-	config.EnableTransactionLimit = true
-	config.EnableTransactionLimitDryRun = true
-	config.TransactionLimitByUsername = true
-	config.TransactionLimitByPrincipal = false
-	config.TransactionLimitByComponent = false
-	config.TransactionLimitBySubcomponent = false
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.TxPool.Size = 10
+	cfg.TransactionLimitPerUser = 0.3
+	cfg.EnableTransactionLimit = true
+	cfg.EnableTransactionLimitDryRun = true
+	cfg.TransactionLimitByUsername = true
+	cfg.TransactionLimitByPrincipal = false
+	cfg.TransactionLimitByComponent = false
+	cfg.TransactionLimitBySubcomponent = false
 
 	// This should allow 3 slots to all users
-	newlimiter := New(tabletenv.NewEnv(config, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	newlimiter := New(tabletenv.NewEnv(cfg, "TabletServerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	limiter, ok := newlimiter.(*Impl)
 	if !ok {
 		t.Fatalf("New returned limiter of unexpected type: got %T, want %T", newlimiter, limiter)

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -45,11 +46,11 @@ func resetVariables(txs *TxSerializer) {
 }
 
 func TestTxSerializer_NoHotRow(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 1
-	config.HotRowProtection.MaxGlobalQueueSize = 1
-	config.HotRowProtection.MaxConcurrency = 5
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 1
+	cfg.HotRowProtection.MaxGlobalQueueSize = 1
+	cfg.HotRowProtection.MaxConcurrency = 5
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	resetVariables(txs)
 
 	done, waited, err := txs.Wait(context.Background(), "t1 where1", "t1")
@@ -77,11 +78,11 @@ func TestTxSerializerRedactDebugUI(t *testing.T) {
 		streamlog.SetRedactDebugUIQueries(false)
 	}()
 
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 1
-	config.HotRowProtection.MaxGlobalQueueSize = 1
-	config.HotRowProtection.MaxConcurrency = 5
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 1
+	cfg.HotRowProtection.MaxGlobalQueueSize = 1
+	cfg.HotRowProtection.MaxConcurrency = 5
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	resetVariables(txs)
 
 	done, waited, err := txs.Wait(context.Background(), "t1 where1", "t1")
@@ -104,8 +105,8 @@ func TestTxSerializerRedactDebugUI(t *testing.T) {
 }
 
 func TestKeySanitization(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	// with a where clause
 	key := "t1 where c1='foo'"
 	want := "t1 ... [REDACTED]"
@@ -123,11 +124,11 @@ func TestKeySanitization(t *testing.T) {
 }
 
 func TestTxSerializer(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 2
-	config.HotRowProtection.MaxGlobalQueueSize = 3
-	config.HotRowProtection.MaxConcurrency = 1
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 2
+	cfg.HotRowProtection.MaxGlobalQueueSize = 3
+	cfg.HotRowProtection.MaxConcurrency = 1
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	resetVariables(txs)
 
 	// tx1.
@@ -196,11 +197,11 @@ func TestTxSerializer(t *testing.T) {
 
 func TestTxSerializer_ConcurrentTransactions(t *testing.T) {
 	// Allow up to 2 concurrent transactions per hot row.
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 3
-	config.HotRowProtection.MaxGlobalQueueSize = 3
-	config.HotRowProtection.MaxConcurrency = 2
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 3
+	cfg.HotRowProtection.MaxGlobalQueueSize = 3
+	cfg.HotRowProtection.MaxConcurrency = 2
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	resetVariables(txs)
 
 	// tx1.
@@ -319,11 +320,11 @@ func testHTTPHandler(txs *TxSerializer, count int, redacted bool) error {
 // tx1 and tx2 are allowed to run concurrently while tx3 and tx4 are queued.
 // tx3 will get canceled and tx4 will be unblocked once tx1 is done.
 func TestTxSerializerCancel(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 4
-	config.HotRowProtection.MaxGlobalQueueSize = 4
-	config.HotRowProtection.MaxConcurrency = 2
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 4
+	cfg.HotRowProtection.MaxGlobalQueueSize = 4
+	cfg.HotRowProtection.MaxConcurrency = 2
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	resetVariables(txs)
 
 	// tx3 and tx4 will record their number once they're done waiting.
@@ -419,12 +420,12 @@ func TestTxSerializerCancel(t *testing.T) {
 // TestTxSerializerDryRun verifies that the dry-run mode does not serialize
 // the two concurrent transactions for the same key.
 func TestTxSerializerDryRun(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.Mode = tabletenv.Dryrun
-	config.HotRowProtection.MaxQueueSize = 1
-	config.HotRowProtection.MaxGlobalQueueSize = 2
-	config.HotRowProtection.MaxConcurrency = 1
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.Mode = tabletenv.Dryrun
+	cfg.HotRowProtection.MaxQueueSize = 1
+	cfg.HotRowProtection.MaxGlobalQueueSize = 2
+	cfg.HotRowProtection.MaxConcurrency = 1
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	resetVariables(txs)
 
 	// tx1.
@@ -490,11 +491,11 @@ func TestTxSerializerDryRun(t *testing.T) {
 // reject transactions although they may succeed within the txpool constraints
 // and RPC deadline.
 func TestTxSerializerGlobalQueueOverflow(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 1
-	config.HotRowProtection.MaxGlobalQueueSize = 1
-	config.HotRowProtection.MaxConcurrency = 1
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 1
+	cfg.HotRowProtection.MaxGlobalQueueSize = 1
+	cfg.HotRowProtection.MaxConcurrency = 1
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 
 	// tx1.
 	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
@@ -531,22 +532,22 @@ func TestTxSerializerGlobalQueueOverflow(t *testing.T) {
 }
 
 func TestTxSerializerPending(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 1
-	config.HotRowProtection.MaxGlobalQueueSize = 1
-	config.HotRowProtection.MaxConcurrency = 1
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 1
+	cfg.HotRowProtection.MaxGlobalQueueSize = 1
+	cfg.HotRowProtection.MaxConcurrency = 1
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 	if got, want := txs.Pending("t1 where1"), 0; got != want {
 		t.Errorf("there should be no pending transaction: got = %v, want = %v", got, want)
 	}
 }
 
 func BenchmarkTxSerializer_NoHotRow(b *testing.B) {
-	config := tabletenv.NewDefaultConfig()
-	config.HotRowProtection.MaxQueueSize = 1
-	config.HotRowProtection.MaxGlobalQueueSize = 1
-	config.HotRowProtection.MaxConcurrency = 5
-	txs := New(tabletenv.NewEnv(config, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser()))
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.MaxQueueSize = 1
+	cfg.HotRowProtection.MaxGlobalQueueSize = 1
+	cfg.HotRowProtection.MaxConcurrency = 5
+	txs := New(tabletenv.NewEnv(cfg, "TxSerializerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion))
 
 	b.ResetTimer()
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/throttler"
@@ -42,9 +43,9 @@ import (
 )
 
 func TestDisabledThrottler(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	config.EnableTxThrottler = false
-	env := tabletenv.NewEnv(config, t.Name(), collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.EnableTxThrottler = false
+	env := tabletenv.NewEnv(cfg, t.Name(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	throttler := NewTxThrottler(env, nil)
 	throttler.InitDBConfig(&querypb.Target{
 		Keyspace: "keyspace",
@@ -104,11 +105,11 @@ func TestEnabledThrottler(t *testing.T) {
 	call4.After(call3)
 	calllast.After(call4)
 
-	config := tabletenv.NewDefaultConfig()
-	config.EnableTxThrottler = true
-	config.TxThrottlerTabletTypes = &topoproto.TabletTypeListFlag{topodatapb.TabletType_REPLICA}
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.EnableTxThrottler = true
+	cfg.TxThrottlerTabletTypes = &topoproto.TabletTypeListFlag{topodatapb.TabletType_REPLICA}
 
-	env := tabletenv.NewEnv(config, t.Name(), collations.MySQL8(), sqlparser.NewTestParser())
+	env := tabletenv.NewEnv(cfg, t.Name(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	throttler := NewTxThrottler(env, ts)
 	throttlerImpl, _ := throttler.(*txThrottler)
 	assert.NotNil(t, throttlerImpl)
@@ -170,8 +171,8 @@ func TestFetchKnownCells(t *testing.T) {
 }
 
 func TestDryRunThrottler(t *testing.T) {
-	config := tabletenv.NewDefaultConfig()
-	env := tabletenv.NewEnv(config, t.Name(), collations.MySQL8(), sqlparser.NewTestParser())
+	cfg := tabletenv.NewDefaultConfig()
+	env := tabletenv.NewEnv(cfg, t.Name(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	testCases := []struct {
 		Name                           string

--- a/go/vt/vttablet/tabletserver/vstreamer/main_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/main_flaky_test.go
@@ -27,6 +27,7 @@ import (
 	_flag "vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -92,10 +93,10 @@ func customEngine(t *testing.T, modifier func(mysql.ConnParams) mysql.ConnParams
 	original, err := env.Dbcfgs.AppWithDB().MysqlParams()
 	require.NoError(t, err)
 	modified := modifier(*original)
-	config := env.TabletEnv.Config().Clone()
-	config.DB = dbconfigs.NewTestDBConfigs(modified, modified, modified.DbName)
+	cfg := env.TabletEnv.Config().Clone()
+	cfg.DB = dbconfigs.NewTestDBConfigs(modified, modified, modified.DbName)
 
-	engine := NewEngine(tabletenv.NewEnv(config, "VStreamerTest", collations.MySQL8(), sqlparser.NewTestParser()), env.SrvTopo, env.SchemaEngine, nil, env.Cells[0])
+	engine := NewEngine(tabletenv.NewEnv(cfg, "VStreamerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion), env.SrvTopo, env.SchemaEngine, nil, env.Cells[0])
 	engine.InitDBConfig(env.KeyspaceName, env.ShardName)
 	engine.Open()
 	return engine

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/proto/topodata"
@@ -258,6 +259,7 @@ func TestPlanBuilder(t *testing.T) {
 				},
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -289,6 +291,7 @@ func TestPlanBuilder(t *testing.T) {
 				KeyRange:      nil,
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -312,6 +315,7 @@ func TestPlanBuilder(t *testing.T) {
 				},
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -335,6 +339,7 @@ func TestPlanBuilder(t *testing.T) {
 				},
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -358,6 +363,7 @@ func TestPlanBuilder(t *testing.T) {
 				},
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -389,6 +395,7 @@ func TestPlanBuilder(t *testing.T) {
 				KeyRange:      nil,
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -420,6 +427,7 @@ func TestPlanBuilder(t *testing.T) {
 				KeyRange:      nil,
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -451,6 +459,7 @@ func TestPlanBuilder(t *testing.T) {
 				KeyRange:      nil,
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t2,
@@ -485,6 +494,7 @@ func TestPlanBuilder(t *testing.T) {
 				KeyRange:      nil,
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -509,6 +519,7 @@ func TestPlanBuilder(t *testing.T) {
 			}},
 			convertUsingUTF8Columns: map[string]bool{"val": true},
 			collationEnv:            collations.MySQL8(),
+			mysqlVersion:            config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: regional,
@@ -533,6 +544,7 @@ func TestPlanBuilder(t *testing.T) {
 				VindexColumns: []int{0, 1},
 			}},
 			collationEnv: collations.MySQL8(),
+			mysqlVersion: config.DefaultMySQLVersion,
 		},
 	}, {
 		inTable: t1,
@@ -645,7 +657,7 @@ func TestPlanBuilder(t *testing.T) {
 		t.Run(tcase.inRule.String(), func(t *testing.T) {
 			plan, err := buildPlan(tcase.inTable, testLocalVSchema, &binlogdatapb.Filter{
 				Rules: []*binlogdatapb.Rule{tcase.inRule},
-			}, collations.MySQL8(), sqlparser.NewTestParser())
+			}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			if tcase.outErr != "" {
 				assert.Nil(t, plan)
@@ -742,7 +754,7 @@ func TestPlanBuilderFilterComparison(t *testing.T) {
 		t.Run(tcase.name, func(t *testing.T) {
 			plan, err := buildPlan(t1, testLocalVSchema, &binlogdatapb.Filter{
 				Rules: []*binlogdatapb.Rule{{Match: "t1", Filter: tcase.inFilter}},
-			}, collations.MySQL8(), sqlparser.NewTestParser())
+			}, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 			if tcase.outErr != "" {
 				assert.Nil(t, plan)

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -177,7 +177,7 @@ func (rs *rowStreamer) buildPlan() error {
 	// This is because the row format of a read is identical
 	// to the row format of a binlog event. So, the same
 	// filtering will work.
-	rs.plan, err = buildTablePlan(ti, rs.vschema, rs.query, rs.se.CollationEnv(), rs.se.SQLParser())
+	rs.plan, err = buildTablePlan(ti, rs.vschema, rs.query, rs.se.CollationEnv(), rs.se.SQLParser(), rs.se.MySQLVersion())
 	if err != nil {
 		log.Errorf("%s", err.Error())
 		return err

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -108,9 +109,9 @@ func Init(ctx context.Context) (*Env, error) {
 		return nil, fmt.Errorf("could not launch mysql: %v", err)
 	}
 	te.Dbcfgs = dbconfigs.NewTestDBConfigs(te.cluster.MySQLConnParams(), te.cluster.MySQLAppDebugConnParams(), te.cluster.DbName())
-	config := tabletenv.NewDefaultConfig()
-	config.DB = te.Dbcfgs
-	te.TabletEnv = tabletenv.NewEnv(config, "VStreamerTest", collations.MySQL8(), sqlparser.NewTestParser())
+	conf := tabletenv.NewDefaultConfig()
+	conf.DB = te.Dbcfgs
+	te.TabletEnv = tabletenv.NewEnv(conf, "VStreamerTest", collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
 	pos, _ := te.Mysqld.PrimaryPosition()
 	if strings.HasPrefix(strings.ToLower(pos.GTIDSet.Flavor()), string(mysqlctl.FlavorMariaDB)) {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -682,7 +682,7 @@ func (vs *vstreamer) buildJournalPlan(id uint64, tm *mysql.TableMap) error {
 	// Build a normal table plan, which means, return all rows
 	// and columns as is. Special handling is done when we actually
 	// receive the row event. We'll build a JOURNAL event instead.
-	plan, err := buildREPlan(table, nil, "", vs.se.CollationEnv())
+	plan, err := buildREPlan(table, nil, "", vs.se.CollationEnv(), vs.se.MySQLVersion())
 	if err != nil {
 		return err
 	}
@@ -716,7 +716,7 @@ func (vs *vstreamer) buildVersionPlan(id uint64, tm *mysql.TableMap) error {
 	// Build a normal table plan, which means, return all rows
 	// and columns as is. Special handling is done when we actually
 	// receive the row event. We'll build a JOURNAL event instead.
-	plan, err := buildREPlan(table, nil, "", vs.se.CollationEnv())
+	plan, err := buildREPlan(table, nil, "", vs.se.CollationEnv(), vs.se.MySQLVersion())
 	if err != nil {
 		return err
 	}
@@ -738,7 +738,7 @@ func (vs *vstreamer) buildTablePlan(id uint64, tm *mysql.TableMap) (*binlogdatap
 		Name:   tm.Name,
 		Fields: cols,
 	}
-	plan, err := buildPlan(table, vs.vschema, vs.filter, vs.se.CollationEnv(), vs.se.SQLParser())
+	plan, err := buildPlan(table, vs.vschema, vs.filter, vs.se.CollationEnv(), vs.se.SQLParser(), vs.se.MySQLVersion())
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +957,7 @@ func (vs *vstreamer) rebuildPlans() error {
 			// cause that to change.
 			continue
 		}
-		newPlan, err := buildPlan(plan.Table, vs.vschema, vs.filter, vs.se.CollationEnv(), vs.se.SQLParser())
+		newPlan, err := buildPlan(plan.Table, vs.vschema, vs.filter, vs.se.CollationEnv(), vs.se.SQLParser(), vs.se.MySQLVersion())
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -40,6 +40,7 @@ import (
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/proto/logutil"
@@ -556,7 +557,7 @@ func (db *LocalCluster) createVTSchema() error {
 		return db.ExecuteFetch(query, "")
 	}
 
-	if err := sidecardb.Init(context.Background(), sidecardbExec, collations.MySQL8(), sqlparser.NewTestParser()); err != nil {
+	if err := sidecardb.Init(context.Background(), sidecardbExec, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion); err != nil {
 		return err
 	}
 	return nil

--- a/go/vt/wrangler/external_cluster_test.go
+++ b/go/vt/wrangler/external_cluster_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/proto/topodata"
@@ -19,7 +20,7 @@ func TestVitessCluster(t *testing.T) {
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "zone1")
 	tmc := newTestWranglerTMClient()
-	wr := New(logutil.NewConsoleLogger(), ts, tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), ts, tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	name, topoType, topoServer, topoRoot := "c1", "x", "y", "z"
 
 	t.Run("Zero clusters to start", func(t *testing.T) {

--- a/go/vt/wrangler/fake_tablet_test.go
+++ b/go/vt/wrangler/fake_tablet_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -200,6 +201,7 @@ func (ft *fakeTablet) StartActionLoop(t *testing.T, wr *Wrangler) {
 		VDiffEngine:         vdiff2.NewEngine(wr.TopoServer(), ft.Tablet, collations.MySQL8(), sqlparser.NewTestParser()),
 		CollationEnv:        collations.MySQL8(),
 		SQLParser:           sqlparser.NewTestParser(),
+		MySQLVersion:        config.DefaultMySQLVersion,
 	}
 	if err := ft.TM.Start(ft.Tablet, nil); err != nil {
 		t.Fatal(err)

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -445,7 +445,7 @@ func (wr *Wrangler) checkIfPreviousJournalExists(ctx context.Context, mz *materi
 		mu      sync.Mutex
 		exists  bool
 		tablets []string
-		ws      = workflow.NewServer(wr.ts, wr.tmc, wr.collationEnv, wr.parser)
+		ws      = workflow.NewServer(wr.ts, wr.tmc, wr.collationEnv, wr.parser, wr.mysqlVersion)
 	)
 
 	err := forAllSources(func(si *topo.ShardInfo) error {
@@ -1266,7 +1266,7 @@ func (mz *materializer) deploySchema(ctx context.Context) error {
 				// We use schemadiff to normalize the schema.
 				// For now, and because this is could have wider implications, we ignore any errors in
 				// reading the source schema.
-				env := schemadiff.NewEnv(mz.wr.collationEnv, mz.wr.collationEnv.DefaultConnectionCharset(), mz.wr.parser)
+				env := schemadiff.NewEnv(mz.wr.collationEnv, mz.wr.collationEnv.DefaultConnectionCharset(), mz.wr.parser, mz.wr.mysqlVersion)
 				schema, err := schemadiff.NewSchemaFromQueries(env, applyDDLs)
 				if err != nil {
 					log.Error(vterrors.Wrapf(err, "AtomicCopy: failed to normalize schema via schemadiff"))

--- a/go/vt/wrangler/materializer_env_test.go
+++ b/go/vt/wrangler/materializer_env_test.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/goleak"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -131,7 +132,7 @@ func newTestMaterializerEnv(t *testing.T, ctx context.Context, ms *vtctldatapb.M
 		tmc:      newTestMaterializerTMClient(),
 	}
 	parser := sqlparser.NewTestParser()
-	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), parser)
+	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), parser, config.DefaultMySQLVersion)
 	tabletID := 100
 	for _, shard := range sources {
 		_ = env.addTablet(tabletID, env.ms.SourceKeyspace, shard, topodatapb.TabletType_PRIMARY)

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/logutil"
@@ -1543,7 +1544,7 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 	defer cancel()
 
 	topoServ := memorytopo.NewServer(ctx, "cell")
-	wr := New(logutil.NewConsoleLogger(), topoServ, nil, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), topoServ, nil, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	unique := map[string]*vschemapb.Vindex{
 		"v": {
@@ -2543,7 +2544,7 @@ func TestMaterializerNoSourcePrimary(t *testing.T) {
 		cell:     "cell",
 		tmc:      newTestMaterializerTMClient(),
 	}
-	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	defer env.close()
 
 	tabletID := 100

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -60,7 +60,7 @@ func (wr *Wrangler) InitShardPrimary(ctx context.Context, keyspace, shard string
 	ev := &events.Reparent{}
 
 	// do the work
-	err = grpcvtctldserver.NewVtctldServer(wr.ts, wr.collationEnv, wr.parser).InitShardPrimaryLocked(ctx, ev, &vtctldatapb.InitShardPrimaryRequest{
+	err = grpcvtctldserver.NewVtctldServer(wr.ts, wr.collationEnv, wr.parser, wr.mysqlVersion).InitShardPrimaryLocked(ctx, ev, &vtctldatapb.InitShardPrimaryRequest{
 		Keyspace:                keyspace,
 		Shard:                   shard,
 		PrimaryElectTabletAlias: primaryElectTabletAlias,

--- a/go/vt/wrangler/resharder_env_test.go
+++ b/go/vt/wrangler/resharder_env_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/logutil"
@@ -95,7 +96,7 @@ func newTestResharderEnv(t *testing.T, ctx context.Context, sources, targets []s
 		cell:     "cell",
 		tmc:      newTestResharderTMClient(),
 	}
-	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	initTopo(t, env.topoServ, "ks", sources, targets, []string{"cell"})
 	tabletID := 100
 	for _, shard := range sources {

--- a/go/vt/wrangler/tablet_test.go
+++ b/go/vt/wrangler/tablet_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -38,7 +39,7 @@ func TestInitTabletShardConversion(t *testing.T) {
 
 	cell := "cell1"
 	ts := memorytopo.NewServer(ctx, cell)
-	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tablet := &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
@@ -72,7 +73,7 @@ func TestDeleteTabletBasic(t *testing.T) {
 
 	cell := "cell1"
 	ts := memorytopo.NewServer(ctx, cell)
-	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tablet := &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
@@ -104,7 +105,7 @@ func TestDeleteTabletTruePrimary(t *testing.T) {
 
 	cell := "cell1"
 	ts := memorytopo.NewServer(ctx, cell)
-	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tablet := &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
@@ -151,7 +152,7 @@ func TestDeleteTabletFalsePrimary(t *testing.T) {
 
 	cell := "cell1"
 	ts := memorytopo.NewServer(ctx, cell)
-	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tablet1 := &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
@@ -203,7 +204,7 @@ func TestDeleteTabletShardNonExisting(t *testing.T) {
 
 	cell := "cell1"
 	ts := memorytopo.NewServer(ctx, cell)
-	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), ts, nil, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	tablet := &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/capabilities"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
@@ -93,7 +94,7 @@ func testBackupRestore(t *testing.T, cDetails *compressionDetails) error {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -345,7 +346,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -564,7 +565,7 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -739,7 +740,7 @@ func TestDisableActiveReparents(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
@@ -57,7 +58,7 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sets"
 	"vitess.io/vitess/go/vt/discovery"
@@ -51,7 +52,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -205,7 +206,7 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
 
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Create a primary, a couple good replicas
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -51,7 +52,7 @@ func TestTabletExternallyReparentedBasic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -144,7 +145,7 @@ func TestTabletExternallyReparentedToReplica(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Create an old primary, a new primary, two good replicas, one bad replica
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)
@@ -227,7 +228,7 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Create an old primary, a new primary, two good replicas, one bad replica
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)
@@ -320,7 +321,7 @@ func TestTabletExternallyReparentedContinueOnUnexpectedPrimary(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Create an old primary, a new primary, two good replicas, one bad replica
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)
@@ -406,7 +407,7 @@ func TestTabletExternallyReparentedRerun(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Create an old primary, a new primary, and a good replica.
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)
@@ -510,7 +511,7 @@ func TestRPCTabletExternallyReparentedDemotesPrimaryToConfiguredTabletType(t *te
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Create an old primary and a new primary
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_SPARE, nil)

--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -213,6 +214,7 @@ func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
 		VREngine:            vreplication.NewTestEngine(wr.TopoServer(), ft.Tablet.Alias.Cell, ft.FakeMysqlDaemon, binlogplayer.NewFakeDBClient, binlogplayer.NewFakeDBClient, topoproto.TabletDbName(ft.Tablet), nil),
 		CollationEnv:        collations.MySQL8(),
 		SQLParser:           sqlparser.NewTestParser(),
+		MySQLVersion:        config.DefaultMySQLVersion,
 	}
 	if err := ft.TM.Start(ft.Tablet, nil); err != nil {
 		t.Fatalf("Error in tablet - %v, err - %v", topoproto.TabletAliasString(ft.Tablet.Alias), err.Error())

--- a/go/vt/wrangler/testlib/find_tablet_test.go
+++ b/go/vt/wrangler/testlib/find_tablet_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
@@ -38,7 +39,7 @@ func TestFindTablet(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Create an old primary, two good replicas
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)

--- a/go/vt/wrangler/testlib/permissions_test.go
+++ b/go/vt/wrangler/testlib/permissions_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -49,7 +50,7 @@ func TestPermissions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -53,7 +54,7 @@ func TestPlannedReparentShardNoPrimaryProvided(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -169,7 +170,7 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -305,7 +306,7 @@ func TestPlannedReparentInitialization(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -391,7 +392,7 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -499,7 +500,7 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -605,7 +606,7 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -685,7 +686,7 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -770,7 +771,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
@@ -910,7 +911,7 @@ func TestPlannedReparentShardSamePrimary(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/logutil"
@@ -50,7 +51,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// create shard and tablets
 	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0"); err != nil {
@@ -134,7 +135,7 @@ func TestReparentTablet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// create shard and tablets
 	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0"); err != nil {
@@ -191,7 +192,7 @@ func TestSetReplicationSource(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// create shard and tablets
 	_, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0")

--- a/go/vt/wrangler/testlib/shard_test.go
+++ b/go/vt/wrangler/testlib/shard_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
@@ -37,7 +38,7 @@ func TestDeleteShardCleanup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 

--- a/go/vt/wrangler/testlib/version_test.go
+++ b/go/vt/wrangler/testlib/version_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -72,7 +73,7 @@ func TestVersion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1", "cell2")
-	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -78,7 +79,7 @@ func NewVtctlPipe(t *testing.T, ts *topo.Server) *VtctlPipe {
 
 	// Create a gRPC server and listen on the port
 	server := grpc.NewServer()
-	grpcvtctlserver.StartServer(server, ts, collations.MySQL8(), sqlparser.NewTestParser())
+	grpcvtctlserver.StartServer(server, ts, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	go server.Serve(listener)
 
 	// Create a VtctlClient gRPC client to talk to the fake server

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -224,7 +224,7 @@ func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workfl
 		return nil, nil, err
 	}
 
-	ws := workflow.NewServer(wr.ts, wr.tmc, wr.collationEnv, wr.parser)
+	ws := workflow.NewServer(wr.ts, wr.tmc, wr.collationEnv, wr.parser, wr.mysqlVersion)
 	state := &workflow.State{
 		Workflow:           workflowName,
 		SourceKeyspace:     ts.SourceKeyspaceName(),
@@ -1187,7 +1187,7 @@ func (ts *trafficSwitcher) switchShardReads(ctx context.Context, cells []string,
 // If so, it also returns the list of sourceWorkflows that need to be switched.
 func (ts *trafficSwitcher) checkJournals(ctx context.Context) (journalsExist bool, sourceWorkflows []string, err error) {
 	var (
-		ws = workflow.NewServer(ts.TopoServer(), ts.TabletManagerClient(), ts.wr.collationEnv, ts.wr.parser)
+		ws = workflow.NewServer(ts.TopoServer(), ts.TabletManagerClient(), ts.wr.collationEnv, ts.wr.parser, ts.wr.mysqlVersion)
 		mu sync.Mutex
 	)
 

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqlescape"
@@ -121,7 +122,7 @@ func newTestTableMigrater(ctx context.Context, t *testing.T) *testMigraterEnv {
 func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards, targetShards []string, fmtQuery string) *testMigraterEnv {
 	tme := &testMigraterEnv{}
 	tme.ts = memorytopo.NewServer(ctx, "cell1", "cell2")
-	tme.wr = New(logutil.NewConsoleLogger(), tme.ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	tme.wr = New(logutil.NewConsoleLogger(), tme.ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tme.wr.sem = semaphore.NewWeighted(1)
 	tme.sourceShards = sourceShards
 	tme.targetShards = targetShards
@@ -391,7 +392,7 @@ func newTestTablePartialMigrater(ctx context.Context, t *testing.T, shards, shar
 	require.Greater(t, len(shards), 1, "shard by shard migrations can only be done on sharded keyspaces")
 	tme := &testMigraterEnv{}
 	tme.ts = memorytopo.NewServer(ctx, "cell1", "cell2")
-	tme.wr = New(logutil.NewConsoleLogger(), tme.ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	tme.wr = New(logutil.NewConsoleLogger(), tme.ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tme.wr.sem = semaphore.NewWeighted(1)
 	tme.sourceShards = shards
 	tme.targetShards = shards
@@ -554,7 +555,7 @@ func newTestTablePartialMigrater(ctx context.Context, t *testing.T, shards, shar
 func newTestShardMigrater(ctx context.Context, t *testing.T, sourceShards, targetShards []string) *testShardMigraterEnv {
 	tme := &testShardMigraterEnv{}
 	tme.ts = memorytopo.NewServer(ctx, "cell1", "cell2")
-	tme.wr = New(logutil.NewConsoleLogger(), tme.ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser())
+	tme.wr = New(logutil.NewConsoleLogger(), tme.ts, tmclient.NewTabletManagerClient(), collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	tme.sourceShards = sourceShards
 	tme.targetShards = targetShards
 	tme.tmeDB = fakesqldb.New(t)

--- a/go/vt/wrangler/vdiff_env_test.go
+++ b/go/vt/wrangler/vdiff_env_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -79,7 +80,7 @@ func newTestVDiffEnv(t testing.TB, ctx context.Context, sourceShards, targetShar
 		tabletType: topodatapb.TabletType_REPLICA,
 		tmc:        newTestVDiffTMClient(),
 	}
-	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	// Generate a unique dialer name.
 	dialerName := fmt.Sprintf("VDiffTest-%s-%d", t.Name(), rand.Intn(1000000000))

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
@@ -507,7 +508,7 @@ func TestVDiffPlanFailure(t *testing.T) {
 	}}
 	for _, tcase := range testcases {
 		filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
-		df := &vdiff{collationEnv: collations.MySQL8(), parser: sqlparser.NewTestParser()}
+		df := &vdiff{collationEnv: collations.MySQL8(), parser: sqlparser.NewTestParser(), mysqlVersion: config.DefaultMySQLVersion}
 		err := df.buildVDiffPlan(context.Background(), filter, schm, nil)
 		assert.EqualError(t, err, tcase.err, tcase.input)
 	}
@@ -1100,7 +1101,7 @@ func TestVDiffFindPKs(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := findPKs(tc.table, tc.targetSelect, tc.tdIn, collations.MySQL8(), sqlparser.NewTestParser())
+			_, err := findPKs(tc.table, tc.targetSelect, tc.tdIn, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			require.NoError(t, err)
 			require.EqualValues(t, tc.tdOut, tc.tdIn)
 		})
@@ -1137,7 +1138,7 @@ func TestVDiffPlanInclude(t *testing.T) {
 		}},
 	}
 
-	df := &vdiff{collationEnv: collations.MySQL8(), parser: sqlparser.NewTestParser()}
+	df := &vdiff{collationEnv: collations.MySQL8(), parser: sqlparser.NewTestParser(), mysqlVersion: config.DefaultMySQLVersion}
 	rule := &binlogdatapb.Rule{
 		Match: "/.*",
 	}
@@ -1258,7 +1259,7 @@ func TestGetColumnCollations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getColumnCollations(tt.table, collationEnv, sqlparser.NewTestParser())
+			got, err := getColumnCollations(tt.table, collationEnv, sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getColumnCollations() error = %v, wantErr = %t", err, tt.wantErr)
 				return

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/logutil"
@@ -56,7 +57,7 @@ func TestVExec(t *testing.T) {
 	env := newWranglerTestEnv(t, ctx, []string{"0"}, []string{"-80", "80-"}, nil, time.Now().Unix())
 	defer env.close()
 	var logger = logutil.NewMemoryLogger()
-	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	vx := newVExec(ctx, workflow, keyspace, query, wr)
 	err := vx.getPrimaries(nil)
@@ -203,7 +204,7 @@ func TestWorkflowListStreams(t *testing.T) {
 	env := newWranglerTestEnv(t, ctx, []string{"0"}, []string{"-80", "80-"}, nil, 1234)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
-	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	_, err := wr.WorkflowAction(ctx, workflow, keyspace, "listall", false, nil, nil)
 	require.NoError(t, err)
@@ -293,7 +294,7 @@ func TestWorkflowListAll(t *testing.T) {
 	env := newWranglerTestEnv(t, ctx, []string{"0"}, []string{"-80", "80-"}, nil, 0)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
-	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	workflows, err := wr.ListAllWorkflows(ctx, keyspace, true)
 	require.Nil(t, err)
@@ -314,7 +315,7 @@ func TestVExecValidations(t *testing.T) {
 	env := newWranglerTestEnv(t, ctx, []string{"0"}, []string{"-80", "80-"}, nil, 0)
 	defer env.close()
 
-	wr := New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 
 	vx := newVExec(ctx, workflow, keyspace, query, wr)
 
@@ -400,7 +401,7 @@ func TestWorkflowUpdate(t *testing.T) {
 	env := newWranglerTestEnv(t, ctx, []string{"0"}, []string{"-80", "80-"}, nil, 1234)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
-	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	wr := New(logger, env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	nullSlice := textutil.SimulatedNullStringSlice                   // Used to represent a non-provided value
 	nullOnDDL := binlogdatapb.OnDDLAction(textutil.SimulatedNullInt) // Used to represent a non-provided value
 	tests := []struct {

--- a/go/vt/wrangler/wrangler.go
+++ b/go/vt/wrangler/wrangler.go
@@ -61,19 +61,21 @@ type Wrangler struct {
 	sem            *semaphore.Weighted
 	collationEnv   *collations.Environment
 	parser         *sqlparser.Parser
+	mysqlVersion   string
 	WorkflowParams *VReplicationWorkflowParams
 }
 
 // New creates a new Wrangler object.
-func New(logger logutil.Logger, ts *topo.Server, tmc tmclient.TabletManagerClient, collationEnv *collations.Environment, parser *sqlparser.Parser) *Wrangler {
+func New(logger logutil.Logger, ts *topo.Server, tmc tmclient.TabletManagerClient, collationEnv *collations.Environment, parser *sqlparser.Parser, mysqlVersion string) *Wrangler {
 	return &Wrangler{
 		logger:       logger,
 		ts:           ts,
 		tmc:          tmc,
-		vtctld:       grpcvtctldserver.NewVtctldServer(ts, collationEnv, parser),
+		vtctld:       grpcvtctldserver.NewVtctldServer(ts, collationEnv, parser, mysqlVersion),
 		sourceTs:     ts,
 		collationEnv: collationEnv,
 		parser:       parser,
+		mysqlVersion: mysqlVersion,
 	}
 }
 

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
@@ -70,7 +71,7 @@ func newWranglerTestEnv(t testing.TB, ctx context.Context, sourceShards, targetS
 		tabletType: topodatapb.TabletType_REPLICA,
 		tmc:        newTestWranglerTMClient(),
 	}
-	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser())
+	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc, collations.MySQL8(), sqlparser.NewTestParser(), config.DefaultMySQLVersion)
 	env.tmc.tablets = make(map[int]*testWranglerTablet)
 
 	// Generate a unique dialer name.


### PR DESCRIPTION
This refactors out usage of `servenv` inside the `evalengine`. This helps `evalengine` be more of a standalone dependency, so it's easier to use and pulls in way fewer dependencies when used as a library

Transitively this also helps `schemadiff` which ends up using `evalengine` for view semantic analysis and heavily reduces `schemadiff` dependencies as well (together with the refactor also done in #14930. This is similar in nature as well as https://github.com/vitessio/vitess/pull/14822, https://github.com/vitessio/vitess/pull/14781 & https://github.com/vitessio/vitess/pull/14732

## Related Issue(s)

Part of #14717 and when used for https://github.com/planetscale/schemadiff greatly reduces dependencies (and binary size) there. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
