### PR TITLE
Load `--grpc_auth_static_client_creds` file once

### DIFF
--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -29,15 +32,21 @@ var (
 	credsFile string // registered as --grpc_auth_static_client_creds in RegisterFlags
 	// StaticAuthClientCreds implements client interface to be able to WithPerRPCCredentials
 	_ credentials.PerRPCCredentials = (*StaticAuthClientCreds)(nil)
+
+	clientCreds        *StaticAuthClientCreds
+	clientCredsCancel  context.CancelFunc
+	clientCredsErr     error
+	clientCredsMu      sync.Mutex
+	clientCredsSigChan chan os.Signal
 )
 
-// StaticAuthClientCreds holder for client credentials
+// StaticAuthClientCreds holder for client credentials.
 type StaticAuthClientCreds struct {
 	Username string
 	Password string
 }
 
-// GetRequestMetadata  gets the request metadata as a map from StaticAuthClientCreds
+// GetRequestMetadata gets the request metadata as a map from StaticAuthClientCreds.
 func (c *StaticAuthClientCreds) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
 	return map[string]string{
 		"username": c.Username,
@@ -47,30 +56,80 @@ func (c *StaticAuthClientCreds) GetRequestMetadata(context.Context, ...string) (
 
 // RequireTransportSecurity indicates whether the credentials requires transport security.
 // Given that people can use this with or without TLS, at the moment we are not enforcing
-// transport security
+// transport security.
 func (c *StaticAuthClientCreds) RequireTransportSecurity() bool {
 	return false
 }
 
 // AppendStaticAuth optionally appends static auth credentials if provided.
 func AppendStaticAuth(opts []grpc.DialOption) ([]grpc.DialOption, error) {
-	if credsFile == "" {
-		return opts, nil
-	}
-	data, err := os.ReadFile(credsFile)
+	creds, err := getStaticAuthCreds()
 	if err != nil {
 		return nil, err
 	}
-	clientCreds := &StaticAuthClientCreds{}
-	err = json.Unmarshal(data, clientCreds)
-	if err != nil {
-		return nil, err
+	if creds != nil {
+		grpcCreds := grpc.WithPerRPCCredentials(creds)
+		opts = append(opts, grpcCreds)
 	}
-	creds := grpc.WithPerRPCCredentials(clientCreds)
-	opts = append(opts, creds)
 	return opts, nil
 }
 
+// ResetStaticAuth resets the static auth credentials.
+func ResetStaticAuth() {
+	clientCredsMu.Lock()
+	defer clientCredsMu.Unlock()
+	if clientCredsCancel != nil {
+		clientCredsCancel()
+		clientCredsCancel = nil
+	}
+	clientCreds = nil
+	clientCredsErr = nil
+}
+
+// getStaticAuthCreds returns the static auth creds and error.
+func getStaticAuthCreds() (*StaticAuthClientCreds, error) {
+	clientCredsMu.Lock()
+	defer clientCredsMu.Unlock()
+	if credsFile != "" && clientCreds == nil {
+		var ctx context.Context
+		ctx, clientCredsCancel = context.WithCancel(context.Background())
+		go handleClientCredsSignals(ctx)
+		clientCreds, clientCredsErr = loadStaticAuthCredsFromFile(credsFile)
+	}
+	return clientCreds, clientCredsErr
+}
+
+// handleClientCredsSignals handles signals to reload client creds.
+func handleClientCredsSignals(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-clientCredsSigChan:
+			if newCreds, err := loadStaticAuthCredsFromFile(credsFile); err == nil {
+				clientCredsMu.Lock()
+				clientCreds = newCreds
+				clientCredsErr = err
+				clientCredsMu.Unlock()
+			}
+		}
+	}
+}
+
+// loadStaticAuthCredsFromFile loads static auth credentials from a file.
+func loadStaticAuthCredsFromFile(path string) (*StaticAuthClientCreds, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	creds := &StaticAuthClientCreds{}
+	err = json.Unmarshal(data, creds)
+	return creds, err
+}
+
 func init() {
+	clientCredsSigChan = make(chan os.Signal, 1)
+	signal.Notify(clientCredsSigChan, syscall.SIGHUP)
+	_, _ = getStaticAuthCreds() // preload static auth credentials
 	RegisterGRPCDialOptions(AppendStaticAuth)
 }

--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
 	"vitess.io/vitess/go/vt/servenv"
 )
 

--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
@@ -128,8 +129,10 @@ func loadStaticAuthCredsFromFile(path string) (*StaticAuthClientCreds, error) {
 }
 
 func init() {
-	clientCredsSigChan = make(chan os.Signal, 1)
-	signal.Notify(clientCredsSigChan, syscall.SIGHUP)
-	_, _ = getStaticAuthCreds() // preload static auth credentials
+	servenv.OnInit(func() {
+		clientCredsSigChan = make(chan os.Signal, 1)
+		signal.Notify(clientCredsSigChan, syscall.SIGHUP)
+		_, _ = getStaticAuthCreds() // preload static auth credentials
+	})
 	RegisterGRPCDialOptions(AppendStaticAuth)
 }

--- a/go/vt/grpcclient/client_auth_static_test.go
+++ b/go/vt/grpcclient/client_auth_static_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcclient
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestAppendStaticAuth(t *testing.T) {
+	{
+		clientCreds = nil
+		clientCredsErr = nil
+		opts, err := AppendStaticAuth([]grpc.DialOption{})
+		assert.Nil(t, err)
+		assert.Len(t, opts, 0)
+	}
+	{
+		clientCreds = nil
+		clientCredsErr = errors.New("test err")
+		opts, err := AppendStaticAuth([]grpc.DialOption{})
+		assert.NotNil(t, err)
+		assert.Len(t, opts, 0)
+	}
+	{
+		clientCreds = &StaticAuthClientCreds{Username: "test", Password: "123456"}
+		clientCredsErr = nil
+		opts, err := AppendStaticAuth([]grpc.DialOption{})
+		assert.Nil(t, err)
+		assert.Len(t, opts, 1)
+	}
+}
+
+func TestGetStaticAuthCreds(t *testing.T) {
+	tmp, err := os.CreateTemp("", t.Name())
+	assert.Nil(t, err)
+	defer os.Remove(tmp.Name())
+	credsFile = tmp.Name()
+
+	// load old creds
+	fmt.Fprint(tmp, `{"Username": "old", "Password": "123456"}`)
+	ResetStaticAuth()
+	creds, err := getStaticAuthCreds()
+	assert.Nil(t, err)
+	assert.Equal(t, &StaticAuthClientCreds{Username: "old", Password: "123456"}, creds)
+
+	// write new creds to the same file
+	_ = tmp.Truncate(0)
+	_, _ = tmp.Seek(0, 0)
+	fmt.Fprint(tmp, `{"Username": "new", "Password": "123456789"}`)
+
+	// test the creds did not change yet
+	creds, err = getStaticAuthCreds()
+	assert.Nil(t, err)
+	assert.Equal(t, &StaticAuthClientCreds{Username: "old", Password: "123456"}, creds)
+
+	// test SIGHUP signal triggers reload
+	credsOld := creds
+	clientCredsSigChan <- syscall.SIGHUP
+	for {
+		select {
+		case <-time.After(time.Second * 10):
+			assert.Fail(t, "timed out waiting for SIGHUP reload of static auth creds")
+			return
+		default:
+			// confirm new creds get loaded
+			creds, err = getStaticAuthCreds()
+			if reflect.DeepEqual(creds, credsOld) {
+				continue // not changed yet
+			}
+			assert.Nil(t, err)
+			assert.Equal(t, &StaticAuthClientCreds{Username: "new", Password: "123456789"}, creds)
+			return
+		}
+	}
+}
+
+func TestLoadStaticAuthCredsFromFile(t *testing.T) {
+	{
+		f, err := os.CreateTemp("", t.Name())
+		if !assert.Nil(t, err) {
+			assert.FailNowf(t, "cannot create temp file: %s", err.Error())
+		}
+		_, err = f.Write([]byte(`{
+			"Username": "test",
+			"Password": "correct horse battery staple"
+		}`))
+		if !assert.Nil(t, err) {
+			assert.FailNowf(t, "cannot read auth file: %s", err.Error())
+		}
+		defer os.Remove(f.Name())
+
+		creds, err := loadStaticAuthCredsFromFile(f.Name())
+		assert.Nil(t, err)
+		assert.Equal(t, "test", creds.Username)
+		assert.Equal(t, "correct horse battery staple", creds.Password)
+	}
+	{
+		_, err := loadStaticAuthCredsFromFile(`does-not-exist`)
+		assert.NotNil(t, err)
+	}
+}

--- a/go/vt/grpcclient/client_auth_static_test.go
+++ b/go/vt/grpcclient/client_auth_static_test.go
@@ -58,6 +58,7 @@ func TestGetStaticAuthCreds(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.Remove(tmp.Name())
 	credsFile = tmp.Name()
+	clientCredsSigChan = make(chan os.Signal, 1)
 
 	// load old creds
 	fmt.Fprint(tmp, `{"Username": "old", "Password": "123456"}`)

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -108,6 +108,7 @@ func TestGRPCVTGateConnAuth(t *testing.T) {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 	grpcclient.RegisterFlags(fs)
 
+	grpcclient.ResetStaticAuth()
 	err = fs.Parse([]string{
 		"--grpc_auth_static_client_creds",
 		f.Name(),
@@ -148,6 +149,7 @@ func TestGRPCVTGateConnAuth(t *testing.T) {
 	fs = pflag.NewFlagSet("", pflag.ContinueOnError)
 	grpcclient.RegisterFlags(fs)
 
+	grpcclient.ResetStaticAuth()
 	err = fs.Parse([]string{
 		"--grpc_auth_static_client_creds",
 		f.Name(),


### PR DESCRIPTION
## Description

This PR causes the `--grpc_auth_static_client_creds` file to be loaded once in order to avoid high OS-thread usage when `vtgate` starts up. In the right circumstances, the repeat loading of this file can contribute to `vtgate` crashing on `runtime: program exceeds 10000-thread limit`

This stack is seen using a significant amount of blocking syscalls on every spawned healthcheck stream:
```bash
(dlv) stack
 0  0x000000000047f120 in syscall.Syscall6
    at syscall/asm_linux_amd64.s:43
 1  0x000000000047bb05 in syscall.openat
    at syscall/zsyscall_linux_amd64.go:68
 2  0x00000000004f7c5b in syscall.Open
    at syscall/syscall_linux.go:155
 3  0x00000000004f7c5b in os.openFileNolog
    at os/file_unix.go:216
 4  0x00000000004f6585 in os.OpenFile
    at os/file.go:338
 5  0x00000000004f694a in os.Open
    at os/file.go:318
 6  0x00000000004f694a in os.ReadFile
    at os/file.go:670
 7  0x0000000000de2f7a in vitess.io/vitess/go/vt/grpcclient.AppendStaticAuth
    at vitess.io/vitess/go/vt/grpcclient/client_auth_static.go:62
 8  0x0000000000de21cc in vitess.io/vitess/go/vt/grpcclient.DialContext
    at vitess.io/vitess/go/vt/grpcclient/client.go:105
 9  0x0000000001150a45 in vitess.io/vitess/go/vt/grpcclient.Dial
    at vitess.io/vitess/go/vt/grpcclient/client.go:63
10  0x0000000001150a45 in vitess.io/vitess/go/vt/vttablet/grpctabletconn.DialTablet
    at vitess.io/vitess/go/vt/vttablet/grpctabletconn/conn.go:80
11  0x0000000000e5a54c in vitess.io/vitess/go/vt/discovery.(*tabletHealthCheck).connectionLocked
    at vitess.io/vitess/go/vt/discovery/tablet_health_check.go:148
12  0x0000000000e5a430 in vitess.io/vitess/go/vt/discovery.(*tabletHealthCheck).Connection
    at vitess.io/vitess/go/vt/discovery/tablet_health_check.go:143
13  0x0000000000e5a2f1 in vitess.io/vitess/go/vt/discovery.(*tabletHealthCheck).stream
    at vitess.io/vitess/go/vt/discovery/tablet_health_check.go:127
14  0x0000000000e5ae9d in vitess.io/vitess/go/vt/discovery.(*tabletHealthCheck).checkConn
    at vitess.io/vitess/go/vt/discovery/tablet_health_check.go:276
15  0x0000000000e508aa in vitess.io/vitess/go/vt/discovery.(*HealthCheckImpl).AddTablet.func2
    at vitess.io/vitess/go/vt/discovery/healthcheck.go:380
16  0x00000000004692c1 in runtime.goexit
    at runtime/asm_amd64.s:1571
``` 

At startup `vtgate` opens healthcheck streams to every tablet it is watching in parallel, and right now each of those goroutines are loading/unmarshalling the static client creds file

A consequence of this change is a process reload is required to change the file, whereas today you could change the file and it would be re-loaded (sadly by N x goroutines) on each loop of [the topology watcher `.Start(...)` ticker](https://github.com/slackhq/vitess/blob/main/go/vt/discovery/topology_watcher.go#L126), which to me isn't a dealbreaker (I was surprised it's reloaded actually), but I'm curious what everyone thought? I'm happy to adjust this to support `SIGHUP` and I'm curious if there are helpers for that sort of thing

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15031

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
