### PR TITLE
Revert unwanted logging change to `vttestserver`

### DIFF
--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 
 	"google.golang.org/protobuf/encoding/prototext"

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -26,7 +26,6 @@ import (
 	"path"
 	"strings"
 	"syscall"
-	"testing"
 	"time"
 
 	"google.golang.org/protobuf/encoding/prototext"
@@ -142,11 +141,8 @@ func (vtp *VtProcess) WaitStart() (err error) {
 	vtp.proc.Args = append(vtp.proc.Args, vtp.ExtraArgs...)
 	vtp.proc.Env = append(vtp.proc.Env, os.Environ()...)
 	vtp.proc.Env = append(vtp.proc.Env, vtp.Env...)
-
-	if testing.Verbose() {
-		vtp.proc.Stderr = os.Stderr
-		vtp.proc.Stdout = os.Stdout
-	}
+	vtp.proc.Stderr = os.Stderr
+	vtp.proc.Stdout = os.Stdout
 
 	log.Infof("%v %v", strings.Join(vtp.proc.Args, " "))
 	err = vtp.proc.Start()

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -141,8 +141,10 @@ func (vtp *VtProcess) WaitStart() (err error) {
 	vtp.proc.Args = append(vtp.proc.Args, vtp.ExtraArgs...)
 	vtp.proc.Env = append(vtp.proc.Env, os.Environ()...)
 	vtp.proc.Env = append(vtp.proc.Env, vtp.Env...)
-	vtp.proc.Stderr = os.Stderr
-	vtp.proc.Stdout = os.Stdout
+	if !testing.Testing() || testing.Verbose() {
+		vtp.proc.Stderr = os.Stderr
+		vtp.proc.Stdout = os.Stdout
+	}
 
 	log.Infof("%v %v", strings.Join(vtp.proc.Args, " "))
 	err = vtp.proc.Start()


### PR DESCRIPTION
## Description

This PR partially reverts [a recent change to logging in vttestserver](https://github.com/vitessio/vitess/pull/14383/files#diff-c7f2eec761b37939523a6f6faa42a32ea01342f3bcce218baed7c43b23b4a929) which was made in https://github.com/vitessio/vitess/pull/14383.

For normal build (`go build`) logging will be enabled by default, however, for tests logging will be enabled only if the `-v` flag is passed to `go test`.

Backporting this to both `release-18.0` and `release-19.0` as the issue is observed on both branches as described in https://github.com/vitessio/vitess/issues/15119.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/15119

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
