### PR TITLE
Fix character set mapping for `utf8` and use it in schema-tracking tables

### DIFF
--- a/go/mysql/collations/env.go
+++ b/go/mysql/collations/env.go
@@ -180,7 +180,7 @@ func makeEnv(version collver) *Environment {
 		}
 	}
 
-	for from, to := range charsetAliases() {
+	for from, to := range charsetAliases(env.version) {
 		env.byCharset[from] = env.byCharset[to]
 	}
 
@@ -212,14 +212,12 @@ var SystemCollation = TypedCollation{
 // this mapping will change, so it's important to use this helper so that
 // Vitess code has a consistent mapping for the active collations environment.
 func (env *Environment) CharsetAlias(charset string) (alias string, ok bool) {
-	alias, ok = charsetAliases()[charset]
+	alias, ok = charsetAliases(env.version)[charset]
 	return
 }
 
 // CollationAlias returns the internal collaction name for the given charset.
-// For now, this maps all `utf8` to `utf8mb3` collation names; in future versions of MySQL,
-// this mapping will change, so it's important to use this helper so that
-// Vitess code has a consistent mapping for the active collations environment.
+// For now, this maps `utf8` to `utf8mb4` collation names for MySQL 8.0 and maps the rest to `utf8mb3`.
 func (env *Environment) CollationAlias(collation string) (string, bool) {
 	col := env.LookupByName(collation)
 	if col == Unknown {
@@ -233,7 +231,7 @@ func (env *Environment) CollationAlias(collation string) (string, bool) {
 		return collation, false
 	}
 	for _, alias := range allCols.alias {
-		for source, dest := range charsetAliases() {
+		for source, dest := range charsetAliases(env.version) {
 			if strings.HasPrefix(collation, fmt.Sprintf("%s_", source)) &&
 				strings.HasPrefix(alias.name, fmt.Sprintf("%s_", dest)) {
 				return alias.name, true

--- a/go/mysql/collations/mysqlversion.go
+++ b/go/mysql/collations/mysqlversion.go
@@ -58,7 +58,15 @@ func (v collver) String() string {
 		panic("invalid version identifier")
 	}
 }
-func charsetAliases() map[string]string { return map[string]string{"utf8": "utf8mb3"} }
+
+func charsetAliases(version collver) map[string]string {
+	switch version {
+	case collverMySQL8:
+		return map[string]string{"utf8": "utf8mb4"}
+	default:
+		return map[string]string{"utf8": "utf8mb3"}
+	}
+}
 
 var globalVersionInfo = map[ID]struct {
 	alias     []collalias
@@ -108,7 +116,6 @@ var globalVersionInfo = map[ID]struct {
 	43:   {alias: []collalias{{0b01111111, "macce_bin", "macce"}}, isdefault: 0b00000000},
 	44:   {alias: []collalias{{0b01111111, "cp1250_croatian_ci", "cp1250"}}, isdefault: 0b00000000},
 	45:   {alias: []collalias{{0b01111111, "utf8mb4_general_ci", "utf8mb4"}}, isdefault: 0b00111111},
-	46:   {alias: []collalias{{0b01111111, "utf8mb4_bin", "utf8mb4"}}, isdefault: 0b00000000},
 	47:   {alias: []collalias{{0b01111111, "latin1_bin", "latin1"}}, isdefault: 0b00000000},
 	48:   {alias: []collalias{{0b01111111, "latin1_general_ci", "latin1"}}, isdefault: 0b00000000},
 	49:   {alias: []collalias{{0b01111111, "latin1_general_cs", "latin1"}}, isdefault: 0b00000000},
@@ -145,7 +152,7 @@ var globalVersionInfo = map[ID]struct {
 	80:   {alias: []collalias{{0b01111111, "cp850_bin", "cp850"}}, isdefault: 0b00000000},
 	81:   {alias: []collalias{{0b01111111, "cp852_bin", "cp852"}}, isdefault: 0b00000000},
 	82:   {alias: []collalias{{0b01111111, "swe7_bin", "swe7"}}, isdefault: 0b00000000},
-	83:   {alias: []collalias{{0b01111111, "utf8_bin", "utf8"}, {0b01111111, "utf8mb3_bin", "utf8mb3"}}, isdefault: 0b00000000},
+	83:   {alias: []collalias{{0b01111111, "utf8_bin", "utf8"}, {0b01111111, "utf8mb3_bin", "utf8mb3"}, {0b01111111, "utf8mb4_bin", "utf8mb4"}}, isdefault: 0b00000000},
 	84:   {alias: []collalias{{0b01111111, "big5_bin", "big5"}}, isdefault: 0b00000000},
 	85:   {alias: []collalias{{0b01111111, "euckr_bin", "euckr"}}, isdefault: 0b00000000},
 	86:   {alias: []collalias{{0b01111111, "gb2312_bin", "gb2312"}}, isdefault: 0b00000000},

--- a/go/vt/schemadiff/column.go
+++ b/go/vt/schemadiff/column.go
@@ -130,7 +130,7 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 				}()
 				c.columnDefinition.Type.Options.Collate = t1cc.collate
 			}
-			if c.columnDefinition.Type.Options.Collate = t1cc.collate; c.columnDefinition.Type.Options.Collate == "" {
+			if c.columnDefinition.Type.Options.Collate = t1cc.collate; t1cc.charset != "" && c.columnDefinition.Type.Options.Collate == "" {
 				collation := env.CollationEnv().DefaultCollationForCharset(t1cc.charset)
 				if collation == collations.Unknown {
 					return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot match collation to charset %v", t1cc.charset)
@@ -157,7 +157,7 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 				other.columnDefinition.Type.Options.Collate = ""
 			}()
 			other.columnDefinition.Type.Charset.Name = t2cc.charset
-			if other.columnDefinition.Type.Options.Collate = t2cc.collate; other.columnDefinition.Type.Options.Collate == "" {
+			if other.columnDefinition.Type.Options.Collate = t2cc.collate; t2cc.charset != "" && other.columnDefinition.Type.Options.Collate == "" {
 				collation := env.CollationEnv().DefaultCollationForCharset(t2cc.charset)
 				if collation == collations.Unknown {
 					return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot match collation to charset %v", t2cc.charset)

--- a/go/vt/sidecardb/schema/schemaengine/tables.sql
+++ b/go/vt/sidecardb/schema/schemaengine/tables.sql
@@ -16,8 +16,8 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS tables
 (
-    TABLE_SCHEMA varchar(64) CHARACTER SET `utf8mb3` COLLATE `utf8mb3_bin` NOT NULL,
-    TABLE_NAME varchar(64) CHARACTER SET `utf8mb3` COLLATE `utf8mb3_bin` NOT NULL,
+    TABLE_SCHEMA varchar(64) CHARACTER SET `utf8` COLLATE `utf8_bin` NOT NULL,
+    TABLE_NAME varchar(64) CHARACTER SET `utf8` COLLATE `utf8_bin` NOT NULL,
     CREATE_STATEMENT longtext,
     CREATE_TIME BIGINT,
     PRIMARY KEY (TABLE_SCHEMA, TABLE_NAME)

--- a/go/vt/sidecardb/schema/schemaengine/views.sql
+++ b/go/vt/sidecardb/schema/schemaengine/views.sql
@@ -16,8 +16,8 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS views
 (
-    TABLE_SCHEMA varchar(64) CHARACTER SET `utf8mb3` COLLATE `utf8mb3_bin` NOT NULL,
-    TABLE_NAME varchar(64) CHARACTER SET `utf8mb3` COLLATE `utf8mb3_bin` NOT NULL,
+    TABLE_SCHEMA varchar(64) CHARACTER SET `utf8` COLLATE `utf8_bin` NOT NULL,
+    TABLE_NAME varchar(64) CHARACTER SET `utf8` COLLATE `utf8_bin` NOT NULL,
     CREATE_STATEMENT longtext,
     VIEW_DEFINITION longtext NOT NULL,
     PRIMARY KEY (TABLE_SCHEMA, TABLE_NAME)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR builds on the changes made in https://github.com/vitessio/vitess/pull/14904.

In that PR, we used `utf8mb3` as the character set and `utf8mb3_bin` for the collation of schema tracking tables since we wanted them to be case-sensitive. However, we realized that `utf8mb3` is deprecated in MySQL 5.7.

In this PR, we change the schema definitions to use `utf8` instead of `utf8mb3` and also make changes to Vitess to replicate the MySQL behavior where `utf8` maps to `utf8mb3` in MySQL 5.7 and `utf8mb4` in MySQL 8.0.

Tests have been added to verify that the schema-diff creates the correct tables in MySQL 5.7 and MySQL 8.0 and the upgrades and downgrades generate the correct alter statements too.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
