### PR TITLE
planbuilder: Cleanup unused logic

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -270,7 +270,7 @@ func createDeleteOperator(ctx *plancontext.PlanningContext, del *sqlparser.Delet
 
 	var ovq *sqlparser.Select
 	if vTbl.Keyspace.Sharded && vTbl.Type == vindexes.TypeTable {
-		primaryVindex, _ := getVindexInformation(tblID, vTbl)
+		primaryVindex := getVindexInformation(tblID, vTbl)
 		if len(vTbl.Owned) > 0 {
 			ovq = generateOwnedVindexQuery(del, targetTbl, primaryVindex.Columns)
 		}

--- a/go/vt/vtgate/planbuilder/operators/dml_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/dml_planning.go
@@ -59,30 +59,12 @@ func shortDesc(target TargetTable, ovq *sqlparser.Select) string {
 
 // getVindexInformation returns the vindex and VindexPlusPredicates for the DML,
 // If it cannot find a unique vindex match, it returns an error.
-func getVindexInformation(id semantics.TableSet, table *vindexes.Table) (
-	*vindexes.ColumnVindex,
-	[]*VindexPlusPredicates) {
-
+func getVindexInformation(id semantics.TableSet, table *vindexes.Table) *vindexes.ColumnVindex {
 	// Check that we have a primary vindex which is valid
 	if len(table.ColumnVindexes) == 0 || !table.ColumnVindexes[0].IsUnique() {
 		panic(vterrors.VT09001(table.Name))
 	}
-	primaryVindex := table.ColumnVindexes[0]
-
-	var vindexesAndPredicates []*VindexPlusPredicates
-	for _, colVindex := range table.Ordered {
-		if lu, isLu := colVindex.Vindex.(vindexes.LookupBackfill); isLu && lu.IsBackfilling() {
-			// Checking if the Vindex is currently backfilling or not, if it isn't we can read from the vindex table,
-			// and we will be able to do a delete equal. Otherwise, we continue to look for next best vindex.
-			continue
-		}
-
-		vindexesAndPredicates = append(vindexesAndPredicates, &VindexPlusPredicates{
-			ColVindex: colVindex,
-			TableID:   id,
-		})
-	}
-	return primaryVindex, vindexesAndPredicates
+	return table.ColumnVindexes[0]
 }
 
 func createAssignmentExpressions(

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -269,7 +269,7 @@ func createUpdateOperator(ctx *plancontext.PlanningContext, updStmt *sqlparser.U
 		Name:   name,
 	}
 
-	_, cvv, ovq, subQueriesArgOnChangedVindex := getUpdateVindexInformation(ctx, updStmt, targetTbl, assignments)
+	cvv, ovq, subQueriesArgOnChangedVindex := getUpdateVindexInformation(ctx, updStmt, targetTbl, assignments)
 
 	updOp := &Update{
 		DMLCommon: &DMLCommon{
@@ -302,14 +302,14 @@ func getUpdateVindexInformation(
 	updStmt *sqlparser.Update,
 	table TargetTable,
 	assignments []SetExpr,
-) ([]*VindexPlusPredicates, map[string]*engine.VindexValues, *sqlparser.Select, []string) {
+) (map[string]*engine.VindexValues, *sqlparser.Select, []string) {
 	if !table.VTable.Keyspace.Sharded {
-		return nil, nil, nil, nil
+		return nil, nil, nil
 	}
 
-	primaryVindex, vindexAndPredicates := getVindexInformation(table.ID, table.VTable)
+	primaryVindex := getVindexInformation(table.ID, table.VTable)
 	changedVindexValues, ownedVindexQuery, subQueriesArgOnChangedVindex := buildChangedVindexesValues(ctx, updStmt, table.VTable, primaryVindex.Columns, assignments)
-	return vindexAndPredicates, changedVindexValues, ownedVindexQuery, subQueriesArgOnChangedVindex
+	return changedVindexValues, ownedVindexQuery, subQueriesArgOnChangedVindex
 }
 
 func buildFkOperator(ctx *plancontext.PlanningContext, updOp Operator, updClone *sqlparser.Update, parentFks []vindexes.ParentFKInfo, childFks []vindexes.ChildFKInfo, updatedTable *vindexes.Table) Operator {


### PR DESCRIPTION
The `getVindexInformation` call was returning alternative vindexes, but that was never used by callers. `getUpdateVindexInformation` returned it, but it's callers also never used it.

This means we can remove this, as nothing depends on it.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required