### PR TITLE
Use the correct parser for truncation

### DIFF
--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -42,7 +42,7 @@ func (e *Executor) defaultQueryLogger() error {
 	servenv.HTTPHandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
 		ch := queryLogger.Subscribe("querylogz")
 		defer queryLogger.Unsubscribe(ch)
-		querylogzHandler(ch, w, r)
+		querylogzHandler(ch, w, r, e.parser)
 	})
 
 	servenv.HTTPHandleFunc(QueryzHandler, func(w http.ResponseWriter, r *http.Request) {

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -55,10 +55,9 @@ var (
 		</thead>
 	`)
 	querylogzFuncMap = template.FuncMap{
-		"stampMicro":    func(t time.Time) string { return t.Format(time.StampMicro) },
-		"cssWrappable":  logz.Wrappable,
-		"truncateQuery": sqlparser.NewTestParser().TruncateForUI,
-		"unquote":       func(s string) string { return strings.Trim(s, "\"") },
+		"stampMicro":   func(t time.Time) string { return t.Format(time.StampMicro) },
+		"cssWrappable": logz.Wrappable,
+		"unquote":      func(s string) string { return strings.Trim(s, "\"") },
 	}
 	querylogzTmpl = template.Must(template.New("example").Funcs(querylogzFuncMap).Parse(`
 		<tr class="{{.ColorLevel}}">
@@ -74,7 +73,7 @@ var (
 			<td>{{.ExecuteTime.Seconds}}</td>
 			<td>{{.CommitTime.Seconds}}</td>
 			<td>{{.StmtType}}</td>
-			<td>{{.SQL | truncateQuery | unquote | cssWrappable}}</td>
+			<td>{{.SQL | .Parser.TruncateForUI | unquote | cssWrappable}}</td>
 			<td>{{.ShardQueries}}</td>
 			<td>{{.RowsAffected}}</td>
 			<td>{{.ErrorStr}}</td>
@@ -84,7 +83,7 @@ var (
 
 // querylogzHandler serves a human readable snapshot of the
 // current query log.
-func querylogzHandler(ch chan *logstats.LogStats, w http.ResponseWriter, r *http.Request) {
+func querylogzHandler(ch chan *logstats.LogStats, w http.ResponseWriter, r *http.Request, parser *sqlparser.Parser) {
 	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 		acl.SendError(w, err)
 		return
@@ -115,7 +114,8 @@ func querylogzHandler(ch chan *logstats.LogStats, w http.ResponseWriter, r *http
 			tmplData := struct {
 				*logstats.LogStats
 				ColorLevel string
-			}{stats, level}
+				Parser     *sqlparser.Parser
+			}{stats, level, parser}
 			if err := querylogzTmpl.Execute(w, tmplData); err != nil {
 				log.Errorf("querylogz: couldn't execute template: %v", err)
 			}

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/logstats"
 
 	"vitess.io/vitess/go/streamlog"
@@ -73,7 +74,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	response := httptest.NewRecorder()
 	ch := make(chan *logstats.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ := io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, fastQueryPattern, logStats, body)
@@ -103,7 +104,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	response = httptest.NewRecorder()
 	ch = make(chan *logstats.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, mediumQueryPattern, logStats, body)
@@ -132,7 +133,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	logStats.EndTime = logStats.StartTime.Add(500 * time.Millisecond)
 	ch = make(chan *logstats.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
@@ -142,7 +143,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	defer func() { streamlog.SetQueryLogFilterTag("") }()
 	ch = make(chan *logstats.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)

--- a/go/vt/vttablet/tabletserver/querylogz.go
+++ b/go/vt/vttablet/tabletserver/querylogz.go
@@ -26,7 +26,6 @@ import (
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logz"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
@@ -57,10 +56,9 @@ var (
 		</thead>
 	`)
 	querylogzFuncMap = template.FuncMap{
-		"stampMicro":    func(t time.Time) string { return t.Format(time.StampMicro) },
-		"cssWrappable":  logz.Wrappable,
-		"truncateQuery": sqlparser.NewTestParser().TruncateForUI,
-		"unquote":       func(s string) string { return strings.Trim(s, "\"") },
+		"stampMicro":   func(t time.Time) string { return t.Format(time.StampMicro) },
+		"cssWrappable": logz.Wrappable,
+		"unquote":      func(s string) string { return strings.Trim(s, "\"") },
 	}
 	querylogzTmpl = template.Must(template.New("example").Funcs(querylogzFuncMap).Parse(`
 		<tr class="{{.ColorLevel}}">
@@ -74,7 +72,7 @@ var (
 			<td>{{.MysqlResponseTime.Seconds}}</td>
 			<td>{{.WaitingForConnection.Seconds}}</td>
 			<td>{{.PlanType}}</td>
-			<td>{{.OriginalSQL | truncateQuery | unquote | cssWrappable}}</td>
+			<td>{{.OriginalSQL | .Parser.TruncateForUI | unquote | cssWrappable}}</td>
 			<td>{{.NumberOfQueries}}</td>
 			<td>{{.FmtQuerySources}}</td>
 			<td>{{.RowsAffected}}</td>
@@ -86,17 +84,9 @@ var (
 	`))
 )
 
-func init() {
-	servenv.HTTPHandleFunc("/querylogz", func(w http.ResponseWriter, r *http.Request) {
-		ch := tabletenv.StatsLogger.Subscribe("querylogz")
-		defer tabletenv.StatsLogger.Unsubscribe(ch)
-		querylogzHandler(ch, w, r)
-	})
-}
-
 // querylogzHandler serves a human readable snapshot of the
 // current query log.
-func querylogzHandler(ch chan *tabletenv.LogStats, w http.ResponseWriter, r *http.Request) {
+func querylogzHandler(ch chan *tabletenv.LogStats, w http.ResponseWriter, r *http.Request, parser *sqlparser.Parser) {
 	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 		acl.SendError(w, err)
 		return
@@ -127,7 +117,8 @@ func querylogzHandler(ch chan *tabletenv.LogStats, w http.ResponseWriter, r *htt
 			tmplData := struct {
 				*tabletenv.LogStats
 				ColorLevel string
-			}{stats, level}
+				Parser     *sqlparser.Parser
+			}{stats, level, parser}
 			if err := querylogzTmpl.Execute(w, tmplData); err != nil {
 				log.Errorf("querylogz: couldn't execute template: %v", err)
 			}

--- a/go/vt/vttablet/tabletserver/querylogz_test.go
+++ b/go/vt/vttablet/tabletserver/querylogz_test.go
@@ -28,6 +28,7 @@ import (
 
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
@@ -76,7 +77,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	response := httptest.NewRecorder()
 	ch := make(chan *tabletenv.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ := io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, fastQueryPattern, logStats, body)
@@ -107,7 +108,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	response = httptest.NewRecorder()
 	ch = make(chan *tabletenv.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, mediumQueryPattern, logStats, body)
@@ -137,7 +138,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	logStats.EndTime = logStats.StartTime.Add(500 * time.Millisecond)
 	ch = make(chan *tabletenv.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
@@ -147,7 +148,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	defer func() { streamlog.SetQueryLogFilterTag("") }()
 	ch = make(chan *tabletenv.LogStats, 1)
 	ch <- logStats
-	querylogzHandler(ch, response, req)
+	querylogzHandler(ch, response, req, sqlparser.NewTestParser())
 	close(ch)
 	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -31,7 +31,6 @@ import (
 	"vitess.io/vitess/go/vt/logz"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -71,10 +70,6 @@ var (
 			</td>
 		</tr>`))
 )
-
-func init() {
-	servenv.HTTPHandleFunc("/txlogz", txlogzHandler)
-}
 
 // txlogzHandler serves a human readable snapshot of the
 // current transaction log.


### PR DESCRIPTION
This was broken in the parser injection refactor and this didn't inject the properly configured object.

Also cleans up some global init() calls as well and moves it to the pattern of how we initialize the rest which we need to pass in the parser correctly anyway.

## Related Issue(s)

Should have been done in #14822 as part of work on #14717

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required