### PR TITLE
Add testing for shard scoped foreign keys

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/fk_fuzz_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_fuzz_test.go
@@ -708,7 +708,7 @@ func TestFkFuzzTest(t *testing.T) {
 	valFalse := false
 	for _, fkState := range []*bool{nil, &valTrue, &valFalse} {
 		for _, tt := range testcases {
-			for _, keyspace := range []string{unshardedKs, shardedKs, shardScopedKs} {
+			for _, keyspace := range []string{unshardedKs, shardedKs} {
 				for _, queryFormat := range []QueryFormat{OlapSQLQueries, SQLQueries, PreparedStatmentQueries, PreparedStatementPacket} {
 					if fkState != nil && (queryFormat != SQLQueries || tt.concurrency != 1) {
 						continue

--- a/go/test/endtoend/vtgate/foreignkey/fk_fuzz_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_fuzz_test.go
@@ -257,20 +257,20 @@ func (fz *fuzzer) generateDeleteDMLQuery() string {
 }
 
 // start starts running the fuzzer.
-func (fz *fuzzer) start(t *testing.T, sharded bool) {
+func (fz *fuzzer) start(t *testing.T, keyspace string) {
 	// We mark the fuzzer thread to be running now.
 	fz.shouldStop.Store(false)
 	fz.wg.Add(fz.concurrency)
 	for i := 0; i < fz.concurrency; i++ {
 		fuzzerThreadId := i
 		go func() {
-			fz.runFuzzerThread(t, sharded, fuzzerThreadId)
+			fz.runFuzzerThread(t, keyspace, fuzzerThreadId)
 		}()
 	}
 }
 
 // runFuzzerThread is used to run a thread of the fuzzer.
-func (fz *fuzzer) runFuzzerThread(t *testing.T, sharded bool, fuzzerThreadId int) {
+func (fz *fuzzer) runFuzzerThread(t *testing.T, keyspace string, fuzzerThreadId int) {
 	// Whenever we finish running this thread, we should mark the thread has stopped.
 	defer func() {
 		fz.wg.Done()
@@ -293,16 +293,9 @@ func (fz *fuzzer) runFuzzerThread(t *testing.T, sharded bool, fuzzerThreadId int
 		defer mysqlDb.Close()
 	}
 	// Set the correct keyspace to use from VtGates.
-	if sharded {
-		_ = utils.Exec(t, mcmp.VtConn, "use `ks`")
-		if vitessDb != nil {
-			_, _ = vitessDb.Exec("use `ks`")
-		}
-	} else {
-		_ = utils.Exec(t, mcmp.VtConn, "use `uks`")
-		if vitessDb != nil {
-			_, _ = vitessDb.Exec("use `uks`")
-		}
+	_ = utils.Exec(t, mcmp.VtConn, fmt.Sprintf("use `%v`", keyspace))
+	if vitessDb != nil {
+		_, _ = vitessDb.Exec(fmt.Sprintf("use `%v`", keyspace))
 	}
 	if fz.queryFormat == OlapSQLQueries {
 		_ = utils.Exec(t, mcmp.VtConn, "set workload = olap")
@@ -715,21 +708,19 @@ func TestFkFuzzTest(t *testing.T) {
 	valFalse := false
 	for _, fkState := range []*bool{nil, &valTrue, &valFalse} {
 		for _, tt := range testcases {
-			for _, testSharded := range []bool{false, true} {
+			for _, keyspace := range []string{unshardedKs, shardedKs, shardScopedKs} {
 				for _, queryFormat := range []QueryFormat{OlapSQLQueries, SQLQueries, PreparedStatmentQueries, PreparedStatementPacket} {
 					if fkState != nil && (queryFormat != SQLQueries || tt.concurrency != 1) {
 						continue
 					}
-					t.Run(getTestName(tt.name, testSharded)+fmt.Sprintf(" FkState - %v QueryFormat - %v", sqlparser.FkChecksStateString(fkState), queryFormat), func(t *testing.T) {
+					t.Run(getTestName(tt.name, keyspace)+fmt.Sprintf(" FkState - %v QueryFormat - %v", sqlparser.FkChecksStateString(fkState), queryFormat), func(t *testing.T) {
 						mcmp, closer := start(t)
 						defer closer()
-						// Set the correct keyspace to use from VtGates.
-						if testSharded {
+						if keyspace == shardedKs {
 							t.Skip("Skip test since we don't have sharded foreign key support yet")
-							_ = utils.Exec(t, mcmp.VtConn, "use `ks`")
-						} else {
-							_ = utils.Exec(t, mcmp.VtConn, "use `uks`")
 						}
+						// Set the correct keyspace to use from VtGates.
+						_ = utils.Exec(t, mcmp.VtConn, fmt.Sprintf("use `%v`", keyspace))
 
 						// Ensure that the Vitess database is originally empty
 						ensureDatabaseState(t, mcmp.VtConn, true)
@@ -739,7 +730,7 @@ func TestFkFuzzTest(t *testing.T) {
 						fz := newFuzzer(tt.concurrency, tt.maxValForId, tt.maxValForCol, tt.insertShare, tt.deleteShare, tt.updateShare, queryFormat, fkState)
 
 						// Start the fuzzer.
-						fz.start(t, testSharded)
+						fz.start(t, keyspace)
 
 						// Wait for the timeForTesting so that the threads continue to run.
 						totalTime := time.After(tt.timeForTesting)

--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -891,7 +891,7 @@ func TestFkScenarios(t *testing.T) {
 					t.Skip("Skip test since we don't have sharded foreign key support yet")
 				}
 				if keyspace == shardScopedKs && tt.skipShardScoped {
-					t.Skip("Skip test since we don't support updates in vindex columns")
+					t.Skip("Skip test since we don't support updates in primary vindex columns")
 				}
 				// Set the correct keyspace to use from VtGates.
 				_ = utils.Exec(t, mcmp.VtConn, fmt.Sprintf("use `%v`", keyspace))

--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -380,6 +380,7 @@ func TestFkScenarios(t *testing.T) {
 		dataQueries      []string
 		dmlQuery         string
 		dmlShouldErr     bool
+		skipShardScoped  bool
 		assertionQueries []string
 	}{
 		{
@@ -421,7 +422,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_t1(id, col) values (1, 7), (2, 9)",
 				"insert into fk_t2(id, col) values (1, 7)",
 			},
-			dmlQuery: "update fk_t1 set col = 5 where id = 2",
+			dmlQuery:        "update fk_t1 set col = 5 where id = 2",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_t1 order by id",
 				"select * from fk_t2 order by id",
@@ -457,7 +459,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_t3(id, col) values (1, 7)",
 				"insert into fk_t6(id, col) values (1, 7)",
 			},
-			dmlQuery: "update fk_t3 set col = 9 where id = 1",
+			dmlQuery:        "update fk_t3 set col = 9 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_t1 order by id",
 				"select * from fk_t2 order by id",
@@ -491,7 +494,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_t4(id, col) values (1, 7), (2, 9)",
 				"insert into fk_t6(id, col) values (1, 7), (2, 9)",
 			},
-			dmlQuery: "update fk_t2 set col = 9 where id = 1",
+			dmlQuery:        "update fk_t2 set col = 9 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_t1 order by id",
 				"select * from fk_t2 order by id",
@@ -507,7 +511,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_t3(id, col) values (1, 7), (2, 9)",
 				"insert into fk_t6(id, col) values (1, 7)",
 			},
-			dmlQuery: "delete from fk_t3 where id = 1",
+			dmlQuery:        "delete from fk_t3 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_t1 order by id",
 				"select * from fk_t2 order by id",
@@ -541,7 +546,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_t4(id, col) values (1, 7), (2, 9)",
 				"insert into fk_t6(id, col) values (1, 7), (2, 9)",
 			},
-			dmlQuery: "delete from fk_t2 where id = 1",
+			dmlQuery:        "delete from fk_t2 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_t1 order by id",
 				"select * from fk_t2 order by id",
@@ -555,7 +561,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_t10(id, col) values (1, 7), (2, 9)",
 				"insert into fk_t11(id, col) values (1, 7)",
 			},
-			dmlQuery: "update fk_t10 set col = 5 where id = 1",
+			dmlQuery:        "update fk_t10 set col = 5 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_t10 order by id",
 				"select * from fk_t11 order by id",
@@ -581,7 +588,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_t11(id, col) values (1, 7)",
 				"insert into fk_t12(id, col) values (1, 7)",
 			},
-			dmlQuery: "update fk_t10 set col = 5 where id = 1",
+			dmlQuery:        "update fk_t10 set col = 5 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_t10 order by id",
 				"select * from fk_t11 order by id",
@@ -633,7 +641,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_multicol_t17(id, cola, colb) values (1, 7, 1)",
 				"insert into fk_multicol_t18(id, cola, colb) values (1, 7, 1)",
 			},
-			dmlQuery: "delete from fk_multicol_t16 where id = 1",
+			dmlQuery:        "delete from fk_multicol_t16 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_multicol_t15 order by id",
 				"select * from fk_multicol_t16 order by id",
@@ -648,7 +657,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_multicol_t17(id, cola, colb) values (1, 7, 1)",
 				"insert into fk_multicol_t18(id, cola, colb) values (1, 7, 1)",
 			},
-			dmlQuery: "delete from fk_multicol_t15 where id = 1",
+			dmlQuery:        "delete from fk_multicol_t15 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_multicol_t15 order by id",
 				"select * from fk_multicol_t16 order by id",
@@ -663,7 +673,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_multicol_t17(id, cola, colb) values (1, 7, 1)",
 				"insert into fk_multicol_t18(id, cola, colb) values (1, 7, 1)",
 			},
-			dmlQuery: "update fk_multicol_t15 set cola = 3 where id = 1",
+			dmlQuery:        "update fk_multicol_t15 set cola = 3 where id = 1",
+			skipShardScoped: true,
 			assertionQueries: []string{
 				"select * from fk_multicol_t15 order by id",
 				"select * from fk_multicol_t16 order by id",
@@ -675,7 +686,8 @@ func TestFkScenarios(t *testing.T) {
 			dataQueries: []string{
 				"insert into fk_t20(id, col, col2) values (1, 7, NULL)",
 			},
-			dmlQuery: "insert into fk_t20(id, col, col2) values (2, 9, 7), (3, 10, 9)",
+			skipShardScoped: true,
+			dmlQuery:        "insert into fk_t20(id, col, col2) values (2, 9, 7), (3, 10, 9)",
 			assertionQueries: []string{
 				"select * from fk_t20 order by id",
 			},
@@ -684,8 +696,9 @@ func TestFkScenarios(t *testing.T) {
 			dataQueries: []string{
 				"insert into fk_t20(id, col, col2) values (5, 7, NULL)",
 			},
-			dmlQuery:     "insert into fk_t20(id, col, col2) values (6, 9, 6)",
-			dmlShouldErr: true,
+			skipShardScoped: true,
+			dmlQuery:        "insert into fk_t20(id, col, col2) values (6, 9, 6)",
+			dmlShouldErr:    true,
 			assertionQueries: []string{
 				"select * from fk_t20 order by id",
 			},
@@ -697,7 +710,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_multicol_t17(id, cola, colb) values (1, 7, 1)",
 				"insert into fk_multicol_t19(id, cola, colb) values (1, 7, 1)",
 			},
-			dmlQuery: "delete fk_multicol_t15 from fk_multicol_t15 join fk_multicol_t17 where fk_multicol_t15.id = fk_multicol_t17.id",
+			skipShardScoped: true,
+			dmlQuery:        "delete fk_multicol_t15 from fk_multicol_t15 join fk_multicol_t17 where fk_multicol_t15.id = fk_multicol_t17.id",
 			assertionQueries: []string{
 				"select * from fk_multicol_t15 order by id",
 				"select * from fk_multicol_t16 order by id",
@@ -713,7 +727,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_multicol_t18(id, cola, colb) values (1, 7, 1), (3, 11, 1)",
 				"insert into fk_multicol_t19(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
 			},
-			dmlQuery: "delete fk_multicol_t15, fk_multicol_t17 from fk_multicol_t15 join fk_multicol_t17 where fk_multicol_t15.id = fk_multicol_t17.id",
+			skipShardScoped: true,
+			dmlQuery:        "delete fk_multicol_t15, fk_multicol_t17 from fk_multicol_t15 join fk_multicol_t17 where fk_multicol_t15.id = fk_multicol_t17.id",
 			assertionQueries: []string{
 				"select * from fk_multicol_t15 order by id",
 				"select * from fk_multicol_t16 order by id",
@@ -728,7 +743,8 @@ func TestFkScenarios(t *testing.T) {
 				"insert into fk_multicol_t17(id, cola, colb) values (1, 7, 1)",
 				"insert into fk_multicol_t19(id, cola, colb) values (1, 7, 1)",
 			},
-			dmlQuery: "delete from fk_multicol_t15 order by id limit 1",
+			skipShardScoped: true,
+			dmlQuery:        "delete from fk_multicol_t15 order by id limit 1",
 			assertionQueries: []string{
 				"select * from fk_multicol_t15 order by id",
 				"select * from fk_multicol_t16 order by id",
@@ -736,7 +752,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Delete with limit 0 success",
+			name:            "Delete with limit 0 success",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
@@ -751,7 +768,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Update with limit success",
+			name:            "Update with limit success",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
@@ -766,7 +784,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Update with limit 0 success",
+			name:            "Update with limit 0 success",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
@@ -781,7 +800,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Update with non-literal update and limit success",
+			name:            "Update with non-literal update and limit success",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1)",
@@ -796,7 +816,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Update with non-literal update order by and limit - multiple update",
+			name:            "Update with non-literal update order by and limit - multiple update",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
@@ -811,7 +832,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Update with non-literal update order by and limit - single update",
+			name:            "Update with non-literal update order by and limit - single update",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
@@ -826,7 +848,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Multi Table Update with non-literal update",
+			name:            "Multi Table Update with non-literal update",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
@@ -841,7 +864,8 @@ func TestFkScenarios(t *testing.T) {
 				"select * from fk_multicol_t19 order by id",
 			},
 		}, {
-			name: "Multi Target Update with non-literal update",
+			name:            "Multi Target Update with non-literal update",
+			skipShardScoped: true,
 			dataQueries: []string{
 				"insert into fk_multicol_t15(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
 				"insert into fk_multicol_t16(id, cola, colb) values (1, 7, 1), (2, 9, 1), (3, 12, 1)",
@@ -865,6 +889,9 @@ func TestFkScenarios(t *testing.T) {
 				defer closer()
 				if keyspace == shardedKs {
 					t.Skip("Skip test since we don't have sharded foreign key support yet")
+				}
+				if keyspace == shardScopedKs && tt.skipShardScoped {
+					t.Skip("Skip test since we don't support updates in vindex columns")
 				}
 				// Set the correct keyspace to use from VtGates.
 				_ = utils.Exec(t, mcmp.VtConn, fmt.Sprintf("use `%v`", keyspace))
@@ -890,7 +917,7 @@ func TestFkScenarios(t *testing.T) {
 		}
 	}
 
-	for _, keyspace := range []string{unshardedKs, shardedKs, shardScopedKs} {
+	for _, keyspace := range []string{unshardedKs, shardedKs} {
 		t.Run(getTestName("Transactions with intermediate failure", keyspace), func(t *testing.T) {
 			mcmp, closer := start(t)
 			defer closer()
@@ -1111,7 +1138,7 @@ func TestFkQueries(t *testing.T) {
 	}
 
 	for _, tt := range testcases {
-		for _, keyspace := range []string{unshardedKs, shardedKs, shardScopedKs} {
+		for _, keyspace := range []string{unshardedKs, shardedKs} {
 			t.Run(getTestName(tt.name, keyspace), func(t *testing.T) {
 				mcmp, closer := start(t)
 				defer closer()

--- a/go/test/endtoend/vtgate/foreignkey/shard_scoped_vschema.json
+++ b/go/test/endtoend/vtgate/foreignkey/shard_scoped_vschema.json
@@ -1,0 +1,411 @@
+{
+  "sharded": true,
+  "foreignKeyMode": "managed",
+  "vindexes": {
+    "xxhash": {
+      "type": "xxhash"
+    },
+    "multicol_vdx": {
+      "type": "multicol",
+      "params": {
+        "column_count": "3",
+        "column_bytes": "1,3,4",
+        "column_vindex": "hash,binary,unicode_loose_xxhash"
+      }
+    },
+    "multicol_fk_vdx": {
+      "type": "multicol",
+      "params": {
+        "column_count": "2",
+        "column_bytes": "4,4",
+        "column_vindex": "hash,binary"
+      }
+    }
+  },
+  "tables": {
+    "t1": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "t2": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "t3": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "t4": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "t5": {
+      "column_vindexes": [
+        {
+          "column": "sk",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "t6": {
+      "column_vindexes": [
+        {
+          "column": "sk",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "multicol_tbl1": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb",
+            "colc"
+          ],
+          "name": "multicol_vdx"
+        }
+      ]
+    },
+    "multicol_tbl2": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb",
+            "colc"
+          ],
+          "name": "multicol_vdx"
+        }
+      ]
+    },
+    "fk_t1": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t2": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t3": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t4": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t5": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t6": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t7": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t10": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t11": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t12": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t13": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t15": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t16": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t17": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t18": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t19": {
+      "column_vindexes": [
+        {
+          "column": "col",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_t20": {
+      "column_vindexes": [
+        {
+          "column": "col2",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "fk_multicol_t1": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t2": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t3": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t4": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t5": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t6": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t7": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t10": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t11": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t12": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t13": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t15": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t16": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t17": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t18": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    },
+    "fk_multicol_t19": {
+      "column_vindexes": [
+        {
+          "columns": [
+            "cola",
+            "colb"
+          ],
+          "name": "multicol_fk_vdx"
+        }
+      ]
+    }
+  }
+}

--- a/go/test/endtoend/vtgate/foreignkey/utils_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/utils_test.go
@@ -36,12 +36,9 @@ import (
 
 var supportedOpps = []string{"*", "+", "-"}
 
-// getTestName prepends whether the test is for a sharded keyspace or not to the test name.
-func getTestName(testName string, testSharded bool) string {
-	if testSharded {
-		return "Sharded - " + testName
-	}
-	return "Unsharded - " + testName
+// getTestName prepends the test with keyspace name.
+func getTestName(testName string, keyspace string) string {
+	return keyspace + " - " + testName
 }
 
 // isMultiColFkTable tells if the table is a multicol table or not.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds testing for shard-scoped foreign keys. While making these changes we realised that for shard-scoped foreign keys, the foreign key columns have to be part of the sharding key, which automatically fails all the updates on those columns! 😿 

So, we can currently only support `DELETE RESTRICT` and `DELETE CASCADE` style operations. This PR adds the infra for adding the tests for all the scenarios but skips all the ones that don't work for now. For the same reason, I haven't enabled fuzzer tests either for shard-scoped foreign keys because of the very limited number of queries that actually work.

Here are the tests that work as intended - 

![Screenshot 2024-03-27 at 11 49 20 AM](https://github.com/vitessio/vitess/assets/35839558/e059870e-cceb-4487-bb59-89f75674a803)


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #12967 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
