### PR TITLE
WIP: MoveTables Cancel: sort table list taking into account FK order and drop tables in reverse order.

### DIFF
--- a/go/test/endtoend/vreplication/fk_config_test.go
+++ b/go/test/endtoend/vreplication/fk_config_test.go
@@ -21,16 +21,23 @@ var (
 create table parent(id int, name varchar(128), primary key(id)) engine=innodb;
 create table child(id int, parent_id int, name varchar(128), primary key(id), foreign key(parent_id) references parent(id) on delete cascade) engine=innodb;
 create view vparent as select * from parent;
+create table t1(id int, name varchar(128), primary key(id)) engine=innodb;
+create table t2(id int, t1id int, name varchar(128), primary key(id), foreign key(t1id) references t1(id) on delete cascade) engine=innodb;
 `
 	initialFKData = `
 insert into parent values(1, 'parent1'), (2, 'parent2');
-insert into child values(1, 1, 'child11'), (2, 1, 'child21'), (3, 2, 'child32');`
+insert into child values(1, 1, 'child11'), (2, 1, 'child21'), (3, 2, 'child32');
+insert into t1 values(1, 't11'), (2, 't12');
+insert into t2 values(1, 1, 't21'), (2, 1, 't22'), (3, 2, 't23');
+`
 
 	initialFKSourceVSchema = `
 {
   "tables": {
 	"parent": {},
-	"child": {}
+	"child": {},
+	"t1": {},
+	"t2": {}
   }
 }
 `
@@ -56,6 +63,22 @@ insert into child values(1, 1, 'child11'), (2, 1, 'child21'), (3, 2, 'child32');
       "column_vindexes": [
         {
           "column": "parent_id",
+          "name": "reverse_bits"
+        }
+      ]
+    },
+	"t1": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "reverse_bits"
+        }
+      ]
+    },
+	"t2": {
+      "column_vindexes": [
+        {
+          "column": "t1id",
           "name": "reverse_bits"
         }
       ]

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -34,6 +34,8 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
+const testWorkflowFlavor = workflowFlavorVtctl
+
 // TestFKWorkflow runs a MoveTables workflow with atomic copy for a db with foreign key constraints.
 // It inserts initial data, then simulates load. We insert both child rows with foreign keys and those without,
 // i.e. with foreign_key_checks=0.
@@ -95,7 +97,7 @@ func TestFKWorkflow(t *testing.T) {
 		},
 		sourceKeyspace: sourceKeyspace,
 		atomicCopy:     true,
-	}, workflowFlavorRandom)
+	}, testWorkflowFlavor)
 	mt.Create()
 
 	waitForWorkflowState(t, vc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String())
@@ -293,7 +295,7 @@ func testFKCancel(t *testing.T, vc *VitessCluster) {
 		},
 		sourceKeyspace: sourceKeyspace,
 		atomicCopy:     true,
-	}, workflowFlavorRandom)
+	}, testWorkflowFlavor)
 	mt.Create()
 	waitForWorkflowState(t, vc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String())
 	mt.Cancel()

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1395,7 +1395,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 	if vschema == nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no vschema found for target keyspace %s", targetKeyspace)
 	}
-	ksTables, err := getTablesInKeyspace(ctx, sourceTopo, s.tmc, sourceKeyspace)
+	ksTables, err := getTablesInKeyspace(ctx, sourceTopo, s.tmc, sourceKeyspace, s.env, req.AtomicCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -2596,18 +2596,15 @@ func (s *Server) buildTrafficSwitcher(ctx context.Context, targetKeyspace, workf
 				for _, rule := range bls.Filter.Rules {
 					ts.tables = append(ts.tables, rule.Match)
 				}
-				sort.Strings(ts.tables)
 			} else {
 				var tables []string
 				for _, rule := range bls.Filter.Rules {
 					tables = append(tables, rule.Match)
 				}
-				sort.Strings(tables)
 				if !reflect.DeepEqual(ts.tables, tables) {
 					return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "table lists are mismatched across streams: %v vs %v", ts.tables, tables)
 				}
 			}
-
 			if _, ok := ts.sources[bls.Shard]; ok {
 				continue
 			}

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -485,8 +485,9 @@ func (ts *trafficSwitcher) dropParticipatingTablesFromKeyspace(ctx context.Conte
 }
 
 func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType TableRemovalType) error {
+	log.Infof("Removing tables from source keyspaces")
 	err := ts.ForAllSources(func(source *MigrationSource) error {
-		for _, tableName := range ts.Tables() {
+		for _, tableName := range Reversed(ts.Tables()) {
 			primaryDbName, err := sqlescape.EnsureEscaped(source.GetPrimary().DbName())
 			if err != nil {
 				return err
@@ -1067,10 +1068,9 @@ func (ts *trafficSwitcher) dropSourceReverseVReplicationStreams(ctx context.Cont
 }
 
 func (ts *trafficSwitcher) removeTargetTables(ctx context.Context) error {
-	log.Flush()
 	err := ts.ForAllTargets(func(target *MigrationTarget) error {
 		log.Infof("ForAllTargets: %+v", target)
-		for _, tableName := range ts.Tables() {
+		for _, tableName := range Reversed(ts.Tables()) {
 			primaryDbName, err := sqlescape.EnsureEscaped(target.GetPrimary().DbName())
 			if err != nil {
 				return err

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -71,8 +71,7 @@ func SortTablesByForeignKeyConstraints(vtenv *vtenv.Environment, schema *tabletm
 }
 
 func Reversed[T any](s []T) []T {
-	reversed := make([]T, len(s))
-	copy(reversed, s)
+	reversed := slices.Clone(s)
 	slices.Reverse(reversed)
 	return reversed
 }

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/constants/sidecar"
-	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/discovery"
@@ -58,7 +57,6 @@ func (tm *TabletManager) CreateVReplicationWorkflow(ctx context.Context, req *ta
 	}
 	res := &sqltypes.Result{}
 	for _, bls := range req.BinlogSource {
-		protoutil.SortBinlogSourceTables(bls)
 		source, err := prototext.Marshal(bls)
 		if err != nil {
 			return nil, err

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -196,7 +196,7 @@ func TestCreateVReplicationWorkflow(t *testing.T) {
 				TargetKeyspace:     targetKs,
 				Workflow:           wf,
 				Cells:              tenv.cells,
-				IncludeTables:      []string{"zt", "wut", "t1"},
+				IncludeTables:      []string{"zt", "t1", "wut"},
 				SourceTimeZone:     "EDT",
 				OnDdl:              binlogdatapb.OnDDLAction_EXEC.String(),
 				StopAfterCopy:      true,
@@ -204,7 +204,7 @@ func TestCreateVReplicationWorkflow(t *testing.T) {
 				DeferSecondaryKeys: true,
 				AutoStart:          true,
 			},
-			query: fmt.Sprintf(`%s values ('%s', 'keyspace:\"%s\" shard:\"%s\" filter:{rules:{match:\"t1\" filter:\"select * from t1\"} rules:{match:\"wut\" filter:\"select * from wut\"} rules:{match:\"zt\" filter:\"select * from zt\"}} on_ddl:EXEC stop_after_copy:true source_time_zone:\"EDT\" target_time_zone:\"UTC\"', '', 0, 0, '%s', '', now(), 0, 'Stopped', '%s', 1, 0, 1)`,
+			query: fmt.Sprintf(`%s values ('%s', 'keyspace:\"%s\" shard:\"%s\" filter:{rules:{match:\"zt\" filter:\"select * from zt\"} rules:{match:\"t1\" filter:\"select * from t1\"} rules:{match:\"wut\" filter:\"select * from wut\"}} on_ddl:EXEC stop_after_copy:true source_time_zone:\"EDT\" target_time_zone:\"UTC\"', '', 0, 0, '%s', '', now(), 0, 'Stopped', '%s', 1, 0, 1)`,
 				insertVReplicationPrefix, wf, sourceKs, shard, tenv.cells[0], tenv.dbName),
 		},
 		{

--- a/go/vt/vttablet/tabletmanager/vreplication/insert_generator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/insert_generator.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/vt/throttler"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -52,7 +51,6 @@ func NewInsertGenerator(state binlogdatapb.VReplicationWorkflowState, dbname str
 // AddRow adds a row to the insert statement.
 func (ig *InsertGenerator) AddRow(workflow string, bls *binlogdatapb.BinlogSource, pos, cell, tabletTypes string,
 	workflowType binlogdatapb.VReplicationWorkflowType, workflowSubType binlogdatapb.VReplicationWorkflowSubType, deferSecondaryKeys bool) {
-	protoutil.SortBinlogSourceTables(bls)
 	fmt.Fprintf(ig.buf, "%s(%v, %v, %v, %v, %v, %v, %v, %v, 0, '%v', %v, %d, %d, %v)",
 		ig.prefix,
 		encodeString(workflow),


### PR DESCRIPTION

## Description

For `MoveTables` and source schemas with Foreign Keys, we need to drop tables in reverse order of constraint dependency when we drop tables on the target (on a `Cancel`) or source (on a `Complete`) with `keep-data` off.

The PR uses `schemadiff` to get the table order for `AtomicCopy` only at the moment (since that has to be specified for MoveTables with tables that utilize foreign keys). The entry in `_vt.vreplication` is then already in the correct order. While dropping tables, we need to reverse the list so that children are automatically dropped before parents.

This PR also changes the functionality implemented in https://github.com/vitessio/vitess/pull/15152 since that PR was not storing the tables originally in sorted order (in the `BinlogSource` column of `_vt.vreplication` but sorting it later on the fly during specific commands and in vdiffs. This will override any sorting we do upfront for foreign key constraints.


## Related Issue(s)

https://github.com/vitessio/vitess/issues/15232

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
