### PR TITLE
VtctldClient Reshard: add e2e tests to confirm CLI options and fix discovered issues.

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/reshard/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/reshard/create.go
@@ -60,9 +60,8 @@ func commandReshardCreate(cmd *cobra.Command, args []string) error {
 	cli.FinishedParsing(cmd)
 
 	req := &vtctldatapb.ReshardCreateRequest{
-		Workflow: common.BaseOptions.Workflow,
-		Keyspace: common.BaseOptions.TargetKeyspace,
-
+		Workflow:                  common.BaseOptions.Workflow,
+		Keyspace:                  common.BaseOptions.TargetKeyspace,
 		TabletTypes:               common.CreateOptions.TabletTypes,
 		TabletSelectionPreference: tsp,
 		Cells:                     common.CreateOptions.Cells,
@@ -70,10 +69,9 @@ func commandReshardCreate(cmd *cobra.Command, args []string) error {
 		DeferSecondaryKeys:        common.CreateOptions.DeferSecondaryKeys,
 		AutoStart:                 common.CreateOptions.AutoStart,
 		StopAfterCopy:             common.CreateOptions.StopAfterCopy,
-
-		SourceShards:   reshardCreateOptions.sourceShards,
-		TargetShards:   reshardCreateOptions.targetShards,
-		SkipSchemaCopy: reshardCreateOptions.skipSchemaCopy,
+		SourceShards:              reshardCreateOptions.sourceShards,
+		TargetShards:              reshardCreateOptions.targetShards,
+		SkipSchemaCopy:            reshardCreateOptions.skipSchemaCopy,
 	}
 	resp, err := common.GetClient().ReshardCreate(common.GetCommandCtx(), req)
 	if err != nil {

--- a/go/test/endtoend/vreplication/wrappers_test.go
+++ b/go/test/endtoend/vreplication/wrappers_test.go
@@ -74,9 +74,9 @@ type moveTablesWorkflow struct {
 	tables         string
 	atomicCopy     bool
 	sourceShards   string
-	createFlags    []string // currently only used by vtctld
 
 	lastOutput    string
+	createFlags   []string // currently only used by vtctld
 	completeFlags []string
 	switchFlags   []string
 }
@@ -270,7 +270,11 @@ type reshardWorkflow struct {
 	targetShards   string
 	skipSchemaCopy bool
 
-	lastOutput string
+	lastOutput    string
+	createFlags   []string // currently only used by vtctld
+	completeFlags []string
+	cancelFlags   []string
+	switchFlags   []string
 }
 
 type iReshard interface {
@@ -395,11 +399,14 @@ func (v VtctldReshard) Create() {
 	if v.skipSchemaCopy {
 		args = append(args, "--skip-schema-copy="+strconv.FormatBool(v.skipSchemaCopy))
 	}
+	args = append(args, v.createFlags...)
 	v.exec(args...)
 }
 
 func (v VtctldReshard) SwitchReadsAndWrites() {
-	v.exec("SwitchTraffic")
+	args := []string{"SwitchTraffic"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldReshard) ReverseReadsAndWrites() {
@@ -422,11 +429,15 @@ func (v VtctldReshard) SwitchWrites() {
 }
 
 func (v VtctldReshard) Cancel() {
-	v.exec("Cancel")
+	args := []string{"Cancel"}
+	args = append(args, v.cancelFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldReshard) Complete() {
-	v.exec("Complete")
+	args := []string{"Complete"}
+	args = append(args, v.completeFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldReshard) GetLastOutput() string {

--- a/go/test/endtoend/vreplication/wrappers_test.go
+++ b/go/test/endtoend/vreplication/wrappers_test.go
@@ -383,8 +383,9 @@ func (v VtctldReshard) Flavor() string {
 func (v VtctldReshard) exec(args ...string) {
 	args2 := []string{"Reshard", "--workflow=" + v.workflowName, "--target-keyspace=" + v.targetKeyspace}
 	args2 = append(args2, args...)
-	if err := vc.VtctldClient.ExecuteCommand(args2...); err != nil {
-		v.vc.t.Fatalf("failed to create Reshard workflow: %v", err)
+	var err error
+	if v.lastOutput, err = vc.VtctldClient.ExecuteCommandWithOutput(args2...); err != nil {
+		v.vc.t.Fatalf("failed to create Reshard workflow: %v: %s", err, v.lastOutput)
 	}
 }
 
@@ -414,8 +415,7 @@ func (v VtctldReshard) ReverseReadsAndWrites() {
 }
 
 func (v VtctldReshard) Show() {
-	//TODO implement me
-	panic("implement me")
+	v.exec("Show")
 }
 
 func (v VtctldReshard) SwitchReads() {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1672,7 +1672,11 @@ func (s *Server) ReshardCreate(ctx context.Context, req *vtctldatapb.ReshardCrea
 		log.Errorf("%w", err2)
 		return nil, err
 	}
-	rs, err := s.buildResharder(ctx, keyspace, req.Workflow, req.SourceShards, req.TargetShards, strings.Join(cells, ","), "")
+	tabletTypesStr := topoproto.MakeStringTypeCSV(req.TabletTypes)
+	if req.TabletSelectionPreference == tabletmanagerdatapb.TabletSelectionPreference_INORDER {
+		tabletTypesStr = discovery.InOrderHint + tabletTypesStr
+	}
+	rs, err := s.buildResharder(ctx, keyspace, req.Workflow, req.SourceShards, req.TargetShards, strings.Join(cells, ","), tabletTypesStr)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "buildResharder")
 	}
@@ -1695,7 +1699,10 @@ func (s *Server) ReshardCreate(ctx context.Context, req *vtctldatapb.ReshardCrea
 	} else {
 		log.Warningf("Streams will not be started since --auto-start is set to false")
 	}
-	return nil, nil
+	return s.WorkflowStatus(ctx, &vtctldatapb.WorkflowStatusRequest{
+		Keyspace: keyspace,
+		Workflow: req.Workflow,
+	})
 }
 
 // VDiffCreate is part of the vtctlservicepb.VtctldServer interface.


### PR DESCRIPTION
## Description

Expands https://github.com/vitessio/vitess/pull/14957 to check `Reshard`. Found a couple of issues which are also fixed in this PR:
1. `Reshard Create` was not returning any response, resulting in incorrect outputs from the command. 
2. The tablet types options were ignored by the Create command.

Backport to v19 since this is a bug in the vtctldclient-based commands, which were recommended in that version over the vtctlclient ones.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12152
https://github.com/vitessio/vitess/pull/14957

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
