### PR TITLE
evalEngine: Implement TIME_TO_SEC

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1567,6 +1567,18 @@ func (cached *builtinTime) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinTimeToSec) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinToBase64) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3818,6 +3818,19 @@ func (asm *assembler) Fn_FROM_DAYS() {
 	}, "FN FROM_DAYS INT64(SP-1)")
 }
 
+func (asm *assembler) Fn_TIME_TO_SEC() {
+	asm.emit(func(env *ExpressionEnv) int {
+		if env.vm.stack[env.vm.sp-1] == nil {
+			return 1
+		}
+		d := env.vm.stack[env.vm.sp-1].(*evalTemporal)
+
+		sec := d.dt.Time.Hour()*3600 + d.dt.Time.Minute()*60 + d.dt.Time.Second()
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(sec))
+		return 1
+	}, "FN TIME_TO_SEC TIME(SP-1)")
+}
+
 func (asm *assembler) Fn_QUARTER() {
 	asm.emit(func(env *ExpressionEnv) int {
 		if env.vm.stack[env.vm.sp-1] == nil {

--- a/go/vt/vtgate/evalengine/fn_time.go
+++ b/go/vt/vtgate/evalengine/fn_time.go
@@ -119,6 +119,10 @@ type (
 		CallExpr
 	}
 
+	builtinTimeToSec struct {
+		CallExpr
+	}
+
 	builtinQuarter struct {
 		CallExpr
 	}
@@ -183,6 +187,7 @@ var _ IR = (*builtinMonthName)(nil)
 var _ IR = (*builtinLastDay)(nil)
 var _ IR = (*builtinToDays)(nil)
 var _ IR = (*builtinFromDays)(nil)
+var _ IR = (*builtinTimeToSec)(nil)
 var _ IR = (*builtinQuarter)(nil)
 var _ IR = (*builtinSecond)(nil)
 var _ IR = (*builtinTime)(nil)
@@ -1325,6 +1330,43 @@ func (call *builtinFromDays) compile(c *compiler) (ctype, error) {
 	c.asm.Fn_FROM_DAYS()
 	c.asm.jumpDestination(skip)
 	return ctype{Type: sqltypes.Date, Flag: arg.Flag | flagNullable}, nil
+}
+
+func (b *builtinTimeToSec) eval(env *ExpressionEnv) (eval, error) {
+	arg, err := b.arg1(env)
+	if arg == nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	d := evalToTime(arg, -1)
+	if d == nil {
+		return nil, nil
+	}
+
+	sec := d.dt.Time.Hour()*3600 + d.dt.Time.Minute()*60 + d.dt.Time.Second()
+	return newEvalInt64(int64(sec)), nil
+}
+
+func (call *builtinTimeToSec) compile(c *compiler) (ctype, error) {
+	arg, err := call.Arguments[0].compile(c)
+	if err != nil {
+		return ctype{}, err
+	}
+
+	skip := c.compileNullCheck1(arg)
+
+	switch arg.Type {
+	case sqltypes.Date, sqltypes.Datetime, sqltypes.Time:
+	default:
+		c.asm.Convert_xT(1, -1)
+	}
+
+	c.asm.Fn_TIME_TO_SEC()
+	c.asm.jumpDestination(skip)
+	return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: arg.Flag | flagNullable}, nil
 }
 
 func (b *builtinQuarter) eval(env *ExpressionEnv) (eval, error) {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -133,6 +133,7 @@ var Cases = []TestCase{
 	{Run: FnLastDay},
 	{Run: FnToDays},
 	{Run: FnFromDays},
+	{Run: FnTimeToSec},
 	{Run: FnQuarter},
 	{Run: FnSecond},
 	{Run: FnTime},
@@ -1813,6 +1814,26 @@ func FnFromDays(yield Query) {
 
 	for _, d := range days {
 		yield(fmt.Sprintf("FROM_DAYS(%s)", d), nil)
+	}
+}
+
+func FnTimeToSec(yield Query) {
+	for _, d := range inputConversions {
+		yield(fmt.Sprintf("FROM_DAYS(%s)", d), nil)
+	}
+
+	time := []string{
+		`0`,
+		`'00:00:00'`,
+		`'22:23:00'`,
+		`'00:39:38'`,
+		`'000220`,
+		`'2003-09-03 00:39:38'`,
+		`'2003-09-03'`,
+	}
+
+	for _, t := range time {
+		yield(fmt.Sprintf("TIME_TO_SEC(%s)", t), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -429,6 +429,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinFromDays{CallExpr: call}, nil
+	case "time_to_sec":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinTimeToSec{CallExpr: call}, nil
 	case "quarter":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds implementation of [`TIME_TO_SEC`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_time-to-sec) func in evalengine.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #9647
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
