### PR TITLE
go/vt/wrangler: pass reparent options structs

### DIFF
--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -78,13 +78,13 @@ func (wr *Wrangler) InitShardPrimary(ctx context.Context, keyspace, shard string
 func (wr *Wrangler) PlannedReparentShard(
 	ctx context.Context,
 	keyspace, shard string,
-	prsOp reparentutil.PlannedReparentOptions,
+	opts reparentutil.PlannedReparentOptions,
 ) (err error) {
 	_, err = reparentutil.NewPlannedReparenter(wr.ts, wr.tmc, wr.logger).ReparentShard(
 		ctx,
 		keyspace,
 		shard,
-		prsOp,
+		opts,
 	)
 
 	return err
@@ -92,12 +92,12 @@ func (wr *Wrangler) PlannedReparentShard(
 
 // EmergencyReparentShard will make the provided tablet the primary for
 // the shard, when the old primary is completely unreachable.
-func (wr *Wrangler) EmergencyReparentShard(ctx context.Context, keyspace, shard string, ersOp reparentutil.EmergencyReparentOptions) (err error) {
+func (wr *Wrangler) EmergencyReparentShard(ctx context.Context, keyspace, shard string, opts reparentutil.EmergencyReparentOptions) (err error) {
 	_, err = reparentutil.NewEmergencyReparenter(wr.ts, wr.tmc, wr.logger).ReparentShard(
 		ctx,
 		keyspace,
 		shard,
-		ersOp,
+		opts,
 	)
 
 	return err

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/event"
-	"vitess.io/vitess/go/sets"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools/events"
@@ -79,19 +78,13 @@ func (wr *Wrangler) InitShardPrimary(ctx context.Context, keyspace, shard string
 func (wr *Wrangler) PlannedReparentShard(
 	ctx context.Context,
 	keyspace, shard string,
-	primaryElectTabletAlias, avoidTabletAlias *topodatapb.TabletAlias,
-	waitReplicasTimeout, tolerableReplicationLag time.Duration,
+	prsOp reparentutil.PlannedReparentOptions,
 ) (err error) {
 	_, err = reparentutil.NewPlannedReparenter(wr.ts, wr.tmc, wr.logger).ReparentShard(
 		ctx,
 		keyspace,
 		shard,
-		reparentutil.PlannedReparentOptions{
-			AvoidPrimaryAlias:   avoidTabletAlias,
-			NewPrimaryAlias:     primaryElectTabletAlias,
-			WaitReplicasTimeout: waitReplicasTimeout,
-			TolerableReplLag:    tolerableReplicationLag,
-		},
+		prsOp,
 	)
 
 	return err
@@ -99,18 +92,12 @@ func (wr *Wrangler) PlannedReparentShard(
 
 // EmergencyReparentShard will make the provided tablet the primary for
 // the shard, when the old primary is completely unreachable.
-func (wr *Wrangler) EmergencyReparentShard(ctx context.Context, keyspace, shard string, primaryElectTabletAlias *topodatapb.TabletAlias, waitReplicasTimeout time.Duration, ignoredTablets sets.Set[string], preventCrossCellPromotion bool, waitForAllTablets bool) (err error) {
+func (wr *Wrangler) EmergencyReparentShard(ctx context.Context, keyspace, shard string, ersOp reparentutil.EmergencyReparentOptions) (err error) {
 	_, err = reparentutil.NewEmergencyReparenter(wr.ts, wr.tmc, wr.logger).ReparentShard(
 		ctx,
 		keyspace,
 		shard,
-		reparentutil.EmergencyReparentOptions{
-			NewPrimaryAlias:           primaryElectTabletAlias,
-			WaitReplicasTimeout:       waitReplicasTimeout,
-			IgnoreReplicas:            ignoredTablets,
-			PreventCrossCellPromotion: preventCrossCellPromotion,
-			WaitAllTablets:            waitForAllTablets,
-		},
+		ersOp,
 	)
 
 	return err

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/reparenttestutil"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
@@ -279,7 +280,13 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 	defer moreAdvancedReplica.StopActionLoop(t)
 
 	// run EmergencyReparentShard
-	err := wr.EmergencyReparentShard(ctx, newPrimary.Tablet.Keyspace, newPrimary.Tablet.Shard, newPrimary.Tablet.Alias, 10*time.Second, sets.New[string](), false, false)
+	err := wr.EmergencyReparentShard(ctx, newPrimary.Tablet.Keyspace, newPrimary.Tablet.Shard, reparentutil.EmergencyReparentOptions{
+		NewPrimaryAlias:           newPrimary.Tablet.Alias,
+		WaitAllTablets:            false,
+		WaitReplicasTimeout:       10 * time.Second,
+		IgnoreReplicas:            sets.New[string](),
+		PreventCrossCellPromotion: false,
+	})
 	cancel()
 
 	assert.NoError(t, err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

While updating some internal code I noticed that the PRS "tolerable replication lag" parameter had to be added to all call sites that use the wrangler. The function signature was difficult to parse beforehand due to length, and the complexity will increase as more parameters are added.

Use the reparentutil structs as arguments instead of constructing them inside the wrangler in order to make the options lists more legible and extensible.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

n/a, cleanup only.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

n/a

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
