### PR TITLE
`querylog`: json format version 2

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -270,6 +270,7 @@ Flags:
       --querylog-buffer-size int                                         Maximum number of buffered query logs before throttling log output (default 10)
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
+      --querylog-json-v2                                                 use v2 format for querylog-format=json
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -172,6 +172,7 @@ Flags:
       --querylog-buffer-size int                                         Maximum number of buffered query logs before throttling log output (default 10)
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
+      --querylog-json-v2                                                 use v2 format for querylog-format=json
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -263,6 +263,7 @@ Flags:
       --query-log-stream-handler string                                  URL handler for streaming queries log (default "/debug/querylog")
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
+      --querylog-json-v2                                                 use v2 format for querylog-format=json
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type

--- a/go/streamlog/bind_variable.go
+++ b/go/streamlog/bind_variable.go
@@ -33,6 +33,15 @@ func NewBindVariable(bv *querypb.BindVariable) BindVariable {
 	return BindVariable(*bv)
 }
 
+// NewBindVariables returns a string-map of wrapped *querypb.BindVariable objects.
+func NewBindVariables(bvs map[string]*querypb.BindVariable) map[string]BindVariable {
+	out := make(map[string]BindVariable, len(bvs))
+	for key, bindVar := range bvs {
+		out[key] = NewBindVariable(bindVar)
+	}
+	return out
+}
+
 // UnmarshalJSON unmarshals the custom BindVariable json-format.
 // See MarshalJSON for more information.
 func (bv *BindVariable) UnmarshalJSON(b []byte) error {

--- a/go/streamlog/bind_variable.go
+++ b/go/streamlog/bind_variable.go
@@ -69,9 +69,16 @@ func (bv *BindVariable) UnmarshalJSON(b []byte) error {
 //
 // This allows a *querypb.BindVariable that would have marshaled
 // to this:
-//   {"Type":10262,"Value":"FmtAtEq6S9Y="}
+//
+//	{"Type":10262,"Value":"FmtAtEq6S9Y="}
+//
 // to marshal to this:
-//   {"Type":"VARBINARY","Value":"FmtAtEq6S9Y="}
+//
+//	{"Type":"VARBINARY","Value":"FmtAtEq6S9Y="}
+//
+// or if query redaction is enabled, like this:
+//
+//	{"Type":"VARBINARY","Value":null}
 func (bv BindVariable) MarshalJSON() ([]byte, error) {
 	// convert querypb.Type integer to string and pass along Value.
 	out := map[string]interface{}{

--- a/go/streamlog/bind_variable.go
+++ b/go/streamlog/bind_variable.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streamlog
+
+import (
+	"encoding/json"
+	"errors"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var ErrUnrecognizedBindVarType = errors.New("unrecognized bind variable type")
+
+// BindVariable is a wrapper for marshal/unmarshaling querypb.BindVariable as json.
+type BindVariable querypb.BindVariable
+
+// NewBindVariable returns a wrapped *querypb.BindVariable object.
+func NewBindVariable(bv *querypb.BindVariable) BindVariable {
+	return BindVariable(*bv)
+}
+
+// UnmarshalJSON unmarshals the custom BindVariable json-format.
+// See MarshalJSON for more information.
+func (bv *BindVariable) UnmarshalJSON(b []byte) error {
+	in := struct {
+		Type  string
+		Value []byte
+	}{}
+	if err := json.Unmarshal(b, &in); err != nil {
+		return err
+	}
+	// convert type string to querypb.Type and pass along Value.
+	typeVal, found := querypb.Type_value[in.Type]
+	if !found {
+		return ErrUnrecognizedBindVarType
+	}
+	bv.Type = querypb.Type(typeVal)
+	bv.Value = in.Value
+	return nil
+}
+
+// MarshalJSON renders the wrapped *querypb.BindVariable as json. It
+// ensures that the "Type" field is a string representation of the
+// variable type instead of an integer-based code that is less
+// portable and human-readable.
+//
+// This allows a *querypb.BindVariable that would have marshaled
+// to this:
+//   {"Type":10262,"Value":"FmtAtEq6S9Y="}
+// to marshal to this:
+//   {"Type":"VARBINARY","Value":"FmtAtEq6S9Y="}
+func (bv BindVariable) MarshalJSON() ([]byte, error) {
+	// convert querypb.Type integer to string and pass along Value.
+	return json.Marshal(map[string]interface{}{
+		"Type":  bv.Type.String(),
+		"Value": bv.Value,
+	})
+}
+
+// BindVariablesToProto converts a string-map of BindVariable to a string-map of *querypb.BindVariable.
+func BindVariablesToProto(bvs map[string]BindVariable) map[string]*querypb.BindVariable {
+	out := make(map[string]*querypb.BindVariable, len(bvs))
+	for key, bindVar := range bvs {
+		bv := querypb.BindVariable(bindVar)
+		out[key] = &bv
+	}
+	return out
+}

--- a/go/streamlog/bind_variable.go
+++ b/go/streamlog/bind_variable.go
@@ -74,10 +74,14 @@ func (bv *BindVariable) UnmarshalJSON(b []byte) error {
 //   {"Type":"VARBINARY","Value":"FmtAtEq6S9Y="}
 func (bv BindVariable) MarshalJSON() ([]byte, error) {
 	// convert querypb.Type integer to string and pass along Value.
-	return json.Marshal(map[string]interface{}{
+	out := map[string]interface{}{
 		"Type":  bv.Type.String(),
 		"Value": bv.Value,
-	})
+	}
+	if GetRedactDebugUIQueries() {
+		out["Value"] = nil
+	}
+	return json.Marshal(out)
 }
 
 // BindVariablesToProto converts a string-map of BindVariable to a string-map of *querypb.BindVariable.

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -51,6 +51,7 @@ var (
 	queryLogFilterTag    string
 	queryLogRowThreshold uint64
 	queryLogFormat       = "text"
+	queryLogJSONV2       bool
 )
 
 func GetRedactDebugUIQueries() bool {
@@ -77,6 +78,14 @@ func SetQueryLogFormat(newQueryLogFormat string) {
 	queryLogFormat = newQueryLogFormat
 }
 
+func UseQueryLogJSONV2() bool {
+	return queryLogJSONV2
+}
+
+func SetQueryLogJSONV2(enabled bool) {
+	queryLogJSONV2 = enabled
+}
+
 func init() {
 	servenv.OnParseFor("vtcombo", registerStreamLogFlags)
 	servenv.OnParseFor("vttablet", registerStreamLogFlags)
@@ -89,6 +98,9 @@ func registerStreamLogFlags(fs *pflag.FlagSet) {
 
 	// QueryLogFormat controls the format of the query log (either text or json)
 	fs.StringVar(&queryLogFormat, "querylog-format", queryLogFormat, "format for query logs (\"text\" or \"json\")")
+
+	// QueryLogJSONFormat controls whether the new querylog json format is used
+	fs.BoolVar(&queryLogJSONV2, "querylog-json-v2", false, "use v2 format for querylog-format=json")
 
 	// QueryLogFilterTag contains an optional string that must be present in the query for it to be logged
 	fs.StringVar(&queryLogFilterTag, "querylog-filter-tag", queryLogFilterTag, "string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization")

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1093,7 +1093,7 @@ func (e *Executor) getPlan(
 	}
 
 	logStats.SQL = comments.Leading + query + comments.Trailing
-	logStats.BindVariables = sqltypes.CopyBindVariables(bindVars)
+	logStats.BindVariables = streamlog.NewBindVariables(sqltypes.CopyBindVariables(bindVars))
 
 	return e.cacheAndBuildStatement(ctx, vcursor, query, stmt, reservedVars, bindVarNeeds, logStats)
 }

--- a/go/vt/vtgate/logstats/logstats.go
+++ b/go/vt/vtgate/logstats/logstats.go
@@ -144,15 +144,13 @@ func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
 	}()
 
 	formattedBindVars := "\"[REDACTED]\""
-	if !streamlog.GetRedactDebugUIQueries() {
+	if !streamlog.GetRedactDebugUIQueries() && !streamlog.UseQueryLogJSONV2() {
 		_, fullBindParams := params["full"]
 		formattedBindVars = sqltypes.FormatBindVariables(
 			streamlog.BindVariablesToProto(stats.BindVariables),
 			fullBindParams,
 			streamlog.GetQueryLogFormat() == streamlog.QueryLogFormatJSON,
 		)
-	} else {
-		stats.BindVariables = nil
 	}
 
 	// TODO: remove username here we fully enforce immediate caller id

--- a/go/vt/vtgate/logstats/logstats.go
+++ b/go/vt/vtgate/logstats/logstats.go
@@ -146,8 +146,12 @@ func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
 	formattedBindVars := "\"[REDACTED]\""
 	if !streamlog.GetRedactDebugUIQueries() && !streamlog.UseQueryLogJSONV2() {
 		_, fullBindParams := params["full"]
+		bindVarsProto, err := streamlog.BindVariablesToProto(stats.BindVariables)
+		if err != nil {
+			return err
+		}
 		formattedBindVars = sqltypes.FormatBindVariables(
-			streamlog.BindVariablesToProto(stats.BindVariables),
+			bindVarsProto,
 			fullBindParams,
 			streamlog.GetQueryLogFormat() == streamlog.QueryLogFormatJSON,
 		)

--- a/go/vt/vtgate/logstats/logstats.go
+++ b/go/vt/vtgate/logstats/logstats.go
@@ -69,16 +69,12 @@ type LogStatsJSON struct {
 // NewLogStats constructs a new LogStats with supplied Method and ctx
 // field values, and the StartTime field set to the present time.
 func NewLogStats(ctx context.Context, methodName, sql, sessionUUID string, bindVars map[string]*querypb.BindVariable) *LogStats {
-	parsedBindVars := make(map[string]streamlog.BindVariable, len(bindVars))
-	for key, bindVar := range bindVars {
-		parsedBindVars[key] = streamlog.NewBindVariable(bindVar)
-	}
 	return &LogStats{
 		Ctx:           ctx,
 		Method:        methodName,
 		SQL:           sql,
 		SessionUUID:   sessionUUID,
-		BindVariables: parsedBindVars,
+		BindVariables: streamlog.NewBindVariables(bindVars),
 		StartTime:     time.Now(),
 	}
 }

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -189,7 +189,7 @@ func TestLogStatsFormatJSONV2(t *testing.T) {
 		streamlog.SetRedactDebugUIQueries(true)
 		var buf bytes.Buffer
 		assert.Nil(t, logStats.Logf(&buf, nil))
-		assert.Equal(t, `{"RemoteAddr":"","Username":"","ImmediateCaller":"","EffectiveCaller":"","Method":"test","TabletType":"PRIMARY","StmtType":"select","SQL":"select * from testtable where name = :strVal and message = :bytesVal","StartTime":"2017-01-01T01:02:03Z","EndTime":"2017-01-01T01:02:04.000001234Z","ShardQueries":0,"RowsAffected":0,"RowsReturned":0,"PlanTime":0,"ExecuteTime":0,"CommitTime":0,"TablesUsed":["ks1.tbl1","ks2.tbl2"],"SessionUUID":"suuid","CachedPlan":false,"ActiveKeyspace":"db"}`, strings.TrimSpace(buf.String()))
+		assert.Equal(t, `{"RemoteAddr":"","Username":"","ImmediateCaller":"","EffectiveCaller":"","Method":"test","TabletType":"PRIMARY","StmtType":"select","SQL":"select * from testtable where name = :strVal and message = :bytesVal","BindVariables":{"bytesVal":{"Type":"VARBINARY","Value":null},"strVal":{"Type":"VARCHAR","Value":null}},"StartTime":"2017-01-01T01:02:03Z","EndTime":"2017-01-01T01:02:04.000001234Z","ShardQueries":0,"RowsAffected":0,"RowsReturned":0,"PlanTime":0,"ExecuteTime":0,"CommitTime":0,"TablesUsed":["ks1.tbl1","ks2.tbl2"],"SessionUUID":"suuid","CachedPlan":false,"ActiveKeyspace":"db"}`, strings.TrimSpace(buf.String()))
 		assert.Nil(t, json.Unmarshal(buf.Bytes(), &cmpStats))
 	}
 }

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -179,9 +179,9 @@ func TestLogStatsFormatJSONV2(t *testing.T) {
 		assert.Nil(t, logStats.Logf(&buf, nil))
 		assert.Equal(t, `{"RemoteAddr":"","Username":"","ImmediateCaller":"","EffectiveCaller":"","Method":"test","TabletType":"PRIMARY","StmtType":"select","SQL":"select * from testtable where name = :strVal and message = :bytesVal","BindVariables":{"bytesVal":{"Type":"VARBINARY","Value":"FmtAtEq6S9Y="},"strVal":{"Type":"VARCHAR","Value":"YWJj"}},"StartTime":"2017-01-01T01:02:03Z","EndTime":"2017-01-01T01:02:04.000001234Z","ShardQueries":0,"RowsAffected":0,"RowsReturned":0,"PlanTime":0,"ExecuteTime":0,"CommitTime":0,"TablesUsed":["ks1.tbl1","ks2.tbl2"],"SessionUUID":"suuid","CachedPlan":false,"ActiveKeyspace":"db"}`, strings.TrimSpace(buf.String()))
 		assert.Nil(t, json.Unmarshal(buf.Bytes(), &cmpStats))
-		assert.Equal(t, querypb.Type_VARBINARY, cmpStats.BindVariables["bytesVal"].Type)
+		assert.Equal(t, "VARBINARY", cmpStats.BindVariables["bytesVal"].Type)
 		assert.Equal(t, []byte("\x16k@\xb4J\xbaK\xd6"), cmpStats.BindVariables["bytesVal"].Value)
-		assert.Equal(t, querypb.Type_VARCHAR, cmpStats.BindVariables["strVal"].Type)
+		assert.Equal(t, "VARCHAR", cmpStats.BindVariables["strVal"].Type)
 		assert.Equal(t, []byte("abc"), cmpStats.BindVariables["strVal"].Value)
 	}
 	{

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -199,8 +199,12 @@ func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
 	formattedBindVars := "\"[REDACTED]\""
 	if !streamlog.GetRedactDebugUIQueries() && !streamlog.UseQueryLogJSONV2() {
 		_, fullBindParams := params["full"]
+		bindVarsProto, err := streamlog.BindVariablesToProto(stats.BindVariables)
+		if err != nil {
+			return err
+		}
 		formattedBindVars = sqltypes.FormatBindVariables(
-			streamlog.BindVariablesToProto(stats.BindVariables),
+			bindVarsProto,
 			fullBindParams,
 			streamlog.GetQueryLogFormat() == streamlog.QueryLogFormatJSON,
 		)

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -33,8 +33,6 @@ import (
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callinfo"
 	"vitess.io/vitess/go/vt/callinfo/fakecallinfo"
-
-	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 func TestLogStats(t *testing.T) {
@@ -221,9 +219,9 @@ func TestLogStatsFormatJSONV2(t *testing.T) {
 		assert.Nil(t, logStats.Logf(&buf, nil))
 		assert.Equal(t, `{"CallInfo":"","Username":"","ImmediateCaller":"","EffectiveCaller":"","RewrittenSQL":"sql with pii","TotalTime":1000001234,"ResponseSize":1,"Method":"test","PlanType":"","OriginalSQL":"sql","BindVariables":{"bytesVal":{"Type":"VARBINARY","Value":"FmtAtEq6S9Y="},"intVal":{"Type":"INT64","Value":"MQ=="}},"RowsAffected":0,"NumberOfQueries":1,"StartTime":"2017-01-01T01:02:03Z","EndTime":"2017-01-01T01:02:04.000001234Z","MysqlResponseTime":0,"WaitingForConnection":0,"QuerySources":2,"TransactionID":12345,"ReservedID":0,"CachedPlan":false}`, strings.TrimSpace(buf.String()))
 		assert.Nil(t, json.Unmarshal(buf.Bytes(), &cmpStats))
-		assert.Equal(t, querypb.Type_VARBINARY, cmpStats.BindVariables["bytesVal"].Type)
+		assert.Equal(t, "VARBINARY", cmpStats.BindVariables["bytesVal"].Type)
 		assert.Equal(t, []byte("\x16k@\xb4J\xbaK\xd6"), cmpStats.BindVariables["bytesVal"].Value)
-		assert.Equal(t, querypb.Type_INT64, cmpStats.BindVariables["intVal"].Type)
+		assert.Equal(t, "INT64", cmpStats.BindVariables["intVal"].Type)
 		assert.Equal(t, []byte("1"), cmpStats.BindVariables["intVal"].Value)
 	}
 	{

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -231,7 +231,7 @@ func TestLogStatsFormatJSONV2(t *testing.T) {
 		streamlog.SetRedactDebugUIQueries(true)
 		var buf bytes.Buffer
 		assert.Nil(t, logStats.Logf(&buf, nil))
-		assert.Equal(t, `{"CallInfo":"","Username":"","ImmediateCaller":"","EffectiveCaller":"","RewrittenSQL":"[REDACTED]","TotalTime":1000001234,"ResponseSize":1,"Method":"test","PlanType":"","OriginalSQL":"sql","RowsAffected":0,"NumberOfQueries":1,"StartTime":"2017-01-01T01:02:03Z","EndTime":"2017-01-01T01:02:04.000001234Z","MysqlResponseTime":0,"WaitingForConnection":0,"QuerySources":2,"TransactionID":12345,"ReservedID":0,"CachedPlan":false}`, strings.TrimSpace(buf.String()))
+		assert.Equal(t, `{"CallInfo":"","Username":"","ImmediateCaller":"","EffectiveCaller":"","RewrittenSQL":"[REDACTED]","TotalTime":1000001234,"ResponseSize":1,"Method":"test","PlanType":"","OriginalSQL":"sql","BindVariables":{"bytesVal":{"Type":"VARBINARY","Value":null},"intVal":{"Type":"INT64","Value":null}},"RowsAffected":0,"NumberOfQueries":1,"StartTime":"2017-01-01T01:02:03Z","EndTime":"2017-01-01T01:02:04.000001234Z","MysqlResponseTime":0,"WaitingForConnection":0,"QuerySources":2,"TransactionID":12345,"ReservedID":0,"CachedPlan":false}`, strings.TrimSpace(buf.String()))
 		assert.Nil(t, json.Unmarshal(buf.Bytes(), &cmpStats))
 	}
 }

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -38,6 +38,7 @@ import (
 	"vitess.io/vitess/go/pools/smartconnpool"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/tb"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/callerid"
@@ -1546,7 +1547,7 @@ func (tsv *TabletServer) execRequest(
 	logStats := tabletenv.NewLogStats(ctx, requestName)
 	logStats.Target = target
 	logStats.OriginalSQL = sql
-	logStats.BindVariables = sqltypes.CopyBindVariables(bindVariables)
+	logStats.BindVariables = streamlog.NewBindVariables(sqltypes.CopyBindVariables(bindVariables))
 	defer tsv.handlePanicAndSendLogStats(sql, bindVariables, logStats)
 
 	if err = tsv.sm.StartRequest(ctx, target, allowOnShutdown); err != nil {


### PR DESCRIPTION
## Description

This PR adds a new version 2.0 format for `--querylog-format=json`. This new format is opt-in with the flag `--querylog-json-v2`, however I propose the new format replaces the current format in later releases

The motivation is to resolve cases where the [current format produces invalid JSON](https://github.com/vitessio/vitess/issues/12872) caused by certain bind variables values that break `json`'s spec _(bug confirmed/identified by Vinted and Slack in prod - [Slack :thread:](https://vitess.slack.com/archives/CMDJ2KFEZ/p1687883596023629))_

The version 2.0 format resolves the bind-variable breakage by letting `encoding/json` library marshal the `[]byte` value as base64, which is default behaviour in the library. The original implementation builds json manually using `fmt.Sprintf(...)`, printing `[]byte` as `%q`, which explains how we got here. The new format is a breaking change to users of `--querylog-format=json`, however, which is why I added this behind a flag

Breaking changes:
- Bind variable values are base64 encoded _(transparently by `encoding/json`)_
    - Resolves https://github.com/vitessio/vitess/issues/12872
    - Users reading querylogs with Go's `encoding/json` + unmarshal using the `LogStatsJSON` struct _(or the value field only as `[]byte`)_ won't need to know it was base64
    - Users reading querylogs from other languages will need to be aware of the base64 encoding of bind var values, but I think that is unavoidable
- `Effective Caller` field renamed to `EffectiveCaller`, to be consistent with `ImmediateCaller` and other camel-cased fields
    - Also spaces in json keys is kind of gross 😄 
- `Start` and `End` renamed to `StartTime` and `EndTime` respectively, for clarity and to be consistent with the other `Time`-suffixed vars _(eg: `PlanTime`/`ExecuteTime`)_
- Pre-existing `CachedPlan` key/value added to new `vttablet` format
- The order of the key/values changed
- When certain values are `nil`/`""` they are not added to the json _(via `json:",omitempty"`)_

The existing `text` and `json` _(without `--querylog-json-v2` flag)_ formats should be unaffected by this change

Example `vtgate` log _(pretty-printed, without redaction)_:
```json
{
  "RemoteAddr": "<ADDR HERE>",
  "Username": "<USERNAME HERE>",
  "ImmediateCaller": "<CALLER HERE>",
  "EffectiveCaller": "<CALLER HERE>",
  "Method": "test",
  "TabletType": "PRIMARY",
  "StmtType": "select",
  "SQL": "select * from testtable where name = :strVal and message = :bytesVal",
  "BindVariables": {
    "bytesVal": {
      "Type": "VARBINARY",
      "Value": "FmtAtEq6S9Y="
    },
    "strVal": {
      "Type": "VARCHAR",
      "Value": "YWJj"
    }
  },
  "StartTime": "2017-01-01T01:02:03Z",
  "EndTime": "2017-01-01T01:02:04.000001234Z",
  "ShardQueries": 0,
  "RowsAffected": 0,
  "RowsReturned": 0,
  "PlanTime": 0,
  "ExecuteTime": 0,
  "CommitTime": 0,
  "TablesUsed": [
    "ks1.tbl1",
    "ks2.tbl2"
  ],
  "SessionUUID": "suuid",
  "CachedPlan": false,
  "ActiveKeyspace": "db"
}
```

Example `vttablet` log _(pretty-printed, without redaction)_:
```json
{
  "CallInfo": "<INFO HERE>",
  "Username": "<USERNAME HERE>",
  "ImmediateCaller": "<CALLER HERE>",
  "EffectiveCaller": "<CALLER HERE>",
  "RewrittenSQL": "sql with pii",
  "TotalTime": 1000001234,
  "ResponseSize": 1,
  "Method": "test",
  "PlanType": "",
  "OriginalSQL": "sql",
  "BindVariables": {
    "bytesVal": {
      "Type": "VARBINARY",
      "Value": "FmtAtEq6S9Y="
    },
    "intVal": {
      "Type": "INT64",
      "Value": "MQ=="
    }
  },
  "RowsAffected": 0,
  "NumberOfQueries": 1,
  "StartTime": "2017-01-01T01:02:03Z",
  "EndTime": "2017-01-01T01:02:04.000001234Z",
  "MysqlResponseTime": 0,
  "WaitingForConnection": 0,
  "QuerySources": 2,
  "TransactionID": 12345,
  "ReservedID": 0,
  "CachedPlan": false
}
```

## Related Issue(s)

1. https://github.com/vitessio/vitess/issues/12872
2. https://github.com/vitessio/vitess/pull/12988

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
