### PR TITLE
CI: Use FOSSA push-only token for license scans on PRs

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -34,17 +34,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run FOSSA scan and upload build data
-        # Fails on pull requests when using the API key secret.
-        # In order to run it on pull requests we would need to
-        # generate a push only token and specify that as plain
-        # text here:
-        #   https://github.com/fossa-contrib/fossa-action#push-only-api-token
-        # BUT, it also requires that the fork have its own
-        # independent integration setup with fossa.com.
-        if: github.ref == 'refs/heads/main'
         uses: fossa-contrib/fossa-action@v3
         with:
-          fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
+          # This is a push-only API token: https://github.com/fossa-contrib/fossa-action#push-only-api-token
+          fossa-api-key: f62c11ef0c249fef239947f01279aa0f
+          github-token: ${{ github.token }}
 
       - name: Check for changes in Go files
         if: steps.skip-workflow.outputs.skip-workflow == 'false'


### PR DESCRIPTION
## Description

Now that we have the FOSSA license scan working again on merges to main, let's enable the scan on PRs (opened using forks) again by leveraging a push-only token. You can see a successful run here: https://github.com/vitessio/vitess/actions/runs/7893049759/job/21540828304?pr=15222

This gets us back to where we were prior to having to disable it in https://github.com/vitessio/vitess/pull/14119.

## Related Issue(s)

  - Hopefully the last follow-up to: https://github.com/vitessio/vitess/pull/14119

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required