### PR TITLE
Respect Straight Join in Vitess query planning

### DIFF
--- a/go/test/endtoend/vtgate/gen4/gen4_test.go
+++ b/go/test/endtoend/vtgate/gen4/gen4_test.go
@@ -187,26 +187,6 @@ func TestSubQueriesOnOuterJoinOnCondition(t *testing.T) {
 	}
 }
 
-func TestPlannerWarning(t *testing.T) {
-	mcmp, closer := start(t)
-	defer closer()
-
-	// straight_join query
-	_ = utils.Exec(t, mcmp.VtConn, `select 1 from t1 straight_join t2 on t1.id = t2.id`)
-	utils.AssertMatches(t, mcmp.VtConn, `show warnings`, `[[VARCHAR("Warning") UINT16(1235) VARCHAR("straight join is converted to normal join")]]`)
-
-	// execute same query again.
-	_ = utils.Exec(t, mcmp.VtConn, `select 1 from t1 straight_join t2 on t1.id = t2.id`)
-	utils.AssertMatches(t, mcmp.VtConn, `show warnings`, `[[VARCHAR("Warning") UINT16(1235) VARCHAR("straight join is converted to normal join")]]`)
-
-	// random query to reset the warning.
-	_ = utils.Exec(t, mcmp.VtConn, `select 1 from t1`)
-
-	// execute same query again.
-	_ = utils.Exec(t, mcmp.VtConn, `select 1 from t1 straight_join t2 on t1.id = t2.id`)
-	utils.AssertMatches(t, mcmp.VtConn, `show warnings`, `[[VARCHAR("Warning") UINT16(1235) VARCHAR("straight join is converted to normal join")]]`)
-}
-
 func TestHashJoin(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1881,6 +1881,26 @@ func (node DatabaseOptionType) ToString() string {
 	}
 }
 
+// IsCommutative returns whether the join type supports rearranging or not.
+func (joinType JoinType) IsCommutative() bool {
+	switch joinType {
+	case StraightJoinType, LeftJoinType, RightJoinType, NaturalLeftJoinType, NaturalRightJoinType:
+		return false
+	default:
+		return true
+	}
+}
+
+// IsInner returns whether the join type is an inner join or not.
+func (joinType JoinType) IsInner() bool {
+	switch joinType {
+	case StraightJoinType, NaturalJoinType, NormalJoinType:
+		return true
+	default:
+		return false
+	}
+}
+
 // ToString returns the type as a string
 func (ty LockType) ToString() string {
 	switch ty {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -3343,18 +3343,12 @@ func TestGen4SelectStraightJoin(t *testing.T) {
 	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{
 		{
-			Sql:           "select u.id from `user` as u, user2 as u2 where u.id = u2.id",
+			Sql:           "select u.id from `user` as u straight_join user2 as u2 on u.id = u2.id",
 			BindVariables: map[string]*querypb.BindVariable{},
 		},
 	}
-	wantWarnings := []*querypb.QueryWarning{
-		{
-			Code:    1235,
-			Message: "straight join is converted to normal join",
-		},
-	}
 	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	utils.MustMatch(t, wantWarnings, session.Warnings)
+	require.Empty(t, session.Warnings)
 }
 
 func TestGen4MultiColumnVindexEqual(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -464,7 +464,7 @@ func transformApplyJoinPlan(ctx *plancontext.PlanningContext, n *operators.Apply
 		return nil, err
 	}
 	opCode := engine.InnerJoin
-	if n.LeftJoin {
+	if !n.JoinType.IsInner() {
 		opCode = engine.LeftJoin
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -222,20 +222,18 @@ func (qb *queryBuilder) joinWith(other *queryBuilder, onCondition sqlparser.Expr
 		sel.SelectExprs = append(sel.SelectExprs, otherSel.SelectExprs...)
 	}
 
+	qb.mergeWhereClauses(stmt, otherStmt)
+
 	var newFromClause []sqlparser.TableExpr
 	switch joinType {
 	case sqlparser.NormalJoinType:
 		newFromClause = append(stmt.GetFrom(), otherStmt.GetFrom()...)
+		qb.addPredicate(onCondition)
 	default:
 		newFromClause = []sqlparser.TableExpr{buildJoin(stmt, otherStmt, onCondition, joinType)}
 	}
 
 	stmt.SetFrom(newFromClause)
-	qb.mergeWhereClauses(stmt, otherStmt)
-
-	if joinType == sqlparser.NormalJoinType {
-		qb.addPredicate(onCondition)
-	}
 }
 
 func (qb *queryBuilder) mergeWhereClauses(stmt, otherStmt FromStatement) {

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -213,7 +213,7 @@ var _ FromStatement = (*sqlparser.Select)(nil)
 var _ FromStatement = (*sqlparser.Update)(nil)
 var _ FromStatement = (*sqlparser.Delete)(nil)
 
-func (qb *queryBuilder) joinInnerWith(other *queryBuilder, onCondition sqlparser.Expr) {
+func (qb *queryBuilder) joinWith(other *queryBuilder, onCondition sqlparser.Expr, joinType sqlparser.JoinType) {
 	stmt := qb.stmt.(FromStatement)
 	otherStmt := other.stmt.(FromStatement)
 
@@ -222,24 +222,20 @@ func (qb *queryBuilder) joinInnerWith(other *queryBuilder, onCondition sqlparser
 		sel.SelectExprs = append(sel.SelectExprs, otherSel.SelectExprs...)
 	}
 
-	newFromClause := append(stmt.GetFrom(), otherStmt.GetFrom()...)
-	stmt.SetFrom(newFromClause)
-	qb.mergeWhereClauses(stmt, otherStmt)
-	qb.addPredicate(onCondition)
-}
-
-func (qb *queryBuilder) joinOuterWith(other *queryBuilder, onCondition sqlparser.Expr) {
-	stmt := qb.stmt.(FromStatement)
-	otherStmt := other.stmt.(FromStatement)
-
-	if sel, isSel := stmt.(*sqlparser.Select); isSel {
-		otherSel := otherStmt.(*sqlparser.Select)
-		sel.SelectExprs = append(sel.SelectExprs, otherSel.SelectExprs...)
+	var newFromClause []sqlparser.TableExpr
+	switch joinType {
+	case sqlparser.NormalJoinType:
+		newFromClause = append(stmt.GetFrom(), otherStmt.GetFrom()...)
+	default:
+		newFromClause = []sqlparser.TableExpr{buildJoin(stmt, otherStmt, onCondition, joinType)}
 	}
 
-	newFromClause := []sqlparser.TableExpr{buildOuterJoin(stmt, otherStmt, onCondition)}
 	stmt.SetFrom(newFromClause)
 	qb.mergeWhereClauses(stmt, otherStmt)
+
+	if joinType == sqlparser.NormalJoinType {
+		qb.addPredicate(onCondition)
+	}
 }
 
 func (qb *queryBuilder) mergeWhereClauses(stmt, otherStmt FromStatement) {
@@ -254,7 +250,7 @@ func (qb *queryBuilder) mergeWhereClauses(stmt, otherStmt FromStatement) {
 	}
 }
 
-func buildOuterJoin(stmt FromStatement, otherStmt FromStatement, onCondition sqlparser.Expr) *sqlparser.JoinTableExpr {
+func buildJoin(stmt FromStatement, otherStmt FromStatement, onCondition sqlparser.Expr, joinType sqlparser.JoinType) *sqlparser.JoinTableExpr {
 	var lhs sqlparser.TableExpr
 	fromClause := stmt.GetFrom()
 	if len(fromClause) == 1 {
@@ -273,7 +269,7 @@ func buildOuterJoin(stmt FromStatement, otherStmt FromStatement, onCondition sql
 	return &sqlparser.JoinTableExpr{
 		LeftExpr:  lhs,
 		RightExpr: rhs,
-		Join:      sqlparser.LeftJoinType,
+		Join:      joinType,
 		Condition: &sqlparser.JoinCondition{
 			On: onCondition,
 		},
@@ -539,11 +535,7 @@ func buildApplyJoin(op *ApplyJoin, qb *queryBuilder) {
 
 	qbR := &queryBuilder{ctx: qb.ctx}
 	buildQuery(op.RHS, qbR)
-	if op.LeftJoin {
-		qb.joinOuterWith(qbR, pred)
-	} else {
-		qb.joinInnerWith(qbR, pred)
-	}
+	qb.joinWith(qbR, pred, op.JoinType)
 }
 
 func buildUnion(op *Union, qb *queryBuilder) {

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -373,7 +373,7 @@ func pushAggregationThroughApplyJoin(ctx *plancontext.PlanningContext, rootAggr 
 	rhs := createJoinPusher(rootAggr, join.RHS)
 
 	columns := &applyJoinColumns{}
-	output, err := splitAggrColumnsToLeftAndRight(ctx, rootAggr, join, join.LeftJoin, columns, lhs, rhs)
+	output, err := splitAggrColumnsToLeftAndRight(ctx, rootAggr, join, !join.JoinType.IsInner(), columns, lhs, rhs)
 	join.JoinColumns = columns
 	if err != nil {
 		// if we get this error, we just abort the splitting and fall back on simpler ways of solving the same query

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -143,7 +143,7 @@ func (aj *ApplyJoin) SetRHS(operator Operator) {
 
 func (aj *ApplyJoin) MakeInner() {
 	if aj.IsInner() {
-		panic(vterrors.VT13001("Convert an already inner join"))
+		return
 	}
 	aj.JoinType = sqlparser.NormalJoinType
 }

--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -229,7 +229,7 @@ func getOperatorFromJoinTableExpr(ctx *plancontext.PlanningContext, tableExpr *s
 	case sqlparser.NormalJoinType:
 		return createInnerJoin(ctx, tableExpr, lhs, rhs)
 	case sqlparser.LeftJoinType, sqlparser.RightJoinType, sqlparser.StraightJoinType:
-		return createLeftAndStraightJoin(tableExpr, lhs, rhs)
+		return createLeftAndStraightJoin(ctx, tableExpr, lhs, rhs)
 	default:
 		panic(vterrors.VT13001("unsupported: %s", tableExpr.Join.ToString()))
 	}

--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -228,8 +228,10 @@ func getOperatorFromJoinTableExpr(ctx *plancontext.PlanningContext, tableExpr *s
 	switch tableExpr.Join {
 	case sqlparser.NormalJoinType:
 		return createInnerJoin(ctx, tableExpr, lhs, rhs)
-	case sqlparser.LeftJoinType, sqlparser.RightJoinType, sqlparser.StraightJoinType:
-		return createLeftAndStraightJoin(ctx, tableExpr, lhs, rhs)
+	case sqlparser.LeftJoinType, sqlparser.RightJoinType:
+		return createLeftOuterJoin(ctx, tableExpr, lhs, rhs)
+	case sqlparser.StraightJoinType:
+		return createStraightJoin(ctx, tableExpr, lhs, rhs)
 	default:
 		panic(vterrors.VT13001("unsupported: %s", tableExpr.Join.ToString()))
 	}

--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -228,8 +228,8 @@ func getOperatorFromJoinTableExpr(ctx *plancontext.PlanningContext, tableExpr *s
 	switch tableExpr.Join {
 	case sqlparser.NormalJoinType:
 		return createInnerJoin(ctx, tableExpr, lhs, rhs)
-	case sqlparser.LeftJoinType, sqlparser.RightJoinType:
-		return createOuterJoin(tableExpr, lhs, rhs)
+	case sqlparser.LeftJoinType, sqlparser.RightJoinType, sqlparser.StraightJoinType:
+		return createLeftAndStraightJoin(tableExpr, lhs, rhs)
 	default:
 		panic(vterrors.VT13001("unsupported: %s", tableExpr.Join.ToString()))
 	}

--- a/go/vt/vtgate/planbuilder/operators/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/projection_pushing.go
@@ -214,7 +214,7 @@ func pushProjectionInApplyJoin(
 	src *ApplyJoin,
 ) (Operator, *ApplyResult) {
 	ap, err := p.GetAliasedProjections()
-	if src.LeftJoin || err != nil {
+	if !src.IsInner() || err != nil {
 		// we can't push down expression evaluation to the rhs if we are not sure if it will even be executed
 		return p, NoRewrite
 	}

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -408,7 +408,7 @@ func canPushLeft(ctx *plancontext.PlanningContext, aj *ApplyJoin, order []OrderB
 
 func isOuterTable(op Operator, ts semantics.TableSet) bool {
 	aj, ok := op.(*ApplyJoin)
-	if ok && aj.LeftJoin && TableID(aj.RHS).IsOverlapping(ts) {
+	if ok && !aj.IsInner() && TableID(aj.RHS).IsOverlapping(ts) {
 		return true
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -231,7 +231,7 @@ func tryPushSubQueryInJoin(
 		return outer, Rewrote("push subquery into LHS of join")
 	}
 
-	if outer.LeftJoin || len(inner.Predicates) == 0 {
+	if !outer.IsInner() || len(inner.Predicates) == 0 {
 		// we can't push any filters on the RHS of an outer join, and
 		// we don't want to push uncorrelated subqueries to the RHS of a join
 		return nil, NoRewrite
@@ -278,7 +278,7 @@ func extractLHSExpr(
 
 // tryMergeWithRHS attempts to merge a subquery with the RHS of a join
 func tryMergeWithRHS(ctx *plancontext.PlanningContext, inner *SubQuery, outer *ApplyJoin) (Operator, *ApplyResult) {
-	if outer.LeftJoin {
+	if !outer.IsInner() {
 		return nil, nil
 	}
 	// both sides need to be routes

--- a/go/vt/vtgate/planbuilder/testdata/onecase.json
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.json
@@ -1,60 +1,9 @@
-{
-  "OperatorType": "Join",
-  "Variant": "Join",
-  "JoinColumnIndexes": "R:0,R:1,L:0",
-  "JoinVars": {
-    "t1_id1": 1
-  },
-  "TableName": "t1_tbl",
-  "Inputs": [
-    {
-      "OperatorType": "Route",
-      "Variant": "Scatter",
-      "Keyspace": {
-        "Name": "ks_misc",
-        "Sharded": true
-      },
-      "FieldQuery": "select t1.id2, t1.id1 from t1 where 1 != 1",
-      "Query": "select t1.id2, t1.id1 from t1",
-      "Table": "t1"
-    },
-    {
-      "OperatorType": "VindexLookup",
-      "Variant": "EqualUnique",
-      "Keyspace": {
-        "Name": "ks_misc",
-        "Sharded": true
-      },
-      "Values": [
-        ":t1_id1"
-      ],
-      "Vindex": "unq_vdx",
-      "Inputs": [
-        {
-          "OperatorType": "Route",
-          "Variant": "IN",
-          "Keyspace": {
-            "Name": "ks_misc",
-            "Sharded": true
-          },
-          "FieldQuery": "select unq_col, keyspace_id from unq_idx where 1 != 1",
-          "Query": "select unq_col, keyspace_id from unq_idx where unq_col in ::__vals",
-          "Table": "unq_idx",
-          "Values": [
-            "::unq_col"
-          ],
-          "Vindex": "hash"
-        },
-        {
-          "OperatorType": "Route",
-          "Variant": "ByDestination",
-          "Keyspace": {
-            "Name": "ks_misc",
-            "Sharded": true
-          },
-          "FieldQuery": "select tbl.unq_col, tbl.nonunq_col from tbl where 1 != 1",
-          "Query": "select tbl.unq_col, tbl.nonunq_col from tbl where tbl.unq_col = :t1_id1",
-          "Table": "tbl"
-        }
-      ]
+[
+  {
+    "comment": "Add your test case here for debugging and run go test -run=One.",
+    "query": "",
+    "plan": {
+
     }
+  }
+]

--- a/go/vt/vtgate/planbuilder/testdata/onecase.json
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.json
@@ -1,9 +1,60 @@
-[
-  {
-    "comment": "Add your test case here for debugging and run go test -run=One.",
-    "query": "",
-    "plan": {
-
+{
+  "OperatorType": "Join",
+  "Variant": "Join",
+  "JoinColumnIndexes": "R:0,R:1,L:0",
+  "JoinVars": {
+    "t1_id1": 1
+  },
+  "TableName": "t1_tbl",
+  "Inputs": [
+    {
+      "OperatorType": "Route",
+      "Variant": "Scatter",
+      "Keyspace": {
+        "Name": "ks_misc",
+        "Sharded": true
+      },
+      "FieldQuery": "select t1.id2, t1.id1 from t1 where 1 != 1",
+      "Query": "select t1.id2, t1.id1 from t1",
+      "Table": "t1"
+    },
+    {
+      "OperatorType": "VindexLookup",
+      "Variant": "EqualUnique",
+      "Keyspace": {
+        "Name": "ks_misc",
+        "Sharded": true
+      },
+      "Values": [
+        ":t1_id1"
+      ],
+      "Vindex": "unq_vdx",
+      "Inputs": [
+        {
+          "OperatorType": "Route",
+          "Variant": "IN",
+          "Keyspace": {
+            "Name": "ks_misc",
+            "Sharded": true
+          },
+          "FieldQuery": "select unq_col, keyspace_id from unq_idx where 1 != 1",
+          "Query": "select unq_col, keyspace_id from unq_idx where unq_col in ::__vals",
+          "Table": "unq_idx",
+          "Values": [
+            "::unq_col"
+          ],
+          "Vindex": "hash"
+        },
+        {
+          "OperatorType": "Route",
+          "Variant": "ByDestination",
+          "Keyspace": {
+            "Name": "ks_misc",
+            "Sharded": true
+          },
+          "FieldQuery": "select tbl.unq_col, tbl.nonunq_col from tbl where 1 != 1",
+          "Query": "select tbl.unq_col, tbl.nonunq_col from tbl where tbl.unq_col = :t1_id1",
+          "Table": "tbl"
+        }
+      ]
     }
-  }
-]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2329,6 +2329,74 @@
     }
   },
   {
+    "comment": "Straight Join ensures specific ordering of joins",
+    "query": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.foo",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.foo",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0,R:0",
+        "JoinVars": {
+          "user_id": 0
+        },
+        "TableName": "`user`_user_extra",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `user`.id from `user` where 1 != 1",
+            "Query": "select `user`.id from `user`",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select user_extra.user_id from user_extra where 1 != 1",
+            "Query": "select user_extra.user_id from user_extra where user_extra.foo = :user_id",
+            "Table": "user_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "Straight Join preserved in MySQL query",
+    "query": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.user_id",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.user_id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.id, user_extra.user_id from `user` straight_join user_extra on `user`.id = user_extra.user_id where 1 != 1",
+        "Query": "select `user`.id, user_extra.user_id from `user` straight_join user_extra on `user`.id = user_extra.user_id",
+        "Table": "`user`, user_extra"
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
     "comment": "correlated subquery in exists clause",
     "query": "select col from user where exists(select user_id from user_extra where user_id = 3 and user_id < user.id)",
     "plan": {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -47,8 +47,6 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 	switch node := cursor.Node().(type) {
 	case sqlparser.SelectExprs:
 		return r.handleSelectExprs(cursor, node)
-	case *sqlparser.JoinTableExpr:
-		r.handleJoinTableExprDown(node)
 	case *sqlparser.OrExpr:
 		rewriteOrExpr(r.env, cursor, node)
 	case *sqlparser.AndExpr:
@@ -221,15 +219,6 @@ func (r *earlyRewriter) handleSelectExprs(cursor *sqlparser.Cursor, node sqlpars
 		return nil
 	}
 	return r.expandStar(cursor, node)
-}
-
-// handleJoinTableExprDown processes JOIN table expressions and handles the Straight Join type.
-func (r *earlyRewriter) handleJoinTableExprDown(node *sqlparser.JoinTableExpr) {
-	if node.Join != sqlparser.StraightJoinType {
-		return
-	}
-	node.Join = sqlparser.NormalJoinType
-	r.warning = "straight join is converted to normal join"
 }
 
 type orderByIterator struct {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds the feature requested in https://github.com/vitessio/vitess/issues/15527.

After these changes, Vitess respects the order of tables specified in queries using straight joins.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15527

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
