### PR TITLE
evalengine: implement AggregateEvalTypes

### DIFF
--- a/go/vt/vtgate/evalengine/api_type_aggregation.go
+++ b/go/vt/vtgate/evalengine/api_type_aggregation.go
@@ -61,7 +61,7 @@ func AggregateEvalTypes(types []Type, env *collations.Environment) (Type, error)
 		size = max(typ.size, size)
 		scale = max(typ.scale, scale)
 	}
-	return NewTypeEx(typeAgg.result(), collAgg.result().Collation, typeAgg.nullable, 0, 0), nil
+	return NewTypeEx(typeAgg.result(), collAgg.result().Collation, typeAgg.nullable, size, scale), nil
 }
 
 func AggregateTypes(types []sqltypes.Type) sqltypes.Type {

--- a/go/vt/vtgate/evalengine/api_type_aggregation_test.go
+++ b/go/vt/vtgate/evalengine/api_type_aggregation_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package evalengine
 
 import (

--- a/go/vt/vtgate/evalengine/api_type_aggregation_test.go
+++ b/go/vt/vtgate/evalengine/api_type_aggregation_test.go
@@ -1,0 +1,62 @@
+package evalengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+)
+
+var aggregationCases = []struct {
+	types  []sqltypes.Type
+	result sqltypes.Type
+}{
+	{[]sqltypes.Type{sqltypes.Int64, sqltypes.Int32, sqltypes.Float64}, sqltypes.Float64},
+	{[]sqltypes.Type{sqltypes.Int64, sqltypes.Decimal, sqltypes.Float64}, sqltypes.Float64},
+	{[]sqltypes.Type{sqltypes.Int64, sqltypes.Int32, sqltypes.Decimal}, sqltypes.Decimal},
+	{[]sqltypes.Type{sqltypes.Int64, sqltypes.Int32, sqltypes.Int64}, sqltypes.Int64},
+	{[]sqltypes.Type{sqltypes.Int32, sqltypes.Int16, sqltypes.Int8}, sqltypes.Int32},
+	{[]sqltypes.Type{sqltypes.Int32, sqltypes.Uint16, sqltypes.Uint8}, sqltypes.Int32},
+	{[]sqltypes.Type{sqltypes.Int32, sqltypes.Uint16, sqltypes.Uint32}, sqltypes.Int64},
+	{[]sqltypes.Type{sqltypes.Int32, sqltypes.Uint16, sqltypes.Uint64}, sqltypes.Decimal},
+	{[]sqltypes.Type{sqltypes.Bit, sqltypes.Bit, sqltypes.Bit}, sqltypes.Bit},
+	{[]sqltypes.Type{sqltypes.Bit, sqltypes.Int32, sqltypes.Float64}, sqltypes.Float64},
+	{[]sqltypes.Type{sqltypes.Bit, sqltypes.Decimal, sqltypes.Float64}, sqltypes.Float64},
+	{[]sqltypes.Type{sqltypes.Bit, sqltypes.Int32, sqltypes.Decimal}, sqltypes.Decimal},
+	{[]sqltypes.Type{sqltypes.Bit, sqltypes.Int32, sqltypes.Int64}, sqltypes.Int64},
+	{[]sqltypes.Type{sqltypes.Char, sqltypes.VarChar}, sqltypes.VarChar},
+	{[]sqltypes.Type{sqltypes.Char, sqltypes.Char}, sqltypes.VarChar},
+	{[]sqltypes.Type{sqltypes.Char, sqltypes.VarChar, sqltypes.VarBinary}, sqltypes.VarBinary},
+	{[]sqltypes.Type{sqltypes.Char, sqltypes.Char, sqltypes.Set, sqltypes.Enum}, sqltypes.VarChar},
+	{[]sqltypes.Type{sqltypes.TypeJSON, sqltypes.TypeJSON}, sqltypes.TypeJSON},
+	{[]sqltypes.Type{sqltypes.Geometry, sqltypes.Geometry}, sqltypes.Geometry},
+}
+
+func TestTypeAggregations(t *testing.T) {
+	for i, tc := range aggregationCases {
+		t.Run(fmt.Sprintf("%d.%v", i, tc.result), func(t *testing.T) {
+			res := AggregateTypes(tc.types)
+			require.Equalf(t, tc.result, res, "expected aggregate(%v) = %v, got %v", tc.types, tc.result, res)
+		})
+	}
+}
+
+func TestEvalengineTypeAggregations(t *testing.T) {
+	for i, tc := range aggregationCases {
+		t.Run(fmt.Sprintf("%d.%v", i, tc.result), func(t *testing.T) {
+			var types []Type
+			for _, tt := range tc.types {
+				// this test only aggregates binary collations because textual collation
+				// aggregation is tested in the `mysql/collations` package
+				types = append(types, NewType(tt, collations.CollationBinaryID))
+			}
+
+			res, err := AggregateEvalTypes(types, collations.MySQL8())
+			require.NoError(t, err)
+			require.Equalf(t, tc.result, res.Type(), "expected aggregate(%v) = %v, got %v", tc.types, tc.result, res)
+		})
+	}
+}


### PR DESCRIPTION
## Description

As requested by @systay in https://github.com/vitessio/vitess/pull/15069#pullrequestreview-1850341374, this PR implements a helper in the `evalengine` that performs type aggregation on the engine's native `Type` struct, as opposed to `sqltypes.Type` which is what we were previously using.

cc @dbussink 

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/15069#pullrequestreview-1850341374
- 
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
