### PR TITLE
Optimize with IN Clause for UPDATE/DELETE Statements on Vindexes

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -369,7 +369,7 @@ func TestMultiTargetUpdate(t *testing.T) {
 // TestDMLInUnique for update/delete statement using an IN clause with the Vindexes,
 // the query is correctly split according to the corresponding values in the IN list.
 func TestDMLInUnique(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 18, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -18,13 +18,13 @@ package dml
 
 import (
 	"testing"
+
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
 func TestMultiEqual(t *testing.T) {

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -45,7 +45,7 @@ func (del *Delete) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	ctx, cancelFunc := addQueryTimeout(ctx, vcursor, del.QueryTimeout)
 	defer cancelFunc()
 
-	rss, _, err := del.findRoute(ctx, vcursor, bindVars)
+	rss, bvs, err := del.findRoute(ctx, vcursor, bindVars)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (del *Delete) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	case Unsharded:
 		return del.execUnsharded(ctx, del, vcursor, bindVars, rss)
 	case Equal, IN, Scatter, ByDestination, SubShard, EqualUnique, MultiEqual:
-		return del.execMultiDestination(ctx, del, vcursor, bindVars, rss, del.deleteVindexEntries)
+		return del.execMultiDestination(ctx, del, vcursor, bindVars, rss, del.deleteVindexEntries, bvs)
 	default:
 		// Unreachable.
 		return nil, fmt.Errorf("unsupported opcode: %v", del.Opcode)

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -627,7 +627,7 @@ func TestDeleteInUnique(t *testing.T) {
 					evalengine.NewLiteralInt(2),
 					evalengine.NewLiteralInt(4),
 				}}},
-			Query: "delete t where id in ::vals",
+			Query: "delete t where id in ::__vals",
 		},
 	}
 
@@ -641,6 +641,6 @@ func TestDeleteInUnique(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations sharded [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"4"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(d2fd8867d50d2dfe)`,
-		`ExecuteMultiShard sharded.-20: delete t where id in ::vals {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"4"}} sharded.20-: delete t where id in ::vals {__vals: type:TUPLE values:{type:INT64 value:"2"}} true false`,
+		`ExecuteMultiShard sharded.-20: delete t where id in ::__vals {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"4"}} sharded.20-: delete t where id in ::__vals {__vals: type:TUPLE values:{type:INT64 value:"2"}} true false`,
 	})
 }

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -544,7 +544,7 @@ func TestDeleteInChangedVindexMultiCol(t *testing.T) {
 		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\x01N\xb1\x90ɢ\xfa\x16\x9c" true`,
 		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"7" toc: type:VARBINARY value:"\x02N\xb1\x90ɢ\xfa\x16\x9c" true`,
 		// Finally, the actual delete, which is also sent to -20, same route as the subquery.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals0: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} true true`,
 	})
 }
 

--- a/go/vt/vtgate/engine/dml.go
+++ b/go/vt/vtgate/engine/dml.go
@@ -78,7 +78,8 @@ func (dml *DML) execUnsharded(ctx context.Context, primitive Primitive, vcursor 
 	return execShard(ctx, primitive, vcursor, dml.Query, bindVars, rss[0], true /* rollbackOnError */, !dml.PreventAutoCommit /* canAutocommit */)
 }
 
-func (dml *DML) execMultiDestination(ctx context.Context, primitive Primitive, vcursor VCursor, bindVars map[string]*querypb.BindVariable, rss []*srvtopo.ResolvedShard, dmlSpecialFunc func(context.Context, VCursor, map[string]*querypb.BindVariable, []*srvtopo.ResolvedShard) error, bvs []map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (dml *DML) execMultiDestination(ctx context.Context, primitive Primitive, vcursor VCursor, bindVars map[string]*querypb.BindVariable, rss []*srvtopo.ResolvedShard, dmlSpecialFunc func(context.Context, VCursor,
+	map[string]*querypb.BindVariable, []*srvtopo.ResolvedShard) error, bvs []map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	if len(rss) == 0 {
 		return &sqltypes.Result{}, nil
 	}

--- a/go/vt/vtgate/engine/dml.go
+++ b/go/vt/vtgate/engine/dml.go
@@ -78,7 +78,7 @@ func (dml *DML) execUnsharded(ctx context.Context, primitive Primitive, vcursor 
 	return execShard(ctx, primitive, vcursor, dml.Query, bindVars, rss[0], true /* rollbackOnError */, !dml.PreventAutoCommit /* canAutocommit */)
 }
 
-func (dml *DML) execMultiDestination(ctx context.Context, primitive Primitive, vcursor VCursor, bindVars map[string]*querypb.BindVariable, rss []*srvtopo.ResolvedShard, dmlSpecialFunc func(context.Context, VCursor, map[string]*querypb.BindVariable, []*srvtopo.ResolvedShard) error) (*sqltypes.Result, error) {
+func (dml *DML) execMultiDestination(ctx context.Context, primitive Primitive, vcursor VCursor, bindVars map[string]*querypb.BindVariable, rss []*srvtopo.ResolvedShard, dmlSpecialFunc func(context.Context, VCursor, map[string]*querypb.BindVariable, []*srvtopo.ResolvedShard) error, bvs []map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	if len(rss) == 0 {
 		return &sqltypes.Result{}, nil
 	}
@@ -90,7 +90,7 @@ func (dml *DML) execMultiDestination(ctx context.Context, primitive Primitive, v
 	for i := range rss {
 		queries[i] = &querypb.BoundQuery{
 			Sql:           dml.Query,
-			BindVariables: bindVars,
+			BindVariables: bvs[i],
 		}
 	}
 	return execMultiShard(ctx, primitive, vcursor, rss, queries, dml.MultiShardAutocommit)

--- a/go/vt/vtgate/engine/dml_with_input_test.go
+++ b/go/vt/vtgate/engine/dml_with_input_test.go
@@ -164,7 +164,7 @@ func TestDeleteWithMultiTarget(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"3"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(4eb190c9a2fa169c)`,
-		`ExecuteMultiShard ks.-20: dummy_delete_1 {dml_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} true true`,
+		`ExecuteMultiShard ks.-20: dummy_delete_1 {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"} dml_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} true true`,
 		`ResolveDestinations ks [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"3"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(4eb190c9a2fa169c)`,
 		`ExecuteMultiShard ks.-20: dummy_delete_2 {dml_vals: type:TUPLE values:{type:TUPLE value:"\x89\x02\x03100\x89\x02\x011"} values:{type:TUPLE value:"\x89\x02\x03100\x89\x02\x012"} values:{type:TUPLE value:"\x89\x02\x03200\x89\x02\x013"}} true true`,
 	})
@@ -175,7 +175,7 @@ func TestDeleteWithMultiTarget(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"3"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(4eb190c9a2fa169c)`,
-		`ExecuteMultiShard ks.-20: dummy_delete_1 {dml_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} true true`,
+		`ExecuteMultiShard ks.-20: dummy_delete_1 {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"} dml_vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"3"}} true true`,
 		`ResolveDestinations ks [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"3"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(4eb190c9a2fa169c)`,
 		`ExecuteMultiShard ks.-20: dummy_delete_2 {dml_vals: type:TUPLE values:{type:TUPLE value:"\x89\x02\x03100\x89\x02\x011"} values:{type:TUPLE value:"\x89\x02\x03100\x89\x02\x012"} values:{type:TUPLE value:"\x89\x02\x03200\x89\x02\x013"}} true true`,
 	})

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -56,7 +56,7 @@ func (upd *Update) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	ctx, cancelFunc := addQueryTimeout(ctx, vcursor, upd.QueryTimeout)
 	defer cancelFunc()
 
-	rss, _, err := upd.findRoute(ctx, vcursor, bindVars)
+	rss, bvs, err := upd.findRoute(ctx, vcursor, bindVars)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (upd *Update) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	case Unsharded:
 		return upd.execUnsharded(ctx, upd, vcursor, bindVars, rss)
 	case Equal, EqualUnique, IN, Scatter, ByDestination, SubShard, MultiEqual:
-		return upd.execMultiDestination(ctx, upd, vcursor, bindVars, rss, upd.updateVindexEntries)
+		return upd.execMultiDestination(ctx, upd, vcursor, bindVars, rss, upd.updateVindexEntries, bvs)
 	default:
 		// Unreachable.
 		return nil, fmt.Errorf("unsupported opcode: %v", upd.Opcode)

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -949,6 +949,8 @@ func TestUpdateMultiEqual(t *testing.T) {
 	})
 }
 
+// TestUpdateInUnique is a test function for update statement using an IN clause with the Vindexes,
+// the query is correctly split according to the corresponding values in the IN list.
 func TestUpdateInUnique(t *testing.T) {
 	ks := buildTestVSchema().Keyspaces["sharded"]
 	upd := &Update{
@@ -962,17 +964,21 @@ func TestUpdateInUnique(t *testing.T) {
 					evalengine.NewLiteralInt(2),
 					evalengine.NewLiteralInt(4),
 				}}},
-			Query: "dummy_update",
+			Query: "update t set n = 'b' where id in ::vals",
 		},
 	}
 
+	tupleBV := &querypb.BindVariable{
+		Type:   querypb.Type_TUPLE,
+		Values: append([]*querypb.Value{sqltypes.ValueToProto(sqltypes.NewInt64(1))}, sqltypes.ValueToProto(sqltypes.NewInt64(2)), sqltypes.ValueToProto(sqltypes.NewInt64(4))),
+	}
 	vc := newDMLTestVCursor("-20", "20-")
 	vc.shardForKsid = []string{"-20", "20-"}
-	_, err := upd.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	_, err := upd.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{"__vals": tupleBV}, false)
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations sharded [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"4"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(d2fd8867d50d2dfe)`,
-		`ExecuteMultiShard sharded.-20: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"4"}} sharded.20-: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"2"}} true false`,
+		`ExecuteMultiShard sharded.-20: update t set n = 'b' where id in ::vals {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"4"}} sharded.20-: update t set n = 'b' where id in ::vals {__vals: type:TUPLE values:{type:INT64 value:"2"}} true false`,
 	})
 }
 

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -964,7 +964,7 @@ func TestUpdateInUnique(t *testing.T) {
 					evalengine.NewLiteralInt(2),
 					evalengine.NewLiteralInt(4),
 				}}},
-			Query: "update t set n = 'b' where id in ::vals",
+			Query: "update t set n = 'b' where id in ::__vals",
 		},
 	}
 
@@ -978,7 +978,7 @@ func TestUpdateInUnique(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations sharded [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"4"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(d2fd8867d50d2dfe)`,
-		`ExecuteMultiShard sharded.-20: update t set n = 'b' where id in ::vals {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"4"}} sharded.20-: update t set n = 'b' where id in ::vals {__vals: type:TUPLE values:{type:INT64 value:"2"}} true false`,
+		`ExecuteMultiShard sharded.-20: update t set n = 'b' where id in ::__vals {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"4"}} sharded.20-: update t set n = 'b' where id in ::__vals {__vals: type:TUPLE values:{type:INT64 value:"2"}} true false`,
 	})
 }
 

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -638,7 +638,7 @@ func TestUpdateIn(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations sharded [type:INT64 value:"1" type:INT64 value:"2"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f)`,
 		// ResolveDestinations is hard-coded to return -20.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} true true`,
 	})
 }
 
@@ -664,7 +664,7 @@ func TestUpdateInStreamExecute(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations sharded [type:INT64 value:"1" type:INT64 value:"2"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f)`,
 		// ResolveDestinations is hard-coded to return -20.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} true true`,
 	})
 }
 
@@ -689,7 +689,7 @@ func TestUpdateInMultiCol(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		`ResolveDestinationsMultiCol sharded [[INT64(1) INT64(3)] [INT64(1) INT64(4)] [INT64(2) INT64(3)] [INT64(2) INT64(4)]] Destinations:DestinationKeyspaceID(014eb190c9a2fa169c),DestinationKeyspaceID(01d2fd8867d50d2dfe),DestinationKeyspaceID(024eb190c9a2fa169c),DestinationKeyspaceID(02d2fd8867d50d2dfe)`,
 		// ResolveDestinations is hard-coded to return -20.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals0: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} __vals1: type:TUPLE values:{type:INT64 value:"3"} values:{type:INT64 value:"4"}} true true`,
 	})
 }
 
@@ -762,7 +762,7 @@ func TestUpdateInChangedVindex(t *testing.T) {
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"23" toc: type:VARBINARY value:"\x06\xe7\xea\"Βp\x8f" true`,
 		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\x06\xe7\xea\"Βp\x8f" true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} true true`,
 	})
 
 	// No rows changing
@@ -776,7 +776,7 @@ func TestUpdateInChangedVindex(t *testing.T) {
 		// It gets used to perform the subquery to fetch the changing column values.
 		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
 		// Subquery returns no rows. So, no vindexes are updated. We still pass-through the original update.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} true true`,
 	})
 
 	// multiple rows changing.
@@ -819,7 +819,7 @@ func TestUpdateInChangedVindex(t *testing.T) {
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"23" toc: type:VARBINARY value:"\x06\xe7\xea\"Βp\x8f" true`,
 		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\x06\xe7\xea\"Βp\x8f" true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} true true`,
 	})
 }
 
@@ -881,7 +881,7 @@ func TestUpdateInChangedVindexMultiCol(t *testing.T) {
 		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"7" toc: type:VARBINARY value:"\x02N\xb1\x90ɢ\xfa\x16\x9c" true`,
 		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x02N\xb1\x90ɢ\xfa\x16\x9c" true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
-		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals0: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} true true`,
 	})
 }
 
@@ -946,6 +946,33 @@ func TestUpdateMultiEqual(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations sharded [type:INT64 value:"1" type:INT64 value:"5"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(70bb023c810ca87a)`,
 		`ExecuteMultiShard sharded.-20: dummy_update {} sharded.20-: dummy_update {} true false`,
+	})
+}
+
+func TestUpdateInUnique(t *testing.T) {
+	ks := buildTestVSchema().Keyspaces["sharded"]
+	upd := &Update{
+		DML: &DML{
+			RoutingParameters: &RoutingParameters{
+				Opcode:   IN,
+				Keyspace: ks.Keyspace,
+				Vindex:   ks.Vindexes["hash"],
+				Values: []evalengine.Expr{evalengine.TupleExpr{
+					evalengine.NewLiteralInt(1),
+					evalengine.NewLiteralInt(2),
+					evalengine.NewLiteralInt(4),
+				}}},
+			Query: "dummy_update",
+		},
+	}
+
+	vc := newDMLTestVCursor("-20", "20-")
+	vc.shardForKsid = []string{"-20", "20-"}
+	_, err := upd.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations sharded [type:INT64 value:"1" type:INT64 value:"2" type:INT64 value:"4"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(d2fd8867d50d2dfe)`,
+		`ExecuteMultiShard sharded.-20: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"4"}} sharded.20-: dummy_update {__vals: type:TUPLE values:{type:INT64 value:"2"}} true false`,
 	})
 }
 

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -876,8 +876,10 @@ func TestUpdateUseHigherCostVindexIfBackfilling(t *testing.T) {
 			Sql:           "select id, wo_lu_col, erl_lu_col, srl_lu_col, nrl_lu_col, nv_lu_col, lu_col, lu_col = 5 from t2_lookup where wo_lu_col = 2 and lu_col in (1, 2) for update",
 			BindVariables: map[string]*querypb.BindVariable{},
 		}, {
-			Sql:           "update t2_lookup set lu_col = 5 where wo_lu_col = 2 and lu_col in (1, 2)",
-			BindVariables: map[string]*querypb.BindVariable{},
+			Sql: "update t2_lookup set lu_col = 5 where wo_lu_col = 2 and lu_col in ::__vals",
+			BindVariables: map[string]*querypb.BindVariable{
+				"__vals": sqltypes.TestBindVariable([]any{int64(1), int64(2)}),
+			},
 		}}
 
 	vars, _ := sqltypes.BuildBindVariable([]any{
@@ -1109,8 +1111,10 @@ func TestDeleteUseHigherCostVindexIfBackfilling(t *testing.T) {
 			Sql:           "select id, wo_lu_col, erl_lu_col, srl_lu_col, nrl_lu_col, nv_lu_col, lu_col from t2_lookup where wo_lu_col = 1 and lu_col in (1, 2) for update",
 			BindVariables: map[string]*querypb.BindVariable{},
 		}, {
-			Sql:           "delete from t2_lookup where wo_lu_col = 1 and lu_col in (1, 2)",
-			BindVariables: map[string]*querypb.BindVariable{},
+			Sql: "delete from t2_lookup where wo_lu_col = 1 and lu_col in ::__vals",
+			BindVariables: map[string]*querypb.BindVariable{
+				"__vals": sqltypes.TestBindVariable([]any{int64(1), int64(2)}),
+			},
 		}}
 
 	vars, _ := sqltypes.BuildBindVariable([]any{
@@ -3042,7 +3046,7 @@ func TestDeleteMultiTable(t *testing.T) {
 		{Sql: "select `user`.id, `user`.col from `user`", BindVariables: map[string]*querypb.BindVariable{}},
 		bq, bq, bq, bq, bq, bq, bq, bq,
 		{Sql: "select `user`.Id, `user`.`name` from `user` where `user`.id in ::dml_vals for update", BindVariables: map[string]*querypb.BindVariable{"dml_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}},
-		{Sql: "delete from `user` where `user`.id in ::dml_vals", BindVariables: map[string]*querypb.BindVariable{"dml_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}}}
+		{Sql: "delete from `user` where `user`.id in ::dml_vals", BindVariables: map[string]*querypb.BindVariable{"__vals": sqltypes.TestBindVariable([]any{int64(1), int64(1), int64(1), int64(1), int64(1), int64(1), int64(1), int64(1)}), "dml_vals": {Type: querypb.Type_TUPLE, Values: dmlVals}}}}
 	assertQueries(t, sbc1, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -562,7 +562,7 @@ func transformRoutePlan(ctx *plancontext.PlanningContext, op *operators.Route) (
 }
 
 func buildRouteLogicalPlan(ctx *plancontext.PlanningContext, op *operators.Route, stmt sqlparser.SelectStatement, hints *queryHints) (logicalPlan, error) {
-	_ = updateSelectedVindexPredicate(op)
+	_ = updateSelectedVindexPredicate(op.Routing)
 
 	eroute, err := routeToEngineRoute(ctx, op, hints)
 	for _, order := range op.Ordering {
@@ -705,7 +705,7 @@ func buildUpdateLogicalPlan(
 	if upd.VerifyAll {
 		stmt.SetComments(stmt.GetParsedComments().SetMySQLSetVarValue(sysvars.ForeignKeyChecks, "OFF"))
 	}
-
+	_ = updateSelectedVindexPredicate(rb.Routing)
 	edml := createDMLPrimitive(ctx, rb, hints, upd.Target.VTable, generateQuery(stmt), vindexes, vQuery)
 
 	return &primitiveWrapper{prim: &engine.Update{
@@ -725,7 +725,7 @@ func buildDeleteLogicalPlan(ctx *plancontext.PlanningContext, rb *operators.Rout
 		vQuery = sqlparser.String(del.OwnedVindexQuery)
 		vindexes = del.Target.VTable.Owned
 	}
-
+	_ = updateSelectedVindexPredicate(rb.Routing)
 	edml := createDMLPrimitive(ctx, rb, hints, del.Target.VTable, generateQuery(stmt), vindexes, vQuery)
 
 	return &primitiveWrapper{prim: &engine.Delete{DML: edml}}, nil
@@ -755,8 +755,8 @@ func createDMLPrimitive(ctx *plancontext.PlanningContext, rb *operators.Route, h
 	return edml
 }
 
-func updateSelectedVindexPredicate(op *operators.Route) sqlparser.Expr {
-	tr, ok := op.Routing.(*operators.ShardedRouting)
+func updateSelectedVindexPredicate(routing operators.Routing) sqlparser.Expr {
+	tr, ok := routing.(*operators.ShardedRouting)
 	if !ok || tr.Selected == nil {
 		return nil
 	}
@@ -771,7 +771,9 @@ func updateSelectedVindexPredicate(op *operators.Route) sqlparser.Expr {
 		if !ok {
 			continue
 		}
-
+		if sqlparser.Equals.Expr(cmp.Right, sqlparser.ListArg(engine.DmlVals)) {
+			continue
+		}
 		var argName string
 		if isMultiColumn {
 			argName = engine.ListVarName + strconv.Itoa(idx)

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -2157,7 +2157,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1 where user_id in (1, 2)",
+        "Query": "update user_extra set val = 1 where user_id in ::__vals",
         "Table": "user_extra",
         "Values": [
           "(1, 2)"
@@ -2383,7 +2383,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from user_extra where user_id in (1, 2)",
+        "Query": "delete from user_extra where user_id in ::__vals",
         "Table": "user_extra",
         "Values": [
           "(1, 2)"
@@ -2516,7 +2516,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id in (1, 2, 3) for update",
-        "Query": "update `user` set `name` = null where id in (1, 2, 3)",
+        "Query": "update `user` set `name` = null where id in ::__vals",
         "Table": "user",
         "Values": [
           "(1, 2, 3)"
@@ -2601,7 +2601,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id in (1, 2, 3) for update",
-        "Query": "delete from `user` where id in (1, 2, 3)",
+        "Query": "delete from `user` where id in ::__vals",
         "Table": "user",
         "Values": [
           "(1, 2, 3)"
@@ -3101,7 +3101,7 @@
         "KsidLength": 1,
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 10 and c3 in (20, 21) for update",
-        "Query": "delete from t1 where c2 = 10 and c3 in (20, 21)",
+        "Query": "delete from t1 where c2 = 10 and c3 in ::__vals",
         "Table": "t1",
         "Values": [
           "(20, 21)"
@@ -3133,7 +3133,7 @@
         "KsidLength": 1,
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 10 and c3 in (20, 21) for update",
-        "Query": "update t1 set c2 = 1 where c2 = 10 and c3 in (20, 21)",
+        "Query": "update t1 set c2 = 1 where c2 = 10 and c3 in ::__vals",
         "Table": "t1",
         "Values": [
           "(20, 21)"
@@ -3266,7 +3266,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update multicol_tbl set x = 1 where colb in (1, 2) and cola = 1",
+        "Query": "update multicol_tbl set x = 1 where colb in ::__vals1 and cola = 1",
         "Table": "multicol_tbl",
         "Values": [
           "1",
@@ -3293,7 +3293,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update multicol_tbl set x = 1 where colb in (1, 2) and cola in (3, 4)",
+        "Query": "update multicol_tbl set x = 1 where colb in ::__vals1 and cola in ::__vals0",
         "Table": "multicol_tbl",
         "Values": [
           "(3, 4)",
@@ -3383,7 +3383,7 @@
         "KsidLength": 2,
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb in (1, 2) and cola = 1 for update",
-        "Query": "delete from multicol_tbl where colb in (1, 2) and cola = 1",
+        "Query": "delete from multicol_tbl where colb in ::__vals1 and cola = 1",
         "Table": "multicol_tbl",
         "Values": [
           "1",
@@ -3413,7 +3413,7 @@
         "KsidLength": 2,
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb in (1, 2) and cola in (3, 4) for update",
-        "Query": "delete from multicol_tbl where colb in (1, 2) and cola in (3, 4)",
+        "Query": "delete from multicol_tbl where colb in ::__vals1 and cola in ::__vals0",
         "Table": "multicol_tbl",
         "Values": [
           "(3, 4)",
@@ -3563,7 +3563,7 @@
         "KsidLength": 2,
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name`, `name` = 'bar' from multicol_tbl where cola in (1, 2) for update",
-        "Query": "update multicol_tbl set `name` = 'bar' where cola in (1, 2)",
+        "Query": "update multicol_tbl set `name` = 'bar' where cola in ::__vals0",
         "Table": "multicol_tbl",
         "Values": [
           "(1, 2)"
@@ -3676,7 +3676,7 @@
         "KsidLength": 2,
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola in (1, 2) for update",
-        "Query": "delete from multicol_tbl where cola in (1, 2)",
+        "Query": "delete from multicol_tbl where cola in ::__vals0",
         "Table": "multicol_tbl",
         "Values": [
           "(1, 2)"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When I run a SELECT statement using an IN clause with the Vindexes, the query is correctly split according to the corresponding values in the IN list. This ensures that each shard is queried separately, which is the expected behavior for optimized shard querying.

However, when I perform an UPDATE/DELETE statement with an IN clause on the Vindexes, the SQL is not rewritten in the same manner. Instead, the query is sent directly to the shard without being split based on the IN clause values.

I hope to have consistent behavior with SELECT when processing UPDATE/DELETE statements with an IN clause on the Vindexes.

I would like the following UPDATE statement:
```sql
UPDATE test_vindex_signed_int SET id = id + 100 WHERE v_key IN (1, 100)
```
to be rewritten into separate statements, one for each value in the IN clause, like so:
```sql
UPDATE test_vindex_signed_int SET id = id + 100 WHERE v_key IN (1)
UPDATE test_vindex_signed_int SET id = id + 100 WHERE v_key IN (100)
```
This would ensure that the UPDATE/DELETE operation is as efficient as possible, especially for large batch updates, by targeting only the relevant shards.

## Related Issue(s)
- Closes https://github.com/vitessio/vitess/issues/15453
- Closes https://github.com/vitessio/vitess/issues/6343


<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required