### PR TITLE
Added tests for the go/vt/callinfo package

### DIFF
--- a/go/vt/callinfo/callinfo_test.go
+++ b/go/vt/callinfo/callinfo_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package callinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/safehtml"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/callinfo/fakecallinfo"
+)
+
+var fci fakecallinfo.FakeCallInfo = fakecallinfo.FakeCallInfo{
+	User:   "test",
+	Remote: "locahost",
+	Method: "",
+	Html:   safehtml.HTML{},
+}
+
+func TestNewContext(t *testing.T) {
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		ci              CallInfo
+		expectedContext context.Context
+	}{
+		{
+			name:            "empty",
+			ctx:             context.Background(),
+			ci:              nil,
+			expectedContext: context.WithValue(context.Background(), callInfoKey, nil),
+		},
+		{
+			name:            "not empty",
+			ctx:             context.Background(),
+			ci:              &fci,
+			expectedContext: context.WithValue(context.Background(), callInfoKey, &fci),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expectedContext, NewContext(tt.ctx, tt.ci))
+		})
+	}
+}
+
+func TestFromContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		expectedCi CallInfo
+		ok         bool
+	}{
+		{
+			name:       "empty",
+			ctx:        context.WithValue(context.Background(), callInfoKey, nil),
+			expectedCi: nil,
+			ok:         false,
+		},
+		{
+			name:       "not empty",
+			expectedCi: &fci,
+			ctx:        context.WithValue(context.Background(), callInfoKey, &fci),
+			ok:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ci, ok := FromContext(tt.ctx)
+			require.Equal(t, tt.expectedCi, ci)
+			require.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestHTMLFromContext(t *testing.T) {
+	tests := []struct {
+		name         string
+		ctx          context.Context
+		expectedHTML safehtml.HTML
+	}{
+		{
+			name:         "empty",
+			ctx:          context.WithValue(context.Background(), callInfoKey, nil),
+			expectedHTML: safehtml.HTML{},
+		},
+		{
+			name:         "not empty",
+			ctx:          context.WithValue(context.Background(), callInfoKey, &fci),
+			expectedHTML: safehtml.HTML{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expectedHTML, HTMLFromContext(tt.ctx))
+		})
+	}
+}

--- a/go/vt/callinfo/plugin_grpc_test.go
+++ b/go/vt/callinfo/plugin_grpc_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package callinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGRPCCallInfo(t *testing.T) {
+	grpcCi := gRPCCallInfoImpl{
+		method:     "tcp",
+		remoteAddr: "localhost",
+	}
+
+	require.Equal(t, context.Background(), GRPCCallInfo(context.Background()))
+	require.Equal(t, grpcCi.remoteAddr, grpcCi.RemoteAddr())
+	require.Equal(t, "gRPC", grpcCi.Username())
+	require.Equal(t, "localhost:tcp(gRPC)", grpcCi.Text())
+	require.Equal(t, "<b>Method:</b> tcp <b>Remote Addr:</b> localhost", grpcCi.HTML().String())
+}

--- a/go/vt/callinfo/plugin_mysql_test.go
+++ b/go/vt/callinfo/plugin_mysql_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package callinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMysqlCallInfo(t *testing.T) {
+	mysqlCi := mysqlCallInfoImpl{
+		remoteAddr: "localhost",
+		user:       "test",
+	}
+
+	require.Equal(t, mysqlCi.remoteAddr, mysqlCi.RemoteAddr())
+	require.Equal(t, mysqlCi.user, mysqlCi.Username())
+	require.Equal(t, "test@localhost(Mysql)", mysqlCi.Text())
+	require.Equal(t, "<b>MySQL User:</b> test <b>Remote Addr:</b> localhost", mysqlCi.HTML().String())
+}


### PR DESCRIPTION
## Description
This commit increases the code coverage of the `go/vt/callinfo` package to >74%

## Related Issue(s)
https://github.com/vitessio/vitess/issues/14931

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required