### PR TITLE
Added missing tests for the sqltypes package

### DIFF
--- a/go/sqltypes/query_response_test.go
+++ b/go/sqltypes/query_response_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryResponsesEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		r1      []QueryResponse
+		r2      []QueryResponse
+		isEqual bool
+	}{
+		{
+			name: "1 response in each",
+			r1: []QueryResponse{
+				{
+					QueryResult: &Result{},
+					QueryError:  nil,
+				},
+			},
+			r2: []QueryResponse{
+				{
+					QueryResult: &Result{},
+					QueryError:  nil,
+				},
+			},
+			isEqual: true,
+		},
+		{
+			name: "different lengths",
+			r1: []QueryResponse{
+				{
+					QueryResult: &Result{},
+					QueryError:  nil,
+				},
+			},
+			r2:      []QueryResponse{},
+			isEqual: false,
+		},
+		{
+			name: "different query errors",
+			r1: []QueryResponse{
+				{
+					QueryResult: &Result{},
+					QueryError:  fmt.Errorf("some error"),
+				},
+			},
+			r2: []QueryResponse{
+				{
+					QueryResult: &Result{
+						Info: "Test",
+					},
+					QueryError: nil,
+				},
+			},
+			isEqual: false,
+		},
+		{
+			name: "different query results",
+			r1: []QueryResponse{
+				{
+					QueryResult: &Result{
+						RowsAffected: 7,
+					},
+					QueryError: nil,
+				},
+			},
+			r2: []QueryResponse{
+				{
+					QueryResult: &Result{
+						RowsAffected: 10,
+					},
+					QueryError: nil,
+				},
+			},
+			isEqual: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isEqual, QueryResponsesEqual(tt.r1, tt.r2))
+		})
+	}
+}

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
@@ -510,5 +512,90 @@ func TestPrintTypeChecks(t *testing.T) {
 			}
 		}
 		t.Logf("%s(): %s", f.name, strings.Join(match, ", "))
+	}
+}
+
+func TestIsTextOrBinary(t *testing.T) {
+	tests := []struct {
+		name           string
+		ty             querypb.Type
+		isTextorBinary bool
+	}{
+		{
+			name:           "null type",
+			ty:             querypb.Type_NULL_TYPE,
+			isTextorBinary: false,
+		},
+		{
+			name:           "blob type",
+			ty:             querypb.Type_BLOB,
+			isTextorBinary: true,
+		},
+		{
+			name:           "text type",
+			ty:             querypb.Type_TEXT,
+			isTextorBinary: true,
+		},
+		{
+			name:           "binary type",
+			ty:             querypb.Type_BINARY,
+			isTextorBinary: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isTextorBinary, IsTextOrBinary(tt.ty))
+		})
+	}
+}
+
+func TestIsDateOrTime(t *testing.T) {
+	tests := []struct {
+		name         string
+		ty           querypb.Type
+		isDateOrTime bool
+	}{
+		{
+			name:         "null type",
+			ty:           querypb.Type_NULL_TYPE,
+			isDateOrTime: false,
+		},
+		{
+			name:         "blob type",
+			ty:           querypb.Type_BLOB,
+			isDateOrTime: false,
+		},
+		{
+			name:         "timestamp type",
+			ty:           querypb.Type_TIMESTAMP,
+			isDateOrTime: true,
+		},
+		{
+			name:         "date type",
+			ty:           querypb.Type_DATE,
+			isDateOrTime: true,
+		},
+		{
+			name:         "time type",
+			ty:           querypb.Type_TIME,
+			isDateOrTime: true,
+		},
+		{
+			name:         "date time type",
+			ty:           querypb.Type_DATETIME,
+			isDateOrTime: true,
+		},
+		{
+			name:         "year type",
+			ty:           querypb.Type_YEAR,
+			isDateOrTime: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isDateOrTime, IsDateOrTime(tt.ty))
+		})
 	}
 }


### PR DESCRIPTION
## Description
This commit increases the code coverage of the `go/sqltypes` package to 62%.

## Related Issue(s)
Partially addresses: https://github.com/vitessio/vitess/issues/14931

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required