### PR TITLE
Copy expression types to avoid weight_strings and derived tables

### DIFF
--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -81,10 +81,6 @@ func TestUnionDistinct(t *testing.T) {
 				mcmp.AssertMatchesNoOrder(`SELECT 5 from t1 UNION SELECT id2 from t1`, `[[INT64(5)] [INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)]]`)
 				mcmp.AssertMatchesNoOrder(`SELECT id1 from t1 UNION SELECT 2 from t1`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)]]`)
 				mcmp.AssertMatchesNoOrder(`SELECT id1 from t1 UNION SELECT 5 from t1`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)] [INT64(5)]]`)
-				mcmp.AssertMatchesNoOrder(`select 3 from t1 union select DAY("2024-01-31") from t1`, `[[INT64(3)] [INT64(31)]]`)
-				mcmp.AssertMatchesNoOrder(`select DAY("2024-01-31") from t1 union select 3 from t1`, `[[INT64(31)] [INT64(3)]]`)
-				mcmp.AssertMatchesNoOrder(`select DAY("2024-01-31") from t1 union select id1 from t1`, `[[INT64(31)] [INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)]]`)
-				mcmp.Exec(`select 3 from t1 union select curdate() from t1`)
 				mcmp.Exec(`select curdate() from t1 union select 3 from t1`)
 				mcmp.Exec(`select curdate() from t1 union select id1 from t1`)
 			}

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -130,4 +130,11 @@ func TestUnion(t *testing.T) {
 	if utils.BinaryIsAtLeastAtVersion(19, "vtgate") {
 		mcmp.AssertMatches(`(SELECT id2,'a' from t1 where id1 = 1) union (SELECT 'a',id2 from t1 where id1 = 2)`, `[[VARCHAR("1") VARCHAR("a")] [VARCHAR("a") VARCHAR("2")]]`)
 	}
+	mcmp.AssertMatches(`SELECT 1 from t1 UNION SELECT 2 from t1`, `[[INT64(1)] [INT64(2)]]`)
+	mcmp.AssertMatches(`SELECT 4 from t1 UNION SELECT 3 from t1`, `[[INT64(4)] [INT64(3)]]`)
+	mcmp.AssertMatches(`SELECT id1 from t1 UNION SELECT id2 from t1`, `[[INT64(1)] [INT64(2)]]`)
+	mcmp.AssertMatches(`SELECT 1 from t1 UNION SELECT id2 from t1`, `[[INT64(1)] [INT64(2)]]`)
+	mcmp.AssertMatches(`SELECT 3 from t1 UNION SELECT id2 from t1`, `[[INT64(3)] [INT64(1)] [INT64(2)]]`)
+	mcmp.AssertMatches(`SELECT id1 from t1 UNION SELECT 2 from t1`, `[[INT64(1)] [INT64(2)]]`)
+	mcmp.AssertMatches(`SELECT id1 from t1 UNION SELECT 3 from t1`, `[[INT64(1)] [INT64(2)] [INT64(3)]]`)
 }

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -180,25 +180,27 @@ func createMergedUnion(
 	cols := make(sqlparser.SelectExprs, len(lhsExprs))
 	noDeps := len(lhsExprs) != len(rhsExprs)
 	for idx, col := range lhsExprs {
-		ae, ok := col.(*sqlparser.AliasedExpr)
+		lae, ok := col.(*sqlparser.AliasedExpr)
 		if !ok {
 			cols[idx] = col
 			noDeps = true
 			continue
 		}
-		col := sqlparser.NewColName(ae.ColumnName())
+		col := sqlparser.NewColName(lae.ColumnName())
 		cols[idx] = aeWrap(col)
 		if noDeps {
 			continue
 		}
 
-		deps := ctx.SemTable.RecursiveDeps(ae.Expr)
-		ae, ok = rhsExprs[idx].(*sqlparser.AliasedExpr)
+		deps := ctx.SemTable.RecursiveDeps(lae.Expr)
+		rae, ok := rhsExprs[idx].(*sqlparser.AliasedExpr)
 		if !ok {
 			noDeps = true
 			continue
 		}
-		deps = deps.Merge(ctx.SemTable.RecursiveDeps(ae.Expr))
+		deps = deps.Merge(ctx.SemTable.RecursiveDeps(rae.Expr))
+		ctx.SemTable.CopySemanticInfo(rae.Expr, col)
+		ctx.SemTable.CopySemanticInfo(lae.Expr, col)
 		ctx.SemTable.Recursive[col] = deps
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -208,9 +208,6 @@ func createMergedUnion(
 			types := []sqltypes.Type{rt.Type(), lt.Type()}
 			t := evalengine.AggregateTypes(types)
 			ctx.SemTable.ExprTypes[col] = evalengine.NewType(t, collations.Unknown)
-		} else {
-			ctx.SemTable.CopySemanticInfo(rae.Expr, col)
-			ctx.SemTable.CopySemanticInfo(lae.Expr, col)
 		}
 		ctx.SemTable.Recursive[col] = deps
 	}

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1622,5 +1622,96 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "Select literals from table union Select now() from table",
+    "query": "select 3 from user union select now() from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 3 from user union select now() from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 3 from `user` where 1 != 1 union select now() from `user` where 1 != 1",
+            "Query": "select 3 from `user` union select now() from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Select now() from table union Select literals from table",
+    "query": "select now() from user union select 3 from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select now() from user union select 3 from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select now() from `user` where 1 != 1 union select 3 from `user` where 1 != 1",
+            "Query": "select now() from `user` union select 3 from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Select now() from table union Select column from table",
+    "query": "select now() from user union select id from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select now() from user union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `now()`, weight_string(`now()`) from (select now() from `user` where 1 != 1 union select id from `user` where 1 != 1) as dt where 1 != 1",
+            "Query": "select `now()`, weight_string(`now()`) from (select now() from `user` union select id from `user`) as dt",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -373,9 +373,8 @@
       "Instructions": {
         "OperatorType": "Distinct",
         "Collations": [
-          "(0:1)"
+          "0"
         ],
-        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -384,8 +383,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from (select id from `user` where 1 != 1 union select id from music where 1 != 1 union select 1 from dual where 1 != 1) as dt where 1 != 1",
-            "Query": "select id, weight_string(id) from (select id from `user` union select id from music union select 1 from dual) as dt",
+            "FieldQuery": "select id from `user` where 1 != 1 union select id from music where 1 != 1 union select 1 from dual where 1 != 1",
+            "Query": "select id from `user` union select id from music union select 1 from dual",
             "Table": "`user`, dual, music"
           }
         ]
@@ -523,9 +522,8 @@
       "Instructions": {
         "OperatorType": "Distinct",
         "Collations": [
-          "(0:1)"
+          "0"
         ],
-        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -534,8 +532,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select `1`, weight_string(`1`) from (select 1 from dual where 1 != 1 union select null from dual where 1 != 1 union select 1.0 from dual where 1 != 1 union select '1' from dual where 1 != 1 union select 2 from dual where 1 != 1 union select 2.0 from `user` where 1 != 1) as dt where 1 != 1",
-            "Query": "select `1`, weight_string(`1`) from (select 1 from dual union select null from dual union select 1.0 from dual union select '1' from dual union select 2 from dual union select 2.0 from `user`) as dt",
+            "FieldQuery": "select 1 from dual where 1 != 1 union select null from dual where 1 != 1 union select 1.0 from dual where 1 != 1 union select '1' from dual where 1 != 1 union select 2 from dual where 1 != 1 union select 2.0 from `user` where 1 != 1",
+            "Query": "select 1 from dual union select null from dual union select 1.0 from dual union select '1' from dual union select 2 from dual union select 2.0 from `user`",
             "Table": "`user`, dual"
           }
         ]
@@ -836,9 +834,8 @@
           {
             "OperatorType": "Distinct",
             "Collations": [
-              "(0:1)"
+              "0"
             ],
-            "ResultColumns": 1,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -847,8 +844,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select id, weight_string(id) from (select id from `user` where 1 != 1 union select 3 from dual where 1 != 1) as dt where 1 != 1",
-                "Query": "select id, weight_string(id) from (select id from `user` union select 3 from dual limit :__upper_limit) as dt",
+                "FieldQuery": "select id from `user` where 1 != 1 union select 3 from dual where 1 != 1",
+                "Query": "select id from `user` union select 3 from dual limit :__upper_limit",
                 "Table": "`user`, dual"
               }
             ]
@@ -1045,7 +1042,7 @@
           {
             "OperatorType": "Distinct",
             "Collations": [
-              "(0:1)",
+              "0",
               "1"
             ],
             "Inputs": [
@@ -1532,6 +1529,96 @@
       },
       "TablesUsed": [
         "user.music",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Select literals from table union Select literals from table",
+    "query": "SELECT 1 from user UNION SELECT 2 from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT 1 from user UNION SELECT 2 from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from `user` where 1 != 1 union select 2 from `user` where 1 != 1",
+            "Query": "select 1 from `user` union select 2 from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Select column from table union Select literals from table",
+    "query": "select col1 from user union select 3 from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select col1 from user union select 3 from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select col1 from `user` where 1 != 1 union select 3 from `user` where 1 != 1",
+            "Query": "select col1 from `user` union select 3 from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Select literals from table union Select column from table",
+    "query": "select 3 from user union select col1 from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 3 from user union select col1 from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 3 from `user` where 1 != 1 union select col1 from `user` where 1 != 1",
+            "Query": "select 3 from `user` union select col1 from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
         "user.user"
       ]
     }

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -373,8 +373,9 @@
       "Instructions": {
         "OperatorType": "Distinct",
         "Collations": [
-          "0"
+          "(0:1)"
         ],
+        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -383,8 +384,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from `user` where 1 != 1 union select id from music where 1 != 1 union select 1 from dual where 1 != 1",
-            "Query": "select id from `user` union select id from music union select 1 from dual",
+            "FieldQuery": "select id, weight_string(id) from (select id from `user` where 1 != 1 union select id from music where 1 != 1 union select 1 from dual where 1 != 1) as dt where 1 != 1",
+            "Query": "select id, weight_string(id) from (select id from `user` union select id from music union select 1 from dual) as dt",
             "Table": "`user`, dual, music"
           }
         ]
@@ -834,8 +835,9 @@
           {
             "OperatorType": "Distinct",
             "Collations": [
-              "0"
+              "(0:1)"
             ],
+            "ResultColumns": 1,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -844,8 +846,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select id from `user` where 1 != 1 union select 3 from dual where 1 != 1",
-                "Query": "select id from `user` union select 3 from dual limit :__upper_limit",
+                "FieldQuery": "select id, weight_string(id) from (select id from `user` where 1 != 1 union select 3 from dual where 1 != 1) as dt where 1 != 1",
+                "Query": "select id, weight_string(id) from (select id from `user` union select 3 from dual limit :__upper_limit) as dt",
                 "Table": "`user`, dual"
               }
             ]
@@ -1042,7 +1044,7 @@
           {
             "OperatorType": "Distinct",
             "Collations": [
-              "0",
+              "(0:1)",
               "1"
             ],
             "Inputs": [
@@ -1572,8 +1574,9 @@
       "Instructions": {
         "OperatorType": "Distinct",
         "Collations": [
-          "0"
+          "(0:1)"
         ],
+        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1582,8 +1585,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col1 from `user` where 1 != 1 union select 3 from `user` where 1 != 1",
-            "Query": "select col1 from `user` union select 3 from `user`",
+            "FieldQuery": "select col1, weight_string(col1) from (select col1 from `user` where 1 != 1 union select 3 from `user` where 1 != 1) as dt where 1 != 1",
+            "Query": "select col1, weight_string(col1) from (select col1 from `user` union select 3 from `user`) as dt",
             "Table": "`user`"
           }
         ]
@@ -1602,8 +1605,9 @@
       "Instructions": {
         "OperatorType": "Distinct",
         "Collations": [
-          "0"
+          "(0:1)"
         ],
+        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1612,8 +1616,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select 3 from `user` where 1 != 1 union select col1 from `user` where 1 != 1",
-            "Query": "select 3 from `user` union select col1 from `user`",
+            "FieldQuery": "select `3`, weight_string(`3`) from (select 3 from `user` where 1 != 1 union select col1 from `user` where 1 != 1) as dt where 1 != 1",
+            "Query": "select `3`, weight_string(`3`) from (select 3 from `user` union select col1 from `user`) as dt",
             "Table": "`user`"
           }
         ]
@@ -1632,8 +1636,9 @@
       "Instructions": {
         "OperatorType": "Distinct",
         "Collations": [
-          "0"
+          "(0:1)"
         ],
+        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1642,8 +1647,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select 3 from `user` where 1 != 1 union select now() from `user` where 1 != 1",
-            "Query": "select 3 from `user` union select now() from `user`",
+            "FieldQuery": "select `3`, weight_string(`3`) from (select 3 from `user` where 1 != 1 union select now() from `user` where 1 != 1) as dt where 1 != 1",
+            "Query": "select `3`, weight_string(`3`) from (select 3 from `user` union select now() from `user`) as dt",
             "Table": "`user`"
           }
         ]
@@ -1662,8 +1667,9 @@
       "Instructions": {
         "OperatorType": "Distinct",
         "Collations": [
-          "0"
+          "(0:1)"
         ],
+        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1672,8 +1678,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select now() from `user` where 1 != 1 union select 3 from `user` where 1 != 1",
-            "Query": "select now() from `user` union select 3 from `user`",
+            "FieldQuery": "select `now()`, weight_string(`now()`) from (select now() from `user` where 1 != 1 union select 3 from `user` where 1 != 1) as dt where 1 != 1",
+            "Query": "select `now()`, weight_string(`now()`) from (select now() from `user` union select 3 from `user`) as dt",
             "Table": "`user`"
           }
         ]


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The query 

```sql
select 1 from user 
union 
select 2 from user
``` 

was transformed into 

```sql
select `1`, weight_string(`1`) from (
  select 1 from `user` 
  union 
  select 2 from `user`) as dt
```

for execution, but by copying the types, it can be simplified and avoid the generation of a derived table. We can now just use the original query.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
https://github.com/vitessio/vitess/issues/15020

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
