### PR TITLE
Add `release-19.0` to the auto go upgrade

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-18.0, release-17.0, release-16.0 ]
+        branch: [ main, release-19.0, release-18.0, release-17.0, release-16.0 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

This will enable the automation to upgrade the go version on `release-19.0`
