### PR TITLE
Reduce the frequency of the golang dependency upgrade CRON

### DIFF
--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -2,7 +2,7 @@ name: Update Golang Dependencies
 
 on:
   schedule:
-    - cron: "0 0 * * 0" # Runs every week at midnight UTC
+    - cron: "0 0 1,15 * *" # Runs every month on the 1st and 15th days at midnight UTC
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
## Description

This PR reduces the frequency of the Golang Dependency Upgrade CRON from every weeks to roughly every two weeks (on the 1st and 15th of every month).
