### PR TITLE
engine:  fix race in concatenate

### DIFF
--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
-
 	"vitess.io/vitess/go/test/endtoend/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -111,9 +110,15 @@ func TestUnionAll(t *testing.T) {
 			mcmp.AssertMatchesNoOrder("select tbl2.id1 FROM  ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1",
 				"[[INT64(1)] [INT64(2)] [INT64(2)] [INT64(1)]]")
 
-			// union all between two select unique in tables
-			mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
-				"[[INT64(1)] [INT64(2)] [INT64(1)] [INT64(2)]]")
+			// this test is quite good at uncovering races in the Concatenate engine primitive. make it run many times
+			// see: https://github.com/vitessio/vitess/issues/15434
+			if utils.BinaryIsAtLeastAtVersion(20, "vtgate") {
+				for i := 0; i < 100; i++ {
+					// union all between two select unique in tables
+					mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
+						"[[INT64(1)] [INT64(2)] [INT64(1)] [INT64(2)]]")
+				}
+			}
 
 			// 4 tables union all
 			mcmp.AssertMatchesNoOrder("select id1, id2 from t1 where id1 = 1 union all select id3,id4 from t2 where id3 = 3 union all select id1, id2 from t1 where id1 = 2 union all select id3,id4 from t2 where id3 = 4",


### PR DESCRIPTION
## Description

Race in concatenate spotted by @GuptaManan100. 

```
W0308 15:06:30.305024   15472 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/Users/manangupta/vitess/go/test/endtoend/vtgate/queries/union]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
panic: runtime error: index out of range [0] with length 0

goroutine 396 [running]:
vitess.io/vitess/go/vt/vtgate/engine.(*Concatenate).parallelStreamExec.func1(0x14000f29110, 0x30?)
	vitess.io/vitess/go/vt/vtgate/engine/concatenate.go:266 +0x2a8
vitess.io/vitess/go/vt/vtgate/engine.(*Concatenate).parallelStreamExec.func2.1(0x14000f29110)
	vitess.io/vitess/go/vt/vtgate/engine/concatenate.go:323 +0x18c
vitess.io/vitess/go/vt/vtgate/engine.(*Route).streamExecuteShards.func1(0x0?)
	vitess.io/vitess/go/vt/vtgate/engine/route.go:307 +0x150
vitess.io/vitess/go/vt/vttablet/queryservice.(*wrappedService).StreamExecute.func1.1(0x14000b20ec8?)
	vitess.io/vitess/go/vt/vttablet/queryservice/wrapped.go:198 +0x34
vitess.io/vitess/go/vt/vttablet/grpctabletconn.(*gRPCQueryClient).StreamExecute(0x14000271d00, {0x10639f388?, 0x14000f8b540?}, 0x14000ce13e0, {0x14000055a00, 0x28}, 0x14000ce3ad0, 0x0, 0x0, 0x14000d2f5f0, ...)
	vitess.io/vitess/go/vt/vttablet/grpctabletconn/conn.go:190 +0x168
vitess.io/vitess/go/vt/vttablet/queryservice.(*wrappedService).StreamExecute.func1({0x10639f388, 0x14000f8b540}, 0x14000ce13e0, {0x1063bf1d8, 0x14000271d00})
	vitess.io/vitess/go/vt/vttablet/queryservice/wrapped.go:196 +0xfc
vitess.io/vitess/go/vt/vtgate.(*TabletGateway).withRetry(0x140002b6690, {0x10639f388, 0x14000f8b540}, 0x14000ce13e0, {0x14000a04a98?, 0x10506a5c8?}, {0x40?, 0x10628f120?}, 0x0, 0x14000ce8940)
	vitess.io/vitess/go/vt/vtgate/tabletgateway.go:339 +0x420
vitess.io/vitess/go/vt/vttablet/queryservice.(*wrappedService).StreamExecute(0x1400079afd8, {0x10639f388, 0x14000f8b540}, 0x14000ce13e0, {0x14000055a00, 0x28}, 0x14000ce3ad0, 0x0, 0x0, 0x14000d2f5f0, ...)
	vitess.io/vitess/go/vt/vttablet/queryservice/wrapped.go:194 +0x118
vitess.io/vitess/go/vt/vtgate.(*ScatterConn).StreamExecuteMulti.func1(0x14000cd7f08, 0x1, 0x14000cdb1a0)
	vitess.io/vitess/go/vt/vtgate/scatter_conn.go:408 +0x1ec
vitess.io/vitess/go/vt/vtgate.(*ScatterConn).multiGoTransaction.func1(0x14000cd7f08, 0x1)
	vitess.io/vitess/go/vt/vtgate/scatter_conn.go:640 +0x138
vitess.io/vitess/go/vt/vtgate.(*ScatterConn).multiGoTransaction.func2(0x0?, 0x1400059cea0?)
	vitess.io/vitess/go/vt/vtgate/scatter_conn.go:668 +0x58
created by vitess.io/vitess/go/vt/vtgate.(*ScatterConn).multiGoTransaction in goroutine 451
	vitess.io/vitess/go/vt/vtgate/scatter_conn.go:666 +0x188
```


Upon review, we can see that there are two races in this helper. The first one is not locking the `muFields` mutex early enough: we want to lock as soon as we enter the function because a pause between the first `if` and the lock can cause a race. The second one is more obvious: the `fieldTypes` field needs to be written to with the lock being held.

The fixed code is slightly more linear but I don't think that's gonna be a performance regression, and either way it needs to be linear for correctness.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/15434

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
