### PR TITLE
mysql: do not allocate in parseOKPacket

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1525,15 +1525,13 @@ type PacketOK struct {
 	sessionStateData string
 }
 
-func (c *Conn) parseOKPacket(in []byte) (*PacketOK, error) {
+func (c *Conn) parseOKPacket(packetOK *PacketOK, in []byte) error {
 	data := &coder{
 		data: in,
 		pos:  1, // We already read the type.
 	}
-	packetOK := &PacketOK{}
-
-	fail := func(format string, args ...any) (*PacketOK, error) {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, format, args...)
+	fail := func(format string, args ...any) error {
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, format, args...)
 	}
 
 	// Affected rows.
@@ -1578,7 +1576,7 @@ func (c *Conn) parseOKPacket(in []byte) (*PacketOK, error) {
 			if !ok || length == 0 {
 				// In case we have no more data or a zero length string, there's no additional information so
 				// we can return the packet.
-				return packetOK, nil
+				return nil
 			}
 
 			// Alright, now we need to read each sub packet from the session state change.
@@ -1615,7 +1613,7 @@ func (c *Conn) parseOKPacket(in []byte) (*PacketOK, error) {
 		}
 	}
 
-	return packetOK, nil
+	return nil
 }
 
 // isErrorPacket determines whether or not the packet is an error packet. Mostly here for

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -246,7 +246,8 @@ func TestBasicPackets(t *testing.T) {
 	require.NotEmpty(data)
 	assert.EqualValues(data[0], OKPacket, "OKPacket")
 
-	packetOk, err := cConn.parseOKPacket(data)
+	var packetOk PacketOK
+	err = cConn.parseOKPacket(&packetOk, data)
 	require.NoError(err)
 	assert.EqualValues(12, packetOk.affectedRows)
 	assert.EqualValues(34, packetOk.lastInsertID)
@@ -272,7 +273,7 @@ func TestBasicPackets(t *testing.T) {
 	require.NotEmpty(data)
 	assert.EqualValues(data[0], OKPacket, "OKPacket")
 
-	packetOk, err = cConn.parseOKPacket(data)
+	err = cConn.parseOKPacket(&packetOk, data)
 	require.NoError(err)
 	assert.EqualValues(23, packetOk.affectedRows)
 	assert.EqualValues(45, packetOk.lastInsertID)
@@ -295,7 +296,7 @@ func TestBasicPackets(t *testing.T) {
 	require.NotEmpty(data)
 	assert.True(cConn.isEOFPacket(data), "expected EOF")
 
-	packetOk, err = cConn.parseOKPacket(data)
+	err = cConn.parseOKPacket(&packetOk, data)
 	require.NoError(err)
 	assert.EqualValues(12, packetOk.affectedRows)
 	assert.EqualValues(34, packetOk.lastInsertID)
@@ -690,7 +691,8 @@ func TestOkPackets(t *testing.T) {
 			cConn.Capabilities = testCase.cc
 			sConn.Capabilities = testCase.cc
 			// parse the packet
-			packetOk, err := cConn.parseOKPacket(data)
+			var packetOk PacketOK
+			err := cConn.parseOKPacket(&packetOk, data)
 			if testCase.expectedErr != "" {
 				require.Error(t, err)
 				require.Equal(t, testCase.expectedErr, err.Error())
@@ -699,7 +701,7 @@ func TestOkPackets(t *testing.T) {
 			require.NoError(t, err, "failed to parse OK packet")
 
 			// write the ok packet from server
-			err = sConn.writeOKPacket(packetOk)
+			err = sConn.writeOKPacket(&packetOk)
 			require.NoError(t, err, "failed to write OK packet")
 
 			// receive the ok packet on client

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -354,8 +354,9 @@ func (c *Conn) ExecuteFetchWithWarningCount(query string, maxrows int, wantfield
 
 // ReadQueryResult gets the result from the last written query.
 func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (*sqltypes.Result, bool, uint16, error) {
+	var packetOk PacketOK
 	// Get the result.
-	colNumber, packetOk, err := c.readComQueryResponse()
+	colNumber, err := c.readComQueryResponse(&packetOk)
 	if err != nil {
 		return nil, false, 0, err
 	}
@@ -441,8 +442,7 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (*sqltypes.Result, 
 				more = (statusFlags & ServerMoreResultsExists) != 0
 				result.StatusFlags = statusFlags
 			} else {
-				packetOk, err := c.parseOKPacket(data)
-				if err != nil {
+				if err := c.parseOKPacket(&packetOk, data); err != nil {
 					return nil, false, 0, err
 				}
 				warnings = packetOk.warnings
@@ -497,35 +497,34 @@ func (c *Conn) drainResults() error {
 	}
 }
 
-func (c *Conn) readComQueryResponse() (int, *PacketOK, error) {
+func (c *Conn) readComQueryResponse(packetOk *PacketOK) (int, error) {
 	data, err := c.readEphemeralPacket()
 	if err != nil {
-		return 0, nil, sqlerror.NewSQLError(sqlerror.CRServerLost, sqlerror.SSUnknownSQLState, "%v", err)
+		return 0, sqlerror.NewSQLError(sqlerror.CRServerLost, sqlerror.SSUnknownSQLState, "%v", err)
 	}
 	defer c.recycleReadPacket()
 	if len(data) == 0 {
-		return 0, nil, sqlerror.NewSQLError(sqlerror.CRMalformedPacket, sqlerror.SSUnknownSQLState, "invalid empty COM_QUERY response packet")
+		return 0, sqlerror.NewSQLError(sqlerror.CRMalformedPacket, sqlerror.SSUnknownSQLState, "invalid empty COM_QUERY response packet")
 	}
 
 	switch data[0] {
 	case OKPacket:
-		packetOk, err := c.parseOKPacket(data)
-		return 0, packetOk, err
+		return 0, c.parseOKPacket(packetOk, data)
 	case ErrPacket:
 		// Error
-		return 0, nil, ParseErrorPacket(data)
+		return 0, ParseErrorPacket(data)
 	case 0xfb:
 		// Local infile
-		return 0, nil, vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "not implemented")
+		return 0, vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "not implemented")
 	}
 	n, pos, ok := readLenEncInt(data, 0)
 	if !ok {
-		return 0, nil, sqlerror.NewSQLError(sqlerror.CRMalformedPacket, sqlerror.SSUnknownSQLState, "cannot get column number")
+		return 0, sqlerror.NewSQLError(sqlerror.CRMalformedPacket, sqlerror.SSUnknownSQLState, "cannot get column number")
 	}
 	if pos != len(data) {
-		return 0, nil, sqlerror.NewSQLError(sqlerror.CRMalformedPacket, sqlerror.SSUnknownSQLState, "extra data in COM_QUERY response")
+		return 0, sqlerror.NewSQLError(sqlerror.CRMalformedPacket, sqlerror.SSUnknownSQLState, "extra data in COM_QUERY response")
 	}
-	return int(n), &PacketOK{}, nil
+	return int(n), nil
 }
 
 //

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -49,7 +49,8 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 	}
 
 	// Get the result.
-	colNumber, _, err := c.readComQueryResponse()
+	var packetOk PacketOK
+	colNumber, err := c.readComQueryResponse(&packetOk)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

While working on some enterprise customers, @maxenglander noticed a very significant amount of allocations from `readComQueryResponse`. I don't think this is the cause of the increased p99 latencies that the customer was seeing, but it is indeed wasteful and should be fixed.

The allocations happen in `mysql.(*Conn).parseOKPacket`, and there are two sources:

![image](https://github.com/vitessio/vitess/assets/42793/280ac547-c4d6-45ea-bf59-ab6653048e17)

- `&PacketOK{}` instances are being created every time the function is called, because they're returned as a pointer value. This is the 64 byte allocation group seen in the profile, 2.7GB total.
- The `coder` struct that handles parsing of the packet is being allocated in the heap, because _when the parsing fails_ (i.e. very rarely), the struct is passed as an `%v` argument to `vterrors.Errorf`. Since `Errorf` is a variadric API, its arguments are passed as interfaces (`any`), which forces the object to be always moved to the heap upon first instantiation. This is the 32 byte allocation group seen in the profile, 1.3GB total.


The fixes are as follows:

- Since the `PacketOK` being returned from that function is only being used as a temporary, we can change the signature of the function to take the packet as an argument. Since we have a direct function call without interfaces in the way, this is good enough to keep the packet allocated on the stack in all the call-sites for the function.

- For the `coder` struct, simply change the error returns of the function to receive `data.data` instead of the whole struct. This causes the `&coder{}` initialization at the start of the function to remain in the stack. Remember that the Go compiler doesn't necessarily place `&var` constructions directly into the heap: they can be placed on the stack if they're found not to escape.

As a result this PR removes the packet allocation for _all_ queries (not only for queries without results), which should result in a measurable reduction in small allocations for all the benchmarks we're tracking. Furthermore, this applies anywhere where we're using the MySQL clients, not only in the tablets.

After the changes, the `parseOKPacket` API is gone from heap profiles, as it is now zero-allocation:

![image](https://github.com/vitessio/vitess/assets/42793/4fdec1ec-99f8-4606-92fc-3b07c881a2f9)

`readComQueryResponse` is also gone from the profile as it was calling `parseOKPacket` indirectly, so now this API is also zero-allocation. Another 2.6GB of memory gone.

On the `arewefast` benchmarks, we're once again seeing the long standing issue (which I'll eventually fix, I swear) where the changes are not directly comparable between PRs because when you reduce the memory allocations in Vitess, this results in GC changes that affect the throughput:

![image](https://github.com/vitessio/vitess/assets/42793/0e6bf651-2085-4632-b5c5-9a8de9bf3417)

Here you can see that there are very significant memory savings everywhere where we're using a MySQL connection, which also reduces the CPU usage for Vitess as a whole (Total CPU time spent is down), but that results in less QPS, like we saw when introducing the new connection pool in https://github.com/vitessio/vitess/pull/14034.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15071

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
