### PR TITLE
Ensure that WithParams keeps the transport

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -435,7 +435,7 @@ func (bs *S3BackupStorage) Close() error {
 }
 
 func (bs *S3BackupStorage) WithParams(params backupstorage.Params) backupstorage.BackupStorage {
-	return &S3BackupStorage{params: params}
+	return &S3BackupStorage{params: params, transport: bs.transport}
 }
 
 var _ backupstorage.BackupStorage = (*S3BackupStorage)(nil)

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -286,3 +286,13 @@ func TestNewS3Transport(t *testing.T) {
 	assert.NotNil(t, s3.transport.DialContext)
 	assert.NotNil(t, s3.transport.Proxy)
 }
+
+func TestWithParams(t *testing.T) {
+	bases3 := newS3BackupStorage()
+	s3 := bases3.WithParams(backupstorage.Params{}).(*S3BackupStorage)
+	// checking some of the values are present in the returned transport and match the http.DefaultTransport.
+	assert.Equal(t, http.DefaultTransport.(*http.Transport).IdleConnTimeout, s3.transport.IdleConnTimeout)
+	assert.Equal(t, http.DefaultTransport.(*http.Transport).MaxIdleConns, s3.transport.MaxIdleConns)
+	assert.NotNil(t, s3.transport.DialContext)
+	assert.NotNil(t, s3.transport.Proxy)
+}


### PR DESCRIPTION
Not having a transport means we get crash here which we should avoid.

## Related Issue(s)

Fixes #15419

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
