### PR TITLE
vtexplain: Fix setting up the column information

### DIFF
--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -66,12 +66,6 @@ func (mysqld *Mysqld) executeSchemaCommands(ctx context.Context, sql string) err
 	return mysqld.executeMysqlScript(ctx, params, sql)
 }
 
-func EncodeEntityName(name string) string {
-	var buf strings.Builder
-	sqltypes.NewVarChar(name).EncodeSQL(&buf)
-	return buf.String()
-}
-
 // tableListSQL returns an IN clause "('t1', 't2'...) for a list of tables."
 func tableListSQL(tables []string) (string, error) {
 	if len(tables) == 0 {
@@ -80,7 +74,7 @@ func tableListSQL(tables []string) (string, error) {
 
 	encodedTables := make([]string, len(tables))
 	for i, tableName := range tables {
-		encodedTables[i] = EncodeEntityName(tableName)
+		encodedTables[i] = sqltypes.EncodeStringSQL(tableName)
 	}
 
 	return "(" + strings.Join(encodedTables, ", ") + ")", nil
@@ -307,13 +301,13 @@ func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sql
 	if dbName == "" {
 		dbName2 = "database()"
 	} else {
-		dbName2 = EncodeEntityName(dbName)
+		dbName2 = sqltypes.EncodeStringSQL(dbName)
 	}
 	sanitizedTableName, err := sqlescape.UnescapeID(tableName)
 	if err != nil {
 		return "", err
 	}
-	query := fmt.Sprintf(GetColumnNamesQuery, dbName2, EncodeEntityName(sanitizedTableName))
+	query := fmt.Sprintf(GetColumnNamesQuery, dbName2, sqltypes.EncodeStringSQL(sanitizedTableName))
 	qr, err := exec(query, -1, true)
 	if err != nil {
 		return "", err
@@ -407,7 +401,7 @@ func (mysqld *Mysqld) getPrimaryKeyColumns(ctx context.Context, dbName string, t
             FROM information_schema.STATISTICS
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME IN %s AND LOWER(INDEX_NAME) = 'primary'
             ORDER BY table_name, SEQ_IN_INDEX`
-	sql = fmt.Sprintf(sql, EncodeEntityName(dbName), tableList)
+	sql = fmt.Sprintf(sql, sqltypes.EncodeStringSQL(dbName), tableList)
 	qr, err := conn.Conn.ExecuteFetch(sql, len(tables)*100, true)
 	if err != nil {
 		return nil, err
@@ -631,8 +625,8 @@ func GetPrimaryKeyEquivalentColumns(ctx context.Context, exec func(string, int, 
             ) AS pke ON index_cols.INDEX_NAME = pke.INDEX_NAME
             WHERE index_cols.TABLE_SCHEMA = %s AND index_cols.TABLE_NAME = %s AND NON_UNIQUE = 0 AND NULLABLE != 'YES'
             ORDER BY SEQ_IN_INDEX ASC`
-	encodedDbName := EncodeEntityName(dbName)
-	encodedTable := EncodeEntityName(table)
+	encodedDbName := sqltypes.EncodeStringSQL(dbName)
+	encodedTable := sqltypes.EncodeStringSQL(table)
 	sql = fmt.Sprintf(sql, encodedDbName, encodedTable, encodedDbName, encodedTable, encodedDbName, encodedTable)
 	qr, err := exec(sql, 1000, true)
 	if err != nil {

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -66,7 +66,7 @@ func (mysqld *Mysqld) executeSchemaCommands(ctx context.Context, sql string) err
 	return mysqld.executeMysqlScript(ctx, params, sql)
 }
 
-func encodeEntityName(name string) string {
+func EncodeEntityName(name string) string {
 	var buf strings.Builder
 	sqltypes.NewVarChar(name).EncodeSQL(&buf)
 	return buf.String()
@@ -80,7 +80,7 @@ func tableListSQL(tables []string) (string, error) {
 
 	encodedTables := make([]string, len(tables))
 	for i, tableName := range tables {
-		encodedTables[i] = encodeEntityName(tableName)
+		encodedTables[i] = EncodeEntityName(tableName)
 	}
 
 	return "(" + strings.Join(encodedTables, ", ") + ")", nil
@@ -307,13 +307,13 @@ func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sql
 	if dbName == "" {
 		dbName2 = "database()"
 	} else {
-		dbName2 = encodeEntityName(dbName)
+		dbName2 = EncodeEntityName(dbName)
 	}
 	sanitizedTableName, err := sqlescape.UnescapeID(tableName)
 	if err != nil {
 		return "", err
 	}
-	query := fmt.Sprintf(GetColumnNamesQuery, dbName2, encodeEntityName(sanitizedTableName))
+	query := fmt.Sprintf(GetColumnNamesQuery, dbName2, EncodeEntityName(sanitizedTableName))
 	qr, err := exec(query, -1, true)
 	if err != nil {
 		return "", err
@@ -407,7 +407,7 @@ func (mysqld *Mysqld) getPrimaryKeyColumns(ctx context.Context, dbName string, t
             FROM information_schema.STATISTICS
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME IN %s AND LOWER(INDEX_NAME) = 'primary'
             ORDER BY table_name, SEQ_IN_INDEX`
-	sql = fmt.Sprintf(sql, encodeEntityName(dbName), tableList)
+	sql = fmt.Sprintf(sql, EncodeEntityName(dbName), tableList)
 	qr, err := conn.Conn.ExecuteFetch(sql, len(tables)*100, true)
 	if err != nil {
 		return nil, err
@@ -631,8 +631,8 @@ func GetPrimaryKeyEquivalentColumns(ctx context.Context, exec func(string, int, 
             ) AS pke ON index_cols.INDEX_NAME = pke.INDEX_NAME
             WHERE index_cols.TABLE_SCHEMA = %s AND index_cols.TABLE_NAME = %s AND NON_UNIQUE = 0 AND NULLABLE != 'YES'
             ORDER BY SEQ_IN_INDEX ASC`
-	encodedDbName := encodeEntityName(dbName)
-	encodedTable := encodeEntityName(table)
+	encodedDbName := EncodeEntityName(dbName)
+	encodedTable := EncodeEntityName(table)
 	sql = fmt.Sprintf(sql, encodedDbName, encodedTable, encodedDbName, encodedTable, encodedDbName, encodedTable)
 	qr, err := exec(sql, 1000, true)
 	if err != nil {

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -474,8 +474,8 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 			}
 			tEnv.addResult(query, tEnv.getResult(likeQuery))
 
-			likeQuery = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sanitizedLikeTable)
-			query = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sanitizedTable)
+			likeQuery = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", mysqlctl.EncodeEntityName(sanitizedLikeTable))
+			query = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", mysqlctl.EncodeEntityName(sanitizedTable))
 			if tEnv.getResult(likeQuery) == nil {
 				return nil, fmt.Errorf("check your schema, table[%s] doesn't exist", likeTable)
 			}
@@ -516,7 +516,7 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 		tEnv.addResult("SELECT * FROM "+backtickedTable+" WHERE 1 != 1", &sqltypes.Result{
 			Fields: rowTypes,
 		})
-		query := fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sanitizedTable)
+		query := fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", mysqlctl.EncodeEntityName(sanitizedTable))
 		tEnv.addResult(query, &sqltypes.Result{
 			Fields: colTypes,
 			Rows:   colValues,
@@ -618,7 +618,7 @@ func (t *explainTablet) handleSelect(query string) (*sqltypes.Result, error) {
 
 	// Gen4 supports more complex queries so we now need to
 	// handle multiple FROM clauses
-	tables := make([]*sqlparser.AliasedTableExpr, len(selStmt.From))
+	tables := make([]*sqlparser.AliasedTableExpr, 0, len(selStmt.From))
 	for _, from := range selStmt.From {
 		tables = append(tables, getTables(from)...)
 	}

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -474,8 +474,8 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 			}
 			tEnv.addResult(query, tEnv.getResult(likeQuery))
 
-			likeQuery = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", mysqlctl.EncodeEntityName(sanitizedLikeTable))
-			query = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", mysqlctl.EncodeEntityName(sanitizedTable))
+			likeQuery = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sqltypes.EncodeStringSQL(sanitizedLikeTable))
+			query = fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sqltypes.EncodeStringSQL(sanitizedTable))
 			if tEnv.getResult(likeQuery) == nil {
 				return nil, fmt.Errorf("check your schema, table[%s] doesn't exist", likeTable)
 			}
@@ -516,7 +516,7 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 		tEnv.addResult("SELECT * FROM "+backtickedTable+" WHERE 1 != 1", &sqltypes.Result{
 			Fields: rowTypes,
 		})
-		query := fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", mysqlctl.EncodeEntityName(sanitizedTable))
+		query := fmt.Sprintf(mysqlctl.GetColumnNamesQuery, "database()", sqltypes.EncodeStringSQL(sanitizedTable))
 		tEnv.addResult(query, &sqltypes.Result{
 			Fields: colTypes,
 			Rows:   colValues,

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -77,6 +77,10 @@ create table t2 (
 	require.NoError(t, err)
 	defer vte.Stop()
 
+	// Check if the correct schema query is registered.
+	_, found := vte.globalTabletEnv.schemaQueries["SELECT COLUMN_NAME as column_name\n\t\tFROM INFORMATION_SCHEMA.COLUMNS\n\t\tWHERE TABLE_SCHEMA = database() AND TABLE_NAME = 't1'\n\t\tORDER BY ORDINAL_POSITION"]
+	assert.True(t, found)
+
 	sql := "SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.id"
 
 	_, err = vte.Run(sql)


### PR DESCRIPTION
In https://github.com/vitessio/vitess/pull/13312 we fixed how we encode names in `information_schema` queries. The problem there though is that the `GetColumnNamesQuery` string was also used inside `vtexplain`. Its usage there was not updated for the new escaping logic.

This in turn leads to broken queries during `vtexplain` which then leads to a lot of logs. The issue here is not that we log a lot, we log that we actually do have a problem here which is the case.

This fixes the underlying issue of not correctly generating the query as we should.

## Related Issue(s)

Part of https://github.com/vitessio/vitess/issues/15242

Marked for backporting all the way to v16, since that's where the original change in https://github.com/vitessio/vitess/pull/13312 was also back ported to. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
