### PR TITLE
Filter by keyspace earlier in `tabletgateway`s `WaitForTablets(...)`

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -750,30 +750,8 @@ func (hc *HealthCheckImpl) WaitForAllServingTablets(ctx context.Context, targets
 	return hc.waitForTablets(ctx, targets, true)
 }
 
-// FilterTargetsByKeyspaces only returns the targets that are part of the provided keyspaces
-func FilterTargetsByKeyspaces(keyspaces []string, targets []*query.Target) []*query.Target {
-	filteredTargets := make([]*query.Target, 0)
-
-	// Keep them all if there are no keyspaces to watch
-	if len(KeyspacesToWatch) == 0 {
-		return append(filteredTargets, targets...)
-	}
-
-	// Let's remove from the target shards that are not in the keyspaceToWatch list.
-	for _, target := range targets {
-		for _, keyspaceToWatch := range keyspaces {
-			if target.Keyspace == keyspaceToWatch {
-				filteredTargets = append(filteredTargets, target)
-			}
-		}
-	}
-	return filteredTargets
-}
-
 // waitForTablets is the internal method that polls for tablets.
 func (hc *HealthCheckImpl) waitForTablets(ctx context.Context, targets []*query.Target, requireServing bool) error {
-	targets = FilterTargetsByKeyspaces(KeyspacesToWatch, targets)
-
 	for {
 		// We nil targets as we find them.
 		allPresent := true

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -672,20 +672,6 @@ func TestWaitForAllServingTablets(t *testing.T) {
 
 	err = hc.WaitForAllServingTablets(ctx, targets)
 	assert.NotNil(t, err, "error should not be nil (there are no tablets on this keyspace")
-
-	targets = []*querypb.Target{
-
-		{
-			Keyspace:   tablet.Keyspace,
-			Shard:      tablet.Shard,
-			TabletType: tablet.Type,
-		},
-		{
-			Keyspace:   "newkeyspace",
-			Shard:      tablet.Shard,
-			TabletType: tablet.Type,
-		},
-	}
 }
 
 // TestRemoveTablet tests the behavior when a tablet goes away.

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -686,13 +686,6 @@ func TestWaitForAllServingTablets(t *testing.T) {
 			TabletType: tablet.Type,
 		},
 	}
-
-	KeyspacesToWatch = []string{tablet.Keyspace}
-
-	err = hc.WaitForAllServingTablets(ctx, targets)
-	assert.Nil(t, err, "error should be nil. Keyspace with no tablets is filtered")
-
-	KeyspacesToWatch = []string{}
 }
 
 // TestRemoveTablet tests the behavior when a tablet goes away.

--- a/go/vt/srvtopo/discover.go
+++ b/go/vt/srvtopo/discover.go
@@ -30,7 +30,7 @@ import (
 )
 
 // FindAllTargets goes through all serving shards in the topology for the provided keyspaces
-// and tablet types. If no keyspaces are provided, all available keyspaces in the topo are
+// and tablet types. If no keyspaces are provided all available keyspaces in the topo are
 // fetched. It returns one Target object per keyspace/shard/matching TabletType.
 func FindAllTargets(ctx context.Context, ts Server, cell string, keyspaces []string, tabletTypes []topodatapb.TabletType) ([]*querypb.Target, error) {
 	var err error

--- a/go/vt/srvtopo/discover.go
+++ b/go/vt/srvtopo/discover.go
@@ -29,9 +29,9 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
-// FindAllTargets goes through all serving shards in the topology for the provided
-// keyspaces and tablet types. If keyspaces are provided all keyspaces in the topo
-// are used. It returns one Target object per keyspace/shard/matching TabletType.
+// FindAllTargets goes through all serving shards in the topology for the provided keyspaces
+// and tablet types. If no keyspaces are provided, all available keyspaces in the topo are
+// fetched. It returns one Target object per keyspace/shard/matching TabletType.
 func FindAllTargets(ctx context.Context, ts Server, cell string, keyspaces []string, tabletTypes []topodatapb.TabletType) ([]*querypb.Target, error) {
 	var err error
 	if len(keyspaces) == 0 {

--- a/go/vt/srvtopo/discover_test.go
+++ b/go/vt/srvtopo/discover_test.go
@@ -173,7 +173,7 @@ func TestFindAllTargets(t *testing.T) {
 		t.Errorf("got wrong value: %v", ks)
 	}
 
-	// Only get 1 keyspaces only for all types.
+	// Only get 1 keyspace for all types.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{"test_keyspace2"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/go/vt/srvtopo/discover_test.go
+++ b/go/vt/srvtopo/discover_test.go
@@ -210,4 +210,13 @@ func TestFindAllTargets(t *testing.T) {
 	}) {
 		t.Errorf("got wrong value: %v", ks)
 	}
+
+	// Get non-existent keyspace.
+	ks, err = FindAllTargets(ctx, rs, "cell1", []string{"doesnt-exist"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(ks) != 0 {
+		t.Errorf("got non-0 length value: %v", ks)
+	}
 }

--- a/go/vt/srvtopo/discover_test.go
+++ b/go/vt/srvtopo/discover_test.go
@@ -86,7 +86,7 @@ func TestFindAllTargets(t *testing.T) {
 	// Get it.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{"test_keyspace"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY})
 	assert.NoError(t, err)
-	assert.Equal(t, []*querypb.Target{
+	assert.EqualValues(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
 			Keyspace:   "test_keyspace",
@@ -96,9 +96,9 @@ func TestFindAllTargets(t *testing.T) {
 	}, ks)
 
 	// Get any keyspace.
-	ks, err = FindAllTargets(ctx, rs, "cell1", []string{}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY})
+	ks, err = FindAllTargets(ctx, rs, "cell1", nil, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY})
 	assert.NoError(t, err)
-	assert.Equal(t, []*querypb.Target{
+	assert.EqualValues(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
 			Keyspace:   "test_keyspace",
@@ -130,10 +130,10 @@ func TestFindAllTargets(t *testing.T) {
 	}))
 
 	// Get it for any keyspace, all types.
-	ks, err = FindAllTargets(ctx, rs, "cell1", []string{}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
+	ks, err = FindAllTargets(ctx, rs, "cell1", nil, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
 	assert.NoError(t, err)
 	sort.Sort(TargetArray(ks))
-	assert.Equal(t, []*querypb.Target{
+	assert.EqualValues(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
 			Keyspace:   "test_keyspace",
@@ -157,7 +157,7 @@ func TestFindAllTargets(t *testing.T) {
 	// Only get 1 keyspace for all types.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{"test_keyspace2"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
 	assert.NoError(t, err)
-	assert.Equal(t, []*querypb.Target{
+	assert.EqualValues(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
 			Keyspace:   "test_keyspace2",

--- a/go/vt/srvtopo/discover_test.go
+++ b/go/vt/srvtopo/discover_test.go
@@ -66,11 +66,11 @@ func TestFindAllTargets(t *testing.T) {
 
 	// No keyspace / shards.
 	ks, err := FindAllTargets(ctx, rs, "cell1", []string{"test_keyspace"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, ks, 0)
 
 	// Add one.
-	assert.Nilf(t, ts.UpdateSrvKeyspace(ctx, "cell1", "test_keyspace", &topodatapb.SrvKeyspace{
+	assert.NoError(t, ts.UpdateSrvKeyspace(ctx, "cell1", "test_keyspace", &topodatapb.SrvKeyspace{
 		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
 			{
 				ServedType: topodatapb.TabletType_PRIMARY,
@@ -81,11 +81,11 @@ func TestFindAllTargets(t *testing.T) {
 				},
 			},
 		},
-	}), "can't add srvKeyspace: %v", err)
+	}))
 
 	// Get it.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{"test_keyspace"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
@@ -97,7 +97,7 @@ func TestFindAllTargets(t *testing.T) {
 
 	// Get any keyspace.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
@@ -108,7 +108,7 @@ func TestFindAllTargets(t *testing.T) {
 	}, ks)
 
 	// Add another one.
-	assert.Nil(t, ts.UpdateSrvKeyspace(ctx, "cell1", "test_keyspace2", &topodatapb.SrvKeyspace{
+	assert.NoError(t, ts.UpdateSrvKeyspace(ctx, "cell1", "test_keyspace2", &topodatapb.SrvKeyspace{
 		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
 			{
 				ServedType: topodatapb.TabletType_PRIMARY,
@@ -131,7 +131,7 @@ func TestFindAllTargets(t *testing.T) {
 
 	// Get it for any keyspace, all types.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	sort.Sort(TargetArray(ks))
 	assert.Equal(t, []*querypb.Target{
 		{
@@ -156,7 +156,7 @@ func TestFindAllTargets(t *testing.T) {
 
 	// Only get 1 keyspace for all types.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{"test_keyspace2"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
@@ -174,7 +174,7 @@ func TestFindAllTargets(t *testing.T) {
 
 	// Only get the REPLICA targets for any keyspace.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{}, []topodatapb.TabletType{topodatapb.TabletType_REPLICA})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []*querypb.Target{
 		{
 			Cell:       "cell1",
@@ -186,6 +186,6 @@ func TestFindAllTargets(t *testing.T) {
 
 	// Get non-existent keyspace.
 	ks, err = FindAllTargets(ctx, rs, "cell1", []string{"doesnt-exist"}, []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, ks, 0)
 }

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -191,7 +191,7 @@ func (gw *TabletGateway) WaitForTablets(ctx context.Context, tabletTypesToWait [
 	}
 
 	// Finds the targets to look for.
-	targets, err := srvtopo.FindAllTargets(ctx, gw.srvTopoServer, gw.localCell, tabletTypesToWait)
+	targets, err := srvtopo.FindAllTargets(ctx, gw.srvTopoServer, gw.localCell, discovery.KeyspacesToWatch, tabletTypesToWait)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This PR causes the `tabletgateway` `.WaitForTablets(...)` method to filter targets by keyspace _(set by `--keyspaces_to_watch`)_ earlier in the process

Currently, the logic under `.WaitForTablets(...)`:
1. Uses `srvtopo.FindAllTargets(...)` to fetch the targets by-cell for **_any_** keyspace _(even if `--keyspaces_to_watch` is set)_
    - This calls `.GetSrvKeyspace(...)` on the toposerver for every keyspace in goroutines w/wait group
2. Later targets that do not match `--keyspaces_to_watch` are removed from `targets []*querypb.Target`

Instead this PR implements the filtering in `srvtopo.FindAllTargets(...)` by not-fetching keyspaces from the topo that will just get filtered anyways. This can avoid topo calls and unnecessary filtering of results on deployments with many keyspaces and a subset of keyspaces set as `--keyspaces_to_watch`

The changed codepath and signatures are only called by `vtgate`/`tabletgateway` so this change had a limited impact

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/15373

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
