### PR TITLE
VReplication: improve reliability of log management

### DIFF
--- a/go/textutil/strings.go
+++ b/go/textutil/strings.go
@@ -155,8 +155,8 @@ func TruncateText(text string, limit int, location TruncationLocation, indicator
 	}
 	switch location {
 	case TruncationLocationMiddle:
-		prefix := int((float64(limit) * 0.5) - float64(len(indicator)))
-		suffix := int(ol - int(prefix+len(indicator)) + 1)
+		prefix := (limit / 2) - len(indicator)
+		suffix := (ol - (prefix + len(indicator))) + 1
 		return fmt.Sprintf("%s%s%s", text[:prefix], indicator, text[suffix:]), nil
 	case TruncationLocationEnd:
 		return text[:limit-(len(indicator)+1)] + indicator, nil

--- a/go/textutil/strings.go
+++ b/go/textutil/strings.go
@@ -159,7 +159,7 @@ func TruncateText(text string, maxLen int, location TruncationLocation, truncati
 		suffix := int(ol - int(prefix+len(truncationIndicator)) + 1)
 		return fmt.Sprintf("%s%s%s", text[:prefix], truncationIndicator, text[suffix:]), nil
 	case TruncationLocationEnd:
-		return text[:maxLen-len(truncationIndicator)] + truncationIndicator, nil
+		return text[:maxLen-(len(truncationIndicator)+1)] + truncationIndicator, nil
 	default:
 		return "", fmt.Errorf("invalid truncation location: %d", location)
 	}

--- a/go/textutil/strings.go
+++ b/go/textutil/strings.go
@@ -142,13 +142,16 @@ func Title(s string) string {
 		s)
 }
 
+// TruncateText truncates the provided text to the specified length using the
+// provided indicator in place of the truncated text in the specified location
+// of the original.
 func TruncateText(text string, maxLen int, location TruncationLocation, truncationIndicator string) (string, error) {
-	if len(truncationIndicator)+2 >= maxLen {
-		return "", fmt.Errorf("the truncation indicator is too long for the provided text")
-	}
 	ol := len(text)
 	if ol <= maxLen {
 		return text, nil
+	}
+	if len(truncationIndicator)+2 >= maxLen {
+		return "", fmt.Errorf("the truncation indicator is too long for the provided text")
 	}
 	switch location {
 	case TruncationLocationMiddle:

--- a/go/textutil/strings.go
+++ b/go/textutil/strings.go
@@ -142,24 +142,24 @@ func Title(s string) string {
 		s)
 }
 
-// TruncateText truncates the provided text to the specified length using the
-// provided indicator in place of the truncated text in the specified location
-// of the original.
-func TruncateText(text string, maxLen int, location TruncationLocation, truncationIndicator string) (string, error) {
+// TruncateText truncates the provided text, if needed, to the specified maximum
+// length using the provided truncation indicator in place of the truncated text
+// in the specified location of the original string.
+func TruncateText(text string, limit int, location TruncationLocation, indicator string) (string, error) {
 	ol := len(text)
-	if ol <= maxLen {
+	if ol <= limit {
 		return text, nil
 	}
-	if len(truncationIndicator)+2 >= maxLen {
+	if len(indicator)+2 >= limit {
 		return "", fmt.Errorf("the truncation indicator is too long for the provided text")
 	}
 	switch location {
 	case TruncationLocationMiddle:
-		prefix := int((float64(maxLen) * 0.5) - float64(len(truncationIndicator)))
-		suffix := int(ol - int(prefix+len(truncationIndicator)) + 1)
-		return fmt.Sprintf("%s%s%s", text[:prefix], truncationIndicator, text[suffix:]), nil
+		prefix := int((float64(limit) * 0.5) - float64(len(indicator)))
+		suffix := int(ol - int(prefix+len(indicator)) + 1)
+		return fmt.Sprintf("%s%s%s", text[:prefix], indicator, text[suffix:]), nil
 	case TruncationLocationEnd:
-		return text[:maxLen-(len(truncationIndicator)+1)] + truncationIndicator, nil
+		return text[:limit-(len(indicator)+1)] + indicator, nil
 	default:
 		return "", fmt.Errorf("invalid truncation location: %d", location)
 	}

--- a/go/textutil/strings_test.go
+++ b/go/textutil/strings_test.go
@@ -280,6 +280,7 @@ func TestTruncateText(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.want, val)
+				require.LessOrEqual(t, len(val), tt.maxLen)
 			}
 		})
 	}

--- a/go/textutil/strings_test.go
+++ b/go/textutil/strings_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package textutil
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -205,6 +207,80 @@ func TestTitle(t *testing.T) {
 		t.Run(tc.s, func(t *testing.T) {
 			title := Title(tc.s)
 			assert.Equal(t, tc.expect, title)
+		})
+	}
+}
+
+func TestTruncateText(t *testing.T) {
+	defaultLocation := TruncationLocationMiddle
+	defaultMaxLen := 100
+	defaultTruncationIndicator := "..."
+
+	tests := []struct {
+		name                string
+		text                string
+		maxLen              int
+		location            TruncationLocation
+		truncationIndicator string
+		want                string
+		wantErr             string
+	}{
+		{
+			name:     "no truncation",
+			text:     "hello world",
+			maxLen:   defaultMaxLen,
+			location: defaultLocation,
+			want:     "hello world",
+		},
+		{
+			name:     "no truncation - exact",
+			text:     strings.Repeat("a", defaultMaxLen),
+			maxLen:   defaultMaxLen,
+			location: defaultLocation,
+			want:     strings.Repeat("a", defaultMaxLen),
+		},
+		{
+			name:                "barely too long - mid",
+			text:                strings.Repeat("a", defaultMaxLen+1),
+			truncationIndicator: defaultTruncationIndicator,
+			maxLen:              defaultMaxLen,
+			location:            defaultLocation,
+			want:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name:                "barely too long - end",
+			text:                strings.Repeat("a", defaultMaxLen+1),
+			truncationIndicator: defaultTruncationIndicator,
+			maxLen:              defaultMaxLen,
+			location:            TruncationLocationEnd,
+			want:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
+		},
+		{
+			name:                "too small",
+			text:                strings.Repeat("a", defaultMaxLen),
+			truncationIndicator: defaultTruncationIndicator,
+			maxLen:              4,
+			location:            defaultLocation,
+			wantErr:             "the truncation indicator is too long for the provided text",
+		},
+		{
+			name:                "bad location",
+			text:                strings.Repeat("a", defaultMaxLen+1),
+			truncationIndicator: defaultTruncationIndicator,
+			maxLen:              defaultMaxLen,
+			location:            100,
+			wantErr:             "invalid truncation location: 100",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := TruncateText(tt.text, tt.maxLen, tt.location, tt.truncationIndicator)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, val)
+			}
 		})
 	}
 }

--- a/go/textutil/strings_test.go
+++ b/go/textutil/strings_test.go
@@ -253,7 +253,7 @@ func TestTruncateText(t *testing.T) {
 			truncationIndicator: defaultTruncationIndicator,
 			maxLen:              defaultMaxLen,
 			location:            TruncationLocationEnd,
-			want:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
+			want:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
 		},
 		{
 			name:                "too small",

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -43,6 +43,7 @@ import (
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -66,6 +67,10 @@ var (
 	BlplTransaction = "Transaction"
 	// BlplBatchTransaction is the key for the stats map.
 	BlplBatchTransaction = "BatchTransaction"
+
+	// Truncate values in the middle to preserve the end of the message which
+	// typically contains the error text.
+	TruncationLocation = textutil.TruncationLocationMiddle
 )
 
 var TruncationIndicator = fmt.Sprintf(" ... %s ... ", sqlparser.TruncationText)

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -45,6 +45,7 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/throttler"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -66,6 +67,8 @@ var (
 	// BlplBatchTransaction is the key for the stats map.
 	BlplBatchTransaction = "BatchTransaction"
 )
+
+var TruncationIndicator = fmt.Sprintf(" ... %s ... ", sqlparser.TruncationText)
 
 // Stats is the internal stats of a player. It is a different
 // structure that is passed in so stats can be collected over the life

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -130,14 +130,14 @@ func LogError(msg string, err error) {
 
 // LimitString truncates string to specified size
 func LimitString(s string, limit int) string {
-	ls, err := textutil.TruncateText(s, limit, textutil.TruncationLocationMiddle, "...")
+	ts, err := textutil.TruncateText(s, limit, textutil.TruncationLocationMiddle, "...")
 	if err != nil { // Fallback to simple truncation
 		if len(s) <= limit {
 			return s
 		}
 		return s[:limit]
 	}
-	return ls
+	return ts
 }
 
 func (dc *dbClientImpl) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -130,7 +130,7 @@ func LogError(msg string, err error) {
 
 // LimitString truncates string to specified size
 func LimitString(s string, limit int) string {
-	ts, err := textutil.TruncateText(s, limit, textutil.TruncationLocationMiddle, "...")
+	ts, err := textutil.TruncateText(s, limit, TruncationLocation, TruncationIndicator)
 	if err != nil { // Fallback to simple truncation
 		if len(s) <= limit {
 			return s

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -129,10 +130,14 @@ func LogError(msg string, err error) {
 
 // LimitString truncates string to specified size
 func LimitString(s string, limit int) string {
-	if len(s) > limit {
+	ls, err := textutil.TruncateText(s, limit, textutil.TruncationLocationMiddle, "...")
+	if err != nil { // Fallback to simple truncation
+		if len(s) <= limit {
+			return s
+		}
 		return s[:limit]
 	}
-	return s
+	return ls
 }
 
 func (dc *dbClientImpl) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {

--- a/go/vt/binlog/binlogplayer/mock_dbclient.go
+++ b/go/vt/binlog/binlogplayer/mock_dbclient.go
@@ -245,6 +245,13 @@ func (dc *MockDBClient) ExecuteFetchMulti(query string, maxrows int) ([]*sqltype
 	return results, nil
 }
 
+// AddInvariant can be used to customize the behavior of the mock client.
+func (dc *MockDBClient) AddInvariant(query string, result *sqltypes.Result) {
+	dc.expectMu.Lock()
+	defer dc.expectMu.Unlock()
+	dc.invariants[query] = result
+}
+
 // RemoveInvariant can be used to customize the behavior of the mock client.
 func (dc *MockDBClient) RemoveInvariant(query string) {
 	dc.expectMu.Lock()

--- a/go/vt/binlog/binlogplayer/mock_dbclient.go
+++ b/go/vt/binlog/binlogplayer/mock_dbclient.go
@@ -244,3 +244,10 @@ func (dc *MockDBClient) ExecuteFetchMulti(query string, maxrows int) ([]*sqltype
 	}
 	return results, nil
 }
+
+// RemoveInvariant can be used to customize the behavior of the mock client.
+func (dc *MockDBClient) RemoveInvariant(query string) {
+	dc.expectMu.Lock()
+	defer dc.expectMu.Unlock()
+	delete(dc.invariants, query)
+}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -923,7 +923,8 @@ ORDER BY
 
 					if stream.Id > streamLog.StreamId {
 						log.Warningf("Found stream log for nonexistent stream: %+v", streamLog)
-						break
+						// This can happen on manual/failed workflow cleanup so keep going.
+						continue
 					}
 
 					// stream.Id == streamLog.StreamId

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -433,9 +433,7 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 				return nil, err
 			}
 			vre.controllers[id] = ct
-			if err := insertLogWithParams(vdbc, LogStreamCreate, id, params); err != nil {
-				return nil, err
-			}
+			insertLogWithParams(vdbc, LogStreamCreate, id, params)
 		}
 		return qr, nil
 	case updateQuery:
@@ -475,9 +473,7 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 				return nil, err
 			}
 			vre.controllers[id] = ct
-			if err := insertLog(vdbc, LogStateChange, id, params["state"], ""); err != nil {
-				return nil, err
-			}
+			insertLog(vdbc, LogStateChange, id, params["state"], "")
 		}
 		return qr, nil
 	case deleteQuery:
@@ -495,9 +491,7 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 				ct.Stop()
 				delete(vre.controllers, id)
 			}
-			if err := insertLogWithParams(vdbc, LogStreamDelete, id, nil); err != nil {
-				return nil, err
-			}
+			insertLogWithParams(vdbc, LogStreamDelete, id, nil)
 		}
 		if err := dbClient.Begin(); err != nil {
 			return nil, err

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -40,10 +41,6 @@ const (
 	// This comes from the fact that the message column in the vreplication_log table is of type TEXT.
 	maxVReplicationLogMessageLen = 65535
 )
-
-// vrepliationLogTruncationStr is the string that is used to indicate that a message has been
-// truncated before being inserted into one of the vreplication sidecar tables.
-var vreplicationLogTruncationStr = fmt.Sprintf(" ... %s ... ", sqlparser.TruncationText)
 
 const (
 	// Enum values for type column in the vreplication_log table.
@@ -112,7 +109,7 @@ func insertLog(dbClient *vdbClient, typ string, vreplID int32, state, message st
 		// We perform the truncation, if needed, in the middle of the message as the end of the message is likely to
 		// be the most important part as it often explains WHY we e.g. failed to execute an INSERT in the workflow.
 		if len(message) > maxVReplicationLogMessageLen {
-			message, err = textutil.TruncateText(message, maxVReplicationLogMessageLen, truncationLocation, vreplicationLogTruncationStr)
+			message, err = textutil.TruncateText(message, maxVReplicationLogMessageLen, truncationLocation, binlogplayer.TruncationIndicator)
 			if err != nil {
 				log.Errorf("Could not insert vreplication_log record because we failed to truncate the message: %v", err)
 				return

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -107,11 +107,11 @@ func insertLog(dbClient *vdbClient, typ string, vreplID int32, state, message st
 		maxMessageLen := 65535
 		truncationStr := fmt.Sprintf(" ... %s ... ", sqlparser.TruncationText)
 		if len(message) > maxMessageLen {
-			mid := ((len(message) / 2) - len(truncationStr)) - 1
+			mid := (len(message) / 2) - len(truncationStr)
 			for mid > (maxMessageLen / 2) {
 				mid = mid / 2
 			}
-			tail := (len(message) - mid + len(truncationStr))
+			tail := (len(message) - (mid + len(truncationStr))) + 1
 			message = fmt.Sprintf("%s%s%s", message[:mid], truncationStr, message[tail:])
 		}
 		buf.Myprintf("insert into %s.vreplication_log(vrepl_id, type, state, message) values(%s, %s, %s, %s)",

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -39,8 +39,6 @@ const (
 	truncationLocation = textutil.TruncationLocationMiddle
 	// This comes from the fact that the message column in the vreplication_log table is of type TEXT.
 	maxVReplicationLogMessageLen = 65535
-	// This comes from the fact that the message column in the vreplication table is varbinary(1000).
-	maxVReplicationMessageLen = 1000
 )
 
 // vrepliationLogTruncationStr is the string that is used to indicate that a message has been

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -35,9 +35,6 @@ import (
 
 const (
 	vreplicationLogTableName = "vreplication_log"
-	// Truncate values in the middle to preserve the end of the message which typically contains the
-	// error text.
-	truncationLocation = textutil.TruncationLocationMiddle
 	// This comes from the fact that the message column in the vreplication_log table is of type TEXT.
 	maxVReplicationLogMessageLen = 65535
 )
@@ -109,7 +106,7 @@ func insertLog(dbClient *vdbClient, typ string, vreplID int32, state, message st
 		// We perform the truncation, if needed, in the middle of the message as the end of the message is likely to
 		// be the most important part as it often explains WHY we e.g. failed to execute an INSERT in the workflow.
 		if len(message) > maxVReplicationLogMessageLen {
-			message, err = textutil.TruncateText(message, maxVReplicationLogMessageLen, truncationLocation, binlogplayer.TruncationIndicator)
+			message, err = textutil.TruncateText(message, maxVReplicationLogMessageLen, binlogplayer.TruncationLocation, binlogplayer.TruncationIndicator)
 			if err != nil {
 				log.Errorf("Could not insert vreplication_log record because we failed to truncate the message: %v", err)
 				return

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -103,8 +103,6 @@ func insertLog(dbClient *vdbClient, typ string, vreplID int32, state, message st
 		query = fmt.Sprintf("update %s.vreplication_log set count = count + 1 where id = %d", sidecar.GetIdentifier(), id)
 	} else {
 		buf := sqlparser.NewTrackedBuffer(nil)
-		// We perform the truncation, if needed, in the middle of the message as the end of the message is likely to
-		// be the most important part as it often explains WHY we e.g. failed to execute an INSERT in the workflow.
 		if len(message) > maxVReplicationLogMessageLen {
 			message, err = textutil.TruncateText(message, maxVReplicationLogMessageLen, binlogplayer.TruncationLocation, binlogplayer.TruncationIndicator)
 			if err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -35,10 +35,9 @@ import (
 const (
 	vreplicationLogTableName = "vreplication_log"
 	// This comes from the fact that the message column in the vreplication_log table is of type TEXT.
-	// See: go/vt/sidecardb/schema/vreplication/vreplication_log.sql
-	// https://dev.mysql.com/doc/refman/en/string-type-syntax.html and
-	// https://dev.mysql.com/doc/refman/en/storage-requirements.html#data-types-storage-reqs-strings
 	maxVReplicationLogMessageLen = 65535
+	// This comes from the fact that the message column in the vreplication table is varbinary(1000).
+	maxVReplicationMessageLen = 1000
 )
 
 // vrepliationLogTruncationStr is the string that is used to indicate that a message has been

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2024 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -25,7 +25,6 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -81,7 +80,6 @@ func TestInsertLogTruncation(t *testing.T) {
 		t.Run("insertLog", func(t *testing.T) {
 			var messageOut string
 			if tc.expectTruncation {
-				log.Errorf("BEFORE:: Message length: %d", len(tc.message))
 				mid := (len(tc.message) / 2) - len(truncationStr)
 				for mid > (maxMessageLen / 2) {
 					mid = mid / 2

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -25,7 +25,6 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
-	"vitess.io/vitess/go/vt/sqlparser"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
@@ -41,7 +40,6 @@ func TestInsertLogTruncation(t *testing.T) {
 	vrID := int32(1)
 	typ := "Testing"
 	state := binlogdatapb.VReplicationWorkflowState_Error.String()
-	truncationStr := fmt.Sprintf(" ... %s ... ", sqlparser.TruncationText)
 
 	insertStmtf := "insert into _vt.vreplication_log(vrepl_id, type, state, message) values(%d, '%s', '%s', %s)"
 
@@ -79,15 +77,15 @@ func TestInsertLogTruncation(t *testing.T) {
 		t.Run("insertLog", func(t *testing.T) {
 			var messageOut string
 			if tc.expectTruncation {
-				mid := (len(tc.message) / 2) - len(truncationStr)
+				mid := (len(tc.message) / 2) - len(vrepliationLogTruncationStr)
 				for mid > (maxVReplicationLogMessageLen / 2) {
 					mid = mid / 2
 				}
-				tail := (len(tc.message) - (mid + len(truncationStr))) + 1
-				messageOut = fmt.Sprintf("%s%s%s", tc.message[:mid], truncationStr, tc.message[tail:])
+				tail := (len(tc.message) - (mid + len(vrepliationLogTruncationStr))) + 1
+				messageOut = fmt.Sprintf("%s%s%s", tc.message[:mid], vrepliationLogTruncationStr, tc.message[tail:])
 				require.True(t, strings.HasPrefix(messageOut, tc.message[:10]))                 // Confirm we still have the same beginning
 				require.True(t, strings.HasSuffix(messageOut, tc.message[len(tc.message)-10:])) // Confirm we still have the same end
-				require.True(t, strings.Contains(messageOut, truncationStr))                    // Confirm we have the truncation text
+				require.True(t, strings.Contains(messageOut, vrepliationLogTruncationStr))      // Confirm we have the truncation text
 			} else {
 				messageOut = tc.message
 			}

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/sqlparser"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+func TestInsertLogTruncation(t *testing.T) {
+	dbClient := binlogplayer.NewMockDBClient(t)
+	defer dbClient.Close()
+	dbClient.RemoveInvariant("insert into _vt.vreplication_log")
+	stats := binlogplayer.NewStats()
+	defer stats.Stop()
+	vdbClient := newVDBClient(dbClient, stats)
+	defer vdbClient.Close()
+	vrID := int32(1)
+	typ := "Testing"
+	state := binlogdatapb.VReplicationWorkflowState_Error.String()
+	maxMessageLen := 65535
+	truncationStr := fmt.Sprintf(" ... %s ... ", sqlparser.TruncationText)
+
+	insertStmtf := "insert into _vt.vreplication_log(vrepl_id, type, state, message) values(%d, '%s', '%s', %s)"
+
+	tests := []struct {
+		message          string
+		expectTruncation bool
+	}{
+		{
+			message: "Simple message that's not truncated",
+		},
+		{
+			message:          "Simple message that needs to be truncated " + strings.Repeat("a", 80000) + " cuz it's long",
+			expectTruncation: true,
+		},
+		{
+			message: "Simple message that doesn't need to be truncated " + strings.Repeat("b", 64000) + " cuz it's not quite too long",
+		},
+		{
+			message: "Message that is just barely short enough " + strings.Repeat("c", maxMessageLen-(len("Message that is just barely short enough ")+len(" so it doesn't get truncated"))) + " so it doesn't get truncated",
+		},
+		{
+			message:          "Message that is just barely too long " + strings.Repeat("d", maxMessageLen-(len("Message that is just barely too long ")+len(" so it gets truncated"))+1) + " so it gets truncated",
+			expectTruncation: true,
+		},
+		{
+			message:          "Super long message brosef wut r ya doin " + strings.Repeat("e", 60000) + strings.Repeat("f", 60000) + " so maybe don't do that to yourself and your friends",
+			expectTruncation: true,
+		},
+		{
+			message:          "Super duper long message brosef wut r ya doin " + strings.Repeat("g", 120602) + strings.Repeat("h", 120001) + " so maybe really don't do that to yourself and your friends",
+			expectTruncation: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run("insertLog", func(t *testing.T) {
+			var messageOut string
+			if tc.expectTruncation {
+				log.Errorf("BEFORE:: Message length: %d", len(tc.message))
+				mid := (len(tc.message) / 2) - len(truncationStr)
+				for mid > (maxMessageLen / 2) {
+					mid = mid / 2
+				}
+				tail := (len(tc.message) - (mid + len(truncationStr))) + 1
+				messageOut = fmt.Sprintf("%s%s%s", tc.message[:mid], truncationStr, tc.message[tail:])
+				require.True(t, strings.HasPrefix(messageOut, tc.message[:10]))                 // Confirm we still have the same beginning
+				require.True(t, strings.HasSuffix(messageOut, tc.message[len(tc.message)-10:])) // Confirm we still have the same end
+				require.True(t, strings.Contains(messageOut, truncationStr))                    // Confirm we have the truncation text
+			} else {
+				messageOut = tc.message
+			}
+			require.LessOrEqual(t, len(messageOut), 65535)
+			dbClient.ExpectRequest(fmt.Sprintf(insertStmtf, vrID, typ, state, encodeString(messageOut)), &sqltypes.Result{}, nil)
+			err := insertLog(vdbClient, typ, vrID, state, tc.message)
+			require.NoError(t, err)
+			dbClient.Wait()
+		})
+	}
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -81,11 +81,11 @@ func TestInsertLogTruncation(t *testing.T) {
 				err        error
 			)
 			if tc.expectTruncation {
-				messageOut, err = textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, truncationLocation, vreplicationLogTruncationStr)
+				messageOut, err = textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, truncationLocation, binlogplayer.TruncationIndicator)
 				require.NoError(t, err)
 				require.True(t, strings.HasPrefix(messageOut, tc.message[:1024]))                 // Confirm we still have the same beginning
 				require.True(t, strings.HasSuffix(messageOut, tc.message[len(tc.message)-1024:])) // Confirm we still have the same end
-				require.True(t, strings.Contains(messageOut, vreplicationLogTruncationStr))       // Confirm we have the truncation text
+				require.True(t, strings.Contains(messageOut, binlogplayer.TruncationIndicator))   // Confirm we have the truncation text
 				t.Logf("Original message length: %d, truncated message length: %d", len(tc.message), len(messageOut))
 			} else {
 				messageOut = tc.message

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -76,9 +76,12 @@ func TestInsertLogTruncation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run("insertLog", func(t *testing.T) {
-			var messageOut string
+			var (
+				messageOut string
+				err        error
+			)
 			if tc.expectTruncation {
-				messageOut, err := textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, textutil.TruncationLocationMiddle, vreplicationLogTruncationStr)
+				messageOut, err = textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, textutil.TruncationLocationMiddle, vreplicationLogTruncationStr)
 				require.NoError(t, err)
 				require.True(t, strings.HasPrefix(messageOut, tc.message[:1024]))                 // Confirm we still have the same beginning
 				require.True(t, strings.HasSuffix(messageOut, tc.message[len(tc.message)-1024:])) // Confirm we still have the same end

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -96,8 +96,7 @@ func TestInsertLogTruncation(t *testing.T) {
 			}
 			require.LessOrEqual(t, len(messageOut), 65535)
 			dbClient.ExpectRequest(fmt.Sprintf(insertStmtf, vrID, typ, state, encodeString(messageOut)), &sqltypes.Result{}, nil)
-			err := insertLog(vdbClient, typ, vrID, state, tc.message)
-			require.NoError(t, err)
+			insertLog(vdbClient, typ, vrID, state, tc.message)
 			dbClient.Wait()
 		})
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -81,7 +81,7 @@ func TestInsertLogTruncation(t *testing.T) {
 				err        error
 			)
 			if tc.expectTruncation {
-				messageOut, err = textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, textutil.TruncationLocationMiddle, vreplicationLogTruncationStr)
+				messageOut, err = textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, truncationLocation, vreplicationLogTruncationStr)
 				require.NoError(t, err)
 				require.True(t, strings.HasPrefix(messageOut, tc.message[:1024]))                 // Confirm we still have the same beginning
 				require.True(t, strings.HasSuffix(messageOut, tc.message[len(tc.message)-1024:])) // Confirm we still have the same end

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -81,7 +81,7 @@ func TestInsertLogTruncation(t *testing.T) {
 				err        error
 			)
 			if tc.expectTruncation {
-				messageOut, err = textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, truncationLocation, binlogplayer.TruncationIndicator)
+				messageOut, err = textutil.TruncateText(tc.message, maxVReplicationLogMessageLen, binlogplayer.TruncationLocation, binlogplayer.TruncationIndicator)
 				require.NoError(t, err)
 				require.True(t, strings.HasPrefix(messageOut, tc.message[:1024]))                 // Confirm we still have the same beginning
 				require.True(t, strings.HasSuffix(messageOut, tc.message[len(tc.message)-1024:])) // Confirm we still have the same end

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -246,10 +246,7 @@ func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 		if err := vc.vr.setState(binlogdatapb.VReplicationWorkflowState_Copying, ""); err != nil {
 			return err
 		}
-		if err := vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase started for %d table(s)",
-			len(plan.TargetTables))); err != nil {
-			return err
-		}
+		vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase started for %d table(s)", len(plan.TargetTables)))
 
 		if vc.vr.supportsDeferredSecondaryKeys() {
 			settings, err := binlogplayer.ReadVRSettings(vc.vr.dbClient, vc.vr.id)
@@ -257,20 +254,15 @@ func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 				return err
 			}
 			if settings.DeferSecondaryKeys {
-				if err := vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase temporarily dropping secondary keys for %d table(s)",
-					len(plan.TargetTables))); err != nil {
-					return err
-				}
+				vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase temporarily dropping secondary keys for %d table(s)", len(plan.TargetTables)))
 				for _, tableName := range tableNames {
 					if err := vc.vr.stashSecondaryKeys(ctx, tableName); err != nil {
 						return err
 					}
 				}
-				if err := vc.vr.insertLog(LogCopyStart,
+				vc.vr.insertLog(LogCopyStart,
 					fmt.Sprintf("Copy phase finished dropping secondary keys and saving post copy actions to restore them for %d table(s)",
-						len(plan.TargetTables))); err != nil {
-					return err
-				}
+						len(plan.TargetTables)))
 			}
 		}
 	} else {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2799,8 +2799,7 @@ func TestVReplicationLogs(t *testing.T) {
 
 	for _, want := range expected {
 		t.Run("", func(t *testing.T) {
-			err = insertLog(vdbc, LogMessage, 1, binlogdatapb.VReplicationWorkflowState_Running.String(), "message1")
-			require.NoError(t, err)
+			insertLog(vdbc, LogMessage, 1, binlogdatapb.VReplicationWorkflowState_Running.String(), "message1")
 			qr, err := env.Mysqld.FetchSuperQuery(context.Background(), query)
 			require.NoError(t, err)
 			require.Equal(t, want, fmt.Sprintf("%v", qr.Rows))

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -29,7 +29,6 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
@@ -452,10 +451,7 @@ func (vr *vreplicator) readSettings(ctx context.Context, dbClient *vdbClient) (s
 }
 
 func (vr *vreplicator) setMessage(message string) (err error) {
-	message, err = textutil.TruncateText(message, maxVReplicationMessageLen, truncationLocation, vreplicationLogTruncationStr)
-	if err != nil {
-		return err
-	}
+	message = binlogplayer.MessageTruncate(message)
 	vr.stats.History.Add(&binlogplayer.StatsHistoryRecord{
 		Time:    time.Now(),
 		Message: message,

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
@@ -450,8 +451,11 @@ func (vr *vreplicator) readSettings(ctx context.Context, dbClient *vdbClient) (s
 	return settings, numTablesToCopy, nil
 }
 
-func (vr *vreplicator) setMessage(message string) error {
-	message = binlogplayer.MessageTruncate(message)
+func (vr *vreplicator) setMessage(message string) (err error) {
+	message, err = textutil.TruncateText(message, maxVReplicationMessageLen, textutil.TruncationLocationMiddle, vreplicationLogTruncationStr)
+	if err != nil {
+		return err
+	}
 	vr.stats.History.Add(&binlogplayer.StatsHistoryRecord{
 		Time:    time.Now(),
 		Message: message,

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -288,9 +288,7 @@ func (vr *vreplicator) replicate(ctx context.Context) error {
 					return err
 				}
 				if numTablesToCopy == 0 {
-					if err := vr.insertLog(LogCopyEnd, fmt.Sprintf("Copy phase completed at gtid %s", settings.StartPos)); err != nil {
-						return err
-					}
+					vr.insertLog(LogCopyEnd, fmt.Sprintf("Copy phase completed at gtid %s", settings.StartPos))
 				}
 			}
 		case settings.StartPos.IsZero():
@@ -464,14 +462,12 @@ func (vr *vreplicator) setMessage(message string) error {
 	if _, err := vr.dbClient.Execute(query); err != nil {
 		return fmt.Errorf("could not set message: %v: %v", query, err)
 	}
-	if err := insertLog(vr.dbClient, LogMessage, vr.id, vr.state.String(), message); err != nil {
-		return err
-	}
+	insertLog(vr.dbClient, LogMessage, vr.id, vr.state.String(), message)
 	return nil
 }
 
-func (vr *vreplicator) insertLog(typ, message string) error {
-	return insertLog(vr.dbClient, typ, vr.id, vr.state.String(), message)
+func (vr *vreplicator) insertLog(typ, message string) {
+	insertLog(vr.dbClient, typ, vr.id, vr.state.String(), message)
 }
 
 func (vr *vreplicator) setState(state binlogdatapb.VReplicationWorkflowState, message string) error {
@@ -489,9 +485,7 @@ func (vr *vreplicator) setState(state binlogdatapb.VReplicationWorkflowState, me
 	if state == vr.state {
 		return nil
 	}
-	if err := insertLog(vr.dbClient, LogStateChange, vr.id, state.String(), message); err != nil {
-		return err
-	}
+	insertLog(vr.dbClient, LogStateChange, vr.id, state.String(), message)
 	vr.state = state
 
 	return nil
@@ -815,10 +809,7 @@ func (vr *vreplicator) execPostCopyActions(ctx context.Context, tableName string
 		return nil
 	}
 
-	if err := vr.insertLog(LogCopyStart, fmt.Sprintf("Executing %d post copy action(s) for %s table",
-		len(qr.Rows), tableName)); err != nil {
-		return err
-	}
+	vr.insertLog(LogCopyStart, fmt.Sprintf("Executing %d post copy action(s) for %s table", len(qr.Rows), tableName))
 
 	// Save our connection ID so we can use it to easily KILL any
 	// running SQL action we may perform later if needed.
@@ -1039,10 +1030,7 @@ func (vr *vreplicator) execPostCopyActions(ctx context.Context, tableName string
 		}
 	}
 
-	if err := vr.insertLog(LogCopyStart, fmt.Sprintf("Completed all post copy actions for %s table",
-		tableName)); err != nil {
-		return err
-	}
+	vr.insertLog(LogCopyStart, fmt.Sprintf("Completed all post copy actions for %s table", tableName))
 
 	return nil
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -452,7 +452,7 @@ func (vr *vreplicator) readSettings(ctx context.Context, dbClient *vdbClient) (s
 }
 
 func (vr *vreplicator) setMessage(message string) (err error) {
-	message, err = textutil.TruncateText(message, maxVReplicationMessageLen, textutil.TruncationLocationMiddle, vreplicationLogTruncationStr)
+	message, err = textutil.TruncateText(message, maxVReplicationMessageLen, truncationLocation, vreplicationLogTruncationStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

In helping someone debug a VReplication failure, we had seen the following:
1. We failed to create a `_vt.vreplication_log` record and the apparent cause was that the message was too long
2. The truncated error message seen in the `_vt.vreplication` record showed the beginning of a `vcopier` bulk `INSERT` query that failed — truncated at 1000 bytes — but not the *reason why / error it generated*
3. This `_vt.vreplication_log` record generation failure may have caused problems in the workflow (e.g. if this happens after the point of no return in a `SwitchTraffic` then we'll be left in an inconsistent state that needs manual cleanup)

We address all of these issues with the following changes in this PR:
1. We truncate the message as needed before inserting it into the `_vt.vreplication_log` table
2. That truncation happens in the middle of the message so that we don't lose the error shown e.g. after a failed query
3. We no longer consider failing to write a `_vt.vreplication_log` record as "fatal" — meaning that the workflow operation does not stop and return the log generation error — and instead only logs an error in the `vttablet` log

I also moved the existing truncation for the `_vt.vreplication.message` field over to this new truncation method so that we have the error message there as well.

## Related Issue(s)

**I didn't create an issue since this felt more like a minor internal cleanup, but I can create one quickly if others disagree.**

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required