### PR TITLE
evalengine: Implement REPLACE

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1463,6 +1463,18 @@ func (cached *builtinRepeat) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinReplace) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinReverse) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3022,6 +3022,19 @@ func (asm *assembler) Locate2(collation colldata.Collation) {
 	}, "LOCATE VARCHAR(SP-2), VARCHAR(SP-1) COLLATE '%s'", collation.Name())
 }
 
+func (asm *assembler) Replace() {
+	asm.adjustStack(-2)
+
+	asm.emit(func(env *ExpressionEnv) int {
+		str := env.vm.stack[env.vm.sp-3].(*evalBytes)
+		from := env.vm.stack[env.vm.sp-2].(*evalBytes)
+		to := env.vm.stack[env.vm.sp-1].(*evalBytes)
+		env.vm.sp -= 2
+		str.bytes = replace(str.bytes, from.bytes, to.bytes)
+		return 1
+	}, "REPLACE VARCHAR(SP-3), VARCHAR(SP-2) VARCHAR(SP-1)")
+}
+
 func (asm *assembler) Strcmp(collation collations.TypedCollation) {
 	asm.adjustStack(-1)
 

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -627,6 +627,10 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `locate("", "😊😂🤢", 3)`,
 			result:     `INT64(3)`,
 		},
+		{
+			expression: `REPLACE('www.mysql.com', '', 'Ww')`,
+			result:     `VARCHAR("www.mysql.com")`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -83,6 +83,7 @@ var Cases = []TestCase{
 	{Run: FnTrim},
 	{Run: FnSubstr},
 	{Run: FnLocate},
+	{Run: FnReplace},
 	{Run: FnConcat},
 	{Run: FnConcatWs},
 	{Run: FnChar},
@@ -1572,6 +1573,33 @@ func FnLocate(yield Query) {
 
 			for _, i := range radianInputs {
 				yield(fmt.Sprintf("LOCATE(%s, %s, %s)", substr, str, i), nil)
+			}
+		}
+	}
+}
+
+func FnReplace(yield Query) {
+	cases := []string{
+		`REPLACE('www.mysql.com', 'w', 'Ww')`,
+		// MySQL doesn't do collation matching for replace, only
+		// byte equivalence, but make sure to check.
+		`REPLACE('straße', 'ss', 'b')`,
+		`REPLACE('straße', 'ß', 'b')`,
+		// From / to strings are converted into the collation of
+		// the input string.
+		`REPLACE('fooÿbar', _latin1 0xFF, _latin1 0xFE)`,
+		// First occurence is replaced
+		`replace('fff', 'ff', 'gg')`,
+	}
+
+	for _, q := range cases {
+		yield(q, nil)
+	}
+
+	for _, substr := range inputStrings {
+		for _, str := range inputStrings {
+			for _, i := range inputStrings {
+				yield(fmt.Sprintf("REPLACE(%s, %s, %s)", substr, str, i), nil)
 			}
 		}
 	}

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -627,6 +627,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 		}
 		call = CallExpr{Arguments: []IR{call.Arguments[1], call.Arguments[0]}, Method: method}
 		return &builtinLocate{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "replace":
+		if len(args) != 3 {
+			return nil, argError(method)
+		}
+		return &builtinReplace{CallExpr: call, collate: ast.cfg.Collation}, nil
 	default:
 		return nil, translateExprNotSupported(fn)
 	}


### PR DESCRIPTION
This implements the REPLACE function. This function is documented as case sensitive, but in practice is also byte sensitive. This means that equal characters under collation rules are not replaced.

## Related Issue(s)

Part of #9647 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
