### PR TITLE
fix: `Unescape(Escape(str))` now returns the original string

### DIFF
--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -78,5 +78,5 @@ func UnescapeID(in string) (string, error) {
 		}
 		return buf.String(), nil
 	}
-	return "", fmt.Errorf("UnescapeID invalid identifier: \"%s\" must be enclosed in backticks", in)
+	return in, nil
 }

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -52,11 +52,21 @@ func EscapeIDs(identifiers []string) []string {
 	return result
 }
 
-// UnescapeID reverses any backticking in the input string.
+// UnescapeID reverses any backticking in the input string by EscapeID.
 func UnescapeID(in string) string {
 	l := len(in)
 	if l >= 2 && in[0] == '`' && in[l-1] == '`' {
-		return in[1 : l-1]
+		in = in[1 : l-1]
+		var buf strings.Builder
+		buf.Grow(len(in))
+
+		for i := 0; i < len(in); i++ {
+			buf.WriteByte(in[i])
+			if i < len(in)-1 && in[i] == '`' && in[i+1] == '`' {
+				i++ // halves the number of backticks
+			}
+		}
+		return buf.String()
 	}
 	return in
 }

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -59,7 +59,7 @@ func UnescapeID(in string) (string, error) {
 	if l >= 2 && in[0] == '`' && in[l-1] == '`' {
 		in = in[1 : l-1]
 
-		if !strings.ContainsRune(in, '`') {
+		if idx := strings.IndexByte(in, '`'); idx == -1 {
 			return in, nil
 		}
 

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -64,14 +64,14 @@ func UnescapeID(in string) (string, error) {
 	first, last := in[0], in[l-1]
 
 	if l >= 2 && first == '`' && last != '`' {
-		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in %s", 0, in)
+		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in '%s'", 0, in)
 	}
 	if l >= 2 && first != '`' && last == '`' {
-		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in %s", l, in)
+		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in '%s'", l, in)
 	}
 	if l >= 2 && first != '`' && last != '`' {
 		if idx := strings.IndexByte(in, '`'); idx != -1 {
-			return "", fmt.Errorf("UnescapeID error: no outer backticks found in the identifier '%s'", in)
+			return "", fmt.Errorf("UnescapeID err: no outer backticks found in the identifier '%s'", in)
 		}
 		return in, nil
 	}
@@ -93,7 +93,7 @@ func UnescapeID(in string) (string, error) {
 				if in[i+1] == '`' {
 					i++ // halves the number of backticks
 				} else {
-					return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in %s", i, in)
+					return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in '%s'", i, in)
 				}
 			}
 		}

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -69,7 +69,10 @@ func UnescapeID(in string) (string, error) {
 	if l >= 2 && first != '`' && last == '`' {
 		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in %s", l, in)
 	}
-	if idx := strings.IndexByte(in, '`'); idx == -1 && l >= 2 {
+	if l >= 2 && first != '`' && last != '`' {
+		if idx := strings.IndexByte(in, '`'); idx != -1 {
+			return "", fmt.Errorf("UnescapeID error: no outer backticks found in the identifier '%s'", in)
+		}
 		return in, nil
 	}
 
@@ -99,4 +102,12 @@ func UnescapeID(in string) (string, error) {
 	}
 
 	return in, nil
+}
+
+func EnsureEscaped(in string) (string, error) {
+	out, err := UnescapeID(in)
+	if err != nil {
+		return "", err
+	}
+	return EscapeID(out), nil
 }

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -57,38 +57,46 @@ func EscapeIDs(identifiers []string) []string {
 func UnescapeID(in string) (string, error) {
 	l := len(in)
 
-	if idx := strings.IndexByte(in, '`'); idx == -1 && l >= 2 {
+	if l == 0 {
 		return in, nil
 	}
 
 	first, last := in[0], in[l-1]
-	if l >= 2 {
-		if first == '`' && last != '`' {
-			return "", fmt.Errorf("UnescapeID invalid identifier: unexpected single backtick at position %d in %s", 0, in)
-		} else if first != '`' && last == '`' {
-			return "", fmt.Errorf("UnescapeID invalid identifier: unexpected single backtick at position %d in %s", l, in)
-		} else if first == '`' && last == '`' {
-			in = in[1 : l-1]
 
-			if idx := strings.IndexByte(in, '`'); idx == -1 {
-				return in, nil
-			}
+	if l >= 2 && first == '`' && last != '`' {
+		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in %s", 0, in)
+	}
+	if l >= 2 && first != '`' && last == '`' {
+		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in %s", l, in)
+	}
+	if idx := strings.IndexByte(in, '`'); idx == -1 && l >= 2 {
+		return in, nil
+	}
 
-			var buf strings.Builder
-			buf.Grow(len(in))
+	if l >= 2 && first == '`' && last == '`' {
+		in = in[1 : l-1]
 
-			for i := 0; i < len(in); i++ {
-				buf.WriteByte(in[i])
-				if i < len(in)-1 && in[i] == '`' {
-					if in[i+1] == '`' {
-						i++ // halves the number of backticks
-					} else {
-						return "", fmt.Errorf("UnescapeID invalid identifier: unexpected single backtick at position %d in %s", i, in)
-					}
+		if idx := strings.IndexByte(in, '`'); idx == -1 {
+			return in, nil
+		}
+
+		var buf strings.Builder
+		buf.Grow(len(in))
+
+		for i := 0; i < len(in); i++ {
+			buf.WriteByte(in[i])
+
+			if i < len(in)-1 && in[i] == '`' {
+				if in[i+1] == '`' {
+					i++ // halves the number of backticks
+				} else {
+					return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in %s", i, in)
 				}
 			}
-			return buf.String(), nil
 		}
+
+		return buf.String(), nil
 	}
+
 	return in, nil
 }

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -57,8 +57,9 @@ func EscapeIDs(identifiers []string) []string {
 func UnescapeID(in string) (string, error) {
 	l := len(in)
 
-	if l == 0 {
-		return in, nil
+	if l == 0 || in == "``" {
+		return "", fmt.Errorf("UnescapeID err: invalid input identifier '%s'", in)
+
 	}
 
 	if l == 1 {

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -14,7 +14,7 @@ limitations under the License.
 package sqlescape
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -72,11 +72,11 @@ func UnescapeID(in string) (string, error) {
 				if in[i+1] == '`' {
 					i++ // halves the number of backticks
 				} else {
-					return "", errors.New("Invalid identifier: " + in)
+					return "", fmt.Errorf("UnescapeID invalid identifier: unexpected single backtick at position %d in %s", i, in)
 				}
 			}
 		}
 		return buf.String(), nil
 	}
-	return "", errors.New("Invalid identifier: " + in)
+	return "", fmt.Errorf("UnescapeID invalid identifier: \"%s\" must be enclosed in backticks", in)
 }

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -61,47 +61,50 @@ func UnescapeID(in string) (string, error) {
 		return in, nil
 	}
 
+	if l == 1 {
+		if in[0] == '`' {
+			return "", fmt.Errorf("UnescapeID err: invalid input identifier '`'")
+		}
+		return in, nil
+	}
+
 	first, last := in[0], in[l-1]
 
-	if l >= 2 && first == '`' && last != '`' {
+	if first == '`' && last != '`' {
 		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in '%s'", 0, in)
 	}
-	if l >= 2 && first != '`' && last == '`' {
+	if first != '`' && last == '`' {
 		return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in '%s'", l, in)
 	}
-	if l >= 2 && first != '`' && last != '`' {
+	if first != '`' && last != '`' {
 		if idx := strings.IndexByte(in, '`'); idx != -1 {
 			return "", fmt.Errorf("UnescapeID err: no outer backticks found in the identifier '%s'", in)
 		}
 		return in, nil
 	}
 
-	if l >= 2 && first == '`' && last == '`' {
-		in = in[1 : l-1]
+	in = in[1 : l-1]
 
-		if idx := strings.IndexByte(in, '`'); idx == -1 {
-			return in, nil
-		}
-
-		var buf strings.Builder
-		buf.Grow(len(in))
-
-		for i := 0; i < len(in); i++ {
-			buf.WriteByte(in[i])
-
-			if i < len(in)-1 && in[i] == '`' {
-				if in[i+1] == '`' {
-					i++ // halves the number of backticks
-				} else {
-					return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in '%s'", i, in)
-				}
-			}
-		}
-
-		return buf.String(), nil
+	if idx := strings.IndexByte(in, '`'); idx == -1 {
+		return in, nil
 	}
 
-	return in, nil
+	var buf strings.Builder
+	buf.Grow(len(in))
+
+	for i := 0; i < len(in); i++ {
+		buf.WriteByte(in[i])
+
+		if i < len(in)-1 && in[i] == '`' {
+			if in[i+1] == '`' {
+				i++ // halves the number of backticks
+			} else {
+				return "", fmt.Errorf("UnescapeID err: unexpected single backtick at position %d in '%s'", i, in)
+			}
+		}
+	}
+
+	return buf.String(), nil
 }
 
 func EnsureEscaped(in string) (string, error) {

--- a/go/sqlescape/ids_test.go
+++ b/go/sqlescape/ids_test.go
@@ -115,9 +115,11 @@ func TestUnescapeID(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.in, func(t *testing.T) {
 			out, err := UnescapeID(tc.in)
-			assert.Equal(t, tc.out, out, "output mismatch")
 			if tc.err {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.out, out, "output mismatch")
 			}
 		})
 	}

--- a/go/sqlescape/ids_test.go
+++ b/go/sqlescape/ids_test.go
@@ -52,7 +52,7 @@ func TestUnescapeID(t *testing.T) {
 		{
 			in:  "``",
 			out: "",
-			err: false,
+			err: true,
 		},
 		{
 			in:  "a",
@@ -117,7 +117,7 @@ func TestUnescapeID(t *testing.T) {
 		{
 			in:  "",
 			out: "",
-			err: false,
+			err: true,
 		},
 		{
 			in:  "`",
@@ -146,8 +146,8 @@ func TestEnsureEscaped(t *testing.T) {
 	}{
 		{
 			in:  "",
-			out: "``",
-			err: false,
+			out: "",
+			err: true,
 		},
 		{
 			in:  "foo",

--- a/go/sqlescape/ids_test.go
+++ b/go/sqlescape/ids_test.go
@@ -87,6 +87,11 @@ func TestUnescapeID(t *testing.T) {
 			err: true,
 		},
 		{
+			in:  "`fo`o`",
+			out: "",
+			err: true,
+		},
+		{
 			in:  "``fo``o``",
 			out: "",
 			err: true,

--- a/go/sqlescape/ids_test.go
+++ b/go/sqlescape/ids_test.go
@@ -119,6 +119,11 @@ func TestUnescapeID(t *testing.T) {
 			out: "",
 			err: false,
 		},
+		{
+			in:  "`",
+			out: "",
+			err: true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.in, func(t *testing.T) {

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -346,17 +346,16 @@ func GetColumns(dbName, table string, exec func(string, int, bool) (*sqltypes.Re
 	if selectColumns == "" {
 		selectColumns = "*"
 	}
-	sanitizedTable, err := sqlescape.UnescapeID(table)
+	tableSpec, err := sqlescape.EnsureEscaped(table)
 	if err != nil {
 		return nil, nil, err
 	}
-	tableSpec := sqlescape.EscapeID(sanitizedTable)
 	if dbName != "" {
-		sanitizedDbName, err := sqlescape.UnescapeID(dbName)
+		dbName, err := sqlescape.EnsureEscaped(dbName)
 		if err != nil {
 			return nil, nil, err
 		}
-		tableSpec = fmt.Sprintf("%s.%s", sqlescape.EscapeID(sanitizedDbName), tableSpec)
+		tableSpec = fmt.Sprintf("%s.%s", dbName, tableSpec)
 	}
 	query := fmt.Sprintf(GetFieldsQuery, selectColumns, tableSpec)
 	qr, err := exec(query, 0, true)

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -309,7 +309,11 @@ func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sql
 	} else {
 		dbName2 = encodeEntityName(dbName)
 	}
-	query := fmt.Sprintf(GetColumnNamesQuery, dbName2, encodeEntityName(sqlescape.UnescapeID(tableName)))
+	sanitizedTableName, err := sqlescape.UnescapeID(tableName)
+	if err != nil {
+		return "", err
+	}
+	query := fmt.Sprintf(GetColumnNamesQuery, dbName2, encodeEntityName(sanitizedTableName))
 	qr, err := exec(query, -1, true)
 	if err != nil {
 		return "", err
@@ -342,9 +346,17 @@ func GetColumns(dbName, table string, exec func(string, int, bool) (*sqltypes.Re
 	if selectColumns == "" {
 		selectColumns = "*"
 	}
-	tableSpec := sqlescape.EscapeID(sqlescape.UnescapeID(table))
+	sanitizedTable, err := sqlescape.UnescapeID(table)
+	if err != nil {
+		return nil, nil, err
+	}
+	tableSpec := sqlescape.EscapeID(sanitizedTable)
 	if dbName != "" {
-		tableSpec = fmt.Sprintf("%s.%s", sqlescape.EscapeID(sqlescape.UnescapeID(dbName)), tableSpec)
+		sanitizedDbName, err := sqlescape.UnescapeID(dbName)
+		if err != nil {
+			return nil, nil, err
+		}
+		tableSpec = fmt.Sprintf("%s.%s", sqlescape.EscapeID(sanitizedDbName), tableSpec)
 	}
 	query := fmt.Sprintf(GetFieldsQuery, selectColumns, tableSpec)
 	qr, err := exec(query, 0, true)

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -487,27 +487,24 @@ func (ts *trafficSwitcher) dropParticipatingTablesFromKeyspace(ctx context.Conte
 func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType TableRemovalType) error {
 	err := ts.ForAllSources(func(source *MigrationSource) error {
 		for _, tableName := range ts.Tables() {
-			sanitizedPrimaryDbName, err := sqlescape.UnescapeID(source.GetPrimary().DbName())
+			primaryDbName, err := sqlescape.EnsureEscaped(source.GetPrimary().DbName())
 			if err != nil {
 				return err
 			}
-			primaryDbName := sqlescape.EscapeID(sanitizedPrimaryDbName)
-			sanitizedTableName, err := sqlescape.UnescapeID(tableName)
+			tableName, err := sqlescape.EnsureEscaped(tableName)
 			if err != nil {
 				return err
 			}
-			tableName := sqlescape.EscapeID(sanitizedTableName)
 
 			query := fmt.Sprintf("drop table %s.%s", primaryDbName, tableName)
 			if removalType == DropTable {
 				ts.Logger().Infof("%s: Dropping table %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName)
 			} else {
-				sanitizedRename, err := sqlescape.UnescapeID(getRenameFileName(tableName))
+				renameName, err := sqlescape.EnsureEscaped(getRenameFileName(tableName))
 				if err != nil {
 					return err
 				}
-				renameName := sqlescape.EscapeID(sanitizedRename)
 				ts.Logger().Infof("%s: Renaming table %s.%s to %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName, source.GetPrimary().DbName(), renameName)
 				query = fmt.Sprintf("rename table %s.%s TO %s.%s", primaryDbName, tableName, primaryDbName, renameName)
@@ -1074,16 +1071,14 @@ func (ts *trafficSwitcher) removeTargetTables(ctx context.Context) error {
 	err := ts.ForAllTargets(func(target *MigrationTarget) error {
 		log.Infof("ForAllTargets: %+v", target)
 		for _, tableName := range ts.Tables() {
-			sanitizedPrimaryDbName, err := sqlescape.UnescapeID(target.GetPrimary().DbName())
+			primaryDbName, err := sqlescape.EnsureEscaped(target.GetPrimary().DbName())
 			if err != nil {
 				return err
 			}
-			primaryDbName := sqlescape.EscapeID(sanitizedPrimaryDbName)
-			sanitizedTableName, err := sqlescape.UnescapeID(tableName)
+			tableName, err := sqlescape.EnsureEscaped(tableName)
 			if err != nil {
 				return err
 			}
-			tableName := sqlescape.EscapeID(sanitizedTableName)
 			query := fmt.Sprintf("drop table %s.%s", primaryDbName, tableName)
 			ts.Logger().Infof("%s: Dropping table %s.%s\n",
 				target.GetPrimary().String(), target.GetPrimary().DbName(), tableName)

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -491,12 +491,12 @@ func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType T
 			if err != nil {
 				return err
 			}
-			tableName, err := sqlescape.EnsureEscaped(tableName)
+			tableNameEscaped, err := sqlescape.EnsureEscaped(tableName)
 			if err != nil {
 				return err
 			}
 
-			query := fmt.Sprintf("drop table %s.%s", primaryDbName, tableName)
+			query := fmt.Sprintf("drop table %s.%s", primaryDbName, tableNameEscaped)
 			if removalType == DropTable {
 				ts.Logger().Infof("%s: Dropping table %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName)
@@ -507,7 +507,7 @@ func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType T
 				}
 				ts.Logger().Infof("%s: Renaming table %s.%s to %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName, source.GetPrimary().DbName(), renameName)
-				query = fmt.Sprintf("rename table %s.%s TO %s.%s", primaryDbName, tableName, primaryDbName, renameName)
+				query = fmt.Sprintf("rename table %s.%s TO %s.%s", primaryDbName, tableNameEscaped, primaryDbName, renameName)
 			}
 			_, err = ts.ws.tmc.ExecuteFetchAsDba(ctx, source.GetPrimary().Tablet, false, &tabletmanagerdatapb.ExecuteFetchAsDbaRequest{
 				Query:        []byte(query),

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -453,10 +453,18 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 	indexRows := make([][]sqltypes.Value, 0, 4)
 	for _, ddl := range ddls {
 		table := sqlparser.String(ddl.GetTable().Name)
-		backtickedTable := sqlescape.EscapeID(sqlescape.UnescapeID(table))
+		sanitizedTable, err := sqlescape.UnescapeID(table)
+		if err != nil {
+			return nil, err
+		}
+		backtickedTable := sqlescape.EscapeID(sanitizedTable)
 		if ddl.GetOptLike() != nil {
 			likeTable := ddl.GetOptLike().LikeTable.Name.String()
-			backtickedLikeTable := sqlescape.EscapeID(sqlescape.UnescapeID(likeTable))
+			sanitizedLikeTable, err := sqlescape.UnescapeID(likeTable)
+			if err != nil {
+				return nil, err
+			}
+			backtickedLikeTable := sqlescape.EscapeID(sanitizedLikeTable)
 
 			likeQuery := "SELECT * FROM " + backtickedLikeTable + " WHERE 1 != 1"
 			query := "SELECT * FROM " + backtickedTable + " WHERE 1 != 1"
@@ -465,8 +473,8 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 			}
 			tEnv.addResult(query, tEnv.getResult(likeQuery))
 
-			likeQuery = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sqlescape.UnescapeID(likeTable))
-			query = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sqlescape.UnescapeID(table))
+			likeQuery = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sanitizedLikeTable)
+			query = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sanitizedTable)
 			if tEnv.getResult(likeQuery) == nil {
 				return nil, fmt.Errorf("check your schema, table[%s] doesn't exist", likeTable)
 			}
@@ -507,7 +515,7 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 		tEnv.addResult("SELECT * FROM "+backtickedTable+" WHERE 1 != 1", &sqltypes.Result{
 			Fields: rowTypes,
 		})
-		query := fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sqlescape.UnescapeID(table))
+		query := fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sanitizedTable)
 		tEnv.addResult(query, &sqltypes.Result{
 			Fields: colTypes,
 			Rows:   colValues,

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -854,10 +854,18 @@ func escapeQualifiedTable(qualifiedTableName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	sanitizedKeyspace, err := sqlescape.UnescapeID(keyspace)
+	if err != nil {
+		return "", err
+	}
+	sanitizedTableName, err := sqlescape.UnescapeID(tableName)
+	if err != nil {
+		return "", err
+	}
 	return fmt.Sprintf("%s.%s",
 		// unescape() first in case an already escaped string was passed
-		sqlescape.EscapeID(sqlescape.UnescapeID(keyspace)),
-		sqlescape.EscapeID(sqlescape.UnescapeID(tableName))), nil
+		sqlescape.EscapeID(sanitizedKeyspace),
+		sqlescape.EscapeID(sanitizedTableName)), nil
 }
 
 func extractTableParts(tableName string, allowUnqualified bool) (string, string, error) {

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -854,18 +854,16 @@ func escapeQualifiedTable(qualifiedTableName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sanitizedKeyspace, err := sqlescape.UnescapeID(keyspace)
+	// unescape() first in case an already escaped string was passed
+	keyspace, err = sqlescape.EnsureEscaped(keyspace)
 	if err != nil {
 		return "", err
 	}
-	sanitizedTableName, err := sqlescape.UnescapeID(tableName)
+	tableName, err = sqlescape.EnsureEscaped(tableName)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s.%s",
-		// unescape() first in case an already escaped string was passed
-		sqlescape.EscapeID(sanitizedKeyspace),
-		sqlescape.EscapeID(sanitizedTableName)), nil
+	return fmt.Sprintf("%s.%s", keyspace, tableName), nil
 }
 
 func extractTableParts(tableName string, allowUnqualified bool) (string, string, error) {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -273,12 +273,11 @@ func (rs *rowStreamer) buildSelect(st *binlogdatapb.MinimalTable) (string, error
 	// of the PK columns which are used in the ORDER BY clause below.
 	var indexHint string
 	if st.PKIndexName != "" {
-		sanitized, err := sqlescape.UnescapeID(st.PKIndexName)
+		escapedPKIndexName, err := sqlescape.EnsureEscaped(st.PKIndexName)
 		if err != nil {
 			return "", err
 		}
-		indexHint = fmt.Sprintf(" force index (%s)",
-			sqlescape.EscapeID(sanitized))
+		indexHint = fmt.Sprintf(" force index (%s)", escapedPKIndexName)
 	}
 	buf.Myprintf(" from %v%s", sqlparser.NewIdentifierCS(rs.plan.Table.Name), indexHint)
 	if len(rs.lastpk) != 0 {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -273,8 +273,12 @@ func (rs *rowStreamer) buildSelect(st *binlogdatapb.MinimalTable) (string, error
 	// of the PK columns which are used in the ORDER BY clause below.
 	var indexHint string
 	if st.PKIndexName != "" {
+		sanitized, err := sqlescape.UnescapeID(st.PKIndexName)
+		if err != nil {
+			return "", err
+		}
 		indexHint = fmt.Sprintf(" force index (%s)",
-			sqlescape.EscapeID(sqlescape.UnescapeID(st.PKIndexName)))
+			sqlescape.EscapeID(sanitized))
 	}
 	buf.Myprintf(" from %v%s", sqlparser.NewIdentifierCS(rs.plan.Table.Name), indexHint)
 	if len(rs.lastpk) != 0 {

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1772,23 +1772,35 @@ func getRenameFileName(tableName string) string {
 func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType workflow.TableRemovalType) error {
 	err := ts.ForAllSources(func(source *workflow.MigrationSource) error {
 		for _, tableName := range ts.Tables() {
+			sanitizedPrimaryDbName, err := sqlescape.UnescapeID(source.GetPrimary().DbName())
+			if err != nil {
+				return err
+			}
+			sanitizedTableName, err := sqlescape.UnescapeID(tableName)
+			if err != nil {
+				return err
+			}
 			query := fmt.Sprintf("drop table %s.%s",
-				sqlescape.EscapeID(sqlescape.UnescapeID(source.GetPrimary().DbName())),
-				sqlescape.EscapeID(sqlescape.UnescapeID(tableName)))
+				sqlescape.EscapeID(sanitizedPrimaryDbName),
+				sqlescape.EscapeID(sanitizedTableName))
 			if removalType == workflow.DropTable {
 				ts.Logger().Infof("%s: Dropping table %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName)
 			} else {
 				renameName := getRenameFileName(tableName)
+				sanitizedRenameName, err := sqlescape.UnescapeID(renameName)
+				if err != nil {
+					return err
+				}
 				ts.Logger().Infof("%s: Renaming table %s.%s to %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName, source.GetPrimary().DbName(), renameName)
 				query = fmt.Sprintf("rename table %s.%s TO %s.%s",
-					sqlescape.EscapeID(sqlescape.UnescapeID(source.GetPrimary().DbName())),
-					sqlescape.EscapeID(sqlescape.UnescapeID(tableName)),
-					sqlescape.EscapeID(sqlescape.UnescapeID(source.GetPrimary().DbName())),
-					sqlescape.EscapeID(sqlescape.UnescapeID(renameName)))
+					sqlescape.EscapeID(sanitizedPrimaryDbName),
+					sqlescape.EscapeID(sanitizedTableName),
+					sqlescape.EscapeID(sanitizedPrimaryDbName),
+					sqlescape.EscapeID(sanitizedRenameName))
 			}
-			_, err := ts.wr.ExecuteFetchAsDba(ctx, source.GetPrimary().Alias, query, 1, false, true)
+			_, err = ts.wr.ExecuteFetchAsDba(ctx, source.GetPrimary().Alias, query, 1, false, true)
 			if err != nil {
 				ts.Logger().Errorf("%s: Error removing table %s: %v", source.GetPrimary().String(), tableName, err)
 				return err
@@ -1883,12 +1895,20 @@ func (ts *trafficSwitcher) removeTargetTables(ctx context.Context) error {
 	log.Infof("removeTargetTables")
 	err := ts.ForAllTargets(func(target *workflow.MigrationTarget) error {
 		for _, tableName := range ts.Tables() {
+			sanitizedPrimaryDbName, err := sqlescape.UnescapeID(target.GetPrimary().DbName())
+			if err != nil {
+				return err
+			}
+			sanitizedTableName, err := sqlescape.UnescapeID(tableName)
+			if err != nil {
+				return err
+			}
 			query := fmt.Sprintf("drop table %s.%s",
-				sqlescape.EscapeID(sqlescape.UnescapeID(target.GetPrimary().DbName())),
-				sqlescape.EscapeID(sqlescape.UnescapeID(tableName)))
+				sqlescape.EscapeID(sanitizedPrimaryDbName),
+				sqlescape.EscapeID(sanitizedTableName))
 			ts.Logger().Infof("%s: Dropping table %s.%s\n",
 				target.GetPrimary().String(), target.GetPrimary().DbName(), tableName)
-			_, err := ts.wr.ExecuteFetchAsDba(ctx, target.GetPrimary().Alias, query, 1, false, true)
+			_, err = ts.wr.ExecuteFetchAsDba(ctx, target.GetPrimary().Alias, query, 1, false, true)
 			if err != nil {
 				ts.Logger().Errorf("%s: Error removing table %s: %v",
 					target.GetPrimary().String(), tableName, err)

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1772,7 +1772,7 @@ func getRenameFileName(tableName string) string {
 func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType workflow.TableRemovalType) error {
 	err := ts.ForAllSources(func(source *workflow.MigrationSource) error {
 		for _, tableName := range ts.Tables() {
-			PrimaryDbName, err := sqlescape.EnsureEscaped(source.GetPrimary().DbName())
+			primaryDbName, err := sqlescape.EnsureEscaped(source.GetPrimary().DbName())
 			if err != nil {
 				return err
 			}
@@ -1780,7 +1780,7 @@ func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType w
 			if err != nil {
 				return err
 			}
-			query := fmt.Sprintf("drop table %s.%s", PrimaryDbName, tableNameEscaped)
+			query := fmt.Sprintf("drop table %s.%s", primaryDbName, tableNameEscaped)
 			if removalType == workflow.DropTable {
 				ts.Logger().Infof("%s: Dropping table %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName)
@@ -1791,7 +1791,7 @@ func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType w
 				}
 				ts.Logger().Infof("%s: Renaming table %s.%s to %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName, source.GetPrimary().DbName(), renameName)
-				query = fmt.Sprintf("rename table %s.%s TO %s.%s", PrimaryDbName, tableNameEscaped, PrimaryDbName, renameName)
+				query = fmt.Sprintf("rename table %s.%s TO %s.%s", primaryDbName, tableNameEscaped, primaryDbName, renameName)
 			}
 			_, err = ts.wr.ExecuteFetchAsDba(ctx, source.GetPrimary().Alias, query, 1, false, true)
 			if err != nil {
@@ -1888,7 +1888,7 @@ func (ts *trafficSwitcher) removeTargetTables(ctx context.Context) error {
 	log.Infof("removeTargetTables")
 	err := ts.ForAllTargets(func(target *workflow.MigrationTarget) error {
 		for _, tableName := range ts.Tables() {
-			PrimaryDbName, err := sqlescape.EnsureEscaped(target.GetPrimary().DbName())
+			primaryDbName, err := sqlescape.EnsureEscaped(target.GetPrimary().DbName())
 			if err != nil {
 				return err
 			}
@@ -1896,7 +1896,7 @@ func (ts *trafficSwitcher) removeTargetTables(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			query := fmt.Sprintf("drop table %s.%s", PrimaryDbName, tableName)
+			query := fmt.Sprintf("drop table %s.%s", primaryDbName, tableName)
 			ts.Logger().Infof("%s: Dropping table %s.%s\n",
 				target.GetPrimary().String(), target.GetPrimary().DbName(), tableName)
 			_, err = ts.wr.ExecuteFetchAsDba(ctx, target.GetPrimary().Alias, query, 1, false, true)

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1776,11 +1776,11 @@ func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType w
 			if err != nil {
 				return err
 			}
-			tableName, err := sqlescape.EnsureEscaped(tableName)
+			tableNameEscaped, err := sqlescape.EnsureEscaped(tableName)
 			if err != nil {
 				return err
 			}
-			query := fmt.Sprintf("drop table %s.%s", PrimaryDbName, tableName)
+			query := fmt.Sprintf("drop table %s.%s", PrimaryDbName, tableNameEscaped)
 			if removalType == workflow.DropTable {
 				ts.Logger().Infof("%s: Dropping table %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName)
@@ -1791,7 +1791,7 @@ func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType w
 				}
 				ts.Logger().Infof("%s: Renaming table %s.%s to %s.%s\n",
 					source.GetPrimary().String(), source.GetPrimary().DbName(), tableName, source.GetPrimary().DbName(), renameName)
-				query = fmt.Sprintf("rename table %s.%s TO %s.%s", PrimaryDbName, tableName, PrimaryDbName, renameName)
+				query = fmt.Sprintf("rename table %s.%s TO %s.%s", PrimaryDbName, tableNameEscaped, PrimaryDbName, renameName)
 			}
 			_, err = ts.wr.ExecuteFetchAsDba(ctx, source.GetPrimary().Alias, query, 1, false, true)
 			if err != nil {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
`UnescapeID(str)` will now also halve any backticks found within a string.
Associated tests will be added via #14987
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #14992
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
