### PR TITLE
Ignore non-Shard keys in FindAllShardsInKeyspace List impl

### DIFF
--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -103,6 +103,7 @@ func TestServerGetServingShards(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		defer conn.Close()
 		lockKey := fmt.Sprintf("keyspaces/%s/shards/%s/locks/1234", keyspace, shard)
 		_, err = conn.Create(ctx, lockKey, []byte("lock"))
 		return err

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -160,7 +160,7 @@ func TestServerGetServingShards(t *testing.T) {
 				// /vitess/global/keyspaces/<keyspace>/shards/<shardname>/locks/XXXX
 				// We want to confirm that this key is ignored when building
 				// the results.
-				err := createSimulatedLock(ctx, ts, keyspace, shardNames[0])
+				err = createSimulatedLock(ctx, ts, keyspace, shardNames[0])
 				require.NoError(t, err)
 			}
 

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -95,6 +95,18 @@ func TestServerGetServingShards(t *testing.T) {
 	keyspace := "ks1"
 	errNoListImpl := topo.NewError(topo.NoImplementation, "don't be doing no listing round here")
 
+	writeSimulatedLock := func(ctx context.Context, ts *topo.Server, keyspace, shardName string) error {
+		// memorytopo does not use cell paths in the keys so we elide the
+		// leading /vitess/global/ portion.
+		lockKey := fmt.Sprintf("keyspaces/%s/shards/%s/locks/1234", keyspace, shardName)
+		conn, err := ts.ConnForCell(ctx, topo.GlobalCell)
+		if err != nil {
+			return err
+		}
+		_, err = conn.Create(ctx, lockKey, []byte("lock"))
+		return err
+	}
+
 	tests := []struct {
 		shards   int    // Number of shards to create
 		err      string // Error message we expect, if any
@@ -138,10 +150,17 @@ func TestServerGetServingShards(t *testing.T) {
 			if tt.shards > 0 {
 				shardNames, err = key.GenerateShardRanges(tt.shards)
 				require.NoError(t, err)
+				require.Equal(t, tt.shards, len(shardNames))
 				for _, shardName := range shardNames {
 					err = ts.CreateShard(ctx, keyspace, shardName)
 					require.NoError(t, err)
 				}
+				// The lock becomes a key in the topo like this:
+				// /vitess/global/keyspaces/<keyspace>/shards/<shardname>/locks/XXXX
+				// We want to confirm that this key is ignored when building
+				// the results.
+				err := writeSimulatedLock(ctx, ts, keyspace, shardNames[0])
+				require.NoError(t, err)
 			}
 
 			// Verify that we return a complete list of shards and that each

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -103,7 +103,6 @@ func TestServerGetServingShards(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer conn.Close()
 		lockKey := fmt.Sprintf("keyspaces/%s/shards/%s/locks/1234", keyspace, shard)
 		_, err = conn.Create(ctx, lockKey, []byte("lock"))
 		return err

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -98,7 +98,7 @@ func TestServerGetServingShards(t *testing.T) {
 	// This is needed because memorytopo doesn't implement locks using
 	// keys in the topo. So we simulate the behavior of other topo server
 	// implementations and how they implement TopoServer.LockShard().
-	createSimulatedLock := func(ctx context.Context, ts *topo.Server, keyspace, shard string) error {
+	createSimulatedShardLock := func(ctx context.Context, ts *topo.Server, keyspace, shard string) error {
 		conn, err := ts.ConnForCell(ctx, topo.GlobalCell)
 		if err != nil {
 			return err
@@ -160,7 +160,7 @@ func TestServerGetServingShards(t *testing.T) {
 				// /vitess/global/keyspaces/<keyspace>/shards/<shardname>/locks/XXXX
 				// We want to confirm that this key is ignored when building
 				// the results.
-				err = createSimulatedLock(ctx, ts, keyspace, shardNames[0])
+				err = createSimulatedShardLock(ctx, ts, keyspace, shardNames[0])
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
## Description

When doing key range prefix scans via `TopoServer.List()` the scan is "recursive" — we get all keys with the matching prefix. This means that it's possible you can get keys that aren't for the type you're looking for but share the same prefix. A practical example of this would be Keyspaces or Shards, as you can get a lock on either and those are implemented in some topo servers by creating a key with the same prefix of what you're locking and with `/locks/<uid>` appended to it.

When doing key prefix scans, at least for things that you can get a lock on, we should be sure to ignore keys with a different suffix than we're looking for as it's the suffix which reflects the type of value/protobuf stored in it.

I have seen this type of error occur in two CI tests now ([latest example](https://github.com/vitessio/vitess/actions/runs/7750498487/job/21137306628?pr=14424)):
```
FindAllShardsInKeyspace(commerce): invalid data found for shard "locks" in "/vitess/global/keyspaces/commerce/shards/0/locks/7587876423742065323"
```

The updated unit test fails on main:
```
❯ go test -timeout 30s -run ^TestServerGetServingShards$ vitess.io/vitess/go/vt/topo

--- FAIL: TestServerGetServingShards (0.97s)
    --- FAIL: TestServerGetServingShards/2_shards_with_fallback_=_false (0.00s)
        /Users/matt/git/vitess/go/vt/topo/keyspace_external_test.go:174:
                Error Trace:    /Users/matt/git/vitess/go/vt/topo/keyspace_external_test.go:174
                Error:          Received unexpected error:
                                proto: Shard: wiretype end group for non-group
                                FindAllShardsInKeyspace(ks1): invalid data found for shard "locks" in "keyspaces/ks1/shards/-80/locks/1234"
                                failed to get list of shards for keyspace 'ks1'
                Test:           TestServerGetServingShards/2_shards_with_fallback_=_false
    --- FAIL: TestServerGetServingShards/128_shards_with_fallback_=_false (0.01s)
        /Users/matt/git/vitess/go/vt/topo/keyspace_external_test.go:174:
                Error Trace:    /Users/matt/git/vitess/go/vt/topo/keyspace_external_test.go:174
                Error:          Received unexpected error:
                                proto: Shard: wiretype end group for non-group
                                FindAllShardsInKeyspace(ks1): invalid data found for shard "locks" in "keyspaces/ks1/shards/-02/locks/1234"
                                failed to get list of shards for keyspace 'ks1'
                Test:           TestServerGetServingShards/128_shards_with_fallback_=_false
    --- FAIL: TestServerGetServingShards/1024_shards_with_fallback_=_false (0.49s)
        /Users/matt/git/vitess/go/vt/topo/keyspace_external_test.go:174:
                Error Trace:    /Users/matt/git/vitess/go/vt/topo/keyspace_external_test.go:174
                Error:          Received unexpected error:
                                proto: Shard: wiretype end group for non-group
                                FindAllShardsInKeyspace(ks1): invalid data found for shard "locks" in "keyspaces/ks1/shards/-0040/locks/1234"
                                failed to get list of shards for keyspace 'ks1'
                Test:           TestServerGetServingShards/1024_shards_with_fallback_=_false
FAIL
FAIL    vitess.io/vitess/go/vt/topo     1.494s
FAIL
```

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/15047
  - Fixes: https://github.com/vitessio/vitess/issues/15118

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required