### PR TITLE
Handle panics during parallel execution

### DIFF
--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -661,7 +661,7 @@ func (stc *ScatterConn) multiGoTransaction(
 		}
 	} else {
 		var wg sync.WaitGroup
-		panicChan := make(chan interface{}, 1) // buffer 1 to avoid blocking
+		panicChan := make(chan any, 1) // buffer 1 to avoid blocking
 
 		for i, rs := range rss {
 			wg.Add(1)

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -166,6 +166,11 @@ func TestExecutePanic(t *testing.T) {
 		Autocommit: false,
 	}
 
+	original := log.Errorf
+	defer func() {
+		log.Errorf = original
+	}()
+
 	var logMessage string
 	log.Errorf = func(format string, args ...any) {
 		logMessage = fmt.Sprintf(format, args...)

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -105,6 +105,74 @@ func TestExecuteFailOnAutocommit(t *testing.T) {
 	utils.MustMatch(t, []*querypb.BoundQuery{queries[1]}, sbc1.Queries, "")
 }
 
+func TestExecutePanic(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+
+	createSandbox("TestExecutePanic")
+	hc := discovery.NewFakeHealthCheck(nil)
+	sc := newTestScatterConn(ctx, hc, newSandboxForCells(ctx, []string{"aa"}), "aa")
+	sbc0 := hc.AddTestTablet("aa", "0", 1, "TestExecutePanic", "0", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc1 := hc.AddTestTablet("aa", "1", 1, "TestExecutePanic", "1", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc0.SetPanic(42)
+	sbc1.SetPanic(42)
+	rss := []*srvtopo.ResolvedShard{
+		{
+			Target: &querypb.Target{
+				Keyspace:   "TestExecutePanic",
+				Shard:      "0",
+				TabletType: topodatapb.TabletType_PRIMARY,
+			},
+			Gateway: sbc0,
+		},
+		{
+			Target: &querypb.Target{
+				Keyspace:   "TestExecutePanic",
+				Shard:      "1",
+				TabletType: topodatapb.TabletType_PRIMARY,
+			},
+			Gateway: sbc1,
+		},
+	}
+	queries := []*querypb.BoundQuery{
+		{
+			// This will fail to go to shard. It will be rejected at vtgate.
+			Sql: "query1",
+			BindVariables: map[string]*querypb.BindVariable{
+				"bv0": sqltypes.Int64BindVariable(0),
+			},
+		},
+		{
+			// This will go to shard.
+			Sql: "query2",
+			BindVariables: map[string]*querypb.BindVariable{
+				"bv1": sqltypes.Int64BindVariable(1),
+			},
+		},
+	}
+	// shard 0 - has transaction
+	// shard 1 - does not have transaction.
+	session := &vtgatepb.Session{
+		InTransaction: true,
+		ShardSessions: []*vtgatepb.Session_ShardSession{
+			{
+				Target:        &querypb.Target{Keyspace: "TestExecutePanic", Shard: "0", TabletType: topodatapb.TabletType_PRIMARY, Cell: "aa"},
+				TransactionId: 123,
+				TabletAlias:   nil,
+			},
+		},
+		Autocommit: false,
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+
+	_, _ = sc.ExecuteMultiShard(ctx, nil, rss, queries, NewSafeSession(session), true /*autocommit*/, false)
+
+}
+
 func TestReservedOnMultiReplica(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
 


### PR DESCRIPTION
## Description
If something goes horribly wrong during query execution, vtgate will close the connection to the user, but stay up and serving requests. Except if the panic happens during parallel execution - in these cases, vtgate would just crash and the process dies.

This PR changes this so that we catch the panics during the parallel execution, and rethrows them in the main thread, so that we handle all panics the same way.

## Related Issue(s)
This is related to #15434, but does not fix it.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required