### PR TITLE
[release-19.0] Fail insert when primary vindex cannot be mapped to a shard (#15500)

### DIFF
--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -89,6 +89,9 @@ var (
 	VT09017 = errorWithoutState("VT09017", vtrpcpb.Code_FAILED_PRECONDITION, "%s", "Invalid syntax for the statement type.")
 	VT09018 = errorWithoutState("VT09018", vtrpcpb.Code_FAILED_PRECONDITION, "%s", "Invalid syntax for the vindex function statement.")
 	VT09019 = errorWithoutState("VT09019", vtrpcpb.Code_FAILED_PRECONDITION, "keyspace '%s' has cyclic foreign keys", "Vitess doesn't support cyclic foreign keys.")
+	VT09022 = errorWithoutState("VT09022", vtrpcpb.Code_FAILED_PRECONDITION, "Destination does not have exactly one shard: %v", "Cannot send query to multiple shards.")
+	VT09023 = errorWithoutState("VT09023", vtrpcpb.Code_FAILED_PRECONDITION, "could not map %v to a keyspace id", "Unable to determine the shard for the given row.")
+	VT09024 = errorWithoutState("VT09024", vtrpcpb.Code_FAILED_PRECONDITION, "could not map %v to a unique keyspace id: %v", "Unable to determine the shard for the given row.")
 
 	VT10001 = errorWithoutState("VT10001", vtrpcpb.Code_ABORTED, "foreign key constraints are not allowed", "Foreign key constraints are not allowed, see https://vitess.io/blog/2021-06-15-online-ddl-why-no-fk/.")
 	VT10002 = errorWithoutState("VT10002", vtrpcpb.Code_ABORTED, "'replace into' with foreign key constraints are not allowed", "Foreign key constraints sometimes are not written in binary logs and will cause issue with vreplication workflows like online-ddl.")
@@ -168,6 +171,9 @@ var (
 		VT09017,
 		VT09018,
 		VT09019,
+		VT09022,
+		VT09023,
+		VT09024,
 		VT10001,
 		VT10002,
 		VT12001,

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -152,7 +152,7 @@ func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor
 		return nil, err
 	}
 	if len(rss) != 1 {
-		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Keyspace does not have exactly one shard: %v", rss)
+		return nil, vterrors.VT09022(rss)
 	}
 	err = allowOnlyPrimary(rss...)
 	if err != nil {
@@ -208,12 +208,11 @@ func (ic *InsertCommon) processPrimary(ctx context.Context, vcursor VCursor, vin
 			// This is a single keyspace id, we're good.
 			keyspaceIDs[i] = d
 		case key.DestinationNone:
-			// No valid keyspace id, we may return an error.
-			if !ic.Ignore {
-				return nil, fmt.Errorf("could not map %v to a keyspace id", vindexColumnsKeys[i])
-			}
+			// Not a valid keyspace id, so we cannot determine which shard this row belongs to.
+			// We have to return an error.
+			return nil, vterrors.VT09023(vindexColumnsKeys[i])
 		default:
-			return nil, fmt.Errorf("could not map %v to a unique keyspace id: %v", vindexColumnsKeys[i], destination)
+			return nil, vterrors.VT09024(vindexColumnsKeys[i], destination)
 		}
 	}
 

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -1406,7 +1406,7 @@ func TestInsertShardedKeyrange(t *testing.T) {
 		TargetString: "@primary",
 	}
 	_, err := executorExec(ctx, executor, session, "insert into keyrange_table(krcol_unique, krcol) values(1, 1)", nil)
-	require.EqualError(t, err, "could not map [INT64(1)] to a unique keyspace id: DestinationKeyRange(-10)")
+	require.EqualError(t, err, "VT09024: could not map [INT64(1)] to a unique keyspace id: DestinationKeyRange(-10)")
 }
 
 func TestInsertShardedAutocommitLookup(t *testing.T) {
@@ -1503,145 +1503,210 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 func TestInsertShardedIgnore(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup, ctx := createExecutorEnv(t)
 
-	// Build the sequence of responses for sbclookup. This should
-	// match the sequence of queries we validate below.
+	int1 := sqltypes.Int64BindVariable(1)
+	int2 := sqltypes.Int64BindVariable(2)
+	int3 := sqltypes.Int64BindVariable(3)
+	int4 := sqltypes.Int64BindVariable(4)
+	int5 := sqltypes.Int64BindVariable(5)
+	int6 := sqltypes.Int64BindVariable(6)
+	uint1 := sqltypes.Uint64BindVariable(1)
+	uint3 := sqltypes.Uint64BindVariable(3)
+
+	var1 := &querypb.BindVariable{Type: querypb.Type_TUPLE,
+		Values: []*querypb.Value{{Type: int1.Type, Value: int1.Value}},
+	}
+	var2 := &querypb.BindVariable{Type: querypb.Type_TUPLE,
+		Values: []*querypb.Value{{Type: int2.Type, Value: int2.Value}},
+	}
+	var3 := &querypb.BindVariable{Type: querypb.Type_TUPLE,
+		Values: []*querypb.Value{{Type: int3.Type, Value: int3.Value}},
+	}
+	var4 := &querypb.BindVariable{Type: querypb.Type_TUPLE,
+		Values: []*querypb.Value{{Type: int4.Type, Value: int4.Value}},
+	}
+	var5 := &querypb.BindVariable{Type: querypb.Type_TUPLE,
+		Values: []*querypb.Value{{Type: int5.Type, Value: int5.Value}},
+	}
+	var6 := &querypb.BindVariable{Type: querypb.Type_TUPLE,
+		Values: []*querypb.Value{{Type: int6.Type, Value: int6.Value}},
+	}
 	fields := sqltypes.MakeTestFields("b|a", "int64|int64")
 	field := sqltypes.MakeTestFields("a", "int64")
-	sbclookup.SetResults([]*sqltypes.Result{
-		// select music_id
-		sqltypes.MakeTestResult(fields, "1|1", "3|1", "4|1", "5|1", "6|3"),
-		// insert ins_lookup
-		{},
-		// select ins_lookup 1
-		sqltypes.MakeTestResult(field, "1"),
-		// select ins_lookup 3
-		{},
-		// select ins_lookup 4
-		sqltypes.MakeTestResult(field, "4"),
-		// select ins_lookup 5
-		sqltypes.MakeTestResult(field, "5"),
-		// select ins_lookup 6
-		sqltypes.MakeTestResult(field, "6"),
-	})
-	// First row: first shard.
-	// Second row: will fail because primary vindex will fail to map.
-	// Third row: will fail because verification will fail on owned vindex after Create.
-	// Fourth row: will fail because verification will fail on unowned hash vindex.
-	// Fifth row: first shard.
-	// Sixth row: second shard (because 3 hash maps to 40-60).
-	query := "insert ignore into insert_ignore_test(pv, owned, verify) values (1, 1, 1), (2, 2, 2), (3, 3, 1), (4, 4, 4), (5, 5, 1), (6, 6, 3)"
-	session := &vtgatepb.Session{
-		TargetString: "@primary",
-	}
-	_, err := executorExec(ctx, executor, session, query, nil)
-	require.NoError(t, err)
-	wantQueries := []*querypb.BoundQuery{{
-		Sql: "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv_0, :_owned_0, :_verify_0),(:_pv_4, :_owned_4, :_verify_4)",
-		BindVariables: map[string]*querypb.BindVariable{
-			"_pv_0":     sqltypes.Int64BindVariable(1),
-			"_pv_4":     sqltypes.Int64BindVariable(5),
-			"_owned_0":  sqltypes.Int64BindVariable(1),
-			"_owned_4":  sqltypes.Int64BindVariable(5),
-			"_verify_0": sqltypes.Int64BindVariable(1),
-			"_verify_4": sqltypes.Int64BindVariable(1),
-		},
-	}}
-	assertQueries(t, sbc1, wantQueries)
-	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv_5, :_owned_5, :_verify_5)",
-		BindVariables: map[string]*querypb.BindVariable{
-			"_pv_5":     sqltypes.Int64BindVariable(6),
-			"_owned_5":  sqltypes.Int64BindVariable(6),
-			"_verify_5": sqltypes.Int64BindVariable(3),
-		},
-	}}
-	assertQueries(t, sbc2, wantQueries)
+	tcases := []struct {
+		query string
+		input []*sqltypes.Result
 
-	vars, err := sqltypes.BuildBindVariable([]any{
-		sqltypes.NewInt64(1),
-		sqltypes.NewInt64(2),
-		sqltypes.NewInt64(3),
-		sqltypes.NewInt64(4),
-		sqltypes.NewInt64(5),
-		sqltypes.NewInt64(6),
-	})
-	require.NoError(t, err)
-	wantQueries = []*querypb.BoundQuery{{
-		Sql: "select music_id, user_id from music_user_map where music_id in ::music_id for update",
-		BindVariables: map[string]*querypb.BindVariable{
-			"music_id": vars,
+		expectedQueries [3][]*querypb.BoundQuery
+		errString       string
+	}{{
+		// First row: first shard.
+		query: "insert ignore into insert_ignore_test(pv, owned, verify) values (1, 1, 1)",
+		input: []*sqltypes.Result{
+			// select music_id
+			sqltypes.MakeTestResult(fields, "1|1"),
+			// insert ins_lookup 1
+			sqltypes.MakeTestResult(nil),
+			// select ins_lookup 1
+			sqltypes.MakeTestResult(field, "1"),
+		},
+		expectedQueries: [3][]*querypb.BoundQuery{
+			{{
+				Sql:           "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv_0, :_owned_0, :_verify_0)",
+				BindVariables: map[string]*querypb.BindVariable{"_pv_0": int1, "_owned_0": int1, "_verify_0": int1},
+			}},
+			nil,
+			{{
+				Sql:           "select music_id, user_id from music_user_map where music_id in ::music_id for update",
+				BindVariables: map[string]*querypb.BindVariable{"music_id": var1},
+			}, {
+				Sql:           "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0)",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol_0": int1, "tocol_0": uint1},
+			}, {
+				Sql:           "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol": int1, "tocol": uint1},
+			}},
 		},
 	}, {
-		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0), (:fromcol_1, :tocol_1), (:fromcol_2, :tocol_2), (:fromcol_3, :tocol_3), (:fromcol_4, :tocol_4)",
-		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol_0": sqltypes.Int64BindVariable(1),
-			"tocol_0":   sqltypes.Uint64BindVariable(1),
-			"fromcol_1": sqltypes.Int64BindVariable(3),
-			"tocol_1":   sqltypes.Uint64BindVariable(1),
-			"fromcol_2": sqltypes.Int64BindVariable(4),
-			"tocol_2":   sqltypes.Uint64BindVariable(1),
-			"fromcol_3": sqltypes.Int64BindVariable(5),
-			"tocol_3":   sqltypes.Uint64BindVariable(1),
-			"fromcol_4": sqltypes.Int64BindVariable(6),
-			"tocol_4":   sqltypes.Uint64BindVariable(3),
+		// Second row: will fail because primary vindex will fail to map.
+		query: "insert ignore into insert_ignore_test(pv, owned, verify) values (2, 2, 2)",
+		input: []*sqltypes.Result{
+			// select music_id
+			sqltypes.MakeTestResult(fields),
+		},
+		expectedQueries: [3][]*querypb.BoundQuery{
+			nil,
+			nil,
+			{{
+				Sql:           "select music_id, user_id from music_user_map where music_id in ::music_id for update",
+				BindVariables: map[string]*querypb.BindVariable{"music_id": var2},
+			}},
+		},
+		errString: "could not map [INT64(2)] to a keyspace id",
+	}, {
+		// Third row: will fail because verification will fail on owned vindex after Create.
+		query: "insert ignore into insert_ignore_test(pv, owned, verify) values (3, 3, 1)",
+		input: []*sqltypes.Result{
+			// select music_id
+			sqltypes.MakeTestResult(fields, "3|1"),
+			// insert ins_lookup 3
+			sqltypes.MakeTestResult(nil),
+			// select ins_lookup 3
+			sqltypes.MakeTestResult(field),
+		},
+		expectedQueries: [3][]*querypb.BoundQuery{
+			nil,
+			nil,
+			{{
+				Sql:           "select music_id, user_id from music_user_map where music_id in ::music_id for update",
+				BindVariables: map[string]*querypb.BindVariable{"music_id": var3},
+			}, {
+				Sql:           "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0)",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol_0": int3, "tocol_0": uint1},
+			}, {
+				Sql:           "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol": int3, "tocol": uint1},
+			}},
 		},
 	}, {
-		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
-		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol": sqltypes.Int64BindVariable(1),
-			"tocol":   sqltypes.Uint64BindVariable(1),
+		// Fourth row: will fail because verification will fail on unowned hash vindex.
+		query: "insert ignore into insert_ignore_test(pv, owned, verify) values (4, 4, 4)",
+		input: []*sqltypes.Result{
+			// select music_id
+			sqltypes.MakeTestResult(fields, "4|1"),
+			// insert ins_lookup 4
+			sqltypes.MakeTestResult(nil),
+			// select ins_lookup 4
+			sqltypes.MakeTestResult(field, "4"),
+			sqltypes.MakeTestResult(nil),
+		},
+		expectedQueries: [3][]*querypb.BoundQuery{
+			nil,
+			nil,
+			{{
+				Sql:           "select music_id, user_id from music_user_map where music_id in ::music_id for update",
+				BindVariables: map[string]*querypb.BindVariable{"music_id": var4},
+			}, {
+				Sql:           "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0)",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol_0": int4, "tocol_0": uint1},
+			}, {
+				Sql:           "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol": int4, "tocol": uint1},
+			}},
 		},
 	}, {
-		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
-		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol": sqltypes.Int64BindVariable(3),
-			"tocol":   sqltypes.Uint64BindVariable(1),
+		// Fifth row: first shard.
+		query: "insert ignore into insert_ignore_test(pv, owned, verify) values (5, 5, 1)",
+		input: []*sqltypes.Result{
+			// select music_id
+			sqltypes.MakeTestResult(fields, "5|1"),
+			// select ins_lookup 5
+			sqltypes.MakeTestResult(field, "5"),
+		},
+		expectedQueries: [3][]*querypb.BoundQuery{
+			{{
+				Sql:           "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv_0, :_owned_0, :_verify_0)",
+				BindVariables: map[string]*querypb.BindVariable{"_pv_0": int5, "_owned_0": int5, "_verify_0": int1},
+			}},
+			nil,
+			{{
+				Sql:           "select music_id, user_id from music_user_map where music_id in ::music_id for update",
+				BindVariables: map[string]*querypb.BindVariable{"music_id": var5},
+			}, {
+				Sql:           "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0)",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol_0": int5, "tocol_0": uint1},
+			}, {
+				Sql:           "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol": int5, "tocol": uint1},
+			}},
 		},
 	}, {
-		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
-		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol": sqltypes.Int64BindVariable(4),
-			"tocol":   sqltypes.Uint64BindVariable(1),
+		// Sixth row: second shard (because 3 hash maps to 40-60).
+		query: "insert ignore into insert_ignore_test(pv, owned, verify) values (6, 6, 3)",
+		input: []*sqltypes.Result{
+			// select music_id
+			sqltypes.MakeTestResult(fields, "6|3"),
+			// select ins_lookup 6
+			sqltypes.MakeTestResult(field, "6"),
 		},
-	}, {
-		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
-		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol": sqltypes.Int64BindVariable(5),
-			"tocol":   sqltypes.Uint64BindVariable(1),
-		},
-	}, {
-		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
-		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol": sqltypes.Int64BindVariable(6),
-			"tocol":   sqltypes.Uint64BindVariable(3),
+		expectedQueries: [3][]*querypb.BoundQuery{
+			nil,
+			{{
+				Sql:           "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv_0, :_owned_0, :_verify_0)",
+				BindVariables: map[string]*querypb.BindVariable{"_pv_0": int6, "_owned_0": int6, "_verify_0": int3},
+			}},
+			{{
+				Sql:           "select music_id, user_id from music_user_map where music_id in ::music_id for update",
+				BindVariables: map[string]*querypb.BindVariable{"music_id": var6},
+			}, {
+				Sql:           "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0)",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol_0": int6, "tocol_0": uint3},
+			}, {
+				Sql:           "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
+				BindVariables: map[string]*querypb.BindVariable{"fromcol": int6, "tocol": uint3},
+			}},
 		},
 	}}
-	assertQueries(t, sbclookup, wantQueries)
 
-	// Test the 0 rows case,
-	sbc1.Queries = nil
-	sbc2.Queries = nil
-	sbclookup.Queries = nil
-	sbclookup.SetResults([]*sqltypes.Result{
-		{},
-	})
-	query = "insert ignore into insert_ignore_test(pv, owned, verify) values (1, 1, 1)"
-	qr, err := executorExec(ctx, executor, session, query, nil)
-	require.NoError(t, err)
-	if !qr.Equal(&sqltypes.Result{}) {
-		t.Errorf("qr: %v, want empty result", qr)
+	session := &vtgatepb.Session{Autocommit: true}
+	for _, tcase := range tcases {
+		t.Run(tcase.query, func(t *testing.T) {
+			// reset
+			sbc1.Queries = nil
+			sbc2.Queries = nil
+			sbclookup.Queries = nil
+
+			// Build the sequence of responses for sbclookup. This should
+			// match the sequence of queries we validate below.
+			sbclookup.SetResults(tcase.input)
+			_, err := executorExec(ctx, executor, session, tcase.query, nil)
+			if tcase.errString != "" {
+				require.ErrorContains(t, err, tcase.errString)
+			}
+			utils.MustMatch(t, tcase.expectedQueries[0], sbc1.Queries, "sbc1 queries do not match")
+			utils.MustMatch(t, tcase.expectedQueries[1], sbc2.Queries, "sbc2 queries do not match")
+			utils.MustMatch(t, tcase.expectedQueries[2], sbclookup.Queries, "sbclookup queries do not match")
+		})
 	}
-	assertQueries(t, sbc1, nil)
-	assertQueries(t, sbc2, nil)
-	vars, err = sqltypes.BuildBindVariable([]any{sqltypes.NewInt64(1)})
-	require.NoError(t, err)
-	wantQueries = []*querypb.BoundQuery{{
-		Sql: "select music_id, user_id from music_user_map where music_id in ::music_id for update",
-		BindVariables: map[string]*querypb.BindVariable{
-			"music_id": vars,
-		},
-	}}
-	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertOnDupKey(t *testing.T) {


### PR DESCRIPTION
## Description

Backports #15500 to 19.0.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
