### PR TITLE
Correctly set log_dir default in vtcombo

### DIFF
--- a/go/cmd/vtcombo/cli/main.go
+++ b/go/cmd/vtcombo/cli/main.go
@@ -178,7 +178,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 
 	// vtctld UI requires the cell flag
 	cmd.Flags().Set("cell", tpb.Cells[0])
-	if cmd.Flags().Lookup("log_dir") == nil {
+	if f := cmd.Flags().Lookup("log_dir"); f != nil && !f.Changed {
 		cmd.Flags().Set("log_dir", "$VTDATAROOT/tmp")
 	}
 


### PR DESCRIPTION
## Description

I accidentally made it so the old default of `$VTDATAROOT/tmp` was never set for vtcombo.

Now we manually provide this default by first checking that the flag exists, and that the user did not explicitly set a value for it.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

### Demo

```
➜  vitess git:(andrew/vtcombo/log-dir-default) ✗ ./bin/vtcombo --port 33574 --bind-address localhost --log_dir /tmp/vtdataroot/vttest445905202/logs --alsologtostderr --grpc_port 33575 --db_charset utf8mb4 --db_app_user vt_dba 2>/dev/null
log_dir=/tmp/vtdataroot/vttest445905202/logs%  
```

```
➜  vitess git:(andrew/vtcombo/log-dir-default) ✗ ./bin/vtcombo --port 33574 --bind-address localhost --alsologtostderr --grpc_port 33575 --db_charset utf8mb4 --db_app_user vt_dba 2>/dev/null 
log_dir=$VTDATAROOT/tmp% 
```

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15120#issuecomment-1930467173

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
