### PR TITLE
planner: support cross shard DELETE with LIMIT/ORDER BY

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
@@ -77,4 +78,53 @@ func TestMultiTableDelete(t *testing.T) {
 		`[[INT64(2) INT64(4) INT64(55)]]`)
 	mcmp.AssertMatches(`select oid, ename from oevent_tbl order by oid`,
 		`[[INT64(1) VARCHAR("a")] [INT64(2) VARCHAR("b")] [INT64(3) VARCHAR("a")] [INT64(4) VARCHAR("c")]]`)
+}
+
+// TestDeleteWithLimit executed delete queries with limit
+func TestDeleteWithLimit(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+
+	mcmp, closer := start(t)
+	defer closer()
+
+	// initial rows
+	mcmp.Exec("insert into s_tbl(id, num) values (1,10), (2,10), (3,10), (4,20), (5,5), (6,15), (7,17), (8,80)")
+	mcmp.Exec("insert into order_tbl(region_id, oid, cust_no) values (1,1,4), (1,2,2), (2,3,5), (2,4,55)")
+
+	// check rows
+	mcmp.AssertMatches(`select id, num from s_tbl order by id`,
+		`[[INT64(1) INT64(10)] [INT64(2) INT64(10)] [INT64(3) INT64(10)] [INT64(4) INT64(20)] [INT64(5) INT64(5)] [INT64(6) INT64(15)] [INT64(7) INT64(17)] [INT64(8) INT64(80)]]`)
+	mcmp.AssertMatches(`select region_id, oid, cust_no from order_tbl order by oid`,
+		`[[INT64(1) INT64(1) INT64(4)] [INT64(1) INT64(2) INT64(2)] [INT64(2) INT64(3) INT64(5)] [INT64(2) INT64(4) INT64(55)]]`)
+
+	// delete with limit
+	qr := mcmp.Exec(`delete from s_tbl order by num, id limit 3`)
+	require.EqualValues(t, 3, qr.RowsAffected)
+
+	qr = mcmp.Exec(`delete from order_tbl where region_id = 1 limit 1`)
+	require.EqualValues(t, 1, qr.RowsAffected)
+
+	// check rows
+	mcmp.AssertMatches(`select id, num from s_tbl order by id`,
+		`[[INT64(3) INT64(10)] [INT64(4) INT64(20)] [INT64(6) INT64(15)] [INT64(7) INT64(17)] [INT64(8) INT64(80)]]`)
+	// 2 rows matches but limit is 1, so any one of the row can remain in table.
+	mcmp.AssertMatchesAnyNoCompare(`select region_id, oid, cust_no from order_tbl order by oid`,
+		`[[INT64(1) INT64(2) INT64(2)] [INT64(2) INT64(3) INT64(5)] [INT64(2) INT64(4) INT64(55)]]`,
+		`[[INT64(1) INT64(1) INT64(4)] [INT64(2) INT64(3) INT64(5)] [INT64(2) INT64(4) INT64(55)]]`)
+
+	// delete with limit
+	qr = mcmp.Exec(`delete from s_tbl where num < 20 limit 2`)
+	require.EqualValues(t, 2, qr.RowsAffected)
+
+	qr = mcmp.Exec(`delete from order_tbl limit 5`)
+	require.EqualValues(t, 3, qr.RowsAffected)
+
+	// check rows
+	// 3 rows matches `num < 20` but limit is 2 so any one of them can remain in the table.
+	mcmp.AssertMatchesAnyNoCompare(`select id, num from s_tbl order by id`,
+		`[[INT64(4) INT64(20)] [INT64(7) INT64(17)] [INT64(8) INT64(80)]]`,
+		`[[INT64(3) INT64(10)] [INT64(4) INT64(20)] [INT64(8) INT64(80)]]`,
+		`[[INT64(4) INT64(20)] [INT64(6) INT64(15)] [INT64(8) INT64(80)]]`)
+	mcmp.AssertMatches(`select region_id, oid, cust_no from order_tbl order by oid`,
+		`[]`)
 }

--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -127,4 +127,16 @@ func TestDeleteWithLimit(t *testing.T) {
 		`[[INT64(4) INT64(20)] [INT64(6) INT64(15)] [INT64(8) INT64(80)]]`)
 	mcmp.AssertMatches(`select region_id, oid, cust_no from order_tbl order by oid`,
 		`[]`)
+
+	// remove all rows
+	mcmp.Exec(`delete from s_tbl`)
+	mcmp.Exec(`delete from order_tbl limit 5`)
+
+	// try with limit again on empty table.
+	qr = mcmp.Exec(`delete from s_tbl where num < 20 limit 2`)
+	require.EqualValues(t, 0, qr.RowsAffected)
+
+	qr = mcmp.Exec(`delete from order_tbl limit 5`)
+	require.EqualValues(t, 0, qr.RowsAffected)
+
 }

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -195,7 +195,7 @@ func (cached *DeleteWithInput) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(32)
+		size += int64(64)
 	}
 	// field Delete vitess.io/vitess/go/vt/vtgate/engine.Primitive
 	if cc, ok := cached.Delete.(cachedObject); ok {
@@ -204,6 +204,10 @@ func (cached *DeleteWithInput) CachedSize(alloc bool) int64 {
 	// field Input vitess.io/vitess/go/vt/vtgate/engine.Primitive
 	if cc, ok := cached.Input.(cachedObject); ok {
 		size += cc.CachedSize(true)
+	}
+	// field OutputCols []int
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.OutputCols)) * int64(8))
 	}
 	return size
 }

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -189,7 +189,7 @@ func (cached *Delete) CachedSize(alloc bool) int64 {
 	size += cached.DML.CachedSize(true)
 	return size
 }
-func (cached *DeleteMulti) CachedSize(alloc bool) int64 {
+func (cached *DeleteWithInput) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
 	}

--- a/go/vt/vtgate/engine/delete_multi.go
+++ b/go/vt/vtgate/engine/delete_multi.go
@@ -26,36 +26,36 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-var _ Primitive = (*DeleteMulti)(nil)
+var _ Primitive = (*DeleteWithInput)(nil)
 
 const DM_VALS = "dm_vals"
 
-// DeleteMulti represents the instructions to perform a delete.
-type DeleteMulti struct {
+// DeleteWithInput represents the instructions to perform a delete operation based on the input result.
+type DeleteWithInput struct {
 	Delete Primitive
 	Input  Primitive
 
 	txNeeded
 }
 
-func (del *DeleteMulti) RouteType() string {
-	return "DELETEMULTI"
+func (del *DeleteWithInput) RouteType() string {
+	return "DeleteWithInput"
 }
 
-func (del *DeleteMulti) GetKeyspaceName() string {
+func (del *DeleteWithInput) GetKeyspaceName() string {
 	return del.Input.GetKeyspaceName()
 }
 
-func (del *DeleteMulti) GetTableName() string {
+func (del *DeleteWithInput) GetTableName() string {
 	return del.Input.GetTableName()
 }
 
-func (del *DeleteMulti) Inputs() ([]Primitive, []map[string]any) {
+func (del *DeleteWithInput) Inputs() ([]Primitive, []map[string]any) {
 	return []Primitive{del.Input, del.Delete}, nil
 }
 
 // TryExecute performs a non-streaming exec.
-func (del *DeleteMulti) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, _ bool) (*sqltypes.Result, error) {
+func (del *DeleteWithInput) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, _ bool) (*sqltypes.Result, error) {
 	inputRes, err := vcursor.ExecutePrimitive(ctx, del.Input, bindVars, false)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (del *DeleteMulti) TryExecute(ctx context.Context, vcursor VCursor, bindVar
 }
 
 // TryStreamExecute performs a streaming exec.
-func (del *DeleteMulti) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+func (del *DeleteWithInput) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
 	res, err := del.TryExecute(ctx, vcursor, bindVars, wantfields)
 	if err != nil {
 		return err
@@ -82,13 +82,13 @@ func (del *DeleteMulti) TryStreamExecute(ctx context.Context, vcursor VCursor, b
 }
 
 // GetFields fetches the field info.
-func (del *DeleteMulti) GetFields(context.Context, VCursor, map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (del *DeleteWithInput) GetFields(context.Context, VCursor, map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.VT13001("unreachable code for MULTI DELETE")
 }
 
-func (del *DeleteMulti) description() PrimitiveDescription {
+func (del *DeleteWithInput) description() PrimitiveDescription {
 	return PrimitiveDescription{
-		OperatorType:     "DeleteMulti",
+		OperatorType:     "DeleteWithInput",
 		TargetTabletType: topodatapb.TabletType_PRIMARY,
 	}
 }

--- a/go/vt/vtgate/engine/delete_multi_test.go
+++ b/go/vt/vtgate/engine/delete_multi_test.go
@@ -31,7 +31,7 @@ func TestDeleteMulti(t *testing.T) {
 		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3"),
 	}}
 
-	del := &DeleteMulti{
+	del := &DeleteWithInput{
 		Input: input,
 		Delete: &Delete{
 			DML: &DML{

--- a/go/vt/vtgate/engine/delete_with_input.go
+++ b/go/vt/vtgate/engine/delete_with_input.go
@@ -28,7 +28,7 @@ import (
 
 var _ Primitive = (*DeleteWithInput)(nil)
 
-const DM_VALS = "dm_vals"
+const DmVals = "dm_vals"
 
 // DeleteWithInput represents the instructions to perform a delete operation based on the input result.
 type DeleteWithInput struct {
@@ -70,7 +70,7 @@ func (del *DeleteWithInput) TryExecute(ctx context.Context, vcursor VCursor, bin
 		bv = getBVMulti(inputRes, del.OutputCols)
 	}
 
-	bindVars[DM_VALS] = bv
+	bindVars[DmVals] = bv
 	return vcursor.ExecutePrimitive(ctx, del.Delete, bindVars, false)
 }
 

--- a/go/vt/vtgate/engine/delete_with_input_test.go
+++ b/go/vt/vtgate/engine/delete_with_input_test.go
@@ -26,7 +26,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
-func TestDeleteMulti(t *testing.T) {
+func TestDeleteWithInput(t *testing.T) {
 	input := &fakePrimitive{results: []*sqltypes.Result{
 		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3"),
 	}}

--- a/go/vt/vtgate/engine/delete_with_input_test.go
+++ b/go/vt/vtgate/engine/delete_with_input_test.go
@@ -23,10 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
-func TestDeleteWithInput(t *testing.T) {
+func TestDeleteWithInputSingleOffset(t *testing.T) {
 	input := &fakePrimitive{results: []*sqltypes.Result{
 		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3"),
 	}}
@@ -45,26 +46,71 @@ func TestDeleteWithInput(t *testing.T) {
 				Query: "dummy_delete",
 			},
 		},
+		OutputCols: []int{0},
 	}
 
 	vc := newDMLTestVCursor("-20", "20-")
-	_, err := del.TryExecute(context.Background(), vc, nil, false)
+	_, err := del.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
 		`ExecuteMultiShard ` +
-			`ks.-20: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x89\x02\x011"} values:{type:TUPLE value:"\x89\x02\x012"} values:{type:TUPLE value:"\x89\x02\x013"}} ` +
-			`ks.20-: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x89\x02\x011"} values:{type:TUPLE value:"\x89\x02\x012"} values:{type:TUPLE value:"\x89\x02\x013"}} true false`,
+			`ks.-20: dummy_delete {dm_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} ` +
+			`ks.20-: dummy_delete {dm_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} true false`,
 	})
 
 	vc.Rewind()
 	input.rewind()
-	err = del.TryStreamExecute(context.Background(), vc, nil, false, func(result *sqltypes.Result) error { return nil })
+	err = del.TryStreamExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false, func(result *sqltypes.Result) error { return nil })
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
 		`ExecuteMultiShard ` +
-			`ks.-20: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x89\x02\x011"} values:{type:TUPLE value:"\x89\x02\x012"} values:{type:TUPLE value:"\x89\x02\x013"}} ` +
-			`ks.20-: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x89\x02\x011"} values:{type:TUPLE value:"\x89\x02\x012"} values:{type:TUPLE value:"\x89\x02\x013"}} true false`,
+			`ks.-20: dummy_delete {dm_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} ` +
+			`ks.20-: dummy_delete {dm_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} true false`,
+	})
+}
+
+func TestDeleteWithInputMultiOffset(t *testing.T) {
+	input := &fakePrimitive{results: []*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|col", "int64|varchar"), "1|a", "2|b", "3|c"),
+	}}
+
+	del := &DeleteWithInput{
+		Input: input,
+		Delete: &Delete{
+			DML: &DML{
+				RoutingParameters: &RoutingParameters{
+					Opcode: Scatter,
+					Keyspace: &vindexes.Keyspace{
+						Name:    "ks",
+						Sharded: true,
+					},
+				},
+				Query: "dummy_delete",
+			},
+		},
+		OutputCols: []int{1, 0},
+	}
+
+	vc := newDMLTestVCursor("-20", "20-")
+	_, err := del.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ` +
+			`ks.-20: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x950\x01a\x89\x02\x011"} values:{type:TUPLE value:"\x950\x01b\x89\x02\x012"} values:{type:TUPLE value:"\x950\x01c\x89\x02\x013"}} ` +
+			`ks.20-: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x950\x01a\x89\x02\x011"} values:{type:TUPLE value:"\x950\x01b\x89\x02\x012"} values:{type:TUPLE value:"\x950\x01c\x89\x02\x013"}} true false`,
+	})
+
+	vc.Rewind()
+	input.rewind()
+	err = del.TryStreamExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false, func(result *sqltypes.Result) error { return nil })
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ` +
+			`ks.-20: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x950\x01a\x89\x02\x011"} values:{type:TUPLE value:"\x950\x01b\x89\x02\x012"} values:{type:TUPLE value:"\x950\x01c\x89\x02\x013"}} ` +
+			`ks.20-: dummy_delete {dm_vals: type:TUPLE values:{type:TUPLE value:"\x950\x01a\x89\x02\x011"} values:{type:TUPLE value:"\x950\x01b\x89\x02\x012"} values:{type:TUPLE value:"\x950\x01c\x89\x02\x013"}} true false`,
 	})
 }

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -3018,11 +3018,11 @@ func TestInsertReference(t *testing.T) {
 	require.NoError(t, err) // Gen4 planner can redirect the query to correct source for update when reference table is involved.
 }
 
-func TestDeleteMulti(t *testing.T) {
+func TestDeleteMultiTable(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup, ctx := createExecutorEnv(t)
 	executor.vschema.Keyspaces["TestExecutor"].Tables["user"].PrimaryKey = sqlparser.Columns{sqlparser.NewIdentifierCI("id")}
 
-	logChan := executor.queryLogger.Subscribe("TestDeleteMulti")
+	logChan := executor.queryLogger.Subscribe("TestDeleteMultiTable")
 	defer executor.queryLogger.Unsubscribe(logChan)
 
 	session := &vtgatepb.Session{TargetString: "@primary"}

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -3031,7 +3031,7 @@ func TestDeleteMultiTable(t *testing.T) {
 
 	var dmlVals []*querypb.Value
 	for i := 0; i < 8; i++ {
-		dmlVals = append(dmlVals, sqltypes.TupleToProto([]sqltypes.Value{sqltypes.TestValue(sqltypes.Int32, "1")}))
+		dmlVals = append(dmlVals, sqltypes.ValueToProto(sqltypes.NewInt32(1)))
 	}
 
 	bq := &querypb.BoundQuery{
@@ -3041,14 +3041,14 @@ func TestDeleteMultiTable(t *testing.T) {
 	wantQueries := []*querypb.BoundQuery{
 		{Sql: "select `user`.id, `user`.col from `user`", BindVariables: map[string]*querypb.BindVariable{}},
 		bq, bq, bq, bq, bq, bq, bq, bq,
-		{Sql: "select `user`.Id, `user`.`name` from `user` where (`user`.id) in ::dm_vals for update", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}},
-		{Sql: "delete from `user` where (`user`.id) in ::dm_vals", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}}}
+		{Sql: "select `user`.Id, `user`.`name` from `user` where `user`.id in ::dm_vals for update", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}},
+		{Sql: "delete from `user` where `user`.id in ::dm_vals", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}}}
 	assertQueries(t, sbc1, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{
 		{Sql: "select `user`.id, `user`.col from `user`", BindVariables: map[string]*querypb.BindVariable{}},
-		{Sql: "select `user`.Id, `user`.`name` from `user` where (`user`.id) in ::dm_vals for update", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}},
-		{Sql: "delete from `user` where (`user`.id) in ::dm_vals", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}},
+		{Sql: "select `user`.Id, `user`.`name` from `user` where `user`.id in ::dm_vals for update", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}},
+		{Sql: "delete from `user` where `user`.id in ::dm_vals", BindVariables: map[string]*querypb.BindVariable{"dm_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}},
 	}
 	assertQueries(t, sbc2, wantQueries)
 

--- a/go/vt/vtgate/planbuilder/delete_multi.go
+++ b/go/vt/vtgate/planbuilder/delete_multi.go
@@ -31,7 +31,7 @@ var _ logicalPlan = (*deleteMulti)(nil)
 func (d *deleteMulti) Primitive() engine.Primitive {
 	inp := d.input.Primitive()
 	del := d.delete.Primitive()
-	return &engine.DeleteMulti{
+	return &engine.DeleteWithInput{
 		Delete: del,
 		Input:  inp,
 	}

--- a/go/vt/vtgate/planbuilder/delete_with_input.go
+++ b/go/vt/vtgate/planbuilder/delete_with_input.go
@@ -20,19 +20,22 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
-type deleteMulti struct {
+type deleteWithInput struct {
 	input  logicalPlan
 	delete logicalPlan
+
+	outputCols []int
 }
 
-var _ logicalPlan = (*deleteMulti)(nil)
+var _ logicalPlan = (*deleteWithInput)(nil)
 
 // Primitive implements the logicalPlan interface
-func (d *deleteMulti) Primitive() engine.Primitive {
+func (d *deleteWithInput) Primitive() engine.Primitive {
 	inp := d.input.Primitive()
 	del := d.delete.Primitive()
 	return &engine.DeleteWithInput{
-		Delete: del,
-		Input:  inp,
+		Delete:     del,
+		Input:      inp,
+		OutputCols: d.outputCols,
 	}
 }

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -75,13 +75,13 @@ func transformToLogicalPlan(ctx *plancontext.PlanningContext, op operators.Opera
 	case *operators.Sequential:
 		return transformSequential(ctx, op)
 	case *operators.DeleteWithInput:
-		return transformDeleteMulti(ctx, op)
+		return transformDeleteWithInput(ctx, op)
 	}
 
 	return nil, vterrors.VT13001(fmt.Sprintf("unknown type encountered: %T (transformToLogicalPlan)", op))
 }
 
-func transformDeleteMulti(ctx *plancontext.PlanningContext, op *operators.DeleteWithInput) (logicalPlan, error) {
+func transformDeleteWithInput(ctx *plancontext.PlanningContext, op *operators.DeleteWithInput) (logicalPlan, error) {
 	input, err := transformToLogicalPlan(ctx, op.Source)
 	if err != nil {
 		return nil, err
@@ -91,9 +91,10 @@ func transformDeleteMulti(ctx *plancontext.PlanningContext, op *operators.Delete
 	if err != nil {
 		return nil, err
 	}
-	return &deleteMulti{
-		input:  input,
-		delete: del,
+	return &deleteWithInput{
+		input:      input,
+		delete:     del,
+		outputCols: op.Offsets,
 	}, nil
 }
 

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -74,14 +74,14 @@ func transformToLogicalPlan(ctx *plancontext.PlanningContext, op operators.Opera
 		return transformHashJoin(ctx, op)
 	case *operators.Sequential:
 		return transformSequential(ctx, op)
-	case *operators.DeleteMulti:
+	case *operators.DeleteWithInput:
 		return transformDeleteMulti(ctx, op)
 	}
 
 	return nil, vterrors.VT13001(fmt.Sprintf("unknown type encountered: %T (transformToLogicalPlan)", op))
 }
 
-func transformDeleteMulti(ctx *plancontext.PlanningContext, op *operators.DeleteMulti) (logicalPlan, error) {
+func transformDeleteMulti(ctx *plancontext.PlanningContext, op *operators.DeleteWithInput) (logicalPlan, error) {
 	input, err := transformToLogicalPlan(ctx, op.Source)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -401,8 +401,8 @@ func buildDelete(op *Delete, qb *queryBuilder) {
 		Targets:    sqlparser.TableNames{op.Target.Name},
 		TableExprs: sel.From,
 		Where:      sel.Where,
-		OrderBy:    op.OrderBy,
-		Limit:      op.Limit,
+		Limit:      sel.Limit,
+		OrderBy:    sel.OrderBy,
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -29,8 +29,6 @@ import (
 type Delete struct {
 	Target           TargetTable
 	OwnedVindexQuery *sqlparser.Select
-	OrderBy          sqlparser.OrderBy
-	Limit            *sqlparser.Limit
 	Ignore           bool
 	Source           Operator
 
@@ -78,12 +76,6 @@ func (d *Delete) GetOrdering(*plancontext.PlanningContext) []OrderBy {
 func (d *Delete) ShortDescription() string {
 	limit := ""
 	orderBy := ""
-	if d.Limit != nil {
-		limit = " " + sqlparser.String(d.Limit)
-	}
-	if len(d.OrderBy) > 0 {
-		orderBy = " " + sqlparser.String(d.OrderBy)
-	}
 
 	return fmt.Sprintf("%s.%s%s%s", d.Target.VTable.Keyspace.Name, d.Target.VTable.Name.String(), orderBy, limit)
 }
@@ -157,13 +149,47 @@ func createDeleteOperator(ctx *plancontext.PlanningContext, del *sqlparser.Delet
 		}
 	}
 
-	return &Delete{
+	delOp := &Delete{
 		Target:           targetTbl,
 		Source:           op,
 		Ignore:           bool(del.Ignore),
-		Limit:            del.Limit,
-		OrderBy:          del.OrderBy,
 		OwnedVindexQuery: ovq,
+	}
+
+	if del.Limit == nil {
+		return delOp
+	}
+
+	addOrdering(ctx, del, delOp)
+
+	delOp.Source = &Limit{
+		Source: delOp.Source,
+		AST:    del.Limit,
+	}
+
+	return delOp
+}
+
+func addOrdering(ctx *plancontext.PlanningContext, del *sqlparser.Delete, delOp *Delete) {
+	es := &expressionSet{}
+	ordering := &Ordering{
+		Source: delOp.Source,
+	}
+	for _, order := range del.OrderBy {
+		if sqlparser.IsNull(order.Expr) {
+			// ORDER BY null can safely be ignored
+			continue
+		}
+		if !es.add(ctx, order.Expr) {
+			continue
+		}
+		ordering.Order = append(ordering.Order, OrderBy{
+			Inner:          sqlparser.CloneRefOfOrder(order),
+			SimplifiedExpr: order.Expr,
+		})
+	}
+	if len(ordering.Order) > 0 {
+		delOp.Source = ordering
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -74,10 +74,7 @@ func (d *Delete) GetOrdering(*plancontext.PlanningContext) []OrderBy {
 }
 
 func (d *Delete) ShortDescription() string {
-	limit := ""
-	orderBy := ""
-
-	return fmt.Sprintf("%s.%s%s%s", d.Target.VTable.Keyspace.Name, d.Target.VTable.Name.String(), orderBy, limit)
+	return fmt.Sprintf("%s.%s", d.Target.VTable.Keyspace.Name, d.Target.VTable.Name.String())
 }
 
 func createOperatorFromDelete(ctx *plancontext.PlanningContext, deleteStmt *sqlparser.Delete) (op Operator) {

--- a/go/vt/vtgate/planbuilder/operators/delete_multi.go
+++ b/go/vt/vtgate/planbuilder/operators/delete_multi.go
@@ -18,7 +18,7 @@ package operators
 
 import "vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 
-type DeleteMulti struct {
+type DeleteWithInput struct {
 	Source Operator
 	Delete Operator
 
@@ -26,30 +26,30 @@ type DeleteMulti struct {
 	noPredicates
 }
 
-func (d *DeleteMulti) Clone(inputs []Operator) Operator {
+func (d *DeleteWithInput) Clone(inputs []Operator) Operator {
 	newD := *d
 	newD.SetInputs(inputs)
 	return &newD
 }
 
-func (d *DeleteMulti) Inputs() []Operator {
+func (d *DeleteWithInput) Inputs() []Operator {
 	return []Operator{d.Source, d.Delete}
 }
 
-func (d *DeleteMulti) SetInputs(inputs []Operator) {
+func (d *DeleteWithInput) SetInputs(inputs []Operator) {
 	if len(inputs) != 2 {
-		panic("unexpected number of inputs for DeleteMulti operator")
+		panic("unexpected number of inputs for DeleteWithInput operator")
 	}
 	d.Source = inputs[0]
 	d.Delete = inputs[1]
 }
 
-func (d *DeleteMulti) ShortDescription() string {
+func (d *DeleteWithInput) ShortDescription() string {
 	return ""
 }
 
-func (d *DeleteMulti) GetOrdering(ctx *plancontext.PlanningContext) []OrderBy {
+func (d *DeleteWithInput) GetOrdering(ctx *plancontext.PlanningContext) []OrderBy {
 	return nil
 }
 
-var _ Operator = (*DeleteMulti)(nil)
+var _ Operator = (*DeleteWithInput)(nil)

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -35,6 +35,7 @@ const (
 	delegateAggregation
 	addAggrOrdering
 	cleanOutPerfDistinct
+	deleteWithInput
 	subquerySettling
 	DONE
 )
@@ -55,6 +56,8 @@ func (p Phase) String() string {
 		return "optimize Distinct operations"
 	case subquerySettling:
 		return "settle subqueries"
+	case deleteWithInput:
+		return "expand delete to delete with input"
 	default:
 		panic(vterrors.VT13001("unhandled default case"))
 	}
@@ -72,6 +75,8 @@ func (p Phase) shouldRun(s semantics.QuerySignature) bool {
 		return s.Distinct
 	case subquerySettling:
 		return s.SubQueries
+	case deleteWithInput:
+		return s.Delete
 	default:
 		return true
 	}
@@ -89,6 +94,8 @@ func (p Phase) act(ctx *plancontext.PlanningContext, op Operator) Operator {
 		return removePerformanceDistinctAboveRoute(ctx, op)
 	case subquerySettling:
 		return settleSubqueries(ctx, op)
+	case deleteWithInput:
+		return findDeletesAboveRoute(ctx, op)
 	default:
 		return op
 	}
@@ -111,6 +118,19 @@ func (p *phaser) next(ctx *plancontext.PlanningContext) Phase {
 			return curr
 		}
 	}
+}
+
+func findDeletesAboveRoute(ctx *plancontext.PlanningContext, root Operator) Operator {
+	visitor := func(in Operator, _ semantics.TableSet, isRoot bool) (Operator, *ApplyResult) {
+		delOp, ok := in.(*Delete)
+		if !ok {
+			return in, NoRewrite
+		}
+
+		return createDeleteWithInput(ctx, delOp, delOp.Source)
+	}
+
+	return BottomUp(root, TableID, visitor, stopAtRoute)
 }
 
 func removePerformanceDistinctAboveRoute(_ *plancontext.PlanningContext, op Operator) Operator {

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -164,7 +164,7 @@ func createDeleteWithInput(ctx *plancontext.PlanningContext, in *Delete, src Ope
 	if len(leftComp) == 1 {
 		lhs = leftComp[0]
 	}
-	compExpr := sqlparser.NewComparisonExpr(sqlparser.InOp, lhs, sqlparser.ListArg(engine.DM_VALS), nil)
+	compExpr := sqlparser.NewComparisonExpr(sqlparser.InOp, lhs, sqlparser.ListArg(engine.DmVals), nil)
 	targetQT := targetTable.QTable
 	qt := &QueryTable{
 		ID:         targetQT.ID,

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -159,7 +159,12 @@ func createDeleteWithInput(ctx *plancontext.PlanningContext, in *Delete, src Ope
 		panic(vterrors.VT13001("target DELETE table not found"))
 	}
 
-	compExpr := sqlparser.NewComparisonExpr(sqlparser.InOp, leftComp, sqlparser.ListArg(engine.DM_VALS), nil)
+	// optimize for case when there is only single column on left hand side.
+	var lhs sqlparser.Expr = leftComp
+	if len(leftComp) == 1 {
+		lhs = leftComp[0]
+	}
+	compExpr := sqlparser.NewComparisonExpr(sqlparser.InOp, lhs, sqlparser.ListArg(engine.DM_VALS), nil)
 	targetQT := targetTable.QTable
 	qt := &QueryTable{
 		ID:         targetQT.ID,

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -109,11 +109,10 @@ func runRewriters(ctx *plancontext.PlanningContext, root Operator) Operator {
 }
 
 func tryPushDelete(in *Delete) (Operator, *ApplyResult) {
-	switch src := in.Source.(type) {
-	case *Route:
+	if src, ok := in.Source.(*Route); ok {
 		return pushDeleteUnderRoute(in, src)
 	}
-	return in, nil
+	return in, NoRewrite
 }
 
 func pushDeleteUnderRoute(in *Delete, src *Route) (Operator, *ApplyResult) {
@@ -159,11 +158,7 @@ func createDeleteWithInput(ctx *plancontext.PlanningContext, in *Delete, src Ope
 		panic(vterrors.VT13001("target DELETE table not found"))
 	}
 
-	var lhs sqlparser.Expr = leftComp
-	if len(leftComp) == 1 {
-		lhs = leftComp[0]
-	}
-	compExpr := sqlparser.NewComparisonExpr(sqlparser.InOp, lhs, sqlparser.ListArg(engine.DM_VALS), nil)
+	compExpr := sqlparser.NewComparisonExpr(sqlparser.InOp, leftComp, sqlparser.ListArg(engine.DM_VALS), nil)
 	targetQT := targetTable.QTable
 	qt := &QueryTable{
 		ID:         targetQT.ID,

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -139,7 +139,8 @@ func createDeleteWithInput(ctx *plancontext.PlanningContext, in *Delete, src Ope
 	proj := newAliasedProjection(src)
 	for _, col := range in.Target.VTable.PrimaryKey {
 		colName := sqlparser.NewColNameWithQualifier(col.String(), in.Target.Name)
-		proj.AddColumn(ctx, true, false, sqlparser.NewAliasedExpr(colName, ""))
+		proj.AddColumn(ctx, true, false, aeWrap(colName))
+		dm.cols = append(dm.cols, colName)
 		leftComp = append(leftComp, colName)
 		ctx.SemTable.Recursive[colName] = in.Target.ID
 	}

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -5100,7 +5100,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5108,11 +5108,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select `user`.Id, `user`.`Name`, `user`.Costly from `user` where (`user`.id) in ::dm_vals for update",
-            "Query": "delete from `user` where (`user`.id) in ::dm_vals",
+            "OwnedVindexQuery": "select `user`.Id, `user`.`Name`, `user`.Costly from `user` where `user`.id in ::dm_vals for update",
+            "Query": "delete from `user` where `user`.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5172,7 +5172,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5180,11 +5180,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
-            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
+            "Query": "delete from `user` as u where u.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5244,7 +5244,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5252,11 +5252,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
-            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
+            "Query": "delete from `user` as u where u.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5342,7 +5342,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5350,11 +5350,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
-            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
+            "Query": "delete from `user` as u where u.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5415,7 +5415,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5423,11 +5423,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select m.user_id, m.id from music as m where (m.id) in ::dm_vals for update",
-            "Query": "delete from music as m where (m.id) in ::dm_vals",
+            "OwnedVindexQuery": "select m.user_id, m.id from music as m where m.id in ::dm_vals for update",
+            "Query": "delete from music as m where m.id in ::dm_vals",
             "Table": "music",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "music_user_map"
           }
@@ -5472,7 +5472,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5480,11 +5480,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where (`user`.id) in ::dm_vals limit 10 for update",
-            "Query": "delete from `user` where (`user`.id) in ::dm_vals",
+            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id in ::dm_vals limit 10 for update",
+            "Query": "delete from `user` where `user`.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5528,7 +5528,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5536,11 +5536,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where (`user`.id) in ::dm_vals order by `name` asc, col asc limit 5 for update",
-            "Query": "delete from `user` where (`user`.id) in ::dm_vals",
+            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id in ::dm_vals order by `name` asc, col asc limit 5 for update",
+            "Query": "delete from `user` where `user`.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -5057,6 +5057,9 @@
       "Instructions": {
         "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
+        "Offset": [
+          0
+        ],
         "Inputs": [
           {
             "OperatorType": "Join",
@@ -5130,6 +5133,9 @@
       "Instructions": {
         "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
+        "Offset": [
+          0
+        ],
         "Inputs": [
           {
             "OperatorType": "Join",
@@ -5199,6 +5205,9 @@
       "Instructions": {
         "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
+        "Offset": [
+          0
+        ],
         "Inputs": [
           {
             "OperatorType": "Join",
@@ -5294,6 +5303,9 @@
       "Instructions": {
         "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
+        "Offset": [
+          0
+        ],
         "Inputs": [
           {
             "OperatorType": "Join",
@@ -5364,6 +5376,9 @@
       "Instructions": {
         "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
+        "Offset": [
+          0
+        ],
         "Inputs": [
           {
             "OperatorType": "Join",
@@ -5434,6 +5449,9 @@
       "Instructions": {
         "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
+        "Offset": [
+          0
+        ],
         "Inputs": [
           {
             "OperatorType": "Limit",
@@ -5463,6 +5481,62 @@
             "KsidLength": 1,
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where (`user`.id) in ::dm_vals limit 10 for update",
+            "Query": "delete from `user` where (`user`.id) in ::dm_vals",
+            "Table": "user",
+            "Values": [
+              "dm_vals:0"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "sharded delete with order by and limit clause",
+    "query": "delete from user order by name, col limit 5",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from user order by name, col limit 5",
+      "Instructions": {
+        "OperatorType": "DeleteWithInput",
+        "TargetTabletType": "PRIMARY",
+        "Offset": [
+          0
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Limit",
+            "Count": "5",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.id, `name`, weight_string(`name`), col from `user` where 1 != 1",
+                "OrderBy": "(1|2) ASC, 3 ASC",
+                "Query": "select `user`.id, `name`, weight_string(`name`), col from `user` order by `name` asc, col asc limit :__upper_limit",
+                "Table": "`user`"
+              }
+            ]
+          },
+          {
+            "OperatorType": "Delete",
+            "Variant": "MultiEqual",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "KsidLength": 1,
+            "KsidVindex": "user_index",
+            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where (`user`.id) in ::dm_vals order by `name` asc, col asc limit 5 for update",
             "Query": "delete from `user` where (`user`.id) in ::dm_vals",
             "Table": "user",
             "Values": [

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -5097,7 +5097,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5105,11 +5105,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select `user`.Id, `user`.`Name`, `user`.Costly from `user` where (`user`.id) in ::dm_vals for update",
-            "Query": "delete from `user` where (`user`.id) in ::dm_vals",
+            "OwnedVindexQuery": "select `user`.Id, `user`.`Name`, `user`.Costly from `user` where `user`.id in ::dm_vals for update",
+            "Query": "delete from `user` where `user`.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5166,7 +5166,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5174,11 +5174,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
-            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
+            "Query": "delete from `user` as u where u.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5235,7 +5235,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5243,11 +5243,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
-            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
+            "Query": "delete from `user` as u where u.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5330,7 +5330,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5338,11 +5338,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
-            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
+            "Query": "delete from `user` as u where u.id in ::dm_vals",
             "Table": "user",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "user_index"
           }
@@ -5400,7 +5400,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "MultiEqual",
+            "Variant": "IN",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5408,11 +5408,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select m.user_id, m.id from music as m where (m.id) in ::dm_vals for update",
-            "Query": "delete from music as m where (m.id) in ::dm_vals",
+            "OwnedVindexQuery": "select m.user_id, m.id from music as m where m.id in ::dm_vals for update",
+            "Query": "delete from music as m where m.id in ::dm_vals",
             "Table": "music",
             "Values": [
-              "dm_vals:0"
+              "::dm_vals"
             ],
             "Vindex": "music_user_map"
           }
@@ -5422,6 +5422,58 @@
         "user.music",
         "user.user",
         "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "sharded delete with limit clause",
+    "query": "delete from user limit 10",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from user limit 10",
+      "Instructions": {
+        "OperatorType": "DeleteMulti",
+        "TargetTabletType": "PRIMARY",
+        "Inputs": [
+          {
+            "OperatorType": "Limit",
+            "Count": "10",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.id from `user` where 1 != 1",
+                "Query": "select `user`.id from `user` limit :__upper_limit",
+                "Table": "`user`"
+              }
+            ]
+          },
+          {
+            "OperatorType": "Delete",
+            "Variant": "IN",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "KsidLength": 1,
+            "KsidVindex": "user_index",
+            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id in ::dm_vals limit 10 for update",
+            "Query": "delete from `user` where `user`.id in ::dm_vals",
+            "Table": "user",
+            "Values": [
+              "::dm_vals"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
       ]
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -5055,7 +5055,7 @@
       "QueryType": "DELETE",
       "Original": "delete user from user join user_extra on user.id = user_extra.id where user.name = 'foo'",
       "Instructions": {
-        "OperatorType": "DeleteMulti",
+        "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
         "Inputs": [
           {
@@ -5097,7 +5097,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "IN",
+            "Variant": "MultiEqual",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5105,11 +5105,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select `user`.Id, `user`.`Name`, `user`.Costly from `user` where `user`.id in ::dm_vals for update",
-            "Query": "delete from `user` where `user`.id in ::dm_vals",
+            "OwnedVindexQuery": "select `user`.Id, `user`.`Name`, `user`.Costly from `user` where (`user`.id) in ::dm_vals for update",
+            "Query": "delete from `user` where (`user`.id) in ::dm_vals",
             "Table": "user",
             "Values": [
-              "::dm_vals"
+              "dm_vals:0"
             ],
             "Vindex": "user_index"
           }
@@ -5128,7 +5128,7 @@
       "QueryType": "DELETE",
       "Original": "delete u from user u join music m on u.col = m.col",
       "Instructions": {
-        "OperatorType": "DeleteMulti",
+        "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
         "Inputs": [
           {
@@ -5166,7 +5166,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "IN",
+            "Variant": "MultiEqual",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5174,11 +5174,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
-            "Query": "delete from `user` as u where u.id in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
+            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
             "Table": "user",
             "Values": [
-              "::dm_vals"
+              "dm_vals:0"
             ],
             "Vindex": "user_index"
           }
@@ -5197,7 +5197,7 @@
       "QueryType": "DELETE",
       "Original": "delete u from music m join user u where u.col = m.col and m.foo = 42",
       "Instructions": {
-        "OperatorType": "DeleteMulti",
+        "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
         "Inputs": [
           {
@@ -5235,7 +5235,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "IN",
+            "Variant": "MultiEqual",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5243,11 +5243,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
-            "Query": "delete from `user` as u where u.id in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
+            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
             "Table": "user",
             "Values": [
-              "::dm_vals"
+              "dm_vals:0"
             ],
             "Vindex": "user_index"
           }
@@ -5292,7 +5292,7 @@
       "QueryType": "DELETE",
       "Original": "delete u from user u join music m on u.col = m.col join user_extra ue on m.user_id = ue.user_id where ue.foo = 20 and u.col = 30 and m.bar = 40",
       "Instructions": {
-        "OperatorType": "DeleteMulti",
+        "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
         "Inputs": [
           {
@@ -5330,7 +5330,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "IN",
+            "Variant": "MultiEqual",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5338,11 +5338,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dm_vals for update",
-            "Query": "delete from `user` as u where u.id in ::dm_vals",
+            "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where (u.id) in ::dm_vals for update",
+            "Query": "delete from `user` as u where (u.id) in ::dm_vals",
             "Table": "user",
             "Values": [
-              "::dm_vals"
+              "dm_vals:0"
             ],
             "Vindex": "user_index"
           }
@@ -5362,7 +5362,7 @@
       "QueryType": "DELETE",
       "Original": "delete m from user u join music m on u.col = m.col join user_extra ue on m.user_id = ue.user_id where ue.foo = 20 and u.col = 30 and m.bar = 40",
       "Instructions": {
-        "OperatorType": "DeleteMulti",
+        "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
         "Inputs": [
           {
@@ -5400,7 +5400,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "IN",
+            "Variant": "MultiEqual",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5408,11 +5408,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select m.user_id, m.id from music as m where m.id in ::dm_vals for update",
-            "Query": "delete from music as m where m.id in ::dm_vals",
+            "OwnedVindexQuery": "select m.user_id, m.id from music as m where (m.id) in ::dm_vals for update",
+            "Query": "delete from music as m where (m.id) in ::dm_vals",
             "Table": "music",
             "Values": [
-              "::dm_vals"
+              "dm_vals:0"
             ],
             "Vindex": "music_user_map"
           }
@@ -5432,7 +5432,7 @@
       "QueryType": "DELETE",
       "Original": "delete from user limit 10",
       "Instructions": {
-        "OperatorType": "DeleteMulti",
+        "OperatorType": "DeleteWithInput",
         "TargetTabletType": "PRIMARY",
         "Inputs": [
           {
@@ -5454,7 +5454,7 @@
           },
           {
             "OperatorType": "Delete",
-            "Variant": "IN",
+            "Variant": "MultiEqual",
             "Keyspace": {
               "Name": "user",
               "Sharded": true
@@ -5462,11 +5462,11 @@
             "TargetTabletType": "PRIMARY",
             "KsidLength": 1,
             "KsidVindex": "user_index",
-            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id in ::dm_vals limit 10 for update",
-            "Query": "delete from `user` where `user`.id in ::dm_vals",
+            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where (`user`.id) in ::dm_vals limit 10 for update",
+            "Query": "delete from `user` where (`user`.id) in ::dm_vals",
             "Table": "user",
             "Values": [
-              "::dm_vals"
+              "dm_vals:0"
             ],
             "Vindex": "user_index"
           }

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -30,11 +30,6 @@
     "plan": "VT12001: unsupported: subqueries in DML"
   },
   {
-    "comment": "sharded delete with limit clasue",
-    "query": "delete from user_extra limit 10",
-    "plan": "VT12001: unsupported: multi shard DELETE with LIMIT"
-  },
-  {
     "comment": "sharded subquery in unsharded subquery in unsharded delete",
     "query": "delete from unsharded where col = (select id from unsharded where id = (select id from user))",
     "plan": "VT12001: unsupported: subqueries in DML"

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -316,6 +316,8 @@ func (a *analyzer) noteQuerySignature(node sqlparser.SQLNode) {
 		}
 	case sqlparser.AggrFunc:
 		a.sig.Aggregation = true
+	case *sqlparser.Delete:
+		a.sig.Delete = true
 	}
 }
 

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -77,11 +77,12 @@ type (
 
 	// QuerySignature is used to identify shortcuts in the planning process
 	QuerySignature struct {
-		Union,
-		Aggregation,
-		Distinct,
-		SubQueries,
-		HashJoin bool
+		Aggregation bool
+		Delete      bool
+		Distinct    bool
+		HashJoin    bool
+		SubQueries  bool
+		Union       bool
 	}
 
 	// SemTable contains semantic analysis information about the query.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR add support for `Delete` with `Limit` optionally having `Order By` for sharded keyspaces.

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/6854

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
