### PR TITLE
Export `convertMySQLVersionToCommentVersion` to use it in vitess-operator

### DIFF
--- a/go/vt/sqlparser/parser.go
+++ b/go/vt/sqlparser/parser.go
@@ -100,8 +100,8 @@ func (p *Parser) Parse2(sql string) (Statement, BindVars, error) {
 	return tokenizer.ParseTree, tokenizer.BindVars, nil
 }
 
-// convertMySQLVersionToCommentVersion converts the MySQL version into comment version format.
-func convertMySQLVersionToCommentVersion(version string) (string, error) {
+// ConvertMySQLVersionToCommentVersion converts the MySQL version into comment version format.
+func ConvertMySQLVersionToCommentVersion(version string) (string, error) {
 	var res = make([]int, 3)
 	idx := 0
 	val := ""
@@ -323,7 +323,7 @@ func New(opts Options) (*Parser, error) {
 	if opts.MySQLServerVersion == "" {
 		opts.MySQLServerVersion = config.DefaultMySQLVersion
 	}
-	convVersion, err := convertMySQLVersionToCommentVersion(opts.MySQLServerVersion)
+	convVersion, err := ConvertMySQLVersionToCommentVersion(opts.MySQLServerVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func New(opts Options) (*Parser, error) {
 }
 
 func NewTestParser() *Parser {
-	convVersion, err := convertMySQLVersionToCommentVersion(config.DefaultMySQLVersion)
+	convVersion, err := ConvertMySQLVersionToCommentVersion(config.DefaultMySQLVersion)
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/sqlparser/version_test.go
+++ b/go/vt/sqlparser/version_test.go
@@ -49,7 +49,7 @@ func TestConvertMySQLVersion(t *testing.T) {
 
 	for _, tcase := range testcases {
 		t.Run(tcase.version, func(t *testing.T) {
-			output, err := convertMySQLVersionToCommentVersion(tcase.version)
+			output, err := ConvertMySQLVersionToCommentVersion(tcase.version)
 			if tcase.error != "" {
 				require.EqualError(t, err, tcase.error)
 			} else {


### PR DESCRIPTION
## Description

Tiny refactor to export `convertMySQLVersionToCommentVersion` so that it can be used in vitess-operator to validate the MySQL version in order to set the `--mysql_server_version` properly to each Vitess component.