### PR TITLE
vtexplain: Suppress duplicate `vtexplain` error messages

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -773,6 +773,8 @@ func (t *explainTablet) analyzeWhere(selStmt *sqlparser.Select, tableColumnMap m
 	return inColName, inVal, rowCount, nil, nil
 }
 
+var alreadyLogged = make(map[string]int)
+
 func (t *explainTablet) analyzeExpressions(selStmt *sqlparser.Select, tableColumnMap map[sqlparser.IdentifierCS]map[string]querypb.Type) ([]string, []querypb.Type) {
 	colNames := make([]string, 0, 4)
 	colTypes := make([]querypb.Type, 0, 4)
@@ -835,7 +837,11 @@ func inferColTypeFromExpr(node sqlparser.Expr, tableColumnMap map[sqlparser.Iden
 			}
 
 			if colType == querypb.Type_NULL_TYPE {
-				log.Errorf("vtexplain: invalid column %s.%s, tableColumnMap +%v", node.Qualifier.Name, col, tableColumnMap)
+				errorMessage := fmt.Sprintf("vtexplain: invalid column %s.%s, tableColumnMap +%v", node.Qualifier.Name, col, tableColumnMap)
+				if alreadyLogged[errorMessage] == 0 {
+					log.Errorf(errorMessage)
+				}
+				alreadyLogged[errorMessage]++
 			}
 
 			colNames = append(colNames, col)
@@ -847,7 +853,11 @@ func inferColTypeFromExpr(node sqlparser.Expr, tableColumnMap map[sqlparser.Iden
 			colType := colTypeMap[col]
 
 			if colType == querypb.Type_NULL_TYPE {
-				log.Errorf("vtexplain: invalid column %s.%s, tableColumnMap +%v", node.Qualifier.Name, col, tableColumnMap)
+				errorMessage := fmt.Sprintf("vtexplain: invalid column %s.%s, tableColumnMap +%v", node.Qualifier.Name, col, tableColumnMap)
+				if alreadyLogged[errorMessage] == 0 {
+					log.Errorf(errorMessage)
+				}
+				alreadyLogged[errorMessage]++
 			}
 
 			colNames = append(colNames, col)


### PR DESCRIPTION
## Description

`vtexplain` can generate many duplicate error messages, which can also slow execution (especially for batch jobs). This PR aims to suppress duplicate messages by outputting unique error messages once and only once.

The two error messages that tend to repeat are:
1. `vtexplain_vttablet.go:842] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]`, and
2. `throttler.go:510] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo`.

This is a bug fix, and I think the fix should be backported.

**Before**

```
W0129 12:42:18.665555   27941 http.go:57] Beginning in v20, pprof-http will default to `false`; to continue enabling pprof endpoints, please manually set this flag before upgrading.
E0129 12:42:18.717969   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.722407   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
E0129 12:42:18.731644   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.732837   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
E0129 12:42:18.738915   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.739785   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
E0129 12:42:18.746963   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.747931   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
E0129 12:42:18.754793   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.755805   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
E0129 12:42:18.761785   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.762973   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
E0129 12:42:18.772016   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.773177   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
E0129 12:42:18.780159   27941 vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0129 12:42:18.781245   27941 throttler.go:505] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
```

**After**
```
W0214 17:16:18.066363   32650 http.go:57] Beginning in v20, pprof-http will default to `false`; to continue enabling pprof endpoints, please manually set this flag before upgrading.
E0214 17:16:18.083682   32650 vtexplain_vttablet.go:842] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
E0214 17:16:18.090247   32650 throttler.go:510] Throttler.retryReadAndApplyThrottlerConfig(): error reading throttler config. Will retry in 10s. Err=node doesn't exist: cells/explainCell/CellInfo
```

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15242

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

N/A