### PR TITLE
Generate vtctldclient RPC client code from vtctlservice protobufs on make proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ PROTO_SRCS = $(wildcard proto/*.proto)
 PROTO_SRC_NAMES = $(basename $(notdir $(PROTO_SRCS)))
 PROTO_GO_OUTS = $(foreach name, $(PROTO_SRC_NAMES), go/vt/proto/$(name)/$(name).pb.go)
 # This rule rebuilds all the go files from the proto definitions for gRPC.
-proto: $(PROTO_GO_OUTS) vtadmin_web_proto_types
+proto: $(PROTO_GO_OUTS) vtadmin_web_proto_types vtctldclient
 
 ifndef NOBANNER
 	echo $$(date): Compiling proto definitions


### PR DESCRIPTION
## Description

This adds an additional dependency to the `proto` Makefile target, `vtctldclient`, as it is dependent on proto changes — in addition to `vtadmin_web_proto_types` which was already there. This way we will regenerate the `vtctldclient` gRPC client code when the `vtctlservice.proto` is changed and the protobufs are subsequently rebuilt. This ensures that our proto dependent code stays in sync.

We will also then be checking for drift in the [`static_checks` workflow](https://github.com/vitessio/vitess/blob/main/.github/workflows/static_checks_etc.yml) as part of the [`check_make_proto` step](https://github.com/vitessio/vitess/blob/4f2456064a9773447c059193e485d2bf02cfab96/.github/workflows/static_checks_etc.yml#L204-L207).

## Related Issue(s)

  - Prevents future issues like: https://github.com/vitessio/vitess/pull/15558

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required