### PR TITLE
Tablet throttler: starvation fix and consolidation of logic.

### DIFF
--- a/go/stats/counter_map.go
+++ b/go/stats/counter_map.go
@@ -25,7 +25,7 @@ var (
 	countersMu  sync.RWMutex
 )
 
-// GetOrNewCounter returns a Counter with given name; the functiona either creates the counter
+// GetOrNewCounter returns a Counter with given name; the function either creates the counter
 // if it does not exist, or returns a pre-existing one. The function is thread safe.
 func GetOrNewCounter(name string, help string) *Counter {
 	// first, attempt read lock only

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -399,13 +399,15 @@ func TestLag(t *testing.T) {
 		err := clusterInstance.VtctldClientProcess.ExecuteCommand("StopReplication", replicaTablet.Alias)
 		assert.NoError(t, err)
 	})
+	t.Run("accumulating lag, expecting throttler push back", func(t *testing.T) {
+		time.Sleep(2 * throttler.DefaultThreshold)
+	})
 	t.Run("requesting heartbeats while replication stopped", func(t *testing.T) {
+		// By now on-demand heartbeats have stopped.
 		_ = warmUpHeartbeat(t)
 	})
 
-	t.Run("accumulating lag, expecting throttler push back", func(t *testing.T) {
-		time.Sleep(2 * throttler.DefaultThreshold)
-
+	t.Run("expecting throttler push back", func(t *testing.T) {
 		resp, err := throttleCheck(primaryTablet, false)
 		require.NoError(t, err)
 		defer resp.Body.Close()
@@ -417,13 +419,9 @@ func TestLag(t *testing.T) {
 		defer resp.Body.Close()
 		// self (on primary) is unaffected by replication lag
 		if !assert.Equalf(t, http.StatusOK, resp.StatusCode, "Unexpected response from throttler: %s", getResponseBody(resp)) {
-			rs, err := replicaTablet.VttabletProcess.QueryTablet("show replica status", keyspaceName, false)
-			assert.NoError(t, err)
-			t.Logf("Seconds_Behind_Source: %s", rs.Named().Row()["Seconds_Behind_Source"].ToString())
 			t.Logf("throttler primary status: %+v", throttleStatus(t, primaryTablet))
 			t.Logf("throttler replica status: %+v", throttleStatus(t, replicaTablet))
 		}
-
 	})
 	t.Run("replica self-check should show error", func(t *testing.T) {
 		resp, err := throttleCheckSelf(replicaTablet)

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -89,6 +89,7 @@ var (
 	throttledAppsAPIPath = "throttler/throttled-apps"
 	checkAPIPath         = "throttler/check"
 	checkSelfAPIPath     = "throttler/check-self"
+	statusAPIPath        = "throttler/status"
 	getResponseBody      = func(resp *http.Response) string {
 		body, _ := io.ReadAll(resp.Body)
 		return string(body)
@@ -178,6 +179,16 @@ func throttleCheck(tablet *cluster.Vttablet, skipRequestHeartbeats bool) (*http.
 
 func throttleCheckSelf(tablet *cluster.Vttablet) (*http.Response, error) {
 	return httpClient.Get(fmt.Sprintf("http://localhost:%d/%s?app=%s", tablet.HTTPPort, checkSelfAPIPath, testAppName))
+}
+
+func throttleStatus(t *testing.T, tablet *cluster.Vttablet) string {
+	resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/%s", tablet.HTTPPort, statusAPIPath))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(b)
 }
 
 func warmUpHeartbeat(t *testing.T) (respStatus int) {
@@ -314,17 +325,32 @@ func TestInitialThrottler(t *testing.T) {
 	})
 	t.Run("validating OK response from throttler with low threshold, heartbeats running", func(t *testing.T) {
 		time.Sleep(1 * time.Second)
+		cluster.ValidateReplicationIsHealthy(t, replicaTablet)
 		resp, err := throttleCheck(primaryTablet, false)
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		assert.Equalf(t, http.StatusOK, resp.StatusCode, "Unexpected response from throttler: %s", getResponseBody(resp))
+		if !assert.Equalf(t, http.StatusOK, resp.StatusCode, "Unexpected response from throttler: %s", getResponseBody(resp)) {
+			rs, err := replicaTablet.VttabletProcess.QueryTablet("show replica status", keyspaceName, false)
+			assert.NoError(t, err)
+			t.Logf("Seconds_Behind_Source: %s", rs.Named().Row()["Seconds_Behind_Source"].ToString())
+			t.Logf("throttler primary status: %+v", throttleStatus(t, primaryTablet))
+			t.Logf("throttler replica status: %+v", throttleStatus(t, replicaTablet))
+		}
 	})
+
 	t.Run("validating OK response from throttler with low threshold, heartbeats running still", func(t *testing.T) {
 		time.Sleep(1 * time.Second)
+		cluster.ValidateReplicationIsHealthy(t, replicaTablet)
 		resp, err := throttleCheck(primaryTablet, false)
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		assert.Equalf(t, http.StatusOK, resp.StatusCode, "Unexpected response from throttler: %s", getResponseBody(resp))
+		if !assert.Equalf(t, http.StatusOK, resp.StatusCode, "Unexpected response from throttler: %s", getResponseBody(resp)) {
+			rs, err := replicaTablet.VttabletProcess.QueryTablet("show replica status", keyspaceName, false)
+			assert.NoError(t, err)
+			t.Logf("Seconds_Behind_Source: %s", rs.Named().Row()["Seconds_Behind_Source"].ToString())
+			t.Logf("throttler primary status: %+v", throttleStatus(t, primaryTablet))
+			t.Logf("throttler replica status: %+v", throttleStatus(t, replicaTablet))
+		}
 	})
 	t.Run("validating pushback response from throttler on low threshold once heartbeats go stale", func(t *testing.T) {
 		time.Sleep(2 * onDemandHeartbeatDuration) // just... really wait long enough, make sure on-demand stops

--- a/go/timer/rate_limiter.go
+++ b/go/timer/rate_limiter.go
@@ -72,8 +72,8 @@ func (r *RateLimiter) Do(f func() error) (err error) {
 	return err
 }
 
-// Mark is a convenience method to invoke Do() with no function.
-func (r *RateLimiter) Mark() {
+// DoEmpty is a convenience method to invoke Do() with no function.
+func (r *RateLimiter) DoEmpty() {
 	_ = r.Do(nil)
 }
 

--- a/go/timer/rate_limiter.go
+++ b/go/timer/rate_limiter.go
@@ -28,7 +28,7 @@ import (
 // For example, we can create a RateLimiter of 1second. Then, we can ask it, over time, to run many
 // tasks. It will only ever run a single task in any 1 second time frame. The rest are ignored.
 type RateLimiter struct {
-	tickerValue int64
+	tickerValue atomic.Int64
 	lastDoValue int64
 
 	mu     sync.Mutex
@@ -37,7 +37,8 @@ type RateLimiter struct {
 
 // NewRateLimiter creates a new limiter with given duration. It is immediately ready to run tasks.
 func NewRateLimiter(d time.Duration) *RateLimiter {
-	r := &RateLimiter{tickerValue: 1}
+	r := &RateLimiter{}
+	r.tickerValue.Add(1) // start at 1, so that the first Do() call is not rate limited.
 	ctx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
 	go func() {
@@ -48,7 +49,7 @@ func NewRateLimiter(d time.Duration) *RateLimiter {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				atomic.StoreInt64(&r.tickerValue, r.tickerValue+1)
+				r.tickerValue.Add(1)
 			}
 		}
 	}()
@@ -61,13 +62,13 @@ func (r *RateLimiter) Do(f func() error) (err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.lastDoValue >= atomic.LoadInt64(&r.tickerValue) {
+	if r.lastDoValue >= r.tickerValue.Load() {
 		return nil // rate limited. Skipped.
 	}
 	if f != nil {
 		err = f()
 	}
-	r.lastDoValue = atomic.LoadInt64(&r.tickerValue)
+	r.lastDoValue = r.tickerValue.Load()
 	return err
 }
 

--- a/go/timer/rate_limiter.go
+++ b/go/timer/rate_limiter.go
@@ -38,7 +38,7 @@ type RateLimiter struct {
 // NewRateLimiter creates a new limiter with given duration. It is immediately ready to run tasks.
 func NewRateLimiter(d time.Duration) *RateLimiter {
 	r := &RateLimiter{}
-	r.tickerValue.Add(1) // start at 1, so that the first Do() call is not rate limited.
+	r.lastDoValue = math.MinInt32 // Far enough to make a difference, but not too far to overflow.
 	ctx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
 	go func() {

--- a/go/timer/rate_limiter.go
+++ b/go/timer/rate_limiter.go
@@ -72,6 +72,19 @@ func (r *RateLimiter) Do(f func() error) (err error) {
 	return err
 }
 
+// Mark is a convenience method to invoke Do() with no function.
+func (r *RateLimiter) Mark() {
+	_ = r.Do(nil)
+}
+
+// Diff returns the logical clock diff between the ticker and the last Do() call.
+func (r *RateLimiter) Diff() int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.tickerValue.Load() - r.lastDoValue
+}
+
 // Stop terminates rate limiter's operation and will not allow any more Do() executions.
 func (r *RateLimiter) Stop() {
 	r.cancel()

--- a/go/timer/rate_limiter_test.go
+++ b/go/timer/rate_limiter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package timer
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -84,9 +85,9 @@ func TestRateLimiterDiff(t *testing.T) {
 
 	// This assumes the last couple lines of code run faster than 2 seconds, which should be the case.
 	// But if you see flakiness due to slow runners, we can revisit the logic.
-	assert.Equal(t, int64(1), r.Diff())
+	assert.Greater(t, r.Diff(), int64(math.MaxInt32))
 	time.Sleep(d + time.Second)
-	assert.Greater(t, r.Diff(), int64(1))
+	assert.Greater(t, r.Diff(), int64(math.MaxInt32))
 	r.DoEmpty()
 	assert.LessOrEqual(t, r.Diff(), int64(1))
 }

--- a/go/timer/rate_limiter_test.go
+++ b/go/timer/rate_limiter_test.go
@@ -75,3 +75,18 @@ func TestRateLimiterStop(t *testing.T) {
 	}
 	assert.Equal(t, valSnapshot, val)
 }
+
+func TestRateLimiterDiff(t *testing.T) {
+	d := 2 * time.Second
+	r := NewRateLimiter(d)
+	require.NotNil(t, r)
+	defer r.Stop()
+
+	// This assumes the last couple lines of code run faster than 2 seconds, which should be the case.
+	// But if you see flakiness due to slow runners, we can revisit the logic.
+	assert.Equal(t, int64(1), r.Diff())
+	time.Sleep(d + time.Second)
+	assert.Greater(t, r.Diff(), int64(1))
+	r.Mark()
+	assert.LessOrEqual(t, r.Diff(), int64(1))
+}

--- a/go/timer/rate_limiter_test.go
+++ b/go/timer/rate_limiter_test.go
@@ -87,6 +87,6 @@ func TestRateLimiterDiff(t *testing.T) {
 	assert.Equal(t, int64(1), r.Diff())
 	time.Sleep(d + time.Second)
 	assert.Greater(t, r.Diff(), int64(1))
-	r.Mark()
+	r.DoEmpty()
 	assert.LessOrEqual(t, r.Diff(), int64(1))
 }

--- a/go/vt/vttablet/tabletserver/throttle/check.go
+++ b/go/vt/vttablet/tabletserver/throttle/check.go
@@ -149,8 +149,6 @@ func (check *ThrottlerCheck) Check(ctx context.Context, appName string, storeTyp
 
 	checkResult = check.checkAppMetricResult(ctx, appName, storeType, storeName, metricResultFunc, flags)
 	if !throttlerapp.VitessName.Equals(appName) {
-		check.throttler.lastCheckTimeNano.Store(time.Now().UnixNano())
-
 		go func(statusCode int) {
 			stats.GetOrNewCounter("ThrottlerCheckAnyTotal", "total number of checks").Add(1)
 			stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheckAny%s%sTotal", textutil.SingleWordCamel(storeType), textutil.SingleWordCamel(storeName)), "").Add(1)

--- a/go/vt/vttablet/tabletserver/throttle/check.go
+++ b/go/vt/vttablet/tabletserver/throttle/check.go
@@ -148,20 +148,21 @@ func (check *ThrottlerCheck) Check(ctx context.Context, appName string, storeTyp
 	}
 
 	checkResult = check.checkAppMetricResult(ctx, appName, storeType, storeName, metricResultFunc, flags)
-	check.throttler.lastCheckTimeNano.Store(time.Now().UnixNano())
+	if !throttlerapp.VitessName.Equals(appName) {
+		check.throttler.lastCheckTimeNano.Store(time.Now().UnixNano())
 
-	go func(statusCode int) {
-		stats.GetOrNewCounter("ThrottlerCheckAnyTotal", "total number of checks").Add(1)
-		stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheckAny%s%sTotal", textutil.SingleWordCamel(storeType), textutil.SingleWordCamel(storeName)), "").Add(1)
+		go func(statusCode int) {
+			stats.GetOrNewCounter("ThrottlerCheckAnyTotal", "total number of checks").Add(1)
+			stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheckAny%s%sTotal", textutil.SingleWordCamel(storeType), textutil.SingleWordCamel(storeName)), "").Add(1)
 
-		if statusCode != http.StatusOK {
-			stats.GetOrNewCounter("ThrottlerCheckAnyError", "total number of failed checks").Add(1)
-			stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheckAny%s%sError", textutil.SingleWordCamel(storeType), textutil.SingleWordCamel(storeName)), "").Add(1)
-		}
+			if statusCode != http.StatusOK {
+				stats.GetOrNewCounter("ThrottlerCheckAnyError", "total number of failed checks").Add(1)
+				stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheckAny%s%sError", textutil.SingleWordCamel(storeType), textutil.SingleWordCamel(storeName)), "").Add(1)
+			}
 
-		check.throttler.markRecentApp(appName, remoteAddr)
-	}(checkResult.StatusCode)
-
+			check.throttler.markRecentApp(appName, remoteAddr)
+		}(checkResult.StatusCode)
+	}
 	return checkResult
 }
 

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -583,6 +583,10 @@ func (throttler *Throttler) requestHeartbeats() {
 // stimulatePrimaryThrottler sends a check request to the primary tablet in the shard, to stimulate
 // it to request for heartbeats.
 func (throttler *Throttler) stimulatePrimaryThrottler(ctx context.Context, tmClient tmclient.TabletManagerClient) error {
+	// Some reasonable timeout, to ensure we release connections even if they're hanging (otherwise grpc-go keeps polling those connections forever)
+	ctx, cancel := context.WithTimeout(ctx, throttler.dormantPeriod)
+	defer cancel()
+
 	tabletAliases, err := throttler.ts.FindAllTabletAliasesInShard(ctx, throttler.keyspace, throttler.shard)
 	if err != nil {
 		return err

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -88,7 +88,7 @@ const (
 	mysqlRefreshInterval           = 10 * time.Second       // Refreshing tablet inventory
 	mysqlAggregateInterval         = 125 * time.Millisecond
 	throttledAppsSnapshotInterval  = 5 * time.Second
-	recentCheckRateLimiterInterval = 1 * time.Second // Ticker assisting in determining dormancy
+	recentCheckRateLimiterInterval = 1 * time.Second // Ticker assisting in determining when the throttler was last checked
 
 	aggregatedMetricsExpiration = 5 * time.Second
 	recentAppsExpiration        = time.Hour * 24

--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -383,7 +383,7 @@ func TestProbesWhileOperating(t *testing.T) {
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	runThrottler(t, ctx, throttler, 5*time.Second, func(t *testing.T, ctx context.Context) {
+	runThrottler(t, ctx, throttler, time.Minute, func(t *testing.T, ctx context.Context) {
 		t.Run("aggregated", func(t *testing.T) {
 			assert.Equal(t, 2, throttler.aggregatedMetrics.ItemCount()) // flushed upon Disable()
 			aggr := throttler.aggregatedMetricsSnapshot()
@@ -400,7 +400,7 @@ func TestProbesWhileOperating(t *testing.T) {
 					assert.Failf(t, "unknown clusterName", "%v", clusterName)
 				}
 			}
-			cancel()
+			cancel() // end test early
 		})
 	})
 }
@@ -498,7 +498,7 @@ func TestDormant(t *testing.T) {
 			case <-time.After(throttler.dormantPeriod):
 				assert.True(t, throttler.isDormant())
 			}
-			cancel()
+			cancel() // end test early
 		}()
 	})
 }

--- a/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttlerapp/app.go
@@ -42,8 +42,9 @@ func (n Name) Concatenate(other Name) Name {
 
 const (
 	// DefaultName is the app name used by vitess when app doesn't indicate its name
-	DefaultName Name = "default"
-	VitessName  Name = "vitess"
+	DefaultName             Name = "default"
+	VitessName              Name = "vitess"
+	ThrottlerStimulatorName Name = "throttler-stimulator"
 
 	TableGCName   Name = "tablegc"
 	OnlineDDLName Name = "online-ddl"


### PR DESCRIPTION

## Description

This PR addresses a starvation scenario in the tablet throttler. The scenario actually doesn't take place, due to an unintentional change. We fix the unintentional change & we fix the starvation scenario.

We also consolidate two different measurements of "last check" or "recent check":

1. `recentCheckValue`
2. `lastCheckTimeNano`

They are superfluous, because both serve to answer a similar question: "when was this throttler last checked?"

`lastCheckTimeNano` was updated in `check.go` at every check, and that's also where the aforementioned unintentional behavior takes place: this value should not be updated when the app is `"vitess"`. Right now in `main` this value does get updated when the app is `"vitess"`, which means the throttler's self-checks keep that value always recent. In turn, this prevents the throttler from going into _dormant mode_.


We introduce a new, single tracker for the checks, in the form of `recentCheckRateLimiter`. `RateLimiter` now not only produces ticks, and not only rate limits some action, but can also tell us the logical clock diff since last action invocation.

Using this, we can easily determine:

- Whether a check was made in the last 1-2 seconds
- Whether a check was made in the past `1min`

### Starvation prevention through `PRIMARY` stimulation

The fix to the starvation scenario is for the replica to proactively let the `PRIMARY` know that it has been _checked_. The `PRIMARY` still gets that information from the replicas when probing them. But now also, the replica invokes a `CheckThrottler()` directly on the `PRIMARY` with `"throttler-stimulator"` app name. This "stimulates" the `PRIMARY`, as it sees that it has just been _checked_, and therefore immediately renews heartbeat lease.

However, the replica does not overload the `PRIMARY` with these stimulations. Stimulations are rate limited to exactly _dormant period_ (`1min` at this time).

### Unit tests

We add unit tests to validate:

- Dormant mode is correct.
- `"vitess"` app checks does not affect "recently checked" state, neither or `PRIMARY` nor on replicas.
- `"throttler-stimulator"` affects "recently checked" state and causes heartbeat renewals.
- Replica checks invoke `CheckThrottler` on `PRIMARY` with `"throttler-stimulator"` app name.


## Related Issue(s)

https://github.com/vitessio/vitess/issues/15397

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
