### PR TITLE
`schemadiff`: support valid foreign key cycles

### DIFF
--- a/go/vt/graph/graph.go
+++ b/go/vt/graph/graph.go
@@ -104,10 +104,11 @@ func (gr *Graph[C]) HasCycles() bool {
 	return false
 }
 
-// HasCycles checks whether the given graph has a cycle or not.
+// GetCycles returns all known cycles in the graph.
+// It returns a map of vertices to the cycle they are part of.
 // We are using a well-known DFS based colouring algorithm to check for cycles.
 // Look at https://cp-algorithms.com/graph/finding-cycle.html for more details on the algorithm.
-func (gr *Graph[C]) GetCycleVertices() (vertices map[C][]C) {
+func (gr *Graph[C]) GetCycles() (vertices map[C][]C) {
 	// If the graph is empty, then we don't need to check anything.
 	if gr.Empty() {
 		return nil
@@ -121,6 +122,8 @@ func (gr *Graph[C]) GetCycleVertices() (vertices map[C][]C) {
 	for _, vertex := range gr.orderedEdged {
 		// If any vertex is still white, we initiate a new DFS.
 		if color[vertex] == white {
+			// We clone the colors because we wnt full coverage for all vertices.
+			// Otherwise, the algorithm is optimal and stop more-or-less after the first cycle.
 			color := maps.Clone(color)
 			if hasCycle, cycle := gr.hasCyclesDfs(color, vertex); hasCycle {
 				vertices[vertex] = cycle

--- a/go/vt/graph/graph.go
+++ b/go/vt/graph/graph.go
@@ -31,15 +31,15 @@ const (
 
 // Graph is a generic graph implementation.
 type Graph[C comparable] struct {
-	edges        map[C][]C
-	orderedEdged []C
+	edges           map[C][]C
+	orderedVertices []C
 }
 
 // NewGraph creates a new graph for the given comparable type.
 func NewGraph[C comparable]() *Graph[C] {
 	return &Graph[C]{
-		edges:        map[C][]C{},
-		orderedEdged: []C{},
+		edges:           map[C][]C{},
+		orderedVertices: []C{},
 	}
 }
 
@@ -50,7 +50,7 @@ func (gr *Graph[C]) AddVertex(vertex C) {
 		return
 	}
 	gr.edges[vertex] = []C{}
-	gr.orderedEdged = append(gr.orderedEdged, vertex)
+	gr.orderedVertices = append(gr.orderedVertices, vertex)
 }
 
 // AddEdge adds an edge to the given Graph.
@@ -119,7 +119,7 @@ func (gr *Graph[C]) GetCycles() (vertices map[C][]C) {
 	// 1 represents grey.
 	// 2 represents black.
 	color := map[C]int{}
-	for _, vertex := range gr.orderedEdged {
+	for _, vertex := range gr.orderedVertices {
 		// If any vertex is still white, we initiate a new DFS.
 		if color[vertex] == white {
 			// We clone the colors because we wnt full coverage for all vertices.

--- a/go/vt/graph/graph.go
+++ b/go/vt/graph/graph.go
@@ -24,13 +24,15 @@ import (
 
 // Graph is a generic graph implementation.
 type Graph[C comparable] struct {
-	edges map[C][]C
+	edges        map[C][]C
+	orderedEdged []C
 }
 
 // NewGraph creates a new graph for the given comparable type.
 func NewGraph[C comparable]() *Graph[C] {
 	return &Graph[C]{
-		edges: map[C][]C{},
+		edges:        map[C][]C{},
+		orderedEdged: []C{},
 	}
 }
 
@@ -41,6 +43,7 @@ func (gr *Graph[C]) AddVertex(vertex C) {
 		return
 	}
 	gr.edges[vertex] = []C{}
+	gr.orderedEdged = append(gr.orderedEdged, vertex)
 }
 
 // AddEdge adds an edge to the given Graph.
@@ -92,6 +95,30 @@ func (gr *Graph[C]) HasCycles() bool {
 		}
 	}
 	return false
+}
+
+// HasCycles checks whether the given graph has a cycle or not.
+// We are using a well-known DFS based colouring algorithm to check for cycles.
+// Look at https://cp-algorithms.com/graph/finding-cycle.html for more details on the algorithm.
+func (gr *Graph[C]) GetCycleVertices() (vertices []C) {
+	// If the graph is empty, then we don't need to check anything.
+	if gr.Empty() {
+		return nil
+	}
+	// Initialize the coloring map.
+	// 0 represents white.
+	// 1 represents grey.
+	// 2 represents black.
+	color := map[C]int{}
+	for _, vertex := range gr.orderedEdged {
+		// If any vertex is still white, we initiate a new DFS.
+		if color[vertex] == 0 {
+			if gr.hasCyclesDfs(color, vertex) {
+				vertices = append(vertices, vertex)
+			}
+		}
+	}
+	return vertices
 }
 
 // hasCyclesDfs is a utility function for checking for cycles in a graph.

--- a/go/vt/graph/graph_test.go
+++ b/go/vt/graph/graph_test.go
@@ -90,12 +90,12 @@ func TestIntegerGraph(t *testing.T) {
 // TestStringGraph tests that a graph with strings can be created and all graph functions work as intended.
 func TestStringGraph(t *testing.T) {
 	testcases := []struct {
-		name              string
-		edges             [][2]string
-		wantedGraph       string
-		wantEmpty         bool
-		wantHasCycles     bool
-		wantCycleVertices map[string][]string
+		name          string
+		edges         [][2]string
+		wantedGraph   string
+		wantEmpty     bool
+		wantHasCycles bool
+		wantCycles    map[string][]string
 	}{
 		{
 			name:          "empty graph",
@@ -138,7 +138,7 @@ E - F
 F - A`,
 			wantEmpty:     false,
 			wantHasCycles: true,
-			wantCycleVertices: map[string][]string{
+			wantCycles: map[string][]string{
 				"A": {"A", "B", "E", "F", "A"},
 				"B": {"B", "E", "F", "A", "B"},
 				"D": {"D", "E", "F", "A", "B", "E"},
@@ -156,14 +156,14 @@ F - A`,
 			require.Equal(t, tt.wantedGraph, graph.PrintGraph())
 			require.Equal(t, tt.wantEmpty, graph.Empty())
 			require.Equal(t, tt.wantHasCycles, graph.HasCycles())
-			if tt.wantCycleVertices == nil {
-				tt.wantCycleVertices = map[string][]string{}
+			if tt.wantCycles == nil {
+				tt.wantCycles = map[string][]string{}
 			}
-			actualCycleVertices := graph.GetCycleVertices()
-			if actualCycleVertices == nil {
-				actualCycleVertices = map[string][]string{}
+			actualCycles := graph.GetCycles()
+			if actualCycles == nil {
+				actualCycles = map[string][]string{}
 			}
-			require.Equal(t, tt.wantCycleVertices, actualCycleVertices)
+			require.Equal(t, tt.wantCycles, actualCycles)
 		})
 	}
 }

--- a/go/vt/graph/graph_test.go
+++ b/go/vt/graph/graph_test.go
@@ -95,7 +95,7 @@ func TestStringGraph(t *testing.T) {
 		wantedGraph       string
 		wantEmpty         bool
 		wantHasCycles     bool
-		wantCycleVertices []string
+		wantCycleVertices map[string][]string
 	}{
 		{
 			name:          "empty graph",
@@ -136,9 +136,15 @@ C -
 D - E
 E - F
 F - A`,
-			wantEmpty:         false,
-			wantHasCycles:     true,
-			wantCycleVertices: []string{"A", "D"},
+			wantEmpty:     false,
+			wantHasCycles: true,
+			wantCycleVertices: map[string][]string{
+				"A": {"A", "B", "E", "F", "A"},
+				"B": {"B", "E", "F", "A", "B"},
+				"D": {"D", "E", "F", "A", "B", "E"},
+				"E": {"E", "F", "A", "B", "E"},
+				"F": {"F", "A", "B", "E", "F"},
+			},
 		},
 	}
 	for _, tt := range testcases {
@@ -150,7 +156,14 @@ F - A`,
 			require.Equal(t, tt.wantedGraph, graph.PrintGraph())
 			require.Equal(t, tt.wantEmpty, graph.Empty())
 			require.Equal(t, tt.wantHasCycles, graph.HasCycles())
-			require.Equal(t, tt.wantCycleVertices, graph.GetCycleVertices())
+			if tt.wantCycleVertices == nil {
+				tt.wantCycleVertices = map[string][]string{}
+			}
+			actualCycleVertices := graph.GetCycleVertices()
+			if actualCycleVertices == nil {
+				actualCycleVertices = map[string][]string{}
+			}
+			require.Equal(t, tt.wantCycleVertices, actualCycleVertices)
 		})
 	}
 }

--- a/go/vt/graph/graph_test.go
+++ b/go/vt/graph/graph_test.go
@@ -90,11 +90,12 @@ func TestIntegerGraph(t *testing.T) {
 // TestStringGraph tests that a graph with strings can be created and all graph functions work as intended.
 func TestStringGraph(t *testing.T) {
 	testcases := []struct {
-		name          string
-		edges         [][2]string
-		wantedGraph   string
-		wantEmpty     bool
-		wantHasCycles bool
+		name              string
+		edges             [][2]string
+		wantedGraph       string
+		wantEmpty         bool
+		wantHasCycles     bool
+		wantCycleVertices []string
 	}{
 		{
 			name:          "empty graph",
@@ -135,8 +136,9 @@ C -
 D - E
 E - F
 F - A`,
-			wantEmpty:     false,
-			wantHasCycles: true,
+			wantEmpty:         false,
+			wantHasCycles:     true,
+			wantCycleVertices: []string{"A", "D"},
 		},
 	}
 	for _, tt := range testcases {
@@ -148,6 +150,7 @@ F - A`,
 			require.Equal(t, tt.wantedGraph, graph.PrintGraph())
 			require.Equal(t, tt.wantEmpty, graph.Empty())
 			require.Equal(t, tt.wantHasCycles, graph.HasCycles())
+			require.Equal(t, tt.wantCycleVertices, graph.GetCycleVertices())
 		})
 	}
 }

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -313,7 +313,7 @@ func TestDiffTables(t *testing.T) {
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
 			var fromCreateTable *sqlparser.CreateTable
-			hints := &DiffHints{}
+			hints := EmptyDiffHints()
 			if ts.hints != nil {
 				hints = ts.hints
 			}
@@ -448,7 +448,7 @@ func TestDiffViews(t *testing.T) {
 			name: "none",
 		},
 	}
-	hints := &DiffHints{}
+	hints := EmptyDiffHints()
 	env := NewTestEnv()
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
@@ -545,6 +545,7 @@ func TestDiffSchemas(t *testing.T) {
 		cdiffs      []string
 		expectError string
 		tableRename int
+		fkStrategy  int
 	}{
 		{
 			name: "identical tables",
@@ -800,6 +801,45 @@ func TestDiffSchemas(t *testing.T) {
 			},
 		},
 		{
+			name: "create tables with foreign keys, with invalid fk reference",
+			from: "create table t (id int primary key)",
+			to: `
+				create table t (id int primary key);
+				create table t11 (id int primary key, i int, constraint f1101a foreign key (i) references t12 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1201a foreign key (i) references t9 (id) on delete set null);
+			`,
+			expectError: "table `t12` foreign key references nonexistent table `t9`",
+		},
+		{
+			name: "create tables with foreign keys, with invalid fk reference",
+			from: "create table t (id int primary key)",
+			to: `
+				create table t (id int primary key);
+				create table t11 (id int primary key, i int, constraint f1101b foreign key (i) references t12 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1201b foreign key (i) references t9 (id) on delete set null);
+			`,
+			expectError: "table `t12` foreign key references nonexistent table `t9`",
+			fkStrategy:  ForeignKeyCheckStrategyIgnore,
+		},
+		{
+			name: "create tables with foreign keys, with valid cycle",
+			from: "create table t (id int primary key)",
+			to: `
+				create table t (id int primary key);
+				create table t11 (id int primary key, i int, constraint f1101c foreign key (i) references t12 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1201c foreign key (i) references t11 (id) on delete set null);
+			`,
+			diffs: []string{
+				"create table t11 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f1101 (i),\n\tconstraint f1101 foreign key (i) references t12 (id) on delete restrict\n)",
+				"create table t12 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f1201 (i),\n\tconstraint f1201 foreign key (i) references t11 (id) on delete set null\n)",
+			},
+			cdiffs: []string{
+				"CREATE TABLE `t11` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f1101` (`i`),\n\tCONSTRAINT `f1101` FOREIGN KEY (`i`) REFERENCES `t12` (`id`) ON DELETE RESTRICT\n)",
+				"CREATE TABLE `t12` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f1201` (`i`),\n\tCONSTRAINT `f1201` FOREIGN KEY (`i`) REFERENCES `t11` (`id`) ON DELETE SET NULL\n)",
+			},
+			fkStrategy: ForeignKeyCheckStrategyIgnore,
+		},
+		{
 			name: "drop tables with foreign keys, expect specific order",
 			from: "create table t7(id int primary key); create table t5 (id int primary key, i int, constraint f5 foreign key (i) references t7(id)); create table t4 (id int primary key, i int, constraint f4 foreign key (i) references t7(id));",
 			diffs: []string{
@@ -932,14 +972,15 @@ func TestDiffSchemas(t *testing.T) {
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
 			hints := &DiffHints{
-				TableRenameStrategy: ts.tableRename,
+				TableRenameStrategy:     ts.tableRename,
+				ForeignKeyCheckStrategy: ts.fkStrategy,
 			}
 			diff, err := DiffSchemasSQL(env, ts.from, ts.to, hints)
 			if ts.expectError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), ts.expectError)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				diffs, err := diff.OrderedDiffs(ctx)
 				assert.NoError(t, err)
@@ -1024,7 +1065,7 @@ func TestSchemaApplyError(t *testing.T) {
 			to:   "create table t(id int); create view v1 as select * from t; create view v2 as select * from t",
 		},
 	}
-	hints := &DiffHints{}
+	hints := EmptyDiffHints()
 	env := NewTestEnv()
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -830,12 +830,12 @@ func TestDiffSchemas(t *testing.T) {
 				create table t12 (id int primary key, i int, constraint f1201c foreign key (i) references t11 (id) on delete set null);
 			`,
 			diffs: []string{
-				"create table t11 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f1101 (i),\n\tconstraint f1101 foreign key (i) references t12 (id) on delete restrict\n)",
-				"create table t12 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f1201 (i),\n\tconstraint f1201 foreign key (i) references t11 (id) on delete set null\n)",
+				"create table t11 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f1101c (i),\n\tconstraint f1101c foreign key (i) references t12 (id) on delete restrict\n)",
+				"create table t12 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f1201c (i),\n\tconstraint f1201c foreign key (i) references t11 (id) on delete set null\n)",
 			},
 			cdiffs: []string{
-				"CREATE TABLE `t11` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f1101` (`i`),\n\tCONSTRAINT `f1101` FOREIGN KEY (`i`) REFERENCES `t12` (`id`) ON DELETE RESTRICT\n)",
-				"CREATE TABLE `t12` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f1201` (`i`),\n\tCONSTRAINT `f1201` FOREIGN KEY (`i`) REFERENCES `t11` (`id`) ON DELETE SET NULL\n)",
+				"CREATE TABLE `t11` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f1101c` (`i`),\n\tCONSTRAINT `f1101c` FOREIGN KEY (`i`) REFERENCES `t12` (`id`) ON DELETE RESTRICT\n)",
+				"CREATE TABLE `t12` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f1201c` (`i`),\n\tCONSTRAINT `f1201c` FOREIGN KEY (`i`) REFERENCES `t11` (`id`) ON DELETE SET NULL\n)",
 			},
 			fkStrategy: ForeignKeyCheckStrategyIgnore,
 		},

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -288,7 +288,7 @@ func (e *ForeignKeyDependencyUnresolvedError) Error() string {
 
 type ForeignKeyLoopError struct {
 	Table string
-	Loop  []string
+	Loop  []*ForeignKeyTableColumns
 }
 
 func (e *ForeignKeyLoopError) Error() string {
@@ -303,16 +303,16 @@ func (e *ForeignKeyLoopError) Error() string {
 	if len(loop) > 0 {
 		last := loop[len(loop)-1]
 		for i := range loop {
-			if loop[i] == last {
+			if loop[i].Table == last.Table {
 				loop = loop[i:]
 				break
 			}
 		}
 	}
 	escaped := make([]string, len(loop))
-	for i, t := range loop {
-		escaped[i] = sqlescape.EscapeID(t)
-		if t == e.Table {
+	for i, fk := range loop {
+		escaped[i] = fk.Escaped()
+		if fk.Table == e.Table {
 			tableIsInsideLoop = true
 		}
 	}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -18,10 +18,14 @@ package schemadiff
 
 import (
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 
+	"golang.org/x/exp/maps"
+
 	"vitess.io/vitess/go/mysql/capabilities"
+	"vitess.io/vitess/go/vt/graph"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
@@ -72,7 +76,7 @@ func NewSchemaFromEntities(env *Environment, entities []Entity) (*Schema, error)
 			return nil, &UnsupportedEntityError{Entity: c.Name(), Statement: c.Create().CanonicalStatementString()}
 		}
 	}
-	err := schema.normalize()
+	err := schema.normalize(EmptyDiffHints())
 	return schema, err
 }
 
@@ -135,42 +139,6 @@ func getForeignKeyParentTableNames(createTable *sqlparser.CreateTable) (names []
 	return names
 }
 
-// findForeignKeyLoop is a stateful recursive function that determines whether a given table participates in a foreign
-// key loop or derives from one. It returns a list of table names that form a loop, or nil if no loop is found.
-// The function updates and checks the stateful map s.foreignKeyLoopMap to avoid re-analyzing the same table twice.
-func (s *Schema) findForeignKeyLoop(tableName string, seen []string) (loop []string) {
-	if loop := s.foreignKeyLoopMap[tableName]; loop != nil {
-		return loop
-	}
-	t := s.Table(tableName)
-	if t == nil {
-		return nil
-	}
-	seen = append(seen, tableName)
-	for i, seenTable := range seen {
-		if i == len(seen)-1 {
-			// as we've just appended the table name to the end of the slice, we should skip it.
-			break
-		}
-		if seenTable == tableName {
-			// This table alreay appears in `seen`.
-			// We only return the suffix of `seen` that starts (and now ends) with this table.
-			return seen[i:]
-		}
-	}
-	for _, referencedTableName := range getForeignKeyParentTableNames(t.CreateTable) {
-		if loop := s.findForeignKeyLoop(referencedTableName, seen); loop != nil {
-			// Found loop. Update cache.
-			// It's possible for one table to participate in more than one foreign key loop, but
-			// we suffice with one loop, since we already only ever report one foreign key error
-			// per table.
-			s.foreignKeyLoopMap[tableName] = loop
-			return loop
-		}
-	}
-	return nil
-}
-
 // getViewDependentTableNames analyzes a CREATE VIEW definition and extracts all tables/views read by this view
 func getViewDependentTableNames(createView *sqlparser.CreateView) (names []string) {
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
@@ -191,7 +159,7 @@ func getViewDependentTableNames(createView *sqlparser.CreateView) (names []strin
 
 // normalize is called as part of Schema creation process. The user may only get a hold of normalized schema.
 // It validates some cross-entity constraints, and orders entity based on dependencies (e.g. tables, views that read from tables, 2nd level views, etc.)
-func (s *Schema) normalize() error {
+func (s *Schema) normalize(hints *DiffHints) error {
 	var errs error
 
 	s.named = make(map[string]Entity, len(s.tables)+len(s.views))
@@ -284,8 +252,10 @@ func (s *Schema) normalize() error {
 				}
 				referencedEntity, ok := s.named[referencedTableName]
 				if !ok {
-					errs = errors.Join(errs, addEntityFkError(t, &ForeignKeyNonexistentReferencedTableError{Table: name, ReferencedTable: referencedTableName}))
-					continue
+					if hints.ForeignKeyCheckStrategy == ForeignKeyCheckStrategyStrict {
+						errs = errors.Join(errs, addEntityFkError(t, &ForeignKeyNonexistentReferencedTableError{Table: name, ReferencedTable: referencedTableName}))
+						continue
+					}
 				}
 				if _, ok := referencedEntity.(*CreateViewEntity); ok {
 					errs = errors.Join(errs, addEntityFkError(t, &ForeignKeyReferencesViewError{Table: name, ReferencedView: referencedTableName}))
@@ -310,6 +280,77 @@ func (s *Schema) normalize() error {
 			s.foreignKeyParents = append(s.foreignKeyParents, t)
 		}
 	}
+	if len(dependencyLevels) != len(s.tables) {
+		// We have leftover tables. This can happen if there's foreign key loops
+		for _, t := range s.tables {
+			if _, ok := dependencyLevels[t.Name()]; ok {
+				// known table
+				continue
+			}
+			// Table is part of a loop or references a loop
+			s.sorted = append(s.sorted, t)
+			dependencyLevels[t.Name()] = iterationLevel // all in same level
+		}
+
+		// Now, let's see if the loop is valid or invalid. For example:
+		//   users.avatar_id -> avatars.id
+		//   avatars.creator_id -> users.id
+		// is a valid loop, because even though the two tables reference each other, the loop ends in different columns.
+		type tableCol struct {
+			tableName sqlparser.TableName
+			colNames  sqlparser.Columns
+		}
+		var tableColHash = func(tc tableCol) string {
+			res := sqlparser.String(tc.tableName)
+			for _, colName := range tc.colNames {
+				res += "|" + sqlparser.String(colName)
+			}
+			return res
+		}
+		var decodeTableColHash = func(hash string) (tableName string, colNames []string) {
+			tokens := strings.Split(hash, "|")
+			return tokens[0], tokens[1:]
+		}
+		g := graph.NewGraph[string]()
+		for _, table := range s.tables {
+			for _, cfk := range table.TableSpec.Constraints {
+				check, ok := cfk.Details.(*sqlparser.ForeignKeyDefinition)
+				if !ok {
+					// Not a foreign key
+					continue
+				}
+
+				parentVertex := tableCol{
+					tableName: check.ReferenceDefinition.ReferencedTable,
+					colNames:  check.ReferenceDefinition.ReferencedColumns,
+				}
+				childVertex := tableCol{
+					tableName: table.Table,
+					colNames:  check.Source,
+				}
+				g.AddEdge(tableColHash(parentVertex), tableColHash(childVertex))
+			}
+		}
+		cycles := g.GetCycles() // map of table name to cycle
+		// golang maps have undefined iteration order. For consistent output, we sort the keys.
+		vertices := maps.Keys(cycles)
+		slices.Sort(vertices)
+		for _, vertex := range vertices {
+			cycle := cycles[vertex]
+			if len(cycle) == 0 {
+				continue
+			}
+			cycleTables := make([]string, len(cycle))
+			for i := range cycle {
+				// Reduce tablename|colname(s) to just tablename
+				cycleTables[i], _ = decodeTableColHash(cycle[i])
+			}
+			tableName := cycleTables[0]
+			s.foreignKeyLoopMap[tableName] = cycleTables
+			errs = errors.Join(errs, addEntityFkError(s.named[tableName], &ForeignKeyLoopError{Table: tableName, Loop: cycleTables}))
+		}
+	}
+
 	// We now iterate all views. We iterate "dependency levels":
 	// - first we want all views that only depend on tables. These are 1st level views.
 	// - then we only want views that depend on 1st level views or on tables. These are 2nd level views.
@@ -347,14 +388,6 @@ func (s *Schema) normalize() error {
 	}
 
 	if len(s.sorted) != len(s.tables)+len(s.views) {
-
-		for _, t := range s.tables {
-			if _, ok := dependencyLevels[t.Name()]; !ok {
-				if loop := s.findForeignKeyLoop(t.Name(), nil); loop != nil {
-					errs = errors.Join(errs, addEntityFkError(t, &ForeignKeyLoopError{Table: t.Name(), Loop: loop}))
-				}
-			}
-		}
 		// We have leftover tables or views. This can happen if the schema definition is invalid:
 		// - a table's foreign key references a nonexistent table
 		// - two or more tables have circular FK dependency
@@ -724,7 +757,7 @@ func (s *Schema) copy() *Schema {
 
 // apply attempts to apply given list of diffs to this object.
 // These diffs are CREATE/DROP/ALTER TABLE/VIEW.
-func (s *Schema) apply(diffs []EntityDiff) error {
+func (s *Schema) apply(diffs []EntityDiff, hints *DiffHints) error {
 	for _, diff := range diffs {
 		switch diff := diff.(type) {
 		case *CreateTableEntityDiff:
@@ -834,7 +867,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 			return &UnsupportedApplyOperationError{Statement: diff.CanonicalStatementString()}
 		}
 	}
-	if err := s.normalize(); err != nil {
+	if err := s.normalize(hints); err != nil {
 		return err
 	}
 	return nil
@@ -845,7 +878,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 // The operation does not modify this object. Instead, if successful, a new (modified) Schema is returned.
 func (s *Schema) Apply(diffs []EntityDiff) (*Schema, error) {
 	dup := s.copy()
-	if err := dup.apply(diffs); err != nil {
+	if err := dup.apply(diffs, EmptyDiffHints()); err != nil {
 		return nil, err
 	}
 	return dup, nil
@@ -861,7 +894,7 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 	if err != nil {
 		return nil, err
 	}
-	schemaDiff := NewSchemaDiff(s)
+	schemaDiff := NewSchemaDiff(s, hints)
 	schemaDiff.loadDiffs(diffs)
 
 	// Utility function to see whether the given diff has dependencies on diffs that operate on any of the given named entities,

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -681,6 +681,20 @@ func TestSchemaDiff(t *testing.T) {
 			instantCapability: InstantDDLCapabilityImpossible,
 		},
 		{
+			name: "add two valid fk cycle references",
+			toQueries: []string{
+				"create table t1 (id int primary key, info int not null, i int, constraint f1 foreign key (i) references t2 (id) on delete restrict);",
+				"create table t2 (id int primary key, ts timestamp,      i int, constraint f2 foreign key (i) references t1 (id) on delete set null);",
+				"create view v1 as select id from t1",
+			},
+			expectDiffs:       2,
+			expectDeps:        2,
+			sequential:        false,
+			fkStrategy:        ForeignKeyCheckStrategyStrict,
+			entityOrder:       []string{"t1", "t2"},
+			instantCapability: InstantDDLCapabilityImpossible,
+		},
+		{
 			name: "add FK, unrelated alter",
 			toQueries: []string{
 				"create table t1 (id int primary key, info int not null, key info_idx(info));",

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -346,55 +346,80 @@ func TestInvalidSchema(t *testing.T) {
 		},
 		{
 			// t12<->t11
-			schema: "create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict)",
+			schema: `
+				create table t11 (id int primary key, i int, constraint f1103 foreign key (i) references t12 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1203 foreign key (i) references t11 (id) on delete restrict)
+			`,
+		},
+		{
+			// t12<->t11
+			schema: `
+				create table t11 (id int primary key, i int, constraint f1101 foreign key (i) references t12 (i) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1201 foreign key (i) references t11 (i) on delete set null)
+			`,
 			expectErr: errors.Join(
 				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t12", "t11", "t12"}},
 			),
 			expectLoopTables: 2,
 		},
 		{
 			// t10, t12<->t11
-			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict)",
-			expectErr: errors.Join(
-				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
-			),
-			expectLoopTables: 2,
+			schema: `
+				create table t10(id int primary key);
+				create table t11 (id int primary key, i int, constraint f1102 foreign key (i) references t12 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1202 foreign key (i) references t11 (id) on delete restrict)
+			`,
 		},
 		{
 			// t10, t12<->t11<-t13
-			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict); create table t13 (id int primary key, i int, constraint f13 foreign key (i) references t11 (id) on delete restrict)",
-			expectErr: errors.Join(
-				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t13", Loop: []string{"t11", "t12", "t11"}},
-			),
-			expectLoopTables: 3,
+			schema: `
+				create table t10(id int primary key);
+				create table t11 (id int primary key, i int, constraint f1104 foreign key (i) references t12 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1204 foreign key (i) references t11 (id) on delete restrict);
+				create table t13 (id int primary key, i int, constraint f13 foreign key (i) references t11 (id) on delete restrict)`,
 		},
 		{
 			//      t10
 			//       ^
 			//       |
 			//t12<->t11<-t13
-			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, i10 int, constraint f11 foreign key (i) references t12 (id) on delete restrict, constraint f1110 foreign key (i10) references t10 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict); create table t13 (id int primary key, i int, constraint f13 foreign key (i) references t11 (id) on delete restrict)",
+			schema: `
+				create table t10(id int primary key);
+				create table t11 (id int primary key, i int, i10 int, constraint f111205 foreign key (i) references t12 (id) on delete restrict, constraint f111005 foreign key (i10) references t10 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1205 foreign key (id) references t11 (i) on delete restrict);
+				create table t13 (id int primary key, i int, constraint f1305 foreign key (i) references t11 (id) on delete restrict)
+			`,
 			expectErr: errors.Join(
 				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t13", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t12", "t11", "t12"}},
 			),
-			expectLoopTables: 3,
+			expectLoopTables: 2,
 		},
 		{
 			// t10, t12<->t11<-t13<-t14
-			schema: "create table t10(id int primary key); create table t11 (id int primary key, i int, i10 int, constraint f11 foreign key (i) references t12 (id) on delete restrict, constraint f1110 foreign key (i10) references t10 (id) on delete restrict); create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id) on delete restrict); create table t13 (id int primary key, i int, constraint f13 foreign key (i) references t11 (id) on delete restrict); create table t14 (id int primary key, i int, constraint f14 foreign key (i) references t13 (id) on delete restrict)",
+			schema: `
+				create table t10(id int primary key);
+				create table t11 (id int primary key, i int, i10 int, constraint f1106 foreign key (i) references t12 (id) on delete restrict, constraint f111006 foreign key (i10) references t10 (id) on delete restrict);
+				create table t12 (id int primary key, i int, constraint f1206 foreign key (i) references t11 (id) on delete restrict);
+				create table t13 (id int primary key, i int, constraint f1306 foreign key (i) references t11 (id) on delete restrict);
+				create table t14 (id int primary key, i int, constraint f1406 foreign key (i) references t13 (id) on delete restrict)
+			`,
+		},
+		{
+			// t10, t12<-t11<-t13<-t12
+			schema: `
+				create table t10(id int primary key);
+				create table t11 (id int primary key, i int, key i_idx (i), i10 int, constraint f1107 foreign key (i) references t12 (id), constraint f111007 foreign key (i10) references t10 (id));
+				create table t12 (id int primary key, i int, key i_idx (i), constraint f1207 foreign key (id) references t13 (i));
+				create table t13 (id int primary key, i int, key i_idx (i), constraint f1307 foreign key (i) references t11 (i));
+			`,
 			expectErr: errors.Join(
-				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t13", Loop: []string{"t11", "t12", "t11"}},
-				&ForeignKeyLoopError{Table: "t14", Loop: []string{"t11", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t13", "t12", "t11"}},
+				&ForeignKeyLoopError{Table: "t12", Loop: []string{"t12", "t11", "t13", "t12"}},
+				&ForeignKeyLoopError{Table: "t13", Loop: []string{"t13", "t12", "t11", "t13"}},
 			),
-			expectLoopTables: 4,
+			expectLoopTables: 3,
 		},
 		{
 			schema:    "create table t11 (id int primary key, i int, key ix(i), constraint f11 foreign key (i) references t11(id2) on delete restrict)",
@@ -492,7 +517,7 @@ func TestInvalidTableForeignKeyReference(t *testing.T) {
 		// Even though there's errors, we still expect the schema to have been created.
 		assert.NotNil(t, s)
 		// Even though t11 caused an error, we still expect the schema to have parsed all tables.
-		assert.Equal(t, 3, len(s.Entities()))
+		assert.Equalf(t, 3, len(s.Entities()), "found: %+v", s.EntityNames())
 		t11 := s.Table("t11")
 		assert.NotNil(t, t11)
 		// validate t11 table definition is complete, even though it was invalid.
@@ -506,10 +531,19 @@ func TestInvalidTableForeignKeyReference(t *testing.T) {
 			"create table t12 (id int primary key, i int, constraint f13 foreign key (i) references t13(id) on delete restrict)",
 		}
 		_, err := NewSchemaFromQueries(NewTestEnv(), fkQueries)
+		assert.NoError(t, err)
+	}
+	{
+		fkQueries := []string{
+			"create table t13 (id int primary key, i int, constraint f11 foreign key (i) references t11(i) on delete restrict)",
+			"create table t11 (id int primary key, i int, constraint f12 foreign key (i) references t12(i) on delete restrict)",
+			"create table t12 (id int primary key, i int, constraint f13 foreign key (i) references t13(i) on delete restrict)",
+		}
+		_, err := NewSchemaFromQueries(NewTestEnv(), fkQueries)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t12", "t13", "t11"}}).Error())
-		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t12", Loop: []string{"t11", "t12", "t13", "t11"}}).Error())
-		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t13", Loop: []string{"t11", "t12", "t13", "t11"}}).Error())
+		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t11", Loop: []string{"t11", "t13", "t12", "t11"}}).Error())
+		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t12", Loop: []string{"t12", "t11", "t13", "t12"}}).Error())
+		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t13", Loop: []string{"t13", "t12", "t11", "t13"}}).Error())
 	}
 	{
 		fkQueries := []string{
@@ -520,8 +554,6 @@ func TestInvalidTableForeignKeyReference(t *testing.T) {
 		_, err := NewSchemaFromQueries(NewTestEnv(), fkQueries)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, (&ForeignKeyNonexistentReferencedTableError{Table: "t11", ReferencedTable: "t0"}).Error())
-		assert.ErrorContains(t, err, (&ForeignKeyDependencyUnresolvedError{Table: "t12"}).Error())
-		assert.ErrorContains(t, err, (&ForeignKeyDependencyUnresolvedError{Table: "t13"}).Error())
 	}
 	{
 		fkQueries := []string{
@@ -532,8 +564,6 @@ func TestInvalidTableForeignKeyReference(t *testing.T) {
 		_, err := NewSchemaFromQueries(NewTestEnv(), fkQueries)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, (&ForeignKeyNonexistentReferencedTableError{Table: "t11", ReferencedTable: "t0"}).Error())
-		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t12", Loop: []string{"t12", "t13", "t12"}}).Error())
-		assert.ErrorContains(t, err, (&ForeignKeyLoopError{Table: "t13", Loop: []string{"t12", "t13", "t12"}}).Error())
 	}
 }
 
@@ -943,7 +973,7 @@ func TestMassiveSchema(t *testing.T) {
 	})
 
 	t.Run("evaluating diff", func(t *testing.T) {
-		schemaDiff, err := schema0.SchemaDiff(schema1, &DiffHints{})
+		schemaDiff, err := schema0.SchemaDiff(schema1, EmptyDiffHints())
 		require.NoError(t, err)
 		diffs := schemaDiff.UnorderedDiffs()
 		require.NotEmpty(t, diffs)

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -124,6 +124,11 @@ const (
 	EnumReorderStrategyReject
 )
 
+const (
+	ForeignKeyCheckStrategyStrict int = iota
+	ForeignKeyCheckStrategyIgnore
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering         bool
@@ -137,6 +142,11 @@ type DiffHints struct {
 	TableQualifierHint          int
 	AlterTableAlgorithmStrategy int
 	EnumReorderStrategy         int
+	ForeignKeyCheckStrategy     int
+}
+
+func EmptyDiffHints() *DiffHints {
+	return &DiffHints{}
 }
 
 const (

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package schemadiff
 
 import (
+	"strings"
+
+	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -154,3 +157,21 @@ const (
 	ApplyDiffsInOrder      = "ApplyDiffsInOrder"
 	ApplyDiffsSequential   = "ApplyDiffsSequential"
 )
+
+type ForeignKeyTableColumns struct {
+	Table   string
+	Columns []string
+}
+
+func (f ForeignKeyTableColumns) Escaped() string {
+	var b strings.Builder
+	b.WriteString(sqlescape.EscapeID(f.Table))
+	b.WriteString(" (")
+	escapedColumns := make([]string, len(f.Columns))
+	for i, column := range f.Columns {
+		escapedColumns[i] = sqlescape.EscapeID(column)
+	}
+	b.WriteString(strings.Join(escapedColumns, ", "))
+	b.WriteString(")")
+	return b.String()
+}

--- a/go/vt/schemadiff/view_test.go
+++ b/go/vt/schemadiff/view_test.go
@@ -145,7 +145,7 @@ func TestCreateViewDiff(t *testing.T) {
 			cdiff: "ALTER ALGORITHM = TEMPTABLE VIEW `v1` AS SELECT `a` FROM `t`",
 		},
 	}
-	hints := &DiffHints{}
+	hints := EmptyDiffHints()
 	env := NewTestEnv()
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Addressing https://github.com/vitessio/vitess/issues/15430, in this PR `schemadiff` uses the same algorithm as Query-Serving to distinguish between valid and invalid foreign key cycles. `schemadiff` now allows table cycles as long as there's no column-reference cycle.

There's a few implications to this solution. Consider this valid foreign key cycle:

```sql
create table t11 (id int primary key, i int, constraint f11 foreign key (i) references t12 (id));
create table t12 (id int primary key, i int, constraint f12 foreign key (i) references t11 (id));
```

- There is technically no valid ordering to creating these two tables. In MySQL, this could only be achieved by setting `FOREIGN_KEY_CHECKS=0`. However, `schemadiff` is declarative. We introduce `DiffHints.ForeignKeyCheckStrategy` which can be:
  - `ForeignKeyCheckStrategyStrict` (default value), makes `Diff()`, `OrderedDiffs()` etc. behave as if `FOREIGN_KEY_CHECKS=1`
  - `ForeignKeyCheckStrategyIgnore`, assume behavior of `FOREIGN_KEY_CHECKS=0`.
  This means `OrderedDiffs()` can generate an invalid schema whilst applying changes. We add one final validation to ensure that the grand total result is valid.
- The ordering of tables in a `Schema` object is normally by:
  - tables, foreign key dependency order (parents first, children tables)
  - tables, lexicographically
  - views, dependency order
  - views, lexicographically
  
  (See related discussion in https://github.com/vitessio/vitess/pull/15252#discussion_r1491310048).
  However, with cyclic foreign key references the ordering of tables that either participate in a loop, or reference a loop, is undefined. It will always be higher than the order of tables that do not participate in a loop, but no deterministic ordering in between loop-related tables.
- It is up to the consumer of `schemadiff` to actually `SET FOREIGN_KEY_CHECKS=0` in MySQL. `schemadiff` does not generate such SQL statement.



## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15430
- Prior work: https://github.com/vitessio/vitess/pull/15062

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
