### PR TITLE
go/vt/discovery: use protobuf getters for SrvVschema

### DIFF
--- a/go/vt/discovery/keyspace_events.go
+++ b/go/vt/discovery/keyspace_events.go
@@ -391,8 +391,7 @@ func (kss *keyspaceState) getMoveTablesStatus(vs *vschemapb.SrvVSchema) (*MoveTa
 	}
 
 	// if there are no routing rules defined, then movetables is not in progress, exit early
-	if (vs.RoutingRules != nil && len(vs.RoutingRules.Rules) == 0) &&
-		(vs.ShardRoutingRules != nil && len(vs.ShardRoutingRules.Rules) == 0) {
+	if len(vs.GetRoutingRules().GetRules()) == 0 && len(vs.GetShardRoutingRules().GetRules()) == 0 {
 		return mtState, nil
 	}
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Use nil-safe protobuf getters to early exit when no routing rules or shard routing rules are defined. This also prevents a panic on `(*vschemapb.SrvVschema)(nil)`.

I would suggest backporting this bugfix to all supported versions with the prior logic:

```go
	// if there are no routing rules defined, then movetables is not in progress, exit early
	if (vs.RoutingRules != nil && len(vs.RoutingRules.Rules) == 0) &&
		(vs.ShardRoutingRules != nil && len(vs.ShardRoutingRules.Rules) == 0) {
		return mtState, nil
	}
```

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/15342

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

n/a

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
