### PR TITLE
prevent vtctld from creating tons of S3 connections

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -277,17 +277,12 @@ func TestSSECustomerFileBase64Key(t *testing.T) {
 	assert.Nil(t, sseData.customerMd5, "customerMd5 expected to be nil")
 }
 
-func TestGetTransport(t *testing.T) {
-	s3 := S3BackupStorage{}
-
-	transport := s3.getTransport()
+func TestNewS3Transport(t *testing.T) {
+	s3 := newS3BackupStorage()
 
 	// checking some of the values are present in the returned transport and match the http.DefaultTransport.
-	assert.Equal(t, http.DefaultTransport.(*http.Transport).IdleConnTimeout, transport.IdleConnTimeout)
-	assert.Equal(t, http.DefaultTransport.(*http.Transport).MaxIdleConns, transport.MaxIdleConns)
-	assert.NotNil(t, transport.DialContext)
-	assert.NotNil(t, transport.Proxy)
-
-	newTransport := s3.getTransport()
-	assert.Same(t, transport, newTransport) // new call should return the same transport
+	assert.Equal(t, http.DefaultTransport.(*http.Transport).IdleConnTimeout, s3.transport.IdleConnTimeout)
+	assert.Equal(t, http.DefaultTransport.(*http.Transport).MaxIdleConns, s3.transport.MaxIdleConns)
+	assert.NotNil(t, s3.transport.DialContext)
+	assert.NotNil(t, s3.transport.Proxy)
 }

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -277,8 +277,10 @@ func TestSSECustomerFileBase64Key(t *testing.T) {
 	assert.Nil(t, sseData.customerMd5, "customerMd5 expected to be nil")
 }
 
-func Test_getS3Transport(t *testing.T) {
-	transport := getS3Transport()
+func TestGetTransport(t *testing.T) {
+	s3 := S3BackupStorage{}
+
+	transport := s3.getTransport()
 
 	// checking some of the values are present in the returned transport and match the http.DefaultTransport.
 	assert.Equal(t, http.DefaultTransport.(*http.Transport).IdleConnTimeout, transport.IdleConnTimeout)
@@ -286,6 +288,6 @@ func Test_getS3Transport(t *testing.T) {
 	assert.NotNil(t, transport.DialContext)
 	assert.NotNil(t, transport.Proxy)
 
-	newTransport := getS3Transport()
+	newTransport := s3.getTransport()
 	assert.Same(t, transport, newTransport) // new call should return the same transport
 }

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"vitess.io/vitess/go/vt/logutil"
 	stats "vitess.io/vitess/go/vt/mysqlctl/backupstats"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
@@ -275,4 +274,17 @@ func TestSSECustomerFileBase64Key(t *testing.T) {
 	assert.Nil(t, sseData.customerAlg, "customerAlg expected to be nil")
 	assert.Nil(t, sseData.customerKey, "customerKey expected to be nil")
 	assert.Nil(t, sseData.customerMd5, "customerMd5 expected to be nil")
+}
+
+func Test_getS3Transport(t *testing.T) {
+	transport := getS3Transport()
+
+	// checking some of the values are present in the returned transport and match the http.DefaultTransport.
+	assert.Equal(t, http.DefaultTransport.(*http.Transport).IdleConnTimeout, transport.IdleConnTimeout)
+	assert.Equal(t, http.DefaultTransport.(*http.Transport).MaxIdleConns, transport.MaxIdleConns)
+	assert.NotNil(t, transport.DialContext)
+	assert.NotNil(t, transport.Proxy)
+
+	newTransport := getS3Transport()
+	assert.Same(t, transport, newTransport) // new call should return the same transport
 }

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/vt/logutil"
 	stats "vitess.io/vitess/go/vt/mysqlctl/backupstats"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This fixes the issue described in #15335. It seems the bug was introduced in #4200.

The default transport was changed in favour of one were we could skip validating S3 certificates, but instead of cloning the default transport and adjusting the settings, we are creating a new transport from scratch but not setting any defaults ([see current Go defaults for](https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/net/http/transport.go;l=43-54) `DefaultTransport`). By doing so, we don't set keepalives, timeouts, max idle connections, etc and other values in `Transport` and since some default to zero it basically means "no limit". To make matters worse, since we are creating a new transport for every client (in this case, for each request from what I understand), there is no sharing of connections between different requests, so the first call to `GetBackups()` will open some S3 connections and keep them on its private transport instead of sharing it across different requests.

After this fix, the number of established connections seems to be consistently below 5, and from initial testing it seems S3 connection errors seem to be gone.


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

- fixes #15335

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
