### PR TITLE
Remove unneeded loading of the MySQL driver

### DIFF
--- a/go/cmd/vtorc/main.go
+++ b/go/cmd/vtorc/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	_ "github.com/go-sql-driver/mysql"
 	_ "modernc.org/sqlite"
 
 	"vitess.io/vitess/go/cmd/vtorc/cli"

--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -19,7 +19,6 @@ package misc
 import (
 	"testing"
 
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/go/test/endtoend/vtorc/readtopologyinstance/main_test.go
+++ b/go/test/endtoend/vtorc/readtopologyinstance/main_test.go
@@ -30,7 +30,6 @@ import (
 	"vitess.io/vitess/go/vt/vtorc/logic"
 	"vitess.io/vitess/go/vt/vtorc/server"
 
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"


### PR DESCRIPTION
These cases probably at some point actually used MySQL with Go's stdlib `database/sql` logic, but no longer do.

This is mostly testing logic except for `vtorc`. The initial code port from Orchestrator to `vtorc` likely kept the logic for a MySQL backend but we've long since only had `vtorc` using `sqlite` internally.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required