### PR TITLE
VReplication: Fix workflow filtering in GetWorkflows RPC

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
+++ b/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
@@ -61,6 +61,9 @@ func TestVtctldclientCLI(t *testing.T) {
 	workflowName := "wf1"
 	targetTabs := setupMinimalCustomerKeyspace(t)
 
+	t.Run("WorkflowList", func(t *testing.T) {
+		testWorkflowList(t, sourceKeyspaceName, targetKeyspaceName)
+	})
 	t.Run("MoveTablesCreateFlags1", func(t *testing.T) {
 		testMoveTablesFlags1(t, &mt, sourceKeyspaceName, targetKeyspaceName, workflowName, targetTabs)
 	})
@@ -82,9 +85,6 @@ func TestVtctldclientCLI(t *testing.T) {
 			"40-80": targetKeyspace.Shards["40-80"].Tablets["zone1-500"].Vttablet,
 		}
 		splitShard(t, targetKeyspaceName, reshardWorkflowName, sourceShard, newShards, tablets)
-	})
-	t.Run("WorkflowList", func(t *testing.T) {
-		testWorkflowList(t, sourceKeyspaceName, targetKeyspaceName, workflowName, targetTabs)
 	})
 }
 
@@ -181,7 +181,7 @@ func testMoveTablesFlags3(t *testing.T, sourceKeyspace, targetKeyspace string, t
 }
 
 // Create two workflows in order to confirm that listing all workflows works.
-func testWorkflowList(t *testing.T, sourceKeyspace, targetKeyspace, workflowName string, targetTabs map[string]*cluster.VttabletProcess) {
+func testWorkflowList(t *testing.T, sourceKeyspace, targetKeyspace string) {
 	createFlags := []string{"--auto-start=false", "--tablet-types",
 		"primary,rdonly", "--tablet-types-in-preference-order=true", "--all-cells",
 	}

--- a/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
+++ b/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
@@ -191,11 +191,19 @@ func testWorkflowList(t *testing.T, sourceKeyspace, targetKeyspace, workflowName
 		mt := createMoveTables(t, sourceKeyspace, targetKeyspace, wfNames[i], tables[i], createFlags, nil, nil)
 		defer mt.Cancel()
 	}
+	slices.Sort(wfNames)
 
 	workflowNames := workflowList(targetKeyspace)
-	require.Len(t, workflowNames, len(wfNames))
+	slices.Sort(workflowNames)
+	require.EqualValues(t, wfNames, workflowNames)
+
 	workflows := getWorkflows(targetKeyspace)
-	require.Len(t, workflows.Workflows, len(wfNames))
+	workflowNames = make([]string, len(workflows.Workflows))
+	for i := range workflows.Workflows {
+		workflowNames[i] = workflows.Workflows[i].Name
+	}
+	slices.Sort(workflowNames)
+	require.EqualValues(t, wfNames, workflowNames)
 }
 
 func createMoveTables(t *testing.T, sourceKeyspace, targetKeyspace, workflowName, tables string,

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -383,8 +383,9 @@ func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflows
 	span.Annotate("include_logs", req.IncludeLogs)
 	span.Annotate("shards", req.Shards)
 
-	readReq := &tabletmanagerdatapb.ReadVReplicationWorkflowsRequest{
-		IncludeWorkflows: []string{req.Workflow},
+	readReq := &tabletmanagerdatapb.ReadVReplicationWorkflowsRequest{}
+	if req.Workflow != "" {
+		readReq.IncludeWorkflows = []string{req.Workflow}
 	}
 	if req.ActiveOnly {
 		readReq.ExcludeStates = []binlogdatapb.VReplicationWorkflowState{binlogdatapb.VReplicationWorkflowState_Stopped}


### PR DESCRIPTION
## Description

This is a follow-up to the work done in https://github.com/vitessio/vitess/pull/14424 where we moved reads against the vreplication table away from client side generated SQL to typed client-server RPCs (the server then builds the appropriate SELECT against the underlying table).

As part of that work, I errantly always included a workflow include filter in the new RPC request. The result of that is when you want to get/list all workflows, rather than just one, you get no results as the include workflow name filter is `''` — meaning only include workflows where the name is empty.

This PR corrects that and adds tests for `vtctldclient` based "workflow list" related commands.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/15498

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required