### PR TITLE
tests: add tests for `go/protoutil/duration`

### DIFF
--- a/go/protoutil/duration_test.go
+++ b/go/protoutil/duration_test.go
@@ -59,6 +59,16 @@ func TestDurationFromProto(t *testing.T) {
 			isOk:      true,
 			shouldErr: true,
 		},
+		{
+			name: "nanoseconds",
+			in: &vttime.Duration{
+				Seconds: 1,
+				Nanos:   500000000,
+			},
+			expected:  time.Second + 500*time.Millisecond,
+			isOk:      true,
+			shouldErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -77,6 +87,43 @@ func TestDurationFromProto(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.isOk, ok, "expected (_, ok, _) = DurationFromProto; to be ok = %v", tt.isOk)
+		})
+	}
+}
+
+func TestDurationToProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       time.Duration
+		expected *vttime.Duration
+	}{
+		{
+			name:     "success",
+			in:       time.Second * 1000,
+			expected: &vttime.Duration{Seconds: 1000},
+		},
+		{
+			name:     "zero duration",
+			in:       0,
+			expected: &vttime.Duration{},
+		},
+		{
+			name:     "nanoseconds",
+			in:       time.Second + 500*time.Millisecond,
+			expected: &vttime.Duration{Seconds: 1, Nanos: 500000000},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := DurationToProto(tt.in)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/go/protoutil/duration_test.go
+++ b/go/protoutil/duration_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestDurationFromProto(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name      string
@@ -85,7 +84,6 @@ func TestDurationFromProto(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 
 			actual, ok, err := DurationFromProto(tt.in)
 			if tt.shouldErr {
@@ -102,7 +100,6 @@ func TestDurationFromProto(t *testing.T) {
 }
 
 func TestDurationToProto(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -130,7 +127,6 @@ func TestDurationToProto(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 
 			actual := DurationToProto(tt.in)
 			assert.Equal(t, tt.expected, actual)

--- a/go/protoutil/duration_test.go
+++ b/go/protoutil/duration_test.go
@@ -69,6 +69,16 @@ func TestDurationFromProto(t *testing.T) {
 			isOk:      true,
 			shouldErr: false,
 		},
+		{
+			name: "out of range nanoseconds",
+			in: &vttime.Duration{
+				Seconds: -1,
+				Nanos:   500000000,
+			},
+			expected:  0,
+			isOk:      true,
+			shouldErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Adds tests for `DurationToProto` and a `nanoseconds` testcase for `DurationFromProto`

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
#14931

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
