### PR TITLE
schemadiff: add `EntityDiffByStatement`, a testing friendly utility

### DIFF
--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -174,3 +174,25 @@ func DiffSchemas(env *Environment, schema1 *Schema, schema2 *Schema, hints *Diff
 	}
 	return schema1.SchemaDiff(schema2, hints)
 }
+
+// EntityDiffByStatement is a helper function that returns a simplified and incomplete EntityDiff based on the given SQL statement.
+// It is useful for testing purposes as a quick mean to wrap a statement with a diff.
+func EntityDiffByStatement(statement sqlparser.Statement) EntityDiff {
+	switch stmt := statement.(type) {
+	case *sqlparser.CreateTable:
+		return &CreateTableEntityDiff{createTable: stmt}
+	case *sqlparser.RenameTable:
+		return &RenameTableEntityDiff{renameTable: stmt}
+	case *sqlparser.AlterTable:
+		return &AlterTableEntityDiff{alterTable: stmt}
+	case *sqlparser.DropTable:
+		return &DropTableEntityDiff{dropTable: stmt}
+	case *sqlparser.CreateView:
+		return &CreateViewEntityDiff{createView: stmt}
+	case *sqlparser.AlterView:
+		return &AlterViewEntityDiff{alterView: stmt}
+	case *sqlparser.DropView:
+		return &DropViewEntityDiff{dropView: stmt}
+	}
+	return nil
+}


### PR DESCRIPTION

## Description

This very simple PR adds a new utility function, that wraps a `sqlparser.Statement` with an appropriate `EntityDiff`. It is useful for unit tests that run outside the `schemadiff` package, and specifically for those that import `schemadiff` as a library.

## Related Issue(s)

- #10203 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
