### PR TITLE
query_executor: Record `WaitingForConnection` stat in all cases

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -778,9 +778,10 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, error) {
 	start := time.Now()
 	conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
 
+	qre.logStats.WaitingForConnection += time.Since(start)
+
 	switch err {
 	case nil:
-		qre.logStats.WaitingForConnection += time.Since(start)
 		return conn, nil
 	case connpool.ErrConnPoolClosed:
 		return nil, err

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -776,9 +776,10 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, error) {
 	defer span.Finish()
 
 	start := time.Now()
+	defer func() {
+		qre.logStats.WaitingForConnection += time.Since(start)
+	}()
 	conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
-
-	qre.logStats.WaitingForConnection += time.Since(start)
 
 	switch err {
 	case nil:
@@ -794,9 +795,10 @@ func (qre *QueryExecutor) getStreamConn() (*connpool.PooledConn, error) {
 	defer span.Finish()
 
 	start := time.Now()
+	defer func() {
+		qre.logStats.WaitingForConnection += time.Since(start)
+	}()
 	conn, err := qre.tsv.qe.streamConns.Get(ctx, qre.setting)
-
-	qre.logStats.WaitingForConnection += time.Since(start)
 
 	switch err {
 	case nil:

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -775,10 +775,9 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, error) {
 	span, ctx := trace.NewSpan(qre.ctx, "QueryExecutor.getConn")
 	defer span.Finish()
 
-	start := time.Now()
-	defer func() {
+	defer func(start time.Time) {
 		qre.logStats.WaitingForConnection += time.Since(start)
-	}()
+	}(time.Now())
 	conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
 
 	switch err {
@@ -794,10 +793,9 @@ func (qre *QueryExecutor) getStreamConn() (*connpool.PooledConn, error) {
 	span, ctx := trace.NewSpan(qre.ctx, "QueryExecutor.getStreamConn")
 	defer span.Finish()
 
-	start := time.Now()
-	defer func() {
+	defer func(start time.Time) {
 		qre.logStats.WaitingForConnection += time.Since(start)
-	}()
+	}(time.Now())
 	conn, err := qre.tsv.qe.streamConns.Get(ctx, qre.setting)
 
 	switch err {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -795,9 +795,11 @@ func (qre *QueryExecutor) getStreamConn() (*connpool.PooledConn, error) {
 
 	start := time.Now()
 	conn, err := qre.tsv.qe.streamConns.Get(ctx, qre.setting)
+
+	qre.logStats.WaitingForConnection += time.Since(start)
+
 	switch err {
 	case nil:
-		qre.logStats.WaitingForConnection += time.Since(start)
 		return conn, nil
 	case connpool.ErrConnPoolClosed:
 		return nil, err

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1439,6 +1439,7 @@ func TestQueryExecutorShouldConsolidate(t *testing.T) {
 
 func TestGetConnectionLogStats(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
+	defer db.Close()
 
 	ctx := context.Background()
 	tsv := newTestTabletServer(ctx, noFlags, db)


### PR DESCRIPTION
## Description

Record the `WaitingForConnection` stat whether or not the connection succeeds. This stat is needed in the error path for metrics and logging.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/15093

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A