### PR TITLE
Added unit tests for the tools/releases package

### DIFF
--- a/go/tools/releases/releases_test.go
+++ b/go/tools/releases/releases_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDirs(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentDir  dir
+		expectedErr string
+	}{
+		{
+			name:        "Empty dir",
+			currentDir:  dir{},
+			expectedErr: "open : no such file or directory",
+		},
+		{
+			name: "Non empty dir",
+			currentDir: dir{
+				Path: "./",
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Temp dir",
+			currentDir: dir{
+				Path: "/tmp",
+			},
+			expectedErr: "open /tmp/snap-private-tmp: permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := getDirs(tt.currentDir)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestExecReadMeTemplateWithDir(t *testing.T) {
+	tests := []struct {
+		name        string
+		template    string
+		currentDir  dir
+		expectedErr string
+	}{
+		{
+			name:        "Empty dir and empty template",
+			currentDir:  dir{},
+			template:    "",
+			expectedErr: "",
+		},
+		{
+			name: "Invaild directory path",
+			currentDir: dir{
+				Path: `\./`,
+			},
+			template:    "",
+			expectedErr: `open \./README.md: no such file or directory`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := execReadMeTemplateWithDir(tt.currentDir, tt.template)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This commit bumps the code coverage of the `tools/releases` package from 0% to almost 60%.

## Related Issue(s)
Partially addresses: https://github.com/vitessio/vitess/issues/14931

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required