### PR TITLE
evalEngine: Implement `INSTR`

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -931,6 +931,18 @@ func (cached *builtinInetNtoa) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinInstr) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinIsIPV4) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -1418,6 +1418,18 @@ func (asm *assembler) Mod_dd() {
 	}, "MOD DECIMAL(SP-2), DECIMAL(SP-1)")
 }
 
+func (asm *assembler) Fn_INSTR() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(env *ExpressionEnv) int {
+		str := env.vm.stack[env.vm.sp-2].(*evalBytes)
+		substr := env.vm.stack[env.vm.sp-1].(*evalBytes)
+
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(instrIndex(str, substr))
+		return 1
+	}, "FN INSTR VARCHAR(SP-2) VARCHAR(SP-1)")
+}
+
 func (asm *assembler) Fn_ASCII() {
 	asm.emit(func(env *ExpressionEnv) int {
 		arg := env.vm.stack[env.vm.sp-1].(*evalBytes)

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -67,6 +67,7 @@ var Cases = []TestCase{
 	{Run: FnUpper},
 	{Run: FnCharLength},
 	{Run: FnLength},
+	{Run: FnInstr},
 	{Run: FnBitLength},
 	{Run: FnAscii},
 	{Run: FnOrd},
@@ -1336,6 +1337,41 @@ func FnLength(yield Query) {
 	for _, str := range inputStrings {
 		yield(fmt.Sprintf("LENGTH(%s)", str), nil)
 		yield(fmt.Sprintf("OCTET_LENGTH(%s)", str), nil)
+	}
+}
+
+func FnInstr(yield Query) {
+	for _, str := range inputStrings {
+		for _, substr := range inputStrings {
+			yield(fmt.Sprintf("INSTR(%s, %s)", str, substr), nil)
+		}
+	}
+
+	cases := []struct {
+		str    string
+		substr string
+	}{
+		{"'ACABAB'", "'AB'"},
+		{"'ABABAB'", "'AB'"},
+		{"'ABABAB'", "'ab'"},
+		{"'ABABAB'", "'ba'"},
+		{"'CBDASD'", "'ab'"},
+		{"'ABABAB'", "''"},
+		{"'ABABAB'", ""},
+		{"1233", "23"},
+		{"0x616162", "0x6162"},
+		{"0x616162", "0x4141"},
+		{"'AAB'", "123"},
+		{"123", "'ABC'"},
+		{"_binary'FOOBAR'", "'AR'"},
+		{"_binary'FOOBAR'", "BINARY 'AR'"},
+		{"BINARY 'FOOBAR'", "'ar'"},
+		{"'foobarbar'", "'bar'"},
+		{"'xbar'", "'foobar'"},
+	}
+
+	for _, tc := range cases {
+		yield(fmt.Sprintf("INSTR(%s, %s)", tc.str, tc.substr), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -285,6 +285,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinLength{CallExpr: call}, nil
+	case "instr":
+		if len(args) != 2 {
+			return nil, argError(method)
+		}
+		return &builtinInstr{CallExpr: call, collate: ast.cfg.Collation}, nil
 	case "bit_length":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds implementation of [`INSTR`](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_instr) func in evalengine.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #9647 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
