### PR TITLE
Fix error message for planned reparent shard

### DIFF
--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -19,6 +19,7 @@ package reparentutil
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -88,23 +89,23 @@ func ElectNewPrimary(
 
 	// candidates are the list of tablets that can be potentially promoted after filtering out based on preliminary checks.
 	candidates := []*topodatapb.Tablet{}
-	var reasonsToInvalidate string
+	reasonsToInvalidate := strings.Builder{}
 	for _, tablet := range tabletMap {
 		switch {
 		case newPrimaryAlias != nil:
 			// If newPrimaryAlias is provided, then that is the only valid tablet, even if it is not of type replica or in a different cell.
 			if !topoproto.TabletAliasEqual(tablet.Alias, newPrimaryAlias) {
-				reasonsToInvalidate += fmt.Sprintf("\n%v does not match the new primary alias provided", topoproto.TabletAliasString(tablet.Alias))
+				reasonsToInvalidate.WriteString(fmt.Sprintf("\n%v does not match the new primary alias provided", topoproto.TabletAliasString(tablet.Alias)))
 				continue
 			}
 		case primaryCell != "" && tablet.Alias.Cell != primaryCell:
-			reasonsToInvalidate += fmt.Sprintf("\n%v is not in the same cell as the previous primary", topoproto.TabletAliasString(tablet.Alias))
+			reasonsToInvalidate.WriteString(fmt.Sprintf("\n%v is not in the same cell as the previous primary", topoproto.TabletAliasString(tablet.Alias)))
 			continue
 		case avoidPrimaryAlias != nil && topoproto.TabletAliasEqual(tablet.Alias, avoidPrimaryAlias):
-			reasonsToInvalidate += fmt.Sprintf("\n%v matches the primary alias to avoid", topoproto.TabletAliasString(tablet.Alias))
+			reasonsToInvalidate.WriteString(fmt.Sprintf("\n%v matches the primary alias to avoid", topoproto.TabletAliasString(tablet.Alias)))
 			continue
 		case tablet.Tablet.Type != topodatapb.TabletType_REPLICA:
-			reasonsToInvalidate += fmt.Sprintf("\n%v is not a replica", topoproto.TabletAliasString(tablet.Alias))
+			reasonsToInvalidate.WriteString(fmt.Sprintf("\n%v is not a replica", topoproto.TabletAliasString(tablet.Alias)))
 			continue
 		}
 
@@ -130,7 +131,7 @@ func ElectNewPrimary(
 				validTablets = append(validTablets, tb)
 				tabletPositions = append(tabletPositions, pos)
 			} else {
-				reasonsToInvalidate += fmt.Sprintf("\n%v has %v replication lag which is more than the tolerable amount", topoproto.TabletAliasString(tablet.Alias), replLag)
+				reasonsToInvalidate.WriteString(fmt.Sprintf("\n%v has %v replication lag which is more than the tolerable amount", topoproto.TabletAliasString(tablet.Alias), replLag))
 			}
 			return err
 		})
@@ -143,7 +144,7 @@ func ElectNewPrimary(
 
 	// return an error if there are no valid tablets available
 	if len(validTablets) == 0 {
-		return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "cannot find a tablet to reparent to%v", reasonsToInvalidate)
+		return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "cannot find a tablet to reparent to%v", reasonsToInvalidate.String())
 	}
 
 	// sort the tablets for finding the best primary


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue described in https://github.com/vitessio/vitess/issues/15380. 
In `PlannedReparentShard` we now give a more descriptive error message telling exactly why the tablets cannot be promoted. Post these changes, the error message now looks like - 

```
cannot find a tablet to reparent to
zone1-0000000100 does not match the new primary alias provided
zone1-0000000101 does not match the new primary alias provided
zone2-0000000102 is not a replica
zone1-0000000103 is not in the same cell as the previous primary
zone1-0000000104 has 1m40s replication lag which is more than the tolerable amount
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15380

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
