### PR TITLE
Add required tests for `internal/flag`

### DIFF
--- a/go/internal/flag/flag_test.go
+++ b/go/internal/flag/flag_test.go
@@ -33,7 +33,7 @@ func TestPreventGlogVFlagFromClobberingVersionFlagShorthand(t *testing.T) {
 
 	goflag.CommandLine = goflag.NewFlagSet(os.Args[0], goflag.ExitOnError)
 
-	var v, vtest bool
+	var v bool
 
 	goflag.BoolVar(&v, "v", true, "")
 
@@ -44,7 +44,7 @@ func TestPreventGlogVFlagFromClobberingVersionFlagShorthand(t *testing.T) {
 	assert.NotNil(t, f)
 	assert.Equal(t, "", f.Shorthand)
 
-	testFlagSet.BoolVar(&vtest, "vtest", true, "")
+	// The function should not throw any error if -v flag is already defined
 	PreventGlogVFlagFromClobberingVersionFlagShorthand(testFlagSet)
 }
 
@@ -282,27 +282,16 @@ func TestArgs(t *testing.T) {
 }
 
 func TestIsZeroValue(t *testing.T) {
-	oldCommandLine := goflag.CommandLine
-
-	defer func() {
-		goflag.CommandLine = oldCommandLine
-	}()
-
 	var testFlag string
 
-	goflag.StringVar(&testFlag, "testflag", "default", "Description of testflag")
-	goflag.Parse()
+	testFlagSet := goflag.NewFlagSet("testFlagSet", goflag.ExitOnError)
+	testFlagSet.StringVar(&testFlag, "testflag", "default", "Description of testflag")
 
-	f := goflag.Lookup("testflag")
+	f := testFlagSet.Lookup("testflag")
 
-	// Test the isZeroValue function
 	result := isZeroValue(f, "")
-
 	assert.True(t, result)
 
-	// Test again with a non-zero value
 	result = isZeroValue(f, "anyValue")
-	if result {
-		t.Errorf("Expected false, got true. The value 'newvalue' should not be considered as zero value.")
-	}
+	assert.False(t, result)
 }

--- a/go/internal/flag/flag_test.go
+++ b/go/internal/flag/flag_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestPreventGlogVFlagFromClobberingVersionFlagShorthand(t *testing.T) {
+	var v bool
+
+	flag.BoolVar(&v, "v", true, "test flag description")
+
+	testFlagSet := pflag.NewFlagSet("testFlagSet", pflag.ExitOnError)
+	PreventGlogVFlagFromClobberingVersionFlagShorthand(testFlagSet)
+
+	fmt.Println(testFlagSet.Lookup("v"))
+	// f := pflag.Lookup("v")
+	// assert.Equal(t, f.Shorthand, "")
+
+	// testFlagSet.BoolVar(&vtest, "vtest", true, "test flag description")
+	// PreventGlogVFlagFromClobberingVersionFlagShorthand(testFlagSet)
+}
+
+func TestParse(t *testing.T) {
+
+}

--- a/go/internal/flag/flag_test.go
+++ b/go/internal/flag/flag_test.go
@@ -95,22 +95,23 @@ func TestIsFlagProvided(t *testing.T) {
 
 	pflag.CommandLine = pflag.NewFlagSet("testFlagSet", pflag.ExitOnError)
 
-	isProvided := IsFlagProvided("testFlag")
-	assert.False(t, isProvided, "expected IsFlagProvided to return false as provided flag doesn't exist, got true")
+	flagName := "testFlag"
+	isProvided := IsFlagProvided(flagName)
+	assert.False(t, isProvided, "flag %q should not exist", flagName)
 
 	var testFlag bool
-	pflag.BoolVar(&testFlag, "testFlag", false, "")
+	pflag.BoolVar(&testFlag, flagName, false, "")
 
 	// Should return false as testFlag is not set
-	isProvided = IsFlagProvided("testFlag")
-	assert.False(t, isProvided, "expected IsFlagProvided to return false as no flag was provided, got true")
+	isProvided = IsFlagProvided(flagName)
+	assert.False(t, isProvided, "flag %q should not be provided", flagName)
 
 	pflag.Parse()
-	_ = pflag.Set("testFlag", "true")
+	_ = pflag.Set(flagName, "true")
 
 	// Should return true as testFlag is set
-	isProvided = IsFlagProvided("testFlag")
-	assert.True(t, isProvided, "expected IsFlagProvided to return true after providing the flag, got false")
+	isProvided = IsFlagProvided(flagName)
+	assert.True(t, isProvided, "flag %q should be provided", flagName)
 }
 
 func TestFilterTestFlags(t *testing.T) {
@@ -188,11 +189,11 @@ func TestParsed(t *testing.T) {
 	goflag.CommandLine = goflag.NewFlagSet("testGoflagSet", goflag.ExitOnError)
 
 	b := Parsed()
-	assert.False(t, b, "expected Parsed to return false as command-line flags weren't parsed, got true")
+	assert.False(t, b, "command-line flags should not be parsed")
 
 	pflag.Parse()
 	b = Parsed()
-	assert.True(t, b, "expected Parsed to return true as command-line flags were parsed, got false")
+	assert.True(t, b, "command-line flags should be parsed")
 }
 
 func TestLookup(t *testing.T) {
@@ -290,8 +291,8 @@ func TestIsZeroValue(t *testing.T) {
 	f := testFlagSet.Lookup("testflag")
 
 	result := isZeroValue(f, "")
-	assert.True(t, result, "expected isZeroValue to return true as empty string represents zero value for string flag, got false")
+	assert.True(t, result, "empty string should represent zero value for string flag")
 
 	result = isZeroValue(f, "anyValue")
-	assert.False(t, result, "expected isZeroValue to return false as non-empty string doesn't represent zero value for string flag, got true")
+	assert.False(t, result, "non-empty string should not represent zero value for string flag")
 }

--- a/go/internal/flag/flag_test.go
+++ b/go/internal/flag/flag_test.go
@@ -44,8 +44,8 @@ func TestPreventGlogVFlagFromClobberingVersionFlagShorthand(t *testing.T) {
 	assert.NotNil(t, f)
 	assert.Equal(t, "", f.Shorthand)
 
-	// The function should not throw any error if -v flag is already defined
-	PreventGlogVFlagFromClobberingVersionFlagShorthand(testFlagSet)
+	// The function should not panic if -v flag is already defined
+	assert.NotPanics(t, func() { PreventGlogVFlagFromClobberingVersionFlagShorthand(testFlagSet) })
 }
 
 func TestParse(t *testing.T) {
@@ -96,21 +96,21 @@ func TestIsFlagProvided(t *testing.T) {
 	pflag.CommandLine = pflag.NewFlagSet("testFlagSet", pflag.ExitOnError)
 
 	isProvided := IsFlagProvided("testFlag")
-	assert.False(t, isProvided)
+	assert.False(t, isProvided, "expected IsFlagProvided to return false as provided flag doesn't exist, got true")
 
 	var testFlag bool
 	pflag.BoolVar(&testFlag, "testFlag", false, "")
 
 	// Should return false as testFlag is not set
 	isProvided = IsFlagProvided("testFlag")
-	assert.False(t, isProvided)
+	assert.False(t, isProvided, "expected IsFlagProvided to return false as no flag was provided, got true")
 
 	pflag.Parse()
 	_ = pflag.Set("testFlag", "true")
 
 	// Should return true as testFlag is set
 	isProvided = IsFlagProvided("testFlag")
-	assert.True(t, isProvided)
+	assert.True(t, isProvided, "expected IsFlagProvided to return true after providing the flag, got false")
 }
 
 func TestFilterTestFlags(t *testing.T) {
@@ -188,11 +188,11 @@ func TestParsed(t *testing.T) {
 	goflag.CommandLine = goflag.NewFlagSet("testGoflagSet", goflag.ExitOnError)
 
 	b := Parsed()
-	assert.False(t, b)
+	assert.False(t, b, "expected Parsed to return false as command-line flags weren't parsed, got true")
 
 	pflag.Parse()
 	b = Parsed()
-	assert.True(t, b)
+	assert.True(t, b, "expected Parsed to return true as command-line flags were parsed, got false")
 }
 
 func TestLookup(t *testing.T) {
@@ -290,8 +290,8 @@ func TestIsZeroValue(t *testing.T) {
 	f := testFlagSet.Lookup("testflag")
 
 	result := isZeroValue(f, "")
-	assert.True(t, result)
+	assert.True(t, result, "expected isZeroValue to return true as empty string represents zero value for string flag, got false")
 
 	result = isZeroValue(f, "anyValue")
-	assert.False(t, result)
+	assert.False(t, result, "expected isZeroValue to return false as non-empty string doesn't represent zero value for string flag, got true")
 }

--- a/go/internal/flag/usage_test.go
+++ b/go/internal/flag/usage_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	goflag "flag"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetUsage(t *testing.T) {
+	fs := goflag.NewFlagSet("test", goflag.ExitOnError)
+	fs.String("testflag", "default", "`test` flag")
+
+	opts := UsageOptions{
+		Preface: func(w io.Writer) {
+			_, _ = w.Write([]byte("test preface"))
+		},
+		Epilogue: func(w io.Writer) {
+			_, _ = w.Write([]byte("test epilogue"))
+		},
+		FlagFilter: func(f *goflag.Flag) bool {
+			return f.Value.String() == "default"
+		},
+	}
+
+	SetUsage(fs, opts)
+
+	var builder strings.Builder
+	fs.SetOutput(&builder)
+
+	_ = fs.Set("testflag", "not default")
+	fs.Usage()
+
+	output := builder.String()
+	assert.NotContains(t, output, "test flag")
+
+	// Set the value back to default
+	_ = fs.Set("testflag", "default")
+	fs.Usage()
+	output = builder.String()
+
+	assert.Contains(t, output, "test preface")
+	assert.Contains(t, output, "--testflag test")
+	assert.Contains(t, output, "test epilogue")
+	assert.Contains(t, output, "test flag")
+}
+
+func TestSetUsageWithNilFlagFilterAndPreface(t *testing.T) {
+	oldOsArgs := os.Args
+	defer func() {
+		os.Args = oldOsArgs
+	}()
+
+	os.Args = []string{"testOsArg"}
+	fs := goflag.NewFlagSet("test", goflag.ExitOnError)
+	fs.String("testflag", "default", "`test` flag")
+
+	opts := UsageOptions{
+		Epilogue: func(w io.Writer) {
+			_, _ = w.Write([]byte("test epilogue"))
+		},
+	}
+
+	SetUsage(fs, opts)
+
+	var builder strings.Builder
+	fs.SetOutput(&builder)
+	fs.Usage()
+	output := builder.String()
+
+	assert.Contains(t, output, "Usage of testOsArg:")
+	assert.Contains(t, output, "--testflag test")
+	assert.Contains(t, output, "test epilogue")
+}
+
+type testBool struct{}
+
+func (t testBool) IsBoolFlag() bool {
+	return true
+}
+
+func (t testBool) String() string {
+	return "true"
+}
+
+func (t testBool) Set(s string) error {
+	return nil
+}
+
+func TestSetUsageWithBoolFlag(t *testing.T) {
+	fs := goflag.NewFlagSet("test2", goflag.ExitOnError)
+	fs.Var(testBool{}, "t", "`t` flag")
+
+	opts := UsageOptions{
+		Preface: func(w io.Writer) {
+			_, _ = w.Write([]byte("test preface"))
+		},
+		Epilogue: func(w io.Writer) {
+			_, _ = w.Write([]byte("test epilogue"))
+		},
+		FlagFilter: func(f *goflag.Flag) bool {
+			return f.Value.String() == "true"
+		},
+	}
+
+	SetUsage(fs, opts)
+
+	var builder strings.Builder
+	fs.SetOutput(&builder)
+	fs.Usage()
+	output := builder.String()
+
+	assert.Contains(t, output, "test preface")
+	assert.Contains(t, output, "-t\tt flag")
+}

--- a/go/internal/flag/usage_test.go
+++ b/go/internal/flag/usage_test.go
@@ -92,23 +92,10 @@ func TestSetUsageWithNilFlagFilterAndPreface(t *testing.T) {
 	assert.Contains(t, output, "test epilogue")
 }
 
-type testBool struct{}
-
-func (t testBool) IsBoolFlag() bool {
-	return true
-}
-
-func (t testBool) String() string {
-	return "true"
-}
-
-func (t testBool) Set(s string) error {
-	return nil
-}
-
 func TestSetUsageWithBoolFlag(t *testing.T) {
 	fs := goflag.NewFlagSet("test2", goflag.ExitOnError)
-	fs.Var(testBool{}, "t", "`t` flag")
+	var tBool bool
+	fs.BoolVar(&tBool, "t", true, "`t` flag")
 
 	opts := UsageOptions{
 		Preface: func(w io.Writer) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds required tests for `go/internal/flag`.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes part of #14931 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
