### PR TITLE
Ensure to use latest golangci-lint

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Install golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 
       - name: Clean Env
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     # Extras
     - gofmt
     - goimports
-    - exportloopref
     - bodyclose
 
     # revive is a replacement for golint, but we do not run it in CI for now.

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -16,7 +16,7 @@
 GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
 if [ $? -eq 1 ]; then
   echo "Downloading golangci-lint..."
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 fi
 
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')


### PR DESCRIPTION
Install the latest `golangci-lint` and fix up configuration.

Marked for backport as v19 is also on Go 1.22 and needs the latest too and `exportloopref` is not needed there either. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required