### PR TITLE
cleanup: make sure we use the right Offset

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -553,7 +553,10 @@ func (p *Projection) planOffsets(ctx *plancontext.PlanningContext) Operator {
 
 	for _, pe := range ap {
 		switch pe.Info.(type) {
-		case *Offset, *EvalEngine:
+		case Offset:
+			pe.EvalExpr = useOffsets(ctx, pe.EvalExpr, p)
+			continue
+		case *EvalEngine:
 			continue
 		}
 

--- a/go/vt/vtgate/planbuilder/operators/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/projection_pushing.go
@@ -144,7 +144,7 @@ func pushProjectionToOuter(ctx *plancontext.PlanningContext, p *Projection, sq *
 
 	outer := TableID(sq.Outer)
 	for _, pe := range ap {
-		_, isOffset := pe.Info.(*Offset)
+		_, isOffset := pe.Info.(Offset)
 		if isOffset {
 			continue
 		}
@@ -186,7 +186,7 @@ func pushProjectionToOuterContainer(ctx *plancontext.PlanningContext, p *Project
 
 	outer := TableID(src.Outer)
 	for _, pe := range ap {
-		_, isOffset := pe.Info.(*Offset)
+		_, isOffset := pe.Info.(Offset)
 		if isOffset {
 			continue
 		}


### PR DESCRIPTION
## Description
Minor clean-up: we were looking for `*Offset`, but the type used is `Offset`. 
The end-result was the same, but we were taking an unnecessarily long way to get there.
