### PR TITLE
`onlineddl_scheduler` test: fix flakiness in artifact cleanup test

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -1025,6 +1025,9 @@ func testScheduler(t *testing.T) {
 			t1uuid = testOnlineDDLStatement(t, createParams(trivialAlterT1Statement, ddlStrategy+" --postpone-completion --retain-artifacts=1s", "vtctl", "", "", true)) // skip wait
 			onlineddl.WaitForMigrationStatus(t, &vtParams, shards, t1uuid, normalWaitTime, schema.OnlineDDLStatusRunning)
 		})
+		t.Run("wait for ready_to_complete", func(t *testing.T) {
+			waitForReadyToComplete(t, t1uuid, true)
+		})
 		var artifacts []string
 		t.Run("validate artifact exists", func(t *testing.T) {
 			rs := onlineddl.ReadMigrations(t, &vtParams, t1uuid)
@@ -2512,7 +2515,7 @@ func checkTablesCount(t *testing.T, tablet *cluster.Vttablet, showTableName stri
 	query := fmt.Sprintf(`show tables like '%%%s%%';`, showTableName)
 	queryResult, err := tablet.VttabletProcess.QueryTablet(query, keyspaceName, true)
 	require.Nil(t, err)
-	return assert.Equal(t, expectCount, len(queryResult.Rows))
+	return assert.Equalf(t, expectCount, len(queryResult.Rows), "checkTablesCount cannot find table like '%%%s%%'", showTableName)
 }
 
 // checkMigratedTables checks the CREATE STATEMENT of a table after migration


### PR DESCRIPTION

## Description

We've seen flakiness in `onlineddl_scheduler` test, `TestSchemaChange/scheduler/Cleanup_artifacts/validate_artifact_exists`. The test run an open ended (`--postpone-completion`) migration, sets a very low artifact retention, and looks to see that its artifacts exist while the migration is running. Artifacts should only be deleted when the migration completes, fails, or gets cancelled, so this is intended to validate we do not cleanup prematurely.

However, it's possible that the artifact is _not yet created_, and that's the race condition. The fact the test is in `running` state, does not mean it's reached the part where the shadow table gets created.

The fix to the flakiness is to wait until the migration is `ready_to_complete`. This guarantees that the artifact (shadow table) is already created.

## Related Issue(s)

https://github.com/planetscale/vitess-private/actions/runs/8112537427/job/22173985451?pr=4573

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
