### PR TITLE
Fix view tracking on sharded keyspace

### DIFF
--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -280,17 +280,23 @@ func WaitForKsError(t *testing.T, vtgateProcess cluster.VtgateProcess, ks string
 		var ok bool
 		errString, ok = ksErr.(string)
 		return ok
-	})
+	}, "Waiting for error")
 	return errString
 }
 
 // WaitForVschemaCondition waits for the condition to be true
-func WaitForVschemaCondition(t *testing.T, vtgateProcess cluster.VtgateProcess, ks string, conditionMet func(t *testing.T, keyspace map[string]interface{}) bool) {
+func WaitForVschemaCondition(
+	t *testing.T,
+	vtgateProcess cluster.VtgateProcess,
+	ks string,
+	conditionMet func(t *testing.T, keyspace map[string]interface{}) bool,
+	message string,
+) {
 	timeout := time.After(60 * time.Second)
 	for {
 		select {
 		case <-timeout:
-			t.Fatalf("schema tracking did not met the condition within the time for keyspace: %s", ks)
+			t.Fatalf("schema tracking did not met the condition within the time for keyspace: %s\n%s", ks, message)
 		default:
 			res, err := vtgateProcess.ReadVSchema()
 			require.NoError(t, err, res)
@@ -305,12 +311,12 @@ func WaitForVschemaCondition(t *testing.T, vtgateProcess cluster.VtgateProcess, 
 }
 
 // WaitForTableDeletions waits for a table to be deleted
-func WaitForTableDeletions(ctx context.Context, t *testing.T, vtgateProcess cluster.VtgateProcess, ks, tbl string) {
+func WaitForTableDeletions(t *testing.T, vtgateProcess cluster.VtgateProcess, ks, tbl string) {
 	WaitForVschemaCondition(t, vtgateProcess, ks, func(t *testing.T, keyspace map[string]interface{}) bool {
 		tablesMap := keyspace["tables"]
 		_, isPresent := convertToMap(tablesMap)[tbl]
 		return !isPresent
-	})
+	}, "Waiting for table to be deleted")
 }
 
 // WaitForColumn waits for a table's column to be present

--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -1175,12 +1175,11 @@ func TestCyclicFks(t *testing.T) {
 	// Drop the cyclic foreign key constraint.
 	utils.Exec(t, mcmp.VtConn, "alter table fk_t10 drop foreign key test_cyclic_fks")
 
-	// Wait for schema-tracking to be complete.
-	utils.WaitForVschemaCondition(t, clusterInstance.VtgateProcess, unshardedKs, func(t *testing.T, keyspace map[string]interface{}) bool {
+	// Let's clean out the cycle so that the other tests don't fail
+	utils.WaitForVschemaCondition(t, clusterInstance.VtgateProcess, unshardedKs, func(t *testing.T, keyspace map[string]any) bool {
 		_, fieldPresent := keyspace["error"]
 		return !fieldPresent
-	})
-
+	}, "wait for error to disappear")
 }
 
 func TestReplace(t *testing.T) {

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -786,10 +786,10 @@ func createInitialSchema(t *testing.T, tcase *testCase) {
 		}
 	})
 	t.Run("waiting for vschema deletions to apply", func(t *testing.T) {
-		timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		_, cancel := context.WithTimeout(ctx, 1*time.Minute)
 		defer cancel()
 		for _, tableName := range tableNames {
-			utils.WaitForTableDeletions(timeoutCtx, t, clusterInstance.VtgateProcess, keyspaceName, tableName)
+			utils.WaitForTableDeletions(t, clusterInstance.VtgateProcess, keyspaceName, tableName)
 		}
 	})
 	t.Run("creating tables", func(t *testing.T) {

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -786,8 +786,6 @@ func createInitialSchema(t *testing.T, tcase *testCase) {
 		}
 	})
 	t.Run("waiting for vschema deletions to apply", func(t *testing.T) {
-		_, cancel := context.WithTimeout(ctx, 1*time.Minute)
-		defer cancel()
 		for _, tableName := range tableNames {
 			utils.WaitForTableDeletions(t, clusterInstance.VtgateProcess, keyspaceName, tableName)
 		}

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -321,19 +321,6 @@ func TestCreateIndex(t *testing.T) {
 	utils.Exec(t, conn, `create index i2 on ks.t1000 (id1)`)
 }
 
-func TestCreateView(t *testing.T) {
-	// The test wont work since we cant change the vschema without reloading the vtgate.
-	t.Skip()
-	conn, closer := start(t)
-	defer closer()
-	// Test that create view works and the output is as expected
-	utils.Exec(t, conn, `create view v1 as select * from t1`)
-	utils.Exec(t, conn, `insert into t1(id1, id2) values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)`)
-	// This wont work, since ALTER VSCHEMA ADD TABLE is only supported for unsharded keyspaces
-	utils.Exec(t, conn, "alter vschema add table v1")
-	utils.AssertMatches(t, conn, "select * from v1", `[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)] [INT64(5) INT64(5)]]`)
-}
-
 func TestVersions(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/queries/misc/main_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/main_test.go
@@ -73,6 +73,9 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable-views")
+		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-enable-views")
+
 		// Start keyspace
 		keyspace := &cluster.Keyspace{
 			Name:      keyspaceName,

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -374,6 +374,7 @@ func TestAliasesInOuterJoinQueries(t *testing.T) {
 }
 
 func TestAlterTableWithView(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -395,7 +395,7 @@ func TestAlterTableWithView(t *testing.T) {
 	mcmp.Exec(`insert into t1(id1, id2) values (1, 1)`)
 	mcmp.AssertMatches("select * from v1", `[[INT64(1) INT64(1)]]`)
 
-	// alter table
+	// alter table add column
 	mcmp.Exec(`alter table t1 add column test bigint`)
 	mcmp.Exec(`alter view v1 as select * from t1`)
 

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -192,15 +192,48 @@ func findTableDestinationAndKeyspace(vschema plancontext.VSchema, ddlStatement s
 	return destination, keyspace, nil
 }
 
-func buildAlterView(ctx context.Context, vschema plancontext.VSchema, ddl *sqlparser.AlterView, reservedVars *sqlparser.ReservedVars, enableOnlineDDL, enableDirectDDL bool) (key.Destination, *vindexes.Keyspace, error) {
-	// For Alter View, we require that the view exist and the select query can be satisfied within the keyspace itself
+func buildAlterView(
+	ctx context.Context,
+	vschema plancontext.VSchema,
+	ddl *sqlparser.AlterView,
+	reservedVars *sqlparser.ReservedVars,
+	enableOnlineDDL, enableDirectDDL bool,
+) (key.Destination, *vindexes.Keyspace, error) {
+	return buildCreateViewCommon(ctx, vschema, reservedVars, enableOnlineDDL, enableDirectDDL, ddl.Select, ddl)
+}
+
+func buildCreateView(
+	ctx context.Context,
+	vschema plancontext.VSchema,
+	ddl *sqlparser.CreateView,
+	reservedVars *sqlparser.ReservedVars,
+	enableOnlineDDL, enableDirectDDL bool,
+) (key.Destination, *vindexes.Keyspace, error) {
+	return buildCreateViewCommon(ctx, vschema, reservedVars, enableOnlineDDL, enableDirectDDL, ddl.Select, ddl)
+}
+
+func buildCreateViewCommon(
+	ctx context.Context,
+	vschema plancontext.VSchema,
+	reservedVars *sqlparser.ReservedVars,
+	enableOnlineDDL, enableDirectDDL bool,
+	ddlSelect sqlparser.SelectStatement,
+	ddl sqlparser.DDLStatement,
+) (key.Destination, *vindexes.Keyspace, error) {
+	// For Create View, we require that the keyspace exist and the select query can be satisfied within the keyspace itself
 	// We should remove the keyspace name from the table name, as the database name in MySQL might be different than the keyspace name
 	destination, keyspace, err := findTableDestinationAndKeyspace(vschema, ddl)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddl.Select), ddl.Select, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)
+	// because we don't trust the schema tracker to have up-to-date info, we don't want to expand any SELECT * here
+	var expressions []sqlparser.SelectExprs
+	_ = sqlparser.VisitAllSelects(ddlSelect, func(p *sqlparser.Select, idx int) error {
+		expressions = append(expressions, sqlparser.CloneSelectExprs(p.SelectExprs))
+		return nil
+	})
+	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddlSelect), ddlSelect, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -208,6 +241,14 @@ func buildAlterView(ctx context.Context, vschema plancontext.VSchema, ddl *sqlpa
 	if keyspace.Name != selPlanKs {
 		return nil, nil, vterrors.VT12001(ViewDifferentKeyspace)
 	}
+
+	_ = sqlparser.VisitAllSelects(ddlSelect, func(p *sqlparser.Select, idx int) error {
+		p.SelectExprs = expressions[idx]
+		return nil
+	})
+
+	sqlparser.RemoveKeyspace(ddl)
+
 	if vschema.IsViewsEnabled() {
 		if keyspace == nil {
 			return nil, nil, vterrors.VT09005()
@@ -221,57 +262,6 @@ func buildAlterView(ctx context.Context, vschema plancontext.VSchema, ddl *sqlpa
 	if opCode != engine.Unsharded && opCode != engine.EqualUnique && opCode != engine.Scatter {
 		return nil, nil, vterrors.VT12001(ViewComplex)
 	}
-	_ = sqlparser.SafeRewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
-		switch tableName := cursor.Node().(type) {
-		case sqlparser.TableName:
-			cursor.Replace(sqlparser.TableName{
-				Name: tableName.Name,
-			})
-		}
-		return true
-	})
-	return destination, keyspace, nil
-}
-
-func buildCreateView(ctx context.Context, vschema plancontext.VSchema, ddl *sqlparser.CreateView, reservedVars *sqlparser.ReservedVars, enableOnlineDDL, enableDirectDDL bool) (key.Destination, *vindexes.Keyspace, error) {
-	// For Create View, we require that the keyspace exist and the select query can be satisfied within the keyspace itself
-	// We should remove the keyspace name from the table name, as the database name in MySQL might be different than the keyspace name
-	destination, keyspace, _, err := vschema.TargetDestination(ddl.ViewName.Qualifier.String())
-	if err != nil {
-		return nil, nil, err
-	}
-	ddl.ViewName.Qualifier = sqlparser.NewIdentifierCS("")
-
-	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddl.Select), ddl.Select, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)
-	if err != nil {
-		return nil, nil, err
-	}
-	selPlanKs := selectPlan.primitive.GetKeyspaceName()
-	if keyspace.Name != selPlanKs {
-		return nil, nil, vterrors.VT12001(ViewDifferentKeyspace)
-	}
-	if vschema.IsViewsEnabled() {
-		if keyspace == nil {
-			return nil, nil, vterrors.VT09005()
-		}
-		return destination, keyspace, nil
-	}
-	isRoutePlan, opCode := tryToGetRoutePlan(selectPlan.primitive)
-	if !isRoutePlan {
-		return nil, nil, vterrors.VT12001(ViewComplex)
-	}
-	if opCode != engine.Unsharded && opCode != engine.EqualUnique && opCode != engine.Scatter {
-		return nil, nil, vterrors.VT12001(ViewComplex)
-	}
-	_ = sqlparser.SafeRewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
-		switch tableName := cursor.Node().(type) {
-		case sqlparser.TableName:
-			cursor.Replace(sqlparser.TableName{
-				Name: tableName.Name,
-			})
-		}
-		return true
-	})
 	return destination, keyspace, nil
 }
 

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -112,9 +112,9 @@ func buildDDLPlans(ctx context.Context, sql string, ddlStatement sqlparser.DDLSt
 		}
 		err = checkFKError(vschema, ddlStatement, keyspace)
 	case *sqlparser.CreateView:
-		destination, keyspace, err = buildCreateView(ctx, vschema, ddl, reservedVars, enableOnlineDDL, enableDirectDDL)
+		destination, keyspace, err = buildCreateViewCommon(ctx, vschema, reservedVars, enableOnlineDDL, enableDirectDDL, ddl.Select, ddl)
 	case *sqlparser.AlterView:
-		destination, keyspace, err = buildAlterView(ctx, vschema, ddl, reservedVars, enableOnlineDDL, enableDirectDDL)
+		destination, keyspace, err = buildCreateViewCommon(ctx, vschema, reservedVars, enableOnlineDDL, enableDirectDDL, ddl.Select, ddl)
 	case *sqlparser.DropView:
 		destination, keyspace, err = buildDropView(vschema, ddlStatement)
 	case *sqlparser.DropTable:
@@ -190,26 +190,6 @@ func findTableDestinationAndKeyspace(vschema plancontext.VSchema, ddlStatement s
 		ddlStatement.SetTable("", table.Name.String())
 	}
 	return destination, keyspace, nil
-}
-
-func buildAlterView(
-	ctx context.Context,
-	vschema plancontext.VSchema,
-	ddl *sqlparser.AlterView,
-	reservedVars *sqlparser.ReservedVars,
-	enableOnlineDDL, enableDirectDDL bool,
-) (key.Destination, *vindexes.Keyspace, error) {
-	return buildCreateViewCommon(ctx, vschema, reservedVars, enableOnlineDDL, enableDirectDDL, ddl.Select, ddl)
-}
-
-func buildCreateView(
-	ctx context.Context,
-	vschema plancontext.VSchema,
-	ddl *sqlparser.CreateView,
-	reservedVars *sqlparser.ReservedVars,
-	enableOnlineDDL, enableDirectDDL bool,
-) (key.Destination, *vindexes.Keyspace, error) {
-	return buildCreateViewCommon(ctx, vschema, reservedVars, enableOnlineDDL, enableDirectDDL, ddl.Select, ddl)
 }
 
 func buildCreateViewCommon(

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases.json
@@ -374,7 +374,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "create view tmp_view as select user_id, col1, col2 from authoritative"
+        "Query": "create view tmp_view as select * from authoritative"
       },
       "TablesUsed": [
         "user.tmp_view"

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases_no_default_keyspace.json
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases_no_default_keyspace.json
@@ -125,7 +125,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "create view view_a as select user_id, col1, col2 from authoritative"
+        "Query": "create view view_a as select * from authoritative"
       },
       "TablesUsed": [
         "user.view_a"
@@ -144,7 +144,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "create view view_a as select a.user_id, a.col1, a.col2, b.user_id, b.col1, b.col2 from authoritative as a join authoritative as b on a.user_id = b.user_id"
+        "Query": "create view view_a as select * from authoritative as a join authoritative as b on a.user_id = b.user_id"
       },
       "TablesUsed": [
         "user.view_a"
@@ -163,7 +163,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "create view view_a as select user_id, col1, col2 from authoritative as a"
+        "Query": "create view view_a as select a.* from authoritative as a"
       },
       "TablesUsed": [
         "user.view_a"
@@ -201,7 +201,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "create view view_a as select `user`.id, a.user_id, a.col1, a.col2, `user`.col1 from authoritative as a join `user` on a.user_id = `user`.id"
+        "Query": "create view view_a as select `user`.id, a.*, `user`.col1 from authoritative as a join `user` on a.user_id = `user`.id"
       },
       "TablesUsed": [
         "user.view_a"

--- a/go/vt/vtgate/planbuilder/testdata/view_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/view_cases.json
@@ -11,7 +11,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "alter view user_extra as select * from `user`.`user`"
+        "Query": "alter view user_extra as select * from `user`"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -35,7 +35,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "create view view_ac as select user_id, col1, col2 from authoritative"
+        "Query": "create view view_ac as select * from authoritative"
       },
       "TablesUsed": [
         "user.view_ac"

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3069,6 +3069,7 @@ func (e *Executor) executeAlterViewOnline(ctx context.Context, onlineDDL *schema
 		// it actually easier for us to issue a CREATE OR REPLACE, because it
 		// actually creates a view...
 		stmt = &sqlparser.CreateView{
+
 			Algorithm:   viewStmt.Algorithm,
 			Definer:     viewStmt.Definer,
 			Security:    viewStmt.Security,

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3069,7 +3069,6 @@ func (e *Executor) executeAlterViewOnline(ctx context.Context, onlineDDL *schema
 		// it actually easier for us to issue a CREATE OR REPLACE, because it
 		// actually creates a view...
 		stmt = &sqlparser.CreateView{
-
 			Algorithm:   viewStmt.Algorithm,
 			Definer:     viewStmt.Definer,
 			Security:    viewStmt.Security,


### PR DESCRIPTION
## Description
When `vtgate` receives `SELECT *` queries and possesses authoritative column information for the tables in the query, it expands `*` into the actual column list, simplifying subsequent planning.

This column information is sourced from the schema tracker, which experiences a slight delay in reflecting schema changes in `vtgate`. Previously, following an `ALTER TABLE` that modified the column list, an immediate `ALTER VIEW` incorporating a `SELECT *` led `vtgate` to expand the columns using outdated information from the schema tracker, causing the resultant view to misrepresent the updated schema.

The remedy involves refraining from expanding columns in `CREATE/ALTER VIEW` statements, allowing MySQL to handle column expansion. The schema tracker then forwards the view definition to `vtgate`, ensuring consistency.

However, a temporal lag may persist; if a view is queried immediately post-alteration, it might display the previous definition until `vtgate` receives the updated information. Unlike before, where the view would permanently display an incorrect definition, this issue is now transient.

## Related Issue(s)
Fixes #15456

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
