### PR TITLE
Skip for-loop alloc in `go/vt/discovery/healthcheck.go`

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -774,6 +774,7 @@ func FilterTargetsByKeyspaces(keyspaces []string, targets []*query.Target) []*qu
 func (hc *HealthCheckImpl) waitForTablets(ctx context.Context, targets []*query.Target, requireServing bool) error {
 	targets = FilterTargetsByKeyspaces(KeyspacesToWatch, targets)
 
+	var tabletHealths []*TabletHealth
 	for {
 		// We nil targets as we find them.
 		allPresent := true
@@ -782,7 +783,6 @@ func (hc *HealthCheckImpl) waitForTablets(ctx context.Context, targets []*query.
 				continue
 			}
 
-			var tabletHealths []*TabletHealth
 			if requireServing {
 				tabletHealths = hc.GetHealthyTabletStats(target)
 			} else {


### PR DESCRIPTION
## Description

This PR skips an allocation in a `for`-loop from `go/vt/discovery/healthcheck.go`

If I understand correctly this will cause 1 x allocation for `var tabletHealths []*TabletHealth` per execution of `.waitForTablets(...)` vs `<numTargets> x <numRetries>`

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
