### PR TITLE
Fix `buffer_drain_concurrency` not doing anything

### DIFF
--- a/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
+++ b/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
@@ -243,6 +243,7 @@ func (bt *BufferingTest) createCluster() (*cluster.LocalProcessCluster, int) {
 		"--buffer_min_time_between_failovers", "20m",
 		"--buffer_implementation", "keyspace_events",
 		"--tablet_refresh_interval", "1s",
+		"--buffer_drain_concurrency", "4",
 	}
 	clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, bt.VtGateExtraArgs...)
 

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"vitess.io/vitess/go/vt/discovery"
@@ -561,6 +562,18 @@ func (sb *shardBuffer) stopBufferingLocked(reason stopReason, details string) {
 	go sb.drain(q, clientEntryError)
 }
 
+// parallelRangeIndex uses counter to return a unique idx value up to the
+// passed max and ok will be set to false if the counter exceeds the max
+func parallelRangeIndex(counter *atomic.Int64, max int) (idx int, ok bool) {
+	next := counter.Add(1)
+	if next-1 > int64(max) {
+		return -1, false
+	}
+	// if this is a 32-bit platform, max won't exceed the 32-bit integer limit
+	// so a cast from a too-large 64-bit int to a 32-bit int will never happen
+	return int(next) - 1, true
+}
+
 func (sb *shardBuffer) drain(q []*entry, err error) {
 	defer sb.wg.Done()
 
@@ -570,29 +583,29 @@ func (sb *shardBuffer) drain(q []*entry, err error) {
 
 	start := sb.timeNow()
 
-	// Parallelize the drain by pumping the data through a channel.
-	entryChan := make(chan *entry, len(q))
-
-	parallelism := min(bufferDrainConcurrency, len(q))
+	entryCount := len(q)
+	parallelism := min(sb.buf.config.DrainConcurrency, entryCount)
 
 	var wg sync.WaitGroup
-	wg.Add(parallelism)
+	var rangeCounter atomic.Int64
 
+	wg.Add(parallelism)
 	for i := 0; i < parallelism; i++ {
 		go func() {
-			for _, e := range q {
-				sb.unblockAndWait(e, err, true /* releaseSlot */, true /* blockingWait */)
+			defer wg.Done()
+			for {
+				idx, ok := parallelRangeIndex(&rangeCounter, entryCount-1)
+				if !ok {
+					break
+				}
+				// Shared access to the q slice is concurrency-safe because each goroutine receives
+				// a unique set of slice indices from parallelRangeIndex above and the slice remains
+				// immutable for the lifetime of this operation.
+				sb.unblockAndWait(q[idx], err, true /* releaseSlot */, true /* blockingWait */)
 			}
-
-			wg.Done()
 		}()
 	}
 
-	for _, e := range q {
-		entryChan <- e
-	}
-
-	close(entryChan)
 	wg.Wait()
 
 	d := sb.timeNow().Sub(start)


### PR DESCRIPTION
## Description

This is based on a PR from @arthurschreiber with some additional changes based on the review feedback from @vmg. https://github.com/vitessio/vitess/pull/14545

From the previous PR:

> As described in https://github.com/vitessio/vitess/issues/11684, the `--buffer_drain_concurrency` CLI argument to vtgate does not actually do anything.
> 
> This pull request implements the logic required to make this flag actually do something. 😬 When the buffer is drained, we now spawn as many goroutines as specified by `--buffer_drain_concurrency` to drain the buffer in parallel.
>
> I don't think introducing a new flag as described in https://github.com/vitessio/vitess/issues/11684 actually makes sense - instead I propose we mention this in the v19 changelog that this flag is now doing something, and don't backport the change to any earlier releases.

## Related Issue(s)

* Fixes https://github.com/vitessio/vitess/issues/11684

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required