### PR TITLE
fix: remove keyspace from column during query builder

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -623,15 +623,8 @@ func buildDerivedSelect(op *Horizon, qb *queryBuilder, sel *sqlparser.Select) {
 
 func buildHorizon(op *Horizon, qb *queryBuilder) {
 	buildQuery(op.Source, qb)
-
 	stripDownQuery(op.Query, qb.asSelectStatement())
-
-	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-		if aliasedExpr, ok := node.(sqlparser.SelectExpr); ok {
-			removeKeyspaceFromSelectExpr(aliasedExpr)
-		}
-		return true, nil
-	}, qb.stmt)
+	sqlparser.RemoveKeyspaceInCol(qb.stmt)
 }
 
 func mergeHaving(h1, h2 *sqlparser.Where) *sqlparser.Where {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4585,5 +4585,109 @@
         "user.multicol_tbl"
       ]
     }
+  },
+  {
+    "comment": "order by with filter removing the keyspace from order by",
+    "query": "select col from user.user where id = 1 order by user.user.user_id",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select col from user.user where id = 1 order by user.user.user_id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select col from `user` where 1 != 1",
+        "Query": "select col from `user` where id = 1 order by `user`.user_id asc",
+        "Table": "`user`",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "group by with filter removing the keyspace from order by",
+    "query": "select col from user.user where id = 1 group by user.user.user_id",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select col from user.user where id = 1 group by user.user.user_id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select col from `user` where 1 != 1 group by `user`.user_id",
+        "Query": "select col from `user` where id = 1 group by `user`.user_id",
+        "Table": "`user`",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "order with authoritative table - removing keyspace from group by",
+    "query": "select * from user.authoritative where user_id = 5 order by user_id",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select * from user.authoritative where user_id = 5 order by user_id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
+        "Query": "select user_id, col1, col2 from authoritative where user_id = 5 order by authoritative.user_id asc",
+        "Table": "authoritative",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.authoritative"
+      ]
+    }
+  },
+  {
+    "comment": "group by and having with authoritative table - removing keyspace from having",
+    "query": "select * from user.authoritative where user_id = 5 group by user_id having count(user_id) = 6 order by user_id",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select * from user.authoritative where user_id = 5 group by user_id having count(user_id) = 6 order by user_id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1 group by user_id",
+        "Query": "select user_id, col1, col2 from authoritative where user_id = 5 group by user_id having count(user_id) = 6 order by authoritative.user_id asc",
+        "Table": "authoritative",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.authoritative"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR removes the keyspace information from the final query sent down to vttablet for execution as the database name and keyspace name can be different.

This was caused by to recent change in fixing the order by, group by and having clause column resolution logic to match the MySQL rules.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15499

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [X] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required
