### PR TITLE
bugfix: handling of ANDed join predicates

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -156,10 +156,14 @@ func (aj *ApplyJoin) AddJoinPredicate(ctx *plancontext.PlanningContext, expr sql
 	if expr == nil {
 		return
 	}
-	col := breakExpressionInLHSandRHSForApplyJoin(ctx, expr, TableID(aj.LHS))
-	aj.JoinPredicates.add(col)
-	ctx.AddJoinPredicates(expr, col.RHSExpr)
-	rhs := aj.RHS.AddPredicate(ctx, col.RHSExpr)
+	rhs := aj.RHS
+	predicates := sqlparser.SplitAndExpression(nil, expr)
+	for _, pred := range predicates {
+		col := breakExpressionInLHSandRHSForApplyJoin(ctx, pred, TableID(aj.LHS))
+		aj.JoinPredicates.add(col)
+		ctx.AddJoinPredicates(pred, col.RHSExpr)
+		rhs = rhs.AddPredicate(ctx, col.RHSExpr)
+	}
 	aj.RHS = rhs
 }
 

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -158,6 +158,7 @@ func (aj *ApplyJoin) AddJoinPredicate(ctx *plancontext.PlanningContext, expr sql
 	}
 	col := breakExpressionInLHSandRHSForApplyJoin(ctx, expr, TableID(aj.LHS))
 	aj.JoinPredicates.add(col)
+	ctx.AddJoinPredicates(expr, col.RHSExpr)
 	rhs := aj.RHS.AddPredicate(ctx, col.RHSExpr)
 	aj.RHS = rhs
 }

--- a/go/vt/vtgate/planbuilder/operators/expressions.go
+++ b/go/vt/vtgate/planbuilder/operators/expressions.go
@@ -51,7 +51,6 @@ func breakExpressionInLHSandRHSForApplyJoin(
 		cursor.Replace(arg)
 	}, nil).(sqlparser.Expr)
 
-	ctx.AddJoinPredicates(expr, rewrittenExpr)
 	col.RHSExpr = rewrittenExpr
 	col.Original = expr
 	return

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2659,6 +2659,30 @@
     }
   },
   {
+    "comment": "Complex join with multiple conditions merged into single route",
+    "query": "select 0 from user as u join user_extra as s on u.id = s.user_id join music as m on m.user_id = u.id and (s.foo or m.bar)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 0 from user as u join user_extra as s on u.id = s.user_id join music as m on m.user_id = u.id and (s.foo or m.bar)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 0 from `user` as u, user_extra as s, music as m where 1 != 1",
+        "Query": "select 0 from `user` as u, user_extra as s, music as m where u.id = s.user_id and m.user_id = u.id and (s.foo or m.bar)",
+        "Table": "`user`, music, user_extra"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
     "comment": "union as a derived table",
     "query": "select found from (select id as found from user union all (select id from unsharded)) as t",
     "plan": {


### PR DESCRIPTION
## Description
We recently did work to handle derived tables better, and in that change set, a bug snuck in when handling complex join predicates with `AND`s in them. When it was possible to merge everything back into a single route, we did not mark the argument form of the join predicates correctly because of the `AND` and it would show up in the final query sent down to the tablets.

## Related Issue(s)
Fixes #15547
Bug introduced in #14974

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
