### PR TITLE
Added unit tests for the constants/sidecar package

### DIFF
--- a/go/constants/sidecar/queries_test.go
+++ b/go/constants/sidecar/queries_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCreateQuery(t *testing.T) {
+	originalName := GetName()
+	defer func() {
+		SetName(originalName)
+	}()
+
+	require.Equal(t, "_vt", GetIdentifier())
+	require.Equal(t, "create database if not exists _vt", GetCreateQuery())
+	SetName("test")
+	require.Equal(t, "test", GetIdentifier())
+	require.Equal(t, "create database if not exists test", GetCreateQuery())
+}


### PR DESCRIPTION
## Description
This commit increases the code coverage of the `go/constants` package to 100%

## Related Issue(s)
Partially addresses: https://github.com/vitessio/vitess/issues/14931

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required