### PR TITLE
CI: Address data races on memorytopo Conn.closed

### DIFF
--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -28,7 +28,7 @@ import (
 func (c *Conn) NewLeaderParticipation(name, id string) (topo.LeaderParticipation, error) {
 	c.factory.callstats.Add([]string{"NewLeaderParticipation"}, 1)
 
-	if c.closed {
+	if c.closed.Load() {
 		return nil, ErrConnectionClosed
 	}
 
@@ -74,7 +74,7 @@ type cLeaderParticipation struct {
 
 // WaitForLeadership is part of the topo.LeaderParticipation interface.
 func (mp *cLeaderParticipation) WaitForLeadership() (context.Context, error) {
-	if mp.c.closed {
+	if mp.c.closed.Load() {
 		return nil, ErrConnectionClosed
 	}
 
@@ -122,7 +122,7 @@ func (mp *cLeaderParticipation) Stop() {
 
 // GetCurrentLeaderID is part of the topo.LeaderParticipation interface
 func (mp *cLeaderParticipation) GetCurrentLeaderID(ctx context.Context) (string, error) {
-	if mp.c.closed {
+	if mp.c.closed.Load() {
 		return "", ErrConnectionClosed
 	}
 
@@ -141,7 +141,7 @@ func (mp *cLeaderParticipation) GetCurrentLeaderID(ctx context.Context) (string,
 
 // WaitForNewLeader is part of the topo.LeaderParticipation interface
 func (mp *cLeaderParticipation) WaitForNewLeader(ctx context.Context) (<-chan string, error) {
-	if mp.c.closed {
+	if mp.c.closed.Load() {
 		return nil, ErrConnectionClosed
 	}
 

--- a/go/vt/topo/memorytopo/lock.go
+++ b/go/vt/topo/memorytopo/lock.go
@@ -116,7 +116,7 @@ func (ld *memoryTopoLockDescriptor) Unlock(ctx context.Context) error {
 }
 
 func (c *Conn) unlock(ctx context.Context, dirPath string) error {
-	if c.closed {
+	if c.closed.Load() {
 		return ErrConnectionClosed
 	}
 

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -27,7 +27,7 @@ import (
 func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
 	c.factory.callstats.Add([]string{"Watch"}, 1)
 
-	if c.closed {
+	if c.closed.Load() {
 		return nil, nil, ErrConnectionClosed
 	}
 
@@ -79,7 +79,7 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 func (c *Conn) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
 	c.factory.callstats.Add([]string{"WatchRecursive"}, 1)
 
-	if c.closed {
+	if c.closed.Load() {
 		return nil, nil, ErrConnectionClosed
 	}
 


### PR DESCRIPTION
## Description

This resolves the seen data races on the variable: https://github.com/vitessio/vitess/actions/runs/8054421738/job/21999131114?pr=15361

<details>
<summary>Click here to see example data races</summary>

```
2024-02-26T19:44:41.3026420Z ==================
2024-02-26T19:44:41.3026668Z WARNING: DATA RACE
2024-02-26T19:44:41.3026961Z Write at 0x00c001c0ef58 by goroutine 642:
2024-02-26T19:44:41.3027433Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Close()
2024-02-26T19:44:41.3028200Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/memorytopo.go:144 +0x2f
2024-02-26T19:44:41.3028835Z   vitess.io/vitess/go/vt/topo.(*StatsConn).Close()
2024-02-26T19:44:41.3029477Z       /home/runner/work/vitess/vitess/go/vt/topo/stats_conn.go:212 +0x1fa
2024-02-26T19:44:41.3030043Z   vitess.io/vitess/go/vt/topo.(*Server).Close()
2024-02-26T19:44:41.3030653Z       /home/runner/work/vitess/vitess/go/vt/topo/server.go:340 +0x59
2024-02-26T19:44:41.3031194Z   vitess.io/vitess/go/vt/vtgate.(*Executor).Close()
2024-02-26T19:44:41.3031828Z       /home/runner/work/vitess/vitess/go/vt/vtgate/executor.go:1553 +0x95
2024-02-26T19:44:41.3032413Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).Stop()
2024-02-26T19:44:41.3033084Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain.go:216 +0x75
2024-02-26T19:44:41.3033716Z   vitess.io/vitess/go/vt/vtadmin.(*API).VTExplain.func11()
2024-02-26T19:44:41.3034365Z       /home/runner/work/vitess/vitess/go/vt/vtadmin/api.go:2157 +0x33
2024-02-26T19:44:41.3034899Z   runtime.deferreturn()
2024-02-26T19:44:41.3035418Z       /opt/hostedtoolcache/go/1.21.7/x64/src/runtime/panic.go:477 +0x30
2024-02-26T19:44:41.3036215Z   vitess.io/vitess/go/vt/vtadmin_test.TestVTExplain.func2()
2024-02-26T19:44:41.3036946Z       /home/runner/work/vitess/vitess/go/vt/vtadmin/api_authz_test.go:2982 +0x40f
2024-02-26T19:44:41.3037483Z   testing.tRunner()
2024-02-26T19:44:41.3038006Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
2024-02-26T19:44:41.3038497Z   testing.(*T).Run.func1()
2024-02-26T19:44:41.3039030Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44
2024-02-26T19:44:41.3039397Z 
2024-02-26T19:44:41.3039568Z Previous read at 0x00c001c0ef58 by goroutine 2444:
2024-02-26T19:44:41.3040068Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).dial()
2024-02-26T19:44:41.3040795Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/memorytopo.go:132 +0x3d
2024-02-26T19:44:41.3041437Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Get()
2024-02-26T19:44:41.3042116Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/file.go:155 +0x95
2024-02-26T19:44:41.3042697Z   vitess.io/vitess/go/vt/topo.(*StatsConn).Get()
2024-02-26T19:44:41.3043417Z       /home/runner/work/vitess/vitess/go/vt/topo/stats_conn.go:110 +0x27d
2024-02-26T19:44:41.3043994Z   vitess.io/vitess/go/vt/topo.(*Server).GetCellInfo()
2024-02-26T19:44:41.3044666Z       /home/runner/work/vitess/vitess/go/vt/topo/cell_info.go:71 +0x1bd
2024-02-26T19:44:41.3045230Z   vitess.io/vitess/go/vt/topo.(*Server).ConnForCell()
2024-02-26T19:44:41.3046000Z       /home/runner/work/vitess/vitess/go/vt/topo/server.go:269 +0x1a8
2024-02-26T19:44:41.3046571Z   vitess.io/vitess/go/vt/topo.(*Server).GetSrvKeyspace()
2024-02-26T19:44:41.3047242Z       /home/runner/work/vitess/vitess/go/vt/topo/srv_keyspace.go:681 +0x8b
2024-02-26T19:44:41.3048060Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).readThrottlerConfig()
2024-02-26T19:44:41.3049107Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:292 +0xf2
2024-02-26T19:44:41.3050002Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).Open.func1()
2024-02-26T19:44:41.3051002Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:475 +0x14c
2024-02-26T19:44:41.3051878Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).Open.func3()
2024-02-26T19:44:41.3052857Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:501 +0x4f
2024-02-26T19:44:41.3053399Z 
2024-02-26T19:44:41.3053523Z Goroutine 642 (running) created at:
2024-02-26T19:44:41.3053859Z   testing.(*T).Run()
2024-02-26T19:44:41.3054385Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x845
2024-02-26T19:44:41.3054958Z   vitess.io/vitess/go/vt/vtadmin_test.TestVTExplain()
2024-02-26T19:44:41.3055650Z       /home/runner/work/vitess/vitess/go/vt/vtadmin/api_authz_test.go:2966 +0x63c
2024-02-26T19:44:41.3056176Z   testing.tRunner()
2024-02-26T19:44:41.3056687Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
2024-02-26T19:44:41.3057171Z   testing.(*T).Run.func1()
2024-02-26T19:44:41.3057702Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44
2024-02-26T19:44:41.3058069Z 
2024-02-26T19:44:41.3058197Z Goroutine 2444 (finished) created at:
2024-02-26T19:44:41.3058763Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).Open()
2024-02-26T19:44:41.3059720Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:501 +0x58f
2024-02-26T19:44:41.3060597Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).servePrimary()
2024-02-26T19:44:41.3061520Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/state_manager.go:463 +0x1eb
2024-02-26T19:44:41.3062718Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).execTransition()
2024-02-26T19:44:41.3063653Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/state_manager.go:259 +0x131
2024-02-26T19:44:41.3064488Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).SetServingType()
2024-02-26T19:44:41.3065502Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/state_manager.go:225 +0x3b1
2024-02-26T19:44:41.3066333Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*TabletServer).StartService()
2024-02-26T19:44:41.3067245Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/tabletserver.go:388 +0xfe
2024-02-26T19:44:41.3067965Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).newTablet()
2024-02-26T19:44:41.3068722Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vttablet.go:143 +0xed4
2024-02-26T19:44:41.3069466Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).buildTopology.func1()
2024-02-26T19:44:41.3070265Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vtgate.go:173 +0x70
2024-02-26T19:44:41.3070988Z   vitess.io/vitess/go/vt/discovery.(*FakeHealthCheck).AddFakeTablet()
2024-02-26T19:44:41.3071787Z       /home/runner/work/vitess/vitess/go/vt/discovery/fake_healthcheck.go:342 +0xaf0
2024-02-26T19:44:41.3072483Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).buildTopology()
2024-02-26T19:44:41.3073334Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vtgate.go:172 +0x1372
2024-02-26T19:44:41.3074059Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).initVtgateExecutor()
2024-02-26T19:44:41.3074854Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vtgate.go:57 +0x3f8
2024-02-26T19:44:41.3075563Z   vitess.io/vitess/go/vt/vtexplain.Init()
2024-02-26T19:44:41.3076207Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain.go:205 +0x765
2024-02-26T19:44:41.3076792Z   vitess.io/vitess/go/vt/vtadmin.(*API).VTExplain()
2024-02-26T19:44:41.3077417Z       /home/runner/work/vitess/vitess/go/vt/vtadmin/api.go:2153 +0x1759
2024-02-26T19:44:41.3078019Z   vitess.io/vitess/go/vt/vtadmin_test.TestVTExplain.func2()
2024-02-26T19:44:41.3078745Z       /home/runner/work/vitess/vitess/go/vt/vtadmin/api_authz_test.go:2982 +0x40f
2024-02-26T19:44:41.3079281Z   testing.tRunner()
2024-02-26T19:44:41.3079808Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
2024-02-26T19:44:41.3080292Z   testing.(*T).Run.func1()
2024-02-26T19:44:41.3080828Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44
2024-02-26T19:44:41.3081284Z ==================
2024-02-26T19:44:41.3081752Z --- FAIL: TestVTExplain (0.00s)
2024-02-26T19:44:41.3082230Z     --- FAIL: TestVTExplain/authorized_actor (0.09s)
2024-02-26T19:44:41.3082821Z         testing.go:1465: race detected during execution of test
2024-02-26T19:44:41.3083218Z FAIL
2024-02-26T19:44:41.3083474Z FAIL	vitess.io/vitess/go/vt/vtadmin	0.625s



2024-02-26T19:33:19.8270264Z ==================
2024-02-26T19:33:19.8270732Z WARNING: DATA RACE
2024-02-26T19:33:19.8271262Z Write at 0x00c0008f7588 by goroutine 549:
2024-02-26T19:33:19.8272311Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Close()
2024-02-26T19:33:19.8273862Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/memorytopo.go:144 +0x2f
2024-02-26T19:33:19.8274961Z   vitess.io/vitess/go/vt/topo.(*StatsConn).Close()
2024-02-26T19:33:19.8276486Z       /home/runner/work/vitess/vitess/go/vt/topo/stats_conn.go:212 +0x1fa
2024-02-26T19:33:19.8277379Z   vitess.io/vitess/go/vt/topo.(*Server).Close()
2024-02-26T19:33:19.8278856Z       /home/runner/work/vitess/vitess/go/vt/topo/server.go:340 +0x59
2024-02-26T19:33:19.8279791Z   vitess.io/vitess/go/vt/vtgate.(*Executor).Close()
2024-02-26T19:33:19.8281168Z       /home/runner/work/vitess/vitess/go/vt/vtgate/executor.go:1553 +0x95
2024-02-26T19:33:19.8282458Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).Stop()
2024-02-26T19:33:19.8284061Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain.go:216 +0x75
2024-02-26T19:33:19.8285164Z   vitess.io/vitess/go/vt/vtexplain.TestJSONOutput.func1()
2024-02-26T19:33:19.8286449Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_test.go:201 +0x33
2024-02-26T19:33:19.8287646Z   runtime.deferreturn()
2024-02-26T19:33:19.8288559Z       /opt/hostedtoolcache/go/1.21.7/x64/src/runtime/panic.go:477 +0x30
2024-02-26T19:33:19.8289804Z   testing.tRunner()
2024-02-26T19:33:19.8290716Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
2024-02-26T19:33:19.8291788Z   testing.(*T).Run.func1()
2024-02-26T19:33:19.8292360Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44
2024-02-26T19:33:19.8292866Z 
2024-02-26T19:33:19.8293146Z Previous read at 0x00c0008f7588 by goroutine 728:
2024-02-26T19:33:19.8293968Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).dial()
2024-02-26T19:33:19.8295204Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/memorytopo.go:132 +0x3d
2024-02-26T19:33:19.8296840Z   vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Get()
2024-02-26T19:33:19.8298073Z       /home/runner/work/vitess/vitess/go/vt/topo/memorytopo/file.go:155 +0x95
2024-02-26T19:33:19.8299305Z   vitess.io/vitess/go/vt/topo.(*StatsConn).Get()
2024-02-26T19:33:19.8300251Z       /home/runner/work/vitess/vitess/go/vt/topo/stats_conn.go:110 +0x27d
2024-02-26T19:33:19.8301112Z   vitess.io/vitess/go/vt/topo.(*Server).GetCellInfo()
2024-02-26T19:33:19.8302453Z       /home/runner/work/vitess/vitess/go/vt/topo/cell_info.go:71 +0x1bd
2024-02-26T19:33:19.8303449Z   vitess.io/vitess/go/vt/topo.(*Server).ConnForCell()
2024-02-26T19:33:19.8304548Z       /home/runner/work/vitess/vitess/go/vt/topo/server.go:269 +0x1a8
2024-02-26T19:33:19.8305548Z   vitess.io/vitess/go/vt/topo.(*Server).GetSrvKeyspace()
2024-02-26T19:33:19.8306735Z       /home/runner/work/vitess/vitess/go/vt/topo/srv_keyspace.go:681 +0x8b
2024-02-26T19:33:19.8308148Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).readThrottlerConfig()
2024-02-26T19:33:19.8310016Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:292 +0xf2
2024-02-26T19:33:19.8311907Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).Open.func1()
2024-02-26T19:33:19.8313212Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:475 +0x14c
2024-02-26T19:33:19.8314150Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).Open.func3()
2024-02-26T19:33:19.8315128Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:501 +0x4f
2024-02-26T19:33:19.8315653Z 
2024-02-26T19:33:19.8315786Z Goroutine 549 (running) created at:
2024-02-26T19:33:19.8316123Z   testing.(*T).Run()
2024-02-26T19:33:19.8316639Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x845
2024-02-26T19:33:19.8317135Z   testing.runTests.func1()
2024-02-26T19:33:19.8317668Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:2054 +0x84
2024-02-26T19:33:19.8318137Z   testing.tRunner()
2024-02-26T19:33:19.8318639Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
2024-02-26T19:33:19.8319104Z   testing.runTests()
2024-02-26T19:33:19.8319600Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:2052 +0x8ad
2024-02-26T19:33:19.8320068Z   testing.(*M).Run()
2024-02-26T19:33:19.8320850Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1925 +0xcd7
2024-02-26T19:33:19.8321436Z   main.main()
2024-02-26T19:33:19.8321852Z       _testmain.go:61 +0x2bd
2024-02-26T19:33:19.8322054Z 
2024-02-26T19:33:19.8322385Z Goroutine 728 (finished) created at:
2024-02-26T19:33:19.8322951Z   vitess.io/vitess/go/vt/vttablet/tabletserver/throttle.(*Throttler).Open()
2024-02-26T19:33:19.8323901Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/throttle/throttler.go:501 +0x58f
2024-02-26T19:33:19.8324761Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).servePrimary()
2024-02-26T19:33:19.8325672Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/state_manager.go:463 +0x1eb
2024-02-26T19:33:19.8326492Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).execTransition()
2024-02-26T19:33:19.8327488Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/state_manager.go:259 +0x131
2024-02-26T19:33:19.8328305Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).SetServingType()
2024-02-26T19:33:19.8329205Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/state_manager.go:225 +0x3b1
2024-02-26T19:33:19.8330026Z   vitess.io/vitess/go/vt/vttablet/tabletserver.(*TabletServer).StartService()
2024-02-26T19:33:19.8330918Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/tabletserver.go:388 +0xfe
2024-02-26T19:33:19.8331815Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).newTablet()
2024-02-26T19:33:19.8332573Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vttablet.go:143 +0xed4
2024-02-26T19:33:19.8333304Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).buildTopology.func1()
2024-02-26T19:33:19.8334086Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vtgate.go:173 +0x70
2024-02-26T19:33:19.8334909Z   vitess.io/vitess/go/vt/discovery.(*FakeHealthCheck).AddFakeTablet()
2024-02-26T19:33:19.8335691Z       /home/runner/work/vitess/vitess/go/vt/discovery/fake_healthcheck.go:342 +0xaf0
2024-02-26T19:33:19.8336367Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).buildTopology()
2024-02-26T19:33:19.8337135Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vtgate.go:172 +0x1372
2024-02-26T19:33:19.8337843Z   vitess.io/vitess/go/vt/vtexplain.(*VTExplain).initVtgateExecutor()
2024-02-26T19:33:19.8338624Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_vtgate.go:57 +0x3f8
2024-02-26T19:33:19.8339201Z   vitess.io/vitess/go/vt/vtexplain.Init()
2024-02-26T19:33:19.8339820Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain.go:205 +0x765
2024-02-26T19:33:19.8340379Z   vitess.io/vitess/go/vt/vtexplain.initTest()
2024-02-26T19:33:19.8341035Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_test.go:69 +0x252
2024-02-26T19:33:19.8341842Z   vitess.io/vitess/go/vt/vtexplain.TestJSONOutput()
2024-02-26T19:33:19.8342548Z       /home/runner/work/vitess/vitess/go/vt/vtexplain/vtexplain_test.go:200 +0x1e8
2024-02-26T19:33:19.8343082Z   testing.tRunner()
2024-02-26T19:33:19.8343582Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
2024-02-26T19:33:19.8344066Z   testing.(*T).Run.func1()
2024-02-26T19:33:19.8344588Z       /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44
2024-02-26T19:33:19.8345048Z ==================
2024-02-26T19:33:19.8345516Z --- FAIL: TestJSONOutput (0.14s)
2024-02-26T19:33:19.8345977Z     testing.go:1465: race detected during execution of test
2024-02-26T19:33:19.8346491Z FAIL
2024-02-26T19:33:19.8346766Z FAIL	vitess.io/vitess/go/vt/vtexplain	1.429s
```
</details>

We should backport this to v17 to limit CI test failures and work for other PRs that we backport.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required