### PR TITLE
Use a throttled logger for exceeded memory warnings

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -40,6 +40,7 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -73,6 +74,8 @@ var (
 
 	queriesProcessedByTable = stats.NewCountersWithMultiLabels("QueriesProcessedByTable", "Queries processed at vtgate by plan type, keyspace and table", []string{"Plan", "Keyspace", "Table"})
 	queriesRoutedByTable    = stats.NewCountersWithMultiLabels("QueriesRoutedByTable", "Queries routed from vtgate to vttablet by plan type, keyspace and table", []string{"Plan", "Keyspace", "Table"})
+
+	exceedMemoryRowsLogger = logutil.NewThrottledLogger("ExceedMemoryRows", 1*time.Minute)
 )
 
 const (
@@ -231,7 +234,7 @@ func (e *Executor) Execute(ctx context.Context, mysqlCtx vtgateservice.MySQLConn
 		if err != nil {
 			piiSafeSQL = logStats.StmtType
 		}
-		log.Warningf("%q exceeds warning threshold of max memory rows: %v. Actual memory rows: %v", piiSafeSQL, warnMemoryRows, len(result.Rows))
+		exceedMemoryRowsLogger.Warningf("%q exceeds warning threshold of max memory rows: %v. Actual memory rows: %v", piiSafeSQL, warnMemoryRows, len(result.Rows))
 	}
 
 	logStats.SaveEndTime()
@@ -365,7 +368,7 @@ func (e *Executor) StreamExecute(
 		if err != nil {
 			piiSafeSQL = logStats.StmtType
 		}
-		log.Warningf("%q exceeds warning threshold of max memory rows: %v. Actual memory rows: %v", piiSafeSQL, warnMemoryRows, srr.rowsReturned)
+		exceedMemoryRowsLogger.Warningf("%q exceeds warning threshold of max memory rows: %v. Actual memory rows: %v", piiSafeSQL, warnMemoryRows, srr.rowsReturned)
 	}
 
 	logStats.SaveEndTime()

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -236,7 +236,7 @@ func (e *Executor) Execute(ctx context.Context, mysqlCtx vtgateservice.MySQLConn
 			piiSafeSQL = logStats.StmtType
 		}
 		warningMsg := fmt.Sprintf("%q exceeds warning threshold of max memory rows: %v. Actual memory rows: %v", piiSafeSQL, warnMemoryRows, len(result.Rows))
-		exceedMemoryRowsLogger.Warningf(sql, warningMsg)
+		exceedMemoryRowsLogger.Warningf(warningMsg)
 		safeSession.RecordWarning(&querypb.QueryWarning{
 			Code:    uint32(sqlerror.EROutOfMemory),
 			Message: warningMsg,
@@ -375,7 +375,7 @@ func (e *Executor) StreamExecute(
 			piiSafeSQL = logStats.StmtType
 		}
 		warningMsg := fmt.Sprintf("%q exceeds warning threshold of max memory rows: %v. Actual memory rows: %v", piiSafeSQL, warnMemoryRows, srr.rowsReturned)
-		exceedMemoryRowsLogger.Warningf(sql, warningMsg)
+		exceedMemoryRowsLogger.Warningf(warningMsg)
 		safeSession.RecordWarning(&querypb.QueryWarning{
 			Code:    uint32(sqlerror.EROutOfMemory),
 			Message: warningMsg,


### PR DESCRIPTION
## Description

This PR fixes the issue described in https://github.com/vitessio/vitess/issues/15423. 

We now create a throttled logger and use that to log the warnings for exceeding memory row count. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15423

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
