### PR TITLE
tests: add tests for `go/json2`

### DIFF
--- a/go/json2/marshal_test.go
+++ b/go/json2/marshal_test.go
@@ -19,6 +19,8 @@ package json2
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
@@ -29,13 +31,10 @@ func TestMarshalPB(t *testing.T) {
 		Type: querypb.Type_VARCHAR,
 	}
 	b, err := MarshalPB(col)
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	require.NoError(t, err, "MarshalPB(col) error")
 	want := "{\"name\":\"c1\",\"type\":\"VARCHAR\"}"
-	if string(b) != want {
-		t.Errorf("MarshalPB(col): %q, want %q", b, want)
-	}
+	assert.Equal(t, want, string(b), "MarshalPB(col)")
 }
 
 func TestMarshalIndentPB(t *testing.T) {
@@ -45,11 +44,8 @@ func TestMarshalIndentPB(t *testing.T) {
 	}
 	indent := "  "
 	b, err := MarshalIndentPB(col, indent)
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	require.NoError(t, err, "MarshalIndentPB(col, indent) error")
 	want := "{\n  \"name\": \"c1\",\n  \"type\": \"VARCHAR\"\n}"
-	if string(b) != want {
-		t.Errorf("MarshalIndentPB(col, indent): %q, want %q", b, want)
-	}
+	assert.Equal(t, want, string(b), "MarshalIndentPB(col, indent)")
 }

--- a/go/json2/marshal_test.go
+++ b/go/json2/marshal_test.go
@@ -33,9 +33,9 @@ func TestMarshalPB(t *testing.T) {
 	}
 	b, err := MarshalPB(col)
 
-	require.NoError(t, err, "MarshalPB(col) error")
+	require.NoErrorf(t, err, "MarshalPB(%+v) error", col)
 	want := "{\"name\":\"c1\",\"type\":\"VARCHAR\"}"
-	assert.Equal(t, want, string(b), "MarshalPB(col)")
+	assert.Equalf(t, want, string(b), "MarshalPB(%+v)", col)
 }
 
 func TestMarshalIndentPB(t *testing.T) {
@@ -46,7 +46,7 @@ func TestMarshalIndentPB(t *testing.T) {
 	indent := "  "
 	b, err := MarshalIndentPB(col, indent)
 
-	require.NoError(t, err, "MarshalIndentPB(col, indent) error")
+	require.NoErrorf(t, err, "MarshalIndentPB(%+v, %q) error", col, indent)
 	want := "{\n  \"name\": \"c1\",\n  \"type\": \"VARCHAR\"\n}"
-	assert.Equal(t, want, string(b), "MarshalIndentPB(col, indent)")
+	assert.Equal(t, want, string(b), "MarshalIndentPB(%+v, %q)", col, indent)
 }

--- a/go/json2/marshal_test.go
+++ b/go/json2/marshal_test.go
@@ -37,3 +37,19 @@ func TestMarshalPB(t *testing.T) {
 		t.Errorf("MarshalPB(col): %q, want %q", b, want)
 	}
 }
+
+func TestMarshalIndentPB(t *testing.T) {
+	col := &vschemapb.Column{
+		Name: "c1",
+		Type: querypb.Type_VARCHAR,
+	}
+	indent := "  "
+	b, err := MarshalIndentPB(col, indent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "{\n  \"name\": \"c1\",\n  \"type\": \"VARCHAR\"\n}"
+	if string(b) != want {
+		t.Errorf("MarshalIndentPB(col, indent): %q, want %q", b, want)
+	}
+}

--- a/go/json2/marshal_test.go
+++ b/go/json2/marshal_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )

--- a/go/json2/unmarshal_test.go
+++ b/go/json2/unmarshal_test.go
@@ -18,6 +18,8 @@ package json2
 
 import (
 	"testing"
+
+	"gotest.tools/assert"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -37,14 +39,13 @@ func TestUnmarshal(t *testing.T) {
 		err: "",
 	}}
 	for _, tcase := range tcases {
-		out := make(map[string]any)
+		out := make(map[string]interface{})
 		err := Unmarshal([]byte(tcase.in), &out)
+
 		got := ""
 		if err != nil {
 			got = err.Error()
 		}
-		if got != tcase.err {
-			t.Errorf("Unmarshal(%v) err: %v, want %v", tcase.in, got, tcase.err)
-		}
+		assert.Equal(t, tcase.err, got, "Unmarshal(%v) err", tcase.in)
 	}
 }

--- a/go/json2/unmarshal_test.go
+++ b/go/json2/unmarshal_test.go
@@ -20,8 +20,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -50,6 +53,25 @@ func TestUnmarshal(t *testing.T) {
 		}
 		assert.Equal(t, tcase.err, got, "Unmarshal(%v) err", tcase.in)
 	}
+}
+
+func TestUnmarshalProto(t *testing.T) {
+	protoData := &emptypb.Empty{}
+	protoJSONData, err := protojson.Marshal(protoData)
+	assert.Nil(t, err, "protojson.Marshal error")
+
+	tcase := struct {
+		in  string
+		out *emptypb.Empty
+	}{
+		in:  string(protoJSONData),
+		out: &emptypb.Empty{},
+	}
+
+	err = Unmarshal([]byte(tcase.in), tcase.out)
+
+	assert.Nil(t, err, "Unmarshal(%v) protobuf message", tcase.in)
+	assert.Equal(t, protoData, tcase.out, "Unmarshal(%v) protobuf message result", tcase.in)
 }
 
 func TestAnnotate(t *testing.T) {

--- a/go/json2/unmarshal_test.go
+++ b/go/json2/unmarshal_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package json2
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
 
@@ -47,5 +49,23 @@ func TestUnmarshal(t *testing.T) {
 			got = err.Error()
 		}
 		assert.Equal(t, tcase.err, got, "Unmarshal(%v) err", tcase.in)
+	}
+}
+
+func TestAnnotate(t *testing.T) {
+	tcases := []struct {
+		data []byte
+		err  error
+	}{
+		{
+			data: []byte("invalid JSON"),
+			err:  fmt.Errorf("line: 1, position 1: invalid character 'i' looking for beginning of value"),
+		},
+	}
+
+	for _, tcase := range tcases {
+		err := annotate(tcase.data, tcase.err)
+
+		require.Equal(t, tcase.err, err, "annotate(%s, %v) error", string(tcase.data), tcase.err)
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Add `TestMarshalIndentPB` to cover `marshal.go`
Add `TestUnmarshalProto`, `TestAnnotate` to cover `unmarshal.go`

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
#14931
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
