### PR TITLE
Make tablet collation mismatch warning throttled

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
@@ -52,6 +53,8 @@ var (
 	initialTabletTimeout = 30 * time.Second
 	// retryCount is the number of times a query will be retried on error
 	retryCount = 2
+
+	logCollations = logutil.NewThrottledLogger("CollationInconsistent", 1*time.Minute)
 )
 
 func init() {
@@ -435,7 +438,7 @@ func (gw *TabletGateway) updateDefaultConnCollation(tablet *topodatapb.Tablet) {
 		return
 	}
 	if gw.defaultConnCollation.Load() != tablet.DefaultConnCollation {
-		log.Warning("this Vitess cluster has tablets with different default connection collations")
+		logCollations.Warningf("this Vitess cluster has tablets with different default connection collations")
 	}
 }
 


### PR DESCRIPTION
## Description

This is a backport from an internal PR by @aquarapid. The warning which we emit when there's a mismatch between Vitess' collations and the collations in the MySQL cluster can get real noisy because it's emitted once per query. Throttle it with the log throttler.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15187
- 
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
