### PR TITLE
[e2e] vtctld init tablet and some output-based commands

### DIFF
--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -167,7 +167,7 @@ func firstBackupTest(t *testing.T, tabletType string) {
 	mysqlctl.CompressionEngineName = "lz4"
 	defer func() { mysqlctl.CompressionEngineName = "pgzip" }()
 	// now bring up the other replica, letting it restore from backup.
-	err = localCluster.VtctlclientProcess.InitTablet(replica2, cell, keyspaceName, hostname, shardName)
+	err = localCluster.InitTablet(replica2, keyspaceName, shardName)
 	require.Nil(t, err)
 	restore(t, replica2, "replica", "SERVING")
 	// Replica2 takes time to serve. Sleeping for 5 sec.
@@ -266,7 +266,7 @@ func removeBackups(t *testing.T) {
 func initTablets(t *testing.T, startTablet bool, initShardPrimary bool) {
 	// Initialize tablets
 	for _, tablet := range []cluster.Vttablet{*primary, *replica1} {
-		err := localCluster.VtctlclientProcess.InitTablet(&tablet, cell, keyspaceName, hostname, shardName)
+		err := localCluster.InitTablet(&tablet, keyspaceName, shardName)
 		require.Nil(t, err)
 
 		if startTablet {

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -228,13 +228,13 @@ func LaunchCluster(setupType int, streamMode string, stripes int, cDetails *Comp
 	replica2 = shard.Vttablets[2]
 	replica3 = shard.Vttablets[3]
 
-	if err := localCluster.VtctlclientProcess.InitTablet(primary, cell, keyspaceName, hostname, shard.Name); err != nil {
+	if err := localCluster.InitTablet(primary, keyspaceName, shard.Name); err != nil {
 		return 1, err
 	}
-	if err := localCluster.VtctlclientProcess.InitTablet(replica1, cell, keyspaceName, hostname, shard.Name); err != nil {
+	if err := localCluster.InitTablet(replica1, keyspaceName, shard.Name); err != nil {
 		return 1, err
 	}
-	if err := localCluster.VtctlclientProcess.InitTablet(replica2, cell, keyspaceName, hostname, shard.Name); err != nil {
+	if err := localCluster.InitTablet(replica2, keyspaceName, shard.Name); err != nil {
 		return 1, err
 	}
 	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", localCluster.VtctldProcess.GrpcPort, localCluster.TmpDirectory)
@@ -746,7 +746,7 @@ func restartPrimaryAndReplica(t *testing.T) {
 		proc.Wait()
 	}
 	for _, tablet := range []*cluster.Vttablet{primary, replica1} {
-		err := localCluster.VtctlclientProcess.InitTablet(tablet, cell, keyspaceName, hostname, shardName)
+		err := localCluster.InitTablet(tablet, keyspaceName, shardName)
 		require.Nil(t, err)
 		err = tablet.VttabletProcess.Setup()
 		require.Nil(t, err)

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -449,7 +449,7 @@ func primaryBackup(t *testing.T) {
 	}()
 	verifyInitialReplication(t)
 
-	output, err := localCluster.VtctlclientProcess.ExecuteCommandWithOutput("Backup", primary.Alias)
+	output, err := localCluster.VtctldClientProcess.ExecuteCommandWithOutput("Backup", primary.Alias)
 	require.Error(t, err)
 	assert.Contains(t, output, "type PRIMARY cannot take backup. if you really need to do this, rerun the backup command with --allow_primary")
 

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -245,6 +245,11 @@ func (cluster *LocalProcessCluster) StartTopo() (err error) {
 		cluster.VtctlProcess.LogDir = cluster.TmpDirectory
 	}
 
+	if err = cluster.TopoProcess.OpenServer(*topoFlavor, cluster.VtctlProcess.TopoGlobalRoot); err != nil {
+		log.Error(err.Error())
+		return
+	}
+
 	cluster.VtctldProcess = *VtctldProcessInstance(cluster.GetAndReservePort(), cluster.GetAndReservePort(),
 		cluster.TopoProcess.Port, cluster.Hostname, cluster.TmpDirectory)
 	log.Infof("Starting vtctld server on port: %d", cluster.VtctldProcess.Port)

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -245,11 +245,6 @@ func (cluster *LocalProcessCluster) StartTopo() (err error) {
 		cluster.VtctlProcess.LogDir = cluster.TmpDirectory
 	}
 
-	if err = cluster.TopoProcess.OpenServer(*topoFlavor, cluster.VtctlProcess.TopoGlobalRoot); err != nil {
-		log.Error(err.Error())
-		return
-	}
-
 	cluster.VtctldProcess = *VtctldProcessInstance(cluster.GetAndReservePort(), cluster.GetAndReservePort(),
 		cluster.TopoProcess.Port, cluster.Hostname, cluster.TmpDirectory)
 	log.Infof("Starting vtctld server on port: %d", cluster.VtctldProcess.Port)

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -1013,11 +1013,6 @@ func (cluster *LocalProcessCluster) StreamTabletHealthUntil(ctx context.Context,
 	return err
 }
 
-func (cluster *LocalProcessCluster) VtctlclientChangeTabletType(tablet *Vttablet, tabletType topodatapb.TabletType) error {
-	_, err := cluster.VtctlclientProcess.ExecuteCommandWithOutput("ChangeTabletType", "--", tablet.Alias, tabletType.String())
-	return err
-}
-
 // Teardown brings down the cluster by invoking teardown for individual processes
 func (cluster *LocalProcessCluster) Teardown() {
 	PanicHandler(nil)

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -335,8 +335,11 @@ func (cluster *LocalProcessCluster) InitTablet(tablet *Vttablet, keyspace string
 		Shard:    shard,
 	}
 
-	if tablet.Type == "rdonly" {
+	switch tablet.Type {
+	case "rdonly":
 		tabletpb.Type = topodatapb.TabletType_RDONLY
+	case "primary":
+		tabletpb.Type = topodatapb.TabletType_PRIMARY
 	}
 
 	if tablet.MySQLPort > 0 {

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -66,19 +66,21 @@ type TopoProcess struct {
 func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) (err error) {
 	switch topoFlavor {
 	case "zk2":
-		return topo.SetupZookeeper(cluster)
+		err = topo.SetupZookeeper(cluster)
 	case "consul":
-		return topo.SetupConsul(cluster)
+		err = topo.SetupConsul(cluster)
 	default:
 		// Override any inherited ETCDCTL_API env value to
 		// ensure that we use the v3 API and storage.
 		os.Setenv("ETCDCTL_API", "3")
-		return topo.SetupEtcd()
+		err = topo.SetupEtcd()
 	}
-}
 
-func (topo *TopoProcess) OpenServer(topoFlavor string, globalRoot string) (err error) {
-	topo.Server, err = vtopo.OpenServer(topoFlavor, net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port)), globalRoot)
+	if err != nil {
+		return
+	}
+
+	topo.Server, err = vtopo.OpenServer(topoFlavor, net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port)), TopoGlobalRoot(topoFlavor))
 	return
 }
 

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -33,6 +33,11 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 	vtopo "vitess.io/vitess/go/vt/topo"
+
+	// Register topo server implementations
+	_ "vitess.io/vitess/go/vt/topo/consultopo"
+	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
+	_ "vitess.io/vitess/go/vt/topo/zk2topo"
 )
 
 // TopoProcess is a generic handle for a running Topo service .
@@ -51,6 +56,7 @@ type TopoProcess struct {
 	PeerURL            string
 	ZKPorts            string
 	Client             interface{}
+	Server             *vtopo.Server
 
 	proc *exec.Cmd
 	exit chan error
@@ -60,15 +66,22 @@ type TopoProcess struct {
 func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) (err error) {
 	switch topoFlavor {
 	case "zk2":
-		return topo.SetupZookeeper(cluster)
+		err = topo.SetupZookeeper(cluster)
 	case "consul":
-		return topo.SetupConsul(cluster)
+		err = topo.SetupConsul(cluster)
 	default:
 		// Override any inherited ETCDCTL_API env value to
 		// ensure that we use the v3 API and storage.
 		os.Setenv("ETCDCTL_API", "3")
-		return topo.SetupEtcd()
+		err = topo.SetupEtcd()
 	}
+
+	if err != nil {
+		return err
+	}
+
+	topo.Server, err = vtopo.OpenServer(topoFlavor, net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port)), "/vitess/global")
+	return err
 }
 
 // SetupEtcd spawns a new etcd service and initializes it with the defaults.
@@ -289,6 +302,10 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 
 // TearDown shutdowns the running topo service.
 func (topo *TopoProcess) TearDown(Cell string, originalVtRoot string, currentRoot string, keepdata bool, topoFlavor string) error {
+	if topo.Server != nil {
+		topo.Server.Close()
+	}
+
 	if topo.Client != nil {
 		switch cli := topo.Client.(type) {
 		case *clientv3.Client:

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -455,3 +455,13 @@ func TopoProcessInstance(port int, peerPort int, hostname string, flavor string,
 	topo.PeerURL = fmt.Sprintf("http://%s:%d", hostname, peerPort)
 	return topo
 }
+
+// TopoGlobalRoot returns the global root for the given topo flavor.
+func TopoGlobalRoot(flavor string) string {
+	switch flavor {
+	case "consul":
+		return "global"
+	default:
+		return "/vitess/global"
+	}
+}

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -64,13 +64,11 @@ type TopoProcess struct {
 
 // Setup starts a new topo service
 func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) (err error) {
-	root := "/" + topo.Name
 	switch topoFlavor {
 	case "zk2":
 		err = topo.SetupZookeeper(cluster)
 	case "consul":
 		err = topo.SetupConsul(cluster)
-		root = strings.TrimPrefix(root, "/")
 	default:
 		// Override any inherited ETCDCTL_API env value to
 		// ensure that we use the v3 API and storage.
@@ -82,8 +80,12 @@ func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) 
 		return err
 	}
 
-	topo.Server, err = vtopo.OpenServer(topoFlavor, net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port)), root)
 	return err
+}
+
+func (topo *TopoProcess) OpenServer(topoFlavor string, globalRoot string) (err error) {
+	topo.Server, err = vtopo.OpenServer(topoFlavor, net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port)), globalRoot)
+	return
 }
 
 // SetupEtcd spawns a new etcd service and initializes it with the defaults.

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -66,21 +66,15 @@ type TopoProcess struct {
 func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) (err error) {
 	switch topoFlavor {
 	case "zk2":
-		err = topo.SetupZookeeper(cluster)
+		return topo.SetupZookeeper(cluster)
 	case "consul":
-		err = topo.SetupConsul(cluster)
+		return topo.SetupConsul(cluster)
 	default:
 		// Override any inherited ETCDCTL_API env value to
 		// ensure that we use the v3 API and storage.
 		os.Setenv("ETCDCTL_API", "3")
-		err = topo.SetupEtcd()
+		return topo.SetupEtcd()
 	}
-
-	if err != nil {
-		return err
-	}
-
-	return err
 }
 
 func (topo *TopoProcess) OpenServer(topoFlavor string, globalRoot string) (err error) {

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -64,11 +64,13 @@ type TopoProcess struct {
 
 // Setup starts a new topo service
 func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) (err error) {
+	root := "/" + topo.Name
 	switch topoFlavor {
 	case "zk2":
 		err = topo.SetupZookeeper(cluster)
 	case "consul":
 		err = topo.SetupConsul(cluster)
+		root = strings.TrimPrefix(root, "/")
 	default:
 		// Override any inherited ETCDCTL_API env value to
 		// ensure that we use the v3 API and storage.
@@ -80,7 +82,7 @@ func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) 
 		return err
 	}
 
-	topo.Server, err = vtopo.OpenServer(topoFlavor, net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port)), "/vitess/global")
+	topo.Server, err = vtopo.OpenServer(topoFlavor, net.JoinHostPort(topo.Host, fmt.Sprintf("%d", topo.Port)), root)
 	return err
 }
 

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -304,6 +304,7 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 func (topo *TopoProcess) TearDown(Cell string, originalVtRoot string, currentRoot string, keepdata bool, topoFlavor string) error {
 	if topo.Server != nil {
 		topo.Server.Close()
+		topo.Server = nil
 	}
 
 	if topo.Client != nil {

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -111,6 +111,16 @@ func (vtctl *VtctlProcess) ExecuteCommand(args ...string) (err error) {
 	return tmpProcess.Run()
 }
 
+// TopoGlobalRoot returns the global root for the given topo flavor.
+func TopoGlobalRoot(flavor string) string {
+	switch flavor {
+	case "consul":
+		return "global"
+	default:
+		return "/vitess/global"
+	}
+}
+
 // VtctlProcessInstance returns a VtctlProcess handle for vtctl process
 // configured with the given Config.
 // The process must be manually started by calling setup()
@@ -118,7 +128,6 @@ func VtctlProcessInstance(topoPort int, hostname string) *VtctlProcess {
 
 	// Default values for etcd2 topo server.
 	topoImplementation := "etcd2"
-	topoGlobalRoot := "/vitess/global"
 	topoRootPath := "/"
 
 	// Checking and resetting the parameters for required topo server.
@@ -127,7 +136,6 @@ func VtctlProcessInstance(topoPort int, hostname string) *VtctlProcess {
 		topoImplementation = "zk2"
 	case "consul":
 		topoImplementation = "consul"
-		topoGlobalRoot = "global"
 		// For consul we do not need "/" in the path
 		topoRootPath = ""
 	}
@@ -142,7 +150,7 @@ func VtctlProcessInstance(topoPort int, hostname string) *VtctlProcess {
 		Binary:             "vtctl",
 		TopoImplementation: topoImplementation,
 		TopoGlobalAddress:  fmt.Sprintf("%s:%d", hostname, topoPort),
-		TopoGlobalRoot:     topoGlobalRoot,
+		TopoGlobalRoot:     TopoGlobalRoot(*topoFlavor),
 		TopoServerAddress:  fmt.Sprintf("%s:%d", hostname, topoPort),
 		TopoRootPath:       topoRootPath,
 		VtctlMajorVersion:  version,

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -111,16 +111,6 @@ func (vtctl *VtctlProcess) ExecuteCommand(args ...string) (err error) {
 	return tmpProcess.Run()
 }
 
-// TopoGlobalRoot returns the global root for the given topo flavor.
-func TopoGlobalRoot(flavor string) string {
-	switch flavor {
-	case "consul":
-		return "global"
-	default:
-		return "/vitess/global"
-	}
-}
-
 // VtctlProcessInstance returns a VtctlProcess handle for vtctl process
 // configured with the given Config.
 // The process must be manually started by calling setup()

--- a/go/test/endtoend/cluster/vtctldclient_process.go
+++ b/go/test/endtoend/cluster/vtctldclient_process.go
@@ -152,6 +152,15 @@ func (vtctldclient *VtctldClientProcess) ApplyVSchema(keyspace string, json stri
 	)
 }
 
+// ChangeTabletType changes the type of the given tablet.
+func (vtctldclient *VtctldClientProcess) ChangeTabletType(tablet *Vttablet, tabletType topodatapb.TabletType) error {
+	return vtctldclient.ExecuteCommand(
+		"ChangeTabletType",
+		tablet.Alias,
+		tabletType.String(),
+	)
+}
+
 // GetSrvKeyspaces returns a mapping of cell to srv keyspace for the given keyspace.
 func (vtctldclient *VtctldClientProcess) GetSrvKeyspaces(keyspace string, cells ...string) (ksMap map[string]*topodatapb.SrvKeyspace, err error) {
 	args := append([]string{"GetSrvKeyspaces", keyspace}, cells...)

--- a/go/test/endtoend/cluster/vtctldclient_process.go
+++ b/go/test/endtoend/cluster/vtctldclient_process.go
@@ -161,6 +161,19 @@ func (vtctldclient *VtctldClientProcess) ChangeTabletType(tablet *Vttablet, tabl
 	)
 }
 
+// GetShardReplication returns a mapping of cell to shard replication for the given keyspace and shard.
+func (vtctldclient *VtctldClientProcess) GetShardReplication(keyspace string, shard string, cells ...string) (replication map[string]*topodatapb.ShardReplication, err error) {
+	args := append([]string{"GetShardReplication", keyspace + "/" + shard}, cells...)
+	out, err := vtctldclient.ExecuteCommandWithOutput(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	replication = map[string]*topodatapb.ShardReplication{}
+	err = json2.Unmarshal([]byte(out), &replication)
+	return replication, err
+}
+
 // GetSrvKeyspaces returns a mapping of cell to srv keyspace for the given keyspace.
 func (vtctldclient *VtctldClientProcess) GetSrvKeyspaces(keyspace string, cells ...string) (ksMap map[string]*topodatapb.SrvKeyspace, err error) {
 	args := append([]string{"GetSrvKeyspaces", keyspace}, cells...)

--- a/go/test/endtoend/cluster/vtctldclient_process.go
+++ b/go/test/endtoend/cluster/vtctldclient_process.go
@@ -162,16 +162,16 @@ func (vtctldclient *VtctldClientProcess) ChangeTabletType(tablet *Vttablet, tabl
 }
 
 // GetShardReplication returns a mapping of cell to shard replication for the given keyspace and shard.
-func (vtctldclient *VtctldClientProcess) GetShardReplication(keyspace string, shard string, cells ...string) (replication map[string]*topodatapb.ShardReplication, err error) {
+func (vtctldclient *VtctldClientProcess) GetShardReplication(keyspace string, shard string, cells ...string) (map[string]*topodatapb.ShardReplication, error) {
 	args := append([]string{"GetShardReplication", keyspace + "/" + shard}, cells...)
 	out, err := vtctldclient.ExecuteCommandWithOutput(args...)
 	if err != nil {
 		return nil, err
 	}
 
-	replication = map[string]*topodatapb.ShardReplication{}
-	err = json2.Unmarshal([]byte(out), &replication)
-	return replication, err
+	var resp vtctldatapb.GetShardReplicationResponse
+	err = json2.Unmarshal([]byte(out), &resp)
+	return resp.ShardReplicationByCell, err
 }
 
 // GetSrvKeyspaces returns a mapping of cell to srv keyspace for the given keyspace.

--- a/go/test/endtoend/clustertest/vtctld_test.go
+++ b/go/test/endtoend/clustertest/vtctld_test.go
@@ -164,7 +164,7 @@ func testExecuteAsDba(t *testing.T) {
 	}
 	for _, tcase := range tcases {
 		t.Run(tcase.query, func(t *testing.T) {
-			result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDba", clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].Alias, tcase.query)
+			result, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].Alias, tcase.query)
 			if tcase.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -176,7 +176,7 @@ func testExecuteAsDba(t *testing.T) {
 }
 
 func testExecuteAsApp(t *testing.T) {
-	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsApp", clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].Alias, `SELECT 1 AS a`)
+	result, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsApp", clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].Alias, `SELECT 1 AS a`)
 	require.NoError(t, err)
 	assert.Equal(t, result, oneTableOutput)
 }

--- a/go/test/endtoend/clustertest/vtctld_test.go
+++ b/go/test/endtoend/clustertest/vtctld_test.go
@@ -84,7 +84,7 @@ func testTopoDataAPI(t *testing.T, url string) {
 
 func testListAllTablets(t *testing.T) {
 	// first w/o any filters, aside from cell
-	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets", clusterInstance.Cell)
+	result, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetTablets", "--cell", clusterInstance.Cell)
 	require.NoError(t, err)
 
 	tablets := getAllTablets()
@@ -102,10 +102,12 @@ func testListAllTablets(t *testing.T) {
 
 	// now filtering with the first keyspace and tablet type of primary, in
 	// addition to the cell
-	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
-		"ListAllTablets", "--", "--keyspace", clusterInstance.Keyspaces[0].Name,
-		"--tablet_type", "primary",
-		clusterInstance.Cell)
+	result, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput(
+		"GetTablets",
+		"--keyspace", clusterInstance.Keyspaces[0].Name,
+		"--tablet-type", "primary",
+		"--cell", clusterInstance.Cell,
+	)
 	require.NoError(t, err)
 
 	// We should only return a single primary tablet per shard in the first keyspace

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -261,7 +261,7 @@ func TestDeleteKeyspace(t *testing.T) {
 	// Create the serving/replication entries and check that they exist,
 	//  so we can later check they're deleted.
 	_ = clusterForKSTest.VtctldClientProcess.ExecuteCommand("RebuildKeyspaceGraph", "test_delete_keyspace")
-	_, _ = clusterForKSTest.VtctldClientProcess.GetShardReplication("test_delete_keyspace/0", cell)
+	_, _ = clusterForKSTest.VtctldClientProcess.GetShardReplication("test_delete_keyspace", "0", cell)
 	_ = clusterForKSTest.VtctldClientProcess.ExecuteCommand("GetSrvKeyspace", cell, "test_delete_keyspace")
 
 	// Recursive DeleteKeyspace
@@ -274,7 +274,7 @@ func TestDeleteKeyspace(t *testing.T) {
 	require.Error(t, err)
 	err = clusterForKSTest.VtctldClientProcess.ExecuteCommand("GetTablet", "zone1-0000000100")
 	require.Error(t, err)
-	_, err = clusterForKSTest.VtctldClientProcess.GetShardReplication("test_delete_keyspace/0", cell)
+	_, err = clusterForKSTest.VtctldClientProcess.GetShardReplication("test_delete_keyspace", "0", cell)
 	require.Error(t, err)
 	err = clusterForKSTest.VtctldClientProcess.ExecuteCommand("GetSrvKeyspace", cell, "test_delete_keyspace")
 	require.Error(t, err)

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -229,7 +229,11 @@ func TestDeleteKeyspace(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	_ = clusterForKSTest.VtctldClientProcess.CreateKeyspace("test_delete_keyspace", sidecar.DefaultName)
 	_ = clusterForKSTest.VtctldClientProcess.ExecuteCommand("CreateShard", "test_delete_keyspace/0")
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "--", "--keyspace=test_delete_keyspace", "--shard=0", "zone1-0000000100", "primary")
+	_ = clusterForKSTest.InitTablet(&cluster.Vttablet{
+		Type:      "primary",
+		TabletUID: 100,
+		Cell:      "zone1",
+	}, "test_delete_keyspace", "0")
 
 	// Can't delete keyspace if there are shards present.
 	err := clusterForKSTest.VtctldClientProcess.ExecuteCommand("DeleteKeyspace", "test_delete_keyspace")
@@ -247,7 +251,12 @@ func TestDeleteKeyspace(t *testing.T) {
 	// Start over and this time use recursive DeleteKeyspace to do everything.
 	_ = clusterForKSTest.VtctldClientProcess.CreateKeyspace("test_delete_keyspace", sidecar.DefaultName)
 	_ = clusterForKSTest.VtctldClientProcess.ExecuteCommand("CreateShard", "test_delete_keyspace/0")
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "--", "--port=1234", "--bind-address=127.0.0.1", "--keyspace=test_delete_keyspace", "--shard=0", "zone1-0000000100", "primary")
+	_ = clusterForKSTest.InitTablet(&cluster.Vttablet{
+		Type:      "primary",
+		TabletUID: 100,
+		Cell:      "zone1",
+		HTTPPort:  1234,
+	}, "test_delete_keyspace", "0")
 
 	// Create the serving/replication entries and check that they exist,
 	//  so we can later check they're deleted.

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -18,7 +18,6 @@ package sequence
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"flag"
 	"os"
 	"testing"
@@ -211,12 +210,9 @@ func TestGetSrvKeyspacePartitions(t *testing.T) {
 
 func TestShardNames(t *testing.T) {
 	defer cluster.PanicHandler(t)
-	output, err := clusterForKSTest.VtctlclientProcess.ExecuteCommandWithOutput("GetSrvKeyspace", cell, keyspaceShardedName)
-	require.Nil(t, err)
-	var srvKeyspace topodatapb.SrvKeyspace
-
-	err = json.Unmarshal([]byte(output), &srvKeyspace)
-	require.Nil(t, err)
+	output, err := clusterForKSTest.VtctldClientProcess.GetSrvKeyspaces(keyspaceShardedName, cell)
+	require.NoError(t, err)
+	require.NotNil(t, output[cell], "no srvkeyspace for cell %s", cell)
 }
 
 func TestGetKeyspace(t *testing.T) {
@@ -430,11 +426,11 @@ func packKeyspaceID(keyspaceID uint64) []byte {
 }
 
 func getSrvKeyspace(t *testing.T, cell string, ksname string) *topodatapb.SrvKeyspace {
-	output, err := clusterForKSTest.VtctlclientProcess.ExecuteCommandWithOutput("GetSrvKeyspace", cell, ksname)
-	require.Nil(t, err)
-	var srvKeyspace topodatapb.SrvKeyspace
+	output, err := clusterForKSTest.VtctldClientProcess.GetSrvKeyspaces(ksname, cell)
+	require.NoError(t, err)
 
-	err = json.Unmarshal([]byte(output), &srvKeyspace)
-	require.Nil(t, err)
-	return &srvKeyspace
+	srvKeyspace := output[cell]
+	require.NotNil(t, srvKeyspace, "no srvkeyspace for cell %s", cell)
+
+	return srvKeyspace
 }

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sequence
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/json"
 	"flag"
@@ -262,7 +261,7 @@ func TestDeleteKeyspace(t *testing.T) {
 	// Create the serving/replication entries and check that they exist,
 	//  so we can later check they're deleted.
 	_ = clusterForKSTest.VtctldClientProcess.ExecuteCommand("RebuildKeyspaceGraph", "test_delete_keyspace")
-	_, _ = clusterForKSTest.TopoProcess.Server.GetShardReplication(context.Background(), cell, "test_delete_keyspace", "0")
+	_, _ = clusterForKSTest.VtctldClientProcess.GetShardReplication("test_delete_keyspace/0", cell)
 	_ = clusterForKSTest.VtctldClientProcess.ExecuteCommand("GetSrvKeyspace", cell, "test_delete_keyspace")
 
 	// Recursive DeleteKeyspace
@@ -275,7 +274,7 @@ func TestDeleteKeyspace(t *testing.T) {
 	require.Error(t, err)
 	err = clusterForKSTest.VtctldClientProcess.ExecuteCommand("GetTablet", "zone1-0000000100")
 	require.Error(t, err)
-	_, err = clusterForKSTest.TopoProcess.Server.GetShardReplication(context.Background(), cell, "test_delete_keyspace", "0")
+	_, err = clusterForKSTest.VtctldClientProcess.GetShardReplication("test_delete_keyspace/0", cell)
 	require.Error(t, err)
 	err = clusterForKSTest.VtctldClientProcess.ExecuteCommand("GetSrvKeyspace", cell, "test_delete_keyspace")
 	require.Error(t, err)

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -706,7 +706,7 @@ func CheckReplicationStatus(ctx context.Context, t *testing.T, tablet *cluster.V
 }
 
 func WaitForTabletToBeServing(t *testing.T, clusterInstance *cluster.LocalProcessCluster, tablet *cluster.Vttablet, timeout time.Duration) {
-	vTablet, err := clusterInstance.VtctlclientGetTablet(tablet)
+	vTablet, err := clusterInstance.VtctldClientProcess.GetTablet(tablet.Alias)
 	require.NoError(t, err)
 
 	tConn, err := tabletconn.GetDialer()(vTablet, false)

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -510,7 +510,7 @@ func RestartTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster, t
 	tab.MysqlctlProcess.InitMysql = false
 	err := tab.MysqlctlProcess.Start()
 	require.NoError(t, err)
-	err = clusterInstance.VtctlclientProcess.InitTablet(tab, tab.Cell, KeyspaceName, Hostname, ShardName)
+	err = clusterInstance.InitTablet(tab, KeyspaceName, ShardName)
 	require.NoError(t, err)
 }
 
@@ -519,7 +519,7 @@ func ResurrectTablet(ctx context.Context, t *testing.T, clusterInstance *cluster
 	tab.MysqlctlProcess.InitMysql = false
 	err := tab.MysqlctlProcess.Start()
 	require.NoError(t, err)
-	err = clusterInstance.VtctlclientProcess.InitTablet(tab, tab.Cell, KeyspaceName, Hostname, ShardName)
+	err = clusterInstance.InitTablet(tab, KeyspaceName, ShardName)
 	require.NoError(t, err)
 
 	// As there is already a primary the new replica will come directly in SERVING state

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -559,7 +559,7 @@ func GetNewPrimary(t *testing.T, clusterInstance *cluster.LocalProcessCluster) *
 // GetShardReplicationPositions gets the shards replication positions.
 // This should not generally be called directly, instead use the WaitForReplicationToCatchup method.
 func GetShardReplicationPositions(t *testing.T, clusterInstance *cluster.LocalProcessCluster, keyspaceName, shardName string, doPrint bool) []string {
-	output, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
+	output, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput(
 		"ShardReplicationPositions", fmt.Sprintf("%s/%s", keyspaceName, shardName))
 	require.NoError(t, err)
 	strArray := strings.Split(output, "\n")

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -606,12 +606,13 @@ func CheckReplicaStatus(ctx context.Context, t *testing.T, tablet *cluster.Vttab
 
 // CheckReparentFromOutside checks that cluster was reparented from outside
 func CheckReparentFromOutside(t *testing.T, clusterInstance *cluster.LocalProcessCluster, tablet *cluster.Vttablet, downPrimary bool, baseTime int64) {
-	result, err := clusterInstance.TopoProcess.Server.GetShardReplication(context.Background(), cell1, KeyspaceName, ShardName)
+	result, err := clusterInstance.VtctldClientProcess.GetShardReplication(KeyspaceName, ShardName, cell1)
 	require.Nil(t, err, "error should be Nil")
+	require.NotNil(t, result[cell1], "result should not be nil")
 	if !downPrimary {
-		assert.Len(t, result.Nodes, 3)
+		assert.Len(t, result[cell1].Nodes, 3)
 	} else {
-		assert.Len(t, result.Nodes, 2)
+		assert.Len(t, result[cell1].Nodes, 2)
 	}
 
 	// make sure the primary status page says it's the primary

--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -124,7 +124,7 @@ func TestVtgateReplicationStatusCheckWithTabletTypeChange(t *testing.T) {
 	require.NoError(t, err)
 	// Change it back to RDONLY afterward as the cluster is re-used.
 	defer func() {
-		err = clusterInstance.VtctlclientChangeTabletType(rdOnlyTablet, topodata.TabletType_RDONLY)
+		err = clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", rdOnlyTablet.Alias, "rdonly")
 		require.NoError(t, err)
 	}()
 

--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -120,7 +120,7 @@ func TestVtgateReplicationStatusCheckWithTabletTypeChange(t *testing.T) {
 
 	// change the RDONLY tablet to SPARE
 	rdOnlyTablet := clusterInstance.Keyspaces[0].Shards[0].Rdonly()
-	err = clusterInstance.VtctlclientChangeTabletType(rdOnlyTablet, topodata.TabletType_SPARE)
+	err = clusterInstance.VtctldClientProcess.ChangeTabletType(rdOnlyTablet, topodata.TabletType_SPARE)
 	require.NoError(t, err)
 	// Change it back to RDONLY afterward as the cluster is re-used.
 	defer func() {

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -186,23 +186,26 @@ func runHookAndAssert(t *testing.T, params []string, expectedStatus int64, expec
 func TestShardReplicationFix(t *testing.T) {
 	// make sure the replica is in the replication graph, 2 nodes: 1 primary, 1 replica
 	defer cluster.PanicHandler(t)
-	result, err := clusterInstance.TopoProcess.Server.GetShardReplication(context.Background(), cell, keyspaceName, shardName)
+	result, err := clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceShard, cell)
 	require.Nil(t, err, "error should be Nil")
-	assert.Len(t, result.Nodes, 3)
+	require.NotNil(t, result[cell], "result should not be Nil")
+	assert.Len(t, result[cell].Nodes, 3)
 
 	// Manually add a bogus entry to the replication graph, and check it is removed by ShardReplicationFix
 	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ShardReplicationAdd", keyspaceShard, fmt.Sprintf("%s-9000", cell))
 	require.Nil(t, err, "error should be Nil")
 
-	result, err = clusterInstance.TopoProcess.Server.GetShardReplication(context.Background(), cell, keyspaceName, shardName)
+	result, err = clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceShard, cell)
 	require.Nil(t, err, "error should be Nil")
-	assert.Len(t, result.Nodes, 4)
+	require.NotNil(t, result[cell], "result should not be Nil")
+	assert.Len(t, result[cell].Nodes, 4)
 
 	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ShardReplicationFix", cell, keyspaceShard)
 	require.Nil(t, err, "error should be Nil")
-	result, err = clusterInstance.TopoProcess.Server.GetShardReplication(context.Background(), cell, keyspaceName, shardName)
+	result, err = clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceShard, cell)
 	require.Nil(t, err, "error should be Nil")
-	assert.Len(t, result.Nodes, 3)
+	require.NotNil(t, result[cell], "result should not be Nil")
+	assert.Len(t, result[cell].Nodes, 3)
 }
 
 func TestGetSchema(t *testing.T) {

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -186,7 +186,7 @@ func runHookAndAssert(t *testing.T, params []string, expectedStatus int64, expec
 func TestShardReplicationFix(t *testing.T) {
 	// make sure the replica is in the replication graph, 2 nodes: 1 primary, 1 replica
 	defer cluster.PanicHandler(t)
-	result, err := clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceShard, cell)
+	result, err := clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceName, shardName, cell)
 	require.Nil(t, err, "error should be Nil")
 	require.NotNil(t, result[cell], "result should not be Nil")
 	assert.Len(t, result[cell].Nodes, 3)
@@ -195,14 +195,14 @@ func TestShardReplicationFix(t *testing.T) {
 	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ShardReplicationAdd", keyspaceShard, fmt.Sprintf("%s-9000", cell))
 	require.Nil(t, err, "error should be Nil")
 
-	result, err = clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceShard, cell)
+	result, err = clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceName, shardName, cell)
 	require.Nil(t, err, "error should be Nil")
 	require.NotNil(t, result[cell], "result should not be Nil")
 	assert.Len(t, result[cell].Nodes, 4)
 
 	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ShardReplicationFix", cell, keyspaceShard)
 	require.Nil(t, err, "error should be Nil")
-	result, err = clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceShard, cell)
+	result, err = clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceName, shardName, cell)
 	require.Nil(t, err, "error should be Nil")
 	require.NotNil(t, result[cell], "result should not be Nil")
 	assert.Len(t, result[cell].Nodes, 3)

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -23,16 +23,14 @@ import (
 	"reflect"
 	"testing"
 
-	"vitess.io/vitess/go/json2"
-	"vitess.io/vitess/go/test/endtoend/utils"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
-	"github.com/stretchr/testify/assert"
-
+	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
 
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 )

--- a/go/test/endtoend/topoconncache/topo_conn_cache_test.go
+++ b/go/test/endtoend/topoconncache/topo_conn_cache_test.go
@@ -51,7 +51,7 @@ func TestVtctldListAllTablets(t *testing.T) {
 
 func testListAllTablets(t *testing.T) {
 	// first w/o any filters, aside from cell
-	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets")
+	result, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetTablets")
 	require.NoError(t, err)
 
 	tablets := getAllTablets()
@@ -84,7 +84,7 @@ func deleteCell(t *testing.T) {
 	clusterInstance.Keyspaces[0].Shards = []cluster.Shard{shard1, shard2}
 
 	// Now list all tablets
-	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets")
+	result, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetTablets")
 	require.NoError(t, err)
 
 	tablets := getAllTablets()
@@ -184,7 +184,7 @@ func addCellback(t *testing.T) {
 	shard2.Vttablets = append(shard2.Vttablets, shard2Replica)
 	shard2.Vttablets = append(shard2.Vttablets, shard1Rdonly)
 
-	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets")
+	result, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetTablets")
 	require.NoError(t, err)
 
 	tablets := getAllTablets()

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -396,7 +396,6 @@ func NewVitessCluster(t *testing.T, opts *clusterOptions) *VitessCluster {
 
 	vc.setupVtctld()
 	vc.setupVtctl()
-	require.NoError(t, vc.Topo.OpenServer("etcd2", vc.Vtctl.TopoGlobalRoot))
 	vc.setupVtctlClient()
 	vc.setupVtctldClient()
 

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -396,6 +396,7 @@ func NewVitessCluster(t *testing.T, opts *clusterOptions) *VitessCluster {
 
 	vc.setupVtctld()
 	vc.setupVtctl()
+	require.NoError(t, vc.Topo.OpenServer("etcd2", vc.Vtctl.TopoGlobalRoot))
 	vc.setupVtctlClient()
 	vc.setupVtctldClient()
 


### PR DESCRIPTION

## Description

This PR began as an attempt to remove the deprecated `InitTablet` with the underlying topo call, and then evolved to also migrate some of the output-based commands from `vtctlclient` to `vtctldclient`

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15273

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
