### PR TITLE
tests: add tests for `zkfs` utilities

### DIFF
--- a/go/cmd/zk/internal/zkfs/zkfs.go
+++ b/go/cmd/zk/internal/zkfs/zkfs.go
@@ -158,6 +158,10 @@ func IsFile(path string) bool {
 
 // ParsePermMode parses the mode string as a perm mask.
 func ParsePermMode(mode string) (mask int32) {
+	if len(mode) < 2 {
+		panic("invalid mode")
+	}
+
 	for _, c := range mode[2:] {
 		mask |= charPermMap[string(c)]
 	}

--- a/go/cmd/zk/internal/zkfs/zkfs_test.go
+++ b/go/cmd/zk/internal/zkfs/zkfs_test.go
@@ -48,7 +48,7 @@ func TestParsePermMode(t *testing.T) {
 	assert.Equal(t, int32(0), ParsePermMode("zk"))
 	assert.Equal(t, int32(zk.PermRead|zk.PermWrite), ParsePermMode("zkrw"))
 	assert.Equal(t, int32(zk.PermRead|zk.PermWrite|zk.PermAdmin), ParsePermMode("zkrwa"))
-	assert.PanicsWithError(t, "invalid mode", func() {
+	assert.PanicsWithValue(t, "invalid mode", func() {
 		ParsePermMode("")
 		ParsePermMode("z")
 	})

--- a/go/cmd/zk/internal/zkfs/zkfs_test.go
+++ b/go/cmd/zk/internal/zkfs/zkfs_test.go
@@ -17,26 +17,11 @@ limitations under the License.
 package zkfs
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/z-division/go-zookeeper/zk"
 )
-
-func TestFS_CopyContext(t *testing.T) {
-	// fs := &FS{}
-
-	// Create a temporary directories for testing
-	srcPath, err := os.MkdirTemp("", "source")
-	assert.NoError(t, err)
-	defer os.RemoveAll(srcPath)
-
-	dstPath, err := os.MkdirTemp("", "destination")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dstPath)
-
-}
 
 func TestIsFile(t *testing.T) {
 	assert.True(t, IsFile("/zk/somepath"))
@@ -50,6 +35,8 @@ func TestParsePermMode(t *testing.T) {
 	assert.Equal(t, int32(zk.PermRead|zk.PermWrite|zk.PermAdmin), ParsePermMode("zkrwa"))
 	assert.PanicsWithValue(t, "invalid mode", func() {
 		ParsePermMode("")
+	})
+	assert.PanicsWithValue(t, "invalid mode", func() {
 		ParsePermMode("z")
 	})
 }
@@ -88,8 +75,6 @@ func TestFormatACL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, FormatACL(tc.acl))
-		})
+		assert.Equal(t, tc.expected, FormatACL(tc.acl), tc.name)
 	}
 }

--- a/go/cmd/zk/internal/zkfs/zkfs_test.go
+++ b/go/cmd/zk/internal/zkfs/zkfs_test.go
@@ -77,7 +77,7 @@ func TestFormatACL(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, FormatACL(tc.acl), tc.name)
+			assert.Equal(t, tc.expected, FormatACL(tc.acl))
 		})
 	}
 }

--- a/go/cmd/zk/internal/zkfs/zkfs_test.go
+++ b/go/cmd/zk/internal/zkfs/zkfs_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package zkfs
 
 import (

--- a/go/cmd/zk/internal/zkfs/zkfs_test.go
+++ b/go/cmd/zk/internal/zkfs/zkfs_test.go
@@ -75,6 +75,9 @@ func TestFormatACL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expected, FormatACL(tc.acl), tc.name)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, FormatACL(tc.acl), tc.name)
+		})
 	}
 }


### PR DESCRIPTION
## Description
- Added the tests for some utilities for `vitess/go/cmd/zk/internal/zkfs`
- I couldn't add the complete coverage code as I am having trouble mocking the `zk2topo.ZkConn` in a simple manner for testing. If anyone can point me to any files that might have done the same previously, or give me some clue as to how we might go about it (without defining all the required methods explicitly), I would love to update the PR to handle the same as well. 

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #14931 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
