### PR TITLE
Ensure we send all Stream messages in a single go routine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
+	github.com/onsi/gomega v1.23.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/xlab/treeprint v1.2.0
@@ -158,7 +159,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
-	github.com/onsi/gomega v1.23.0 // indirect
 	github.com/outcaste-io/ristretto v0.2.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
+github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
+github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=

--- a/go/vt/vtgate/grpcvtgateservice/server_test.go
+++ b/go/vt/vtgate/grpcvtgateservice/server_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcvtgateservice
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/onsi/gomega/gleak/goroutine"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"vitess.io/vitess/go/sqltypes"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtgateservicepb "vitess.io/vitess/go/vt/proto/vtgateservice"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vtgate/vtgateservice"
+)
+
+type mockVtgateService struct{}
+
+func (m *mockVtgateService) Execute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable) (*vtgatepb.Session, *sqltypes.Result, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVtgateService) ExecuteBatch(ctx context.Context, session *vtgatepb.Session, sqlList []string, bindVariablesList []map[string]*querypb.BindVariable) (*vtgatepb.Session, []sqltypes.QueryResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+// StreamExecute in mockVtgateService calls the callback from two different go routines.
+func (m *mockVtgateService) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+	resOne := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|col", "int64|int64"), "1|1", "2|1")
+	resTwo := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|col", "int64|int64"), "1|1", "2|2")
+	var errOne, errTwo error
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		errOne = callback(resOne)
+		wg.Done()
+	}()
+	go func() {
+		errTwo = callback(resTwo)
+		wg.Done()
+	}()
+	wg.Wait()
+	if errOne != nil {
+		return session, errOne
+	}
+	return session, errTwo
+}
+
+func (m *mockVtgateService) Prepare(ctx context.Context, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable) (*vtgatepb.Session, []*querypb.Field, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVtgateService) CloseSession(ctx context.Context, session *vtgatepb.Session) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVtgateService) ResolveTransaction(ctx context.Context, dtid string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVtgateService) VStream(ctx context.Context, tabletType topodatapb.TabletType, vgtid *binlogdatapb.VGtid, filter *binlogdatapb.Filter, flags *vtgatepb.VStreamFlags, send func([]*binlogdatapb.VEvent) error) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVtgateService) HandlePanic(err *error) {}
+
+var _ vtgateservice.VTGateService = (*mockVtgateService)(nil)
+
+type mockStreamExecuteServer struct {
+	mu          sync.Mutex
+	goRoutineId uint64
+}
+
+// Send in mockStreamExecuteServer stores the go routine ID that it is called from.
+// If Send is called from 2 different go-routines, then it throws an error.
+func (m *mockStreamExecuteServer) Send(response *vtgatepb.StreamExecuteResponse) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	gr := goroutine.Current()
+	if m.goRoutineId == 0 {
+		m.goRoutineId = gr.ID
+	}
+	if gr.ID != m.goRoutineId {
+		return fmt.Errorf("two go routines are calling Send - %v and %v", gr.ID, m.goRoutineId)
+	}
+	return nil
+}
+
+func (m *mockStreamExecuteServer) SetHeader(md metadata.MD) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockStreamExecuteServer) SendHeader(md metadata.MD) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockStreamExecuteServer) SetTrailer(md metadata.MD) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockStreamExecuteServer) Context() context.Context {
+	return context.Background()
+}
+
+func (m *mockStreamExecuteServer) SendMsg(msg any) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockStreamExecuteServer) RecvMsg(msg any) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+var _ vtgateservicepb.Vitess_StreamExecuteServer = (*mockStreamExecuteServer)(nil)
+
+// TestVTGateStreamExecuteConcurrency tests that calling StreamExecute with a mock executor that calls
+// Send from 2 different go routines is safe.
+func TestVTGateStreamExecuteConcurrency(t *testing.T) {
+	testcases := []struct {
+		name        string
+		sendSession bool
+	}{
+		{
+			name:        "send session",
+			sendSession: true,
+		},
+		{
+			name:        "dont send session",
+			sendSession: false,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			oldVal := sendSessionInStreaming
+			defer func() {
+				sendSessionInStreaming = oldVal
+			}()
+			sendSessionInStreaming = tt.sendSession
+			vtg := &VTGate{
+				UnimplementedVitessServer: vtgateservicepb.UnimplementedVitessServer{},
+				server:                    &mockVtgateService{},
+			}
+			err := vtg.StreamExecute(&vtgatepb.StreamExecuteRequest{
+				CallerId: &vtrpcpb.CallerID{},
+				Query:    &querypb.BoundQuery{},
+			}, &mockStreamExecuteServer{
+				mu:          sync.Mutex{},
+				goRoutineId: 0,
+			})
+			require.NoError(t, err)
+		})
+	}
+
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue pointed out in https://github.com/vitessio/vitess/issues/14760#issuecomment-1945869133 after following up on https://github.com/vitessio/vitess/pull/14939#pullrequestreview-1872819017.

The proposed fix is to create a new struct that ensures that all the stream messages are sent from a single go routine. Tests have also been added to ensure that everywith works as intended.

## Related Issue(s)
- Fixes #14760 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
