### PR TITLE
Remove loopclosure captures from tests

### DIFF
--- a/go/flagutil/enum_test.go
+++ b/go/flagutil/enum_test.go
@@ -56,7 +56,6 @@ func TestStringEnum(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var enum *StringEnum
 			if tt.caseInsensitive {

--- a/go/protoutil/duration_test.go
+++ b/go/protoutil/duration_test.go
@@ -81,8 +81,6 @@ func TestDurationFromProto(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 
 			actual, ok, err := DurationFromProto(tt.in)
@@ -124,8 +122,6 @@ func TestDurationToProto(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 
 			actual := DurationToProto(tt.in)

--- a/go/vt/callinfo/callinfo_test.go
+++ b/go/vt/callinfo/callinfo_test.go
@@ -55,7 +55,6 @@ func TestNewContext(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expectedContext, NewContext(tt.ctx, tt.ci))
 		})
@@ -84,7 +83,6 @@ func TestFromContext(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ci, ok := FromContext(tt.ctx)
 			require.Equal(t, tt.expectedCi, ci)
@@ -112,7 +110,6 @@ func TestHTMLFromContext(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expectedHTML, HTMLFromContext(tt.ctx))
 		})

--- a/go/vt/logz/logz_utils_test.go
+++ b/go/vt/logz/logz_utils_test.go
@@ -45,7 +45,6 @@ func TestWrappable(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.input, func(t *testing.T) {
 			require.Equal(t, tt.output, Wrappable(tt.input))
 		})

--- a/go/vt/topo/topotests/cell_info_test.go
+++ b/go/vt/topo/topotests/cell_info_test.go
@@ -217,7 +217,6 @@ func TestExpandCells(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				expanded, err := ts.ExpandCells(ctx, tt.in)
 				if tt.shouldErr {

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -547,8 +547,6 @@ func TestFindSchema(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -862,8 +860,6 @@ func TestGetClusters(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1052,8 +1048,6 @@ func TestGetKeyspace(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1284,8 +1278,6 @@ func TestGetKeyspaces(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1538,8 +1530,6 @@ func TestGetSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -2179,8 +2169,6 @@ func TestGetSchemas(t *testing.T) {
 		// Note that these test cases were written prior to the existence of
 		// WithTestServers, so they are all written with the assumption that
 		// there are exactly 2 clusters.
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -2626,8 +2614,6 @@ func TestGetSrvKeyspace(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2787,8 +2773,6 @@ func TestGetSrvKeyspaces(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -2956,8 +2940,6 @@ func TestGetSrvVSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -3250,8 +3232,6 @@ func TestGetSrvVSchemas(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -3531,8 +3511,6 @@ func TestGetTablet(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3726,8 +3704,6 @@ func TestGetTablets(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3872,8 +3848,6 @@ func TestGetVSchema(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4198,8 +4172,6 @@ func TestGetVSchemas(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4419,8 +4391,6 @@ func TestGetWorkflow(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4858,8 +4828,6 @@ func TestGetWorkflows(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -5099,8 +5067,6 @@ func TestVTExplain(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -5350,8 +5316,6 @@ func TestServeHTTP(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cache/cache_test.go
+++ b/go/vt/vtadmin/cache/cache_test.go
@@ -67,7 +67,6 @@ func TestBackfillDuplicates(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -131,7 +130,6 @@ func TestBackfillTTL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cache/refresh_test.go
+++ b/go/vt/vtadmin/cache/refresh_test.go
@@ -65,7 +65,6 @@ func TestShouldRefreshFromIncomingContext(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -114,7 +113,6 @@ func TestShouldRefreshFromRequest(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/go/vt/vtadmin/cluster/cluster_internal_test.go
+++ b/go/vt/vtadmin/cluster/cluster_internal_test.go
@@ -142,8 +142,6 @@ func TestDeleteTablets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -331,8 +329,6 @@ func TestEmergencyFailoverShard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -493,8 +489,6 @@ func Test_getShardSets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -662,8 +656,6 @@ func TestPlannedFailoverShard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -775,8 +767,6 @@ func TestRefreshState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -899,8 +889,6 @@ func TestRefreshTabletReplicationSource(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1189,8 +1177,6 @@ func Test_reloadKeyspaceSchemas(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1516,8 +1502,6 @@ func Test_reloadShardSchemas(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1700,8 +1684,6 @@ func Test_reloadTabletSchemas(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1903,8 +1885,6 @@ func TestTabletExternallyPromoted(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -255,7 +255,6 @@ func TestCreateShard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			defer tt.tc.Cluster.Close()
 			_, err := tt.tc.Cluster.CreateShard(ctx, tt.req)
@@ -595,8 +594,6 @@ func TestFindTablet(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -807,8 +804,6 @@ func TestFindTablets(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1195,8 +1190,6 @@ func TestFindWorkflows(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1474,7 +1467,6 @@ func TestGetCellInfos(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1557,7 +1549,6 @@ func TestGetCellsAliases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1704,8 +1695,6 @@ func TestGetSchema(t *testing.T) {
 
 	for i, tt := range tests {
 		i := i
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2683,8 +2672,6 @@ func TestGetSchema(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
-
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -2942,8 +2929,6 @@ func TestGetShardReplicationPositions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3032,8 +3017,6 @@ func TestGetVSchema(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3191,8 +3174,6 @@ func TestGetWorkflow(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3358,8 +3339,6 @@ func TestGetWorkflows(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3436,8 +3415,6 @@ func TestSetWritable(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3583,8 +3560,6 @@ func TestToggleTabletReplication(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/config_test.go
+++ b/go/vt/vtadmin/cluster/config_test.go
@@ -131,8 +131,6 @@ func TestMergeConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
@@ -233,8 +233,6 @@ func TestConsulDiscoverVTGates(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -344,8 +342,6 @@ func TestConsulDiscoverVTGate(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -442,8 +438,6 @@ func TestConsulDiscoverVTGateAddr(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/discovery/discovery_dynamic_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_dynamic_test.go
@@ -93,8 +93,6 @@ func TestDynamicDiscoverVTGate(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			disco := &DynamicDiscovery{}
@@ -237,8 +235,6 @@ func TestDynamicDiscoverVTGates(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -330,8 +326,6 @@ func TestDynamicDiscoverVtctld(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -475,8 +469,6 @@ func TestDynamicDiscoverVtctlds(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
@@ -93,8 +93,6 @@ func TestDiscoverVTGate(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -238,8 +236,6 @@ func TestDiscoverVTGates(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -331,8 +327,6 @@ func TestDiscoverVtctld(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -476,8 +470,6 @@ func TestDiscoverVtctlds(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/discovery/discovery_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_test.go
@@ -50,8 +50,6 @@ func TestNew(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/dynamic/cluster_test.go
+++ b/go/vt/vtadmin/cluster/dynamic/cluster_test.go
@@ -53,7 +53,6 @@ func TestClusterFromString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/file_config_test.go
+++ b/go/vt/vtadmin/cluster/file_config_test.go
@@ -215,7 +215,6 @@ name="devcluster"`,
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -380,8 +379,6 @@ func TestCombine(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/flags_test.go
+++ b/go/vt/vtadmin/cluster/flags_test.go
@@ -98,8 +98,6 @@ func TestMergeFlagsByImpl(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/cluster/internal/caches/schemacache/cache_test.go
+++ b/go/vt/vtadmin/cluster/internal/caches/schemacache/cache_test.go
@@ -131,7 +131,6 @@ func TestLoadOptions(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -291,7 +291,6 @@ func TestBuild(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/credentials/credentials_test.go
+++ b/go/vt/vtadmin/credentials/credentials_test.go
@@ -56,8 +56,6 @@ func Test_loadCredentials(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/http/request_test.go
+++ b/go/vt/vtadmin/http/request_test.go
@@ -71,8 +71,6 @@ func TestParseQueryParamAsBool(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/internal/backoff/backoff_test.go
+++ b/go/vt/vtadmin/internal/backoff/backoff_test.go
@@ -51,7 +51,6 @@ func TestExponentialBackoff(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/rbac/authorizer_test.go
+++ b/go/vt/vtadmin/rbac/authorizer_test.go
@@ -104,8 +104,6 @@ func TestIsAuthorized(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
@@ -291,8 +291,6 @@ func TestEmergencyReparentShardSlow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -593,8 +591,6 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -1660,8 +1660,6 @@ func TestChangeTabletType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2590,8 +2588,6 @@ func TestCreateKeyspace(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2869,8 +2865,6 @@ func TestCreateShard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if tt.req == nil {
@@ -3731,8 +3725,6 @@ func TestDeleteShards(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3860,8 +3852,6 @@ func TestDeleteSrvKeyspace(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4334,8 +4324,6 @@ func TestDeleteTablets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4708,7 +4696,6 @@ func TestExecuteFetchAsApp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4835,7 +4822,6 @@ func TestExecuteFetchAsDBA(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -5382,8 +5368,6 @@ func TestGetFullStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -5579,7 +5563,6 @@ func TestGetPermissions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -5648,7 +5631,6 @@ func TestGetRoutingRules(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -6136,8 +6118,6 @@ func TestGetShard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -6258,8 +6238,6 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -6425,8 +6403,6 @@ func TestGetSrvKeyspaces(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -6670,8 +6646,6 @@ func TestGetSrvVSchemas(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -7353,8 +7327,6 @@ func TestGetTablets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -7447,8 +7419,6 @@ func TestGetTopologyPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -8178,7 +8148,6 @@ func TestRebuildVSchemaGraph(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -8570,7 +8539,6 @@ func TestReloadSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -8664,7 +8632,6 @@ func TestReloadSchemaKeyspace(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -8822,7 +8789,6 @@ func TestReloadSchemaShard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -9034,8 +9000,6 @@ func TestRemoveKeyspaceCell(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -9323,8 +9287,6 @@ func TestRemoveShardCell(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -9929,8 +9891,6 @@ func TestReparentTablet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -10391,7 +10351,6 @@ func TestRunHealthCheck(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -10471,7 +10430,6 @@ func TestSetKeyspaceDurabilityPolicy(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -11021,7 +10979,6 @@ func TestSetWritable(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -11532,7 +11489,6 @@ func TestSourceShardAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -11667,7 +11623,6 @@ func TestSourceShardDelete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -11853,7 +11808,6 @@ func TestStartReplication(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -11992,7 +11946,6 @@ func TestStopReplication(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -12377,8 +12330,6 @@ func TestTabletExternallyReparented(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -12558,7 +12509,6 @@ func TestUpdateCellInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -12699,7 +12649,6 @@ func TestUpdateCellsAlias(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -60,8 +60,6 @@ func TestNewEmergencyReparenter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -100,8 +98,6 @@ func TestEmergencyReparenter_getLockAction(t *testing.T) {
 	erp := &EmergencyReparenter{}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1900,8 +1896,6 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -2428,8 +2422,6 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 
 	durability, _ := GetDurabilityPolicy("none")
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2716,8 +2708,6 @@ func TestEmergencyReparenter_waitForAllRelayLogsToApply(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3542,8 +3532,6 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 
 	durability, _ := GetDurabilityPolicy("none")
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3990,8 +3978,6 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 
 	durability, _ := GetDurabilityPolicy("none")
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -62,8 +62,6 @@ func TestNewPlannedReparenter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -444,8 +442,6 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -542,8 +538,6 @@ func TestPlannedReparenter_getLockAction(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1063,8 +1057,6 @@ func TestPlannedReparenter_preflightChecks(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1676,8 +1668,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1838,8 +1828,6 @@ func TestPlannedReparenter_performInitialPromotion(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2009,8 +1997,6 @@ func TestPlannedReparenter_performPartialPromotionRecovery(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2375,8 +2361,6 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3196,8 +3180,6 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3813,8 +3795,6 @@ func TestPlannedReparenter_reparentTablets(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -205,8 +205,6 @@ func TestFindValidEmergencyReparentCandidates(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1280,8 +1278,6 @@ func Test_stopReplicationAndBuildStatusMaps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			durability, err := GetDurabilityPolicy(tt.durability)
 			require.NoError(t, err)
@@ -1377,8 +1373,6 @@ func TestReplicaWasRunning(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1465,8 +1459,6 @@ func TestSQLThreadWasRunning(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1563,8 +1555,6 @@ func TestWaitForRelayLogsToApply(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -712,8 +712,6 @@ func TestElectNewPrimary(t *testing.T) {
 	durability, err := GetDurabilityPolicy("none")
 	require.NoError(t, err)
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1007,8 +1005,6 @@ func TestFindCurrentPrimary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/schematools/reload_test.go
+++ b/go/vt/vtctl/schematools/reload_test.go
@@ -325,7 +325,6 @@ func TestReloadShard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -133,7 +133,6 @@ func TestCheckReshardingJournalExistsOnTablet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/workflow/vexec/query_plan_test.go
+++ b/go/vt/vtctl/workflow/vexec/query_plan_test.go
@@ -153,8 +153,6 @@ func TestQueryPlanExecute(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -303,8 +301,6 @@ func TestQueryPlanExecuteScatter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtctl/workflow/vexec/query_planner_test.go
+++ b/go/vt/vtctl/workflow/vexec/query_planner_test.go
@@ -65,8 +65,6 @@ func TestVReplicationQueryPlanner_PlanQuery(t *testing.T) {
 	planner := NewVReplicationQueryPlanner(nil, "", "")
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -115,8 +113,6 @@ func TestVReplicationQueryPlanner_planSelect(t *testing.T) {
 	planner := NewVReplicationQueryPlanner(nil, "testworkflow", "vt_testkeyspace")
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -169,8 +165,6 @@ func TestVReplicationQueryPlanner_planUpdate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -230,8 +224,6 @@ func TestVReplicationQueryPlanner_planDelete(t *testing.T) {
 	planner := NewVReplicationQueryPlanner(nil, "", "vt_testkeyspace")
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -351,8 +343,6 @@ func TestVReplicationLogQueryPlanner(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
-
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -633,7 +633,6 @@ func TestGetBuildTags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.skipCSV, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Description
[Go 1.22 changes `for` loops](https://go.dev/blog/loopvar-preview) to make variables have per-iteration scope instead of per-loop scope. This removes the need for the following variable assignments in tests:
```go
for _, tt := range tests {
    tt := tt // no longer needed in go 1.22
    t.Run(...) { ... }
}
```

## Related Issue(s)
* vitessio/vitess#15183

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

