### PR TITLE
Add required tests for `go/mysql/hex`

### DIFF
--- a/go/mysql/hex/hex_test.go
+++ b/go/mysql/hex/hex_test.go
@@ -98,5 +98,5 @@ func TestDecodeBytes(t *testing.T) {
 	// DecodeBytes should return an error for "é" as
 	// hex.decode returns an error for non-ASCII characters
 	err = DecodeBytes([]byte("testDst"), []byte("é"))
-	assert.Error(t, err, "DecodeBytes() should have errored as src contains non-ASCII character")
+	assert.Error(t, err)
 }

--- a/go/mysql/hex/hex_test.go
+++ b/go/mysql/hex/hex_test.go
@@ -98,5 +98,5 @@ func TestDecodeBytes(t *testing.T) {
 	// DecodeBytes should return an error for "é" as
 	// hex.decode returns an error for non-ASCII characters
 	err = DecodeBytes([]byte("testDst"), []byte("é"))
-	assert.Errorf(t, err, "expected error to appear for invalid byte, got %v", err)
+	assert.Error(t, err)
 }

--- a/go/mysql/hex/hex_test.go
+++ b/go/mysql/hex/hex_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeBytes(t *testing.T) {
+	testCases := []struct {
+		input []byte
+		want  []byte
+	}{
+		{[]byte{0xAB, 0xCD, 0xEF}, []byte("ABCDEF")},
+		{[]byte{0x01, 0x23, 0x45}, []byte("012345")},
+	}
+
+	for _, tCase := range testCases {
+		got := EncodeBytes(tCase.input)
+		assert.Equalf(t, tCase.want, got, "got %v, want %v", got, tCase.want)
+	}
+}
+
+func TestEncodeUint(t *testing.T) {
+	testCases := []struct {
+		input uint64
+		want  []byte
+	}{
+		{0, []byte("0")},
+		{123, []byte("7B")},
+		{255, []byte("FF")},
+		{4096, []byte("1000")},
+	}
+
+	for _, tCase := range testCases {
+		got := EncodeUint(tCase.input)
+		assert.Equalf(t, tCase.want, got, "got %v, want %v", got, tCase.want)
+	}
+}
+
+func TestDecodeUint(t *testing.T) {
+	testCases := []struct {
+		input uint64
+		want  []byte
+	}{
+		{0, []byte{0}},
+		{123, []byte{0x01, 0x23}},
+		{255, []byte{0x02, 0x55}},
+		{4096, []byte{0x40, 0x96}},
+	}
+
+	for _, tCase := range testCases {
+		got := DecodeUint(tCase.input)
+		assert.Equalf(t, tCase.want, got, "got %v, want %v", got, tCase.want)
+	}
+}
+
+func TestDecodedLen(t *testing.T) {
+	testCases := []struct {
+		input []byte
+		want  int
+	}{
+		{[]byte{0}, 1},
+		{[]byte{0x01, 0x23}, 1},
+		{[]byte("ABCDE"), 3},
+		{[]byte("0123456789ABCDEF"), 8},
+	}
+
+	for _, tCase := range testCases {
+		got := DecodedLen(tCase.input)
+		assert.Equalf(t, tCase.want, got, "got %d, want %d", got, tCase.want)
+	}
+}
+
+func TestDecodeBytes(t *testing.T) {
+	err := DecodeBytes([]byte("testDst"), []byte("1"))
+	assert.NoErrorf(t, err, "expected no error, got %v", err)
+
+	err = DecodeBytes([]byte("testDst"), []byte("12"))
+	assert.NoErrorf(t, err, "expected no error, got %v", err)
+
+	// DecodeBytes should return an error for "é" as
+	// hex.decode returns an error for non-ASCII characters
+	err = DecodeBytes([]byte("testDst"), []byte("é"))
+	assert.Errorf(t, err, "expected error to appear for invalid byte, got %v", err)
+}

--- a/go/mysql/hex/hex_test.go
+++ b/go/mysql/hex/hex_test.go
@@ -33,7 +33,7 @@ func TestEncodeBytes(t *testing.T) {
 
 	for _, tCase := range testCases {
 		got := EncodeBytes(tCase.input)
-		assert.Equalf(t, tCase.want, got, "got %v, want %v", got, tCase.want)
+		assert.Equal(t, tCase.want, got)
 	}
 }
 
@@ -50,7 +50,7 @@ func TestEncodeUint(t *testing.T) {
 
 	for _, tCase := range testCases {
 		got := EncodeUint(tCase.input)
-		assert.Equalf(t, tCase.want, got, "got %v, want %v", got, tCase.want)
+		assert.Equal(t, tCase.want, got)
 	}
 }
 
@@ -67,7 +67,7 @@ func TestDecodeUint(t *testing.T) {
 
 	for _, tCase := range testCases {
 		got := DecodeUint(tCase.input)
-		assert.Equalf(t, tCase.want, got, "got %v, want %v", got, tCase.want)
+		assert.Equal(t, tCase.want, got)
 	}
 }
 
@@ -84,16 +84,16 @@ func TestDecodedLen(t *testing.T) {
 
 	for _, tCase := range testCases {
 		got := DecodedLen(tCase.input)
-		assert.Equalf(t, tCase.want, got, "got %d, want %d", got, tCase.want)
+		assert.Equal(t, tCase.want, got)
 	}
 }
 
 func TestDecodeBytes(t *testing.T) {
 	err := DecodeBytes([]byte("testDst"), []byte("1"))
-	assert.NoErrorf(t, err, "expected no error, got %v", err)
+	assert.NoError(t, err)
 
 	err = DecodeBytes([]byte("testDst"), []byte("12"))
-	assert.NoErrorf(t, err, "expected no error, got %v", err)
+	assert.NoError(t, err)
 
 	// DecodeBytes should return an error for "é" as
 	// hex.decode returns an error for non-ASCII characters

--- a/go/mysql/hex/hex_test.go
+++ b/go/mysql/hex/hex_test.go
@@ -98,5 +98,5 @@ func TestDecodeBytes(t *testing.T) {
 	// DecodeBytes should return an error for "é" as
 	// hex.decode returns an error for non-ASCII characters
 	err = DecodeBytes([]byte("testDst"), []byte("é"))
-	assert.Error(t, err)
+	assert.Error(t, err, "DecodeBytes() should have errored as src contains non-ASCII character")
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds required tests for `go/mysql/hex`
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #14931 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
