### PR TITLE
Enum value parsing: do not parse by whitespace

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/enum-whitespace/alter
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/enum-whitespace/alter
@@ -1,0 +1,1 @@
+change e e enum('red', 'light green', 'blue', 'orange', 'yellow') collate 'utf8_bin' null default null

--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/enum-whitespace/create.sql
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/enum-whitespace/create.sql
@@ -1,0 +1,27 @@
+drop table if exists onlineddl_test;
+create table onlineddl_test (
+  id int auto_increment,
+  i int not null,
+  e enum('red', 'light green', 'blue', 'orange') null default null collate 'utf8_bin',
+  primary key(id)
+) auto_increment=1;
+
+drop event if exists onlineddl_test;
+delimiter ;;
+create event onlineddl_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into onlineddl_test values (null, 11, 'red');
+  insert into onlineddl_test values (null, 13, 'light green');
+  insert into onlineddl_test values (null, 17, 'blue');
+  set @last_insert_id := last_insert_id();
+  update onlineddl_test set e='orange' where id = @last_insert_id;
+  insert into onlineddl_test values (null, 23, null);
+  set @last_insert_id := last_insert_id();
+  update onlineddl_test set i=i+1, e=null where id = @last_insert_id;
+end ;;

--- a/go/vt/schema/parser.go
+++ b/go/vt/schema/parser.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 
-	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -122,7 +121,7 @@ func parseEnumOrSetTokens(enumOrSetValues string) (tokens []string) {
 		// input should not contain `enum(...)` column definition, just the comma delimited list
 		return tokens
 	}
-	tokens = textutil.SplitDelimitedList(enumOrSetValues)
+	tokens = strings.Split(enumOrSetValues, ",")
 	for i := range tokens {
 		if strings.HasPrefix(tokens[i], `'`) && strings.HasSuffix(tokens[i], `'`) {
 			tokens[i] = strings.Trim(tokens[i], `'`)

--- a/go/vt/schema/parser_test.go
+++ b/go/vt/schema/parser_test.go
@@ -145,6 +145,12 @@ func TestParseEnumTokens(t *testing.T) {
 		assert.Equal(t, expect, enumTokens)
 	}
 	{
+		input := `'with '' quote','and \n newline'`
+		enumTokens := parseEnumOrSetTokens(input)
+		expect := []string{"with ' quote", "and \n newline"}
+		assert.Equal(t, expect, enumTokens)
+	}
+	{
 		input := `enum('x-small','small','medium','large','x-large')`
 		enumTokens := parseEnumOrSetTokens(input)
 		assert.Nil(t, enumTokens)

--- a/go/vt/schema/parser_test.go
+++ b/go/vt/schema/parser_test.go
@@ -89,6 +89,19 @@ func TestParseEnumValues(t *testing.T) {
 			assert.Equal(t, input, enumValues)
 		}
 	}
+
+	{
+		inputs := []string{
+			``,
+			`abc`,
+			`func('x small','small','medium','large','x large')`,
+			`set('x small','small','medium','large','x large')`,
+		}
+		for _, input := range inputs {
+			enumValues := ParseEnumValues(input)
+			assert.Equal(t, input, enumValues)
+		}
+	}
 }
 
 func TestParseSetValues(t *testing.T) {
@@ -123,6 +136,12 @@ func TestParseEnumTokens(t *testing.T) {
 		input := `'x-small','small','medium','large','x-large'`
 		enumTokens := parseEnumOrSetTokens(input)
 		expect := []string{"x-small", "small", "medium", "large", "x-large"}
+		assert.Equal(t, expect, enumTokens)
+	}
+	{
+		input := `'x small','small','medium','large','x large'`
+		enumTokens := parseEnumOrSetTokens(input)
+		expect := []string{"x small", "small", "medium", "large", "x large"}
 		assert.Equal(t, expect, enumTokens)
 	}
 	{

--- a/go/vt/vttablet/onlineddl/vrepl/columns_test.go
+++ b/go/vt/vttablet/onlineddl/vrepl/columns_test.go
@@ -333,11 +333,11 @@ func TestGetExpandedColumnNames(t *testing.T) {
 			"expand enum",
 			Column{
 				Type:       EnumColumnType,
-				EnumValues: "'a', 'b'",
+				EnumValues: "'a','b'",
 			},
 			Column{
 				Type:       EnumColumnType,
-				EnumValues: "'a', 'x'",
+				EnumValues: "'a','x'",
 			},
 			true,
 		},
@@ -345,11 +345,11 @@ func TestGetExpandedColumnNames(t *testing.T) {
 			"expand enum",
 			Column{
 				Type:       EnumColumnType,
-				EnumValues: "'a', 'b'",
+				EnumValues: "'a','b'",
 			},
 			Column{
 				Type:       EnumColumnType,
-				EnumValues: "'a', 'b', 'c'",
+				EnumValues: "'a','b','c'",
 			},
 			true,
 		},
@@ -357,11 +357,11 @@ func TestGetExpandedColumnNames(t *testing.T) {
 			"reduce enum",
 			Column{
 				Type:       EnumColumnType,
-				EnumValues: "'a', 'b', 'c'",
+				EnumValues: "'a','b','c'",
 			},
 			Column{
 				Type:       EnumColumnType,
-				EnumValues: "'a', 'b'",
+				EnumValues: "'a','b'",
 			},
 			false,
 		},


### PR DESCRIPTION
## Description

Addressing https://github.com/vitessio/vitess/issues/15492, this is an initial simple fix that allows whitespace in `enum` value. A more formal fix to follow, as this fix is incomplete in that it still requires more escaping.

A complete fix is likely to benefit from some `sqlparser` capabilities, though the use case goes beyond parsing `CREATE TABLE` statements and thus we might still take a lesser-than-`yacc` approach.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15492

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
