### PR TITLE
evalengine: Implement BIN, OCT & CHAR functions

### DIFF
--- a/go/mysql/fastparse/fastparse.go
+++ b/go/mysql/fastparse/fastparse.go
@@ -26,11 +26,19 @@ import (
 	"vitess.io/vitess/go/hack"
 )
 
+func ParseUint64(s string, base int) (uint64, error) {
+	return parseUint64(s, base, false)
+}
+
+func ParseUint64WithNeg(s string, base int) (uint64, error) {
+	return parseUint64(s, base, true)
+}
+
 // ParseUint64 parses uint64 from s.
 //
 // It is equivalent to strconv.ParseUint(s, base, 64) in case it succeeds,
 // but on error it will return the best effort value of what it has parsed so far.
-func ParseUint64(s string, base int) (uint64, error) {
+func parseUint64(s string, base int, allowNeg bool) (uint64, error) {
 	if len(s) == 0 {
 		return 0, fmt.Errorf("cannot parse uint64 from empty string")
 	}
@@ -43,6 +51,22 @@ func ParseUint64(s string, base int) (uint64, error) {
 			break
 		}
 		i++
+	}
+
+	if i >= uint(len(s)) {
+		return 0, fmt.Errorf("cannot parse uint64 from %q", s)
+	}
+	// For some reason, MySQL parses things as uint64 even with
+	// a negative sign and then turns it into the 2s complement value.
+	minus := s[i] == '-'
+	if minus {
+		if !allowNeg {
+			return 0, fmt.Errorf("cannot parse uint64 from %q", s)
+		}
+		i++
+		if i >= uint(len(s)) {
+			return 0, fmt.Errorf("cannot parse uint64 from %q", s)
+		}
 	}
 
 	d := uint64(0)
@@ -75,17 +99,23 @@ next:
 			cutoff = math.MaxUint64/uint64(base) + 1
 		}
 		if d >= cutoff {
+			if minus {
+				return 0, fmt.Errorf("cannot parse uint64 from %q: %w", s, ErrOverflow)
+			}
 			return math.MaxUint64, fmt.Errorf("cannot parse uint64 from %q: %w", s, ErrOverflow)
 		}
 		v := d*uint64(base) + uint64(b)
 		if v < d {
+			if minus {
+				return 0, fmt.Errorf("cannot parse uint64 from %q: %w", s, ErrOverflow)
+			}
 			return math.MaxUint64, fmt.Errorf("cannot parse uint64 from %q: %w", s, ErrOverflow)
 		}
 		d = v
 		i++
 	}
 	if i <= j {
-		return d, fmt.Errorf("cannot parse uint64 from %q", s)
+		return uValue(d, minus), fmt.Errorf("cannot parse uint64 from %q", s)
 	}
 
 	for i < uint(len(s)) {
@@ -97,9 +127,9 @@ next:
 
 	if i < uint(len(s)) {
 		// Unparsed tail left.
-		return d, fmt.Errorf("unparsed tail left after parsing uint64 from %q: %q", s, s[i:])
+		return uValue(d, minus), fmt.Errorf("unparsed tail left after parsing uint64 from %q: %q", s, s[i:])
 	}
-	return d, nil
+	return uValue(d, minus), nil
 }
 
 var ErrOverflow = errors.New("overflow")
@@ -260,4 +290,11 @@ func isSpace(c byte) bool {
 	default:
 		return false
 	}
+}
+
+func uValue(v uint64, neg bool) uint64 {
+	if neg {
+		return -v
+	}
+	return v
 }

--- a/go/mysql/fastparse/fastparse_test.go
+++ b/go/mysql/fastparse/fastparse_test.go
@@ -335,6 +335,17 @@ func TestParseUint64(t *testing.T) {
 			expected: 1,
 		},
 		{
+			input:    "-",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse uint64 from "-"`,
+		},
+		{
+			input: "-1",
+			base:  10,
+			err:   `cannot parse uint64 from "-1"`,
+		},
+		{
 			input:    "10",
 			base:     2,
 			expected: 2,
@@ -467,6 +478,61 @@ func TestParseUint64(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.input, func(t *testing.T) {
 			val, err := ParseUint64(tc.input, tc.base)
+			if tc.err == "" {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, val)
+			} else {
+				require.Equal(t, tc.expected, val)
+				require.EqualError(t, err, tc.err)
+			}
+		})
+	}
+}
+
+func TestParseUint64WithNeg(t *testing.T) {
+	testcases := []struct {
+		input    string
+		base     int
+		expected uint64
+		err      string
+	}{
+		{
+			input:    "-",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse uint64 from "-"`,
+		},
+		{
+			input:    "-1",
+			base:     10,
+			expected: 18446744073709551615,
+		},
+		{
+			input:    "-9223372036854775808",
+			base:     10,
+			expected: 9223372036854775808,
+		},
+		{
+			input:    "-9223372036854775809",
+			base:     10,
+			expected: 9223372036854775807,
+		},
+		{
+			input:    "-18446744073709551616",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse uint64 from "-18446744073709551616": overflow`,
+		},
+		{
+			input:    "-31415926535897932384",
+			base:     10,
+			expected: 0,
+			err:      `cannot parse uint64 from "-31415926535897932384": overflow`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.input, func(t *testing.T) {
+			val, err := ParseUint64WithNeg(tc.input, tc.base)
 			if tc.err == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, val)

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -571,6 +571,18 @@ func (cached *builtinChangeCase) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinChar) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinCharLength) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -2008,7 +2008,7 @@ func (asm *assembler) Fn_CONV_bu(offset int, baseOffset int) {
 		i, err := fastparse.ParseInt64(arg.string(), int(base.i))
 		u = uint64(i)
 		if errors.Is(err, fastparse.ErrOverflow) {
-			u, _ = fastparse.ParseUint64(arg.string(), int(base.i))
+			u, _ = fastparse.ParseUint64WithNeg(arg.string(), int(base.i))
 		}
 		env.vm.stack[env.vm.sp-offset] = env.vm.arena.newEvalUint64(u)
 		return 1

--- a/go/vt/vtgate/evalengine/fn_numeric.go
+++ b/go/vt/vtgate/evalengine/fn_numeric.go
@@ -1332,7 +1332,7 @@ func (call *builtinConv) eval(env *ExpressionEnv) (eval, error) {
 		i, err := fastparse.ParseInt64(nStr.string(), int(fromBase))
 		u = uint64(i)
 		if errors.Is(err, fastparse.ErrOverflow) {
-			u, _ = fastparse.ParseUint64(nStr.string(), int(fromBase))
+			u, _ = fastparse.ParseUint64WithNeg(nStr.string(), int(fromBase))
 		}
 	}
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -116,6 +116,7 @@ var Cases = []TestCase{
 	{Run: FnTruncate},
 	{Run: FnCrc32},
 	{Run: FnConv},
+	{Run: FnBin},
 	{Run: FnMD5},
 	{Run: FnSHA1},
 	{Run: FnSHA2},
@@ -661,6 +662,15 @@ func FnConv(yield Query) {
 				yield(fmt.Sprintf("CONV(%s, %s, %s)", num1, num2, num3), nil)
 			}
 		}
+	}
+}
+
+func FnBin(yield Query) {
+	for _, num := range radianInputs {
+		yield(fmt.Sprintf("BIN(%s)", num), nil)
+	}
+	for _, num := range inputBitwise {
+		yield(fmt.Sprintf("BIN(%s)", num), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -118,6 +118,7 @@ var Cases = []TestCase{
 	{Run: FnCrc32},
 	{Run: FnConv},
 	{Run: FnBin},
+	{Run: FnOct},
 	{Run: FnMD5},
 	{Run: FnSHA1},
 	{Run: FnSHA2},
@@ -672,6 +673,15 @@ func FnBin(yield Query) {
 	}
 	for _, num := range inputBitwise {
 		yield(fmt.Sprintf("BIN(%s)", num), nil)
+	}
+}
+
+func FnOct(yield Query) {
+	for _, num := range radianInputs {
+		yield(fmt.Sprintf("OCT(%s)", num), nil)
+	}
+	for _, num := range inputBitwise {
+		yield(fmt.Sprintf("OCT(%s)", num), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -85,6 +85,7 @@ var Cases = []TestCase{
 	{Run: FnLocate},
 	{Run: FnConcat},
 	{Run: FnConcatWs},
+	{Run: FnChar},
 	{Run: FnHex},
 	{Run: FnUnhex},
 	{Run: FnCeil},
@@ -1611,6 +1612,31 @@ func FnConcatWs(yield Query) {
 		for _, str2 := range inputStrings {
 			for _, str3 := range inputConversions {
 				yield(fmt.Sprintf("CONCAT_WS(%s, %s, %s)", str1, str2, str3), nil)
+			}
+		}
+	}
+}
+
+func FnChar(yield Query) {
+	mysqlDocSamples := []string{
+		`CHAR(77,121,83,81,'76')`,
+		`CHAR(77,77.3,'77.3')`,
+		`CHAR(77,121,83,81,'76' USING utf8mb4)`,
+		`CHAR(77,77.3,'77.3' USING utf8mb4)`,
+		`HEX(CHAR(1,0))`,
+		`HEX(CHAR(256))`,
+		`HEX(CHAR(1,0,0))`,
+		`HEX(CHAR(256*256)`,
+	}
+
+	for _, q := range mysqlDocSamples {
+		yield(q, nil)
+	}
+
+	for _, i1 := range radianInputs {
+		for _, i2 := range inputBitwise {
+			for _, i3 := range inputConversions {
+				yield(fmt.Sprintf("CHAR(%s, %s, %s)", i1, i2, i3), nil)
 			}
 		}
 	}

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -255,6 +255,14 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinConv{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "bin":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		args = append(args, NewLiteralInt(10))
+		args = append(args, NewLiteralInt(2))
+		var cexpr = CallExpr{Arguments: args, Method: "BIN"}
+		return &builtinConv{CallExpr: cexpr, collate: ast.cfg.Collation}, nil
 	case "left", "right":
 		if len(args) != 2 {
 			return nil, argError(method)

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -264,6 +264,14 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 		args = append(args, NewLiteralInt(2))
 		var cexpr = CallExpr{Arguments: args, Method: "BIN"}
 		return &builtinConv{CallExpr: cexpr, collate: ast.cfg.Collation}, nil
+	case "oct":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		args = append(args, NewLiteralInt(10))
+		args = append(args, NewLiteralInt(8))
+		var cexpr = CallExpr{Arguments: args, Method: "OCT"}
+		return &builtinConv{CallExpr: cexpr, collate: ast.cfg.Collation}, nil
 	case "left", "right":
 		if len(args) != 2 {
 			return nil, argError(method)


### PR DESCRIPTION
This implements `BIN(<val>)` as `CONV(<val>, 10, 2)`. It also fixes an edge case in uint64 parsing to match MySQL behavior that was exposed with new tests added for `BIN`. 

Also adds `OCT(<val>)` as `CONV(<val>, 10, 8)` and adds `CHAR` too. 

## Related Issue(s)

Part of #9647 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required