### PR TITLE
Bugfix: GROUP BY/HAVING alias resolution

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -673,3 +673,80 @@ func TestDistinctAggregation(t *testing.T) {
 		})
 	}
 }
+
+func TestHavingQueries(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	inserts := []string{
+		`INSERT INTO emp (empno, ename, job, mgr, hiredate, sal, comm, deptno) VALUES
+	(1, 'John', 'Manager', NULL, '2022-01-01', 5000, 500, 1),
+	(2, 'Doe', 'Analyst', 1, '2023-01-01', 4500, NULL, 1),
+	(3, 'Jane', 'Clerk', 1, '2023-02-01', 3000, 200, 2),
+	(4, 'Mary', 'Analyst', 2, '2022-03-01', 4700, NULL, 1),
+	(5, 'Smith', 'Salesman', 3, '2023-01-15', 3200, 300, 3)`,
+		"INSERT INTO dept (deptno, dname, loc) VALUES (1, 'IT', 'New York'), (2, 'HR', 'London'), (3, 'Sales', 'San Francisco')",
+		"INSERT INTO t1 (t1_id, name, value, shardKey) VALUES (1, 'Name1', 'Value1', 100), (2, 'Name2', 'Value2', 100), (3, 'Name1', 'Value3', 200)",
+		"INSERT INTO aggr_test_dates (id, val1, val2) VALUES (1, '2023-01-01', '2023-01-02'), (2, '2023-02-01', '2023-02-02'), (3, '2023-03-01', '2023-03-02')",
+		"INSERT INTO t10 (k, a, b) VALUES (1, 10, 20), (2, 30, 40), (3, 50, 60)",
+		"INSERT INTO t3 (id5, id6, id7) VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)",
+		"INSERT INTO t9 (id1, id2, id3) VALUES (1, 'A1', 'B1'), (2, 'A2', 'B2'), (3, 'A1', 'B3')",
+		"INSERT INTO aggr_test (id, val1, val2) VALUES (1, 'Test1', 100), (2, 'Test2', 200), (3, 'Test1', 300), (4, 'Test3', 400)",
+		"INSERT INTO t2 (id, shardKey) VALUES (1, 100), (2, 200), (3, 300)",
+		`INSERT INTO bet_logs (id, merchant_game_id, bet_amount, game_id) VALUES
+	(1, 1, 100.0, 10),
+	(2, 1, 200.0, 11),
+	(3, 2, 300.0, 10),
+	(4, 3, 400.0, 12)`,
+	}
+
+	for _, insert := range inserts {
+		mcmp.Exec(insert)
+	}
+
+	queries := []string{
+		// these first queries are all failing in different ways. let's check that Vitess also fails
+		"SELECT ename FROM emp GROUP BY ename HAVING sal > 5000",
+		"SELECT deptno, AVG(sal) AS average_salary HAVING average_salary > 5000 FROM emp",
+		"SELECT job, COUNT(empno) AS num_employees FROM emp HAVING num_employees > 2",
+		"SELECT dname, SUM(sal) FROM dept JOIN emp ON dept.deptno = emp.deptno HAVING AVG(sal) > 6000",
+		"SELECT COUNT(*) AS count FROM emp WHERE count > 5",
+		"SELECT `name`, AVG(`value`) FROM t1 GROUP BY `name` HAVING `name`",
+		"SELECT val1, COUNT(val2) FROM aggr_test_dates GROUP BY val1 HAVING val2 > 5",
+		"SELECT k, a FROM t10 GROUP BY k HAVING b > 2",
+		"SELECT empno, MAX(sal) FROM emp HAVING COUNT(*) > 3",
+		"SELECT loc FROM dept GROUP BY loc HAVING COUNT(deptno) AND dname = 'Sales'",
+		"SELECT id, SUM(bet_amount) AS total_bets FROM bet_logs HAVING total_bets > 1000",
+		"SELECT merchant_game_id FROM bet_logs GROUP BY merchant_game_id HAVING SUM(bet_amount)",
+		"SELECT shardKey, COUNT(id) FROM t2 HAVING shardKey > 100",
+		"SELECT AVG(val2) AS average_val2 FROM aggr_test HAVING val1 = 'Test'",
+		"SELECT deptno FROM emp GROUP BY deptno HAVING MAX(hiredate) > '2020-01-01'",
+
+		"SELECT deptno, COUNT(*) AS num_employees FROM emp GROUP BY deptno HAVING num_employees > 5",
+		"SELECT ename, SUM(sal) FROM emp GROUP BY ename HAVING SUM(sal) > 10000",
+		"SELECT dname, AVG(sal) AS average_salary FROM emp JOIN dept ON emp.deptno = dept.deptno GROUP BY dname HAVING average_salary > 5000",
+		"SELECT dname, MAX(sal) AS max_salary FROM emp JOIN dept ON emp.deptno = dept.deptno GROUP BY dname HAVING max_salary < 10000",
+		"SELECT YEAR(hiredate) AS year, COUNT(*) FROM emp GROUP BY year HAVING COUNT(*) > 2",
+		"SELECT mgr, COUNT(empno) AS managed_employees FROM emp WHERE mgr IS NOT NULL GROUP BY mgr HAVING managed_employees >= 3",
+		"SELECT deptno, SUM(comm) AS total_comm FROM emp GROUP BY deptno HAVING total_comm > AVG(total_comm)",
+		"SELECT id2, COUNT(*) AS count FROM t9 GROUP BY id2 HAVING count > 1",
+		"SELECT val1, COUNT(*) FROM aggr_test GROUP BY val1 HAVING COUNT(*) > 1",
+		"SELECT DATE(val1) AS date, SUM(val2) FROM aggr_test_dates GROUP BY date HAVING SUM(val2) > 100",
+		"SELECT shardKey, AVG(`value`) FROM t1 WHERE `value` IS NOT NULL GROUP BY shardKey HAVING AVG(`value`) > 10",
+		"SELECT job, COUNT(*) AS job_count FROM emp GROUP BY job HAVING job_count > 3",
+		"SELECT b, AVG(a) AS avg_a FROM t10 GROUP BY b HAVING AVG(a) > 5",
+		"SELECT merchant_game_id, SUM(bet_amount) AS total_bets FROM bet_logs GROUP BY merchant_game_id HAVING total_bets > 1000",
+		"SELECT loc, COUNT(deptno) AS num_depts FROM dept GROUP BY loc HAVING num_depts > 1",
+		"SELECT `name`, COUNT(*) AS name_count FROM t1 GROUP BY `name` HAVING name_count > 2",
+		"SELECT COUNT(*) AS num_jobs FROM emp GROUP BY empno HAVING num_jobs > 1",
+		"SELECT id, COUNT(*) AS count FROM t2 GROUP BY id HAVING count > 1",
+		"SELECT val2, SUM(id) FROM aggr_test GROUP BY val2 HAVING SUM(id) > 10",
+		"SELECT game_id, COUNT(*) AS num_logs FROM bet_logs GROUP BY game_id HAVING num_logs > 5",
+	}
+
+	for _, query := range queries {
+		mcmp.Run(query, func(mcmp *utils.MySQLCompare) {
+			mcmp.Exec(query)
+		})
+	}
+}

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -40,7 +40,21 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	deleteAll := func() {
 		_, _ = utils.ExecAllowError(t, mcmp.VtConn, "set workload = oltp")
 
-		tables := []string{"t9", "aggr_test", "t3", "t7_xxhash", "aggr_test_dates", "t7_xxhash_idx", "t1", "t2", "t10"}
+		tables := []string{
+			"t3",
+			"t3_id7_idx",
+			"t9",
+			"aggr_test",
+			"aggr_test_dates",
+			"t7_xxhash",
+			"t7_xxhash_idx",
+			"t1",
+			"t2",
+			"t10",
+			"emp",
+			"dept",
+			"bet_logs",
+		}
 		for _, table := range tables {
 			_, _ = mcmp.ExecAndIgnore("delete from " + table)
 		}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1932,7 +1932,7 @@ func TestSelectScatterOrderBy(t *testing.T) {
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select col1, col2, weight_string(col2) from `user` order by col2 desc",
+		Sql:           "select col1, col2, weight_string(col2) from `user` order by `user`.col2 desc",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
@@ -2005,7 +2005,7 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select col1, textcol, weight_string(textcol) from `user` order by textcol desc",
+		Sql:           "select col1, textcol, weight_string(textcol) from `user` order by `user`.textcol desc",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
@@ -2071,7 +2071,7 @@ func TestStreamSelectScatterOrderBy(t *testing.T) {
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select id, col, weight_string(col) from `user` order by col desc",
+		Sql:           "select id, col, weight_string(col) from `user` order by `user`.col desc",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
@@ -2133,7 +2133,7 @@ func TestStreamSelectScatterOrderByVarChar(t *testing.T) {
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select id, textcol, weight_string(textcol) from `user` order by textcol desc",
+		Sql:           "select id, textcol, weight_string(textcol) from `user` order by `user`.textcol desc",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
@@ -2329,7 +2329,7 @@ func TestSelectScatterLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select col1, col2, weight_string(col2) from `user` order by col2 desc limit :__upper_limit",
+		Sql:           "select col1, col2, weight_string(col2) from `user` order by `user`.col2 desc limit :__upper_limit",
 		BindVariables: map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)},
 	}}
 	for _, conn := range conns {
@@ -2401,7 +2401,7 @@ func TestStreamSelectScatterLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select col1, col2, weight_string(col2) from `user` order by col2 desc limit :__upper_limit",
+		Sql:           "select col1, col2, weight_string(col2) from `user` order by `user`.col2 desc limit :__upper_limit",
 		BindVariables: map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)},
 	}}
 	for _, conn := range conns {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -1580,7 +1580,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1 group by id",
-        "Query": "select id from `user` group by id having count(`user`.id) = 10",
+        "Query": "select id from `user` group by id having count(id) = 10",
         "Table": "`user`"
       },
       "TablesUsed": [
@@ -1735,10 +1735,10 @@
   },
   {
     "comment": "Column and Literal equality filter on scatter aggregates",
-    "query": "select count(*) a from user having a = 10",
+    "query": "select count(*) a from authoritative having a = 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a = 10",
+      "Original": "select count(*) a from authoritative having a = 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 10",
@@ -1755,25 +1755,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Equality filtering with column and string literal on scatter aggregates",
-    "query": "select count(*) a from user having a = '1'",
+    "query": "select count(*) a from authoritative having a = '1'",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a = '1'",
+      "Original": "select count(*) a from authoritative having a = '1'",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = '1'",
@@ -1790,25 +1790,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Column and Literal not equal filter on scatter aggregates",
-    "query": "select count(*) a from user having a != 10",
+    "query": "select count(*) a from authoritative having a != 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a != 10",
+      "Original": "select count(*) a from authoritative having a != 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) != 10",
@@ -1825,25 +1825,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Not equal filter with column and string literal on scatter aggregates",
-    "query": "select count(*) a from user having a != '1'",
+    "query": "select count(*) a from authoritative having a != '1'",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a != '1'",
+      "Original": "select count(*) a from authoritative having a != '1'",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) != '1'",
@@ -1860,25 +1860,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Greater than filter on scatter aggregates",
-    "query": "select count(*) a from user having a > 10",
+    "query": "select count(*) a from authoritative having a > 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a > 10",
+      "Original": "select count(*) a from authoritative having a > 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) > 10",
@@ -1895,25 +1895,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Greater Equal filter on scatter aggregates",
-    "query": "select count(*) a from user having a >= 10",
+    "query": "select count(*) a from authoritative having a >= 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a >= 10",
+      "Original": "select count(*) a from authoritative having a >= 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) >= 10",
@@ -1930,25 +1930,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Less than filter on scatter aggregates",
-    "query": "select count(*) a from user having a < 10",
+    "query": "select count(*) a from authoritative having a < 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a < 10",
+      "Original": "select count(*) a from authoritative having a < 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) < 10",
@@ -1965,25 +1965,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Less Equal filter on scatter aggregates",
-    "query": "select count(*) a from user having a <= 10",
+    "query": "select count(*) a from authoritative having a <= 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a <= 10",
+      "Original": "select count(*) a from authoritative having a <= 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) <= 10",
@@ -2000,25 +2000,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "Less Equal filter on scatter with grouping",
-    "query": "select col, count(*) a from user group by col having a <= 10",
+    "query": "select col1, count(*) a from authoritative group by col1 having a <= 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select col, count(*) a from user group by col having a <= 10",
+      "Original": "select col1, count(*) a from authoritative group by col1 having a <= 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) <= 10",
@@ -2027,7 +2027,7 @@
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(1) AS a",
-            "GroupBy": "0",
+            "GroupBy": "0 COLLATE latin1_swedish_ci",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2036,26 +2036,26 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select col, count(*) as a from `user` where 1 != 1 group by col",
-                "OrderBy": "0 ASC",
-                "Query": "select col, count(*) as a from `user` group by col order by col asc",
-                "Table": "`user`"
+                "FieldQuery": "select col1, count(*) as a from authoritative where 1 != 1 group by col1",
+                "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
+                "Query": "select col1, count(*) as a from authoritative group by col1 order by col1 asc",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "We should be able to find grouping keys on ordered aggregates",
-    "query": "select count(*) as a, val1 from user group by val1 having a = 1.00",
+    "query": "select count(*) as a, col2 from authoritative group by col2 having a = 1.00",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) as a, val1 from user group by val1 having a = 1.00",
+      "Original": "select count(*) as a, col2 from authoritative group by col2 having a = 1.00",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 1.00",
@@ -2074,17 +2074,17 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a, val1, weight_string(val1) from `user` where 1 != 1 group by val1, weight_string(val1)",
+                "FieldQuery": "select count(*) as a, col2, weight_string(col2) from authoritative where 1 != 1 group by col2, weight_string(col2)",
                 "OrderBy": "(1|2) ASC",
-                "Query": "select count(*) as a, val1, weight_string(val1) from `user` group by val1, weight_string(val1) order by val1 asc",
-                "Table": "`user`"
+                "Query": "select count(*) as a, col2, weight_string(col2) from authoritative group by col2, weight_string(col2) order by col2 asc",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
@@ -2925,14 +2925,14 @@
       "Original": "select foo, sum(foo) as fooSum, sum(bar) as barSum from user group by foo having fooSum+sum(bar) = 42",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": "sum(`user`.foo) + sum(bar) = 42",
+        "Predicate": "fooSum + sum(bar) = 42",
         "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS fooSum, sum(2) AS barSum",
-            "GroupBy": "(0|3)",
+            "GroupBy": "(0|4), 3 COLLATE utf8mb4_0900_ai_ci",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2941,9 +2941,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
-                "OrderBy": "(0|3) ASC",
-                "Query": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
+                "FieldQuery": "select foo, sum(foo) as fooSum, sum(bar) as barSum, fooSum, weight_string(foo) from `user` where 1 != 1 group by foo, fooSum, weight_string(foo)",
+                "OrderBy": "(0|4) ASC, 3 ASC COLLATE utf8mb4_0900_ai_ci",
+                "Query": "select foo, sum(foo) as fooSum, sum(bar) as barSum, fooSum, weight_string(foo) from `user` group by foo, fooSum, weight_string(foo) order by foo asc, fooSum asc",
                 "Table": "`user`"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -2535,10 +2535,10 @@
   },
   {
     "comment": "group by column alias",
-    "query": "select ascii(col2) as a, count(*) from authoritative group by a",
+    "query": "select ascii(col2) as a, count(*) from user group by a",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select ascii(col2) as a, count(*) from authoritative group by a",
+      "Original": "select ascii(col2) as a, count(*) from user group by a",
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
@@ -2553,15 +2553,15 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from authoritative where 1 != 1 group by ascii(col2), weight_string(ascii(col2))",
+            "FieldQuery": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from `user` where 1 != 1 group by ascii(col2), weight_string(ascii(col2))",
             "OrderBy": "(0|2) ASC",
-            "Query": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from authoritative group by ascii(col2), weight_string(ascii(col2)) order by ascii(col2) asc",
-            "Table": "authoritative"
+            "Query": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from `user` group by ascii(col2), weight_string(ascii(col2)) order by ascii(col2) asc",
+            "Table": "`user`"
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
@@ -6888,5 +6888,10 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "baz in the HAVING clause can't be accessed because of the GROUP BY",
+    "query": "select foo, count(bar) as x from user group by foo having baz > avg(baz) order by x",
+    "plan": "Unknown column 'baz' in 'having clause'"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -2861,7 +2861,7 @@
       "Original": "select foo, sum(foo), sum(bar) from user group by foo having sum(foo)+sum(bar) = 42",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": "sum(`user`.foo) + sum(bar) = 42",
+        "Predicate": "sum(foo) + sum(bar) = 42",
         "ResultColumns": 3,
         "Inputs": [
           {
@@ -6848,6 +6848,41 @@
         "Query": "select id, from_unixtime(min(col)) as col, min(col) from `user` group by id order by min(col) asc",
         "ResultColumns": 2,
         "Table": "`user`"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "col is a column on user, but the HAVING is referring to an alias",
+    "query": "select sum(x) col from user where x > 0 having col = 2",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select sum(x) col from user where x > 0 having col = 2",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "sum(`user`.x) = 2",
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Scalar",
+            "Aggregates": "sum(0) AS col",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select sum(x) as col from `user` where 1 != 1",
+                "Query": "select sum(x) as col from `user` where x > 0",
+                "Table": "`user`"
+              }
+            ]
+          }
+        ]
       },
       "TablesUsed": [
         "user.user"

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -925,7 +925,7 @@
             },
             "FieldQuery": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` where 1 != 1 group by a, b, c, weight_string(a), weight_string(b), weight_string(c)",
             "OrderBy": "(0|5) ASC, (1|6) ASC, (2|7) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, b, c, weight_string(a), weight_string(b), weight_string(c) order by a asc, b asc, c asc",
+            "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, b, c, weight_string(a), weight_string(b), weight_string(c) order by `user`.a asc, `user`.b asc, `user`.c asc",
             "Table": "`user`"
           }
         ]
@@ -957,7 +957,7 @@
             },
             "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
             "OrderBy": "(3|5) ASC, (1|6) ASC, (0|7) ASC, (2|8) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by d asc, b asc, a asc, c asc",
+            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc",
             "Table": "`user`"
           }
         ]
@@ -989,7 +989,7 @@
             },
             "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
             "OrderBy": "(3|5) ASC, (1|6) ASC, (0|7) ASC, (2|8) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by d asc, b asc, a asc, c asc",
+            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc",
             "Table": "`user`"
           }
         ]
@@ -1021,7 +1021,7 @@
             },
             "FieldQuery": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` where 1 != 1 group by a, c, b, weight_string(a), weight_string(c), weight_string(b)",
             "OrderBy": "(0|4) DESC, (2|5) DESC, (1|6) ASC",
-            "Query": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` group by a, c, b, weight_string(a), weight_string(c), weight_string(b) order by a desc, c desc, b asc",
+            "Query": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` group by a, c, b, weight_string(a), weight_string(c), weight_string(b) order by a desc, c desc, `user`.b asc",
             "Table": "`user`"
           }
         ]
@@ -1109,7 +1109,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from ref where 1 != 1",
-        "Query": "select col from ref order by col asc",
+        "Query": "select col from ref order by ref.col asc",
         "Table": "ref"
       },
       "TablesUsed": [
@@ -1580,7 +1580,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1 group by id",
-        "Query": "select id from `user` group by id having count(id) = 10",
+        "Query": "select id from `user` group by id having count(`user`.id) = 10",
         "Table": "`user`"
       },
       "TablesUsed": [
@@ -1642,7 +1642,7 @@
             },
             "FieldQuery": "select char_length(col1) as a, count(*), weight_string(char_length(col1)) from authoritative where 1 != 1 group by char_length(col1), weight_string(char_length(col1))",
             "OrderBy": "(0|2) ASC",
-            "Query": "select char_length(col1) as a, count(*), weight_string(char_length(col1)) from authoritative group by char_length(col1), weight_string(char_length(col1)) order by char_length(col1) asc",
+            "Query": "select char_length(col1) as a, count(*), weight_string(char_length(col1)) from authoritative group by char_length(col1), weight_string(char_length(col1)) order by char_length(authoritative.col1) asc",
             "Table": "authoritative"
           }
         ]
@@ -1705,7 +1705,7 @@
             },
             "FieldQuery": "select col, id, weight_string(id) from `user` where 1 != 1",
             "OrderBy": "(1|2) ASC",
-            "Query": "select col, id, weight_string(id) from `user` order by id asc",
+            "Query": "select col, id, weight_string(id) from `user` order by `user`.id asc",
             "ResultColumns": 2,
             "Table": "`user`"
           },
@@ -2925,7 +2925,7 @@
       "Original": "select foo, sum(foo) as fooSum, sum(bar) as barSum from user group by foo having fooSum+sum(bar) = 42",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": "sum(foo) + sum(bar) = 42",
+        "Predicate": "sum(`user`.foo) + sum(bar) = 42",
         "ResultColumns": 3,
         "Inputs": [
           {
@@ -3496,7 +3496,7 @@
                     },
                     "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
                     "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by val1 asc limit :__upper_limit",
+                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by `user`.val1 asc limit :__upper_limit",
                     "Table": "`user`"
                   }
                 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -677,34 +677,7 @@
   {
     "comment": "scatter aggregate group by aggregate function - since we don't have authoratative columns for user, we can't be sure that the user isn't referring a column named b",
     "query": "select count(*) b from user group by b",
-    "plan": {
-      "QueryType": "SELECT",
-      "Original": "select count(*) b from user group by b",
-      "Instructions": {
-        "OperatorType": "Aggregate",
-        "Variant": "Ordered",
-        "Aggregates": "sum_count_star(0) AS b",
-        "GroupBy": "(1|2)",
-        "ResultColumns": 1,
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select count(*) as b, b, weight_string(b) from `user` where 1 != 1 group by b, weight_string(b)",
-            "OrderBy": "(1|2) ASC",
-            "Query": "select count(*) as b, b, weight_string(b) from `user` group by b, weight_string(b) order by b asc",
-            "Table": "`user`"
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user"
-      ]
-    }
+    "plan": "VT03005: cannot group on 'count(*)'"
   },
   {
     "comment": "scatter aggregate group by aggregate function with column information",
@@ -1735,10 +1708,10 @@
   },
   {
     "comment": "Column and Literal equality filter on scatter aggregates",
-    "query": "select count(*) a from authoritative having a = 10",
+    "query": "select count(*) a from user having a = 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a = 10",
+      "Original": "select count(*) a from user having a = 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 10",
@@ -1755,25 +1728,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Equality filtering with column and string literal on scatter aggregates",
-    "query": "select count(*) a from authoritative having a = '1'",
+    "query": "select count(*) a from user having a = '1'",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a = '1'",
+      "Original": "select count(*) a from user having a = '1'",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = '1'",
@@ -1790,25 +1763,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Column and Literal not equal filter on scatter aggregates",
-    "query": "select count(*) a from authoritative having a != 10",
+    "query": "select count(*) a from user having a != 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a != 10",
+      "Original": "select count(*) a from user having a != 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) != 10",
@@ -1825,25 +1798,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Not equal filter with column and string literal on scatter aggregates",
-    "query": "select count(*) a from authoritative having a != '1'",
+    "query": "select count(*) a from user having a != '1'",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a != '1'",
+      "Original": "select count(*) a from user having a != '1'",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) != '1'",
@@ -1860,25 +1833,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Greater than filter on scatter aggregates",
-    "query": "select count(*) a from authoritative having a > 10",
+    "query": "select count(*) a from user having a > 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a > 10",
+      "Original": "select count(*) a from user having a > 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) > 10",
@@ -1895,25 +1868,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Greater Equal filter on scatter aggregates",
-    "query": "select count(*) a from authoritative having a >= 10",
+    "query": "select count(*) a from user having a >= 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a >= 10",
+      "Original": "select count(*) a from user having a >= 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) >= 10",
@@ -1930,25 +1903,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Less than filter on scatter aggregates",
-    "query": "select count(*) a from authoritative having a < 10",
+    "query": "select count(*) a from user having a < 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a < 10",
+      "Original": "select count(*) a from user having a < 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) < 10",
@@ -1965,25 +1938,25 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Less Equal filter on scatter aggregates",
-    "query": "select count(*) a from authoritative having a <= 10",
+    "query": "select count(*) a from user having a <= 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a <= 10",
+      "Original": "select count(*) a from user having a <= 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) <= 10",
@@ -2000,34 +1973,35 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "Less Equal filter on scatter with grouping",
-    "query": "select col1, count(*) a from authoritative group by col1 having a <= 10",
+    "query": "select col1, count(*) a from user group by col1 having a <= 10",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select col1, count(*) a from authoritative group by col1 having a <= 10",
+      "Original": "select col1, count(*) a from user group by col1 having a <= 10",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) <= 10",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(1) AS a",
-            "GroupBy": "0 COLLATE latin1_swedish_ci",
+            "GroupBy": "(0|2)",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2036,26 +2010,26 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select col1, count(*) as a from authoritative where 1 != 1 group by col1",
-                "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-                "Query": "select col1, count(*) as a from authoritative group by col1 order by col1 asc",
-                "Table": "authoritative"
+                "FieldQuery": "select col1, count(*) as a, weight_string(col1) from `user` where 1 != 1 group by col1, weight_string(col1)",
+                "OrderBy": "(0|2) ASC",
+                "Query": "select col1, count(*) as a, weight_string(col1) from `user` group by col1, weight_string(col1) order by col1 asc",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
   {
     "comment": "We should be able to find grouping keys on ordered aggregates",
-    "query": "select count(*) as a, col2 from authoritative group by col2 having a = 1.00",
+    "query": "select count(*) as a, col2 from user group by col2 having a = 1.00",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) as a, col2 from authoritative group by col2 having a = 1.00",
+      "Original": "select count(*) as a, col2 from user group by col2 having a = 1.00",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 1.00",
@@ -2074,17 +2048,17 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a, col2, weight_string(col2) from authoritative where 1 != 1 group by col2, weight_string(col2)",
+                "FieldQuery": "select count(*) as a, col2, weight_string(col2) from `user` where 1 != 1 group by col2, weight_string(col2)",
                 "OrderBy": "(1|2) ASC",
-                "Query": "select count(*) as a, col2, weight_string(col2) from authoritative group by col2, weight_string(col2) order by col2 asc",
-                "Table": "authoritative"
+                "Query": "select count(*) as a, col2, weight_string(col2) from `user` group by col2, weight_string(col2) order by col2 asc",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },
@@ -2887,7 +2861,7 @@
       "Original": "select foo, sum(foo), sum(bar) from user group by foo having sum(foo)+sum(bar) = 42",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": "sum(foo) + sum(bar) = 42",
+        "Predicate": "sum(`user`.foo) + sum(bar) = 42",
         "ResultColumns": 3,
         "Inputs": [
           {
@@ -2925,14 +2899,14 @@
       "Original": "select foo, sum(foo) as fooSum, sum(bar) as barSum from user group by foo having fooSum+sum(bar) = 42",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": "fooSum + sum(bar) = 42",
+        "Predicate": "sum(`user`.foo) + sum(bar) = 42",
         "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS fooSum, sum(2) AS barSum",
-            "GroupBy": "(0|4), 3 COLLATE utf8mb4_0900_ai_ci",
+            "GroupBy": "(0|3)",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2941,9 +2915,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select foo, sum(foo) as fooSum, sum(bar) as barSum, fooSum, weight_string(foo) from `user` where 1 != 1 group by foo, fooSum, weight_string(foo)",
-                "OrderBy": "(0|4) ASC, 3 ASC COLLATE utf8mb4_0900_ai_ci",
-                "Query": "select foo, sum(foo) as fooSum, sum(bar) as barSum, fooSum, weight_string(foo) from `user` group by foo, fooSum, weight_string(foo) order by foo asc, fooSum asc",
+                "FieldQuery": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
+                "OrderBy": "(0|3) ASC",
+                "Query": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
                 "Table": "`user`"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -675,9 +675,41 @@
     }
   },
   {
-    "comment": "scatter aggregate group by aggregate function",
+    "comment": "scatter aggregate group by aggregate function - since we don't have authoratative columns for user, we can't be sure that the user isn't referring a column named b",
     "query": "select count(*) b from user group by b",
-    "plan": "VT03005: cannot group on 'count(*)'"
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(*) b from user group by b",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "sum_count_star(0) AS b",
+        "GroupBy": "(1|2)",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select count(*) as b, b, weight_string(b) from `user` where 1 != 1 group by b, weight_string(b)",
+            "OrderBy": "(1|2) ASC",
+            "Query": "select count(*) as b, b, weight_string(b) from `user` group by b, weight_string(b) order by b asc",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "scatter aggregate group by aggregate function with column information",
+    "query": "select count(*) b from authoritative group by b",
+    "plan": "VT03005: cannot group on 'b'"
   },
   {
     "comment": "scatter aggregate multiple group by (columns)",
@@ -1035,32 +1067,6 @@
             ]
           }
         ]
-      },
-      "TablesUsed": [
-        "user.user"
-      ]
-    }
-  },
-  {
-    "comment": "Group by with collate operator",
-    "query": "select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci",
-    "plan": {
-      "QueryType": "SELECT",
-      "Original": "select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci",
-      "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "EqualUnique",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select `user`.col1 as a from `user` where 1 != 1 group by `user`.col1 collate utf8_general_ci",
-        "Query": "select `user`.col1 as a from `user` where `user`.id = 5 group by `user`.col1 collate utf8_general_ci",
-        "Table": "`user`",
-        "Values": [
-          "5"
-        ],
-        "Vindex": "user_index"
       },
       "TablesUsed": [
         "user.user"
@@ -1584,10 +1590,10 @@
   },
   {
     "comment": "weight_string addition to group by",
-    "query": "select lower(textcol1) as v, count(*) from user group by v",
+    "query": "select lower(col1) as v, count(*) from authoritative group by v",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select lower(textcol1) as v, count(*) from user group by v",
+      "Original": "select lower(col1) as v, count(*) from authoritative group by v",
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
@@ -1602,24 +1608,24 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select lower(textcol1) as v, count(*), weight_string(lower(textcol1)) from `user` where 1 != 1 group by lower(textcol1), weight_string(lower(textcol1))",
+            "FieldQuery": "select lower(col1) as v, count(*), weight_string(lower(col1)) from authoritative where 1 != 1 group by lower(col1), weight_string(lower(col1))",
             "OrderBy": "(0|2) ASC",
-            "Query": "select lower(textcol1) as v, count(*), weight_string(lower(textcol1)) from `user` group by lower(textcol1), weight_string(lower(textcol1)) order by lower(textcol1) asc",
-            "Table": "`user`"
+            "Query": "select lower(col1) as v, count(*), weight_string(lower(col1)) from authoritative group by lower(col1), weight_string(lower(col1)) order by lower(col1) asc",
+            "Table": "authoritative"
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
   {
     "comment": "weight_string addition to group by when also there in order by",
-    "query": "select char_length(texcol1) as a, count(*) from user group by a order by a",
+    "query": "select char_length(col1) as a, count(*) from authoritative group by a order by a",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select char_length(texcol1) as a, count(*) from user group by a order by a",
+      "Original": "select char_length(col1) as a, count(*) from authoritative group by a order by a",
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
@@ -1634,15 +1640,15 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select char_length(texcol1) as a, count(*), weight_string(char_length(texcol1)) from `user` where 1 != 1 group by char_length(texcol1), weight_string(char_length(texcol1))",
+            "FieldQuery": "select char_length(col1) as a, count(*), weight_string(char_length(col1)) from authoritative where 1 != 1 group by char_length(col1), weight_string(char_length(col1))",
             "OrderBy": "(0|2) ASC",
-            "Query": "select char_length(texcol1) as a, count(*), weight_string(char_length(texcol1)) from `user` group by char_length(texcol1), weight_string(char_length(texcol1)) order by char_length(texcol1) asc",
-            "Table": "`user`"
+            "Query": "select char_length(col1) as a, count(*), weight_string(char_length(col1)) from authoritative group by char_length(col1), weight_string(char_length(col1)) order by char_length(col1) asc",
+            "Table": "authoritative"
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
@@ -2114,71 +2120,6 @@
     }
   },
   {
-    "comment": "aggregation filtering by having on a route with no group by with non-unique vindex filter",
-    "query": "select 1 from user having count(id) = 10 and name = 'a'",
-    "plan": {
-      "QueryType": "SELECT",
-      "Original": "select 1 from user having count(id) = 10 and name = 'a'",
-      "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "count(id) = 10",
-        "ResultColumns": 1,
-        "Inputs": [
-          {
-            "OperatorType": "Aggregate",
-            "Variant": "Scalar",
-            "Aggregates": "any_value(0) AS 1, sum_count(1) AS count(id)",
-            "Inputs": [
-              {
-                "OperatorType": "VindexLookup",
-                "Variant": "Equal",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "Values": [
-                  "'a'"
-                ],
-                "Vindex": "name_user_map",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "IN",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
-                    "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                    "Table": "name_user_vdx",
-                    "Values": [
-                      "::name"
-                    ],
-                    "Vindex": "user_index"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "ByDestination",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1, count(id) from `user` where 1 != 1",
-                    "Query": "select 1, count(id) from `user` where `name` = 'a'",
-                    "Table": "`user`"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user"
-      ]
-    }
-  },
-  {
     "comment": "Aggregates and joins",
     "query": "select count(*) from user join user_extra",
     "plan": {
@@ -2620,10 +2561,10 @@
   },
   {
     "comment": "group by column alias",
-    "query": "select ascii(val1) as a, count(*) from user group by a",
+    "query": "select ascii(col2) as a, count(*) from authoritative group by a",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select ascii(val1) as a, count(*) from user group by a",
+      "Original": "select ascii(col2) as a, count(*) from authoritative group by a",
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
@@ -2638,15 +2579,15 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select ascii(val1) as a, count(*), weight_string(ascii(val1)) from `user` where 1 != 1 group by ascii(val1), weight_string(ascii(val1))",
+            "FieldQuery": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from authoritative where 1 != 1 group by ascii(col2), weight_string(ascii(col2))",
             "OrderBy": "(0|2) ASC",
-            "Query": "select ascii(val1) as a, count(*), weight_string(ascii(val1)) from `user` group by ascii(val1), weight_string(ascii(val1)) order by ascii(val1) asc",
-            "Table": "`user`"
+            "Query": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from authoritative group by ascii(col2), weight_string(ascii(col2)) order by ascii(col2) asc",
+            "Table": "authoritative"
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },
@@ -3328,10 +3269,10 @@
   },
   {
     "comment": "group by and ',' joins",
-    "query": "select user.id from user, user_extra group by id",
+    "query": "select user.id from user, user_extra group by user.id",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select user.id from user, user_extra group by id",
+      "Original": "select user.id from user, user_extra group by user.id",
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -2094,6 +2094,71 @@
     }
   },
   {
+    "comment": "aggregation filtering by having on a route with no group by with non-unique vindex filter",
+    "query": "select 1 from user having count(id) = 10 and name = 'a'",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from user having count(id) = 10 and name = 'a'",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "count(id) = 10",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Scalar",
+            "Aggregates": "any_value(0) AS 1, sum_count(1) AS count(id)",
+            "Inputs": [
+              {
+                "OperatorType": "VindexLookup",
+                "Variant": "Equal",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "Values": [
+                  "'a'"
+                ],
+                "Vindex": "name_user_map",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "IN",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
+                    "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
+                    "Table": "name_user_vdx",
+                    "Values": [
+                      "::name"
+                    ],
+                    "Vindex": "user_index"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "ByDestination",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1, count(id) from `user` where 1 != 1",
+                    "Query": "select 1, count(id) from `user` where `name` = 'a'",
+                    "Table": "`user`"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "Aggregates and joins",
     "query": "select count(*) from user join user_extra",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -348,7 +348,7 @@
                     },
                     "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
                     "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by val1 asc limit :__upper_limit",
+                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by `user`.val1 asc limit :__upper_limit",
                     "Table": "`user`"
                   }
                 ]

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4018,7 +4018,7 @@
           "Sharded": true
         },
         "FieldQuery": "select a + 2 as a from `user` where 1 != 1",
-        "Query": "select a + 2 as a from `user` where a + 2 = 42",
+        "Query": "select a + 2 as a from `user` where `user`.a + 2 = 42",
         "Table": "`user`"
       },
       "TablesUsed": [
@@ -4041,7 +4041,7 @@
         },
         "FieldQuery": "select a + 2 as a, weight_string(a + 2) from `user` where 1 != 1",
         "OrderBy": "(0|1) ASC",
-        "Query": "select a + 2 as a, weight_string(a + 2) from `user` order by a + 2 asc",
+        "Query": "select a + 2 as a, weight_string(a + 2) from `user` order by `user`.a + 2 asc",
         "ResultColumns": 1,
         "Table": "`user`"
       },

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4018,7 +4018,7 @@
           "Sharded": true
         },
         "FieldQuery": "select a + 2 as a from `user` where 1 != 1",
-        "Query": "select a + 2 as a from `user` where `user`.a + 2 = 42",
+        "Query": "select a + 2 as a from `user` where a = 42",
         "Table": "`user`"
       },
       "TablesUsed": [
@@ -4064,7 +4064,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col + 2 as a from `user` where 1 != 1",
-        "Query": "select `user`.col + 2 as a from `user` where `user`.col + 2 = 42",
+        "Query": "select `user`.col + 2 as a from `user` where a = 42",
         "Table": "`user`"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4018,7 +4018,7 @@
           "Sharded": true
         },
         "FieldQuery": "select a + 2 as a from `user` where 1 != 1",
-        "Query": "select a + 2 as a from `user` where a = 42",
+        "Query": "select a + 2 as a from `user` where `user`.a + 2 = 42",
         "Table": "`user`"
       },
       "TablesUsed": [
@@ -4064,7 +4064,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col + 2 as a from `user` where 1 != 1",
-        "Query": "select `user`.col + 2 as a from `user` where a = 42",
+        "Query": "select `user`.col + 2 as a from `user` where `user`.col + 2 = 42",
         "Table": "`user`"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4149,71 +4149,7 @@
   {
     "comment": "Like clause evaluated on the vtgate",
     "query": "select a.textcol1 from user a join user b where a.textcol1 = b.textcol2 group by a.textcol1 having repeat(a.textcol1,sum(a.id)) like \"And%res\"",
-    "plan": {
-      "QueryType": "SELECT",
-      "Original": "select a.textcol1 from user a join user b where a.textcol1 = b.textcol2 group by a.textcol1 having repeat(a.textcol1,sum(a.id)) like \"And%res\"",
-      "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "repeat(a.textcol1, sum(a.id)) like 'And%res'",
-        "ResultColumns": 1,
-        "Inputs": [
-          {
-            "OperatorType": "Aggregate",
-            "Variant": "Ordered",
-            "Aggregates": "sum(1) AS sum(a.id)",
-            "GroupBy": "0 COLLATE latin1_swedish_ci",
-            "Inputs": [
-              {
-                "OperatorType": "Projection",
-                "Expressions": [
-                  ":2 as textcol1",
-                  "sum(a.id) * count(*) as sum(a.id)"
-                ],
-                "Inputs": [
-                  {
-                    "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "L:0,R:0,L:1",
-                    "JoinVars": {
-                      "a_textcol1": 1
-                    },
-                    "TableName": "`user`_`user`",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select sum(a.id), a.textcol1 from `user` as a where 1 != 1 group by a.textcol1",
-                        "OrderBy": "1 ASC COLLATE latin1_swedish_ci",
-                        "Query": "select sum(a.id), a.textcol1 from `user` as a group by a.textcol1 order by a.textcol1 asc",
-                        "Table": "`user`"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select count(*) from `user` as b where 1 != 1 group by .0",
-                        "Query": "select count(*) from `user` as b where b.textcol2 = :a_textcol1 group by .0",
-                        "Table": "`user`"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user"
-      ]
-    }
+    "plan": "Unknown column 'textcol1' in 'having clause'"
   },
   {
     "comment": "two predicates that mean the same thing",

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4149,7 +4149,71 @@
   {
     "comment": "Like clause evaluated on the vtgate",
     "query": "select a.textcol1 from user a join user b where a.textcol1 = b.textcol2 group by a.textcol1 having repeat(a.textcol1,sum(a.id)) like \"And%res\"",
-    "plan": "Unknown column 'textcol1' in 'having clause'"
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select a.textcol1 from user a join user b where a.textcol1 = b.textcol2 group by a.textcol1 having repeat(a.textcol1,sum(a.id)) like \"And%res\"",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "repeat(a.textcol1, sum(a.id)) like 'And%res'",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "sum(1) AS sum(a.id)",
+            "GroupBy": "0 COLLATE latin1_swedish_ci",
+            "Inputs": [
+              {
+                "OperatorType": "Projection",
+                "Expressions": [
+                  ":2 as textcol1",
+                  "sum(a.id) * count(*) as sum(a.id)"
+                ],
+                "Inputs": [
+                  {
+                    "OperatorType": "Join",
+                    "Variant": "Join",
+                    "JoinColumnIndexes": "L:0,R:0,L:1",
+                    "JoinVars": {
+                      "a_textcol1": 1
+                    },
+                    "TableName": "`user`_`user`",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select sum(a.id), a.textcol1 from `user` as a where 1 != 1 group by a.textcol1",
+                        "OrderBy": "1 ASC COLLATE latin1_swedish_ci",
+                        "Query": "select sum(a.id), a.textcol1 from `user` as a group by a.textcol1 order by a.textcol1 asc",
+                        "Table": "`user`"
+                      },
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*) from `user` as b where 1 != 1 group by .0",
+                        "Query": "select count(*) from `user` as b where b.textcol2 = :a_textcol1 group by .0",
+                        "Table": "`user`"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   },
   {
     "comment": "two predicates that mean the same thing",

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -552,9 +552,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, convert(a, binary), weight_string(convert(a, binary)) from `user` where 1 != 1",
+        "FieldQuery": "select a, convert(`user`.a, binary), weight_string(convert(`user`.a, binary)) from `user` where 1 != 1",
         "OrderBy": "(1|2) DESC",
-        "Query": "select a, convert(a, binary), weight_string(convert(a, binary)) from `user` order by convert(a, binary) desc",
+        "Query": "select a, convert(`user`.a, binary), weight_string(convert(`user`.a, binary)) from `user` order by convert(`user`.a, binary) desc",
         "ResultColumns": 1,
         "Table": "`user`"
       },

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -24,9 +24,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a)",
+                "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(`user`.b) from `user` where 1 != 1 group by a, weight_string(a)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*), weight_string(a), weight_string(b) from `user` group by a, weight_string(a) order by a asc",
+                "Query": "select a, b, count(*), weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc",
                 "Table": "`user`"
               }
             ]
@@ -102,9 +102,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select a, b, count(*) as k, weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a)",
+                "FieldQuery": "select a, b, count(*) as k, weight_string(a), weight_string(`user`.b) from `user` where 1 != 1 group by a, weight_string(a)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*) as k, weight_string(a), weight_string(b) from `user` group by a, weight_string(a) order by a asc",
+                "Query": "select a, b, count(*) as k, weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc",
                 "Table": "`user`"
               }
             ]
@@ -259,7 +259,7 @@
             },
             "FieldQuery": "select id, weight_string(id) from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
             "OrderBy": "(0|1) ASC",
-            "Query": "select id, weight_string(id) from (select `user`.id, `user`.col from `user`) as t order by id asc",
+            "Query": "select id, weight_string(id) from (select `user`.id, `user`.col from `user`) as t order by t.id asc",
             "Table": "`user`"
           },
           {
@@ -624,7 +624,7 @@
         },
         "FieldQuery": "select id, intcol from `user` where 1 != 1",
         "OrderBy": "1 ASC",
-        "Query": "select id, intcol from `user` order by intcol asc",
+        "Query": "select id, intcol from `user` order by `user`.intcol asc",
         "Table": "`user`"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/oltp_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/oltp_cases.json
@@ -91,7 +91,7 @@
         },
         "FieldQuery": "select c from sbtest1 where 1 != 1",
         "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-        "Query": "select c from sbtest1 where id between 50 and 235 order by c asc",
+        "Query": "select c from sbtest1 where id between 50 and 235 order by sbtest1.c asc",
         "Table": "sbtest1"
       },
       "TablesUsed": [
@@ -119,7 +119,7 @@
             },
             "FieldQuery": "select c from sbtest30 where 1 != 1 group by c",
             "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-            "Query": "select c from sbtest30 where id between 1 and 10 group by c order by c asc",
+            "Query": "select c from sbtest30 where id between 1 and 10 group by c order by sbtest30.c asc",
             "Table": "sbtest30"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -1,5 +1,27 @@
 [
   {
+    "comment": "HAVING implicitly references table col",
+    "query": "select user.col1 from user having col2 = 2",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select user.col1 from user having col2 = 2",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col1 from `user` where 1 != 1",
+        "Query": "select `user`.col1 from `user` where col2 = 2",
+        "Table": "`user`"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "ambiguous symbol reference",
     "query": "select user.col1, user_extra.col1 from user join user_extra having col1 = 2",
     "plan": "Column 'col1' in field list is ambiguous"

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -1995,7 +1995,63 @@
   {
     "comment": "having filter with %",
     "query": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
-    "plan": "Unknown column 'tcol1' in 'having clause'"
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "repeat(a.tcol1, min(a.id)) like 'A\\%B'",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "min(1|3) AS min(a.id)",
+            "GroupBy": "(0|2)",
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:1,L:0,L:2,L:3",
+                "JoinVars": {
+                  "a_tcol1": 1
+                },
+                "TableName": "`user`_music",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1), weight_string(a.id)",
+                    "OrderBy": "(1|2) ASC",
+                    "Query": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a group by a.tcol1, weight_string(a.tcol1), weight_string(a.id) order by a.tcol1 asc",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1 from music as b where 1 != 1 group by .0",
+                    "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by .0",
+                    "Table": "music"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user"
+      ]
+    }
   },
   {
     "comment": "distinct with order by using aggregation engine",

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -1995,63 +1995,7 @@
   {
     "comment": "having filter with %",
     "query": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
-    "plan": {
-      "QueryType": "SELECT",
-      "Original": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
-      "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "repeat(a.tcol1, min(a.id)) like 'A\\%B'",
-        "ResultColumns": 1,
-        "Inputs": [
-          {
-            "OperatorType": "Aggregate",
-            "Variant": "Ordered",
-            "Aggregates": "min(1|3) AS min(a.id)",
-            "GroupBy": "(0|2)",
-            "Inputs": [
-              {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:1,L:0,L:2,L:3",
-                "JoinVars": {
-                  "a_tcol1": 1
-                },
-                "TableName": "`user`_music",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1), weight_string(a.id)",
-                    "OrderBy": "(1|2) ASC",
-                    "Query": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a group by a.tcol1, weight_string(a.tcol1), weight_string(a.id) order by a.tcol1 asc",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1 from music as b where 1 != 1 group by .0",
-                    "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by .0",
-                    "Table": "music"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.music",
-        "user.user"
-      ]
-    }
+    "plan": "Unknown column 'tcol1' in 'having clause'"
   },
   {
     "comment": "distinct with order by using aggregation engine",

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -123,7 +123,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where :__sq_has_values and id in ::__vals",
+            "Query": "select id from `user` where :__sq_has_values and `user`.id in ::__vals",
             "Table": "`user`",
             "Values": [
               "::__sq1"
@@ -204,7 +204,7 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "OrderBy": "0 ASC",
-        "Query": "select col from `user` order by col asc",
+        "Query": "select col from `user` order by `user`.col asc",
         "Table": "`user`"
       },
       "TablesUsed": [
@@ -227,7 +227,7 @@
         },
         "FieldQuery": "select user_id, col1, col2, weight_string(user_id) from authoritative where 1 != 1",
         "OrderBy": "(0|3) ASC",
-        "Query": "select user_id, col1, col2, weight_string(user_id) from authoritative order by user_id asc",
+        "Query": "select user_id, col1, col2, weight_string(user_id) from authoritative order by authoritative.user_id asc",
         "ResultColumns": 3,
         "Table": "authoritative"
       },
@@ -251,7 +251,7 @@
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
         "OrderBy": "1 ASC COLLATE latin1_swedish_ci",
-        "Query": "select user_id, col1, col2 from authoritative order by col1 asc",
+        "Query": "select user_id, col1, col2 from authoritative order by authoritative.col1 asc",
         "Table": "authoritative"
       },
       "TablesUsed": [
@@ -274,7 +274,7 @@
         },
         "FieldQuery": "select a, textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1",
         "OrderBy": "(0|3) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|4) ASC",
-        "Query": "select a, textcol1, b, weight_string(a), weight_string(b) from `user` order by a asc, textcol1 asc, b asc",
+        "Query": "select a, textcol1, b, weight_string(a), weight_string(b) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
         "ResultColumns": 3,
         "Table": "`user`"
       },
@@ -298,7 +298,7 @@
         },
         "FieldQuery": "select a, `user`.textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1",
         "OrderBy": "(0|3) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|4) ASC",
-        "Query": "select a, `user`.textcol1, b, weight_string(a), weight_string(b) from `user` order by a asc, `user`.textcol1 asc, b asc",
+        "Query": "select a, `user`.textcol1, b, weight_string(a), weight_string(b) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
         "ResultColumns": 3,
         "Table": "`user`"
       },
@@ -322,7 +322,7 @@
         },
         "FieldQuery": "select a, textcol1, b, textcol2, weight_string(a), weight_string(b), weight_string(textcol2) from `user` where 1 != 1",
         "OrderBy": "(0|4) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|5) ASC, (3|6) ASC COLLATE ",
-        "Query": "select a, textcol1, b, textcol2, weight_string(a), weight_string(b), weight_string(textcol2) from `user` order by a asc, textcol1 asc, b asc, textcol2 asc",
+        "Query": "select a, textcol1, b, textcol2, weight_string(a), weight_string(b), weight_string(textcol2) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc, `user`.textcol2 asc",
         "ResultColumns": 4,
         "Table": "`user`"
       },
@@ -418,7 +418,7 @@
             },
             "FieldQuery": "select col from `user` where 1 != 1",
             "OrderBy": "0 ASC",
-            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1 order by col asc",
+            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1 order by `user`.col asc",
             "Table": "`user`"
           }
         ]
@@ -1057,7 +1057,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` as route1 where 1 != 1",
-        "Query": "select col from `user` as route1 where id = 1 order by col asc",
+        "Query": "select col from `user` as route1 where id = 1 order by route1.col asc",
         "Table": "`user`",
         "Values": [
           "1"
@@ -1343,7 +1343,7 @@
         },
         "FieldQuery": "select id as foo, weight_string(id) from music where 1 != 1",
         "OrderBy": "(0|1) ASC",
-        "Query": "select id as foo, weight_string(id) from music order by id asc",
+        "Query": "select id as foo, weight_string(id) from music order by music.id asc",
         "ResultColumns": 1,
         "Table": "music"
       },
@@ -1367,7 +1367,7 @@
         },
         "FieldQuery": "select id as foo, id2 as id, weight_string(id2) from music where 1 != 1",
         "OrderBy": "(1|2) ASC",
-        "Query": "select id as foo, id2 as id, weight_string(id2) from music order by id2 asc",
+        "Query": "select id as foo, id2 as id, weight_string(id2) from music order by music.id2 asc",
         "ResultColumns": 2,
         "Table": "music"
       },
@@ -1397,7 +1397,7 @@
             },
             "FieldQuery": "select `name`, weight_string(`name`) from `user` where 1 != 1",
             "OrderBy": "(0|1) ASC",
-            "Query": "select `name`, weight_string(`name`) from `user` order by `name` asc",
+            "Query": "select `name`, weight_string(`name`) from `user` order by `user`.`name` asc",
             "Table": "`user`"
           },
           {
@@ -1584,7 +1584,7 @@
                 },
                 "FieldQuery": "select `name`, weight_string(`name`) from `user` where 1 != 1",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select `name`, weight_string(`name`) from `user` order by `name` asc",
+                "Query": "select `name`, weight_string(`name`) from `user` order by `user`.`name` asc",
                 "Table": "`user`"
               },
               {
@@ -1623,7 +1623,7 @@
         },
         "FieldQuery": "select id, id, weight_string(id) from `user` where 1 != 1",
         "OrderBy": "(0|2) ASC",
-        "Query": "select id, id, weight_string(id) from `user` order by id asc",
+        "Query": "select id, id, weight_string(id) from `user` order by `user`.id asc",
         "ResultColumns": 2,
         "Table": "`user`"
       },
@@ -2073,7 +2073,7 @@
             },
             "FieldQuery": "select col from `user` where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col from `user` where id between :vtg1 and :vtg2 group by col order by col asc",
+            "Query": "select col from `user` where id between :vtg1 and :vtg2 group by col order by `user`.col asc",
             "Table": "`user`"
           }
         ]
@@ -2104,7 +2104,7 @@
             },
             "FieldQuery": "select foo, col, weight_string(foo) from `user` where 1 != 1 group by col, foo, weight_string(foo)",
             "OrderBy": "1 ASC, (0|2) ASC",
-            "Query": "select foo, col, weight_string(foo) from `user` where id between :vtg1 and :vtg2 group by col, foo, weight_string(foo) order by col asc, foo asc",
+            "Query": "select foo, col, weight_string(foo) from `user` where id between :vtg1 and :vtg2 group by col, foo, weight_string(foo) order by `user`.col asc, foo asc",
             "Table": "`user`"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -1,27 +1,5 @@
 [
   {
-    "comment": "HAVING implicitly references table col",
-    "query": "select user.col1 from user having col2 = 2",
-    "plan": {
-      "QueryType": "SELECT",
-      "Original": "select user.col1 from user having col2 = 2",
-      "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "Scatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select `user`.col1 from `user` where 1 != 1",
-        "Query": "select `user`.col1 from `user` where col2 = 2",
-        "Table": "`user`"
-      },
-      "TablesUsed": [
-        "user.user"
-      ]
-    }
-  },
-  {
     "comment": "ambiguous symbol reference",
     "query": "select user.col1, user_extra.col1 from user join user_extra having col1 = 2",
     "plan": "Column 'col1' in field list is ambiguous"

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -123,7 +123,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where :__sq_has_values and id in ::__vals",
+            "Query": "select id from `user` where :__sq_has_values and `user`.id in ::__vals",
             "Table": "`user`",
             "Values": [
               "::__sq1"

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -123,7 +123,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where :__sq_has_values and `user`.id in ::__vals",
+            "Query": "select id from `user` where :__sq_has_values and id in ::__vals",
             "Table": "`user`",
             "Values": [
               "::__sq1"
@@ -1810,10 +1810,10 @@
   },
   {
     "comment": "Equal filter with hexadecimal value",
-    "query": "select count(*) a from user having a = 0x01",
+    "query": "select count(*) a from authoritative having a = 0x01",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from user having a = 0x01",
+      "Original": "select count(*) a from authoritative having a = 0x01",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 0x01",
@@ -1830,16 +1830,16 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
+                "Query": "select count(*) as a from authoritative",
+                "Table": "authoritative"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.user"
+        "user.authoritative"
       ]
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -1810,10 +1810,10 @@
   },
   {
     "comment": "Equal filter with hexadecimal value",
-    "query": "select count(*) a from authoritative having a = 0x01",
+    "query": "select count(*) a from user having a = 0x01",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select count(*) a from authoritative having a = 0x01",
+      "Original": "select count(*) a from user having a = 0x01",
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 0x01",
@@ -1830,16 +1830,16 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a from authoritative where 1 != 1",
-                "Query": "select count(*) as a from authoritative",
-                "Table": "authoritative"
+                "FieldQuery": "select count(*) as a from `user` where 1 != 1",
+                "Query": "select count(*) as a from `user`",
+                "Table": "`user`"
               }
             ]
           }
         ]
       },
       "TablesUsed": [
-        "user.authoritative"
+        "user.user"
       ]
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1078,7 +1078,7 @@
             },
             "FieldQuery": "select user_id, weight_string(user_id) from music where 1 != 1",
             "OrderBy": "(0|1) ASC",
-            "Query": "select user_id, weight_string(user_id) from music order by user_id asc limit :__upper_limit",
+            "Query": "select user_id, weight_string(user_id) from music order by music.user_id asc limit :__upper_limit",
             "ResultColumns": 1,
             "Table": "music"
           }
@@ -1884,7 +1884,7 @@
                 },
                 "FieldQuery": "select user_id, count(id), weight_string(user_id) from music where 1 != 1 group by user_id",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select user_id, count(id), weight_string(user_id) from music group by user_id having count(user_id) = 1 order by user_id asc limit :__upper_limit",
+                "Query": "select user_id, count(id), weight_string(user_id) from music group by user_id having count(music.user_id) = 1 order by music.user_id asc limit :__upper_limit",
                 "ResultColumns": 2,
                 "Table": "music"
               }
@@ -1903,7 +1903,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) from (select user_id, count(id) from music where 1 != 1 group by user_id) as t where 1 != 1",
-                "Query": "select count(*) from (select user_id, count(id) from music group by user_id having count(user_id) = 1) as t",
+                "Query": "select count(*) from (select user_id, count(id) from music group by user_id having count(music.user_id) = 1) as t",
                 "Table": "music"
               }
             ]
@@ -2414,7 +2414,7 @@
                 },
                 "FieldQuery": "select col, `user`.id from `user` where 1 != 1",
                 "OrderBy": "0 ASC",
-                "Query": "select col, `user`.id from `user` order by col asc",
+                "Query": "select col, `user`.id from `user` order by `user`.col asc",
                 "Table": "`user`"
               },
               {
@@ -2840,7 +2840,7 @@
                 },
                 "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select id, weight_string(id) from `user` order by id asc limit :__upper_limit",
+                "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit :__upper_limit",
                 "Table": "`user`"
               }
             ]
@@ -2853,8 +2853,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select :__sq1 as `(select id from ``user`` order by id asc limit 1)` from user_extra where 1 != 1",
-            "Query": "select :__sq1 as `(select id from ``user`` order by id asc limit 1)` from user_extra",
+            "FieldQuery": "select :__sq1 as `(select id from ``user`` order by ``user``.id asc limit 1)` from user_extra where 1 != 1",
+            "Query": "select :__sq1 as `(select id from ``user`` order by ``user``.id asc limit 1)` from user_extra",
             "Table": "user_extra"
           }
         ]
@@ -3330,7 +3330,7 @@
                     },
                     "FieldQuery": "select id, `name`, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|2) ASC",
-                    "Query": "select id, `name`, weight_string(id) from `user` where `name` = 'aa' order by id asc limit :__upper_limit",
+                    "Query": "select id, `name`, weight_string(id) from `user` where `name` = 'aa' order by `user`.id asc limit :__upper_limit",
                     "ResultColumns": 2,
                     "Table": "`user`"
                   }

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1884,7 +1884,7 @@
                 },
                 "FieldQuery": "select user_id, count(id), weight_string(user_id) from music where 1 != 1 group by user_id",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select user_id, count(id), weight_string(user_id) from music group by user_id having count(music.user_id) = 1 order by music.user_id asc limit :__upper_limit",
+                "Query": "select user_id, count(id), weight_string(user_id) from music group by user_id having count(user_id) = 1 order by music.user_id asc limit :__upper_limit",
                 "ResultColumns": 2,
                 "Table": "music"
               }
@@ -1903,7 +1903,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) from (select user_id, count(id) from music where 1 != 1 group by user_id) as t where 1 != 1",
-                "Query": "select count(*) from (select user_id, count(id) from music group by user_id having count(music.user_id) = 1) as t",
+                "Query": "select count(*) from (select user_id, count(id) from music group by user_id having count(user_id) = 1) as t",
                 "Table": "music"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
@@ -947,7 +947,7 @@
           "Sharded": true
         },
         "FieldQuery": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where 1 != 1 group by o_c_id, o_d_id, o_w_id) as t, orders1 as o where 1 != 1",
-        "Query": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id > 2100 and o_id < 11153 group by o_c_id, o_d_id, o_w_id having count(distinct orders1.o_id) > 1 limit 1) as t, orders1 as o where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
+        "Query": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id > 2100 and o_id < 11153 group by o_c_id, o_d_id, o_w_id having count(distinct o_id) > 1 limit 1) as t, orders1 as o where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
         "Table": "orders1",
         "Values": [
           "1"

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
@@ -556,7 +556,7 @@
           "Sharded": true
         },
         "FieldQuery": "select c_balance, c_first, c_middle, c_id from customer1 where 1 != 1",
-        "Query": "select c_balance, c_first, c_middle, c_id from customer1 where c_w_id = 840 and c_d_id = 1 and c_last = 'test' order by c_first asc",
+        "Query": "select c_balance, c_first, c_middle, c_id from customer1 where c_w_id = 840 and c_d_id = 1 and c_last = 'test' order by customer1.c_first asc",
         "Table": "customer1",
         "Values": [
           "840"
@@ -608,7 +608,7 @@
           "Sharded": true
         },
         "FieldQuery": "select o_id, o_carrier_id, o_entry_d from orders1 where 1 != 1",
-        "Query": "select o_id, o_carrier_id, o_entry_d from orders1 where o_w_id = 9894 and o_d_id = 3 and o_c_id = 159 order by o_id desc",
+        "Query": "select o_id, o_carrier_id, o_entry_d from orders1 where o_w_id = 9894 and o_d_id = 3 and o_c_id = 159 order by orders1.o_id desc",
         "Table": "orders1",
         "Values": [
           "9894"
@@ -660,7 +660,7 @@
           "Sharded": true
         },
         "FieldQuery": "select no_o_id from new_orders1 where 1 != 1",
-        "Query": "select no_o_id from new_orders1 where no_d_id = 689 and no_w_id = 15 order by no_o_id asc limit 1 for update",
+        "Query": "select no_o_id from new_orders1 where no_d_id = 689 and no_w_id = 15 order by new_orders1.no_o_id asc limit 1 for update",
         "Table": "new_orders1",
         "Values": [
           "15"
@@ -947,7 +947,7 @@
           "Sharded": true
         },
         "FieldQuery": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where 1 != 1 group by o_c_id, o_d_id, o_w_id) as t, orders1 as o where 1 != 1",
-        "Query": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id > 2100 and o_id < 11153 group by o_c_id, o_d_id, o_w_id having count(distinct o_id) > 1 limit 1) as t, orders1 as o where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
+        "Query": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id > 2100 and o_id < 11153 group by o_c_id, o_d_id, o_w_id having count(distinct orders1.o_id) > 1 limit 1) as t, orders1 as o where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
         "Table": "orders1",
         "Values": [
           "1"

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
@@ -947,7 +947,7 @@
           "Sharded": true
         },
         "FieldQuery": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where 1 != 1 group by o_c_id, o_d_id, o_w_id) as t, orders1 as o where 1 != 1",
-        "Query": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id > 2100 and o_id < 11153 group by o_c_id, o_d_id, o_w_id having count(distinct o_id) > 1 limit 1) as t, orders1 as o where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
+        "Query": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id > 2100 and o_id < 11153 group by o_c_id, o_d_id, o_w_id having count(distinct orders1.o_id) > 1 limit 1) as t, orders1 as o where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
         "Table": "orders1",
         "Values": [
           "1"

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -35,7 +35,7 @@
                 },
                 "FieldQuery": "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, sum(l_quantity) as avg_qty, sum(l_extendedprice) as avg_price, sum(l_discount) as avg_disc, count(*) as count_order, count(l_quantity), count(l_extendedprice), count(l_discount), weight_string(l_returnflag), weight_string(l_linestatus) from lineitem where 1 != 1 group by l_returnflag, l_linestatus, weight_string(l_returnflag), weight_string(l_linestatus)",
                 "OrderBy": "(0|13) ASC, (1|14) ASC",
-                "Query": "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, sum(l_quantity) as avg_qty, sum(l_extendedprice) as avg_price, sum(l_discount) as avg_disc, count(*) as count_order, count(l_quantity), count(l_extendedprice), count(l_discount), weight_string(l_returnflag), weight_string(l_linestatus) from lineitem where l_shipdate <= '1998-12-01' - interval '108' day group by l_returnflag, l_linestatus, weight_string(l_returnflag), weight_string(l_linestatus) order by l_returnflag asc, l_linestatus asc",
+                "Query": "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, sum(l_quantity) as avg_qty, sum(l_extendedprice) as avg_price, sum(l_discount) as avg_disc, count(*) as count_order, count(l_quantity), count(l_extendedprice), count(l_discount), weight_string(l_returnflag), weight_string(l_linestatus) from lineitem where l_shipdate <= '1998-12-01' - interval '108' day group by l_returnflag, l_linestatus, weight_string(l_returnflag), weight_string(l_linestatus) order by lineitem.l_returnflag asc, lineitem.l_linestatus asc",
                 "Table": "lineitem"
               }
             ]
@@ -213,7 +213,7 @@
                 },
                 "FieldQuery": "select o_orderpriority, count(*) as order_count, o_orderkey, weight_string(o_orderpriority) from orders where 1 != 1 group by o_orderpriority, o_orderkey, weight_string(o_orderpriority)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select o_orderpriority, count(*) as order_count, o_orderkey, weight_string(o_orderpriority) from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-07-01') + interval '3' month group by o_orderpriority, o_orderkey, weight_string(o_orderpriority) order by o_orderpriority asc",
+                "Query": "select o_orderpriority, count(*) as order_count, o_orderkey, weight_string(o_orderpriority) from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-07-01') + interval '3' month group by o_orderpriority, o_orderkey, weight_string(o_orderpriority) order by orders.o_orderpriority asc",
                 "Table": "orders"
               },
               {
@@ -631,9 +631,9 @@
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select sum(volume) as revenue, l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year), supp_nation, weight_string(supp_nation), cust_nation, weight_string(cust_nation) from (select extract(year from l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume, l_suppkey as l_suppkey, l_orderkey as l_orderkey from lineitem where 1 != 1) as shipping where 1 != 1 group by l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year)",
+                                    "FieldQuery": "select sum(volume) as revenue, l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year), shipping.supp_nation, weight_string(shipping.supp_nation), shipping.cust_nation, weight_string(shipping.cust_nation) from (select extract(year from l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume, l_suppkey as l_suppkey, l_orderkey as l_orderkey from lineitem where 1 != 1) as shipping where 1 != 1 group by l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year)",
                                     "OrderBy": "(5|6) ASC, (7|8) ASC, (1|4) ASC",
-                                    "Query": "select sum(volume) as revenue, l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year), supp_nation, weight_string(supp_nation), cust_nation, weight_string(cust_nation) from (select extract(year from l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume, l_suppkey as l_suppkey, l_orderkey as l_orderkey from lineitem where l_shipdate between date('1995-01-01') and date('1996-12-31')) as shipping group by l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year) order by supp_nation asc, cust_nation asc, l_year asc",
+                                    "Query": "select sum(volume) as revenue, l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year), shipping.supp_nation, weight_string(shipping.supp_nation), shipping.cust_nation, weight_string(shipping.cust_nation) from (select extract(year from l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume, l_suppkey as l_suppkey, l_orderkey as l_orderkey from lineitem where l_shipdate between date('1995-01-01') and date('1996-12-31')) as shipping group by l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year) order by shipping.supp_nation asc, shipping.cust_nation asc, shipping.l_year asc",
                                     "Table": "lineitem"
                                   },
                                   {
@@ -1518,7 +1518,7 @@
             },
             "FieldQuery": "select s_suppkey, s_name, s_address, s_phone, total_revenue, weight_string(s_suppkey) from supplier, revenue0 where 1 != 1",
             "OrderBy": "(0|5) ASC",
-            "Query": "select s_suppkey, s_name, s_address, s_phone, total_revenue, weight_string(s_suppkey) from supplier, revenue0 where s_suppkey = supplier_no and total_revenue = :__sq1 order by s_suppkey asc",
+            "Query": "select s_suppkey, s_name, s_address, s_phone, total_revenue, weight_string(s_suppkey) from supplier, revenue0 where s_suppkey = supplier_no and total_revenue = :__sq1 order by supplier.s_suppkey asc",
             "ResultColumns": 5,
             "Table": "revenue0, supplier"
           }

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -128,7 +128,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from `user` order by id desc limit :__upper_limit",
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id desc limit :__upper_limit",
                     "Table": "`user`"
                   }
                 ]
@@ -146,7 +146,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from music where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from music order by id desc limit :__upper_limit",
+                    "Query": "select id, weight_string(id) from music order by music.id desc limit :__upper_limit",
                     "Table": "music"
                   }
                 ]
@@ -258,7 +258,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) ASC",
-                    "Query": "select id, weight_string(id) from `user` order by id asc limit :__upper_limit",
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit :__upper_limit",
                     "Table": "`user`"
                   }
                 ]
@@ -276,7 +276,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from music where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from music order by id desc limit :__upper_limit",
+                    "Query": "select id, weight_string(id) from music order by music.id desc limit :__upper_limit",
                     "Table": "music"
                   }
                 ]
@@ -962,7 +962,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) ASC",
-                    "Query": "select id, weight_string(id) from `user` order by id asc limit :__upper_limit",
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit :__upper_limit",
                     "Table": "`user`"
                   }
                 ]
@@ -980,7 +980,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from `user` order by id desc limit :__upper_limit",
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id desc limit :__upper_limit",
                     "Table": "`user`"
                   }
                 ]

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -76,6 +76,7 @@ func (a *analyzer) lateInit() {
 		env:             a.si.Environment(),
 		aliasMapCache:   map[*sqlparser.Select]map[string]exprContainer{},
 		reAnalyze:       a.reAnalyze,
+		tables:          a.tables,
 	}
 }
 

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -37,6 +37,7 @@ type analyzer struct {
 	sig         QuerySignature
 	si          SchemaInformation
 	currentDb   string
+	recheck     bool
 
 	err          error
 	inProjection int
@@ -74,7 +75,7 @@ func (a *analyzer) lateInit() {
 		expandedColumns: map[sqlparser.TableName][]*sqlparser.ColName{},
 		env:             a.si.Environment(),
 		aliasMapCache:   map[*sqlparser.Select]map[string]exprContainer{},
-		reAnalyze:       a.lateAnalyze,
+		reAnalyze:       a.reAnalyze,
 	}
 }
 
@@ -249,9 +250,12 @@ func (a *analyzer) analyzeUp(cursor *sqlparser.Cursor) bool {
 		return false
 	}
 
-	if err := a.rewriter.up(cursor); err != nil {
-		a.setError(err)
-		return true
+	if !a.recheck {
+		// no need to run the rewriter on rechecking
+		if err := a.rewriter.up(cursor); err != nil {
+			a.setError(err)
+			return true
+		}
 	}
 
 	if err := a.scoper.up(cursor); err != nil {
@@ -357,6 +361,14 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 func (a *analyzer) lateAnalyze(statement sqlparser.SQLNode) error {
 	_ = sqlparser.Rewrite(statement, a.analyzeDown, a.analyzeUp)
 	return a.err
+}
+
+func (a *analyzer) reAnalyze(statement sqlparser.SQLNode) error {
+	a.recheck = true
+	defer func() {
+		a.recheck = false
+	}()
+	return a.lateAnalyze(statement)
 }
 
 // canShortCut checks if we are dealing with a single unsharded keyspace and no tables that have managed foreign keys
@@ -637,6 +649,10 @@ func (p ProjError) Error() string {
 // if the query is not unsharded
 type ShardedError struct {
 	Inner error
+}
+
+func (p ShardedError) Unwrap() error {
+	return p.Inner
 }
 
 func (p ShardedError) Error() string {

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -710,9 +710,7 @@ func TestGroupByBinding(t *testing.T) {
 		TS0,
 	}, {
 		"select 1 as c from tabl group by c",
-		// because we don't have authoritative information about `tabl`,
-		// we assume that it has a column named `c`
-		TS0,
+		NoTables,
 	}, {
 		"select t1.id from t1, t2 group by id",
 		TS0,

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -745,44 +745,47 @@ func TestGroupByBinding(t *testing.T) {
 
 func TestHavingBinding(t *testing.T) {
 	tcases := []struct {
-		sql  string
-		deps TableSet
+		sql, err string
+		deps     TableSet
 	}{{
-		"select col from tabl having col = 1",
-		TS0,
+		sql:  "select col from tabl having col = 1",
+		deps: TS0,
 	}, {
-		"select col from tabl having tabl.col = 1",
-		TS0,
+		sql:  "select col from tabl having tabl.col = 1",
+		deps: TS0,
 	}, {
-		"select col from tabl having d.tabl.col = 1",
-		TS0,
+		sql:  "select col from tabl having d.tabl.col = 1",
+		deps: TS0,
 	}, {
-		"select tabl.col as x from tabl having x = 1",
-		TS0,
+		sql:  "select tabl.col as x from tabl having col = 1",
+		deps: TS0,
 	}, {
-		"select tabl.col as x from tabl having col",
-		TS0,
+		sql:  "select tabl.col as x from tabl having x = 1",
+		deps: TS0,
 	}, {
-		"select col from tabl having 1 = 1",
-		NoTables,
+		sql:  "select tabl.col as x from tabl having col",
+		deps: TS0,
 	}, {
-		"select col as c from tabl having c = 1",
-		TS0,
+		sql:  "select col from tabl having 1 = 1",
+		deps: NoTables,
 	}, {
-		"select 1 as c from tabl having c = 1",
-		NoTables,
+		sql:  "select col as c from tabl having c = 1",
+		deps: TS0,
 	}, {
-		"select t1.id from t1, t2 having id = 1",
-		TS0,
+		sql:  "select 1 as c from tabl having c = 1",
+		deps: NoTables,
 	}, {
-		"select t.id from t, t1 having id = 1",
-		TS0,
+		sql:  "select t1.id from t1, t2 having id = 1",
+		deps: TS0,
 	}, {
-		"select t.id, count(*) as a from t, t1 group by t.id having a = 1",
-		MergeTableSets(TS0, TS1),
+		sql:  "select t.id from t, t1 having id = 1",
+		deps: TS0,
 	}, {
-		"select t.id, sum(t2.name) as a from t, t2 group by t.id having a = 1",
-		TS1,
+		sql:  "select t.id, count(*) as a from t, t1 group by t.id having a = 1",
+		deps: MergeTableSets(TS0, TS1),
+	}, {
+		sql:  "select t.id, sum(t2.name) as a from t, t2 group by t.id having a = 1",
+		deps: TS1,
 	}, {
 		sql:  "select u2.a, u1.a from u1, u2 having u2.a = 2",
 		deps: TS1,

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -710,7 +710,9 @@ func TestGroupByBinding(t *testing.T) {
 		TS0,
 	}, {
 		"select 1 as c from tabl group by c",
-		NoTables,
+		// because we don't have authoritative information about `tabl`,
+		// we assume that it has a column named `c`
+		TS0,
 	}, {
 		"select t1.id from t1, t2 group by id",
 		TS0,
@@ -722,7 +724,10 @@ func TestGroupByBinding(t *testing.T) {
 		TS1,
 	}, {
 		"select a.id from t as a, t1 group by id",
-		TS0,
+		// since we have authoritative info on t1, we know that it does have an `id` column,
+		// and we are missing column info for `t`, we just assume this is coming from t1.
+		// we really need schema tracking here
+		TS1,
 	}, {
 		"select a.id from t, t1 as a group by id",
 		TS1,

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -243,19 +243,11 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 		var err error
 		thisDeps, err = b.resolveColumnInScope(current, colName, allowMulti)
 		if err != nil {
-			err = makeAmbiguousError(colName, err)
-			if thisDeps == nil {
-				return dependency{}, err
-			}
+			return dependency{}, makeAmbiguousError(colName, err)
 		}
 		if !thisDeps.empty() {
-			deps, thisErr := thisDeps.get()
-			if thisErr != nil {
-				err = makeAmbiguousError(colName, thisErr)
-			}
-			return deps, err
-		} else if err != nil {
-			return dependency{}, err
+			deps, err := thisDeps.get()
+			return deps, makeAmbiguousError(colName, err)
 		}
 		if current.parent == nil &&
 			len(current.tables) == 1 &&

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -400,17 +400,3 @@ func GetSubqueryAndOtherSide(node *sqlparser.ComparisonExpr) (*sqlparser.Subquer
 	}
 	return subq, exp
 }
-
-func equalsWithDeps(org originable) *sqlparser.Comparator {
-	return &sqlparser.Comparator{
-		RefOfColName_: func(a, b *sqlparser.ColName) bool {
-			_, aDeps, _ := org.depsForExpr(a)
-			_, bDeps, _ := org.depsForExpr(b)
-			if aDeps != bDeps && (aDeps.IsEmpty() || bDeps.IsEmpty()) {
-				// if we don't know, we don't know
-				return sqlparser.Equals.RefOfColName(a, b)
-			}
-			return a.Name.Equal(b.Name) && aDeps == bDeps
-		},
-	}
-}

--- a/go/vt/vtgate/semantics/dependencies.go
+++ b/go/vt/vtgate/semantics/dependencies.go
@@ -32,6 +32,7 @@ type (
 		merge(other dependencies, allowMulti bool) dependencies
 	}
 	dependency struct {
+		certain   bool
 		direct    TableSet
 		recursive TableSet
 		typ       evalengine.Type
@@ -52,6 +53,7 @@ var ambigousErr = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "ambiguous")
 func createCertain(direct TableSet, recursive TableSet, qt evalengine.Type) *certain {
 	c := &certain{
 		dependency: dependency{
+			certain:   true,
 			direct:    direct,
 			recursive: recursive,
 		},
@@ -65,6 +67,7 @@ func createCertain(direct TableSet, recursive TableSet, qt evalengine.Type) *cer
 func createUncertain(direct TableSet, recursive TableSet) *uncertain {
 	return &uncertain{
 		dependency: dependency{
+			certain:   false,
 			direct:    direct,
 			recursive: recursive,
 		},
@@ -131,7 +134,7 @@ func (n *nothing) empty() bool {
 }
 
 func (n *nothing) get() (dependency, error) {
-	return dependency{}, nil
+	return dependency{certain: true}, nil
 }
 
 func (n *nothing) merge(d dependencies, _ bool) dependencies {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -91,11 +91,10 @@ func (r *earlyRewriter) up(cursor *sqlparser.Cursor) error {
 		}
 		return r.handleOrderBy(cursor.Parent(), iter)
 	case *sqlparser.Where:
-		if node.Type != sqlparser.HavingClause {
-			return nil
+		if node.Type == sqlparser.HavingClause {
+			return r.handleHavingClause(node, cursor.Parent())
 		}
 
-		return r.handleHavingClause(node, cursor.Parent())
 	}
 	return nil
 }

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -574,6 +574,10 @@ func TestHavingColumnName(t *testing.T) {
 		sql:     "select sum(sal) empno from emp where ename > 0 having empno = 2",
 		expSQL:  "select sum(sal) as empno from emp where ename > 0 having sum(emp.sal) = 2",
 		expDeps: TS0,
+	}, {
+		// test with missing schema info
+		sql:    "select foo, count(bar) as x from someTable group by foo having id > avg(baz)",
+		expErr: "Unknown column 'id' in 'having clause'",
 	}}
 
 	for _, tcase := range tcases {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -578,6 +578,10 @@ func TestHavingColumnName(t *testing.T) {
 		// test with missing schema info
 		sql:    "select foo, count(bar) as x from someTable group by foo having id > avg(baz)",
 		expErr: "Unknown column 'id' in 'having clause'",
+	}, {
+		sql:     "select t1.foo as alias, count(bar) as x from t1 group by foo having foo+54 = 56",
+		expSQL:  "select t1.foo as alias, count(bar) as x from t1 group by foo having foo + 54 = 56",
+		expDeps: TS0,
 	}}
 
 	for _, tcase := range tcases {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -565,7 +565,17 @@ func TestHavingColumnName(t *testing.T) {
 		sql:     "select foo as X, sal as foo from t1, emp having sum(X) > 1000",
 		expSQL:  "select foo as X, sal as foo from t1, emp having sum(t1.foo) > 1000",
 		expDeps: TS0,
+	}, {
+		sql:     "select count(*) a from someTable having a = 10",
+		expSQL:  "select count(*) as a from someTable having count(*) = 10",
+		expDeps: TS0,
+		warning: "Missing table info, so not binding to anything on the FROM clause",
+	}, {
+		sql:     "select count(*) from emp having ename = 10",
+		expSQL:  "select count(*) from emp having ename = 10",
+		expDeps: TS0,
 	}}
+
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {
 			ast, err := sqlparser.NewTestParser().Parse(tcase.sql)

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -582,6 +582,10 @@ func TestHavingColumnName(t *testing.T) {
 		sql:     "select t1.foo as alias, count(bar) as x from t1 group by foo having foo+54 = 56",
 		expSQL:  "select t1.foo as alias, count(bar) as x from t1 group by foo having foo + 54 = 56",
 		expDeps: TS0,
+	}, {
+		sql:     "select 1 from t1 group by foo having foo = 1 and count(*) > 1",
+		expSQL:  "select 1 from t1 group by foo having foo = 1 and count(*) > 1",
+		expDeps: TS0,
 	}}
 
 	for _, tcase := range tcases {

--- a/go/vt/vtgate/semantics/errors.go
+++ b/go/vt/vtgate/semantics/errors.go
@@ -72,8 +72,9 @@ type (
 		Column *sqlparser.ColName
 		Table  *sqlparser.TableName
 	}
-	ColumnNotFoundInGroupByError struct {
+	ColumnNotFoundClauseError struct {
 		Column string
+		Clause string
 	}
 )
 
@@ -320,14 +321,14 @@ func (e *CantGroupOn) ErrorState() vterrors.State {
 }
 
 // ColumnNotFoundInGroupByError
-func (e *ColumnNotFoundInGroupByError) Error() string {
-	return fmt.Sprintf("Unknown column '%s' in 'group statement'", e.Column)
+func (e *ColumnNotFoundClauseError) Error() string {
+	return fmt.Sprintf("Unknown column '%s' in '%s'", e.Column, e.Clause)
 }
 
-func (*ColumnNotFoundInGroupByError) ErrorCode() vtrpcpb.Code {
+func (*ColumnNotFoundClauseError) ErrorCode() vtrpcpb.Code {
 	return vtrpcpb.Code_INVALID_ARGUMENT
 }
 
-func (e *ColumnNotFoundInGroupByError) ErrorState() vterrors.State {
+func (e *ColumnNotFoundClauseError) ErrorState() vterrors.State {
 	return vterrors.BadFieldError
 }

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -250,16 +250,6 @@ func (s *scoper) up(cursor *sqlparser.Cursor) error {
 	return nil
 }
 
-func (s *scoper) foobar() {
-	id := EmptyTableSet()
-	for _, tableInfo := range s.currentScope().tables {
-		set := tableInfo.getTableSet(s.org)
-		id = id.Merge(set)
-	}
-	s.statementIDs[s.currentScope().stmt] = id
-	s.popScope()
-}
-
 func ValidAsMapKey(s sqlparser.SQLNode) bool {
 	return reflect.TypeOf(s).Comparable()
 }

--- a/go/vt/vtgate/semantics/vtable.go
+++ b/go/vt/vtgate/semantics/vtable.go
@@ -42,15 +42,36 @@ func (v *vTableInfo) dependencies(colName string, org originable) (dependencies,
 		if name != colName {
 			continue
 		}
-		directDeps, recursiveDeps, qt := org.depsForExpr(v.cols[i])
-
-		newDeps := createCertain(directDeps, recursiveDeps, qt)
-		deps = deps.merge(newDeps, false)
+		deps = deps.merge(v.createCertainForCol(org, i), false)
 	}
 	if deps.empty() && v.hasStar() {
 		return createUncertain(v.tables, v.tables), nil
 	}
 	return deps, nil
+}
+
+func (v *vTableInfo) dependenciesInGroupBy(colName string, org originable) (dependencies, error) {
+	// this method is consciously very similar to vTableInfo.dependencies and should remain so
+	var deps dependencies = &nothing{}
+	for i, name := range v.columnNames {
+		if name != colName {
+			continue
+		}
+		if sqlparser.ContainsAggregation(v.cols[i]) {
+			return nil, &CantGroupOn{name}
+		}
+		deps = deps.merge(v.createCertainForCol(org, i), false)
+	}
+	if deps.empty() && v.hasStar() {
+		return createUncertain(v.tables, v.tables), nil
+	}
+	return deps, nil
+}
+
+func (v *vTableInfo) createCertainForCol(org originable, i int) *certain {
+	directDeps, recursiveDeps, qt := org.depsForExpr(v.cols[i])
+	newDeps := createCertain(directDeps, recursiveDeps, qt)
+	return newDeps
 }
 
 // IsInfSchema implements the TableInfo interface


### PR DESCRIPTION
## Description
Following up on #15302, this PR does the same fix for `GROUP BY` and `HAVING`.

## Related Issue(s)
#15302 (fix for `ORDER BY`)
#14935 (pr that introduced some bad rewrites)

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
