### PR TITLE
New unified internal table names format: part 2, generating new names

### DIFF
--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -319,7 +319,10 @@ func TestPopulateTable(t *testing.T) {
 }
 
 func generateRenameStatement(newFormat bool, fromTableName string, state schema.TableGCState, tm time.Time) (statement string, toTableName string, err error) {
-	return schema.GenerateRenameStatementWithUUID(fromTableName, state, "", tm)
+	if newFormat {
+		return schema.GenerateRenameStatement(fromTableName, state, tm)
+	}
+	return schema.GenerateRenameStatementOldFormat(fromTableName, state, tm)
 }
 
 func TestHold(t *testing.T) {

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -319,10 +319,7 @@ func TestPopulateTable(t *testing.T) {
 }
 
 func generateRenameStatement(newFormat bool, fromTableName string, state schema.TableGCState, tm time.Time) (statement string, toTableName string, err error) {
-	if newFormat {
-		return schema.GenerateRenameStatementNewFormat(fromTableName, state, tm)
-	}
-	return schema.GenerateRenameStatement(fromTableName, state, tm)
+	return schema.GenerateRenameStatementWithUUID(fromTableName, state, "", tm)
 }
 
 func TestHold(t *testing.T) {
@@ -448,7 +445,7 @@ func TestPurge(t *testing.T) {
 
 func TestPurgeView(t *testing.T) {
 	populateTable(t)
-	query, tableName, err := schema.GenerateRenameStatement("v1", schema.PurgeTableGCState, time.Now().UTC().Add(tableTransitionExpiration))
+	query, tableName, err := generateRenameStatement(true, "v1", schema.PurgeTableGCState, time.Now().UTC().Add(tableTransitionExpiration))
 	require.NoError(t, err)
 
 	_, err = primaryTablet.VttabletProcess.QueryTablet(query, keyspaceName, true)

--- a/go/vt/schema/name.go
+++ b/go/vt/schema/name.go
@@ -49,7 +49,7 @@ func (h InternalTableHint) String() string {
 }
 
 var (
-	// internalTableNameRegexp parses new intrnal table name format, e.g. _vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_
+	// internalTableNameRegexp parses new internal table name format, e.g. _vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_
 	internalTableNameRegexp = regexp.MustCompile(InternalTableNameExpression)
 )
 

--- a/go/vt/schema/name_test.go
+++ b/go/vt/schema/name_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNameIsGCTableName(t *testing.T) {
@@ -165,10 +166,54 @@ func TestAnalyzeInternalTableName(t *testing.T) {
 			assert.Equal(t, ts.isInternal, isInternal)
 			if ts.isInternal {
 				assert.NoError(t, err)
-				assert.True(t, IsGCUUID(uuid))
+				assert.True(t, isCondensedUUID(uuid))
 				assert.Equal(t, ts.hint, hint)
 				assert.Equal(t, ts.t, tm)
 			}
 		})
+	}
+}
+
+func TestToReadableTimestamp(t *testing.T) {
+	ti, err := time.Parse(time.UnixDate, "Wed Feb 25 11:06:39 PST 2015")
+	assert.NoError(t, err)
+
+	readableTimestamp := ToReadableTimestamp(ti)
+	assert.Equal(t, readableTimestamp, "20150225110639")
+}
+
+func TestGenerateInternalTableName(t *testing.T) {
+	ti, err := time.Parse(time.UnixDate, "Wed Feb 25 11:06:39 PST 2015")
+	assert.NoError(t, err)
+
+	{
+		uuid := "6ace8bcef73211ea87e9f875a4d24e90"
+		tableName, err := GenerateInternalTableName(InternalTableGCPurgeHint.String(), uuid, ti)
+		require.NoError(t, err)
+		assert.Equal(t, "_vt_prg_6ace8bcef73211ea87e9f875a4d24e90_20150225110639_", tableName)
+		assert.True(t, IsInternalOperationTableName(tableName))
+	}
+	{
+		uuid := "4e5dcf80_354b_11eb_82cd_f875a4d24e90"
+		tableName, err := GenerateInternalTableName(InternalTableGCPurgeHint.String(), uuid, ti)
+		require.NoError(t, err)
+		assert.Equal(t, "_vt_prg_4e5dcf80354b11eb82cdf875a4d24e90_20150225110639_", tableName)
+		assert.True(t, IsInternalOperationTableName(tableName))
+	}
+	{
+		uuid := ""
+		tableName, err := GenerateInternalTableName(InternalTableGCPurgeHint.String(), uuid, ti)
+		require.NoError(t, err)
+		assert.True(t, IsInternalOperationTableName(tableName))
+	}
+	{
+		uuid := "4e5dcf80_354b_11eb_82cd_f875a4d24e90_00001111"
+		_, err := GenerateInternalTableName(InternalTableGCPurgeHint.String(), uuid, ti)
+		require.ErrorContains(t, err, "Invalid UUID")
+	}
+	{
+		uuid := "6ace8bcef73211ea87e9f875a4d24e90"
+		_, err := GenerateInternalTableName("abcdefg", uuid, ti)
+		require.ErrorContains(t, err, "Invalid hint")
 	}
 }

--- a/go/vt/schema/name_test.go
+++ b/go/vt/schema/name_test.go
@@ -201,6 +201,13 @@ func TestGenerateInternalTableName(t *testing.T) {
 		assert.True(t, IsInternalOperationTableName(tableName))
 	}
 	{
+		uuid := "4e5dcf80-354b-11eb-82cd-f875a4d24e90"
+		tableName, err := GenerateInternalTableName(InternalTableGCPurgeHint.String(), uuid, ti)
+		require.NoError(t, err)
+		assert.Equal(t, "_vt_prg_4e5dcf80354b11eb82cdf875a4d24e90_20150225110639_", tableName)
+		assert.True(t, IsInternalOperationTableName(tableName))
+	}
+	{
 		uuid := ""
 		tableName, err := GenerateInternalTableName(InternalTableGCPurgeHint.String(), uuid, ti)
 		require.NoError(t, err)

--- a/go/vt/schema/name_test.go
+++ b/go/vt/schema/name_test.go
@@ -179,7 +179,7 @@ func TestToReadableTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 
 	readableTimestamp := ToReadableTimestamp(ti)
-	assert.Equal(t, readableTimestamp, "20150225110639")
+	assert.Equal(t, "20150225110639", readableTimestamp)
 }
 
 func TestGenerateInternalTableName(t *testing.T) {

--- a/go/vt/schema/online_ddl_test.go
+++ b/go/vt/schema/online_ddl_test.go
@@ -59,7 +59,7 @@ func TestGetGCUUID(t *testing.T) {
 		onlineDDL, err := NewOnlineDDL("ks", "tbl", "alter table t drop column c", NewDDLStrategySetting(DDLStrategyDirect, ""), "", "", parser)
 		assert.NoError(t, err)
 		gcUUID := onlineDDL.GetGCUUID()
-		assert.True(t, IsGCUUID(gcUUID))
+		assert.True(t, isCondensedUUID(gcUUID))
 		uuids[gcUUID] = true
 	}
 	assert.Equal(t, count, len(uuids))

--- a/go/vt/schema/tablegc.go
+++ b/go/vt/schema/tablegc.go
@@ -45,18 +45,10 @@ const (
 )
 
 func (s TableGCState) TableHint() InternalTableHint {
-	switch s {
-	case HoldTableGCState:
-		return InternalTableGCHoldHint
-	case PurgeTableGCState:
-		return InternalTableGCPurgeHint
-	case EvacTableGCState:
-		return InternalTableGCEvacHint
-	case DropTableGCState:
-		return InternalTableGCDropHint
-	default:
-		return InternalTableUnknownHint
+	if hint, ok := gcStatesTableHints[s]; ok {
+		return hint
 	}
+	return InternalTableUnknownHint
 }
 
 const (
@@ -69,10 +61,15 @@ var (
 	condensedUUIDRegexp  = regexp.MustCompile(`^[0-f]{32}$`)
 	oldGCTableNameRegexp = regexp.MustCompile(OldGCTableNameExpression)
 
-	gcStates = map[string]TableGCState{}
+	gcStates           = map[string]TableGCState{}
+	gcStatesTableHints = map[TableGCState]InternalTableHint{}
 )
 
 func init() {
+	gcStatesTableHints[HoldTableGCState] = InternalTableGCHoldHint
+	gcStatesTableHints[PurgeTableGCState] = InternalTableGCPurgeHint
+	gcStatesTableHints[EvacTableGCState] = InternalTableGCEvacHint
+	gcStatesTableHints[DropTableGCState] = InternalTableGCDropHint
 	for _, gcState := range []TableGCState{HoldTableGCState, PurgeTableGCState, EvacTableGCState, DropTableGCState} {
 		gcStates[string(gcState)] = gcState
 		gcStates[gcState.TableHint().String()] = gcState

--- a/go/vt/schema/tablegc.go
+++ b/go/vt/schema/tablegc.go
@@ -155,6 +155,25 @@ func GenerateRenameStatementWithUUID(fromTableName string, state TableGCState, u
 	return fmt.Sprintf("RENAME TABLE `%s` TO %s", fromTableName, toTableName), toTableName, nil
 }
 
+// GenerateRenameStatementWithUUIDNewFormat generates a "RENAME TABLE" statement, where a table is renamed to a GC table, with preset UUID
+func generateRenameStatementWithUUIDOldFormat(fromTableName string, state TableGCState, uuid string, t time.Time) (statement string, toTableName string, err error) {
+	toTableName, err = generateGCTableNameOldFormat(state, uuid, t)
+	if err != nil {
+		return "", "", err
+	}
+	return fmt.Sprintf("RENAME TABLE `%s` TO %s", fromTableName, toTableName), toTableName, nil
+}
+
+// GenerateRenameStatement generates a "RENAME TABLE" statement, where a table is renamed to a GC table.
+func GenerateRenameStatement(fromTableName string, state TableGCState, t time.Time) (statement string, toTableName string, err error) {
+	return GenerateRenameStatementWithUUID(fromTableName, state, "", t)
+}
+
+// GenerateRenameStatement generates a "RENAME TABLE" statement, where a table is renamed to a GC table.
+func GenerateRenameStatementOldFormat(fromTableName string, state TableGCState, t time.Time) (statement string, toTableName string, err error) {
+	return generateRenameStatementWithUUIDOldFormat(fromTableName, state, "", t)
+}
+
 // ParseGCLifecycle parses a comma separated list of gc states and returns a map of indicated states
 func ParseGCLifecycle(gcLifecycle string) (states map[TableGCState]bool, err error) {
 	states = make(map[TableGCState]bool)

--- a/go/vt/schema/tablegc.go
+++ b/go/vt/schema/tablegc.go
@@ -61,7 +61,7 @@ func (s TableGCState) TableHint() InternalTableHint {
 
 const (
 	OldGCTableNameExpression string = `^_vt_(HOLD|PURGE|EVAC|DROP)_([0-f]{32})_([0-9]{14})$`
-	// GCTableNameExpression parses new intrnal table name format, e.g. _vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_
+	// GCTableNameExpression parses new internal table name format, e.g. _vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_
 	GCTableNameExpression string = `^_vt_(hld|prg|evc|drp)_([0-f]{32})_([0-9]{14})_$`
 )
 

--- a/go/vt/schema/tablegc_test.go
+++ b/go/vt/schema/tablegc_test.go
@@ -26,18 +26,20 @@ import (
 )
 
 func TestGCStates(t *testing.T) {
-	assert.Equal(t, HoldTableGCState, gcStates["hld"])
-	assert.Equal(t, HoldTableGCState, gcStates["HOLD"])
-	assert.Equal(t, PurgeTableGCState, gcStates["prg"])
-	assert.Equal(t, PurgeTableGCState, gcStates["PURGE"])
-	assert.Equal(t, EvacTableGCState, gcStates["evc"])
-	assert.Equal(t, EvacTableGCState, gcStates["EVAC"])
-	assert.Equal(t, DropTableGCState, gcStates["drp"])
-	assert.Equal(t, DropTableGCState, gcStates["DROP"])
+	// These are all hard coded
+	require.Equal(t, HoldTableGCState, gcStates["hld"])
+	require.Equal(t, HoldTableGCState, gcStates["HOLD"])
+	require.Equal(t, PurgeTableGCState, gcStates["prg"])
+	require.Equal(t, PurgeTableGCState, gcStates["PURGE"])
+	require.Equal(t, EvacTableGCState, gcStates["evc"])
+	require.Equal(t, EvacTableGCState, gcStates["EVAC"])
+	require.Equal(t, DropTableGCState, gcStates["drp"])
+	require.Equal(t, DropTableGCState, gcStates["DROP"])
 	_, ok := gcStates["purge"]
-	assert.False(t, ok)
+	require.False(t, ok)
 	_, ok = gcStates["vrp"]
-	assert.False(t, ok)
+	require.False(t, ok)
+	require.Equal(t, 2*4, len(gcStates)) // 4 states, 2 forms each
 }
 
 func TestIsGCTableName(t *testing.T) {

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1438,7 +1438,7 @@ func (e *Executor) initVreplicationOriginalMigration(ctx context.Context, online
 		return v, err
 	}
 
-	vreplTableName := fmt.Sprintf("_%s_%s_vrepl", onlineDDL.UUID, ReadableTimestamp())
+	vreplTableName, err := schema.GenerateInternalTableName(schema.InternalTableVreplicationHint.String(), onlineDDL.UUID, time.Now())
 	if err := e.updateArtifacts(ctx, onlineDDL.UUID, vreplTableName); err != nil {
 		return v, err
 	}
@@ -1757,7 +1757,8 @@ exit $exit_code
 
 	runGhost := func(execute bool) error {
 		alterOptions := e.parseAlterOptions(ctx, onlineDDL)
-		forceTableNames := fmt.Sprintf("%s_%s", onlineDDL.UUID, ReadableTimestamp())
+		timeNow := time.Now()
+		forceTableNames := fmt.Sprintf("%s_%s", onlineDDL.UUID, schema.ToReadableTimestamp(timeNow))
 
 		if err := e.updateArtifacts(ctx, onlineDDL.UUID,
 			fmt.Sprintf("_%s_gho", forceTableNames),
@@ -1988,7 +1989,7 @@ export MYSQL_PWD
 
 	runPTOSC := func(execute bool) error {
 		os.Setenv("MYSQL_PWD", onlineDDLPassword)
-		newTableName := fmt.Sprintf("_%s_%s_new", onlineDDL.UUID, ReadableTimestamp())
+		newTableName := fmt.Sprintf("_%s_%s_new", onlineDDL.UUID, schema.ReadableTimestamp())
 
 		if err := e.updateArtifacts(ctx, onlineDDL.UUID,
 			fmt.Sprintf("_%s_old", onlineDDL.Table),

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1439,6 +1439,9 @@ func (e *Executor) initVreplicationOriginalMigration(ctx context.Context, online
 	}
 
 	vreplTableName, err := schema.GenerateInternalTableName(schema.InternalTableVreplicationHint.String(), onlineDDL.UUID, time.Now())
+	if err != nil {
+		return v, err
+	}
 	if err := e.updateArtifacts(ctx, onlineDDL.UUID, vreplTableName); err != nil {
 		return v, err
 	}

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1760,8 +1760,7 @@ exit $exit_code
 
 	runGhost := func(execute bool) error {
 		alterOptions := e.parseAlterOptions(ctx, onlineDDL)
-		timeNow := time.Now()
-		forceTableNames := fmt.Sprintf("%s_%s", onlineDDL.UUID, schema.ToReadableTimestamp(timeNow))
+		forceTableNames := fmt.Sprintf("%s_%s", onlineDDL.UUID, schema.ReadableTimestamp())
 
 		if err := e.updateArtifacts(ctx, onlineDDL.UUID,
 			fmt.Sprintf("_%s_gho", forceTableNames),

--- a/go/vt/vttablet/onlineddl/util.go
+++ b/go/vt/vttablet/onlineddl/util.go
@@ -26,13 +26,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"vitess.io/vitess/go/vt/log"
-)
-
-const (
-	readableTimeFormat = "20060102150405"
 )
 
 // execCmd searches the PATH for a command and runs it, logging the output.
@@ -88,18 +83,4 @@ func RandomHash() string {
 	hasher := sha256.New()
 	hasher.Write(rb)
 	return hex.EncodeToString(hasher.Sum(nil))
-}
-
-// ToReadableTimestamp returns a timestamp, in seconds resolution, that is human readable
-// (as opposed to unix timestamp which is just a number)
-// Example: for Aug 25 2020, 16:04:25 we return "20200825160425"
-func ToReadableTimestamp(t time.Time) string {
-	return t.Format(readableTimeFormat)
-}
-
-// ReadableTimestamp returns a timestamp, in seconds resolution, that is human readable
-// (as opposed to unix timestamp which is just a number), and which corresponds to the time now.
-// Example: for Aug 25 2020, 16:04:25 we return "20200825160425"
-func ReadableTimestamp() string {
-	return ToReadableTimestamp(time.Now())
 }

--- a/go/vt/vttablet/onlineddl/util_test.go
+++ b/go/vt/vttablet/onlineddl/util_test.go
@@ -18,7 +18,6 @@ package onlineddl
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -30,12 +29,4 @@ func TestRandomHash(t *testing.T) {
 	assert.Equal(t, len(h1), 64)
 	assert.Equal(t, len(h2), 64)
 	assert.NotEqual(t, h1, h2)
-}
-
-func TestToReadableTimestamp(t *testing.T) {
-	ti, err := time.Parse(time.UnixDate, "Wed Feb 25 11:06:39 PST 2015")
-	assert.NoError(t, err)
-
-	readableTimestamp := ToReadableTimestamp(ti)
-	assert.Equal(t, readableTimestamp, "20150225110639")
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -330,8 +330,8 @@ func (vr *vreplicator) buildColInfoMap(ctx context.Context) (map[string][]*Colum
 	req := &tabletmanagerdatapb.GetSchemaRequest{
 		Tables: []string{"/.*/"},
 		ExcludeTables: []string{
+			"/" + schema.OldGCTableNameExpression + "/",
 			"/" + schema.GCTableNameExpression + "/",
-			"/" + schema.NewGCTableNameExpression + "/",
 		},
 	}
 	schema, err := vr.mysqld.GetSchema(ctx, vr.dbClient.DBName(), req)


### PR DESCRIPTION
## Description


This is the 2nd part of introducing the new vitess internal table names. This PR is post `v19`, and will be merged in `v20`.
In this PR, we still support both old name format and new name format. However, we now generate internal table names in new format only. This means:

- GC table names will look like `_vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
- OnlineDDL/Vreplication table names will look like `_vt_vrp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`

Some implementation notes:
- This PR renames functions in the likeness of "NameNewFormat" to "Name", and "Name" to "NameOldFormat".
- Formalized `InternalTableHint`, which is also used in `TableGCState`
- OnlineDDL/Executor previously generated the `"_vrepl"` table name by itself, directly; now it uses `go/vt/schema` to do so.
- TabletManager/TableGC remains largely unaware of the change.
- A few functions are not really used in production anymore, but are kept for the sake of existing testing. In `v21` we will remove them.
- `gh-ost` table names and `pt-osc` table names are unaffected by this change. `gh-ost` is a bit of a problem because there's no way right now to force it to accept the new naming format. We could update `gh-ost`, but then don't really have control over the `gh-ost` version the user chooses to install. Also, we're moving away from `gh-ost` and so it's not as important. This is a discussion for another issue.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/14582
- Part 1: https://github.com/vitessio/vitess/pull/14613

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
