### PR TITLE
Fix some binaries to print the versions

### DIFF
--- a/go/cmd/mysqlctld/cli/mysqlctld.go
+++ b/go/cmd/mysqlctld/cli/mysqlctld.go
@@ -67,6 +67,7 @@ var (
 	--mysql_port=17100 \
 	--socket_file=/path/to/socket_file`,
 		Args:    cobra.NoArgs,
+		Version: servenv.AppVersion.String(),
 		PreRunE: servenv.CobraPreRunE,
 		RunE:    run,
 	}

--- a/go/cmd/topo2topo/cli/topo2topo.go
+++ b/go/cmd/topo2topo/cli/topo2topo.go
@@ -52,6 +52,7 @@ var (
 It can also be used to compare data between two topologies.`,
 		Args:    cobra.NoArgs,
 		PreRunE: servenv.CobraPreRunE,
+		Version: servenv.AppVersion.String(),
 		RunE:    run,
 	}
 )

--- a/go/cmd/vtexplain/cli/vtexplain.go
+++ b/go/cmd/vtexplain/cli/vtexplain.go
@@ -84,6 +84,7 @@ If no keyspace name is present, VTExplain will return the following error:
 			"```\nvtexplain -- -shards 128 --vschema-file vschema.json --schema-file schema.sql --replication-mode \"ROW\" --output-mode text --sql \"INSERT INTO users (user_id, name) VALUES(1, 'john')\"\n```\n",
 		Args:    cobra.NoArgs,
 		PreRunE: servenv.CobraPreRunE,
+		Version: servenv.AppVersion.String(),
 		RunE:    run,
 	}
 )

--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -104,6 +104,7 @@ func New() (cmd *cobra.Command) {
 		Short:   "vttestserver allows users to spawn a self-contained Vitess server for local testing/CI.",
 		Args:    cobra.NoArgs,
 		PreRunE: servenv.CobraPreRunE,
+		Version: servenv.AppVersion.String(),
 		RunE:    run,
 	}
 

--- a/go/cmd/zkctld/cli/zkctld.go
+++ b/go/cmd/zkctld/cli/zkctld.go
@@ -41,6 +41,7 @@ var (
 		Use:               "zkctld",
 		Short:             "zkctld is a daemon that starts or initializes ZooKeeper with Vitess-specific configuration. It will stay running as long as the underlying ZooKeeper server, and will pass along SIGTERM.",
 		Args:              cobra.NoArgs,
+		Version:           servenv.AppVersion.String(),
 		PersistentPreRunE: servenv.CobraPreRunE,
 		PostRun: func(cmd *cobra.Command, args []string) {
 			logutil.Flush()

--- a/go/flags/endtoend/zkctld.txt
+++ b/go/flags/endtoend/zkctld.txt
@@ -4,4 +4,5 @@ Usage:
   zkctld [flags]
 
 Flags:
-  -h, --help   help for zkctld
+  -h, --help      help for zkctld
+  -v, --version   version for zkctld


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue pointed out in https://github.com/vitessio/vitess/issues/15305. 

The fix is just to specify the Version field when we initialize the root command for the binaries.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15305

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
