### PR TITLE
Fixed bug in flagutil package and added tests

### DIFF
--- a/go/flagutil/enum.go
+++ b/go/flagutil/enum.go
@@ -86,11 +86,12 @@ func newStringEnum(name string, initialValue string, choices []string, caseInsen
 	}
 
 	return &StringEnum{
-		name:         name,
-		val:          initialValue,
-		choices:      choiceMap,
-		choiceNames:  choiceNames,
-		choiceMapper: choiceMapper,
+		name:            name,
+		val:             initialValue,
+		choices:         choiceMap,
+		choiceNames:     choiceNames,
+		choiceMapper:    choiceMapper,
+		caseInsensitive: caseInsensitive,
 	}
 }
 

--- a/go/flagutil/enum_test.go
+++ b/go/flagutil/enum_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringEnum(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialValue    string
+		choices         []string
+		caseInsensitive bool
+		secondValue     string
+		expectedErr     string
+	}{
+		{
+			name:            "valid set call",
+			initialValue:    "mango",
+			choices:         []string{"apple", "mango", "kiwi"},
+			caseInsensitive: true,
+			secondValue:     "kiwi",
+		},
+		{
+			name:            "invalid set call",
+			initialValue:    "apple",
+			choices:         []string{"apple", "mango", "kiwi"},
+			caseInsensitive: false,
+			secondValue:     "banana",
+			expectedErr:     "invalid choice for enum (valid choices: [apple kiwi mango])",
+		},
+		{
+			name:            "invalid set call case insensitive",
+			initialValue:    "apple",
+			choices:         []string{"apple", "kiwi"},
+			caseInsensitive: true,
+			secondValue:     "banana",
+			expectedErr:     "invalid choice for enum (valid choices: [apple kiwi] [case insensitive])",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var enum *StringEnum
+			if tt.caseInsensitive {
+				enum = NewCaseInsensitiveStringEnum(tt.name, tt.initialValue, tt.choices)
+			} else {
+				enum = NewStringEnum(tt.name, tt.initialValue, tt.choices)
+			}
+
+			require.Equal(t, "string", enum.Type())
+			err := enum.Set(tt.secondValue)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.secondValue, enum.String())
+			} else {
+				require.ErrorContains(t, err, tt.expectedErr)
+				require.Equal(t, tt.initialValue, enum.String())
+			}
+		})
+	}
+}

--- a/go/flagutil/flagutil_test.go
+++ b/go/flagutil/flagutil_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringList(t *testing.T) {
@@ -105,4 +106,18 @@ func TestStringMap(t *testing.T) {
 			t.Errorf("v.String(): want %#v, got %#v", want.in, vs)
 		}
 	}
+}
+
+func TestStringListValue(t *testing.T) {
+	strListVal := StringListValue{"temp", "val"}
+	require.Equal(t, []string([]string{"temp", "val"}), strListVal.Get())
+	require.Equal(t, "strings", strListVal.Type())
+}
+
+func TestStringMapValue(t *testing.T) {
+	strMapVal := StringMapValue{
+		"key": "val",
+	}
+	require.Equal(t, "StringMap", strMapVal.Type())
+	require.Equal(t, map[string]string(map[string]string{"key": "val"}), strMapVal.Get())
 }

--- a/go/flagutil/optional_test.go
+++ b/go/flagutil/optional_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOptionalFloat64(t *testing.T) {
+	fl := NewOptionalFloat64(4.187)
+	require.NotEmpty(t, fl)
+	require.Equal(t, false, fl.IsSet())
+
+	require.Equal(t, "4.187", fl.String())
+	require.Equal(t, "float64", fl.Type())
+
+	err := fl.Set("invalid value")
+	require.ErrorContains(t, err, "parse error")
+
+	err = fl.Set("7.77")
+	require.NoError(t, err)
+	require.Equal(t, 7.77, fl.Get())
+	require.Equal(t, true, fl.IsSet())
+
+	err = fl.Set("1e1000")
+	require.ErrorContains(t, err, "value out of range")
+}
+
+func TestNewOptionalString(t *testing.T) {
+	optStr := NewOptionalString("4.187")
+	require.NotEmpty(t, optStr)
+	require.Equal(t, false, optStr.IsSet())
+
+	require.Equal(t, "4.187", optStr.String())
+	require.Equal(t, "string", optStr.Type())
+
+	err := optStr.Set("value")
+	require.NoError(t, err)
+
+	require.Equal(t, "value", optStr.Get())
+	require.Equal(t, true, optStr.IsSet())
+}

--- a/go/flagutil/sets_test.go
+++ b/go/flagutil/sets_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringSetFlag(t *testing.T) {
+	strSetFlag := StringSetFlag{}
+	set := strSetFlag.ToSet()
+	require.Empty(t, set)
+
+	set = set.Insert("mango", "apple", "mango")
+	strSetFlag.set = set
+
+	require.Equal(t, "StringSetFlag", strSetFlag.Type())
+	require.Equal(t, "apple, mango", strSetFlag.String())
+
+	err := strSetFlag.Set("guvava")
+	require.NoError(t, err)
+	require.Equal(t, "apple, guvava, mango", strSetFlag.String())
+
+	require.NotEmpty(t, strSetFlag.ToSet())
+}
+
+func TestStringSetFlagWithEmptySet(t *testing.T) {
+	strSetFlag := StringSetFlag{}
+	require.Equal(t, "", strSetFlag.String())
+
+	err := strSetFlag.Set("tmp")
+	require.NoError(t, err)
+	require.Empty(t, strSetFlag.ToSet())
+
+	err = strSetFlag.Set("guvava")
+	require.NoError(t, err)
+	require.Equal(t, "guvava", strSetFlag.String())
+}


### PR DESCRIPTION
## Description
Bug: the `caseInsensitive` variables was not being used in
     `StringEnum` initialization.
Fix: Added code to initialize the `caseInsensitive` variable when the
     `StringEnum` instance is created.

Added unit tests to increase the code coverage of the `flagutil` package.

## Related Issue(s)
Partially addresses: https://github.com/vitessio/vitess/issues/14931

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required