### PR TITLE
ExecuteFetchAsDBA(): handle 'allowZeroInDate' and batched queries

### DIFF
--- a/go/vt/sqlparser/utils_test.go
+++ b/go/vt/sqlparser/utils_test.go
@@ -278,3 +278,72 @@ func TestReplaceTableQualifiers(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceTableQualifiersMultiQuery(t *testing.T) {
+	origDB := "_vt"
+	tests := []struct {
+		name    string
+		in      string
+		newdb   string
+		out     string
+		wantErr bool
+	}{
+		{
+			name:    "invalid select",
+			in:      "select frog bar person",
+			out:     "",
+			wantErr: true,
+		},
+		{
+			name: "simple select",
+			in:   "select * from _vt.foo",
+			out:  "select * from foo",
+		},
+		{
+			name:  "simple select with new db",
+			in:    "select * from _vt.foo",
+			newdb: "_vt_test",
+			out:   "select * from _vt_test.foo",
+		},
+		{
+			name:  "simple select with new db same",
+			in:    "select * from _vt.foo where id=1", // should be unchanged
+			newdb: "_vt",
+			out:   "select * from _vt.foo where id=1",
+		},
+		{
+			name:  "simple select with new db needing escaping",
+			in:    "select * from _vt.foo",
+			newdb: "1_vt-test",
+			out:   "select * from `1_vt-test`.foo",
+		},
+		{
+			name: "multi query",
+			in:   "select * from _vt.foo ; select * from _vt.bar",
+			out:  "select * from foo;select * from bar",
+		},
+		{
+			name:  "multi query with new db",
+			in:    "select * from _vt.foo ; select * from _vt.bar",
+			newdb: "_vt_test",
+			out:   "select * from _vt_test.foo;select * from _vt_test.bar",
+		},
+		{
+			name:    "multi query with error",
+			in:      "select * from _vt.foo ; select * from _vt.bar ; sel ect fr om wh at",
+			wantErr: true,
+		},
+	}
+	parser := NewTestParser()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.ReplaceTableQualifiersMultiQuery(tt.in, origDB, tt.newdb)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.out, got, "RemoveTableQualifiers(); in: %s, out: %s", tt.in, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This is a backport-compliant fix for https://github.com/vitessio/vitess/issues/14952. In this PR:

- `ExecuteFetchAsDBA()` correctly identifies the existence of `/*vt+ allowZeroInDate=true */` in either a single or a multi statement SQL. However, this is a hacky solution in that it is enough that a single query has this directive, that we apply it to all queries.
- `ExecuteFetchAsDBA()` drains the results of a multi-statement SQL, and as effect `ReloadSchema` loads all tables effected in a multi-statement SQL.

This is backport compliant solution, and so it intentionally **does not** error when a multi-statement SQL is provided. Technically, it's not the correct mechanism for running multiple queries, because it only returns a single result set.

A followup PR, that will build on top of this one for backwards compatibility reasons, will make `proto` changes to better formalize multi-statement SQLs as well as the request for a `allowZeroInDate` friendly connection.

## Backport

This should be backported to `release-18.0` because `--batch-size` is included in `release-18.0`.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/14952
- https://github.com/vitessio/vitess/issues/14948

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
