### PR TITLE
test: skip should mark the correct *testing.T

### DIFF
--- a/go/test/endtoend/utils/cmp.go
+++ b/go/test/endtoend/utils/cmp.go
@@ -70,6 +70,12 @@ func (mcmp *MySQLCompare) AssertMatches(query, expected string) {
 	}
 }
 
+// SkipIfBinaryIsBelowVersion should be used instead of using utils.SkipIfBinaryIsBelowVersion(t,
+// This is because we might be inside a Run block that has a different `t` variable
+func (mcmp *MySQLCompare) SkipIfBinaryIsBelowVersion(majorVersion int, binary string) {
+	SkipIfBinaryIsBelowVersion(mcmp.t, majorVersion, binary)
+}
+
 // AssertMatchesAny ensures the given query produces any one of the expected results.
 func (mcmp *MySQLCompare) AssertMatchesAny(query string, expected ...string) {
 	mcmp.t.Helper()

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -74,7 +74,7 @@ func TestAggregateTypes(t *testing.T) {
 	mcmp.AssertMatches("select val1 as a, count(*) from aggr_test group by a order by 2, a", `[[VARCHAR("b") INT64(1)] [VARCHAR("d") INT64(1)] [VARCHAR("a") INT64(2)] [VARCHAR("c") INT64(2)] [VARCHAR("e") INT64(2)]]`)
 	mcmp.AssertMatches("select sum(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	mcmp.Run("Average for sharded keyspaces", func(mcmp *utils.MySQLCompare) {
-		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches("select avg(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	})
 }
@@ -178,7 +178,7 @@ func TestAggrOnJoin(t *testing.T) {
 		`[[VARCHAR("a")]]`)
 
 	mcmp.Run("Average in join for sharded", func(mcmp *utils.MySQLCompare) {
-		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches(`select avg(a1.val2), avg(a2.val2) from aggr_test a1 join aggr_test a2 on a1.val2 = a2.id join t3 t on a2.val2 = t.id7`,
 			"[[DECIMAL(1.5000) DECIMAL(1.0000)]]")
 
@@ -336,7 +336,7 @@ func TestAggOnTopOfLimit(t *testing.T) {
 			mcmp.AssertMatches("select val1, count(*) from (select id, val1 from aggr_test where val2 < 4 order by val1 limit 2) as x group by val1", `[[NULL INT64(1)] [VARCHAR("a") INT64(1)]]`)
 			mcmp.AssertMatchesNoOrder("select val1, count(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1", `[[NULL INT64(1)] [VARCHAR("a") INT64(2)] [VARCHAR("b") INT64(1)] [VARCHAR("c") INT64(2)]]`)
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches("select avg(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[NULL]]")
 				mcmp.AssertMatchesNoOrder("select val1, avg(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1", `[[NULL DECIMAL(2.0000)] [VARCHAR("a") DECIMAL(3.5000)] [VARCHAR("b") DECIMAL(1.0000)] [VARCHAR("c") DECIMAL(3.5000)]]`)
 			})
@@ -348,7 +348,7 @@ func TestAggOnTopOfLimit(t *testing.T) {
 			mcmp.AssertMatches("select count(val2), sum(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[INT64(0) NULL]]")
 			mcmp.AssertMatches("select val1, count(*), sum(id) from (select id, val1 from aggr_test where val2 < 4 order by val1 limit 2) as x group by val1", `[[NULL INT64(1) DECIMAL(7)] [VARCHAR("a") INT64(1) DECIMAL(2)]]`)
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches("select count(*), sum(val1), avg(val1) from (select id, val1 from aggr_test where val2 < 4 order by val1 desc limit 2) as x", "[[INT64(2) FLOAT64(0) FLOAT64(0)]]")
 				mcmp.AssertMatches("select count(val1), sum(id), avg(id) from (select id, val1 from aggr_test where val2 < 4 order by val1 desc limit 2) as x", "[[INT64(2) DECIMAL(7) DECIMAL(3.5000)]]")
 				mcmp.AssertMatchesNoOrder("select val1, count(val2), sum(val2), avg(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1",
@@ -370,7 +370,7 @@ func TestEmptyTableAggr(t *testing.T) {
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches(" select count(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 				mcmp.AssertMatches(" select avg(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[NULL]]")
 			})
@@ -386,7 +386,7 @@ func TestEmptyTableAggr(t *testing.T) {
 			mcmp.AssertMatches(" select count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches(" select count(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 				mcmp.AssertMatches(" select avg(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[NULL]]")
 				mcmp.AssertMatches(" select t1.`name`, count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
@@ -435,7 +435,7 @@ func TestAggregateLeftJoin(t *testing.T) {
 	mcmp.AssertMatches("SELECT count(*) FROM t2 LEFT JOIN t1 ON t1.t1_id = t2.id WHERE IFNULL(t1.name, 'NOTSET') = 'r'", `[[INT64(1)]]`)
 
 	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches("SELECT avg(t1.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(0.5000)]]`)
 		mcmp.AssertMatches("SELECT avg(t2.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(1.0000)]]`)
 		aggregations := []string{
@@ -492,7 +492,7 @@ func TestScalarAggregate(t *testing.T) {
 	mcmp.Exec("insert into aggr_test(id, val1, val2) values(1,'a',1), (2,'A',1), (3,'b',1), (4,'c',3), (5,'c',4)")
 	mcmp.AssertMatches("select count(distinct val1) from aggr_test", `[[INT64(3)]]`)
 	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches("select avg(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	})
 }
@@ -552,7 +552,7 @@ func TestComplexAggregation(t *testing.T) {
 	mcmp.Exec(`SELECT name+COUNT(t1_id)+1 FROM t1 GROUP BY name`)
 	mcmp.Exec(`SELECT COUNT(*)+shardkey+MIN(t1_id)+1+MAX(t1_id)*SUM(t1_id)+1+name FROM t1 GROUP BY shardkey, name`)
 	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
+		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.Exec(`SELECT COUNT(t1_id)+MAX(shardkey)+AVG(t1_id) FROM t1`)
 	})
 }


### PR DESCRIPTION
## Description
When we are inside a `t.Run` or `mcmp.Run`, we need to mark the correct `t` as skipped. Since the `mcmp` struct contains the `*testing.T` we are using, we should not use the outer `t` for skipping.
