### PR TITLE
fix backup goroutine leak

### DIFF
--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -16,7 +16,7 @@
 GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
 if [ $? -eq 1 ]; then
   echo "Downloading golangci-lint..."
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 fi
 
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Close the reader and writer in a defer func. This ensures that the progress goroutine receives a message on the done channel and returns.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Note that the golangci-lint hook broke after the go1.22 upgrade, so I've updated it to the latest version.

## Related Issue(s)
Fixes #15409 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
