### PR TITLE
Remove `AppendFloat` from `go/mysql/format` and add required tests

### DIFF
--- a/go/mysql/format/float.go
+++ b/go/mysql/format/float.go
@@ -25,11 +25,7 @@ const expUpperThreshold = 1000000000000000.0
 const expLowerThreshold = 0.000000000000001
 
 // FormatFloat formats a float64 as a byte string in a similar way to what MySQL does
-func FormatFloat(v float64) []byte {
-	return AppendFloat(nil, v)
-}
-
-func AppendFloat(buf []byte, f float64) []byte {
+func FormatFloat(f float64) []byte {
 	format := byte('f')
 	if f >= expUpperThreshold || f <= -expUpperThreshold || (f < expLowerThreshold && f > -expLowerThreshold) {
 		format = 'g'
@@ -39,7 +35,7 @@ func AppendFloat(buf []byte, f float64) []byte {
 	// do that, and there's no way to customize it, so we must strip the
 	// redundant positive sign manually
 	// e.g. 1.234E+56789 -> 1.234E56789
-	fstr := strconv.AppendFloat(buf, f, format, -1, 64)
+	fstr := strconv.AppendFloat(nil, f, format, -1, 64)
 	if idx := bytes.IndexByte(fstr, 'e'); idx >= 0 {
 		if fstr[idx+1] == '+' {
 			fstr = append(fstr[:idx+1], fstr[idx+2:]...)

--- a/go/mysql/format/float_test.go
+++ b/go/mysql/format/float_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package format
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatFloat(t *testing.T) {
+	testCases := []struct {
+		input float64
+		want  []byte
+	}{
+		{123.456, []byte("123.456")},
+		{-1.13456e15, []byte("-1.13456e15")},
+		{2e15, []byte("2e15")},
+		{2e-15, []byte("0.000000000000002")},
+		{-1e-16, []byte("-1e-16")},
+		{0.0, []byte("0")},
+	}
+
+	for _, tCase := range testCases {
+		got := FormatFloat(tCase.input)
+		assert.Equal(t, tCase.want, got)
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR removes `AppendFloat` from `go/mysql/format`.
This PR also adds required unit tests for `go/mysql/format`
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #14972 
Fixes part of #14931 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
