### PR TITLE
Added unit tests for the cmd/mysqlctl package

### DIFF
--- a/go/cmd/mysqlctl/command/position_test.go
+++ b/go/cmd/mysqlctl/command/position_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPosition(t *testing.T) {
+	cmd := Position
+	require.NotNil(t, cmd)
+	require.Equal(t, "position", cmd.Name())
+
+	tests := []struct {
+		name        string
+		args        []string
+		expectedErr string
+	}{
+		{
+			name:        "empty args",
+			args:        []string{},
+			expectedErr: "accepts 3 arg(s), received 0",
+		},
+		{
+			name: "non-empty args",
+			args: []string{"equal", "at_least", "append"},
+		},
+		{
+			name:        "non-empty args",
+			args:        []string{"temp", "at_least", "append"},
+			expectedErr: "invalid operation temp (choices are 'equal', 'at_least', 'append')",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cmd.Args(&cobra.Command{}, tt.args)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestPositionRun(t *testing.T) {
+	cmd := Position
+	require.NotNil(t, cmd)
+	require.Equal(t, "position", cmd.Name())
+
+	tests := []struct {
+		name        string
+		args        []string
+		expectedErr string
+	}{
+		{
+			name:        "parse error",
+			args:        []string{"equal", "at_least", "append"},
+			expectedErr: "parse error: unknown GTIDSet flavor \"\"",
+		},
+		{
+			name: "only equal",
+			args: []string{"equal", "", ""},
+		},
+		{
+			name:        "only equal with error",
+			args:        []string{"equal", "", "error"},
+			expectedErr: "parse error: unknown GTIDSet flavor \"\"",
+		},
+		{
+			name: "only append",
+			args: []string{"append", "", ""},
+		},
+		{
+			name:        "only append with error",
+			args:        []string{"append", "", "error"},
+			expectedErr: "parse error: unknown GTID flavor \"\"",
+		},
+		{
+			name: "only at_least",
+			args: []string{"at_least", "", ""},
+		},
+		{
+			name:        "only at_least with error",
+			args:        []string{"at_least", "", "error"},
+			expectedErr: "parse error: unknown GTIDSet flavor \"\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cmd.RunE(&cobra.Command{}, tt.args)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, tt.expectedErr, err.Error())
+			}
+		})
+	}
+}

--- a/go/cmd/mysqlctl/command/start_test.go
+++ b/go/cmd/mysqlctl/command/start_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestList(t *testing.T) {
+	require.NotNil(t, Start)
+	require.Equal(t, "start", Start.Name())
+	require.Equal(t, "Starts mysqld on an already 'init'-ed directory.", Start.Short)
+
+	err := Start.RunE(&cobra.Command{}, []string{})
+	require.ErrorContains(t, err, "failed to find mysql config")
+}


### PR DESCRIPTION
## Description

## Related Issue(s)
Partially addresses: https://github.com/vitessio/vitess/issues/14931

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required