### PR TITLE
Auto-set 5s on-demand heartbeat if --enable_heartbeat is disabled

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -169,7 +169,7 @@ Flags:
       --healthcheck_timeout duration                                     the health check timeout period (default 1m0s)
       --heartbeat_enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the sidecar database's heartbeat table. The result is used to inform the serving state of the vttablet via healthchecks.
       --heartbeat_interval duration                                      How frequently to read and write replication heartbeat. (default 1s)
-      --heartbeat_on_demand_duration duration                            If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently; when requests are infrequent heartbeat may completely stop between requests
+      --heartbeat_on_demand_duration duration                            If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently. Automatically set to 5s when --heartbeat_enable is unset.
   -h, --help                                                             help for vtcombo
       --hot_row_protection_concurrent_transactions int                   Number of concurrent transactions let through to the txpool/MySQL for the same hot row. Should be > 1 to have enough 'ready' transactions in MySQL and benefit from a pipelining effect. (default 5)
       --hot_row_protection_max_global_queue_size int                     Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -196,7 +196,7 @@ Flags:
       --health_check_interval duration                                   Interval between health checks (default 20s)
       --heartbeat_enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the sidecar database's heartbeat table. The result is used to inform the serving state of the vttablet via healthchecks.
       --heartbeat_interval duration                                      How frequently to read and write replication heartbeat. (default 1s)
-      --heartbeat_on_demand_duration duration                            If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently; when requests are infrequent heartbeat may completely stop between requests
+      --heartbeat_on_demand_duration duration                            If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently. Automatically set to 5s when --heartbeat_enable is unset.
   -h, --help                                                             help for vttablet
       --hot_row_protection_concurrent_transactions int                   Number of concurrent transactions let through to the txpool/MySQL for the same hot row. Should be > 1 to have enough 'ready' transactions in MySQL and benefit from a pipelining effect. (default 5)
       --hot_row_protection_max_global_queue_size int                     Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -251,7 +251,7 @@ func Init() {
 	if heartbeatOnDemandDuration < 0 {
 		heartbeatOnDemandDuration = 0
 	}
-	if !enableHeartbeat {
+	if heartbeatOnDemandDuration == 0 && !enableHeartbeat {
 		heartbeatOnDemandDuration = 5 * time.Second
 	}
 	currentConfig.ReplicationTracker.HeartbeatInterval = heartbeatInterval

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -183,7 +183,7 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&enableHeartbeat, "heartbeat_enable", false, "If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the sidecar database's heartbeat table. The result is used to inform the serving state of the vttablet via healthchecks.")
 	fs.DurationVar(&heartbeatInterval, "heartbeat_interval", 1*time.Second, "How frequently to read and write replication heartbeat.")
-	fs.DurationVar(&heartbeatOnDemandDuration, "heartbeat_on_demand_duration", 0, "If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently; when requests are infrequent heartbeat may completely stop between requests")
+	fs.DurationVar(&heartbeatOnDemandDuration, "heartbeat_on_demand_duration", 0, "If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently. Automatically set to 5s when --heartbeat_enable is unset.")
 
 	fs.BoolVar(&currentConfig.EnforceStrictTransTables, "enforce_strict_trans_tables", defaultConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
 	flagutil.DualFormatBoolVar(fs, &enableConsolidator, "enable_consolidator", true, "This option enables the query consolidator.")
@@ -250,6 +250,9 @@ func Init() {
 	}
 	if heartbeatOnDemandDuration < 0 {
 		heartbeatOnDemandDuration = 0
+	}
+	if !enableHeartbeat {
+		heartbeatOnDemandDuration = 5 * time.Second
 	}
 	currentConfig.ReplicationTracker.HeartbeatInterval = heartbeatInterval
 	currentConfig.ReplicationTracker.HeartbeatOnDemand = heartbeatOnDemandDuration

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -252,6 +252,14 @@ func Init() {
 		heartbeatOnDemandDuration = 0
 	}
 	if heartbeatOnDemandDuration == 0 && !enableHeartbeat {
+		// Neither heartbeat-related flag was set. We want to always have some heartbeat capability,
+		// because the tablet throttler depends on the availability of a heartbeat.
+		// To that effect, we choose to set a minimal and relaxed heartbeat setup: a 5s on-demand lease.
+		// Ad on-demand heartbeats go, this has no impact when the throttler is disabled, and no impact
+		// when the throttler is enabled but otherwise not engaged with some consumer. Heartbeats are
+		// only leased and generated when the throttler is requested by some consumer (e.g. vreplication)
+		// to provide throttling advice. We keep the lease to a very low 5s, so that heartbeats are only
+		// generated while an active consumer is requesting them, and only up to 5s afterwards.
 		heartbeatOnDemandDuration = 5 * time.Second
 	}
 	currentConfig.ReplicationTracker.HeartbeatInterval = heartbeatInterval

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -214,6 +214,7 @@ func TestFlags(t *testing.T) {
 	want.Healthcheck.UnhealthyThreshold = 2 * time.Hour
 	want.ReplicationTracker.HeartbeatInterval = time.Second
 	want.ReplicationTracker.Mode = Disable
+	want.ReplicationTracker.HeartbeatOnDemand = 5 * time.Second
 	assert.Equal(t, want.DB, currentConfig.DB)
 	assert.Equal(t, want, currentConfig)
 
@@ -266,21 +267,36 @@ func TestFlags(t *testing.T) {
 	assert.Equal(t, want, currentConfig)
 
 	enableHeartbeat = true
+	heartbeatOnDemandDuration = 0
 	heartbeatInterval = 1 * time.Second
 	currentConfig.ReplicationTracker.Mode = ""
 	currentConfig.ReplicationTracker.HeartbeatInterval = 0
 	Init()
 	want.ReplicationTracker.Mode = Heartbeat
 	want.ReplicationTracker.HeartbeatInterval = time.Second
+	want.ReplicationTracker.HeartbeatOnDemand = 0
 	assert.Equal(t, want, currentConfig)
 
 	enableHeartbeat = false
+	heartbeatOnDemandDuration = 0
 	heartbeatInterval = 1 * time.Second
 	currentConfig.ReplicationTracker.Mode = ""
 	currentConfig.ReplicationTracker.HeartbeatInterval = 0
 	Init()
 	want.ReplicationTracker.Mode = Disable
 	want.ReplicationTracker.HeartbeatInterval = time.Second
+	want.ReplicationTracker.HeartbeatOnDemand = 5 * time.Second
+	assert.Equal(t, want, currentConfig)
+
+	enableHeartbeat = false
+	heartbeatOnDemandDuration = 7 * time.Second
+	heartbeatInterval = 1 * time.Second
+	currentConfig.ReplicationTracker.Mode = ""
+	currentConfig.ReplicationTracker.HeartbeatInterval = 0
+	Init()
+	want.ReplicationTracker.Mode = Disable
+	want.ReplicationTracker.HeartbeatInterval = time.Second
+	want.ReplicationTracker.HeartbeatOnDemand = 7 * time.Second
 	assert.Equal(t, want, currentConfig)
 
 	enableReplicationReporter = true


### PR DESCRIPTION
## Description

This work started with https://github.com/vitessio/vitess/issues/14978 and https://github.com/vitessio/vitess/pull/14980. And while the discussion was about the `examples` suite, it applies to all environments.

After https://github.com/vitessio/vitess/pull/14980 was merged, we realized `examples` could no longer facilitate the tablet throttler with its default setup. That's because the throttler, by default, relies on replication lag calculated from `_vt.heartbeat`.

And while the throttler can be enabled/disabled dynamically, the heartbeat configuration is set on startup.

Following #14980 we asked ourselves: should the throttler be available for operation in `examples`? And we agreed that it should -- same as any other component in Vitess. To that effect, the throttler should be able to read valid heartbeat information.

There are multiple ways to go about it, and some considerations are:

- `examples` are expected to run on local laptops or otherwise small hosts. `examples` should not generate any excessive load.
- Likewise, any testing or even prod Vitess environment should not generate any excessive load.
- The issue in #14978 should be addressed. In #14978, the tablet `/debug/status` page reported lag due to stale heartbeats, and even though there was no actual lag.
- We don't want to introduce programmatic complexity, such as a dependency or control of the throttler over the heartbeat mechanism (there's already some relationship between the two, it should not be even larger).

The solution in this PR is simple: if `--heartbeat_enable` is set, great, heartbeats are on, and nothing else to do. But if it is unset, and neither is `heartbeat_on_demand_duration`, then we set `heartbeat_on_demand_duration` to `5s`. Meaning, there has to be some sort of heartbeat.

As a reminder, the rules for `heartbeat_on_demand_duration` are:
- One single injection of a heartbeat value on tablet's startup/`Open()`.
- A lease of heartbeats, limited in time, e.g. `5s`, _upon request_.
- The only entity right now that requests heartbeats is the tablet throttler.
- The throttler will only do so when a consumer (e.g. `vreplication`) actively asks it for throttling feedback.

In short, with this new `5s` on-demand heartbeat default value, the the throttler will be able to work correctly in `examples` and in any other Vitess setup that is otherwise not configured for heartbeats. Heartbeats will only be generated while the throttler is both enabled and actively engaged with some vreplication workflow or Online DDL operation etc.


And, back to `examples`, because `heartbeat_enable` is unset, then `heartbeatReader` is not enabled, and as result `/debug/status` reports replication lag based on MySQL replication as opposed to based on `_vt.heartbeat`. So this PR still respects #14978.


## Related Issue(s)

- https://github.com/vitessio/vitess/issues/14978

## Backporting

Like https://github.com/vitessio/vitess/pull/15099, this should be backported to `18.0` and `17.0` and for the same reasons.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
