### PR TITLE
tests: Add tests for `go/textutil`

### DIFF
--- a/go/textutil/strings_test.go
+++ b/go/textutil/strings_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 func TestSplitDelimitedList(t *testing.T) {
@@ -65,6 +67,12 @@ func TestSplitUnescape(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, elems)
 	}
+	{
+		s := "invalid%2"
+		elems, err := SplitUnescape(s, ",")
+		assert.Error(t, err)
+		assert.Equal(t, []string{}, elems)
+	}
 }
 
 func TestSingleWordCamel(t *testing.T) {
@@ -105,6 +113,97 @@ func TestSingleWordCamel(t *testing.T) {
 		t.Run(tc.word, func(t *testing.T) {
 			camel := SingleWordCamel(tc.word)
 			assert.Equal(t, tc.expect, camel)
+		})
+	}
+}
+
+func TestValueIsSimulatedNull(t *testing.T) {
+	tt := []struct {
+		name   string
+		val    interface{}
+		isNull bool
+	}{
+		{
+			name:   "case string false",
+			val:    "test",
+			isNull: false,
+		},
+		{
+			name:   "case string true",
+			val:    SimulatedNullString,
+			isNull: true,
+		},
+		{
+			name:   "case []string true",
+			val:    []string{SimulatedNullString},
+			isNull: true,
+		},
+		{
+			name:   "case []string false",
+			val:    []string{SimulatedNullString, SimulatedNullString},
+			isNull: false,
+		},
+		{
+			name:   "case binlogdatapb.OnDDLAction true",
+			val:    binlogdatapb.OnDDLAction(SimulatedNullInt),
+			isNull: true,
+		},
+		{
+			name:   "case int true",
+			val:    SimulatedNullInt,
+			isNull: true,
+		},
+		{
+			name:   "case int32 true",
+			val:    int32(SimulatedNullInt),
+			isNull: true,
+		},
+		{
+			name:   "case int64 true",
+			val:    int64(SimulatedNullInt),
+			isNull: true,
+		},
+		{
+			name:   "case []topodatapb.TabletType true",
+			val:    []topodatapb.TabletType{topodatapb.TabletType(SimulatedNullInt)},
+			isNull: true,
+		},
+		{
+			name:   "case binlogdatapb.VReplicationWorkflowState true",
+			val:    binlogdatapb.VReplicationWorkflowState(SimulatedNullInt),
+			isNull: true,
+		},
+		{
+			name:   "case default",
+			val:    float64(1),
+			isNull: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			isNull := ValueIsSimulatedNull(tc.val)
+			assert.Equal(t, tc.isNull, isNull)
+		})
+	}
+}
+
+func TestTitle(t *testing.T) {
+	tt := []struct {
+		s      string
+		expect string
+	}{
+		{s: "hello world", expect: "Hello World"},
+		{s: "snake_case", expect: "Snake_case"},
+		{s: "TITLE CASE", expect: "TITLE CASE"},
+		{s: "HelLo wOrLd", expect: "HelLo WOrLd"},
+		{s: "", expect: ""},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.s, func(t *testing.T) {
+			title := Title(tc.s)
+			assert.Equal(t, tc.expect, title)
 		})
 	}
 }

--- a/go/textutil/strings_test.go
+++ b/go/textutil/strings_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )

--- a/go/textutil/template_test.go
+++ b/go/textutil/template_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package textutil
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteTemplate(t *testing.T) {
+	tmplText := "Result: {{.Value}}"
+	inputData := struct{ Value string }{Value: "Test"}
+	tmpl, err := template.New("test").Parse(tmplText)
+	require.NoError(t, err)
+
+	result, err := ExecuteTemplate(tmpl, inputData)
+	require.NoError(t, err)
+
+	expectedResult := "Result: Test"
+	assert.Equal(t, expectedResult, result)
+}

--- a/go/textutil/template_test.go
+++ b/go/textutil/template_test.go
@@ -39,13 +39,13 @@ func TestExecuteTemplate(t *testing.T) {
 }
 
 func TestExecuteTemplateWithError(t *testing.T) {
-	invalidTemplate := "{{.UndefinedVariable}}"
-	inputData := struct{ Name string }{Name: "foo"}
+	templText := "{{.UndefinedVariable}}"
+	invalidInput := struct{ Name string }{Name: "foo"}
 
-	tmpl, err := template.New("test").Parse(invalidTemplate)
+	tmpl, err := template.New("test").Parse(templText)
 	require.NoError(t, err)
 
-	result, err := ExecuteTemplate(tmpl, inputData)
+	result, err := ExecuteTemplate(tmpl, invalidInput)
 	assert.Error(t, err)
 	assert.Equal(t, "", result)
 }

--- a/go/textutil/template_test.go
+++ b/go/textutil/template_test.go
@@ -35,4 +35,17 @@ func TestExecuteTemplate(t *testing.T) {
 
 	expectedResult := "Result: Test"
 	assert.Equal(t, expectedResult, result)
+
+}
+
+func TestExecuteTemplateWithError(t *testing.T) {
+	invalidTemplate := "{{.UndefinedVariable}}"
+	inputData := struct{ Name string }{Name: "foo"}
+
+	tmpl, err := template.New("test").Parse(invalidTemplate)
+	require.NoError(t, err)
+
+	result, err := ExecuteTemplate(tmpl, inputData)
+	assert.Error(t, err)
+	assert.Equal(t, result, "")
 }

--- a/go/textutil/template_test.go
+++ b/go/textutil/template_test.go
@@ -47,5 +47,5 @@ func TestExecuteTemplateWithError(t *testing.T) {
 
 	result, err := ExecuteTemplate(tmpl, inputData)
 	assert.Error(t, err)
-	assert.Equal(t, result, "")
+	assert.Equal(t, "", result)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
#14931
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
