### PR TITLE
evalengine: Implement LAST_DAY

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1075,6 +1075,18 @@ func (cached *builtinJSONUnquote) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinLastDay) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinLeftRight) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3638,7 +3638,7 @@ func (asm *assembler) Fn_MAKEDATE() {
 		y := env.vm.stack[env.vm.sp-1].(*evalInt64)
 		yd := env.vm.stack[env.vm.sp-2].(*evalInt64)
 
-		t := yearDayToTime(env, y.i, yd.i)
+		t := yearDayToTime(env.currentTimezone(), y.i, yd.i)
 		if t.IsZero() {
 			env.vm.stack[env.vm.sp-2] = nil
 		} else {
@@ -3784,7 +3784,7 @@ func (asm *assembler) Fn_LAST_DAY() {
 			return 1
 		}
 		arg := env.vm.stack[env.vm.sp-1].(*evalTemporal)
-		d := lastDay(env, arg.dt)
+		d := lastDay(env.currentTimezone(), arg.dt)
 		if d.IsZero() {
 			env.vm.stack[env.vm.sp-1] = nil
 			return 1

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3638,7 +3638,7 @@ func (asm *assembler) Fn_MAKEDATE() {
 		y := env.vm.stack[env.vm.sp-1].(*evalInt64)
 		yd := env.vm.stack[env.vm.sp-2].(*evalInt64)
 
-		t := yearDayToTime(y.i, yd.i)
+		t := yearDayToTime(env, y.i, yd.i)
 		if t.IsZero() {
 			env.vm.stack[env.vm.sp-2] = nil
 		} else {
@@ -3784,8 +3784,8 @@ func (asm *assembler) Fn_LAST_DAY() {
 			return 1
 		}
 		arg := env.vm.stack[env.vm.sp-1].(*evalTemporal)
-		d, ok := lastDay(arg.dt)
-		if !ok {
+		d := lastDay(env, arg.dt)
+		if d.IsZero() {
 			env.vm.stack[env.vm.sp-1] = nil
 			return 1
 		}

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3784,11 +3784,12 @@ func (asm *assembler) Fn_LAST_DAY() {
 			return 1
 		}
 		arg := env.vm.stack[env.vm.sp-1].(*evalTemporal)
-		d := lastDay(env.currentTimezone(), arg.dt)
-		if d.IsZero() {
+		if arg.dt.IsZero() {
 			env.vm.stack[env.vm.sp-1] = nil
 			return 1
 		}
+
+		d := lastDay(env.currentTimezone(), arg.dt)
 		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalDate(d)
 		return 1
 	}, "FN LAST_DAY DATETIME(SP-1)")

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3778,6 +3778,22 @@ func (asm *assembler) Fn_MONTHNAME(col collations.TypedCollation) {
 	}, "FN MONTHNAME DATE(SP-1)")
 }
 
+func (asm *assembler) Fn_LAST_DAY() {
+	asm.emit(func(env *ExpressionEnv) int {
+		if env.vm.stack[env.vm.sp-1] == nil {
+			return 1
+		}
+		arg := env.vm.stack[env.vm.sp-1].(*evalTemporal)
+		d, ok := lastDay(arg.dt)
+		if !ok {
+			env.vm.stack[env.vm.sp-1] = nil
+			return 1
+		}
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalDate(d)
+		return 1
+	}, "FN LAST_DAY DATETIME(SP-1)")
+}
+
 func (asm *assembler) Fn_QUARTER() {
 	asm.emit(func(env *ExpressionEnv) int {
 		if env.vm.stack[env.vm.sp-1] == nil {

--- a/go/vt/vtgate/evalengine/fn_time.go
+++ b/go/vt/vtgate/evalengine/fn_time.go
@@ -1228,10 +1228,6 @@ func (b *builtinLastDay) eval(env *ExpressionEnv) (eval, error) {
 	}
 
 	d := lastDay(env.currentTimezone(), dt.dt)
-	if d.IsZero() {
-		return nil, nil
-	}
-
 	return newEvalDate(d, env.sqlmode.AllowZeroDate()), nil
 }
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -1747,6 +1747,23 @@ func FnLastDay(yield Query) {
 	for _, d := range inputConversions {
 		yield(fmt.Sprintf("LAST_DAY(%s)", d), nil)
 	}
+
+	dates := []string{
+		`DATE'2024-02-18'`,
+		`DATE'2023-02-01'`,
+		`DATE'2100-02-01'`,
+		`TIMESTAMP'2020-12-31 23:59:59'`,
+		`TIMESTAMP'2025-01-01 00:00:00'`,
+		`'2000-02-01'`,
+		`'2020-12-31 23:59:59'`,
+		`'2025-01-01 00:00:00'`,
+		`20250101`,
+		`'20250101'`,
+	}
+
+	for _, d := range dates {
+		yield(fmt.Sprintf("LAST_DAY(%s)", d), nil)
+	}
 }
 
 func FnQuarter(yield Query) {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -130,6 +130,7 @@ var Cases = []TestCase{
 	{Run: FnMinute},
 	{Run: FnMonth},
 	{Run: FnMonthName},
+	{Run: FnLastDay},
 	{Run: FnQuarter},
 	{Run: FnSecond},
 	{Run: FnTime},
@@ -1739,6 +1740,12 @@ func FnMonth(yield Query) {
 func FnMonthName(yield Query) {
 	for _, d := range inputConversions {
 		yield(fmt.Sprintf("MONTHNAME(%s)", d), nil)
+	}
+}
+
+func FnLastDay(yield Query) {
+	for _, d := range inputConversions {
+		yield(fmt.Sprintf("LAST_DAY(%s)", d), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -414,6 +414,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinMonthName{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "last_day":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinLastDay{CallExpr: call}, nil
 	case "quarter":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds implementation of [`LAST_DAY`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_last-day) func in evalengine.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #9647
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
