### PR TITLE
19.0 release notes: ExecuteFetchAsDBA breaking change

### DIFF
--- a/changelog/19.0/19.0.0/summary.md
+++ b/changelog/19.0/19.0.0/summary.md
@@ -76,7 +76,7 @@ Previously, `ExecuteFetchAsDBA` silently accepted multi statement SQL. It would 
 
 - It would only indicate error for the first statement. Errors on 2nd, 3rd, ... statements were silently ignored.
 - It would not consume the result sets of the 2nd, 3rd, ... statements. It would then return the used connection to the pool in a dirty state. Any further query that happens to take that connection out of the pool could get unexpected results.
-- As another side effect, multi-statement schema changes would cause schema to be reloaded with only the 1st change, leaving the cached schema inconsistent with the underlying database.
+- As another side effect, multi-statement schema changes would cause schema to be reloaded with only the first change, leaving the cached schema inconsistent with the underlying database.
 
 `ExecuteFetchAsDBA` does allow a specific use case of multi-statement SQL, which is where all statements are in the form of `CREATE TABLE` or `CREATE VIEW`. This is to support a common pattern of schema initialization, formalized in `ApplySchema --batch-size` which uses `ExecuteFetchAsDBA` under the hood.
 

--- a/changelog/19.0/19.0.0/summary.md
+++ b/changelog/19.0/19.0.0/summary.md
@@ -7,6 +7,8 @@
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
     - [VTTablet Flags](#vttablet-flags)
     - [MySQL binary in vitess/lite Docker image](#mysql-binary-in-lite-image)
+  - **[Breaking Changes](#breaking-changes)**
+     - [ExecuteFetchAsDBA rejects multi-statement SQL](#execute-fetch-as-dba-reject-multi)
   - **[New Stats](#new-stats)**
     - [Stream Consolidations](#stream-consolidations)
     - [Build Version in `/debug/vars`](#build-version-in-debug-vars)
@@ -61,6 +63,22 @@ Below is an example of a kubernetes yaml file before and after upgrading to an o
     mysqld:
       mysql80Compatible: mysql:8.0.30 # or even mysql:8.0.34 for instance
 ```
+
+### <a id="breaking-changes"/>Breaking Changes
+
+#### <a id="execute-fetch-as-dba-reject-multi"/>ExecuteFetchAsDBA rejects multi-statement SQL
+
+`vtctldclient ExecuteFetchAsDBA` (and similarly the `vtctl` and `vtctlclient` commands) now reject multi-statement SQL with error.
+
+For example, `vtctldclient ExecuteFetchAsDBA my-tablet "stop replica; change replication source to auto_position=1; start replica` will return an error, without attempting to execute any of these queries.
+
+Previously, `ExecuteFetchAsDBA` silently accepted multi statement SQL. It would (attempt to) execute all of them, but:
+
+- It would only indicate error for the first statement. Errors on 2nd, 3rd, ... statements were silently ignored.
+- It would not consume the result sets of the 2nd, 3rd, ... statements. It would then return the used connection to the pool in a dirty state. Any further query that happens to take that connection out of the pool could get unexpected results.
+- As another side effect, multi-statement schema changes would cause schema to be reloaded with only the 1st change, leaving the cached schema inconsistent with the underlying database.
+
+`ExecuteFetchAsDBA` does allow a specific use case of multi-statement SQL, which is where all statements are in the form of `CREATE TABLE` or `CREATE VIEW`. This is to support a common pattern of schema initialization, formalized in `ApplySchema --batch-size` which uses `ExecuteFetchAsDBA` under the hood.
 
 ### <a id="new-stats"/>New Stats
 


### PR DESCRIPTION
## Description

Towards `release-19.0`: Documenting the breaking change in https://github.com/vitessio/vitess/pull/14954

## Related Issue(s)


https://github.com/vitessio/vitess/pull/14984

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
