### PR TITLE
evalEngine: Implement SPACE, REVERSE

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1423,6 +1423,18 @@ func (cached *builtinRepeat) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinReverse) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinRound) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -1484,6 +1496,18 @@ func (cached *builtinSign) CachedSize(alloc bool) int64 {
 	return size
 }
 func (cached *builtinSin) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
+func (cached *builtinSpace) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
 	}

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -1430,6 +1430,29 @@ func (asm *assembler) Fn_ASCII() {
 	}, "FN ASCII VARCHAR(SP-1)")
 }
 
+func (asm *assembler) Fn_REVERSE() {
+	asm.emit(func(env *ExpressionEnv) int {
+		arg := env.vm.stack[env.vm.sp-1].(*evalBytes)
+
+		arg.tt = int16(sqltypes.VarChar)
+		arg.bytes = reverse(arg)
+		return 1
+	}, "FN REVERSE VARCHAR(SP-1)")
+}
+
+func (asm *assembler) Fn_SPACE(col collations.TypedCollation) {
+	asm.emit(func(env *ExpressionEnv) int {
+		arg := env.vm.stack[env.vm.sp-1].(*evalInt64).i
+
+		if !validMaxLength(1, arg) {
+			env.vm.stack[env.vm.sp-1] = nil
+			return 1
+		}
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalText(space(arg), col)
+		return 1
+	}, "FN SPACE INT64(SP-1)")
+}
+
 func (asm *assembler) Fn_ORD(col collations.ID) {
 	asm.emit(func(env *ExpressionEnv) int {
 		arg := env.vm.stack[env.vm.sp-1].(*evalBytes)

--- a/go/vt/vtgate/evalengine/fn_string.go
+++ b/go/vt/vtgate/evalengine/fn_string.go
@@ -267,16 +267,14 @@ func (call *builtinASCII) compile(c *compiler) (ctype, error) {
 
 func reverse(in *evalBytes) []byte {
 	cs := colldata.Lookup(in.col.Collation).Charset()
-	out, cur := make([]byte, len(in.bytes)), len(in.bytes)
+	b := in.bytes
 
-	for i := 0; i < charset.Length(cs, in.bytes); i++ {
-		b := charset.Slice(cs, in.bytes, i, i+1)
-		l := len(b)
-
-		copy(out[cur-l:cur], b)
-		cur = cur - l
+	out, cur := make([]byte, len(b)), len(b)
+	for _, size := cs.DecodeRune(b); size > 0; _, size = cs.DecodeRune(b) {
+		copy(out[cur-size:cur], b[:size])
+		b = b[size:]
+		cur = cur - size
 	}
-
 	return out
 }
 

--- a/go/vt/vtgate/evalengine/fn_string.go
+++ b/go/vt/vtgate/evalengine/fn_string.go
@@ -269,11 +269,12 @@ func reverse(in *evalBytes) []byte {
 	cs := colldata.Lookup(in.col.Collation).Charset()
 	b := in.bytes
 
-	out, cur := make([]byte, len(b)), len(b)
-	for _, size := cs.DecodeRune(b); size > 0; _, size = cs.DecodeRune(b) {
-		copy(out[cur-size:cur], b[:size])
+	out, end := make([]byte, len(b)), len(b)
+	for len(b) > 0 {
+		_, size := cs.DecodeRune(b)
+		copy(out[end-size:end], b[:size])
 		b = b[size:]
-		cur = cur - size
+		end -= size
 	}
 	return out
 }

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -69,6 +69,8 @@ var Cases = []TestCase{
 	{Run: FnLength},
 	{Run: FnBitLength},
 	{Run: FnAscii},
+	{Run: FnReverse},
+	{Run: FnSpace},
 	{Run: FnOrd},
 	{Run: FnRepeat},
 	{Run: FnLeft},
@@ -1349,6 +1351,34 @@ func FnBitLength(yield Query) {
 func FnAscii(yield Query) {
 	for _, str := range inputStrings {
 		yield(fmt.Sprintf("ASCII(%s)", str), nil)
+	}
+}
+
+func FnReverse(yield Query) {
+	for _, str := range inputStrings {
+		yield(fmt.Sprintf("REVERSE(%s)", str), nil)
+	}
+}
+
+func FnSpace(yield Query) {
+	counts := []string{
+		"0",
+		"12",
+		"23",
+		"-1",
+		"-12393128120",
+		"-432766734237843674326423876243876234786",
+		"'-432766734237843674326423876243876234786'",
+		"432766734237843674326423876243876234786",
+		"1073741825",
+		"1.5",
+		"-3.2",
+		"'jhgjhg'",
+		"6",
+	}
+
+	for _, c := range counts {
+		yield(fmt.Sprintf("SPACE(%s)", c), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -295,6 +295,16 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinASCII{CallExpr: call}, nil
+	case "reverse":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinReverse{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "space":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinSpace{CallExpr: call, collate: ast.cfg.Collation}, nil
 	case "ord":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds implementation of [`SPACE`](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_space) and [`REVERSE`](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_reverse) func in evalengine.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #9647 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
