### PR TITLE
Added tests for the vtaclcheck/cli package

### DIFF
--- a/go/cmd/vtaclcheck/cli/vtactlcheck_test.go
+++ b/go/cmd/vtaclcheck/cli/vtactlcheck_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name           string
+		aclFile        string
+		staticAuthFile string
+		expectErr      bool
+	}{
+		{
+			name:      "no options specified",
+			expectErr: true,
+		},
+		{
+			name:    "valid acl file",
+			aclFile: "../tableacl1.json",
+		},
+		{
+			name:    "valid acl file",
+			aclFile: "../tableacl2.json",
+		},
+		{
+			name:      "bad acl file",
+			aclFile:   "../tableacl_bad.json",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldAclFile := aclFile
+			oldStaticAuthFile := staticAuthFile
+
+			defer func() {
+				aclFile = oldAclFile
+				staticAuthFile = oldStaticAuthFile
+			}()
+
+			aclFile = tt.aclFile
+			staticAuthFile = tt.staticAuthFile
+
+			err := Main.RunE(&cobra.Command{}, []string{})
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This commit introduces new tests for the `go/cmd/vtaclcheck/cli` package.

## Checklist
-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required