### PR TITLE
[release-18.0] VtctldClient Reshard: add e2e tests to confirm CLI options and fix discovered issues. (#15353)

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/reshard/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/reshard/create.go
@@ -60,9 +60,8 @@ func commandReshardCreate(cmd *cobra.Command, args []string) error {
 	cli.FinishedParsing(cmd)
 
 	req := &vtctldatapb.ReshardCreateRequest{
-		Workflow: common.BaseOptions.Workflow,
-		Keyspace: common.BaseOptions.TargetKeyspace,
-
+		Workflow:                  common.BaseOptions.Workflow,
+		Keyspace:                  common.BaseOptions.TargetKeyspace,
 		TabletTypes:               common.CreateOptions.TabletTypes,
 		TabletSelectionPreference: tsp,
 		Cells:                     common.CreateOptions.Cells,
@@ -70,10 +69,9 @@ func commandReshardCreate(cmd *cobra.Command, args []string) error {
 		DeferSecondaryKeys:        common.CreateOptions.DeferSecondaryKeys,
 		AutoStart:                 common.CreateOptions.AutoStart,
 		StopAfterCopy:             common.CreateOptions.StopAfterCopy,
-
-		SourceShards:   reshardCreateOptions.sourceShards,
-		TargetShards:   reshardCreateOptions.targetShards,
-		SkipSchemaCopy: reshardCreateOptions.skipSchemaCopy,
+		SourceShards:              reshardCreateOptions.sourceShards,
+		TargetShards:              reshardCreateOptions.targetShards,
+		SkipSchemaCopy:            reshardCreateOptions.skipSchemaCopy,
 	}
 	resp, err := common.GetClient().ReshardCreate(common.GetCommandCtx(), req)
 	if err != nil {


### PR DESCRIPTION

## Description

This is a backport of #15353

I had to redo this because https://github.com/vitessio/vitess/pull/15363 refused to start CI workflows, apparently due to a Skip Label issue.