### PR TITLE
Remove concurrency group for check labels workflow

### DIFF
--- a/.github/workflows/check_label.yml
+++ b/.github/workflows/check_label.yml
@@ -3,10 +3,6 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
-concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Check Pull Request labels')
-  cancel-in-progress: true
-
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
## Description

I _think_ this will fix the issue we have been seeing with the check labels workflow being stuck in "pending". It seems like the repeated addition or deletion of labels cancels the workflow over and over.