### PR TITLE
mysqlctl: Improve handling of the lock file

### DIFF
--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -193,8 +193,14 @@ func TestCleanupLockfile(t *testing.T) {
 	assert.NoError(t, cleanupLockfile("mysql.sock", ts))
 	assert.NoFileExists(t, "mysql.sock.lock")
 
-	// If the lockfile exists, and the process is found, we don't clean it up.
+	// If the lockfile exists, and the process is found, but it's for ourselves,
+	// we clean it up.
 	os.WriteFile("mysql.sock.lock", []byte(strconv.Itoa(os.Getpid())), 0o600)
+	assert.NoError(t, cleanupLockfile("mysql.sock", ts))
+	assert.NoFileExists(t, "mysql.sock.lock")
+
+	// If the lockfile exists, and the process is found, we don't clean it up.
+	os.WriteFile("mysql.sock.lock", []byte(strconv.Itoa(os.Getppid())), 0o600)
 	assert.Error(t, cleanupLockfile("mysql.sock", ts))
 	assert.FileExists(t, "mysql.sock.lock")
 }


### PR DESCRIPTION
This handles the case where mysqlctld might get assigned the same pid and improves the logging for when this case happens.

## Related Issue(s)

Part of addressing #14552

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required