### PR TITLE
Delete with subquery support

### DIFF
--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -7,6 +7,7 @@
     - [Vindex Hints](#vindex-hints)
     - [Update with Limit Support](#update-limit)
     - [Update with Multi Table Support](#multi-table-update)
+    - [Delete with Subquery Support](#delete-subquery)
   - **[Flag changes](#flag-changes)**
     - [`pprof-http` default change](#pprof-http-default)
 - **[Minor Changes](#minor-changes)**
@@ -44,6 +45,13 @@ Support is added for sharded multi-table update with column update on single tar
 Example: `update t1 join t2 on t1.id = t2.id join t3 on t1.col = t3.col set t1.baz = 'abc', t1.apa = 23 where t3.foo = 5 and t2.bar = 7`
 
 More details about how it works is available in [MySQL Docs](https://dev.mysql.com/doc/refman/8.0/en/update.html)
+
+#### <a id="delete-subquery"/> Delete with Subquery Support
+
+Support is added for sharded table delete with subquery
+
+Example: `delete from t1 where id in (select col from t2 where foo = 32 and bar = 43)`
+
 
 ### <a id="flag-changes"/>Flag Changes
 

--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -244,7 +244,7 @@ func TestMultiTableUpdate(t *testing.T) {
 
 // TestDeleteWithSubquery executed delete queries with subqueries
 func TestDeleteWithSubquery(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -144,19 +144,5 @@ func checkIfDeleteSupported(del *sqlparser.Delete, semTable *semantics.SemTable)
 		return vterrors.VT12001("multi-table DELETE statement with multi-target")
 	}
 
-	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-		switch node.(type) {
-		case *sqlparser.Subquery, *sqlparser.DerivedTable:
-			// We have a subquery, so we must fail the planning.
-			// If this subquery and the table expression were all belonging to the same unsharded keyspace,
-			// we would have already created a plan for them before doing these checks.
-			return false, vterrors.VT12001("subqueries in DML")
-		}
-		return true, nil
-	}, del)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -688,6 +688,8 @@ func buildUpdateLogicalPlan(
 	var vindexes []*vindexes.ColumnVindex
 	vQuery := ""
 	if len(upd.ChangedVindexValues) > 0 {
+		upd.OwnedVindexQuery.From = stmt.GetFrom()
+		upd.OwnedVindexQuery.Where = stmt.Where
 		vQuery = sqlparser.String(upd.OwnedVindexQuery)
 		vindexes = upd.Target.VTable.ColumnVindexes
 		if upd.OwnedVindexQuery.Limit != nil && len(upd.OwnedVindexQuery.OrderBy) == 0 {
@@ -709,6 +711,8 @@ func buildDeleteLogicalPlan(ctx *plancontext.PlanningContext, rb *operators.Rout
 	var vindexes []*vindexes.ColumnVindex
 	vQuery := ""
 	if del.OwnedVindexQuery != nil {
+		del.OwnedVindexQuery.From = stmt.GetFrom()
+		del.OwnedVindexQuery.Where = stmt.Where
 		vQuery = sqlparser.String(del.OwnedVindexQuery)
 		vindexes = del.Target.VTable.Owned
 	}

--- a/go/vt/vtgate/planbuilder/operators/dml_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/dml_planning.go
@@ -109,7 +109,6 @@ func buildChangedVindexesValues(
 	ctx *plancontext.PlanningContext,
 	update *sqlparser.Update,
 	table *vindexes.Table,
-	ate *sqlparser.AliasedTableExpr,
 	ksidCols []sqlparser.IdentifierCI,
 	assignments []SetExpr,
 ) (vv map[string]*engine.VindexValues, ownedVindexQuery *sqlparser.Select, subQueriesArgOnChangedVindex []string) {
@@ -145,11 +144,8 @@ func buildChangedVindexesValues(
 		return nil, nil, nil
 	}
 	// generate rest of the owned vindex query.
-	tblExpr := sqlparser.NewAliasedTableExpr(sqlparser.TableName{Name: table.Name}, ate.As.String())
 	ovq := &sqlparser.Select{
-		From:        []sqlparser.TableExpr{tblExpr},
 		SelectExprs: selExprs,
-		Where:       update.Where,
 		OrderBy:     update.OrderBy,
 		Limit:       update.Limit,
 		Lock:        sqlparser.ForUpdateLock,

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -279,6 +279,7 @@ func TestOne(t *testing.T) {
 	lv := loadSchema(t, "vschemas/schema.json", true)
 	setFks(t, lv)
 	addPKs(t, lv, "user", []string{"user", "music"})
+	addPKs(t, lv, "main", []string{"unsharded"})
 	vschema := &vschemawrapper.VSchemaWrapper{
 		V:           lv,
 		TestBuilder: TestBuilder,

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -5012,7 +5012,7 @@
         "TargetTabletType": "PRIMARY",
         "KsidLength": 1,
         "KsidVindex": "user_index",
-        "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u join ref_with_source as r on u.col = r.col for update",
+        "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u, ref_with_source as r where u.col = r.col for update",
         "Query": "delete u from `user` as u, ref_with_source as r where u.col = r.col",
         "Table": "user"
       },
@@ -5038,7 +5038,7 @@
         "TargetTabletType": "PRIMARY",
         "KsidLength": 1,
         "KsidVindex": "user_index",
-        "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u join music as m on u.id = m.user_id for update",
+        "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u, music as m where u.id = m.user_id for update",
         "Query": "delete u from `user` as u, music as m where u.id = m.user_id",
         "Table": "user"
       },
@@ -5284,7 +5284,7 @@
         "TargetTabletType": "PRIMARY",
         "KsidLength": 1,
         "KsidVindex": "user_index",
-        "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u join music as m where u.id = m.user_id and m.foo = 42 for update",
+        "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u, music as m where m.foo = 42 and u.id = m.user_id for update",
         "Query": "delete u from `user` as u, music as m where m.foo = 42 and u.id = m.user_id",
         "Table": "user"
       },
@@ -5899,6 +5899,293 @@
       },
       "TablesUsed": [
         "user.music"
+      ]
+    }
+  },
+  {
+    "comment": "sharded subquery in sharded delete",
+    "query": "delete from user where id = (select id from music where user_id = 1)",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from user where id = (select id from music where user_id = 1)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from music where 1 != 1",
+            "Query": "select id from music where user_id = 1",
+            "Table": "music",
+            "Values": [
+              "1"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Delete",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "KsidLength": 1,
+            "KsidVindex": "user_index",
+            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id = :__sq1 for update",
+            "Query": "delete from `user` where id = :__sq1",
+            "Table": "user",
+            "Values": [
+              ":__sq1"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "unsharded subquery in sharded delete",
+    "query": "delete from user where col = (select id from unsharded)",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from user where col = (select id from unsharded)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select id from unsharded where 1 != 1",
+            "Query": "select id from unsharded",
+            "Table": "unsharded"
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Delete",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "TargetTabletType": "PRIMARY",
+            "KsidLength": 1,
+            "KsidVindex": "user_index",
+            "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where col = :__sq1 for update",
+            "Query": "delete from `user` where col = :__sq1",
+            "Table": "user"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "sharded subquery in unsharded delete",
+    "query": "delete from unsharded where col = (select id from user)",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from unsharded where col = (select id from user)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1",
+            "Query": "select id from `user`",
+            "Table": "`user`"
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Delete",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "delete from unsharded where col = :__sq1",
+            "Table": "unsharded"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "sharded subquery in unsharded subquery in unsharded delete",
+    "query": "delete from unsharded where col = (select id from unsharded where id = (select id from user))",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from unsharded where col = (select id from unsharded where id = (select id from user))",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutValue",
+            "PulloutVars": [
+              "__sq2"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select id from `user` where 1 != 1",
+                "Query": "select id from `user`",
+                "Table": "`user`"
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select id from unsharded where 1 != 1",
+                "Query": "select id from unsharded where id = :__sq2",
+                "Table": "unsharded"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Delete",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "delete from unsharded where col = :__sq1",
+            "Table": "unsharded"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "sharded join unsharded subquery in unsharded delete",
+    "query": "delete from unsharded where col = (select id from unsharded join user on unsharded.id = user.id)",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "delete from unsharded where col = (select id from unsharded join user on unsharded.id = user.id)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "R:0",
+            "JoinVars": {
+              "unsharded_id": 0
+            },
+            "TableName": "unsharded_`user`",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
+                "Query": "select unsharded.id from unsharded",
+                "Table": "unsharded"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select id from `user` where 1 != 1",
+                "Query": "select id from `user` where `user`.id = :unsharded_id",
+                "Table": "`user`",
+                "Values": [
+                  ":unsharded_id"
+                ],
+                "Vindex": "user_index"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Delete",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "TargetTabletType": "PRIMARY",
+            "Query": "delete from unsharded where col = :__sq1",
+            "Table": "unsharded"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
       ]
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -20,26 +20,6 @@
     "plan": "VT12001: unsupported: subqueries in GROUP BY"
   },
   {
-    "comment": "subqueries in delete",
-    "query": "delete from user where col = (select id from unsharded)",
-    "plan": "VT12001: unsupported: subqueries in DML"
-  },
-  {
-    "comment": "sharded subqueries in unsharded delete",
-    "query": "delete from unsharded where col = (select id from user)",
-    "plan": "VT12001: unsupported: subqueries in DML"
-  },
-  {
-    "comment": "sharded subquery in unsharded subquery in unsharded delete",
-    "query": "delete from unsharded where col = (select id from unsharded where id = (select id from user))",
-    "plan": "VT12001: unsupported: subqueries in DML"
-  },
-  {
-    "comment": "sharded join unsharded subqueries in unsharded delete",
-    "query": "delete from unsharded where col = (select id from unsharded join user on unsharded.id = user.id)",
-    "plan": "VT12001: unsupported: subqueries in DML"
-  },
-  {
     "comment": "update changes primary vindex column",
     "query": "update user set id = 1 where id = 1",
     "plan": "VT12001: unsupported: you cannot UPDATE primary vindex columns; invalid update on vindex: user_index"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds support for a subquery in a Delete.
e.g. `delete from user where id > (select col from music where id = 2)`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/3838

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
