### PR TITLE
tests: add tests for `go/mysql/format`

### DIFF
--- a/go/mysql/format/float_test.go
+++ b/go/mysql/format/float_test.go
@@ -55,6 +55,11 @@ func TestFormatFloat(t *testing.T) {
 			expected: []byte("1.23456789e15"),
 		},
 		{
+			name:     "large negative exponent",
+			input:    1.23456789e-15,
+			expected: []byte("0.00000000000000123456789"),
+		},
+		{
 			name:     "zero",
 			input:    0.0,
 			expected: []byte("0"),

--- a/go/mysql/format/float_test.go
+++ b/go/mysql/format/float_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package format
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatFloat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected []byte
+	}{
+		{
+			name:     "positive integer",
+			input:    123.0,
+			expected: []byte("123"),
+		},
+		{
+			name:     "negative integer",
+			input:    -456.0,
+			expected: []byte("-456"),
+		},
+		{
+			name:     "positive float",
+			input:    12.34,
+			expected: []byte("12.34"),
+		},
+		{
+			name:     "negative float",
+			input:    -56.789,
+			expected: []byte("-56.789"),
+		},
+		{
+			name:     "large positive exponent",
+			input:    1.23456789e15,
+			expected: []byte("1.23456789e15"),
+		},
+		{
+			name:     "zero",
+			input:    0.0,
+			expected: []byte("0"),
+		},
+		{
+			name:     "positive infinity",
+			input:    math.Inf(1),
+			expected: []byte("+Inf"),
+		},
+		{
+			name:     "negative infinity",
+			input:    math.Inf(-1),
+			expected: []byte("-Inf"),
+		},
+		{
+			name:     "NaN",
+			input:    math.NaN(),
+			expected: []byte("NaN"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatFloat(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Achieves 100% coverage for `go/mysql/format`
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
#14931
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
