### PR TITLE
Incremental restore: copy files under Vitess dataroot dir

### DIFF
--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -41,6 +41,7 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/vt/concurrency"
+	vtenv "vitess.io/vitess/go/vt/env"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	stats "vitess.io/vitess/go/vt/mysqlctl/backupstats"
@@ -942,6 +943,7 @@ func (be *BuiltinBackupEngine) executeRestoreIncrementalBackup(ctx context.Conte
 		if err != nil {
 			return vterrors.Wrap(err, "failed to restore file")
 		}
+
 		req := &mysqlctlpb.ApplyBinlogFileRequest{
 			BinlogFileName:        binlogFile,
 			BinlogRestoreDatetime: protoutil.TimeToProto(params.RestoreToTimestamp),
@@ -1006,7 +1008,7 @@ func (be *BuiltinBackupEngine) restoreFiles(ctx context.Context, params RestoreP
 	}
 
 	if bm.Incremental {
-		createdDir, err = os.MkdirTemp("", "restore-incremental-*")
+		createdDir, err = os.MkdirTemp(vtenv.VtDataRoot(), "restore-incremental-*")
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION

## Description

During an incremental restore process, the built-in engine copies backup files onto a temporary directory. Right now this temporary directory is rooted at the default OS temp dir (i.e. `/tmp` on Linux).

In `k8s` deployments, this directory is not shared among pods. This means that the files written by the build in engine on one pod, are not visible to `mysqlctl` on the `mysqld` pod, where `mysqlbinlog` binary expects to find and apply them.

This PR roots the temporary directory under the Vitess data root.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/14765

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
