### PR TITLE
unit test for go/sets/set.go

### DIFF
--- a/go/sets/set_test.go
+++ b/go/sets/set_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Vitess Authors.
+Copyright 2024 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/sets/set_test.go
+++ b/go/sets/set_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sets
 
 import (

--- a/go/sets/set_test.go
+++ b/go/sets/set_test.go
@@ -1,0 +1,38 @@
+package sets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet(t *testing.T) {
+	testSet := New[int](1, 2, 3)
+
+	assert.Equal(t, testSet.Len(), 3)
+
+	testSet.Insert(4, 5, 6)
+	compareSet := New[int](1, 2, 3, 4, 5, 6)
+	assert.Equal(t, testSet, compareSet)
+
+	assert.True(t, testSet.Equal(compareSet))
+	compareSet.Insert(-1, -2)
+	assert.False(t, testSet.Equal(compareSet))
+
+	//tests for Difference func
+	diffSet := New[int](-1, -2)
+	assert.Equal(t, diffSet, compareSet.Difference(testSet))
+
+	//tests for Has func
+	assert.True(t, testSet.Has(3))
+	assert.False(t, testSet.Has(-1))
+
+	//tests for HasAny func
+	assert.True(t, testSet.HasAny(1, 10, 11, 12))
+	assert.False(t, testSet.HasAny(-1, 10, 11, 12))
+
+	//tests for Delete func
+	testSet.Delete(1, 2, 3, 4, 5, 6)
+	assert.Empty(t, testSet)
+
+}

--- a/go/sets/set_test.go
+++ b/go/sets/set_test.go
@@ -22,33 +22,57 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSet(t *testing.T) {
+func TestInsert(t *testing.T) {
 	testSet := New[int](1, 2, 3)
-
-	assert.Equal(t, testSet.Len(), 3)
-
 	testSet.Insert(4, 5, 6)
 	compareSet := New[int](1, 2, 3, 4, 5, 6)
 	assert.Equal(t, testSet, compareSet)
+}
 
+func TestDelete(t *testing.T) {
+	testSet := New[int](1, 2, 3, 4, 5, 6)
+	testSet.Delete(1, 5)
+	compareSet := New[int](2, 3, 4, 6)
+	assert.Equal(t, testSet, compareSet)
+	testSet.Delete(2, 3, 4, 6)
+	assert.Empty(t, testSet)
+}
+
+func TestHas(t *testing.T) {
+	testSet := New[int](1, 2, 3)
+	assert.True(t, testSet.Has(3))
+	assert.False(t, testSet.Has(-1))
+}
+
+func TestHasAny(t *testing.T) {
+	testSet := New[int](1, 2, 3)
+	assert.True(t, testSet.HasAny(1, 10, 11))
+	assert.False(t, testSet.HasAny(-1, 10, 11))
+}
+
+func TestDifference(t *testing.T) {
+	testSet := New[int](1, 2, 3)
+	compareSet := New[int](-1, -2, 1, 2, 3)
+	diffSet := New[int](-1, -2)
+	assert.Equal(t, diffSet, compareSet.Difference(testSet))
+}
+
+func TestIntersection(t *testing.T) {
+	setA := New[int](1, 2, 3)
+	setB := New[int](1, 2, 8, 9, 10)
+	expectedSet := New[int](1, 2)
+	assert.Equal(t, expectedSet, setA.Intersection(setB))
+}
+
+func TestEqual(t *testing.T) {
+	testSet := New[int](1, 2, 3, 4, 5, 6)
+	compareSet := New[int](1, 2, 3, 4, 5, 6)
 	assert.True(t, testSet.Equal(compareSet))
 	compareSet.Insert(-1, -2)
 	assert.False(t, testSet.Equal(compareSet))
+}
 
-	//tests for Difference func
-	diffSet := New[int](-1, -2)
-	assert.Equal(t, diffSet, compareSet.Difference(testSet))
-
-	//tests for Has func
-	assert.True(t, testSet.Has(3))
-	assert.False(t, testSet.Has(-1))
-
-	//tests for HasAny func
-	assert.True(t, testSet.HasAny(1, 10, 11, 12))
-	assert.False(t, testSet.HasAny(-1, 10, 11, 12))
-
-	//tests for Delete func
-	testSet.Delete(1, 2, 3, 4, 5, 6)
-	assert.Empty(t, testSet)
-
+func TestLen(t *testing.T) {
+	testSet := New[int](1, 2, 3)
+	assert.Equal(t, testSet.Len(), 3)
 }

--- a/go/sets/set_test.go
+++ b/go/sets/set_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInsert(t *testing.T) {
@@ -75,4 +76,10 @@ func TestEqual(t *testing.T) {
 func TestLen(t *testing.T) {
 	testSet := New[int](1, 2, 3)
 	assert.Equal(t, testSet.Len(), 3)
+}
+
+func TestList(t *testing.T) {
+	testSet := New[string]("a string", "testing", "Capital", "34")
+	list := List(testSet)
+	require.EqualValues(t, []string{"34", "Capital", "a string", "testing"}, list)
 }


### PR DESCRIPTION
Partial Fix to #14931 

Covers unit test for `go/sets/set.go`

![image](https://github.com/vitessio/vitess/assets/21123621/e2750f1a-5ce2-4760-b91e-ac231bf7b0a6)

`ok      vitess.io/vitess/go/sets        0.011s  coverage: 73.8% of statements`
