### PR TITLE
Throttler: fix nil pointer dereference error

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -772,7 +772,6 @@ func (throttler *Throttler) generateTabletProbeFunction(ctx context.Context, clu
 		req := &tabletmanagerdatapb.CheckThrottlerRequest{} // We leave AppName empty; it will default to VitessName anyway, and we can save some proto space
 		resp, gRPCErr := tmClient.CheckThrottler(ctx, probe.Tablet, req)
 		if gRPCErr != nil {
-			resp.StatusCode = http.StatusInternalServerError
 			mySQLThrottleMetric.Err = fmt.Errorf("gRPC error accessing tablet %v. Err=%v", probe.Alias, gRPCErr)
 			return mySQLThrottleMetric
 		}


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/15179 by removing excessive and ineffective line of code.

## This needs to be backported to release 19

The `nil pointer dereference` error could happen when a `v19` primary runs with a `v18` replica.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15179

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
