### PR TITLE
VStream: Allow for automatic resume after reshard

### DIFF
--- a/examples/local/vstream_client.go
+++ b/examples/local/vstream_client.go
@@ -47,16 +47,16 @@ func main() {
 				Shard:    "-80",
 				// Gtid "" is to stream from the start, "current" is to stream from the current gtid
 				// you can also specify a gtid to start with.
-				Gtid: "", //"current"  // "MySQL56/36a89abd-978f-11eb-b312-04ed332e05c2:1-265"
+				Gtid: "MySQL56/d96014f4-d808-11ee-bb36-65ec7170dd04:1-52", //"current"  // "MySQL56/36a89abd-978f-11eb-b312-04ed332e05c2:1-265"
 			}, {
 				Keyspace: "customer",
 				Shard:    "80-",
-				Gtid:     "",
+				Gtid:     "MySQL56/d96014f4-d808-11ee-bb36-65ec7170dd04:1-52",
 			}}}
 	} else {
 		vgtid = &binlogdatapb.VGtid{
 			ShardGtids: []*binlogdatapb.ShardGtid{{
-				Keyspace: "commerce",
+				Keyspace: "customer",
 				Shard:    "0",
 				Gtid:     "",
 			}}}

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -671,45 +671,6 @@ func (ts *trafficSwitcher) createJournals(ctx context.Context, sourceWorkflows [
 		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, statement); err != nil {
 			return err
 		}
-		/*
-			if ts.workflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
-				// Add this source's GTID_EXECUTED set to each target shard's GTID_PURGED
-				// set to avoid losing GTID metadata history and support smooth vstream
-				// resumes.
-				err := ts.ForAllTargets(func(target *MigrationTarget) error {
-					if _, err := ts.TopoServer().UpdateShardFields(ctx, ts.TargetKeyspaceName(), target.GetShard().ShardName(), func(si *topo.ShardInfo) error {
-						return si.UpdateDeniedTables(ctx, topodatapb.TabletType_PRIMARY, nil, true, ts.Tables())
-					}); err != nil {
-						return err
-					}
-					rtbsCtx, cancel := context.WithTimeout(ctx, shardTabletRefreshTimeout)
-					defer cancel()
-					_, _, err := topotools.RefreshTabletsByShard(rtbsCtx, ts.TopoServer(), ts.TabletManagerClient(), target.GetShard(), nil, ts.Logger())
-					if key.KeyRangeIntersect(source.si.KeyRange, target.si.KeyRange) {
-						var localGTIDSet string
-						before, after, found := strings.Cut(journal.LocalPosition, "/")
-						if found {
-							localGTIDSet = after
-						} else {
-							localGTIDSet = before
-						}
-						query := fmt.Sprintf("set @@global.gtid_purged=concat(@@global.gtid_purged, gtid_subtract('%s', @@global.gtid_purged))", localGTIDSet)
-						_, err = ts.TabletManagerClient().ExecuteFetchAsDba(ctx, target.GetPrimary().Tablet, true, &tabletmanagerdatapb.ExecuteFetchAsDbaRequest{
-							Query: []byte(query),
-						})
-						if err != nil {
-							return fmt.Errorf("failed to add the GTID_EXECUTED set metdata from %s to the GTID_EXECUTED set on %s: %v",
-								topoproto.TabletAliasString(source.GetPrimary().Tablet.GetAlias()), topoproto.TabletAliasString(target.GetPrimary().Tablet.GetAlias()), err)
-						}
-					}
-					return err
-				})
-				if err != nil {
-					return vterrors.Wrapf(err, "failed to add the GTID_EXECUTED set metadata from the source shards (%v) to the GTID_PURGED metadata on the target shards (%s)",
-						ts.SourceShards(), ts.TargetShards())
-				}
-			}
-		*/
 		return nil
 	})
 }

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -671,6 +671,45 @@ func (ts *trafficSwitcher) createJournals(ctx context.Context, sourceWorkflows [
 		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, statement); err != nil {
 			return err
 		}
+		/*
+			if ts.workflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
+				// Add this source's GTID_EXECUTED set to each target shard's GTID_PURGED
+				// set to avoid losing GTID metadata history and support smooth vstream
+				// resumes.
+				err := ts.ForAllTargets(func(target *MigrationTarget) error {
+					if _, err := ts.TopoServer().UpdateShardFields(ctx, ts.TargetKeyspaceName(), target.GetShard().ShardName(), func(si *topo.ShardInfo) error {
+						return si.UpdateDeniedTables(ctx, topodatapb.TabletType_PRIMARY, nil, true, ts.Tables())
+					}); err != nil {
+						return err
+					}
+					rtbsCtx, cancel := context.WithTimeout(ctx, shardTabletRefreshTimeout)
+					defer cancel()
+					_, _, err := topotools.RefreshTabletsByShard(rtbsCtx, ts.TopoServer(), ts.TabletManagerClient(), target.GetShard(), nil, ts.Logger())
+					if key.KeyRangeIntersect(source.si.KeyRange, target.si.KeyRange) {
+						var localGTIDSet string
+						before, after, found := strings.Cut(journal.LocalPosition, "/")
+						if found {
+							localGTIDSet = after
+						} else {
+							localGTIDSet = before
+						}
+						query := fmt.Sprintf("set @@global.gtid_purged=concat(@@global.gtid_purged, gtid_subtract('%s', @@global.gtid_purged))", localGTIDSet)
+						_, err = ts.TabletManagerClient().ExecuteFetchAsDba(ctx, target.GetPrimary().Tablet, true, &tabletmanagerdatapb.ExecuteFetchAsDbaRequest{
+							Query: []byte(query),
+						})
+						if err != nil {
+							return fmt.Errorf("failed to add the GTID_EXECUTED set metdata from %s to the GTID_EXECUTED set on %s: %v",
+								topoproto.TabletAliasString(source.GetPrimary().Tablet.GetAlias()), topoproto.TabletAliasString(target.GetPrimary().Tablet.GetAlias()), err)
+						}
+					}
+					return err
+				})
+				if err != nil {
+					return vterrors.Wrapf(err, "failed to add the GTID_EXECUTED set metadata from the source shards (%v) to the GTID_PURGED metadata on the target shards (%s)",
+						ts.SourceShards(), ts.TargetShards())
+				}
+			}
+		*/
 		return nil
 	})
 }


### PR DESCRIPTION
## Description

When the scenario is detected, and we have the needed info, we will start a new copy resume phase to automatically resume when a `Reshard` has occurred since the last client stream.

Manual test on this branch:
```
./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql; ./201_customer_tablets.sh ; ./202_move_tables.sh; ./203_switch_reads.sh; ./204_switch_writes.sh; ./205_clean_commerce.sh; ./301_customer_sharded.sh; ./302_new_shards.sh; ./303_reshard.sh; ./304_switch_reads.sh; ./305_switch_writes.sh

sleep 10

mysql -e "insert into customer (email) values ('mlord@planetscale.com')"
mysql -e "insert into customer (email) values ('mlord@planetscale.com')"

go run vstream_client.go

# In another shell
mysql -e "insert into customer (email) values ('mlord@planetscale.com')"
```

You'll see that we did not miss any post Reshard writes.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required