### PR TITLE
`transaction_mode` variable to return flag default if unset

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -287,6 +287,8 @@ func TestAnalyze(t *testing.T) {
 
 // TestTransactionModeVar executes SELECT on `transaction_mode` variable
 func TestTransactionModeVar(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -284,3 +284,34 @@ func TestAnalyze(t *testing.T) {
 		})
 	}
 }
+
+// TestTransactionModeVar executes SELECT on `transaction_mode` variable
+func TestTransactionModeVar(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	tcases := []struct {
+		setStmt string
+		expRes  string
+	}{{
+		expRes: `[[VARCHAR("MULTI")]]`,
+	}, {
+		setStmt: `set transaction_mode = single`,
+		expRes:  `[[VARCHAR("SINGLE")]]`,
+	}, {
+		setStmt: `set transaction_mode = multi`,
+		expRes:  `[[VARCHAR("MULTI")]]`,
+	}, {
+		setStmt: `set transaction_mode = twopc`,
+		expRes:  `[[VARCHAR("TWOPC")]]`,
+	}}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.setStmt, func(t *testing.T) {
+			if tcase.setStmt != "" {
+				utils.Exec(t, mcmp.VtConn, tcase.setStmt)
+			}
+			utils.AssertMatches(t, mcmp.VtConn, "select @@transaction_mode", tcase.expRes)
+		})
+	}
+}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -461,7 +461,11 @@ func (e *Executor) addNeededBindVars(vcursor *vcursorImpl, bindVarNeeds *sqlpars
 			})
 			bindVars[key] = sqltypes.Int64BindVariable(v)
 		case sysvars.TransactionMode.Name:
-			bindVars[key] = sqltypes.StringBindVariable(session.TransactionMode.String())
+			txMode := session.TransactionMode
+			if txMode == vtgatepb.TransactionMode_UNSPECIFIED {
+				txMode = getTxMode()
+			}
+			bindVars[key] = sqltypes.StringBindVariable(txMode.String())
 		case sysvars.Workload.Name:
 			var v string
 			ifOptionsExist(session, func(options *querypb.ExecuteOptions) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -801,7 +801,7 @@ func TestSelectSystemVariables(t *testing.T) {
 			sqltypes.NewInt64(0),
 			sqltypes.NewInt64(0),
 			sqltypes.NewInt64(0),
-			sqltypes.NewVarChar("UNSPECIFIED"),
+			sqltypes.NewVarChar("MULTI"),
 			sqltypes.NewVarChar(""),
 			// these have been set at the beginning of the test
 			sqltypes.NewVarChar("a fine gtid"),


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes to return the flag default for `transaction_mode` instead of `UNSPECIFIED` value.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/8150

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
