### PR TITLE
CI: Disable CodeCov GitHub Changed Files Annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -39,6 +39,9 @@ ignore:
   # Ignore proto files
   - "go/vt/proto/**"
 
+github_checks:
+    annotations: false
+
 comment: # https://docs.codecov.com/docs/pull-request-comments
     hide_project_coverage: false
 


### PR DESCRIPTION
## Description

The uncovered lines annotations added to the GitHub PR's `Files changed` view has proven to be a distraction which makes reviews more difficult.

This same general information — seeing what lines are NOT covered by unit tests — is available in two alternative locations:
  - The GitHub Actions: https://docs.codecov.com/docs/github-checks#annotations-in-the-checks-tab
  - The CodeCov UI when viewing the PR details using the link added to the CodeCov comment, e.g. https://app.codecov.io/gh/vitessio/vitess/pull/15440

Given both of these points, let's disable the GitHub annotations for now. We can always add them back in the future if we decide it's worth it.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required