### PR TITLE
vtgate: increment vtgate_warnings counter for non atomic commits

### DIFF
--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -158,6 +158,7 @@ func (txc *TxConn) commitNormal(ctx context.Context, session *SafeSession) error
 					Code:    uint32(sqlerror.ERNonAtomicCommit),
 					Message: fmt.Sprintf("multi-db commit failed after committing to %d shards: %s", i, strings.Join(sNames, ", ")),
 				})
+				warnings.Add("NonAtomicCommit", 1)
 			}
 			_ = txc.Release(ctx, session)
 			return err

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -72,6 +72,7 @@ func TestTxConnCommitFailure(t *testing.T) {
 
 	sc, sbcs, rssm, rssa := newTestTxConnEnvNShards(t, ctx, "TestTxConn", 3)
 	sc.txConn.mode = vtgatepb.TransactionMode_MULTI
+	nonAtomicCommitCount := warnings.Counts()["NonAtomicCommit"]
 
 	// Sequence the executes to ensure commit order
 
@@ -163,6 +164,8 @@ func TestTxConnCommitFailure(t *testing.T) {
 	}
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 	assert.EqualValues(t, 1, sbcs[0].CommitCount.Load(), "sbc0.CommitCount")
+
+	require.Equal(t, nonAtomicCommitCount+1, warnings.Counts()["NonAtomicCommit"])
 }
 
 func TestTxConnCommitFailureAfterNonAtomicCommitMaxShards(t *testing.T) {
@@ -170,6 +173,7 @@ func TestTxConnCommitFailureAfterNonAtomicCommitMaxShards(t *testing.T) {
 
 	sc, sbcs, rssm, _ := newTestTxConnEnvNShards(t, ctx, "TestTxConn", 18)
 	sc.txConn.mode = vtgatepb.TransactionMode_MULTI
+	nonAtomicCommitCount := warnings.Counts()["NonAtomicCommit"]
 
 	// Sequence the executes to ensure commit order
 
@@ -214,6 +218,8 @@ func TestTxConnCommitFailureAfterNonAtomicCommitMaxShards(t *testing.T) {
 	for i := 0; i < 17; i++ {
 		assert.EqualValues(t, 1, sbcs[i].CommitCount.Load(), fmt.Sprintf("sbc%d.CommitCount", i))
 	}
+
+	require.Equal(t, nonAtomicCommitCount+1, warnings.Counts()["NonAtomicCommit"])
 }
 
 func TestTxConnCommitFailureBeforeNonAtomicCommitMaxShards(t *testing.T) {
@@ -221,6 +227,7 @@ func TestTxConnCommitFailureBeforeNonAtomicCommitMaxShards(t *testing.T) {
 
 	sc, sbcs, rssm, _ := newTestTxConnEnvNShards(t, ctx, "TestTxConn", 17)
 	sc.txConn.mode = vtgatepb.TransactionMode_MULTI
+	nonAtomicCommitCount := warnings.Counts()["NonAtomicCommit"]
 
 	// Sequence the executes to ensure commit order
 
@@ -265,6 +272,8 @@ func TestTxConnCommitFailureBeforeNonAtomicCommitMaxShards(t *testing.T) {
 	for i := 0; i < 16; i++ {
 		assert.EqualValues(t, 1, sbcs[i].CommitCount.Load(), fmt.Sprintf("sbc%d.CommitCount", i))
 	}
+
+	require.Equal(t, nonAtomicCommitCount+1, warnings.Counts()["NonAtomicCommit"])
 }
 
 func TestTxConnCommitSuccess(t *testing.T) {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -187,7 +187,7 @@ var (
 	// Error counters should be global so they can be set from anywhere
 	errorCounts = stats.NewCountersWithMultiLabels("VtgateApiErrorCounts", "Vtgate API error counts per error type", []string{"Operation", "Keyspace", "DbType", "Code"})
 
-	warnings = stats.NewCountersWithSingleLabel("VtGateWarnings", "Vtgate warnings", "type", "IgnoredSet", "ResultsExceeded", "WarnPayloadSizeExceeded")
+	warnings = stats.NewCountersWithSingleLabel("VtGateWarnings", "Vtgate warnings", "type", "IgnoredSet", "ResultsExceeded", "WarnPayloadSizeExceeded", "NonAtomicCommit")
 
 	vstreamSkewDelayCount = stats.NewCounter("VStreamEventsDelayedBySkewAlignment",
 		"Number of events that had to wait because the skew across shards was too high")


### PR DESCRIPTION
## Description

This change was supposed to get merged with  https://github.com/vitessio/vitess/pull/14848 but it looks like I never pushed it up 😮‍💨 

## Related Issue(s)

https://github.com/vitessio/vitess/pull/14848
https://github.com/vitessio/vitess/issues/14815

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
