### PR TITLE
Fix: transition to `math/rand/v2` for Improved Performance and Code Clarity

### DIFF
--- a/go/hack/runtime.go
+++ b/go/hack/runtime.go
@@ -46,6 +46,3 @@ func Atof64(s string) (float64, int, error)
 
 //go:linkname Atof32 strconv.atof32
 func Atof32(s string) (float32, int, error)
-
-//go:linkname FastRand runtime.fastrand
-func FastRand() uint32

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -18,12 +18,12 @@ package smartconnpool
 
 import (
 	"context"
+	"math/rand/v2"
 	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/vt/log"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
@@ -373,8 +373,7 @@ func (pool *ConnPool[D]) extendedMaxLifetime() time.Duration {
 	if maxLifetime == 0 {
 		return 0
 	}
-	extended := hack.FastRand() % uint32(maxLifetime)
-	return time.Duration(maxLifetime) + time.Duration(extended)
+	return time.Duration(maxLifetime) + time.Duration(rand.Uint32N(uint32(maxLifetime)))
 }
 
 func (pool *ConnPool[C]) connReopen(ctx context.Context, dbconn *Pooled[C], now time.Time) error {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This Pull Request removes a reference to runtime.fastrand in `go/hack/runtime.go` and replaces a call to `hack.FastRand()` with `math/rand/v2.Uint32N` in `go/pools/smartconnpool/pool.go`. These change aim to enhance code readability, performance, and reduce dependency on specific runtime implementations.

`math/rand/v2` employs [Lemire](https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/)'s algorithm in functions such as N, IntN, UintN, and others. Preliminary benchmark tests show a 40% improvement compared to `Int31n` in `v1` and a 75% improvement compared to `Int63n` in `v1`.

Furthermore, `math/rand/v2` default utilizes ChaCha8 for the global random number generator in each OS thread.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
