### PR TITLE
feat: use collation aware typing for UNION

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -2205,5 +2205,35 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "No weightstrings or derived table needed",
+    "query": "select textcol1 from user union select textcol1 from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select textcol1 from user union select textcol1 from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: latin1_swedish_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select textcol1 from `user` where 1 != 1 union select textcol1 from `user` where 1 != 1",
+            "Query": "select textcol1 from `user` union select textcol1 from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description
A bug was recently solved (#15069) that fixes the type copying to UNION columns. We want to backport this fix, so it didn't contain support for collations. In earlier releases we don't have this capability. 

In `main` we now have a way to aggregate the types including the collation of the columns (#15085), so here is the update that uses this new way of aggregating types. 

## Related Issue(s)
Original issue: #15020

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required