### PR TITLE
Suppress invalid column errors in `vtexplain`

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -834,7 +834,7 @@ func inferColTypeFromExpr(node sqlparser.Expr, tableColumnMap map[sqlparser.Iden
 				}
 			}
 
-			if colType == querypb.Type_NULL_TYPE {
+			if colType == querypb.Type_NULL_TYPE && col != "column_name" {
 				log.Errorf("vtexplain: invalid column %s.%s, tableColumnMap +%v", node.Qualifier.Name, col, tableColumnMap)
 			}
 
@@ -846,7 +846,7 @@ func inferColTypeFromExpr(node sqlparser.Expr, tableColumnMap map[sqlparser.Iden
 			col := strings.ToLower(node.Name.String())
 			colType := colTypeMap[col]
 
-			if colType == querypb.Type_NULL_TYPE {
+			if colType == querypb.Type_NULL_TYPE && col != "column_name" {
 				log.Errorf("vtexplain: invalid column %s.%s, tableColumnMap +%v", node.Qualifier.Name, col, tableColumnMap)
 			}
 


### PR DESCRIPTION
## Description

This PR suppresses unwanted `invalid column` errors in `vtexplain`.

After [changing the way we encode queries](https://github.com/vitessio/vitess/commit/2702da2fb2ed717c47f3971bc2e9c75aa7700ce0), `vtexplain` started showing these errors on routine executions:

```
vtexplain_vttablet.go:838] vtexplain: invalid column .column_name, tableColumnMap +map[:map[]]
```

This repeated error causes `vtexplain` to significantly slow down. We get this error whenever the following query is executed:

```sql
SELECT COLUMN_NAME as column_name
FROM INFORMATION_SCHEMA.COLUMNS
WHERE TABLE_SCHEMA = database() AND TABLE_NAME = 'table_name_being_vtexplained'
ORDER BY ORDINAL_POSITION
```

Previously, the above query evaluated to:

```
&{[name:"column_type" type:VARCHAR] %!s(uint64=0) %!s(uint64=0) [[VARCHAR("id")] [VARCHAR("next_id")] [VARCHAR("cache")]]  %!s(uint16=0) }
```

After the [change](https://github.com/vitessio/vitess/commit/2702da2fb2ed717c47f3971bc2e9c75aa7700ce0), the query evaluates to:

```
&{[name:"column_name"] %!s(uint64=0) %!s(uint64=0) [[NULL]]  %!s(uint16=0) }
```

and importantly, is now classified as a `SELECT`:

https://github.com/vitessio/vitess/blob/54c6dfc05c5ca5d88a4f2b23ad7a8914832e855c/go/vt/vtexplain/vtexplain_vttablet.go#L577-L583

`handleSelect` kicks off a series of steps, including inferring the column type, which is `null` after the [change](https://github.com/vitessio/vitess/commit/2702da2fb2ed717c47f3971bc2e9c75aa7700ce0).

This PR adds logic such that if we are in the special case of a `null` column type and the column name is `column_name`, do not log an error. Not logging an error reduces `vtexplain`'s runtime by several factors.

This is a bug fix, and I think it should be backported.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/15242

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

N/A