### PR TITLE
VDiff: Make max diff duration upgrade/downgrade safe

### DIFF
--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1725,6 +1725,15 @@ func (s *Server) VDiffCreate(ctx context.Context, req *vtctldatapb.VDiffCreateRe
 	if req.MaxDiffDuration == nil {
 		req.MaxDiffDuration = &vttimepb.Duration{}
 	}
+	// The other vttime.Duration vars should not be nil as the
+	// client should always provide them, but we check anyway to
+	// be safe.
+	if req.FilteredReplicationWaitTime == nil {
+		req.FilteredReplicationWaitTime = &vttimepb.Duration{}
+	}
+	if req.WaitUpdateInterval == nil {
+		req.WaitUpdateInterval = &vttimepb.Duration{}
+	}
 
 	options := &tabletmanagerdatapb.VDiffOptions{
 		PickerOptions: &tabletmanagerdatapb.VDiffPickerOptions{

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1720,6 +1720,12 @@ func (s *Server) VDiffCreate(ctx context.Context, req *vtctldatapb.VDiffCreateRe
 		tabletTypesStr = discovery.InOrderHint + tabletTypesStr
 	}
 
+	// This is a pointer so there's no ZeroValue in the message
+	// and an older v18 client will not provide it.
+	if req.MaxDiffDuration == nil {
+		req.MaxDiffDuration = &vttimepb.Duration{}
+	}
+
 	options := &tabletmanagerdatapb.VDiffOptions{
 		PickerOptions: &tabletmanagerdatapb.VDiffPickerOptions{
 			TabletTypes: tabletTypesStr,

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -29,14 +29,15 @@ import (
 	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
-	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 )
 
 type fakeTMC struct {


### PR DESCRIPTION
## Description

In v19 we added a new feature to support auto restarting the diff of a table periodically in https://github.com/vitessio/vitess/pull/14786.

The [proto field used for that is a `vttime.Duration` type](https://github.com/vitessio/vitess/blob/9af869232ad252e013a91a6ba2be1f1db079737c/proto/vtctldata.proto#L1745). Because it [ends up being a pointer in the proto message](https://github.com/vitessio/vitess/blob/9af869232ad252e013a91a6ba2be1f1db079737c/go/vt/proto/vtctldata/vtctldata.pb.go#L13330) there is no ZeroValue in the server side (`vtctld`) message when the client (`vtctldclient`) sent an older version of the `VDiffCreateRequest` proto message from a v18 `vtctldclient` binary and thus when we [passed on `req.MaxDiffDuration.Seconds` to the tablets](https://github.com/vitessio/vitess/blob/9af869232ad252e013a91a6ba2be1f1db079737c/go/vt/vtctl/workflow/server.go#L1736) we got a nil pointer exception. 

This PR adds a server side nil check for this new field in the server's message and sets it to a pointer to the type's ZeroValue so that this is upgrade/downgrade safe.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/14996

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required