### PR TITLE
Tablet throttler: adding more stats

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_throttler.go
+++ b/go/vt/vttablet/tabletmanager/rpc_throttler.go
@@ -19,6 +19,7 @@ package tabletmanager
 import (
 	"context"
 
+	"vitess.io/vitess/go/stats"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -28,6 +29,7 @@ import (
 
 // CheckThrottler executes a throttler check
 func (tm *TabletManager) CheckThrottler(ctx context.Context, req *tabletmanagerdatapb.CheckThrottlerRequest) (*tabletmanagerdatapb.CheckThrottlerResponse, error) {
+	go stats.GetOrNewCounter("ThrottlerCheckRequest", "CheckThrottler requests").Add(1)
 	if req.AppName == "" {
 		req.AppName = throttlerapp.VitessName.String()
 	}

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -791,6 +791,7 @@ func (throttler *Throttler) generateTabletProbeFunction(ctx context.Context, clu
 			// We have just probed a tablet, and it reported back that someone just recently "check"ed it.
 			// We therefore renew the heartbeats lease.
 			throttler.requestHeartbeats()
+			go stats.GetOrNewCounter("ThrottlerProbeRecentlyChecked", "probe recently checked").Add(1)
 		}
 		return mySQLThrottleMetric
 	}
@@ -1186,6 +1187,7 @@ func (throttler *Throttler) checkStore(ctx context.Context, appName string, stor
 		// If this tablet is a REPLICA or RDONLY, we want to advertise to the PRIMARY that someone did a recent check,
 		// so that the PRIMARY knows it must renew the heartbeat lease.
 		checkResult.RecentlyChecked = true
+		go stats.GetOrNewCounter("ThrottlerRecentlyChecked", "recently checked").Add(1)
 	}
 
 	return checkResult

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -59,6 +59,7 @@ import (
 
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/protoutil"
+	"vitess.io/vitess/go/stats"
 
 	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/timer"
@@ -443,7 +444,7 @@ func (throttler *Throttler) Enable() *sync.WaitGroup {
 	throttler.Operate(ctx, wg)
 
 	// Make a one-time request for a lease of heartbeats
-	go throttler.heartbeatWriter.RequestHeartbeats()
+	throttler.requestHeartbeats()
 
 	return wg
 }
@@ -566,6 +567,13 @@ func (throttler *Throttler) Close() {
 		throttler.cancelOpenContext()
 	}
 	log.Infof("Throttler: finished execution of Close")
+}
+
+// requestHeartbeats sends a heartbeat lease request to the heartbeat writer.
+// This action is recorded in stats.
+func (throttler *Throttler) requestHeartbeats() {
+	go throttler.heartbeatWriter.RequestHeartbeats()
+	go stats.GetOrNewCounter("ThrottlerHeartbeatRequests", "heartbeat requests").Add(1)
 }
 
 func (throttler *Throttler) generateSelfMySQLThrottleMetricFunc(ctx context.Context, probe *mysql.Probe) func() *mysql.MySQLThrottleMetric {
@@ -708,7 +716,7 @@ func (throttler *Throttler) Operate(ctx context.Context, wg *sync.WaitGroup) {
 					if transitionedIntoLeader {
 						// transitioned into leadership, let's speed up the next 'refresh' and 'collect' ticks
 						go mysqlRefreshTicker.TickNow()
-						go throttler.heartbeatWriter.RequestHeartbeats()
+						throttler.requestHeartbeats()
 					}
 				}()
 			case <-mysqlCollectTicker.C:
@@ -782,7 +790,7 @@ func (throttler *Throttler) generateTabletProbeFunction(ctx context.Context, clu
 		if resp.RecentlyChecked {
 			// We have just probed a tablet, and it reported back that someone just recently "check"ed it.
 			// We therefore renew the heartbeats lease.
-			go throttler.heartbeatWriter.RequestHeartbeats()
+			throttler.requestHeartbeats()
 		}
 		return mySQLThrottleMetric
 	}
@@ -1017,7 +1025,7 @@ func (throttler *Throttler) ThrottleApp(appName string, expireAt time.Time, rati
 func (throttler *Throttler) UnthrottleApp(appName string) (appThrottle *base.AppThrottle) {
 	throttler.throttledApps.Delete(appName)
 	// the app is likely to check
-	go throttler.heartbeatWriter.RequestHeartbeats()
+	throttler.requestHeartbeats()
 	return base.NewAppThrottle(appName, time.Now(), 0, false)
 }
 
@@ -1164,7 +1172,7 @@ func (throttler *Throttler) checkStore(ctx context.Context, appName string, stor
 		return okMetricCheckResult
 	}
 	if !flags.SkipRequestHeartbeats && !throttlerapp.VitessName.Equals(appName) {
-		go throttler.heartbeatWriter.RequestHeartbeats()
+		throttler.requestHeartbeats()
 		// This check was made by someone other than the throttler itself, i.e. this came from online-ddl or vreplication or other.
 		// We mark the fact that someone just made a check. If this is a REPLICA or RDONLY tables, this will be reported back
 		// to the PRIMARY so that it knows it must renew the heartbeat lease.


### PR DESCRIPTION
## Description

Closes https://github.com/vitessio/vitess/issues/15223 by adding these counter metrics:

- `ThrottlerHeartbeatRequests`: incremented each time the throttler requests heartbeat lease (especially useful when `--heartbeat_on_demand_duration` is set).
- `ThrottlerRecentlyChecked`: for when a tablet's throttler is recently checked. This applies to any tablet type. For example, a vreplication `rowstream` could run on a particular replica. That replica would report itself as being "recently checked".
- `ThrottlerProbeRecentlyChecked`: for when a `PRIMARY` tablet throttler probes the shard tablets, and one of the probed tablets reports it has been "recently checked".
- `ThrottlerCheckRequest`: when a tablet receives a gRPC `CheckThrottler` call.

These metrics will help to pinpoint throttler behavior, and better understand the flow of requests.

## Related Issue(s)


- https://github.com/vitessio/vitess/issues/15223
- Docs PR: https://github.com/vitessio/website/pull/1690

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
