### PR TITLE
fix: ignore internal tables in schema tracking

### DIFF
--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -23,6 +23,7 @@ import (
 	"vitess.io/vitess/go/vt/graph"
 	"vitess.io/vitess/go/vt/log"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
@@ -217,6 +218,10 @@ func (vm *VSchemaManager) updateFromSchema(vschema *vindexes.VSchema) {
 				continue
 			}
 			for _, fkDef := range tblInfo.ForeignKeys {
+				// Ignore internal tables as part of foreign key references.
+				if schema.IsInternalOperationTableName(fkDef.ReferenceDefinition.ReferencedTable.Name.String()) {
+					continue
+				}
 				parentTbl, err := vschema.FindRoutedTable(ksName, fkDef.ReferenceDefinition.ReferencedTable.Name.String(), topodatapb.TabletType_PRIMARY)
 				if err != nil {
 					log.Errorf("error finding parent table %s: %v", fkDef.ReferenceDefinition.ReferencedTable.Name.String(), err)

--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -438,56 +438,6 @@ func TestRebuildVSchema(t *testing.T) {
 	}
 }
 
-func makeTestVSchema(ks string, sharded bool, tbls map[string]*vindexes.Table) *vindexes.VSchema {
-	keyspaceSchema := &vindexes.KeyspaceSchema{
-		Keyspace: &vindexes.Keyspace{
-			Name:    ks,
-			Sharded: sharded,
-		},
-		// Default foreign key mode
-		ForeignKeyMode: vschemapb.Keyspace_unmanaged,
-		Tables:         tbls,
-		Vindexes:       map[string]vindexes.Vindex{},
-	}
-	vs := makeTestEmptyVSchema()
-	vs.Keyspaces[ks] = keyspaceSchema
-	vs.ResetCreated()
-	return vs
-}
-
-func makeTestEmptyVSchema() *vindexes.VSchema {
-	return &vindexes.VSchema{
-		RoutingRules: map[string]*vindexes.RoutingRule{},
-		Keyspaces:    map[string]*vindexes.KeyspaceSchema{},
-	}
-}
-
-func makeTestSrvVSchema(ks string, sharded bool, tbls map[string]*vschemapb.Table) *vschemapb.SrvVSchema {
-	keyspaceSchema := &vschemapb.Keyspace{
-		Sharded: sharded,
-		Tables:  tbls,
-		// Default foreign key mode
-		ForeignKeyMode: vschemapb.Keyspace_unmanaged,
-	}
-	return &vschemapb.SrvVSchema{
-		Keyspaces: map[string]*vschemapb.Keyspace{ks: keyspaceSchema},
-	}
-}
-
-type fakeSchema struct {
-	t map[string]*vindexes.TableInfo
-}
-
-func (f *fakeSchema) Tables(string) map[string]*vindexes.TableInfo {
-	return f.t
-}
-
-func (f *fakeSchema) Views(string) map[string]sqlparser.SelectStatement {
-	return nil
-}
-
-var _ SchemaInfo = (*fakeSchema)(nil)
-
 func TestMarkErrorIfCyclesInFk(t *testing.T) {
 	ksName := "ks"
 	keyspace := &vindexes.Keyspace{
@@ -573,6 +523,86 @@ func TestMarkErrorIfCyclesInFk(t *testing.T) {
 	}
 }
 
+// TestVSchemaUpdateWithFKReferenceToInternalTables tests that any internal table as part of fk reference is ignored.
+func TestVSchemaUpdateWithFKReferenceToInternalTables(t *testing.T) {
+	ks := &vindexes.Keyspace{Name: "ks"}
+	cols1 := []vindexes.Column{{
+		Name: sqlparser.NewIdentifierCI("id"),
+		Type: querypb.Type_INT64,
+	}}
+	sqlparserCols1 := sqlparser.MakeColumns("id")
+
+	vindexTable_t1 := &vindexes.Table{
+		Name:                    sqlparser.NewIdentifierCS("t1"),
+		Keyspace:                ks,
+		Columns:                 cols1,
+		ColumnListAuthoritative: true,
+	}
+	vindexTable_t2 := &vindexes.Table{
+		Name:                    sqlparser.NewIdentifierCS("t2"),
+		Keyspace:                ks,
+		Columns:                 cols1,
+		ColumnListAuthoritative: true,
+	}
+
+	vindexTable_t1.ChildForeignKeys = append(vindexTable_t1.ChildForeignKeys, vindexes.ChildFKInfo{
+		Table:         vindexTable_t2,
+		ChildColumns:  sqlparserCols1,
+		ParentColumns: sqlparserCols1,
+		OnDelete:      sqlparser.SetNull,
+		OnUpdate:      sqlparser.Cascade,
+	})
+	vindexTable_t2.ParentForeignKeys = append(vindexTable_t2.ParentForeignKeys, vindexes.ParentFKInfo{
+		Table:         vindexTable_t1,
+		ChildColumns:  sqlparserCols1,
+		ParentColumns: sqlparserCols1,
+	})
+
+	vm := &VSchemaManager{}
+	var vs *vindexes.VSchema
+	vm.subscriber = func(vschema *vindexes.VSchema, _ *VSchemaStats) {
+		vs = vschema
+		vs.ResetCreated()
+	}
+	vm.schema = &fakeSchema{t: map[string]*vindexes.TableInfo{
+		"t1": {Columns: cols1},
+		"t2": {
+			Columns: cols1,
+			ForeignKeys: []*sqlparser.ForeignKeyDefinition{
+				createFkDefinition([]string{"id"}, "t1", []string{"id"}, sqlparser.Cascade, sqlparser.SetNull),
+				createFkDefinition([]string{"id"}, "_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410", []string{"id"}, sqlparser.Cascade, sqlparser.SetNull),
+			},
+		},
+	}}
+	vm.VSchemaUpdate(&vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks": {
+				ForeignKeyMode: vschemapb.Keyspace_managed,
+				Tables: map[string]*vschemapb.Table{
+					"t1": {Columns: []*vschemapb.Column{{Name: "id", Type: querypb.Type_INT64}}},
+					"t2": {Columns: []*vschemapb.Column{{Name: "id", Type: querypb.Type_INT64}}},
+				},
+			},
+		},
+	}, nil)
+
+	utils.MustMatchFn(".globalTables", ".uniqueVindexes")(t, &vindexes.VSchema{
+		RoutingRules: map[string]*vindexes.RoutingRule{},
+		Keyspaces: map[string]*vindexes.KeyspaceSchema{
+			"ks": {
+				Keyspace:       ks,
+				ForeignKeyMode: vschemapb.Keyspace_managed,
+				Vindexes:       map[string]vindexes.Vindex{},
+				Tables: map[string]*vindexes.Table{
+					"t1": vindexTable_t1,
+					"t2": vindexTable_t2,
+				},
+			},
+		},
+	}, vs)
+	utils.MustMatch(t, vs, vm.currentVschema, "currentVschema should have same reference as Vschema")
+}
+
 // createFkDefinition is a helper function to create a Foreign key definition struct from the columns used in it provided as list of strings.
 func createFkDefinition(childCols []string, parentTableName string, parentCols []string, onUpdate, onDelete sqlparser.ReferenceAction) *sqlparser.ForeignKeyDefinition {
 	pKs, pTbl, _ := sqlparser.NewTestParser().ParseTable(parentTableName)
@@ -586,3 +616,53 @@ func createFkDefinition(childCols []string, parentTableName string, parentCols [
 		},
 	}
 }
+
+func makeTestVSchema(ks string, sharded bool, tbls map[string]*vindexes.Table) *vindexes.VSchema {
+	keyspaceSchema := &vindexes.KeyspaceSchema{
+		Keyspace: &vindexes.Keyspace{
+			Name:    ks,
+			Sharded: sharded,
+		},
+		// Default foreign key mode
+		ForeignKeyMode: vschemapb.Keyspace_unmanaged,
+		Tables:         tbls,
+		Vindexes:       map[string]vindexes.Vindex{},
+	}
+	vs := makeTestEmptyVSchema()
+	vs.Keyspaces[ks] = keyspaceSchema
+	vs.ResetCreated()
+	return vs
+}
+
+func makeTestEmptyVSchema() *vindexes.VSchema {
+	return &vindexes.VSchema{
+		RoutingRules: map[string]*vindexes.RoutingRule{},
+		Keyspaces:    map[string]*vindexes.KeyspaceSchema{},
+	}
+}
+
+func makeTestSrvVSchema(ks string, sharded bool, tbls map[string]*vschemapb.Table) *vschemapb.SrvVSchema {
+	keyspaceSchema := &vschemapb.Keyspace{
+		Sharded: sharded,
+		Tables:  tbls,
+		// Default foreign key mode
+		ForeignKeyMode: vschemapb.Keyspace_unmanaged,
+	}
+	return &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{ks: keyspaceSchema},
+	}
+}
+
+type fakeSchema struct {
+	t map[string]*vindexes.TableInfo
+}
+
+func (f *fakeSchema) Tables(string) map[string]*vindexes.TableInfo {
+	return f.t
+}
+
+func (f *fakeSchema) Views(string) map[string]sqlparser.SelectStatement {
+	return nil
+}
+
+var _ SchemaInfo = (*fakeSchema)(nil)

--- a/go/vt/vttablet/endtoend/rpc_test.go
+++ b/go/vt/vttablet/endtoend/rpc_test.go
@@ -172,7 +172,7 @@ func TestGetSchemaRPC(t *testing.T) {
 		}, {
 			name: "Create some internal tables",
 			queries: []string{
-				"create table _vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410 (eid int);",
+				"create table if not exists _vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410(id bigint primary key);",
 				"create table vitess_temp1 (eid int);",
 				"create view vitess_view1 as select eid from vitess_a",
 			},

--- a/go/vt/vttablet/endtoend/rpc_test.go
+++ b/go/vt/vttablet/endtoend/rpc_test.go
@@ -169,6 +169,25 @@ func TestGetSchemaRPC(t *testing.T) {
 			},
 			getSchemaQueryType: querypb.SchemaTableType_ALL,
 			getSchemaTables:    []string{"vitess_temp1", "vitess_temp3", "unknown_table", "vitess_view3", "vitess_view1", "unknown_view"},
+		}, {
+			name: "Create some internal tables",
+			queries: []string{
+				"create table _vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410 (eid int);",
+				"create table vitess_temp1 (eid int);",
+				"create view vitess_view1 as select eid from vitess_a",
+			},
+			deferQueries: []string{
+				"drop table _vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+				"drop table vitess_temp1",
+				"drop view vitess_view1",
+			},
+			mapToExpect: map[string]string{
+				"vitess_view1": "CREATE ALGORITHM=UNDEFINED DEFINER=`vt_dba`@`localhost` SQL SECURITY DEFINER VIEW `vitess_view1` AS select `vitess_a`.`eid` AS `eid` from `vitess_a`",
+				"vitess_temp1": "CREATE TABLE `vitess_temp1` (\n  `eid` int DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+				// These shouldn't be part of the result, so we verify it is empty.
+				"_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410": "",
+			},
+			getSchemaQueryType: querypb.SchemaTableType_ALL,
 		},
 	}
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -1182,7 +1182,12 @@ func (qre *QueryExecutor) executeGetSchemaQuery(query string, callback func(sche
 	return qre.execStreamSQL(conn, false /* isTransaction */, query, func(result *sqltypes.Result) error {
 		schemaDef := make(map[string]string)
 		for _, row := range result.Rows {
-			schemaDef[row[0].ToString()] = row[1].ToString()
+			tableName := row[0].ToString()
+			// Schema RPC should ignore the internal table in the response.
+			if schema.IsInternalOperationTableName(tableName) {
+				continue
+			}
+			schemaDef[tableName] = row[1].ToString()
 		}
 		return callback(&querypb.GetSchemaResponse{TableDefinition: schemaDef})
 	})


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR removed internal tables to be removed from schema tracking in the `GetSchema` RPC and from the Foreign Key Schema definition. They are temporary tables should be ignored for foreign key planning.


Backport to v18: An issue exists on v18 which can cause queries on unexpected tables.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes https://github.com/vitessio/vitess/issues/15145

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
