### PR TITLE
schemadiff: Clean up MySQL version from diff hints

### DIFF
--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1003,7 +1003,7 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 
 	// Check and assign capabilities:
 	// Reminder: schemadiff assumes a MySQL flavor, so we only check for MySQL capabilities.
-	if capableOf := capabilities.MySQLVersionCapableOf(hints.MySQLServerVersion); capableOf != nil {
+	if capableOf := capabilities.MySQLVersionCapableOf(s.env.MySQLVersion()); capableOf != nil {
 		for _, diff := range schemaDiff.UnorderedDiffs() {
 			switch diff := diff.(type) {
 			case *AlterTableEntityDiff:

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -137,8 +137,6 @@ type DiffHints struct {
 	TableQualifierHint          int
 	AlterTableAlgorithmStrategy int
 	EnumReorderStrategy         int
-
-	MySQLServerVersion string // Used to determine specific capabilities such as INSTANT DDL support
 }
 
 const (


### PR DESCRIPTION
We already now have the MySQL version in the schemadiff environment, so we should use it from there. Having it also in the diff hints is duplicated and confusing this way.

## Related Issue(s)

This should have been cleaned up in #14994 but was overlooked. I'd like to also backport this to v19 as well for consistency reasons since we ship that refactor there and this should have been included in that. Otherwise we have v19 with this slight difference again compared to v20. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
