### PR TITLE
SHOW VITESS_REPLICATION_STATUS: Only use replication tracker when it's enabled

### DIFF
--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -81,7 +81,7 @@ func TestVtgateReplicationStatusCheck(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}()
-	// Stop replication on the non-primary tablets.
+	// Stop replication on the non-PRIMARY tablets.
 	_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Replica().Alias, "stop slave")
 	require.NoError(t, err)
 	_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Rdonly().Alias, "stop slave")

--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -86,6 +86,13 @@ func TestVtgateReplicationStatusCheck(t *testing.T) {
 	require.NoError(t, err)
 	_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Rdonly().Alias, "stop slave")
 	require.NoError(t, err)
+	// Restart replication as the cluster is re-used.
+	defer func() {
+		_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Replica().Alias, "start slave")
+		require.NoError(t, err)
+		_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Rdonly().Alias, "start slave")
+		require.NoError(t, err)
+	}()
 	time.Sleep(2 * time.Second) // Build up some replication lag
 	res, err := conn.ExecuteFetch("show vitess_replication_status", 2, false)
 	require.NoError(t, err)

--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -86,7 +86,7 @@ func TestVtgateReplicationStatusCheck(t *testing.T) {
 	require.NoError(t, err)
 	_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Rdonly().Alias, "stop slave")
 	require.NoError(t, err)
-	// Restart replication as the cluster is re-used.
+	// Restart replication afterward as the cluster is re-used.
 	defer func() {
 		_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDBA", clusterInstance.Keyspaces[0].Shards[0].Replica().Alias, "start slave")
 		require.NoError(t, err)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -951,7 +951,7 @@ func (e *Executor) showVitessReplicationStatus(ctx context.Context, filter *sqlp
 				replLastError = row["Last_Error"].ToString()
 				if tabletenv.NewCurrentConfig().ReplicationTracker.Mode == tabletenv.Disable { // Use the value from mysqld
 					if row["Seconds_Behind_Master"].IsNull() {
-						replLag = "NULL" // Uppercase to match mysqld's output in SHOW REPLICA STATUS
+						replLag = strings.ToUpper(sqltypes.NullStr) // Uppercase to match mysqld's output in SHOW REPLICA STATUS
 					} else {
 						replLag = row["Seconds_Behind_Master"].ToString()
 					}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -28,7 +29,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/cache/theine"
@@ -40,6 +40,11 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/srvtopo"
@@ -57,15 +62,6 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vtgateservice"
 	"vitess.io/vitess/go/vt/vthash"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
-	"vitess.io/vitess/go/vt/vttablet/tmclient"
-
-	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 var (
@@ -914,7 +910,6 @@ func (e *Executor) showVitessReplicationStatus(ctx context.Context, filter *sqlp
 	rows := [][]sqltypes.Value{}
 
 	status := e.scatterConn.GetHealthCheckCacheStatus()
-	tmc := tmclient.NewTabletManagerClient()
 
 	for _, s := range status {
 		for _, ts := range s.TabletsStats {
@@ -933,16 +928,9 @@ func (e *Executor) showVitessReplicationStatus(ctx context.Context, filter *sqlp
 			}
 
 			tabletHostPort := ts.GetTabletHostPort()
-
-			res, err := tmc.CheckThrottler(ctx, ts.Tablet, &tabletmanagerdatapb.CheckThrottlerRequest{
-				AppName: throttlerapp.VTGateName,
-			})
+			throttlerStatus, err := getTabletThrottlerStatus(tabletHostPort)
 			if err != nil {
-				log.Warningf("Could not get check the tablet throttler on %s: %v", topoproto.TabletAliasString(ts.Tablet.Alias), err)
-			}
-			throttlerStatus, err := protojson.Marshal(res)
-			if err != nil {
-				log.Warningf("Invalid tablet throttler response from %s: %v", topoproto.TabletAliasString(ts.Tablet.Alias), err)
+				log.Warningf("Could not get throttler status from %s: %v", tabletHostPort, err)
 			}
 
 			replSourceHost := ""
@@ -984,7 +972,7 @@ func (e *Executor) showVitessReplicationStatus(ctx context.Context, filter *sqlp
 				fmt.Sprintf("%s:%d", replSourceHost, replSourcePort),
 				replicationHealth,
 				replLag,
-				string(throttlerStatus),
+				throttlerStatus,
 			))
 		}
 	}
@@ -1496,6 +1484,42 @@ func (e *Executor) checkThatPlanIsValid(stmt sqlparser.Statement, plan *engine.P
 	}
 
 	return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "plan includes scatter, which is disallowed using the `no_scatter` command line argument")
+}
+
+func getTabletThrottlerStatus(tabletHostPort string) (string, error) {
+	client := http.Client{
+		Timeout: 100 * time.Millisecond,
+	}
+	resp, err := client.Get(fmt.Sprintf("http://%s/throttler/check-self", tabletHostPort))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var elements struct {
+		StatusCode int
+		Value      float64
+		Threshold  float64
+		Message    string
+	}
+	err = json.Unmarshal(body, &elements)
+	if err != nil {
+		return "", err
+	}
+
+	httpStatusStr := http.StatusText(elements.StatusCode)
+
+	load := float64(0)
+	if elements.Threshold > 0 {
+		load = float64((elements.Value / elements.Threshold) * 100)
+	}
+
+	status := fmt.Sprintf("{\"state\":\"%s\",\"load\":%.2f,\"message\":\"%s\"}", httpStatusStr, load, elements.Message)
+	return status, nil
 }
 
 // ReleaseLock implements the IExecutor interface

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -42,11 +42,6 @@ import (
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/discovery"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
-	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtgate/buffer"
@@ -55,6 +50,12 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 	"vitess.io/vitess/go/vt/vtgate/vschemaacl"
 	"vitess.io/vitess/go/vt/vtgate/vtgateservice"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 func TestExecutorResultsExceeded(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/repltracker/poller.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller.go
@@ -21,10 +21,10 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/stats"
-
 	"vitess.io/vitess/go/vt/mysqlctl"
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 var replicationLagSeconds = stats.NewGauge("replicationLagSec", "replication lag in seconds")

--- a/go/vt/vttablet/tabletserver/repltracker/repltracker.go
+++ b/go/vt/vttablet/tabletserver/repltracker/repltracker.go
@@ -23,10 +23,11 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/heartbeat"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 var (

--- a/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
@@ -41,7 +41,7 @@ func (n Name) Concatenate(other Name) Name {
 }
 
 const (
-	// DefaultName is the app name used by vitess when app doesn't indicate its name
+	// DefaultName is the app name used by vitess when app doesn't indicate its name.
 	DefaultName Name = "default"
 	VitessName  Name = "vitess"
 
@@ -62,6 +62,8 @@ const (
 	BinlogWatcherName Name = "binlog-watcher"
 	MessagerName      Name = "messager"
 	SchemaTrackerName Name = "schema-tracker"
+
+	VTGateName = "vtgate"
 )
 
 var (

--- a/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
@@ -41,7 +41,7 @@ func (n Name) Concatenate(other Name) Name {
 }
 
 const (
-	// DefaultName is the app name used by vitess when app doesn't indicate its name.
+	// DefaultName is the app name used by vitess when app doesn't indicate its name
 	DefaultName Name = "default"
 	VitessName  Name = "vitess"
 
@@ -62,8 +62,6 @@ const (
 	BinlogWatcherName Name = "binlog-watcher"
 	MessagerName      Name = "messager"
 	SchemaTrackerName Name = "schema-tracker"
-
-	VTGateName = "vtgate"
 )
 
 var (

--- a/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
@@ -62,6 +62,8 @@ const (
 	BinlogWatcherName Name = "binlog-watcher"
 	MessagerName      Name = "messager"
 	SchemaTrackerName Name = "schema-tracker"
+
+	VTGateName = "vtgate"
 )
 
 var (

--- a/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
@@ -62,8 +62,6 @@ const (
 	BinlogWatcherName Name = "binlog-watcher"
 	MessagerName      Name = "messager"
 	SchemaTrackerName Name = "schema-tracker"
-
-	VTGateName = "vtgate"
 )
 
 var (


### PR DESCRIPTION
## Description

We added the `show vitess_replication_status` query in https://github.com/vitessio/vitess/pull/8900. At the time I chose to use the tablet's replication lag stats variable as we could get a more accurate representation of the lag than using mysqld's `seconds_behind_[master|source]` value. The stat relied on polling — in which case we can also estimate the lag when replication is not running – or sub-second heartbeats, and it was more accurate for these reasons.

This query was first introduced in v12 and at that time the [`ReplicationTracker`](https://github.com/vitessio/vitess/blob/main/go/vt/vttablet/tabletserver/repltracker/repltracker.go) was [always enabled in the local examples](https://github.com/vitessio/vitess/blob/release-12.0/examples/local/scripts/vttablet-up.sh#L49) using the [polling method](https://github.com/vitessio/vitess/blob/d8f771c695b5b82ec8b104b66587018b6e18f2fa/go/vt/vttablet/tabletserver/tabletenv/config.go#L263-L270), where the manual testing was done. In v17 [we changed the vttablet flags](https://github.com/vitessio/vitess/commit/1a0c3fe777948e5d14e9c5144701547da4115f30#diff-dc8c0e33cc9dd25172ebf049d769def95c273efc4dbb496e991b64c54ac38fd1) in the local examples in order to switch from the polling based method to the heartbeat based method [before subsequently removing the heartbeats as well](https://github.com/vitessio/vitess/commit/82be9db48d1c493323f0f54d334fc93977f98229) and after that we instead [started using on-demand heartbeats](https://github.com/vitessio/vitess/commit/885355efc0068aaae410fef6ef6b803552b985c4) alone — so today the [replication tracker is disabled](https://github.com/vitessio/vitess/blob/d8f771c695b5b82ec8b104b66587018b6e18f2fa/go/vt/vttablet/tabletserver/tabletenv/config.go#L263-L270) entirely in the local examples.

In any event, the real issue was that we didn't have adequate testing of this feature. This PR addresses the issue by:
1. Only using the tablet's tracker based stat when replication tracking is enabled (heartbeat or polling based)
2. Adds an e2e test 🙂 

You can see a manual test case here: https://github.com/vitessio/vitess/issues/15341#issuecomment-1962423780

I think that this should be backported for the following reasons:
1. The changes are simple and isolated to users of this query
2. The results were incorrect for the query

I also updated the throttler check to use `check-self` as `check?app=vtgate` is not useful because:
1. `check` is only applicable on a `PRIMARY` tablet and we are checking non-`PRIMARY` tablets
2. An app of `vtgate` doesn't make sense as `vtgate` does not interface with the tablet throttler 

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/15341

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required