### PR TITLE
Add check to avoid runtime error and add tests for `go/mysql/fastparse`

### DIFF
--- a/go/mysql/fastparse/fastparse.go
+++ b/go/mysql/fastparse/fastparse.go
@@ -123,6 +123,9 @@ func ParseInt64(s string, base int) (int64, error) {
 		i++
 	}
 
+	if i >= uint(len(s)) {
+		return 0, fmt.Errorf("cannot parse int64 from %q", s)
+	}
 	minus := s[i] == '-'
 	if minus {
 		i++

--- a/go/mysql/fastparse/fastparse_test.go
+++ b/go/mysql/fastparse/fastparse_test.go
@@ -190,6 +190,48 @@ func TestParseInt64(t *testing.T) {
 			expected: 42,
 			err:      `unparsed tail left after parsing int64 from "\t 42 \n": "\n"`,
 		},
+		{
+			input:    "",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse int64 from empty string`,
+		},
+		{
+			input:    "256",
+			base:     1,
+			expected: 0,
+			err:      `invalid base 1; must be in [2, 36]`,
+		},
+		{
+			input:    "256",
+			base:     37,
+			expected: 0,
+			err:      `invalid base 37; must be in [2, 36]`,
+		},
+		{
+			input:    "  -",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse int64 from "  -"`,
+		},
+		{
+			input:    "-18446744073709551615",
+			base:     10,
+			expected: -9223372036854775808,
+			err:      `cannot parse int64 from "-18446744073709551615": overflow`,
+		},
+		{
+			input:    "  ",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse int64 from "  "`,
+		},
+		{
+			input:    "  :",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse int64 from "  :"`,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.input, func(t *testing.T) {
@@ -325,6 +367,36 @@ func TestParseUint64(t *testing.T) {
 			base:     10,
 			expected: 42,
 			err:      `unparsed tail left after parsing uint64 from "\t 42 \n": "\n"`,
+		},
+		{
+			input:    "",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse uint64 from empty string`,
+		},
+		{
+			input:    "256",
+			base:     1,
+			expected: 0,
+			err:      `invalid base 1; must be in [2, 36]`,
+		},
+		{
+			input:    "256",
+			base:     37,
+			expected: 0,
+			err:      `invalid base 37; must be in [2, 36]`,
+		},
+		{
+			input:    "  ",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse uint64 from "  "`,
+		},
+		{
+			input:    "  :",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse uint64 from "  :"`,
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds a check to avoid runtime error and adds tests for `go/mysql/fastparse`

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #14931 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
