### PR TITLE
Add initialize_with_vt_dba_tcp flag to enable TCP/IP connection access to the underlying MySQL instance

### DIFF
--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path"
 	"strconv"
 	"strings"
 	"syscall"
@@ -47,13 +48,14 @@ type topoFlags struct {
 }
 
 var (
-	basePort  int
-	config    vttest.Config
-	doSeed    bool
-	mycnf     string
-	protoTopo string
-	seed      vttest.SeedConfig
-	topo      topoFlags
+	basePort        int
+	config          vttest.Config
+	doSeed          bool
+	mycnf           string
+	protoTopo       string
+	seed            vttest.SeedConfig
+	topo            topoFlags
+	doCreateTCPUser bool
 )
 
 func (t *topoFlags) buildTopology() (*vttestpb.VTTestTopology, error) {
@@ -219,24 +221,43 @@ func New() (cmd *cobra.Command) {
 	cmd.Flags().StringVar(&config.ExternalTopoGlobalRoot, "external_topo_global_root", "", "the path of the global topology data in the global topology server for vtcombo process")
 
 	cmd.Flags().DurationVar(&config.VtgateTabletRefreshInterval, "tablet_refresh_interval", 10*time.Second, "Interval at which vtgate refreshes tablet information from topology server.")
+
+	cmd.Flags().BoolVar(&doCreateTCPUser, "initialize_with_vt_dba_tcp", false, "If this flag is enabled, MySQL will be initialized with an additional user named vt_dba_tcp, who will have access via TCP/IP connection.")
 	acl.RegisterFlags(cmd.Flags())
 
 	return cmd
 }
 
-func newEnv() (env vttest.Environment, err error) {
-	if basePort != 0 {
+func newEnv() (env *vttest.LocalTestEnv, err error) {
+	if basePort == 0 {
+		env, err = vttest.NewLocalTestEnv(0)
+	} else {
 		if config.DataDir == "" {
 			env, err = vttest.NewLocalTestEnv(basePort)
-			if err != nil {
-				return
-			}
 		} else {
 			env, err = vttest.NewLocalTestEnvWithDirectory(basePort, config.DataDir)
-			if err != nil {
-				return
-			}
 		}
+	}
+	if err != nil {
+		return
+	}
+
+	if doCreateTCPUser {
+		// The original initFile does not have any users who can access through TCP/IP connection.
+		// Here we update the init file to create the user.
+		mysqlInitFile := env.InitDBFile
+		createUserCmd := `
+			# Admin user for TCP/IP connection with all privileges.
+			CREATE USER 'vt_dba_tcp'@'%';
+			GRANT ALL ON *.* TO 'vt_dba_tcp'@'%';
+			GRANT GRANT OPTION ON *.* TO 'vt_dba_tcp'@'%';
+		`
+		newInitFile := path.Join(env.Directory(), "init_db_with_vt_dba_tcp.sql")
+		err = vttest.WriteInitDBFile(mysqlInitFile, createUserCmd, newInitFile)
+		if err != nil {
+			return
+		}
+		env.InitDBFile = newInitFile
 	}
 
 	if protoTopo == "" {

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -73,6 +73,7 @@ Flags:
       --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
   -h, --help                                                             help for vttestserver
       --initialize_with_random_data                                      If this flag is each table-shard will be initialized with random data. See also the 'rng_seed' and 'min_shard_size' and 'max_shard_size' flags.
+      --initialize_with_vt_dba_tcp                                       If this flag is enabled, MySQL will be initialized with an additional user named vt_dba_tcp, who will have access via TCP/IP connection.
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --keyspaces strings                                                Comma separated list of keyspaces (default [test_keyspace])

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -99,6 +99,7 @@ type LocalTestEnv struct {
 	BasePort        int
 	TmpPath         string
 	DefaultMyCnf    []string
+	InitDBFile      string
 	Env             []string
 	EnableToxiproxy bool
 }
@@ -133,7 +134,7 @@ func (env *LocalTestEnv) BinaryPath(binary string) string {
 func (env *LocalTestEnv) MySQLManager(mycnf []string, snapshot string) (MySQLManager, error) {
 	mysqlctl := &Mysqlctl{
 		Binary:    env.BinaryPath("mysqlctl"),
-		InitFile:  path.Join(os.Getenv("VTROOT"), "config/init_db.sql"),
+		InitFile:  env.InitDBFile,
 		Directory: env.TmpPath,
 		Port:      env.PortForProtocol("mysql", ""),
 		MyCnf:     append(env.DefaultMyCnf, mycnf...),
@@ -281,6 +282,7 @@ func NewLocalTestEnvWithDirectory(basePort int, directory string) (*LocalTestEnv
 		BasePort:     basePort,
 		TmpPath:      directory,
 		DefaultMyCnf: mycnf,
+		InitDBFile:   path.Join(os.Getenv("VTROOT"), "config/init_db.sql"),
 		Env: []string{
 			fmt.Sprintf("VTDATAROOT=%s", directory),
 			"VTTEST=endtoend",

--- a/go/vt/vttest/toxiproxyctl.go
+++ b/go/vt/vttest/toxiproxyctl.go
@@ -63,21 +63,16 @@ func NewToxiproxyctl(binary string, apiPort, mysqlPort int, mysqlctl *Mysqlctl, 
 
 	// The original initFile does not have any users who can access through TCP/IP connection.
 	// Here we update the init file to create the user.
-	initDb, _ := os.ReadFile(mysqlctl.InitFile)
 	createUserCmd := fmt.Sprintf(`
 		# Admin user for TCP/IP connection with all privileges.
 		CREATE USER '%s'@'127.0.0.1';
 		GRANT ALL ON *.* TO '%s'@'127.0.0.1';
 		GRANT GRANT OPTION ON *.* TO '%s'@'127.0.0.1';
 	`, dbaUser, dbaUser, dbaUser)
-	sql, err := getInitDBSQL(string(initDb), createUserCmd)
+	newInitFile := path.Join(mysqlctl.Directory, "init_db_toxiproxyctl.sql")
+	err := WriteInitDBFile(mysqlctl.InitFile, createUserCmd, newInitFile)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "failed to get a modified init db sql")
-	}
-	newInitFile := path.Join(mysqlctl.Directory, "init_db_toxiproxyctl.sql")
-	err = os.WriteFile(newInitFile, []byte(sql), 0600)
-	if err != nil {
-		return nil, vterrors.Wrap(err, "failed to write a modified init db file")
 	}
 	mysqlctl.InitFile = newInitFile
 
@@ -233,6 +228,20 @@ func (ctl *Toxiproxyctl) UpdateTimeoutToxicity(toxicity float32) error {
 func (ctl *Toxiproxyctl) RemoveTimeoutToxic() error {
 	log.Info("Removing timeout toxic")
 	return ctl.proxy.RemoveToxic("my-timeout")
+}
+
+// WriteInitDBFile is a helper function that writes a modified init_db.sql file with custom SQL statements.
+func WriteInitDBFile(initFile, customSQL, newInitFile string) error {
+	initDb, _ := os.ReadFile(initFile)
+	sql, err := getInitDBSQL(string(initDb), customSQL)
+	if err != nil {
+		return vterrors.Wrap(err, "failed to get a modified init db sql")
+	}
+	err = os.WriteFile(newInitFile, []byte(sql), 0600)
+	if err != nil {
+		return vterrors.Wrap(err, "failed to write a modified init db file")
+	}
+	return nil
 }
 
 // getInitDBSQL is a helper function that retrieves the modified contents of the init_db.sql file with custom SQL statements.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds `initialize_with_vt_dba_tcp` flag to vttestserver. If this flag is enabled, MySQL will be initialized with an additional user named `vt_dba_tcp`, who will have access via TCP/IP connection. The default value is false.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #15267

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
