### PR TITLE
Fix logging issue when running in Docker with the syslog daemon disabled

### DIFF
--- a/go/event/syslogger/syslogger.go
+++ b/go/event/syslogger/syslogger.go
@@ -147,9 +147,18 @@ func listener(ev Syslogger) {
 }
 
 func init() {
+	// We only want to init syslog when the app is being initialized
+	// Some binaries import the syslog package indirectly leading to
+	// the syslog.New function being called and this might fail if
+	// running inside Docker without the syslog daemon enabled, leading
+	// logging the error which will make glog think there are not --log_dir
+	// flag set as we have not parsed the flags yet.
+	// https://github.com/vitessio/vitess/issues/15120
 	servenv.OnInit(func() {
 		initSyslog()
 	})
+
+	// We still do the init of syslog if we are testing this package.
 	if testing.Testing() {
 		initSyslog()
 	}

--- a/go/event/syslogger/syslogger.go
+++ b/go/event/syslogger/syslogger.go
@@ -54,6 +54,7 @@ import (
 	"fmt"
 	"log/syslog"
 	"os"
+	"testing"
 
 	"vitess.io/vitess/go/event"
 	"vitess.io/vitess/go/vt/log"
@@ -147,13 +148,20 @@ func listener(ev Syslogger) {
 
 func init() {
 	servenv.OnInit(func() {
-		var err error
-		writer, err = syslog.New(syslog.LOG_INFO|syslog.LOG_USER, os.Args[0])
-		if err != nil {
-			log.Errorf("can't connect to syslog: %v", err.Error())
-			writer = nil
-		}
-
-		event.AddListener(listener)
+		initSyslog()
 	})
+	if testing.Testing() {
+		initSyslog()
+	}
+}
+
+func initSyslog() {
+	var err error
+	writer, err = syslog.New(syslog.LOG_INFO|syslog.LOG_USER, os.Args[0])
+	if err != nil {
+		log.Errorf("can't connect to syslog: %v", err.Error())
+		writer = nil
+	}
+
+	event.AddListener(listener)
 }

--- a/go/event/syslogger/syslogger.go
+++ b/go/event/syslogger/syslogger.go
@@ -57,6 +57,7 @@ import (
 
 	"vitess.io/vitess/go/event"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 // Syslogger is the interface that events should implement if they want to be
@@ -145,12 +146,14 @@ func listener(ev Syslogger) {
 }
 
 func init() {
-	var err error
-	writer, err = syslog.New(syslog.LOG_INFO|syslog.LOG_USER, os.Args[0])
-	if err != nil {
-		log.Errorf("can't connect to syslog")
-		writer = nil
-	}
+	servenv.OnInit(func() {
+		var err error
+		writer, err = syslog.New(syslog.LOG_INFO|syslog.LOG_USER, os.Args[0])
+		if err != nil {
+			log.Errorf("can't connect to syslog: %v", err.Error())
+			writer = nil
+		}
 
-	event.AddListener(listener)
+		event.AddListener(listener)
+	})
 }


### PR DESCRIPTION
## Description

Commit https://github.com/vitessio/vitess/commit/35dd1b429e21a1034cbde000b765d00ee9349238 upgraded the `glog` version from `v1.0.0` to `v1.1.2`.  Since then, writing logs to `VTDATAROOT/logs` no longer works for `vtcombo` when running inside Docker.

The cause for this is that in `vtcombo`, one of the first packages to be defined is `"vitess.io/vitess/go/vt/log"` which sets all the logging mechanism with `glog`, followed soon after by the package `"vitess.io/vitess/go/event/syslogger"`. The latter has an `init()` function that will directly fail when running inside Docker if you have not properly setup you syslog daemon. The call to `syslog.New` will fail with `Unix syslog delivery error`.

When the `syslog.New` call fails, we log a message using `log.Errorf` which calls `glog`. However, our flags are not parsed yet and `glog` has no idea about `--log_dir`'s value. Leading to `glog` using the default `/tmp` directory to write logs.

This PR changes the `init()` function of `syslogger` to only run the `syslog.New` call on init (`OnInit`).

```
> docker run \
	--name=vttestserver   --platform linux/amd64  \
	--rm   -p 33577:33577   --health-cmd="mysqladmin ping -h127.0.0.1 -P33577"   \
	--health-interval=5s   --health-timeout=2s   --health-retries=5 \
	vitess/vttestserver:mysql80   /vt/bin/vttestserver  \
	--alsologtostderr     --port=33574     --mysql_bind_host=0.0.0.0  \
	--keyspaces=test,unsharded     --num_shards="2,1"
```
```
> docker exec  -it vttestserver /bin/bash
> ls /vt/vtdataroot/vttest84762148/logs/
vtcombo.ERROR  vtcombo.WARNING                                            vtcombo.ea0c944ec77b.vitess.log.INFO.20240208-011230.718
vtcombo.INFO   vtcombo.ea0c944ec77b.vitess.log.ERROR.20240208-011230.718  vtcombo.ea0c944ec77b.vitess.log.WARNING.20240208-011230.718
```

Backporting this to `release-18.0` and `release-19.0` as the issue lives there too.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/15120

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
