### PR TITLE
Update toolchain version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.37.0


### PR DESCRIPTION
In recent Go versions, it can automatically pick up newer toolchain versions, but it means you have to use the right version number.

We had 1.22 here, but with 1.22.0 it can pick up the right one. See also https://github.com/golang/go/issues/62278#issuecomment-1933790368 for example.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required