### PR TITLE
Enable 'heartbeat_on_demand_duration' in local/examples

### DIFF
--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -53,6 +53,7 @@ vttablet \
  --grpc_port $grpc_port \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
+ --heartbeat_on_demand_duration=5s \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 
 # Block waiting for the tablet to be listening


### PR DESCRIPTION

## Description

Followup to https://github.com/vitessio/vitess/issues/14978, https://github.com/vitessio/vitess/pull/14980, and https://github.com/vitessio/vitess/pull/15099. This PR re-enables `heartbeat_on_demand_duration` in `vttablet-up.sh` script in `examples/local`.

This comes at no cost when the throttler is disabled, and makes it possible for the throttler to work based on replication lag.

Future work to change the defaults/default behavior of heartbeat mechanism. See discussion in https://github.com/vitessio/vitess/pull/15099.

Without this PR, the throttler won't work properly in `examples`. I therefore want to backport this to all supported versions, just as https://github.com/vitessio/vitess/pull/14980 was backported.


## Related Issue(s)

- https://github.com/vitessio/vitess/issues/14978
- https://github.com/vitessio/vitess/pull/14980
- https://github.com/vitessio/vitess/pull/15099

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
