### PR TITLE
mysql: remove more allocations from parseOKPacket

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1530,28 +1530,25 @@ func (c *Conn) parseOKPacket(packetOK *PacketOK, in []byte) error {
 		data: in,
 		pos:  1, // We already read the type.
 	}
-	fail := func(format string, args ...any) error {
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, format, args...)
-	}
 
 	// Affected rows.
 	affectedRows, ok := data.readLenEncInt()
 	if !ok {
-		return fail("invalid OK packet affectedRows: %v", data)
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid OK packet affectedRows: %v", data.data)
 	}
 	packetOK.affectedRows = affectedRows
 
 	// Last Insert ID.
 	lastInsertID, ok := data.readLenEncInt()
 	if !ok {
-		return fail("invalid OK packet lastInsertID: %v", data)
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid OK packet lastInsertID: %v", data.data)
 	}
 	packetOK.lastInsertID = lastInsertID
 
 	// Status flags.
 	statusFlags, ok := data.readUint16()
 	if !ok {
-		return fail("invalid OK packet statusFlags: %v", data)
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid OK packet statusFlags: %v", data.data)
 	}
 	packetOK.statusFlags = statusFlags
 
@@ -1559,7 +1556,7 @@ func (c *Conn) parseOKPacket(packetOK *PacketOK, in []byte) error {
 	// Warnings.
 	warnings, ok := data.readUint16()
 	if !ok {
-		return fail("invalid OK packet warnings: %v", data)
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid OK packet warnings: %v", data.data)
 	}
 	packetOK.warnings = warnings
 
@@ -1588,7 +1585,7 @@ func (c *Conn) parseOKPacket(packetOK *PacketOK, in []byte) error {
 				}
 				sessionLen, ok := data.readLenEncInt()
 				if !ok {
-					return fail("invalid OK packet session state change length for type %v", sscType)
+					return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid OK packet session state change length for type %v", sscType)
 				}
 
 				if sscType != SessionTrackGtids {
@@ -1601,12 +1598,12 @@ func (c *Conn) parseOKPacket(packetOK *PacketOK, in []byte) error {
 				// read (and ignore for now) the GTIDS encoding specification code: 1 byte
 				_, ok = data.readByte()
 				if !ok {
-					return fail("invalid OK packet gtids type: %v", data)
+					return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid OK packet gtids type: %v", data.data)
 				}
 
 				gtids, ok := data.readLenEncString()
 				if !ok {
-					return fail("invalid OK packet gtids: %v", data)
+					return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid OK packet gtids: %v", data.data)
 				}
 				packetOK.sessionStateData = gtids
 			}

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -357,7 +357,7 @@ func TestOkPackets(t *testing.T) {
 		dataIn: `
 00000000  00 00 00 02 00                                    |.....|`,
 		cc:          CapabilityClientTransactions,
-		expectedErr: "invalid OK packet warnings: &{[0 0 0 2 0] 0}",
+		expectedErr: "invalid OK packet warnings: [0 0 0 2 0]",
 	}, {
 		dataIn: `
 00000000  FE 00 00 22 40 00 00                              |.....|`,

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -442,14 +442,15 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (*sqltypes.Result, 
 				more = (statusFlags & ServerMoreResultsExists) != 0
 				result.StatusFlags = statusFlags
 			} else {
-				if err := c.parseOKPacket(&packetOk, data); err != nil {
+				var packetEof PacketOK
+				if err := c.parseOKPacket(&packetEof, data); err != nil {
 					return nil, false, 0, err
 				}
-				warnings = packetOk.warnings
-				more = (packetOk.statusFlags & ServerMoreResultsExists) != 0
-				result.SessionStateChanges = packetOk.sessionStateData
-				result.StatusFlags = packetOk.statusFlags
-				result.Info = packetOk.info
+				warnings = packetEof.warnings
+				more = (packetEof.statusFlags & ServerMoreResultsExists) != 0
+				result.SessionStateChanges = packetEof.sessionStateData
+				result.StatusFlags = packetEof.statusFlags
+				result.Info = packetEof.info
 			}
 			return result, more, warnings, nil
 


### PR DESCRIPTION
## Description

ooops! I actually forgot to push the second commit from https://github.com/vitessio/vitess/pull/15067 before that PR was merged. My bad!

This commit removes the second allocation as described in the PR description for the previous PR. With this change, the `parseOKPacket` API is _actually_ zero-allocation.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/15067
- https://github.com/vitessio/vitess/issues/15071

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
