### PR TITLE
discovery: fix crash with nil server vschema

### DIFF
--- a/go/vt/discovery/keyspace_events.go
+++ b/go/vt/discovery/keyspace_events.go
@@ -529,6 +529,11 @@ func (kss *keyspaceState) isServing() bool {
 // In addition, the traffic switcher updates SrvVSchema when the DeniedTables attributes in a Shard record is
 // modified.
 func (kss *keyspaceState) onSrvVSchema(vs *vschemapb.SrvVSchema, err error) bool {
+	// the vschema can be nil if the server is currently shutting down
+	if vs == nil {
+		return true
+	}
+
 	kss.mu.Lock()
 	defer kss.mu.Unlock()
 	kss.moveTablesState, _ = kss.getMoveTablesStatus(vs)


### PR DESCRIPTION
## Description

Fixes https://github.com/vitessio/vitess/issues/15080

We spotted this crash in CI, where the incoming server vschema is nil and causes a nil pointer dereference panic. This can only happen while the server is shutting down. We need to explicitly check it at the function entry point to prevent the crash.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15080

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
