### PR TITLE
evalengine: Implement LOCATE and friends

### DIFF
--- a/go/mysql/collations/charset/eightbit/8bit.go
+++ b/go/mysql/collations/charset/eightbit/8bit.go
@@ -81,3 +81,17 @@ func (Charset_8bit) Length(src []byte) int {
 func (Charset_8bit) MaxWidth() int {
 	return 1
 }
+
+func (Charset_8bit) Slice(src []byte, from, to int) []byte {
+	if from >= len(src) {
+		return nil
+	}
+	if to > len(src) {
+		to = len(src)
+	}
+	return src[from:to]
+}
+
+func (Charset_8bit) Validate(src []byte) bool {
+	return true
+}

--- a/go/mysql/collations/charset/eightbit/binary.go
+++ b/go/mysql/collations/charset/eightbit/binary.go
@@ -62,3 +62,17 @@ func (Charset_binary) Length(src []byte) int {
 func (Charset_binary) MaxWidth() int {
 	return 1
 }
+
+func (Charset_binary) Slice(src []byte, from, to int) []byte {
+	if from >= len(src) {
+		return nil
+	}
+	if to > len(src) {
+		to = len(src)
+	}
+	return src[from:to]
+}
+
+func (Charset_binary) Validate(src []byte) bool {
+	return true
+}

--- a/go/mysql/collations/charset/eightbit/latin1.go
+++ b/go/mysql/collations/charset/eightbit/latin1.go
@@ -230,3 +230,17 @@ func (Charset_latin1) Length(src []byte) int {
 func (Charset_latin1) MaxWidth() int {
 	return 1
 }
+
+func (Charset_latin1) Slice(src []byte, from, to int) []byte {
+	if from >= len(src) {
+		return nil
+	}
+	if to > len(src) {
+		to = len(src)
+	}
+	return src[from:to]
+}
+
+func (Charset_latin1) Validate(src []byte) bool {
+	return true
+}

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1147,6 +1147,18 @@ func (cached *builtinLn) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinLocate) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinLog) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -2986,61 +2986,7 @@ func (asm *assembler) Like_collate(expr *LikeExpr, collation colldata.Collation)
 	}, "LIKE VARCHAR(SP-2), VARCHAR(SP-1) COLLATE '%s'", collation.Name())
 }
 
-func (asm *assembler) Locate_coerce3(coercion *compiledCoercion) {
-	asm.adjustStack(-2)
-
-	asm.emit(func(env *ExpressionEnv) int {
-		substr := env.vm.stack[env.vm.sp-3].(*evalBytes)
-		str := env.vm.stack[env.vm.sp-2].(*evalBytes)
-		pos := env.vm.stack[env.vm.sp-1].(*evalInt64)
-		env.vm.sp -= 2
-
-		if pos.i < 1 {
-			env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(0)
-			return 1
-		}
-
-		var bsub, bstr []byte
-		bsub, env.vm.err = coercion.left(nil, substr.bytes)
-		if env.vm.err != nil {
-			return 0
-		}
-		bstr, env.vm.err = coercion.right(nil, str.bytes)
-		if env.vm.err != nil {
-			return 0
-		}
-
-		found := colldata.Index(coercion.col, bstr, bsub, int(pos.i)-1)
-		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(found) + 1)
-		return 1
-	}, "LOCATE VARCHAR(SP-3), VARCHAR(SP-2) INT64(SP-1) COERCE AND COLLATE '%s'", coercion.col.Name())
-}
-
-func (asm *assembler) Locate_coerce2(coercion *compiledCoercion) {
-	asm.adjustStack(-1)
-
-	asm.emit(func(env *ExpressionEnv) int {
-		substr := env.vm.stack[env.vm.sp-2].(*evalBytes)
-		str := env.vm.stack[env.vm.sp-1].(*evalBytes)
-		env.vm.sp--
-
-		var bsub, bstr []byte
-		bsub, env.vm.err = coercion.left(nil, substr.bytes)
-		if env.vm.err != nil {
-			return 0
-		}
-		bstr, env.vm.err = coercion.right(nil, str.bytes)
-		if env.vm.err != nil {
-			return 0
-		}
-
-		found := colldata.Index(coercion.col, bstr, bsub, 0)
-		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(found) + 1)
-		return 1
-	}, "LOCATE VARCHAR(SP-2), VARCHAR(SP-1) COERCE AND COLLATE '%s'", coercion.col.Name())
-}
-
-func (asm *assembler) Locate_collate3(collation colldata.Collation) {
+func (asm *assembler) Locate3(collation colldata.Collation) {
 	asm.adjustStack(-2)
 
 	asm.emit(func(env *ExpressionEnv) int {
@@ -3060,7 +3006,7 @@ func (asm *assembler) Locate_collate3(collation colldata.Collation) {
 	}, "LOCATE VARCHAR(SP-3), VARCHAR(SP-2) INT64(SP-1) COLLATE '%s'", collation.Name())
 }
 
-func (asm *assembler) Locate_collate2(collation colldata.Collation) {
+func (asm *assembler) Locate2(collation colldata.Collation) {
 	asm.adjustStack(-1)
 
 	asm.emit(func(env *ExpressionEnv) int {

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -2986,6 +2986,94 @@ func (asm *assembler) Like_collate(expr *LikeExpr, collation colldata.Collation)
 	}, "LIKE VARCHAR(SP-2), VARCHAR(SP-1) COLLATE '%s'", collation.Name())
 }
 
+func (asm *assembler) Locate_coerce3(coercion *compiledCoercion) {
+	asm.adjustStack(-2)
+
+	asm.emit(func(env *ExpressionEnv) int {
+		substr := env.vm.stack[env.vm.sp-3].(*evalBytes)
+		str := env.vm.stack[env.vm.sp-2].(*evalBytes)
+		pos := env.vm.stack[env.vm.sp-1].(*evalInt64)
+		env.vm.sp -= 2
+
+		if pos.i < 1 {
+			env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(0)
+			return 1
+		}
+
+		var bsub, bstr []byte
+		bsub, env.vm.err = coercion.left(nil, substr.bytes)
+		if env.vm.err != nil {
+			return 0
+		}
+		bstr, env.vm.err = coercion.right(nil, str.bytes)
+		if env.vm.err != nil {
+			return 0
+		}
+
+		found := colldata.Index(coercion.col, bstr, bsub, int(pos.i)-1)
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(found) + 1)
+		return 1
+	}, "LOCATE VARCHAR(SP-3), VARCHAR(SP-2) INT64(SP-1) COERCE AND COLLATE '%s'", coercion.col.Name())
+}
+
+func (asm *assembler) Locate_coerce2(coercion *compiledCoercion) {
+	asm.adjustStack(-1)
+
+	asm.emit(func(env *ExpressionEnv) int {
+		substr := env.vm.stack[env.vm.sp-2].(*evalBytes)
+		str := env.vm.stack[env.vm.sp-1].(*evalBytes)
+		env.vm.sp--
+
+		var bsub, bstr []byte
+		bsub, env.vm.err = coercion.left(nil, substr.bytes)
+		if env.vm.err != nil {
+			return 0
+		}
+		bstr, env.vm.err = coercion.right(nil, str.bytes)
+		if env.vm.err != nil {
+			return 0
+		}
+
+		found := colldata.Index(coercion.col, bstr, bsub, 0)
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(found) + 1)
+		return 1
+	}, "LOCATE VARCHAR(SP-2), VARCHAR(SP-1) COERCE AND COLLATE '%s'", coercion.col.Name())
+}
+
+func (asm *assembler) Locate_collate3(collation colldata.Collation) {
+	asm.adjustStack(-2)
+
+	asm.emit(func(env *ExpressionEnv) int {
+		substr := env.vm.stack[env.vm.sp-3].(*evalBytes)
+		str := env.vm.stack[env.vm.sp-2].(*evalBytes)
+		pos := env.vm.stack[env.vm.sp-1].(*evalInt64)
+		env.vm.sp -= 2
+
+		if pos.i < 1 || pos.i > math.MaxInt {
+			env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(0)
+			return 1
+		}
+
+		found := colldata.Index(collation, str.bytes, substr.bytes, int(pos.i)-1)
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(found) + 1)
+		return 1
+	}, "LOCATE VARCHAR(SP-3), VARCHAR(SP-2) INT64(SP-1) COLLATE '%s'", collation.Name())
+}
+
+func (asm *assembler) Locate_collate2(collation colldata.Collation) {
+	asm.adjustStack(-1)
+
+	asm.emit(func(env *ExpressionEnv) int {
+		substr := env.vm.stack[env.vm.sp-2].(*evalBytes)
+		str := env.vm.stack[env.vm.sp-1].(*evalBytes)
+		env.vm.sp--
+
+		found := colldata.Index(collation, str.bytes, substr.bytes, 0)
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(found) + 1)
+		return 1
+	}, "LOCATE VARCHAR(SP-2), VARCHAR(SP-1) COLLATE '%s'", collation.Name())
+}
+
 func (asm *assembler) Strcmp(collation collations.TypedCollation) {
 	asm.adjustStack(-1)
 

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3921,11 +3921,6 @@ func (asm *assembler) Fn_LAST_DAY() {
 			return 1
 		}
 		arg := env.vm.stack[env.vm.sp-1].(*evalTemporal)
-		if arg.dt.IsZero() {
-			env.vm.stack[env.vm.sp-1] = nil
-			return 1
-		}
-
 		d := lastDay(env.currentTimezone(), arg.dt)
 		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalDate(d)
 		return 1
@@ -3938,12 +3933,8 @@ func (asm *assembler) Fn_TO_DAYS() {
 			return 1
 		}
 		arg := env.vm.stack[env.vm.sp-1].(*evalTemporal)
-		if arg.dt.Date.IsZero() {
-			env.vm.stack[env.vm.sp-1] = nil
-		} else {
-			numDays := datetime.MysqlDayNumber(arg.dt.Date.Year(), arg.dt.Date.Month(), arg.dt.Date.Day())
-			env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(numDays))
-		}
+		numDays := datetime.MysqlDayNumber(arg.dt.Date.Year(), arg.dt.Date.Month(), arg.dt.Date.Day())
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(int64(numDays))
 		return 1
 	}, "FN TO_DAYS DATE(SP-1)")
 }

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -615,6 +615,18 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `time('1111:66:56')`,
 			result:     `NULL`,
 		},
+		{
+			expression: `locate('Å', 'a')`,
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `locate('a', 'Å')`,
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `locate("", "😊😂🤢", 3)`,
+			result:     `INT64(3)`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")

--- a/go/vt/vtgate/evalengine/fn_time.go
+++ b/go/vt/vtgate/evalengine/fn_time.go
@@ -282,8 +282,8 @@ func (b *builtinDateFormat) eval(env *ExpressionEnv) (eval, error) {
 	case *evalTemporal:
 		t = e.toDateTime(datetime.DefaultPrecision, env.now)
 	default:
-		t = evalToDateTime(date, datetime.DefaultPrecision, env.now, env.sqlmode.AllowZeroDate())
-		if t == nil || t.isZero() {
+		t = evalToDateTime(date, datetime.DefaultPrecision, env.now, false)
+		if t == nil {
 			return nil, nil
 		}
 	}
@@ -379,8 +379,8 @@ func (call *builtinConvertTz) eval(env *ExpressionEnv) (eval, error) {
 		return nil, nil
 	}
 
-	dt := evalToDateTime(n, -1, env.now, env.sqlmode.AllowZeroDate())
-	if dt == nil || dt.isZero() {
+	dt := evalToDateTime(n, -1, env.now, false)
+	if dt == nil {
 		return nil, nil
 	}
 
@@ -388,7 +388,7 @@ func (call *builtinConvertTz) eval(env *ExpressionEnv) (eval, error) {
 	if !ok {
 		return nil, nil
 	}
-	return newEvalDateTime(out, int(dt.prec), env.sqlmode.AllowZeroDate()), nil
+	return newEvalDateTime(out, int(dt.prec), false), nil
 }
 
 func (call *builtinConvertTz) compile(c *compiler) (ctype, error) {
@@ -504,8 +504,8 @@ func (b *builtinDayOfWeek) eval(env *ExpressionEnv) (eval, error) {
 	if date == nil {
 		return nil, nil
 	}
-	d := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
-	if d == nil || d.isZero() {
+	d := evalToDate(date, env.now, false)
+	if d == nil {
 		return nil, nil
 	}
 	return newEvalInt64(int64(d.dt.Date.Weekday() + 1)), nil
@@ -537,8 +537,8 @@ func (b *builtinDayOfYear) eval(env *ExpressionEnv) (eval, error) {
 	if date == nil {
 		return nil, nil
 	}
-	d := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
-	if d == nil || d.isZero() {
+	d := evalToDate(date, env.now, false)
+	if d == nil {
 		return nil, nil
 	}
 	return newEvalInt64(int64(d.dt.Date.ToStdTime(env.currentTimezone()).YearDay())), nil
@@ -815,7 +815,7 @@ func (b *builtinMakedate) eval(env *ExpressionEnv) (eval, error) {
 	if t.IsZero() {
 		return nil, nil
 	}
-	return newEvalDate(datetime.NewDateTimeFromStd(t).Date, env.sqlmode.AllowZeroDate()), nil
+	return newEvalDate(datetime.NewDateTimeFromStd(t).Date, false), nil
 }
 
 func (call *builtinMakedate) compile(c *compiler) (ctype, error) {
@@ -1189,7 +1189,7 @@ func (b *builtinMonthName) eval(env *ExpressionEnv) (eval, error) {
 	if date == nil {
 		return nil, nil
 	}
-	d := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
+	d := evalToDate(date, env.now, false)
 	if d == nil {
 		return nil, nil
 	}
@@ -1212,7 +1212,7 @@ func (call *builtinMonthName) compile(c *compiler) (ctype, error) {
 	switch arg.Type {
 	case sqltypes.Date, sqltypes.Datetime:
 	default:
-		c.asm.Convert_xD(1, c.sqlmode.AllowZeroDate())
+		c.asm.Convert_xD(1, false)
 	}
 	col := typedCoercionCollation(sqltypes.VarChar, call.collate)
 	c.asm.Fn_MONTHNAME(col)
@@ -1272,8 +1272,8 @@ func (b *builtinToDays) eval(env *ExpressionEnv) (eval, error) {
 	if date == nil {
 		return nil, nil
 	}
-	dt := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
-	if dt == nil || dt.isZero() {
+	dt := evalToDate(date, env.now, false)
+	if dt == nil {
 		return nil, nil
 	}
 
@@ -1292,7 +1292,7 @@ func (call *builtinToDays) compile(c *compiler) (ctype, error) {
 	switch arg.Type {
 	case sqltypes.Date, sqltypes.Datetime:
 	default:
-		c.asm.Convert_xD(1, true)
+		c.asm.Convert_xD(1, false)
 	}
 	c.asm.Fn_TO_DAYS()
 	c.asm.jumpDestination(skip)
@@ -1477,8 +1477,8 @@ func dateTimeUnixTimestamp(env *ExpressionEnv, date eval) evalNumeric {
 	case *evalTemporal:
 		dt = e.toDateTime(int(e.prec), env.now)
 	default:
-		dt = evalToDateTime(date, -1, env.now, env.sqlmode.AllowZeroDate())
-		if dt == nil || dt.isZero() {
+		dt = evalToDateTime(date, -1, env.now, false)
+		if dt == nil {
 			var prec int32
 			switch d := date.(type) {
 			case *evalInt64, *evalUint64:
@@ -1584,8 +1584,8 @@ func (b *builtinWeek) eval(env *ExpressionEnv) (eval, error) {
 		return nil, nil
 	}
 
-	d := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
-	if d == nil || d.isZero() {
+	d := evalToDate(date, env.now, false)
+	if d == nil {
 		return nil, nil
 	}
 
@@ -1644,8 +1644,8 @@ func (b *builtinWeekDay) eval(env *ExpressionEnv) (eval, error) {
 	if date == nil {
 		return nil, nil
 	}
-	d := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
-	if d == nil || d.isZero() {
+	d := evalToDate(date, env.now, false)
+	if d == nil {
 		return nil, nil
 	}
 	return newEvalInt64(int64(d.dt.Date.Weekday()+6) % 7), nil
@@ -1678,8 +1678,8 @@ func (b *builtinWeekOfYear) eval(env *ExpressionEnv) (eval, error) {
 	if date == nil {
 		return nil, nil
 	}
-	d := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
-	if d == nil || d.isZero() {
+	d := evalToDate(date, env.now, false)
+	if d == nil {
 		return nil, nil
 	}
 
@@ -1750,8 +1750,8 @@ func (b *builtinYearWeek) eval(env *ExpressionEnv) (eval, error) {
 		return nil, nil
 	}
 
-	d := evalToDate(date, env.now, env.sqlmode.AllowZeroDate())
-	if d == nil || d.isZero() {
+	d := evalToDate(date, env.now, false)
+	if d == nil {
 		return nil, nil
 	}
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -82,6 +82,7 @@ var Cases = []TestCase{
 	{Run: FnRTrim},
 	{Run: FnTrim},
 	{Run: FnSubstr},
+	{Run: FnLocate},
 	{Run: FnConcat},
 	{Run: FnConcatWs},
 	{Run: FnHex},
@@ -1522,6 +1523,34 @@ func FnSubstr(yield Query) {
 
 			for _, j := range radianInputs {
 				yield(fmt.Sprintf("SUBSTRING(%s, %s, %s)", str, i, j), nil)
+			}
+		}
+	}
+}
+
+func FnLocate(yield Query) {
+	mysqlDocSamples := []string{
+		`LOCATE('bar', 'foobarbar')`,
+		`LOCATE('xbar', 'foobar')`,
+		`LOCATE('bar', 'foobarbar', 5)`,
+		`INSTR('foobarbar', 'bar')`,
+		`INSTR('xbar', 'foobar')`,
+		`POSITION('bar' IN 'foobarbar')`,
+		`POSITION('xbar' IN 'foobar')`,
+	}
+
+	for _, q := range mysqlDocSamples {
+		yield(q, nil)
+	}
+
+	for _, substr := range locateStrings {
+		for _, str := range locateStrings {
+			yield(fmt.Sprintf("LOCATE(%s, %s)", substr, str), nil)
+			yield(fmt.Sprintf("INSTR(%s, %s)", str, substr), nil)
+			yield(fmt.Sprintf("POSITION(%s IN %s)", str, substr), nil)
+
+			for _, i := range radianInputs {
+				yield(fmt.Sprintf("LOCATE(%s, %s, %s)", substr, str, i), nil)
 			}
 		}
 	}

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -234,6 +234,42 @@ var insertStrings = []string{
 	// "_ucs2 'AabcÅå'",
 }
 
+var locateStrings = []string{
+	"NULL",
+	"\"\"",
+	"\"a\"",
+	"\"abc\"",
+	"1",
+	"-1",
+	"0123",
+	"0xAACC",
+	"3.1415926",
+	// MySQL has broken behavior for these inputs,
+	// see https://bugs.mysql.com/bug.php?id=113933
+	// "\"Å å\"",
+	// "\"中文测试\"",
+	// "\"日本語テスト\"",
+	// "\"한국어 시험\"",
+	// "\"😊😂🤢\"",
+	// "_utf8mb4 'abcABCÅå'",
+	"DATE '2022-10-11'",
+	"TIME '11:02:23'",
+	"'123'",
+	"9223372036854775807",
+	"-9223372036854775808",
+	"999999999999999999999999",
+	"-999999999999999999999999",
+	"_binary 'Müller' ",
+	"_utf8mb4 'abcABCÅå'",
+	"_latin1 0xFF",
+	// TODO: support other multibyte encodings
+	// "_dec8 'ÒòÅå'",
+	// "_utf8mb3 'abcABCÅå'",
+	// "_utf16 'AabcÅå'",
+	// "_utf32 'AabcÅå'",
+	// "_ucs2 'AabcÅå'",
+}
+
 var inputConversionTypes = []string{
 	"BINARY", "BINARY(1)", "BINARY(0)", "BINARY(16)", "BINARY(-1)",
 	"CHAR", "CHAR(1)", "CHAR(0)", "CHAR(16)", "CHAR(-1)",

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -604,6 +604,12 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinStrcmp{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "instr":
+		if len(args) != 2 {
+			return nil, argError(method)
+		}
+		call = CallExpr{Arguments: []IR{call.Arguments[1], call.Arguments[0]}, Method: method}
+		return &builtinLocate{CallExpr: call, collate: ast.cfg.Collation}, nil
 	default:
 		return nil, translateExprNotSupported(fn)
 	}
@@ -729,7 +735,7 @@ func (ast *astCompiler) translateCallable(call sqlparser.Callable) (IR, error) {
 
 	case *sqlparser.CurTimeFuncExpr:
 		if call.Fsp > 6 {
-			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Too-big precision 12 specified for '%s'. Maximum is 6.", call.Name.String())
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Too-big precision %d specified for '%s'. Maximum is 6.", call.Fsp, call.Name.String())
 		}
 
 		var cexpr = CallExpr{Arguments: nil, Method: call.Name.String()}
@@ -799,6 +805,31 @@ func (ast *astCompiler) translateCallable(call sqlparser.Callable) (IR, error) {
 		}
 		var cexpr = CallExpr{Arguments: args, Method: "SUBSTRING"}
 		return &builtinSubstring{
+			CallExpr: cexpr,
+			collate:  ast.cfg.Collation,
+		}, nil
+	case *sqlparser.LocateExpr:
+		var args []IR
+		substr, err := ast.translateExpr(call.SubStr)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, substr)
+		str, err := ast.translateExpr(call.Str)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, str)
+
+		if call.Pos != nil {
+			to, err := ast.translateExpr(call.Pos)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, to)
+		}
+		var cexpr = CallExpr{Arguments: args, Method: "LOCATE"}
+		return &builtinLocate{
 			CallExpr: cexpr,
 			collate:  ast.cfg.Collation,
 		}, nil


### PR DESCRIPTION
This implements `LOCATE`, `POSITION` and `INSTR` to find substrings inside another string.

It diverges in behavior for multibyte characters because of the bugs in MySQL identified in https://bugs.mysql.com/bug.php?id=113933.

## Related Issue(s)

Part of #9647 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required