### PR TITLE
[vtcombo] Expose `--tablet_types_to_wait` flag

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -353,6 +353,7 @@ Flags:
       --tablet_manager_protocol string                                   Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
       --tablet_refresh_interval duration                                 Tablet refresh interval. (default 1m0s)
       --tablet_refresh_known_tablets                                     Whether to reload the tablet's address/port map from topo in case they change. (default true)
+      --tablet_types_to_wait strings                                     Wait till connected for specified tablet types during Gateway initialization. Should be provided as a comma-separated set of tablet types.
       --tablet_url_template string                                       Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this. (default "http://{{ "{{.GetTabletHostPort}}" }}")
       --throttle_tablet_types string                                     Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' always implicitly included (default "replica")
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)


### PR DESCRIPTION
## Description

At GitHub, we use `vtcombo` in our CI system and our local development environments.

While investigating slow CI setup times, I noticed that `vtcombo` by default is starting 3 tablets (`PRIMARY`, `RDONLY` and `REPLICA`) per keyspace/cell. For a small topology, that's not really an issue, but we run multiple hundreds of keyspaces in CI, and just starting this setup takes almost a minute.

This is quite wasteful, especially because we don't use `RDONLY` and `REPLICA` tablets at all in CI or local development. To improve this, we can set `replicaCount` to `1` to only start a single `REPLICA` tablet (which will be promoted to primary), and `rdonlyCount` to `-1` to start no `RDONLY` tablets.

Unfortunately, `vtcombo` will start `vtgate` and instruct it to wait for `PRIMARY,REPLICA,RDONLY` tablets to be available, which, based on the above configuration, won't ever happen. Eventually, the `vtgate` will run into a timeout while waiting and then start serving requests anyway.

Exposing the `tablet_types_to_wait` CLI flag allows setting the flag to e.g. `PRIMARY` only, which brings down the startup time for `vtcombo` to ~20 seconds in our setup, which is quite an improvement.

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
