### PR TITLE
examples: rm heartbeat flags

### DIFF
--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -53,9 +53,6 @@ vttablet \
  --grpc_port $grpc_port \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
- --heartbeat_enable \
- --heartbeat_interval=250ms \
- --heartbeat_on_demand_duration=5s \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 
 # Block waiting for the tablet to be listening


### PR DESCRIPTION
## Description

I chatted w/ @mattlord about https://github.com/vitessio/vitess/issues/14978, he said:

> We should just remove that flag in the examples. 
>
> I initially added those flags here as I was using the local examples to test it: https://github.com/vitessio/vitess/pull/12737
>
> They shouldn’t be necessary anymore — you can enable the throttler at the keyspace level in the topo using vtctldclient and use defaults for the other things.
>
> We should backport all the way to release-17.0 as well. That’s the oldest version that has those flags in the script.

I tested this by running all the way through the local example, verifying that no lag was reported on `@replica` or `@rdonly`, and did not see any other issues.

## Related Issue(s)

Fixes #14978.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests ~were added or~ are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation ~was added or~ is not required
