### PR TITLE
Column alias expanding on ORDER BY

### DIFF
--- a/go/mysql/sqlerror/sql_error.go
+++ b/go/mysql/sqlerror/sql_error.go
@@ -243,6 +243,7 @@ var stateToMysqlCode = map[vterrors.State]mysqlCode{
 	vterrors.WrongParametersToNativeFct:   {num: ERWrongParametersToNativeFct, state: SSUnknownSQLState},
 	vterrors.KillDeniedError:              {num: ERKillDenied, state: SSUnknownSQLState},
 	vterrors.BadNullError:                 {num: ERBadNullError, state: SSConstraintViolation},
+	vterrors.InvalidGroupFuncUse:          {num: ERInvalidGroupFuncUse, state: SSUnknownSQLState},
 }
 
 func getStateToMySQLState(state vterrors.State) mysqlCode {

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -73,7 +73,7 @@ func TestAggregateTypes(t *testing.T) {
 	mcmp.AssertMatches("select val1 as a, count(*) from aggr_test group by a order by a", `[[VARCHAR("a") INT64(2)] [VARCHAR("b") INT64(1)] [VARCHAR("c") INT64(2)] [VARCHAR("d") INT64(1)] [VARCHAR("e") INT64(2)]]`)
 	mcmp.AssertMatches("select val1 as a, count(*) from aggr_test group by a order by 2, a", `[[VARCHAR("b") INT64(1)] [VARCHAR("d") INT64(1)] [VARCHAR("a") INT64(2)] [VARCHAR("c") INT64(2)] [VARCHAR("e") INT64(2)]]`)
 	mcmp.AssertMatches("select sum(val1) from aggr_test", `[[FLOAT64(0)]]`)
-	t.Run("Average for sharded keyspaces", func(t *testing.T) {
+	mcmp.Run("Average for sharded keyspaces", func(mcmp *utils.MySQLCompare) {
 		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 		mcmp.AssertMatches("select avg(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	})
@@ -101,7 +101,7 @@ func TestEqualFilterOnScatter(t *testing.T) {
 
 	workloads := []string{"oltp", "olap"}
 	for _, workload := range workloads {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
 
 			mcmp.AssertMatches("select count(*) as a from aggr_test having 1 = 1", `[[INT64(5)]]`)
@@ -177,7 +177,7 @@ func TestAggrOnJoin(t *testing.T) {
 	mcmp.AssertMatches("select a.val1 from aggr_test a join t3 t on a.val2 = t.id7 group by a.val1 having count(*) = 4",
 		`[[VARCHAR("a")]]`)
 
-	t.Run("Average in join for sharded", func(t *testing.T) {
+	mcmp.Run("Average in join for sharded", func(mcmp *utils.MySQLCompare) {
 		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 		mcmp.AssertMatches(`select avg(a1.val2), avg(a2.val2) from aggr_test a1 join aggr_test a2 on a1.val2 = a2.id join t3 t on a2.val2 = t.id7`,
 			"[[DECIMAL(1.5000) DECIMAL(1.0000)]]")
@@ -196,7 +196,7 @@ func TestNotEqualFilterOnScatter(t *testing.T) {
 
 	workloads := []string{"oltp", "olap"}
 	for _, workload := range workloads {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
 
 			mcmp.AssertMatches("select count(*) as a from aggr_test having a != 5", `[]`)
@@ -220,7 +220,7 @@ func TestLessFilterOnScatter(t *testing.T) {
 
 	workloads := []string{"oltp", "olap"}
 	for _, workload := range workloads {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
 			mcmp.AssertMatches("select count(*) as a from aggr_test having a < 10", `[[INT64(5)]]`)
 			mcmp.AssertMatches("select count(*) as a from aggr_test having 1 < a", `[[INT64(5)]]`)
@@ -243,7 +243,7 @@ func TestLessEqualFilterOnScatter(t *testing.T) {
 
 	workloads := []string{"oltp", "olap"}
 	for _, workload := range workloads {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
 
 			mcmp.AssertMatches("select count(*) as a from aggr_test having a <= 10", `[[INT64(5)]]`)
@@ -267,7 +267,7 @@ func TestGreaterFilterOnScatter(t *testing.T) {
 
 	workloads := []string{"oltp", "olap"}
 	for _, workload := range workloads {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
 
 			mcmp.AssertMatches("select count(*) as a from aggr_test having a > 1", `[[INT64(5)]]`)
@@ -291,7 +291,7 @@ func TestGreaterEqualFilterOnScatter(t *testing.T) {
 
 	workloads := []string{"oltp", "olap"}
 	for _, workload := range workloads {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
 
 			mcmp.AssertMatches("select count(*) as a from aggr_test having a >= 1", `[[INT64(5)]]`)
@@ -326,7 +326,7 @@ func TestAggOnTopOfLimit(t *testing.T) {
 	mcmp.Exec("insert into aggr_test(id, val1, val2) values(1,'a',6), (2,'a',1), (3,'b',1), (4,'c',3), (5,'c',4), (6,'b',null), (7,null,2), (8,null,null)")
 
 	for _, workload := range []string{"oltp", "olap"} {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
 			mcmp.AssertMatches("select count(*) from (select id, val1 from aggr_test where val2 < 4 limit 2) as x", "[[INT64(2)]]")
 			mcmp.AssertMatches("select count(val1) from (select id, val1 from aggr_test where val2 < 4 order by val1 desc limit 2) as x", "[[INT64(2)]]")
@@ -335,7 +335,7 @@ func TestAggOnTopOfLimit(t *testing.T) {
 			mcmp.AssertMatches("select count(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[INT64(0)]]")
 			mcmp.AssertMatches("select val1, count(*) from (select id, val1 from aggr_test where val2 < 4 order by val1 limit 2) as x group by val1", `[[NULL INT64(1)] [VARCHAR("a") INT64(1)]]`)
 			mcmp.AssertMatchesNoOrder("select val1, count(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1", `[[NULL INT64(1)] [VARCHAR("a") INT64(2)] [VARCHAR("b") INT64(1)] [VARCHAR("c") INT64(2)]]`)
-			t.Run("Average in sharded query", func(t *testing.T) {
+			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
 				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 				mcmp.AssertMatches("select avg(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[NULL]]")
 				mcmp.AssertMatchesNoOrder("select val1, avg(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1", `[[NULL DECIMAL(2.0000)] [VARCHAR("a") DECIMAL(3.5000)] [VARCHAR("b") DECIMAL(1.0000)] [VARCHAR("c") DECIMAL(3.5000)]]`)
@@ -347,7 +347,7 @@ func TestAggOnTopOfLimit(t *testing.T) {
 			mcmp.AssertMatches("select count(val1), sum(id) from (select id, val1 from aggr_test where val2 is null limit 2) as x", "[[INT64(1) DECIMAL(14)]]")
 			mcmp.AssertMatches("select count(val2), sum(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[INT64(0) NULL]]")
 			mcmp.AssertMatches("select val1, count(*), sum(id) from (select id, val1 from aggr_test where val2 < 4 order by val1 limit 2) as x group by val1", `[[NULL INT64(1) DECIMAL(7)] [VARCHAR("a") INT64(1) DECIMAL(2)]]`)
-			t.Run("Average in sharded query", func(t *testing.T) {
+			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
 				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 				mcmp.AssertMatches("select count(*), sum(val1), avg(val1) from (select id, val1 from aggr_test where val2 < 4 order by val1 desc limit 2) as x", "[[INT64(2) FLOAT64(0) FLOAT64(0)]]")
 				mcmp.AssertMatches("select count(val1), sum(id), avg(id) from (select id, val1 from aggr_test where val2 < 4 order by val1 desc limit 2) as x", "[[INT64(2) DECIMAL(7) DECIMAL(3.5000)]]")
@@ -363,13 +363,13 @@ func TestEmptyTableAggr(t *testing.T) {
 	defer closer()
 
 	for _, workload := range []string{"oltp", "olap"} {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", workload))
 			mcmp.AssertMatches(" select count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 			mcmp.AssertMatches(" select count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
-			t.Run("Average in sharded query", func(t *testing.T) {
+			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
 				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 				mcmp.AssertMatches(" select count(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 				mcmp.AssertMatches(" select avg(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[NULL]]")
@@ -380,12 +380,12 @@ func TestEmptyTableAggr(t *testing.T) {
 	mcmp.Exec("insert into t1(t1_id, `name`, `value`, shardkey) values(1,'a1','foo',100), (2,'b1','foo',200), (3,'c1','foo',300), (4,'a1','foo',100), (5,'b1','bar',200)")
 
 	for _, workload := range []string{"oltp", "olap"} {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", workload))
 			mcmp.AssertMatches(" select count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 			mcmp.AssertMatches(" select count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
-			t.Run("Average in sharded query", func(t *testing.T) {
+			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
 				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 				mcmp.AssertMatches(" select count(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 				mcmp.AssertMatches(" select avg(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[NULL]]")
@@ -434,7 +434,7 @@ func TestAggregateLeftJoin(t *testing.T) {
 	mcmp.AssertMatches("SELECT sum(t2.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(1)]]`)
 	mcmp.AssertMatches("SELECT count(*) FROM t2 LEFT JOIN t1 ON t1.t1_id = t2.id WHERE IFNULL(t1.name, 'NOTSET') = 'r'", `[[INT64(1)]]`)
 
-	t.Run("Average in sharded query", func(t *testing.T) {
+	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
 		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 		mcmp.AssertMatches("SELECT avg(t1.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(0.5000)]]`)
 		mcmp.AssertMatches("SELECT avg(t2.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(1.0000)]]`)
@@ -491,7 +491,7 @@ func TestScalarAggregate(t *testing.T) {
 
 	mcmp.Exec("insert into aggr_test(id, val1, val2) values(1,'a',1), (2,'A',1), (3,'b',1), (4,'c',3), (5,'c',4)")
 	mcmp.AssertMatches("select count(distinct val1) from aggr_test", `[[INT64(3)]]`)
-	t.Run("Average in sharded query", func(t *testing.T) {
+	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
 		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 		mcmp.AssertMatches("select avg(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	})
@@ -551,7 +551,7 @@ func TestComplexAggregation(t *testing.T) {
 	mcmp.Exec(`SELECT shardkey + MIN(t1_id)+MAX(t1_id) FROM t1 GROUP BY shardkey`)
 	mcmp.Exec(`SELECT name+COUNT(t1_id)+1 FROM t1 GROUP BY name`)
 	mcmp.Exec(`SELECT COUNT(*)+shardkey+MIN(t1_id)+1+MAX(t1_id)*SUM(t1_id)+1+name FROM t1 GROUP BY shardkey, name`)
-	t.Run("Average in sharded query", func(t *testing.T) {
+	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
 		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 		mcmp.Exec(`SELECT COUNT(t1_id)+MAX(shardkey)+AVG(t1_id) FROM t1`)
 	})

--- a/go/test/endtoend/vtgate/queries/dml/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/insert_test.go
@@ -38,7 +38,7 @@ func TestSimpleInsertSelect(t *testing.T) {
 	mcmp.Exec("insert into u_tbl(id, num) values (1,2),(3,4)")
 
 	for i, mode := range []string{"oltp", "olap"} {
-		t.Run(mode, func(t *testing.T) {
+		mcmp.Run(mode, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", mode))
 
 			qr := mcmp.Exec(fmt.Sprintf("insert into s_tbl(id, num) select id*%d, num*%d from s_tbl where id < 10", 10+i, 20+i))
@@ -65,7 +65,7 @@ func TestFailureInsertSelect(t *testing.T) {
 	mcmp.Exec("insert into u_tbl(id, num) values (1,2),(3,4)")
 
 	for _, mode := range []string{"oltp", "olap"} {
-		t.Run(mode, func(t *testing.T) {
+		mcmp.Run(mode, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", mode))
 
 			// primary key same
@@ -127,7 +127,7 @@ func TestAutoIncInsertSelect(t *testing.T) {
 	}}
 
 	for _, tcase := range tcases {
-		t.Run(tcase.query, func(t *testing.T) {
+		mcmp.Run(tcase.query, func(mcmp *utils.MySQLCompare) {
 			qr := utils.Exec(t, mcmp.VtConn, tcase.query)
 			assert.EqualValues(t, tcase.expRowsAffected, qr.RowsAffected)
 			assert.EqualValues(t, tcase.expInsertID, qr.InsertID)
@@ -178,7 +178,7 @@ func TestAutoIncInsertSelectOlapMode(t *testing.T) {
 	}}
 
 	for _, tcase := range tcases {
-		t.Run(tcase.query, func(t *testing.T) {
+		mcmp.Run(tcase.query, func(mcmp *utils.MySQLCompare) {
 			qr := utils.Exec(t, mcmp.VtConn, tcase.query)
 			assert.EqualValues(t, tcase.expRowsAffected, qr.RowsAffected)
 			assert.EqualValues(t, tcase.expInsertID, qr.InsertID)
@@ -386,7 +386,7 @@ func TestInsertSelectUnshardedUsingSharded(t *testing.T) {
 	mcmp.Exec("insert into s_tbl(id, num) values (1,2),(3,4)")
 
 	for _, mode := range []string{"oltp", "olap"} {
-		t.Run(mode, func(t *testing.T) {
+		mcmp.Run(mode, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", mode))
 			qr := mcmp.Exec("insert into u_tbl(id, num) select id, num from s_tbl where s_tbl.id in (1,3)")
 			assert.EqualValues(t, 2, qr.RowsAffected)
@@ -453,7 +453,7 @@ func TestMixedCases(t *testing.T) {
 	}}
 
 	for _, tc := range tcases {
-		t.Run(tc.insQuery, func(t *testing.T) {
+		mcmp.Run(tc.insQuery, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, tc.insQuery)
 			utils.AssertMatches(t, mcmp.VtConn, tc.selQuery, tc.exp)
 		})

--- a/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
+++ b/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
@@ -134,7 +134,7 @@ func TestLookupQueries(t *testing.T) {
 	(3, 'monkey', 'monkey')`)
 
 	for _, workload := range []string{"olap", "oltp"} {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, "set workload = "+workload)
 
 			mcmp.AssertMatches("select id from user where lookup = 'apa'", "[[INT64(1)] [INT64(2)]]")

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -311,7 +311,7 @@ func TestAnalyze(t *testing.T) {
 	defer closer()
 
 	for _, workload := range []string{"olap", "oltp"} {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", workload))
 			utils.Exec(t, mcmp.VtConn, "analyze table t1")
 			utils.Exec(t, mcmp.VtConn, "analyze table uks.unsharded")
@@ -344,7 +344,7 @@ func TestTransactionModeVar(t *testing.T) {
 	}}
 
 	for _, tcase := range tcases {
-		t.Run(tcase.setStmt, func(t *testing.T) {
+		mcmp.Run(tcase.setStmt, func(mcmp *utils.MySQLCompare) {
 			if tcase.setStmt != "" {
 				utils.Exec(t, mcmp.VtConn, tcase.setStmt)
 			}

--- a/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
@@ -85,6 +85,9 @@ func TestOrderBy(t *testing.T) {
 }
 
 func TestOrderByComplex(t *testing.T) {
+	// tests written to try to trick the ORDER BY engine and planner
+	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -111,6 +114,37 @@ func TestOrderByComplex(t *testing.T) {
 		"select email, max(col) as xyz from user group by email order by abs(xyz) + email",
 		"select email, max(col) as xyz from user group by email order by abs(xyz)",
 		"select email, max(col) as xyz from user group by email order by abs(col)",
+		"select email, max(col) as max_col from user group by email order by max_col desc, length(email)",
+		"select email, max(col) as max_col, min(col) as min_col from user group by email order by max_col - min_col",
+		"select email, max(col) as col1, count(*) as col2 from user group by email order by col2 * col1",
+		"select email, sum(col) as sum_col from user group by email having sum_col > 10 order by sum_col / count(email)",
+		"select email, max(col) as max_col, char_length(email) as len_email from user group by email order by len_email, max_col desc",
+		"select email, max(col) as col_alias from user group by email order by case when col_alias > 100 then 0 else 1 end, col_alias",
+		"select email, count(*) as cnt, max(col) as max_col from user group by email order by cnt desc, max_col + cnt",
+		"select email, max(col) as max_col from user group by email order by if(max_col > 50, max_col, -max_col) desc",
+		"select email, max(col) as col, sum(col) as sum_col from user group by email order by col * sum_col desc",
+		"select email, max(col) as col, (select min(col) from user as u2 where u2.email = user.email) as min_col from user group by email order by col - min_col",
+		"select email, max(col) as max_col, (max(col) % 10) as mod_col from user group by email order by mod_col, max_col",
+		"select email, max(col) as 'value', count(email) as 'number' from user group by email order by 'number', 'value'",
+		"select email, max(col) as col, concat('email: ', email, ' col: ', max(col)) as complex_alias from user group by email order by complex_alias desc",
+		"select email, max(col) as max_col from user group by email union select email, min(col) as min_col from user group by email order by email",
+		"select email, max(col) as col from user where col > 50 group by email order by col desc",
+		"select email, max(col) as col from user group by email order by length(email), col",
+		"select email, max(col) as max_col, substring(email, 1, 3) as sub_email from user group by email order by sub_email, max_col desc",
+		"select email, max(col) as max_col from user group by email order by reverse(email), max_col",
+		"select email, max(col) as max_col from user group by email having max_col > avg(max_col) order by max_col desc",
+		"select email, count(*) as count, max(col) as max_col from user group by email order by count * max_col desc",
+		"select email, max(col) as col_alias from user group by email order by col_alias limit 10",
+		"select email, max(col) as col from user group by email order by col desc, email",
+		"select concat(email, ' ', max(col)) as combined from user group by email order by combined desc",
+		"select email, max(col) as max_col from user group by email order by ascii(email), max_col",
+		"select email, char_length(email) as email_length, max(col) as max_col from user group by email order by email_length desc, max_col",
+		"select email, max(col) as col from user group by email having col between 10 and 100 order by col",
+		"select email, max(col) as max_col, min(col) as min_col from user group by email order by max_col + min_col desc",
+		"select email, max(col) as 'max', count(*) as 'count' from user group by email order by 'max' desc, 'count'",
+		"select email, max(col) as max_col from (select email, col from user where col > 20) as filtered group by email order by max_col",
+		"select a.email, a.max_col from (select email, max(col) as max_col from user group by email) as a order by a.max_col desc",
+		"select email, max(col) as max_col from user where email like 'a%' group by email order by max_col, email",
 	}
 
 	for _, query := range queries {

--- a/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
@@ -114,8 +114,8 @@ func TestOrderByComplex(t *testing.T) {
 	}
 
 	for _, query := range queries {
-		t.Run(query, func(t *testing.T) {
-			mcmp.ExecAllowAndCompareError(query)
+		mcmp.Run(query, func(mcmp *utils.MySQLCompare) {
+			_, _ = mcmp.ExecAllowAndCompareError(query)
 		})
 	}
 }

--- a/go/test/endtoend/vtgate/queries/orderby/schema.sql
+++ b/go/test/endtoend/vtgate/queries/orderby/schema.sql
@@ -27,3 +27,12 @@ create table t4_id2_idx
 ) Engine = InnoDB
   DEFAULT charset = utf8mb4
   COLLATE = utf8mb4_general_ci;
+
+create table user
+(
+    id bigint primary key,
+    col bigint,
+    email varchar(20)
+) Engine = InnoDB
+  DEFAULT charset = utf8mb4
+  COLLATE = utf8mb4_general_ci;

--- a/go/test/endtoend/vtgate/queries/orderby/vschema.json
+++ b/go/test/endtoend/vtgate/queries/orderby/vschema.json
@@ -66,6 +66,14 @@
           "name": "unicode_loose_md5"
         }
       ]
+    },
+    "user": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ]
     }
   }
 }

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -57,7 +57,7 @@ func TestUnionDistinct(t *testing.T) {
 	mcmp.Exec("insert into t2(id3, id4) values (2, 3), (3, 4), (4,4), (5,5)")
 
 	for _, workload := range []string{"oltp", "olap"} {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, "set workload = "+workload)
 			mcmp.AssertMatches("select 1 union select null", "[[INT64(1)] [NULL]]")
 			mcmp.AssertMatches("select null union select null", "[[NULL]]")
@@ -69,7 +69,7 @@ func TestUnionDistinct(t *testing.T) {
 			mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 = 1 union select 452 union select id1 from t1 where id1 = 4", "[[INT64(1)] [INT64(452)] [INT64(4)]]")
 			mcmp.AssertMatchesNoOrder("select id1, id2 from t1 union select 827, 452 union select id3,id4 from t2",
 				"[[INT64(4) INT64(4)] [INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(827) INT64(452)] [INT64(2) INT64(3)] [INT64(3) INT64(4)] [INT64(5) INT64(5)]]")
-			t.Run("skipped for now", func(t *testing.T) {
+			mcmp.Run("skipped for now", func(mcmp *utils.MySQLCompare) {
 				t.Skip()
 				mcmp.AssertMatches("select 1 from dual where 1 IN (select 1 as col union select 2)", "[[INT64(1)]]")
 			})
@@ -97,7 +97,7 @@ func TestUnionAll(t *testing.T) {
 	mcmp.Exec("insert into t2(id3, id4) values(3, 3), (4, 4)")
 
 	for _, workload := range []string{"oltp", "olap"} {
-		t.Run(workload, func(t *testing.T) {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
 			utils.Exec(t, mcmp.VtConn, "set workload = "+workload)
 			// union all between two selectuniqueequal
 			mcmp.AssertMatches("select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -69,10 +69,7 @@ func TestUnionDistinct(t *testing.T) {
 			mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 = 1 union select 452 union select id1 from t1 where id1 = 4", "[[INT64(1)] [INT64(452)] [INT64(4)]]")
 			mcmp.AssertMatchesNoOrder("select id1, id2 from t1 union select 827, 452 union select id3,id4 from t2",
 				"[[INT64(4) INT64(4)] [INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(827) INT64(452)] [INT64(2) INT64(3)] [INT64(3) INT64(4)] [INT64(5) INT64(5)]]")
-			mcmp.Run("skipped for now", func(mcmp *utils.MySQLCompare) {
-				t.Skip()
-				mcmp.AssertMatches("select 1 from dual where 1 IN (select 1 as col union select 2)", "[[INT64(1)]]")
-			})
+			mcmp.AssertMatches("select 1 from dual where 1 IN (select 1 as col union select 2)", "[[INT64(1)]]")
 			if utils.BinaryIsAtLeastAtVersion(19, "vtgate") {
 				mcmp.AssertMatches(`SELECT 1 from t1 UNION SELECT 2 from t1`, `[[INT64(1)] [INT64(2)]]`)
 				mcmp.AssertMatches(`SELECT 5 from t1 UNION SELECT 6 from t1`, `[[INT64(5)] [INT64(6)]]`)

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1058,7 +1058,7 @@ func (s *Schema) ValidateViewReferences() error {
 					Column:    e.Column,
 					Ambiguous: true,
 				}
-			case *semantics.ColumnNotFoundError:
+			case semantics.ColumnNotFoundError:
 				return &InvalidColumnReferencedInViewError{
 					View:   view.Name(),
 					Column: e.Column.Name.String(),

--- a/go/vt/vterrors/state.go
+++ b/go/vt/vterrors/state.go
@@ -48,6 +48,7 @@ const (
 	WrongValue
 	WrongArguments
 	BadNullError
+	InvalidGroupFuncUse
 
 	// failed precondition
 	NoDB

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -2235,5 +2235,139 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "ORDER BY literal works fine even when the columns have the same name",
+    "query": "select a.id, b.id from user as a, user_extra as b union all select 1, 2 order by 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select a.id, b.id from user as a, user_extra as b union all select 1, 2 order by 1",
+      "Instructions": {
+        "OperatorType": "Sort",
+        "Variant": "Memory",
+        "OrderBy": "(0|2) ASC",
+        "ResultColumns": 2,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:0,R:0,L:1",
+                "TableName": "`user`_user_extra",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select a.id, weight_string(a.id) from `user` as a where 1 != 1",
+                    "Query": "select a.id, weight_string(a.id) from `user` as a",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select b.id from user_extra as b where 1 != 1",
+                    "Query": "select b.id from user_extra as b",
+                    "Table": "user_extra"
+                  }
+                ]
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1, 2, weight_string(1) from dual where 1 != 1",
+                "Query": "select 1, 2, weight_string(1) from dual",
+                "Table": "dual"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "ORDER BY literal works fine even when the columns have the same name",
+    "query": "select a.id, b.id from user as a, user_extra as b union all select 1, 2 order by 2",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select a.id, b.id from user as a, user_extra as b union all select 1, 2 order by 2",
+      "Instructions": {
+        "OperatorType": "Sort",
+        "Variant": "Memory",
+        "OrderBy": "(1|2) ASC",
+        "ResultColumns": 2,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:0,R:0,R:1",
+                "TableName": "`user`_user_extra",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select a.id from `user` as a where 1 != 1",
+                    "Query": "select a.id from `user` as a",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select b.id, weight_string(b.id) from user_extra as b where 1 != 1",
+                    "Query": "select b.id, weight_string(b.id) from user_extra as b",
+                    "Table": "user_extra"
+                  }
+                ]
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1, 2, weight_string(2) from dual where 1 != 1",
+                "Query": "select 1, 2, weight_string(2) from dual",
+                "Table": "dual"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -180,11 +180,6 @@
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
-    "comment": "rewrite of 'order by 2' that becomes 'order by id', leading to ambiguous binding.",
-    "query": "select a.id, b.id from user as a, user_extra as b union select 1, 2 order by 2",
-    "plan": "Column 'id' in field list is ambiguous"
-  },
-  {
     "comment": "unsupported with clause in delete statement",
     "query": "with x as (select * from user) delete from x",
     "plan": "VT12001: unsupported: WITH expression in DELETE statement"

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -70,11 +70,11 @@ func (a *analyzer) lateInit() {
 	a.scoper.binder = a.binder
 	a.rewriter = &earlyRewriter{
 		binder:          a.binder,
-		typer:           a.typer,
 		scoper:          a.scoper,
 		expandedColumns: map[sqlparser.TableName][]*sqlparser.ColName{},
 		env:             a.si.Environment(),
 		aliasMapCache:   map[*sqlparser.Select]map[string]exprContainer{},
+		reAnalyze:       a.lateAnalyze,
 	}
 }
 
@@ -351,6 +351,10 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 
 	a.lateInit()
 
+	return a.lateAnalyze(statement)
+}
+
+func (a *analyzer) lateAnalyze(statement sqlparser.SQLNode) error {
 	_ = sqlparser.Rewrite(statement, a.analyzeDown, a.analyzeUp)
 	return a.err
 }

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -70,6 +70,7 @@ func (a *analyzer) lateInit() {
 	a.scoper.binder = a.binder
 	a.rewriter = &earlyRewriter{
 		binder:          a.binder,
+		typer:           a.typer,
 		scoper:          a.scoper,
 		expandedColumns: map[sqlparser.TableName][]*sqlparser.ColName{},
 		env:             a.si.Environment(),

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -29,6 +29,7 @@ import (
 
 type earlyRewriter struct {
 	binder          *binder
+	typer           *typer
 	scoper          *scoper
 	clause          string
 	warning         string
@@ -259,7 +260,12 @@ func (it *orderByIterator) replace(e sqlparser.Expr) (err error) {
 
 	sqlparser.Rewrite(e, nil, func(cursor *sqlparser.Cursor) bool {
 		err = it.r.binder.up(cursor)
-		return true
+		if err != nil {
+			return false
+		}
+		err = it.r.typer.up(cursor)
+
+		return err == nil
 	})
 
 	return nil

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -553,8 +553,8 @@ func (r *earlyRewriter) rewriteAliasesInHavingAndGroupBy(node sqlparser.Expr, se
 func (r *earlyRewriter) rewriteAliasesInOrderBy(node sqlparser.Expr, sel *sqlparser.Select) (expr sqlparser.Expr, err error) {
 	currentScope := r.scoper.currentScope()
 	if currentScope.isUnion {
-		// for now, punt on these queries and let the old code handle it
-		return r.rewriteAliasesInHavingAndGroupBy(node, sel)
+		// It is not safe to rewrite order by clauses in unions.
+		return node, nil
 	}
 
 	aliases := r.getAliasMap(sel)

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -399,14 +399,14 @@ func TestOrderByLiteral(t *testing.T) {
 	}, {
 		sql:    "select id from t1 order by 2",
 		expErr: "Unknown column '2' in 'order clause'",
-		// }, {
-		// 	sql:     "select a.id, b.id from user as a, user_extra as b union select 1, 2 order by 1",
-		// 	expSQL:  "select a.id, b.id from `user` as a, user_extra as b union select 1, 2 from dual order by id asc",
-		// 	expDeps: TS0,
-		// }, {
-		// 	sql:     "select a.id, b.id from user as a, user_extra as b union select 1, 2 order by 2",
-		// 	expSQL:  "select a.id, b.id from `user` as a, user_extra as b union select 1, 2 from dual order by id asc",
-		// 	expDeps: TS1,
+	}, {
+		sql:     "select a.id, b.id from user as a, user_extra as b union select 1, 2 order by 1",
+		expSQL:  "select a.id, b.id from `user` as a, user_extra as b union select 1, 2 from dual order by id asc",
+		expDeps: TS0,
+	}, {
+		sql:     "select a.id, b.id from user as a, user_extra as b union select 1, 2 order by 2",
+		expSQL:  "select a.id, b.id from `user` as a, user_extra as b union select 1, 2 from dual order by id asc",
+		expDeps: TS1,
 	}}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -326,9 +326,6 @@ func TestGroupByLiteral(t *testing.T) {
 		sql:    "select id from t1 group by 2",
 		expErr: "Unknown column '2' in 'group clause'",
 	}, {
-		sql:    "select id from t1 order by 2",
-		expErr: "Unknown column '2' in 'order clause'",
-	}, {
 		sql:    "select *, id from t1 group by 2",
 		expErr: "cannot use column offsets in group clause when using `*`",
 	}}
@@ -399,6 +396,9 @@ func TestOrderByLiteral(t *testing.T) {
 		sql:     "select id from `user` union select 1 from dual order by 1",
 		expSQL:  "select id from `user` union select 1 from dual order by id asc",
 		expDeps: TS0,
+	}, {
+		sql:    "select id from t1 order by 2",
+		expErr: "Unknown column '2' in 'order clause'",
 		// }, {
 		// 	sql:     "select a.id, b.id from user as a, user_extra as b union select 1, 2 order by 1",
 		// 	expSQL:  "select a.id, b.id from `user` as a, user_extra as b union select 1, 2 from dual order by id asc",

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -407,6 +407,10 @@ func TestOrderByLiteral(t *testing.T) {
 		sql:     "select a.id, b.id from user as a, user_extra as b union select 1, 2 order by 2",
 		expSQL:  "select a.id, b.id from `user` as a, user_extra as b union select 1, 2 from dual order by id asc",
 		expDeps: TS1,
+	}, {
+		sql:     "select user.id as foo from user union select col from user_extra order by 1",
+		expSQL:  "select `user`.id as foo from `user` union select col from user_extra order by foo asc",
+		expDeps: MergeTableSets(TS0, TS1),
 	}}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {
@@ -526,7 +530,11 @@ func TestOrderByColumnName(t *testing.T) {
 	}, {
 		sql:    "select id, count(distinct foo) k from t1 group by id order by k",
 		expSQL: "select id, count(distinct foo) as k from t1 group by id order by count(distinct foo) asc",
-	}}
+	}, {
+		sql:    "select user.id as foo from user union select col from user_extra order by foo",
+		expSQL: "select `user`.id as foo from `user` union select col from user_extra order by foo asc",
+	},
+	}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {
 			ast, err := sqlparser.NewTestParser().Parse(tcase.sql)


### PR DESCRIPTION
## Description
In a recent [PR](https://github.com/vitessio/vitess/pull/14935), I did some work on how to rewrite column aliases used in ORDER BY,  GROUP BY and HAVING.

I did not get that right, and introduced issues for a set of queries. This PR tries to correctly rewrite more column using the same rules that MySQL has.

### Rewrite rules
Terminology first: an expression in the `SELECT` clause is a SELECT-expression. These can have aliased.
An ORDER BY expression is an expression listed in the ORDER BY clause, without the ASC/DESC modifier.

Rewrite rule:
An unqualified column name in the ORDER BY that matches an alias among the SELECT expressions will be replaced with the SELECT expression if:
- ORDER BY is on SELECT and not UNION
- It's the full ORDER BY expression, _OR_ no table has a matching column name, _OR_ it's used inside an aggregation function.


## Related Issue(s)
Original PR #14935

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
