### PR TITLE
`schemadiff`: analyze and report foreign key loops/cycles

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -286,6 +286,29 @@ func (e *ForeignKeyDependencyUnresolvedError) Error() string {
 		sqlescape.EscapeID(e.Table))
 }
 
+type ForeignKeyLoopError struct {
+	Table string
+	Loop  []string
+}
+
+func (e *ForeignKeyLoopError) Error() string {
+	tableIsInsideLoop := false
+
+	escaped := make([]string, 0, len(e.Loop))
+	for _, t := range e.Loop {
+		escaped = append(escaped, sqlescape.EscapeID(t))
+		if t == e.Table {
+			tableIsInsideLoop = true
+		}
+	}
+	if tableIsInsideLoop {
+		return fmt.Sprintf("table %s participates in foreign key loop: %s",
+			sqlescape.EscapeID(e.Table), strings.Join(escaped, ", "))
+	}
+	return fmt.Sprintf("table %s references foreign key loop: %s",
+		sqlescape.EscapeID(e.Table), strings.Join(escaped, ", "))
+}
+
 type ForeignKeyNonexistentReferencedTableError struct {
 	Table           string
 	ReferencedTable string

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -294,18 +294,18 @@ type ForeignKeyLoopError struct {
 func (e *ForeignKeyLoopError) Error() string {
 	tableIsInsideLoop := false
 
-	escaped := make([]string, 0, len(e.Loop))
-	for _, t := range e.Loop {
-		escaped = append(escaped, sqlescape.EscapeID(t))
+	escaped := make([]string, len(e.Loop))
+	for i, t := range e.Loop {
+		escaped[i] = sqlescape.EscapeID(t)
 		if t == e.Table {
 			tableIsInsideLoop = true
 		}
 	}
 	if tableIsInsideLoop {
-		return fmt.Sprintf("table %s participates in foreign key loop: %s",
+		return fmt.Sprintf("table %s participates in a circular foreign key reference: %s",
 			sqlescape.EscapeID(e.Table), strings.Join(escaped, ", "))
 	}
-	return fmt.Sprintf("table %s references foreign key loop: %s",
+	return fmt.Sprintf("table %s references a circular foreign key reference: %s",
 		sqlescape.EscapeID(e.Table), strings.Join(escaped, ", "))
 }
 

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -282,7 +282,7 @@ type ForeignKeyDependencyUnresolvedError struct {
 }
 
 func (e *ForeignKeyDependencyUnresolvedError) Error() string {
-	return fmt.Sprintf("table %s has unresolved/loop foreign key dependencies",
+	return fmt.Sprintf("table %s has unresolved foreign key dependencies",
 		sqlescape.EscapeID(e.Table))
 }
 

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -166,9 +166,7 @@ func (s *Schema) findForeignKeyLoop(tableName string, seen []string) (loop []str
 			// It's possible for one table to participate in more than one foreign key loop, but
 			// we suffice with one loop, since we already only ever report one foreign key error
 			// per table.
-			if _, ok := s.foreignKeyLoopMap[tableName]; !ok {
-				s.foreignKeyLoopMap[tableName] = loop
-			}
+			s.foreignKeyLoopMap[tableName] = loop
 			return loop
 		}
 	}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -156,7 +156,7 @@ func (s *Schema) findForeignKeyLoop(tableName string, seen []string) (loop []str
 		}
 		if seenTable == tableName {
 			// This table alreay appears in `seen`.
-			// We only return the loop portion of `seen` that starts and ends with this table.
+			// We only return the suffix of `seen` that starts (and now ends) with this table.
 			return seen[i:]
 		}
 	}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -39,6 +39,7 @@ type Schema struct {
 
 	foreignKeyParents  []*CreateTableEntity // subset of tables
 	foreignKeyChildren []*CreateTableEntity // subset of tables
+	foreignKeyLoopMap  map[string][]string  // map of table name that either participate, or directly or indirectly reference foreign key loops
 
 	env *Environment
 }
@@ -53,6 +54,7 @@ func newEmptySchema(env *Environment) *Schema {
 
 		foreignKeyParents:  []*CreateTableEntity{},
 		foreignKeyChildren: []*CreateTableEntity{},
+		foreignKeyLoopMap:  map[string][]string{},
 
 		env: env,
 	}
@@ -133,6 +135,44 @@ func getForeignKeyParentTableNames(createTable *sqlparser.CreateTable) (names []
 		}
 	}
 	return names
+}
+
+// findForeignKeyLoop is a stateful recursive function that determines whether a given table participates in a foreign
+// key loop or derives from one. It returns a list of table names that form a loop, or nil if no loop is found.
+// The function updates and checks the stateful map s.foreignKeyLoopMap to avoid re-analyzing the same table twice.
+func (s *Schema) findForeignKeyLoop(tableName string, seen []string) (loop []string) {
+	if loop := s.foreignKeyLoopMap[tableName]; loop != nil {
+		return loop
+	}
+	t := s.Table(tableName)
+	if t == nil {
+		return nil
+	}
+	seen = append(seen, tableName)
+	for i, seenTable := range seen {
+		if i == len(seen)-1 {
+			// as we've just appended the table name to the end of the slice, we should skip it.
+			break
+		}
+		if seenTable == tableName {
+			// This table alreay appears in `seen`.
+			// We only return the loop portion of `seen` that starts and ends with this table.
+			return seen[i:]
+		}
+	}
+	for _, referencedTableName := range getForeignKeyParentTableNames(t.CreateTable) {
+		if loop := s.findForeignKeyLoop(referencedTableName, seen); loop != nil {
+			// Found loop. Update cache.
+			// It's possible for one table to participate in more than one foreign key loop, but
+			// we suffice with one loop, since we already only ever report one foreign key error
+			// per table.
+			if _, ok := s.foreignKeyLoopMap[tableName]; !ok {
+				s.foreignKeyLoopMap[tableName] = loop
+			}
+			return loop
+		}
+	}
+	return nil
 }
 
 // getViewDependentTableNames analyzes a CREATE VIEW definition and extracts all tables/views read by this view
@@ -309,7 +349,16 @@ func (s *Schema) normalize() error {
 		}
 		iterationLevel++
 	}
+
 	if len(s.sorted) != len(s.tables)+len(s.views) {
+
+		for _, t := range s.tables {
+			if _, ok := dependencyLevels[t.Name()]; !ok {
+				if loop := s.findForeignKeyLoop(t.Name(), nil); loop != nil {
+					errs = errors.Join(errs, addEntityFkError(t, &ForeignKeyLoopError{Table: t.Name(), Loop: loop}))
+				}
+			}
+		}
 		// We have leftover tables or views. This can happen if the schema definition is invalid:
 		// - a table's foreign key references a nonexistent table
 		// - two or more tables have circular FK dependency

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -310,8 +310,9 @@ func TestTableForeignKeyOrdering(t *testing.T) {
 
 func TestInvalidSchema(t *testing.T) {
 	tt := []struct {
-		schema    string
-		expectErr error
+		schema           string
+		expectErr        error
+		expectLoopTables int
 	}{
 		{
 			schema: "create table t11 (id int primary key, i int, key ix(i), constraint f11 foreign key (i) references t11(id) on delete restrict)",
@@ -340,11 +341,60 @@ func TestInvalidSchema(t *testing.T) {
 			expectErr: &ForeignKeyReferencesViewError{Table: "t11", ReferencedView: "v"},
 		},
 		{
+			// t11 self loop
+			schema: "create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t11 (id) on delete restrict)",
+		},
+		{
+			// t12<->t11
 			schema: "create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict)",
 			expectErr: errors.Join(
-				&ForeignKeyDependencyUnresolvedError{Table: "t11"},
-				&ForeignKeyDependencyUnresolvedError{Table: "t12"},
+				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
 			),
+			expectLoopTables: 2,
+		},
+		{
+			// t10, t12<->t11
+			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict)",
+			expectErr: errors.Join(
+				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
+			),
+			expectLoopTables: 2,
+		},
+		{
+			// t10, t12<->t11<-t13
+			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict); create table t13 (id int primary key, i int, constraint f13 foreign key (i) references t11 (id) on delete restrict)",
+			expectErr: errors.Join(
+				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t13", Loop: []string{"t11", "t12", "t11"}},
+			),
+			expectLoopTables: 3,
+		},
+		{
+			//      t10
+			//       ^
+			//       |
+			//t12<->t11<-t13
+			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, i10 int, constraint f11 foreign key (i) references t12 (id) on delete restrict, constraint f1110 foreign key (i10) references t10 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict); create table t13 (id int primary key, i int, constraint f13 foreign key (i) references t11 (id) on delete restrict)",
+			expectErr: errors.Join(
+				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t13", Loop: []string{"t11", "t12", "t11"}},
+			),
+			expectLoopTables: 3,
+		},
+		{
+			// t10, t12<->t11<-t13<-t14
+			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, i10 int, constraint f11 foreign key (i) references t12 (id) on delete restrict, constraint f1110 foreign key (i10) references t10 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict); create table t13 (id int primary key, i int, constraint f13 foreign key (i) references t11 (id) on delete restrict); create table t14 (id int primary key, i int, constraint f14 foreign key (i) references t13 (id) on delete restrict)",
+			expectErr: errors.Join(
+				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t13", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t14", Loop: []string{"t11", "t12", "t11"}},
+			),
+			expectLoopTables: 4,
 		},
 		{
 			schema:    "create table t11 (id int primary key, i int, key ix(i), constraint f11 foreign key (i) references t11(id2) on delete restrict)",
@@ -406,13 +456,14 @@ func TestInvalidSchema(t *testing.T) {
 	for _, ts := range tt {
 		t.Run(ts.schema, func(t *testing.T) {
 
-			_, err := NewSchemaFromSQL(NewTestEnv(), ts.schema)
+			s, err := NewSchemaFromSQL(NewTestEnv(), ts.schema)
 			if ts.expectErr == nil {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)
 				assert.EqualError(t, err, ts.expectErr.Error())
 			}
+			assert.Equal(t, ts.expectLoopTables, len(s.foreignKeyLoopMap))
 		})
 	}
 }


### PR DESCRIPTION
## Description

See https://github.com/vitessio/vitess/issues/15061 for details.

`schemadiff` does not support foreign key cycles (with the exception of self referencing tables). In this PR, `schemadiff` identifies cycles and reports those cycles as part of the schema validation process. Taking the same example from https://github.com/vitessio/vitess/issues/15061:

```sql
create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id));
create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id));
```

As of this PR, `schemadiff` will now report:
```
table `t11` participates in foreign key loop: `t11`, `t12`, `t11`
table `t12` participates in foreign key loop: `t11`, `t12`, `t11`
```

`schemadiff` will further identify tables that reference foreign key loops, i.e. their immediate parent or on of their indirect parents participates in a loop, and will report something like:

```
table `t13` references foreign key loop: `t11`, `t12`, `t11`
```

Computing foreign key loops uses DFS, and for every loop found it caches the tables participating in that loop, so as to never recompute the same table twice. This limits the number of loops found per table to `1`, which is sufficient, as we already only report one foreign key error per table anyway (otherwise this can blow up with excessive error messages).

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/15061
- #10203 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
