### PR TITLE
go1.22: remove outdated loopclosure captures in tests

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/query_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/query_test.go
@@ -25,12 +25,11 @@ import (
 
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/vtctl/schematools"
 
-	"vitess.io/vitess/go/test/utils"
-
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
-	"vitess.io/vitess/go/vt/proto/vttime"
+	vttimepb "vitess.io/vitess/go/vt/proto/vttime"
 )
 
 var now = time.Now()
@@ -86,7 +85,6 @@ func TestRowToSchemaMigration(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			out, err := rowToSchemaMigration(test.row)
 			if test.shouldErr {
@@ -110,7 +108,7 @@ func TestValueToVTTime(t *testing.T) {
 	tests := []struct {
 		name      string
 		value     string
-		expected  *vttime.Time
+		expected  *vttimepb.Time
 		shouldErr bool
 	}{
 		{
@@ -130,7 +128,6 @@ func TestValueToVTTime(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -153,7 +150,7 @@ func TestValueToVTDuration(t *testing.T) {
 		name        string
 		value       string
 		defaultUnit string
-		expected    *vttime.Duration
+		expected    *vttimepb.Duration
 		shouldErr   bool
 	}{
 		{
@@ -182,7 +179,6 @@ func TestValueToVTDuration(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			out, err := valueToVTDuration(test.value, test.defaultUnit)
 			if test.shouldErr {
@@ -197,6 +193,8 @@ func TestValueToVTDuration(t *testing.T) {
 }
 
 func TestAlterSchemaMigrationQuery(t *testing.T) {
+	t.Parallel()
+
 	uuid := "4e5dcf80_354b_11eb_82cd_f875a4d24e90"
 
 	tcases := []struct {
@@ -228,6 +226,8 @@ func TestAlterSchemaMigrationQuery(t *testing.T) {
 	for _, tcase := range tcases {
 		testName := fmt.Sprintf("%s %s", tcase.command, tcase.uuid)
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			query, err := alterSchemaMigrationQuery(tcase.command, tcase.uuid)
 			assert.NoError(t, err)
 			assert.Equal(t, tcase.expect, query)

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -1426,8 +1426,8 @@ func TestCancelSchemaMigration(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -1930,6 +1930,8 @@ func TestCleanupSchemaMigration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			ts := memorytopo.NewServer(ctx, "zone1")
@@ -2132,6 +2134,8 @@ func TestForceCutOverSchemaMigration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			ts := memorytopo.NewServer(ctx, "zone1")
@@ -2333,11 +2337,11 @@ func TestCompleteSchemaMigration(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-			ctx, Complete := context.WithCancel(context.Background())
-			defer Complete()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			ts := memorytopo.NewServer(ctx, "zone1")
 
 			testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{
@@ -5998,7 +6002,6 @@ func TestGetSchemaMigrations(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -7664,11 +7667,11 @@ func TestLaunchSchemaMigration(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-			ctx, Launch := context.WithCancel(context.Background())
-			defer Launch()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			ts := memorytopo.NewServer(ctx, "zone1")
 
 			testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -424,7 +424,6 @@ func TestVerifyTxThrottlerConfig(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION


## Description

Also parallelizes some tests and tidies up some imports while I'm here.

## Related Issue(s)

#15202 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
