### PR TITLE
Use latest go version in update golang version workflow

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.6
+          go-version: 1.22.0
 
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

In the latest automated golang upgrade (from 1.21.6 to 1.22.0) the build failed with:
```
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```
