### PR TITLE
WIP: `TabletManagerClient` real pool dialer

### DIFF
--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -733,7 +733,7 @@ func MakeAPICall(t *testing.T, vtorc *cluster.VTOrcProcess, url string) (status 
 // The function provided takes in the status and response and returns if we should continue to retry or not
 func MakeAPICallRetry(t *testing.T, vtorc *cluster.VTOrcProcess, url string, retry func(int, string) bool) (status int, response string) {
 	t.Helper()
-	timeout := time.After(10 * time.Second)
+	timeout := time.After(30 * time.Second)
 	for {
 		select {
 		case <-timeout:


### PR DESCRIPTION

## Description

An alternative to https://github.com/vitessio/vitess/pull/15520, using same tests, but with different solution.

The `TabletManagerClient` pool dialer is not a real pool. It holds `n` clients, and shares them arbitrarily among potentially unlimited users. This means a single client (connection) can be held concurrently by many users. Not one user has the ownership to `Close()` a client on error, because other users could be using that connection at that same time.,

This PR addresses specifically `CheckThrottler` and `FullStatus` functions, which are invoked mroe frequently than others, and creates a new, actual pool implementation. We don't want to impact otherwise existing logic for `Execute*Fetch*` functions, which are also users of `dialPool`. Hence we create a 2nd pool mechanism, to be used specifically by the aforementioned two functions.


## Related Issue(s)

https://github.com/vitessio/vitess/pull/15520

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
