### PR TITLE
Fix cycle detection for foreign keys

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2556,6 +2556,16 @@ func (ra ReferenceAction) IsRestrict() bool {
 	}
 }
 
+// IsCascade returns true if the reference action is of cascade type.
+func (ra ReferenceAction) IsCascade() bool {
+	switch ra {
+	case Cascade:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsLiteral returns true if the expression is of a literal type.
 func IsLiteral(expr Expr) bool {
 	switch expr.(type) {

--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -260,19 +260,6 @@ func (vm *VSchemaManager) updateFromSchema(vschema *vindexes.VSchema) {
 	}
 }
 
-type tableCol struct {
-	tableName sqlparser.TableName
-	colNames  sqlparser.Columns
-}
-
-var tableColHash = func(tc tableCol) string {
-	res := sqlparser.String(tc.tableName)
-	for _, colName := range tc.colNames {
-		res += "|" + sqlparser.String(colName)
-	}
-	return res
-}
-
 func markErrorIfCyclesInFk(vschema *vindexes.VSchema) {
 	for ksName, ks := range vschema.Keyspaces {
 		// Only check cyclic foreign keys for keyspaces that have
@@ -280,23 +267,52 @@ func markErrorIfCyclesInFk(vschema *vindexes.VSchema) {
 		if ks.ForeignKeyMode != vschemapb.Keyspace_managed {
 			continue
 		}
+		/*
+			3 cases for creating the graph for cycle detection:
+			1. ON DELETE RESTRICT ON UPDATE RESTRICT: This is the simplest case where no update/delete is required on the child table, we only need to verify whether a value exists or not. So we don't need to add any edge for this case.
+			2. ON DELETE SET NULL, ON UPDATE SET NULL, ON UPDATE CASCADE: In this case having any update/delete on any of the columns in the parent side of the foreign key will make a corresponding delete/update on all the column in the child side of the foreign key. So we will add an edge from all the columns in the parent side to all the columns in the child side.
+			3. ON DELETE CASCADE: This is a special case wherein a deletion on the parent table will affect all the columns in the child table irrespective of the columns involved in the foreign key! So, we'll add an edge from all the columns in the parent side of the foreign key to all the columns of the child table.
+		*/
 		g := graph.NewGraph[string]()
 		for _, table := range ks.Tables {
 			for _, cfk := range table.ChildForeignKeys {
 				childTable := cfk.Table
-				parentVertex := tableCol{
-					tableName: table.GetTableName(),
-					colNames:  cfk.ParentColumns,
+
+				// Check for case 1.
+				if cfk.OnUpdate.IsRestrict() && cfk.OnDelete.IsRestrict() {
+					continue
 				}
-				childVertex := tableCol{
-					tableName: childTable.GetTableName(),
-					colNames:  cfk.ChildColumns,
+				var parentVertices []string
+				var childVertices []string
+				for _, column := range cfk.ParentColumns {
+					parentVertices = append(parentVertices, sqlparser.String(sqlparser.NewColNameWithQualifier(column.String(), table.GetTableName())))
 				}
-				g.AddEdge(tableColHash(parentVertex), tableColHash(childVertex))
+
+				// Check for case 3.
+				if cfk.OnDelete.IsCascade() {
+					for _, column := range childTable.Columns {
+						childVertices = append(childVertices, sqlparser.String(sqlparser.NewColNameWithQualifier(column.Name.String(), childTable.GetTableName())))
+					}
+				} else {
+					// Case 2.
+					for _, column := range cfk.ChildColumns {
+						childVertices = append(childVertices, sqlparser.String(sqlparser.NewColNameWithQualifier(column.String(), childTable.GetTableName())))
+					}
+				}
+				addCrossEdges(g, parentVertices, childVertices)
 			}
 		}
 		if g.HasCycles() {
 			ks.Error = vterrors.VT09019(ksName)
+		}
+	}
+}
+
+// addCrossEdges adds the edges from all the vertices in the first list to all the vertices in the second list.
+func addCrossEdges(g *graph.Graph[string], from []string, to []string) {
+	for _, fromStr := range from {
+		for _, toStr := range to {
+			g.AddEdge(fromStr, toStr)
 		}
 	}
 }

--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -449,7 +449,7 @@ func TestMarkErrorIfCyclesInFk(t *testing.T) {
 		errWanted  string
 	}{
 		{
-			name: "Has a cycle",
+			name: "Has a direct cycle",
 			getVschema: func() *vindexes.VSchema {
 				vschema := &vindexes.VSchema{
 					Keyspaces: map[string]*vindexes.KeyspaceSchema{
@@ -472,12 +472,43 @@ func TestMarkErrorIfCyclesInFk(t *testing.T) {
 						},
 					},
 				}
-				_ = vschema.AddForeignKey("ks", "t2", createFkDefinition([]string{"col"}, "t1", []string{"col"}, sqlparser.Cascade, sqlparser.Cascade))
-				_ = vschema.AddForeignKey("ks", "t3", createFkDefinition([]string{"col"}, "t2", []string{"col"}, sqlparser.Cascade, sqlparser.Cascade))
-				_ = vschema.AddForeignKey("ks", "t1", createFkDefinition([]string{"col"}, "t3", []string{"col"}, sqlparser.Cascade, sqlparser.Cascade))
+				_ = vschema.AddForeignKey("ks", "t2", createFkDefinition([]string{"col"}, "t1", []string{"col"}, sqlparser.SetNull, sqlparser.SetNull))
+				_ = vschema.AddForeignKey("ks", "t3", createFkDefinition([]string{"col"}, "t2", []string{"col"}, sqlparser.SetNull, sqlparser.SetNull))
+				_ = vschema.AddForeignKey("ks", "t1", createFkDefinition([]string{"col"}, "t3", []string{"col"}, sqlparser.SetNull, sqlparser.SetNull))
 				return vschema
 			},
 			errWanted: "VT09019: keyspace 'ks' has cyclic foreign keys",
+		},
+		{
+			name: "Has a direct cycle but there is a restrict constraint in between",
+			getVschema: func() *vindexes.VSchema {
+				vschema := &vindexes.VSchema{
+					Keyspaces: map[string]*vindexes.KeyspaceSchema{
+						ksName: {
+							ForeignKeyMode: vschemapb.Keyspace_managed,
+							Tables: map[string]*vindexes.Table{
+								"t1": {
+									Name:     sqlparser.NewIdentifierCS("t1"),
+									Keyspace: keyspace,
+								},
+								"t2": {
+									Name:     sqlparser.NewIdentifierCS("t2"),
+									Keyspace: keyspace,
+								},
+								"t3": {
+									Name:     sqlparser.NewIdentifierCS("t3"),
+									Keyspace: keyspace,
+								},
+							},
+						},
+					},
+				}
+				_ = vschema.AddForeignKey("ks", "t2", createFkDefinition([]string{"col"}, "t1", []string{"col"}, sqlparser.SetNull, sqlparser.SetNull))
+				_ = vschema.AddForeignKey("ks", "t3", createFkDefinition([]string{"col"}, "t2", []string{"col"}, sqlparser.Restrict, sqlparser.Restrict))
+				_ = vschema.AddForeignKey("ks", "t1", createFkDefinition([]string{"col"}, "t3", []string{"col"}, sqlparser.SetNull, sqlparser.SetNull))
+				return vschema
+			},
+			errWanted: "",
 		},
 		{
 			name: "No cycle",
@@ -508,6 +539,134 @@ func TestMarkErrorIfCyclesInFk(t *testing.T) {
 				return vschema
 			},
 			errWanted: "",
+		}, {
+			name: "Self-referencing foreign key with delete cascade",
+			getVschema: func() *vindexes.VSchema {
+				vschema := &vindexes.VSchema{
+					Keyspaces: map[string]*vindexes.KeyspaceSchema{
+						ksName: {
+							ForeignKeyMode: vschemapb.Keyspace_managed,
+							Tables: map[string]*vindexes.Table{
+								"t1": {
+									Name:     sqlparser.NewIdentifierCS("t1"),
+									Keyspace: keyspace,
+									Columns: []vindexes.Column{
+										{
+											Name: sqlparser.NewIdentifierCI("id"),
+										},
+										{
+											Name: sqlparser.NewIdentifierCI("manager_id"),
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				_ = vschema.AddForeignKey("ks", "t1", createFkDefinition([]string{"manager_id"}, "t1", []string{"id"}, sqlparser.SetNull, sqlparser.Cascade))
+				return vschema
+			},
+			errWanted: "VT09019: keyspace 'ks' has cyclic foreign keys",
+		}, {
+			name: "Self-referencing foreign key without delete cascade",
+			getVschema: func() *vindexes.VSchema {
+				vschema := &vindexes.VSchema{
+					Keyspaces: map[string]*vindexes.KeyspaceSchema{
+						ksName: {
+							ForeignKeyMode: vschemapb.Keyspace_managed,
+							Tables: map[string]*vindexes.Table{
+								"t1": {
+									Name:     sqlparser.NewIdentifierCS("t1"),
+									Keyspace: keyspace,
+									Columns: []vindexes.Column{
+										{
+											Name: sqlparser.NewIdentifierCI("id"),
+										},
+										{
+											Name: sqlparser.NewIdentifierCI("manager_id"),
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				_ = vschema.AddForeignKey("ks", "t1", createFkDefinition([]string{"manager_id"}, "t1", []string{"id"}, sqlparser.SetNull, sqlparser.SetNull))
+				return vschema
+			},
+			errWanted: "",
+		}, {
+			name: "Has an indirect cycle because of cascades",
+			getVschema: func() *vindexes.VSchema {
+				vschema := &vindexes.VSchema{
+					Keyspaces: map[string]*vindexes.KeyspaceSchema{
+						ksName: {
+							ForeignKeyMode: vschemapb.Keyspace_managed,
+							Tables: map[string]*vindexes.Table{
+								"t1": {
+									Name:     sqlparser.NewIdentifierCS("t1"),
+									Keyspace: keyspace,
+									Columns: []vindexes.Column{
+										{
+											Name: sqlparser.NewIdentifierCI("a"),
+										},
+										{
+											Name: sqlparser.NewIdentifierCI("b"),
+										},
+										{
+											Name: sqlparser.NewIdentifierCI("c"),
+										},
+									},
+								},
+								"t2": {
+									Name:     sqlparser.NewIdentifierCS("t2"),
+									Keyspace: keyspace,
+									Columns: []vindexes.Column{
+										{
+											Name: sqlparser.NewIdentifierCI("d"),
+										},
+										{
+											Name: sqlparser.NewIdentifierCI("e"),
+										},
+										{
+											Name: sqlparser.NewIdentifierCI("f"),
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				_ = vschema.AddForeignKey("ks", "t2", createFkDefinition([]string{"f"}, "t1", []string{"a"}, sqlparser.SetNull, sqlparser.Cascade))
+				_ = vschema.AddForeignKey("ks", "t1", createFkDefinition([]string{"b"}, "t2", []string{"e"}, sqlparser.SetNull, sqlparser.Cascade))
+				return vschema
+			},
+			errWanted: "VT09019: keyspace 'ks' has cyclic foreign keys",
+		}, {
+			name: "Cycle part of a multi-column foreign key",
+			getVschema: func() *vindexes.VSchema {
+				vschema := &vindexes.VSchema{
+					Keyspaces: map[string]*vindexes.KeyspaceSchema{
+						ksName: {
+							ForeignKeyMode: vschemapb.Keyspace_managed,
+							Tables: map[string]*vindexes.Table{
+								"t1": {
+									Name:     sqlparser.NewIdentifierCS("t1"),
+									Keyspace: keyspace,
+								},
+								"t2": {
+									Name:     sqlparser.NewIdentifierCS("t2"),
+									Keyspace: keyspace,
+								},
+							},
+						},
+					},
+				}
+				_ = vschema.AddForeignKey("ks", "t2", createFkDefinition([]string{"e", "f"}, "t1", []string{"a", "b"}, sqlparser.SetNull, sqlparser.SetNull))
+				_ = vschema.AddForeignKey("ks", "t1", createFkDefinition([]string{"b"}, "t2", []string{"e"}, sqlparser.SetNull, sqlparser.SetNull))
+				return vschema
+			},
+			errWanted: "VT09019: keyspace 'ks' has cyclic foreign keys",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

### The Problem

The problem was found in a foreign key constraint referencing a column in the same table and having a delete cascade constraint. The reason we didn't catch this in our test suite, is that we have little testing for self-referencing foreign key constraints. We only have tests with `on delete restrict` and `on update restrict` constraints. We reject cyclic foreign keys anyway, but this specific case was missed.

Let's look at the schema of the table - 
```sql
CREATE TABLE `employee` (
	`id` bigint unsigned NOT NULL AUTO_INCREMENT,
	`manager_id` bigint unsigned NOT NULL,
	PRIMARY KEY (`id`),
	UNIQUE KEY `idx_manager_id` (`manager_id`),
        -- The following constraint is the problematic one:
	CONSTRAINT `self_referencing_key_with_cascade` FOREIGN KEY (`manager_id`) REFERENCES `employee` (`id`) ON DELETE CASCADE
) ENGINE InnoDB,
  CHARSET utf8mb4,
  COLLATE utf8mb4_0900_ai_ci;
```

Now let's consider how a vtgate would plan a query like `delete from employee where id = 3`.

The first thing that vtgate notices is that the table has a foreign key constraint so it needs to do some cascades. So, we first create a select query that would look something like `select id from employee where id = 3`. This selection would give us a list of `id` values that we will use to run a cascaded deleted like `delete from employee where manager_id in :dmvals`.
But wait a minute, that delete query will also be planned and vtgate would again infer that it can lead to cascades, so we would create a selection query that would look something like `select id from employee where manager_id in :dmvals`. Using this selection we would plan a delete query like `delete from employee where manager_id in :dmvals2`
Lo and behold, we are in an infinite loop!!! This process will keep on going and this causes a stack overflow eventually!

This is very interesting because our logic for rejecting self-referenced foreign keys was to exactly prevent this kind of infinite loop in planning, because the **only** correct way to plan these queries is to change the plan from a tree to a cyclic directed graph. That will be an involved change because the rewriter and various other components of the planner will need to account for this paradigm change.

The next question to answer is that why didn't we fail this query. The answer to that lies in how we detect cycles in foreign keys. The way we do that is by creating a graph where a vertex is a combination of table name and a list of column names and an edge represents a foreign key contraint between them. Then we just detect cycles on the created graph.

The special thing here is that even though the foreign key is from `employee.id` to `employee.manager_id` because of the delete cascade we still end up in a planning loop even though there is no direct cycle in the graph.

### The Fix to FK Cycle Detection

I have been thinking about this since yesterday, and I think I've got what changes we need to make. As I stated ☝️ the graph we create now has vertices that are a combination of a table name and a list of column names and an edge represents a foreign key constraint between them. This I think needs to change.

Instead, we should just have single table-name qualified columns as vertices. Then we can add edges between them, that represent that an update/delete operation to a certain column can potentially lead to an update/delete to the other column.

Now while adding edges, we need to be careful about the type of foreign key as well - 
1. `ON DELETE RESTRICT ON UPDATE RESTRICT` - This is the simplest case where no update/delete is required on the child table, we only need to verify whether a value exists or not. So we don't need to add any edge for this case.
2. `ON DELETE SET NULL`, `ON UPDATE SET NULL`, `ON UPDATE CASCADE` - In this case having any update/delete on any of the columns in the parent side of the foreign key will make a corresponding delete/update on all the column in the child side of the foreign key. So we will add an edge from all the columns in the parent side to all the columns in the child side.
3. `ON DELETE CASCADE` - This is a special case wherein a deletion on the parent table will affect all the columns in the child table irrespective of the columns involved in the foreign key! This is vastly important because even if the foreign keys aren't in a cycle, this is the reason why we are seeing this bug. So, we'll add an edge from all the columns in the parent side of the foreign key to all the columns of the child table.

Once we have this graph generated, we just need to detect cycles on it. Any cycle in this graph will lead to the planning going into an infinite loop since a certain update/delete on a column (that is part of the cycle), will end up causing an update/delete cascade to itself!

Let's look at a few examples of how this works in practice.

#### Example 1
Let's start with the case that is reported in this issue itself - 
```
CREATE TABLE `employee` (
	`id` bigint unsigned NOT NULL AUTO_INCREMENT,
	`manager_id` bigint unsigned NOT NULL,
	PRIMARY KEY (`id`),
	UNIQUE KEY `idx_manager_id` (`manager_id`),
        -- The following constraint is the problematic one:
	CONSTRAINT `self_referencing_key_with_cascade` FOREIGN KEY (`manager_id`) REFERENCES `employee` (`id`) ON DELETE CASCADE
) ENGINE InnoDB,
  CHARSET utf8mb4,
  COLLATE utf8mb4_0900_ai_ci;
```
Because of the `on delete cascade` in the foreign key, we'll end up with a graph like so - 
```mermaid
flowchart TD
    A[employee.id]--> B[empoyee.manager_id]
    A --> A
```

#### Example 2
This same situation can arise in a multi table schema as well.

```
CREATE TABLE `One` (
	`a` bigint unsigned NOT NULL AUTO_INCREMENT,
	`b` bigint unsigned NOT NULL,
	`c` bigint unsigned NOT NULL,
	PRIMARY KEY (`a`),
	CONSTRAINT `fk_1` FOREIGN KEY (`b`) REFERENCES `Two` (`f`) ON DELETE CASCADE
) ENGINE InnoDB,
  CHARSET utf8mb4,
  COLLATE utf8mb4_0900_ai_ci;

CREATE TABLE `Two` (
	`d` bigint unsigned NOT NULL AUTO_INCREMENT,
	`e` bigint unsigned NOT NULL,
	`f` bigint unsigned NOT NULL,
	PRIMARY KEY (`d`),
	CONSTRAINT `fk_2` FOREIGN KEY (`e`) REFERENCES `One` (`a`) ON DELETE CASCADE
) ENGINE InnoDB,
  CHARSET utf8mb4,
  COLLATE utf8mb4_0900_ai_ci;
```
Because of the `on delete cascade` in the foreign key, we'll end up with a graph like so - 
```mermaid
flowchart TD
    A[One.a]
    B[One.b]
    C[One.c]
    D[Two.d]
    E[Two.e]
    F[Two.f]
    B --> D
    B --> E
    B --> F
    E --> A
    E --> B
    E --> C
```


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15457

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
