### PR TITLE
Add api end point to print the current database state in VTOrc

### DIFF
--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -93,6 +93,16 @@ func TestAPIEndpoints(t *testing.T) {
 		return response != "null"
 	})
 
+	t.Run("Database State", func(t *testing.T) {
+		// Get database state
+		status, resp, err := utils.MakeAPICall(t, vtorc, "/api/database-state")
+		require.NoError(t, err)
+		assert.Equal(t, 200, status)
+		assert.Contains(t, resp, "alias:{zone1-0000000101 true}")
+		assert.Contains(t, resp, `Table vitess_keyspace
+map[durability_policy:{none true} keyspace:{ks true} keyspace_type:{0 true}]`)
+	})
+
 	t.Run("Disable Recoveries API", func(t *testing.T) {
 		// Disable recoveries of VTOrc
 		status, resp, err := utils.MakeAPICall(t, vtorc, "/api/disable-global-recoveries")

--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -98,9 +98,8 @@ func TestAPIEndpoints(t *testing.T) {
 		status, resp, err := utils.MakeAPICall(t, vtorc, "/api/database-state")
 		require.NoError(t, err)
 		assert.Equal(t, 200, status)
-		assert.Contains(t, resp, "alias:{zone1-0000000101 true}")
-		assert.Contains(t, resp, `Table vitess_keyspace
-map[durability_policy:{none true} keyspace:{ks true} keyspace_type:{0 true}]`)
+		assert.Contains(t, resp, `"alias":"zone1-0000000101"`)
+		assert.Contains(t, resp, `{"TableName":"vitess_keyspace","Rows":[{"durability_policy":"none","keyspace":"ks","keyspace_type":"0"}]}`)
 	})
 
 	t.Run("Disable Recoveries API", func(t *testing.T) {

--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -98,8 +98,17 @@ func TestAPIEndpoints(t *testing.T) {
 		status, resp, err := utils.MakeAPICall(t, vtorc, "/api/database-state")
 		require.NoError(t, err)
 		assert.Equal(t, 200, status)
-		assert.Contains(t, resp, `"alias":"zone1-0000000101"`)
-		assert.Contains(t, resp, `{"TableName":"vitess_keyspace","Rows":[{"durability_policy":"none","keyspace":"ks","keyspace_type":"0"}]}`)
+		assert.Contains(t, resp, `"alias": "zone1-0000000101"`)
+		assert.Contains(t, resp, `{
+		"TableName": "vitess_keyspace",
+		"Rows": [
+			{
+				"durability_policy": "none",
+				"keyspace": "ks",
+				"keyspace_type": "0"
+			}
+		]
+	},`)
 	})
 
 	t.Run("Disable Recoveries API", func(t *testing.T) {

--- a/go/vt/external/golib/sqlutils/sqlutils.go
+++ b/go/vt/external/golib/sqlutils/sqlutils.go
@@ -40,7 +40,7 @@ type RowMap map[string]CellData
 // CellData is the result of a single (atomic) column in a single row
 type CellData sql.NullString
 
-func (this *CellData) MarshalJSON() ([]byte, error) {
+func (this CellData) MarshalJSON() ([]byte, error) {
 	if this.Valid {
 		return json.Marshal(this.String)
 	} else {

--- a/go/vt/vtorc/db/generate_base.go
+++ b/go/vt/vtorc/db/generate_base.go
@@ -16,6 +16,28 @@
 
 package db
 
+var TableNames = []string{
+	"database_instance",
+	"audit",
+	"active_node",
+	"node_health",
+	"topology_recovery",
+	"database_instance_topology_history",
+	"candidate_database_instance",
+	"topology_failure_detection",
+	"blocked_topology_recovery",
+	"database_instance_last_analysis",
+	"database_instance_analysis_changelog",
+	"node_health_history",
+	"vtorc_db_deployments",
+	"global_recovery_disable",
+	"topology_recovery_steps",
+	"database_instance_stale_binlog_coordinates",
+	"vitess_tablet",
+	"vitess_keyspace",
+	"vitess_shard",
+}
+
 // vtorcBackend is a list of SQL statements required to build the vtorc backend
 var vtorcBackend = []string{
 	`

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -1210,3 +1210,20 @@ func ExpireStaleInstanceBinlogCoordinates() error {
 	}
 	return ExecDBWriteFunc(writeFunc)
 }
+
+// SnapshotDatabaseState takes the snapshot of the database and returns it.
+func SnapshotDatabaseState() (string, error) {
+	var finalOutput string
+	for _, tableName := range db.TableNames {
+		finalOutput += "Table " + tableName + "\n"
+		err := db.QueryVTOrc("select * from "+tableName, nil, func(rowMap sqlutils.RowMap) error {
+			finalOutput += fmt.Sprintf("%v\n", rowMap)
+			return nil
+		})
+		if err != nil {
+			return "", err
+		}
+		finalOutput += "\n"
+	}
+	return finalOutput, nil
+}

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -1233,7 +1233,7 @@ func GetDatabaseState() (string, error) {
 		}
 		dbState = append(dbState, ts)
 	}
-	jsonData, err := json.Marshal(dbState)
+	jsonData, err := json.MarshalIndent(dbState, "", "\t")
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -747,7 +747,7 @@ func waitForCacheInitialization() {
 	}
 }
 
-func TestSnapshotDatabaseState(t *testing.T) {
+func TestGetDatabaseState(t *testing.T) {
 	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
 	defer func() {
 		db.ClearVTOrcDatabase()
@@ -758,7 +758,7 @@ func TestSnapshotDatabaseState(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	snapshot, err := SnapshotDatabaseState()
+	ds, err := GetDatabaseState()
 	require.NoError(t, err)
-	require.Contains(t, snapshot, `alias:{zone1-0000000112 true}`)
+	require.Contains(t, ds, `"alias":"zone1-0000000112"`)
 }

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -760,5 +760,5 @@ func TestGetDatabaseState(t *testing.T) {
 
 	ds, err := GetDatabaseState()
 	require.NoError(t, err)
-	require.Contains(t, ds, `"alias":"zone1-0000000112"`)
+	require.Contains(t, ds, `"alias": "zone1-0000000112"`)
 }

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -746,3 +746,19 @@ func waitForCacheInitialization() {
 		time.Sleep(100 * time.Millisecond)
 	}
 }
+
+func TestSnapshotDatabaseState(t *testing.T) {
+	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
+	defer func() {
+		db.ClearVTOrcDatabase()
+	}()
+
+	for _, query := range initialSQL {
+		_, err := db.ExecVTOrc(query)
+		require.NoError(t, err)
+	}
+
+	snapshot, err := SnapshotDatabaseState()
+	require.NoError(t, err)
+	require.Contains(t, snapshot, `alias:{zone1-0000000112 true}`)
+}

--- a/go/vt/vtorc/server/api.go
+++ b/go/vt/vtorc/server/api.go
@@ -45,6 +45,7 @@ const (
 	disableGlobalRecoveriesAPI    = "/api/disable-global-recoveries"
 	enableGlobalRecoveriesAPI     = "/api/enable-global-recoveries"
 	replicationAnalysisAPI        = "/api/replication-analysis"
+	databaseStateAPI              = "/api/database-state"
 	healthAPI                     = "/debug/health"
 	AggregatedDiscoveryMetricsAPI = "/api/aggregated-discovery-metrics"
 
@@ -60,6 +61,7 @@ var (
 		disableGlobalRecoveriesAPI,
 		enableGlobalRecoveriesAPI,
 		replicationAnalysisAPI,
+		databaseStateAPI,
 		healthAPI,
 		AggregatedDiscoveryMetricsAPI,
 	}
@@ -86,6 +88,8 @@ func (v *vtorcAPI) ServeHTTP(response http.ResponseWriter, request *http.Request
 		errantGTIDsAPIHandler(response, request)
 	case replicationAnalysisAPI:
 		replicationAnalysisAPIHandler(response, request)
+	case databaseStateAPI:
+		databaseStateAPIHandler(response)
 	case AggregatedDiscoveryMetricsAPI:
 		AggregatedDiscoveryMetricsAPIHandler(response, request)
 	default:
@@ -104,7 +108,7 @@ func getACLPermissionLevelForAPI(apiEndpoint string) string {
 		return acl.ADMIN
 	case replicationAnalysisAPI:
 		return acl.MONITORING
-	case healthAPI:
+	case healthAPI, databaseStateAPI:
 		return acl.MONITORING
 	}
 	return acl.ADMIN
@@ -164,6 +168,16 @@ func errantGTIDsAPIHandler(response http.ResponseWriter, request *http.Request) 
 		return
 	}
 	returnAsJSON(response, http.StatusOK, instances)
+}
+
+// databaseStateAPIHandler is the handler for the databaseStateAPI endpoint
+func databaseStateAPIHandler(response http.ResponseWriter) {
+	snapshot, err := inst.SnapshotDatabaseState()
+	if err != nil {
+		http.Error(response, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writePlainTextResponse(response, snapshot, http.StatusOK)
 }
 
 // AggregatedDiscoveryMetricsAPIHandler is the handler for the discovery metrics endpoint

--- a/go/vt/vtorc/server/api.go
+++ b/go/vt/vtorc/server/api.go
@@ -172,12 +172,12 @@ func errantGTIDsAPIHandler(response http.ResponseWriter, request *http.Request) 
 
 // databaseStateAPIHandler is the handler for the databaseStateAPI endpoint
 func databaseStateAPIHandler(response http.ResponseWriter) {
-	snapshot, err := inst.SnapshotDatabaseState()
+	ds, err := inst.GetDatabaseState()
 	if err != nil {
 		http.Error(response, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	writePlainTextResponse(response, snapshot, http.StatusOK)
+	writePlainTextResponse(response, ds, http.StatusOK)
 }
 
 // AggregatedDiscoveryMetricsAPIHandler is the handler for the discovery metrics endpoint


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds a new API endpoint for VTOrc, that allows the users to see the current database state of the instance. This is useful for debugging.

The new endpoint is `/api/database-state` and it looks like - 

![Screenshot 2024-03-21 at 12 21 44 PM](https://github.com/vitessio/vitess/assets/35839558/c1a30b83-aae6-4ad2-93ee-ac71baaa794a)


![Screenshot 2024-03-21 at 12 21 51 PM](https://github.com/vitessio/vitess/assets/35839558/36812771-feb4-47f8-98b2-cd148eeac1a8)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15484

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required - https://github.com/vitessio/website/pull/1705

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
