### PR TITLE
delete unused code in vreplication e2e tests

### DIFF
--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -139,9 +139,6 @@ type Keyspace struct {
 	VSchema       string
 	Schema        string
 	SidecarDBName string
-
-	numReplicas int
-	numRDOnly   int
 }
 
 // Shard represents a Vitess shard in a keyspace

--- a/go/test/endtoend/vreplication/fk_ext_test.go
+++ b/go/test/endtoend/vreplication/fk_ext_test.go
@@ -32,10 +32,6 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
-const (
-	shardStatusWaitTimeout = 30 * time.Second
-)
-
 var (
 	//go:embed schema/fkext/source_schema.sql
 	FKExtSourceSchema string

--- a/go/test/endtoend/vreplication/performance_test.go
+++ b/go/test/endtoend/vreplication/performance_test.go
@@ -43,8 +43,6 @@ create table largebin(pid int, maindata varbinary(4096), primary key(pid));
 create table customer(cid int, name varbinary(128), meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),ts timestamp not null default current_timestamp, primary key(cid))  CHARSET=utf8mb4;
 `
 
-	const defaultCellName = "zone1"
-
 	const sourceKs = "stress_src"
 	const targetKs = "stress_tgt"
 


### PR DESCRIPTION


## Description

Note that I left `queryLog` as well as the `exec(...)WithRetry` bits untouched since we use those when debugging (maybe we should add a flag to toggle that behavior rather than having to edit tests)

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
