### PR TITLE
Improve efficiency and accuracy of mysqld.GetVersionString

### DIFF
--- a/go/vt/env/env.go
+++ b/go/vt/env/env.go
@@ -85,7 +85,7 @@ func VtMysqlRoot() (string, error) {
 	// packages (apt, dnf, etc).
 	sbinEnvOnce.Do(func() {
 		envPath := os.Getenv("PATH")
-		if !slices.Contains(strings.Split(envPath, ":"), sbinPath) {
+		if !slices.Contains(filepath.SplitList(envPath), sbinPath) {
 			newEnvPath := fmt.Sprintf("%s:%s", sbinPath, envPath)
 			os.Setenv("PATH", newEnvPath)
 		}

--- a/go/vt/env/env.go
+++ b/go/vt/env/env.go
@@ -80,8 +80,9 @@ func VtMysqlRoot() (string, error) {
 		// the PATH by default and this is often the default location
 		// used by mysqld OS system packages (apt, dnf, etc).
 		fi, err := os.Stat(mysqldSbinPath)
-		if err == nil /* file exists */ && fi.Mode().IsRegular() /* is not a DIR or other special file */ && fi.Mode()&0111 != 0 /* is executable by anyone */ {
-			return "/usr", nil
+		if err == nil /* file exists */ && fi.Mode().IsRegular() /* is not a DIR or other special file */ &&
+			fi.Mode()&0111 != 0 /* is executable by anyone */ {
+			return "/usr", nil // Value is expected to be a base path without the mysqld and sbin parts
 		}
 		return "", errMysqldNotFound
 	}

--- a/go/vt/env/env_test.go
+++ b/go/vt/env/env_test.go
@@ -73,7 +73,7 @@ func TestVtMysqlRoot(t *testing.T) {
 	}
 	testcases := []testcase{
 		{
-			name:              "env var set",
+			name:              "VT_MYSQL_ROOT set",
 			vtMysqlRootEnvVal: "/home/mysql/binaries",
 		},
 		{
@@ -85,11 +85,6 @@ func TestVtMysqlRoot(t *testing.T) {
 			},
 			expect: testDir + "/usr",
 		},
-		{
-			name:       "VT_MYSQL_ROOT empty; PATH with /usr/sbin",
-			pathEnvVal: "",
-			expectErr:  errMysqldNotFound.Error(),
-		},
 	}
 
 	// If /usr/sbin/mysqld exists, confirm that we find it even
@@ -97,11 +92,15 @@ func TestVtMysqlRoot(t *testing.T) {
 	_, err := os.Stat(mysqldSbinPath)
 	if err == nil {
 		t.Logf("Found %s, confirming auto detection behavior", mysqldSbinPath)
-		tc := testcase{
+		testcases = append(testcases, testcase{
 			name:   "VT_MYSQL_ROOT empty; PATH empty; mysqld in /usr/sbin",
 			expect: "/usr",
-		}
-		testcases = append(testcases, tc)
+		})
+	} else {
+		testcases = append(testcases, testcase{ // Error expected
+			name:      "VT_MYSQL_ROOT empty; PATH empty; mysqld not in /usr/sbin",
+			expectErr: errMysqldNotFound.Error(),
+		})
 	}
 
 	for _, tc := range testcases {

--- a/go/vt/env/env_test.go
+++ b/go/vt/env/env_test.go
@@ -19,8 +19,8 @@ package env
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,7 +88,7 @@ func TestVtMysqlRoot(t *testing.T) {
 
 	// Confirm the PATH value now after all test runs.
 	currentPATH := os.Getenv("PATH")
-	if slices.Contains(strings.Split(originalPATH, ":"), sbinPath) {
+	if slices.Contains(filepath.SplitList(originalPATH), sbinPath) {
 		// The PATH already had /usr/sbin and we should not have changed it.
 		require.Equal(t, originalPATH, currentPATH)
 	} else {

--- a/go/vt/env/env_test.go
+++ b/go/vt/env/env_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package env
 
 import (
+	"fmt"
 	"os"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,6 +86,12 @@ func TestVtMysqlRoot(t *testing.T) {
 		})
 	}
 
-	// After all of the test runs, the PATH should only have had /usr/sbin added once.
-	require.Equal(t, "/usr/sbin:"+originalPATH, os.Getenv("PATH"))
+	// Confirm the PATH after all test runs.
+	if slices.Contains(strings.Split(originalPATH, ":"), sbinPath) {
+		// The PATH already had /usr/sbin and we should not have changed it.
+		require.Equal(t, originalPATH, os.Getenv("PATH"))
+	} else {
+		// We should have prepended it exactly once.
+		require.Equal(t, fmt.Sprintf("%s:%s", sbinPath, originalPATH), os.Getenv("PATH"))
+	}
 }

--- a/go/vt/env/env_test.go
+++ b/go/vt/env/env_test.go
@@ -82,11 +82,11 @@ func TestVtMysqlRoot(t *testing.T) {
 				require.Equal(t, tc.envVal, path)
 				require.NoError(t, err)
 			}
-			// We don't require a non-error as the test env may not have mysql installed.
+			// We don't require a nil error as the test env may not have MySQL installed.
 		})
 	}
 
-	// Confirm the PATH after all test runs.
+	// Confirm the PATH value after all test runs.
 	if slices.Contains(strings.Split(originalPATH, ":"), sbinPath) {
 		// The PATH already had /usr/sbin and we should not have changed it.
 		require.Equal(t, originalPATH, os.Getenv("PATH"))

--- a/go/vt/env/env_test.go
+++ b/go/vt/env/env_test.go
@@ -77,8 +77,9 @@ func TestVtMysqlRoot(t *testing.T) {
 			vtMysqlRootEnvVal: "/home/mysql/binaries",
 		},
 		{
-			name:       "VT_MYSQL_ROOT empty; PATH set without /usr/sbin",
-			pathEnvVal: testDir + filepath.Dir(mysqldSbinPath) + ":/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin:/home/mysql/binaries",
+			name: "VT_MYSQL_ROOT empty; PATH set without /usr/sbin",
+			pathEnvVal: testDir + filepath.Dir(mysqldSbinPath) +
+				":/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin:/home/mysql/binaries",
 			preFunc: func() error {
 				return createExecutable(mysqldSbinPath)
 			},

--- a/go/vt/env/env_test.go
+++ b/go/vt/env/env_test.go
@@ -86,12 +86,13 @@ func TestVtMysqlRoot(t *testing.T) {
 		})
 	}
 
-	// Confirm the PATH value after all test runs.
+	// Confirm the PATH value now after all test runs.
+	currentPATH := os.Getenv("PATH")
 	if slices.Contains(strings.Split(originalPATH, ":"), sbinPath) {
 		// The PATH already had /usr/sbin and we should not have changed it.
-		require.Equal(t, originalPATH, os.Getenv("PATH"))
+		require.Equal(t, originalPATH, currentPATH)
 	} else {
 		// We should have prepended it exactly once.
-		require.Equal(t, fmt.Sprintf("%s:%s", sbinPath, originalPATH), os.Getenv("PATH"))
+		require.Equal(t, fmt.Sprintf("%s:%s", sbinPath, originalPATH), currentPATH)
 	}
 }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1198,7 +1198,6 @@ func (mysqld *Mysqld) GetVersionString(ctx context.Context) (string, error) {
 	qr, err := mysqld.FetchSuperQuery(ctx, versionSQLQuery)
 	if err == nil && len(qr.Rows) == 1 {
 		return qr.Rows[0][0].ToString(), nil
-
 	}
 	// Execute as remote action on mysqlctld to use the actual running MySQL
 	// version.


### PR DESCRIPTION
## Description

The following vitess binaries call the tabletmanager [`FullStatus`](https://github.com/vitessio/vitess/blob/31472406194450a258faba02f3477c29f2330b40/go/vt/vttablet/tabletmanager/rpc_replication.go#L53) RPC:
  - `vtorc`: It runs it via `refreshAllTablets()` every 15 seconds by default
  - `vtadmin`: It runs it on the tablet view pages (I believe with a regular auto refresh)
  - `vtctldclient`: Any time the [`GetFullStatus`](https://vitess.io/docs/18.0/reference/programs/vtctldclient/vtctldclient_getfullstatus/) command is used  

In the `vtorc` (for sure) and `vtadmin` (I think) cases, it's run automatically and periodically. So over time, this RPC can be called many thousands of times on a tablet. And this RPC is merely one thing that ends up calling the `VtMySQLRoot()` function. This function was blindly prepending `/usr/sbin:` to the `PATH` and updating the environment variable **_every time it was called_** when `VT_MYSQL_ROOT` was not set: https://github.com/vitessio/vitess/blob/31472406194450a258faba02f3477c29f2330b40/go/vt/env/env.go#L69-L79

In the case of the `FullStatus` RPC, it ends up there via:
  1. https://github.com/vitessio/vitess/blob/31472406194450a258faba02f3477c29f2330b40/go/vt/vttablet/tabletmanager/rpc_replication.go#L95-L96
  2. https://github.com/vitessio/vitess/blob/31472406194450a258faba02f3477c29f2330b40/go/vt/mysqlctl/mysqld.go#L1188
  3. https://github.com/vitessio/vitess/blob/31472406194450a258faba02f3477c29f2330b40/go/vt/mysqlctl/mysqld.go#L192-L195

This ends up making a sys exec call to execute `mysqld --version`: https://github.com/vitessio/vitess/blob/31472406194450a258faba02f3477c29f2330b40/go/vt/mysqlctl/mysqld.go#L203

And every time we do this the `PATH` env var grows by 11 bytes as `/usr/sbin:` is prepended to it and saved in the env every time. When we exec the `mysqld` command it inherits a copy-on-write copy of the vttablet's env (with the ever growing `PATH` value) — because we set `cmd.Env` to nil. Eventually this will cause the [`execve`](https://linux.die.net/man/2/execve) call to fail with `E2BIG (Argument list too long)` as the the arguments and env size count against the `ARG_MAX` OS limit. 

If you want to try and repeat it yourself, you can do so using this manual test: https://github.com/vitessio/vitess/issues/15095#issuecomment-1918341025

I think that we should *at least* backport this to v18 since we expect everyone to be using `vtorc`, `vtadmin`, and `vtctldclient`. 

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/15095

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required