### PR TITLE
Fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.22
+go 1.22.1
 
 require (
 	cloud.google.com/go/storage v1.39.0


### PR DESCRIPTION
This was broken in https://github.com/vitessio/vitess/pull/15405, looks like the tooling to upgrade is busted if it rewrites those to drop the last patch level.

## Related Issue(s)

Broken in https://github.com/vitessio/vitess/pull/15405

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required