### PR TITLE
evalEngine: Implement string `INSERT`

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -931,6 +931,18 @@ func (cached *builtinInetNtoa) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinInsert) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinIsIPV4) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler.go
+++ b/go/vt/vtgate/evalengine/compiler.go
@@ -327,6 +327,15 @@ func (c *compiler) compileNullCheck3(arg1, arg2, arg3 ctype) *jump {
 	return nil
 }
 
+func (c *compiler) compileNullCheck4(arg1, arg2, arg3, arg4 ctype) *jump {
+	if arg1.nullable() || arg2.nullable() || arg3.nullable() || arg4.nullable() {
+		j := c.asm.jumpFrom()
+		c.asm.NullCheck4(j)
+		return j
+	}
+	return nil
+}
+
 func (c *compiler) compileNullCheckArg(ct ctype, offset int) *jump {
 	if ct.nullable() {
 		j := c.asm.jumpFrom()

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3162,6 +3162,17 @@ func (asm *assembler) NullCheck3(j *jump) {
 	}, "NULLCHECK SP-1, SP-2, SP-3")
 }
 
+func (asm *assembler) NullCheck4(j *jump) {
+	asm.emit(func(env *ExpressionEnv) int {
+		if env.vm.stack[env.vm.sp-4] == nil || env.vm.stack[env.vm.sp-3] == nil || env.vm.stack[env.vm.sp-2] == nil || env.vm.stack[env.vm.sp-1] == nil {
+			env.vm.stack[env.vm.sp-4] = nil
+			env.vm.sp -= 3
+			return j.offset()
+		}
+		return 1
+	}, "NULLCHECK SP-1, SP-2, SP-3, SP-4")
+}
+
 func (asm *assembler) NullCheckArg(j *jump, offset int) {
 	asm.emit(func(env *ExpressionEnv) int {
 		if env.vm.stack[env.vm.sp-1] == nil {

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -2354,7 +2354,14 @@ func (asm *assembler) Fn_INSERT(col collations.TypedCollation) {
 		l := env.vm.stack[env.vm.sp-2].(*evalInt64).i
 		newstr := env.vm.stack[env.vm.sp-1].(*evalBytes)
 
-		env.vm.stack[env.vm.sp-4] = env.vm.arena.newEvalText(insert(str, newstr, int(pos), int(l)), col)
+		res := insert(str, newstr, int(pos), int(l))
+		if !validMaxLength(int64(len(res)), 1) {
+			env.vm.stack[env.vm.sp-4] = nil
+			env.vm.sp -= 3
+			return 1
+		}
+
+		env.vm.stack[env.vm.sp-4] = env.vm.arena.newEvalText(res, col)
 		env.vm.sp -= 3
 		return 1
 	}, "FN INSERT VARCHAR(SP-4) INT64(SP-3) INT64(SP-2) VARCHAR(SP-1)")

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -2322,6 +2322,19 @@ func (asm *assembler) Fn_BIT_LENGTH() {
 	}, "FN BIT_LENGTH VARCHAR(SP-1)")
 }
 
+func (asm *assembler) Fn_INSERT() {
+	asm.emit(func(env *ExpressionEnv) int {
+		str := env.vm.stack[env.vm.sp-4].(*evalBytes)
+		pos := env.vm.stack[env.vm.sp-3].(*evalInt64).i
+		l := env.vm.stack[env.vm.sp-2].(*evalInt64).i
+		newstr := env.vm.stack[env.vm.sp-1].(*evalBytes)
+
+		env.vm.stack[env.vm.sp-4] = env.vm.arena.newEvalText(insert(str, newstr, int(pos), int(l)), str.col)
+		env.vm.sp -= 3
+		return 1
+	}, "FN INSERT VARCHAR(SP-4) INT64(SP-3) INT64(SP-2) VARCHAR(SP-1)")
+}
+
 func (asm *assembler) Fn_LUCASE(upcase bool) {
 	if upcase {
 		asm.emit(func(env *ExpressionEnv) int {

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -2322,14 +2322,16 @@ func (asm *assembler) Fn_BIT_LENGTH() {
 	}, "FN BIT_LENGTH VARCHAR(SP-1)")
 }
 
-func (asm *assembler) Fn_INSERT() {
+func (asm *assembler) Fn_INSERT(col collations.TypedCollation) {
+	asm.adjustStack(-3)
+
 	asm.emit(func(env *ExpressionEnv) int {
 		str := env.vm.stack[env.vm.sp-4].(*evalBytes)
 		pos := env.vm.stack[env.vm.sp-3].(*evalInt64).i
 		l := env.vm.stack[env.vm.sp-2].(*evalInt64).i
 		newstr := env.vm.stack[env.vm.sp-1].(*evalBytes)
 
-		env.vm.stack[env.vm.sp-4] = env.vm.arena.newEvalText(insert(str, newstr, int(pos), int(l)), str.col)
+		env.vm.stack[env.vm.sp-4] = env.vm.arena.newEvalText(insert(str, newstr, int(pos), int(l)), col)
 		env.vm.sp -= 3
 		return 1
 	}, "FN INSERT VARCHAR(SP-4) INT64(SP-3) INT64(SP-2) VARCHAR(SP-1)")

--- a/go/vt/vtgate/evalengine/fn_string.go
+++ b/go/vt/vtgate/evalengine/fn_string.go
@@ -174,7 +174,6 @@ func (call *builtinInsert) eval(env *ExpressionEnv) (eval, error) {
 	pos := evalToInt64(args[1]).i
 	l := evalToInt64(args[2]).i
 
-	// We should convert newstr's collation to converted str's collation
 	newstr, err := evalToVarchar(args[3], str.col.Collation, true)
 	if err != nil {
 		return nil, err
@@ -221,12 +220,9 @@ func (call *builtinInsert) compile(c *compiler) (ctype, error) {
 	case str.isTextual():
 	default:
 		c.asm.Convert_xce(4, str.Type, call.collate)
-
-		// We fall back to default collation, if str isn't textual
 		col = typedCoercionCollation(sqltypes.VarChar, call.collate)
 	}
 
-	// We should convert newstr's collation to str's converted collation
 	c.asm.Convert_xce(1, newstr.Type, col.Collation)
 
 	c.asm.Fn_INSERT(col)

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -63,6 +63,7 @@ var Cases = []TestCase{
 	{Run: TupleComparisons},
 	{Run: Comparisons},
 	{Run: InStatement},
+	{Run: FnInsert},
 	{Run: FnLower},
 	{Run: FnUpper},
 	{Run: FnCharLength},
@@ -1310,6 +1311,24 @@ var JSONExtract_Schema = []*querypb.Field{
 		Type:       sqltypes.TypeJSON,
 		ColumnType: "JSON",
 	},
+}
+
+func FnInsert(yield Query) {
+	str := []string{
+		"'Quadratic'",
+		"'What'",
+	}
+
+	pos := []string{
+		"3",
+		"4",
+	}
+
+	for _, s := range str {
+		for _, p := range pos {
+			yield(fmt.Sprintf("INSERT(%s, %s, %s, %s)", s, p, p, s), nil)
+		}
+	}
 }
 
 func FnLower(yield Query) {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -1316,23 +1316,10 @@ var JSONExtract_Schema = []*querypb.Field{
 }
 
 func FnInsert(yield Query) {
-	num := []string{
-		"-1",
-		"3",
-		"4",
-		"10",
-		"20",
-		"'14'",
-		"100",
-		"5",
-		"0",
-		"2",
-	}
-
 	for _, s := range insertStrings {
 		for _, ns := range insertStrings {
-			for _, l := range num {
-				for _, p := range num {
+			for _, l := range inputBitwise {
+				for _, p := range inputBitwise {
 					yield(fmt.Sprintf("INSERT(%s, %s, %s, %s)", s, p, l, ns), nil)
 				}
 			}

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -1314,20 +1314,37 @@ var JSONExtract_Schema = []*querypb.Field{
 }
 
 func FnInsert(yield Query) {
-	str := []string{
-		"'Quadratic'",
-		"'What'",
-	}
-
-	pos := []string{
+	num := []string{
+		"-1",
 		"3",
 		"4",
+		"10",
+		"20",
+		"'14'",
+		"100",
+		"5",
+		"0",
+		"2",
 	}
 
-	for _, s := range str {
-		for _, p := range pos {
-			yield(fmt.Sprintf("INSERT(%s, %s, %s, %s)", s, p, p, s), nil)
+	for _, s := range insertStrings {
+		for _, ns := range insertStrings {
+			for _, l := range num {
+				for _, p := range num {
+					yield(fmt.Sprintf("INSERT(%s, %s, %s, %s)", s, p, l, ns), nil)
+				}
+			}
 		}
+	}
+
+	mysqlDocSamples := []string{
+		"INSERT('Quadratic', 3, 4, 'What')",
+		"INSERT('Quadratic', -1, 4, 'What')",
+		"INSERT('Quadratic', 3, 100, 'What')",
+	}
+
+	for _, q := range mysqlDocSamples {
+		yield(q, nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -199,6 +199,40 @@ var inputStrings = []string{
 	// "_ucs2 'AabcÅå'",
 }
 
+var insertStrings = []string{
+	"NULL",
+	"\"\"",
+	"\"a\"",
+	"\"abc\"",
+	"1",
+	"-1",
+	"0123",
+	"0xAACC",
+	"3.1415926",
+	// MySQL has broken behavior for these inputs,
+	// "\"Å å\"",
+	// "\"中文测试\"",
+	// "\"日本語テスト\"",
+	// "\"한국어 시험\"",
+	// "\"😊😂🤢\"",
+	"DATE '2022-10-11'",
+	"TIME '11:02:23'",
+	"'123'",
+	"9223372036854775807",
+	"-9223372036854775808",
+	"999999999999999999999999",
+	"-999999999999999999999999",
+	"_binary 'Müller' ",
+	"_utf8mb4 'abcABCÅå'",
+	"_latin1 0xFF",
+	// TODO: support other multibyte encodings
+	// "_dec8 'ÒòÅå'",
+	// "_utf8mb3 'abcABCÅå'",
+	// "_utf16 'AabcÅå'",
+	// "_utf32 'AabcÅå'",
+	// "_ucs2 'AabcÅå'",
+}
+
 var inputConversionTypes = []string{
 	"BINARY", "BINARY(1)", "BINARY(0)", "BINARY(16)", "BINARY(-1)",
 	"CHAR", "CHAR(1)", "CHAR(0)", "CHAR(16)", "CHAR(-1)",

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -210,6 +210,7 @@ var insertStrings = []string{
 	"0xAACC",
 	"3.1415926",
 	// MySQL has broken behavior for these inputs,
+	// see https://github.com/mysql/mysql-server/pull/517
 	// "\"Å å\"",
 	// "\"中文测试\"",
 	// "\"日本語テスト\"",

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -215,6 +215,7 @@ var insertStrings = []string{
 	// "\"日本語テスト\"",
 	// "\"한국어 시험\"",
 	// "\"😊😂🤢\"",
+	// "_utf8mb4 'abcABCÅå'",
 	"DATE '2022-10-11'",
 	"TIME '11:02:23'",
 	"'123'",
@@ -223,7 +224,6 @@ var insertStrings = []string{
 	"999999999999999999999999",
 	"-999999999999999999999999",
 	"_binary 'Müller' ",
-	"_utf8mb4 'abcABCÅå'",
 	"_latin1 0xFF",
 	// TODO: support other multibyte encodings
 	// "_dec8 'ÒòÅå'",

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -18,6 +18,7 @@ package evalengine
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -265,6 +266,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinPad{CallExpr: call, collate: ast.cfg.Collation, left: method == "lpad"}, nil
+	case "insert":
+		if len(args) != 4 {
+			return nil, argError(method)
+		}
+		return &builtinInsert{CallExpr: call, collate: ast.cfg.Collation}, nil
 	case "lower", "lcase":
 		if len(args) != 1 {
 			return nil, argError(method)
@@ -599,9 +605,21 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 	}
 }
 
+func GetFunctionName(i interface{}) {
+	r := reflect.ValueOf(&i).Elem()
+	rt := r.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+		rv := reflect.ValueOf(&i)
+		value := reflect.Indirect(rv).FieldByName(field.Name)
+		fmt.Println(field.Name, value.String())
+	}
+}
+
 func (ast *astCompiler) translateCallable(call sqlparser.Callable) (IR, error) {
 	switch call := call.(type) {
 	case *sqlparser.FuncExpr:
+		fmt.Println("working")
 		return ast.translateFuncExpr(call)
 
 	case *sqlparser.ConvertExpr:
@@ -975,6 +993,7 @@ func (ast *astCompiler) translateCallable(call sqlparser.Callable) (IR, error) {
 			CallExpr: CallExpr{Arguments: args, Method: "REGEXP_REPLACE"},
 		}, nil
 	default:
+		GetFunctionName(call)
 		return nil, translateExprNotSupported(call)
 	}
 }

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -3048,15 +3048,15 @@
       "QueryType": "SELECT",
       "Original": "select insert('Quadratic', 3, 4, 'What')",
       "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "Reference",
-        "Keyspace": {
-          "Name": "main",
-          "Sharded": false
-        },
-        "FieldQuery": "select insert('Quadratic', 3, 4, 'What') from dual where 1 != 1",
-        "Query": "select insert('Quadratic', 3, 4, 'What') from dual",
-        "Table": "dual"
+        "OperatorType": "Projection",
+        "Expressions": [
+          "'QuWhattic' as insert('Quadratic', 3, 4, 'What')"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "SingleRow"
+          }
+        ]
       },
       "TablesUsed": [
         "main.dual"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds implementation of [`INSERT`](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_insert) func in evalengine.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #9647 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
