### PR TITLE
VReplication: Move the Reshard v2 workflow to vtctldclient

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/common/switchtraffic.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/switchtraffic.go
@@ -91,6 +91,7 @@ func commandSwitchTraffic(cmd *cobra.Command, args []string) error {
 	req := &vtctldatapb.WorkflowSwitchTrafficRequest{
 		Keyspace:                  BaseOptions.TargetKeyspace,
 		Workflow:                  BaseOptions.Workflow,
+		Cells:                     SwitchTrafficOptions.Cells,
 		TabletTypes:               SwitchTrafficOptions.TabletTypes,
 		MaxReplicationLagAllowed:  protoutil.DurationToProto(SwitchTrafficOptions.MaxReplicationLagAllowed),
 		Timeout:                   protoutil.DurationToProto(SwitchTrafficOptions.Timeout),

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -216,7 +216,7 @@ func TestFile(t *testing.T) {
 	logger.Send(&logMessage{"test 2"})
 
 	// Allow time for propagation
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	want := "test 1\ntest 2\n"
 	contents, _ := os.ReadFile(logPath)
@@ -230,7 +230,7 @@ func TestFile(t *testing.T) {
 	os.Rename(logPath, rotatedPath)
 
 	logger.Send(&logMessage{"test 3"})
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	want = "test 1\ntest 2\ntest 3\n"
 	contents, _ = os.ReadFile(rotatedPath)
@@ -244,10 +244,10 @@ func TestFile(t *testing.T) {
 	if err := syscall.Kill(syscall.Getpid(), syscall.SIGUSR2); err != nil {
 		t.Logf("failed to send streamlog rotate signal: %v", err)
 	}
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	logger.Send(&logMessage{"test 4"})
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	want = "test 1\ntest 2\ntest 3\n"
 	contents, _ = os.ReadFile(rotatedPath)

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -690,6 +690,7 @@ func VttabletProcessInstance(port, grpcPort, tabletUID int, cell, shard, keyspac
 		Binary:                      "vttablet",
 		FileToLogQueries:            path.Join(tmpDirectory, fmt.Sprintf("/vt_%010d_querylog.txt", tabletUID)),
 		Directory:                   path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d", tabletUID)),
+		Cell:                        cell,
 		TabletPath:                  fmt.Sprintf("%s-%010d", cell, tabletUID),
 		ServiceMap:                  "grpc-queryservice,grpc-tabletmanager,grpc-updatestream,grpc-throttler",
 		LogDir:                      tmpDirectory,

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -34,7 +34,7 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
-const testWorkflowFlavor = workflowFlavorVtctld
+const testWorkflowFlavor = workflowFlavorRandom
 
 // TestFKWorkflow runs a MoveTables workflow with atomic copy for a db with foreign key constraints.
 // It inserts initial data, then simulates load. We insert both child rows with foreign keys and those without,

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -34,7 +34,7 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
-const testWorkflowFlavor = workflowFlavorRandom
+const testWorkflowFlavor = workflowFlavorVtctld
 
 // TestFKWorkflow runs a MoveTables workflow with atomic copy for a db with foreign key constraints.
 // It inserts initial data, then simulates load. We insert both child rows with foreign keys and those without,

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -368,6 +368,7 @@ func waitForWorkflowState(t *testing.T, vc *VitessCluster, ksWorkflow string, wa
 					streamInfos.ForEach(func(attributeKey, attributeValue gjson.Result) bool { // for each attribute in the stream
 						// we need to wait for all streams to have the desired state
 						state = attributeValue.Get("State").String()
+						t.Logf("Workflow %s, on %s, state: %s", ksWorkflow, tabletId.String(), state)
 						if state == wantState {
 							for i := 0; i < len(fieldEqualityChecks); i++ {
 								if kvparts := strings.Split(fieldEqualityChecks[i], "=="); len(kvparts) == 2 {
@@ -378,6 +379,9 @@ func waitForWorkflowState(t *testing.T, vc *VitessCluster, ksWorkflow string, wa
 										done = false
 									}
 								}
+							}
+							if wantState == binlogdatapb.VReplicationWorkflowState_Running.String() && attributeValue.Get("Pos").String() == "" {
+								done = false
 							}
 						} else {
 							done = false

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -50,7 +50,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-	"vitess.io/vitess/go/vt/proto/topodata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 const (
@@ -433,7 +433,7 @@ func confirmTablesHaveSecondaryKeys(t *testing.T, tablets []*cluster.VttabletPro
 	}
 	for _, tablet := range tablets {
 		// Be sure that the schema is up to date.
-		err := vc.VtctldClient.ExecuteCommand("ReloadSchema", topoproto.TabletAliasString(&topodata.TabletAlias{
+		err := vc.VtctldClient.ExecuteCommand("ReloadSchema", topoproto.TabletAliasString(&topodatapb.TabletAlias{
 			Cell: tablet.Cell,
 			Uid:  uint32(tablet.TabletUID),
 		}))

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -368,7 +368,6 @@ func waitForWorkflowState(t *testing.T, vc *VitessCluster, ksWorkflow string, wa
 					streamInfos.ForEach(func(attributeKey, attributeValue gjson.Result) bool { // for each attribute in the stream
 						// we need to wait for all streams to have the desired state
 						state = attributeValue.Get("State").String()
-						t.Logf("Workflow %s, on %s, state: %s", ksWorkflow, tabletId.String(), state)
 						if state == wantState {
 							for i := 0; i < len(fieldEqualityChecks); i++ {
 								if kvparts := strings.Split(fieldEqualityChecks[i], "=="); len(kvparts) == 2 {

--- a/go/test/endtoend/vreplication/movetables_buffering_test.go
+++ b/go/test/endtoend/vreplication/movetables_buffering_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/wrangler"
 )
 
 func TestMoveTablesBuffering(t *testing.T) {
@@ -16,7 +15,7 @@ func TestMoveTablesBuffering(t *testing.T) {
 	vc = setupMinimalCluster(t)
 	defer vc.TearDown()
 
-	currentWorkflowType = wrangler.MoveTablesWorkflow
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
 	setupMinimalCustomerKeyspace(t)
 	tables := "loadtest"
 	err := tstWorkflowExec(t, defaultCellName, workflowName, sourceKs, targetKs,

--- a/go/test/endtoend/vreplication/partial_movetables_seq_test.go
+++ b/go/test/endtoend/vreplication/partial_movetables_seq_test.go
@@ -27,7 +27,6 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/wrangler"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
@@ -228,12 +227,12 @@ func (wf *workflow) create() {
 	cell := wf.tc.defaultCellName
 	switch typ {
 	case "movetables":
-		currentWorkflowType = wrangler.MoveTablesWorkflow
+		currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
 		sourceShards := strings.Join(wf.options.sourceShards, ",")
 		err = tstWorkflowExec(t, cell, wf.name, wf.fromKeyspace, wf.toKeyspace,
 			strings.Join(wf.options.tables, ","), workflowActionCreate, "", sourceShards, "", defaultWorkflowExecOptions)
 	case "reshard":
-		currentWorkflowType = wrangler.ReshardWorkflow
+		currentWorkflowType = binlogdatapb.VReplicationWorkflowType_Reshard
 		sourceShards := strings.Join(wf.options.sourceShards, ",")
 		targetShards := strings.Join(wf.options.targetShards, ",")
 		if targetShards == "" {
@@ -389,7 +388,7 @@ func TestPartialMoveTablesWithSequences(t *testing.T) {
 
 		// Switch all traffic for the shard
 		wf80Dash.switchTraffic()
-		expectedSwitchOutput := fmt.Sprintf("SwitchTraffic was successful for workflow %s.%s\nStart State: Reads Not Switched. Writes Not Switched\nCurrent State: Reads partially switched, for shards: %s. Writes partially switched, for shards: %s\n\n",
+		expectedSwitchOutput := fmt.Sprintf("SwitchTraffic was successful for workflow %s.%s\n\nStart State: Reads Not Switched. Writes Not Switched\nCurrent State: Reads partially switched, for shards: %s. Writes partially switched, for shards: %s\n\n",
 			targetKs, wfName, shard, shard)
 		require.Equal(t, expectedSwitchOutput, lastOutput)
 		currentCustomerCount = getCustomerCount(t, "")
@@ -449,7 +448,7 @@ func TestPartialMoveTablesWithSequences(t *testing.T) {
 		wfDash80.create()
 		wfDash80.switchTraffic()
 
-		expectedSwitchOutput := fmt.Sprintf("SwitchTraffic was successful for workflow %s.%s\nStart State: Reads partially switched, for shards: 80-. Writes partially switched, for shards: 80-\nCurrent State: All Reads Switched. All Writes Switched\n\n",
+		expectedSwitchOutput := fmt.Sprintf("SwitchTraffic was successful for workflow %s.%s\n\nStart State: Reads partially switched, for shards: 80-. Writes partially switched, for shards: 80-\nCurrent State: All Reads Switched. All Writes Switched\n\n",
 			targetKs, wfName)
 		require.Equal(t, expectedSwitchOutput, lastOutput)
 

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -446,9 +446,6 @@ func testReshardV2Workflow(t *testing.T) {
 
 	createAdditionalCustomerShards(t, "-40,40-80,80-c0,c0-")
 	createReshardWorkflow(t, "-80,80-", "-40,40-80,80-c0,c0-")
-	if !strings.Contains(lastOutput, "Status: Running") {
-		t.Fail()
-	}
 	validateReadsRouteToSource(t, "replica")
 	validateWritesRouteToSource(t)
 
@@ -473,7 +470,6 @@ func testMoveTablesV2Workflow(t *testing.T) {
 	// The purge table should get skipped/ignored
 	// If it's not then we'll get an error as the table doesn't exist in the vschema
 	createMoveTablesWorkflow(t, "customer,loadtest,vdiff_order,reftable,_vt_PURGE_4f9194b43b2011eb8a0104ed332e05c2_20221210194431")
-	require.Contains(t, lastOutput, "Status: Running")
 	waitForWorkflowState(t, vc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String())
 	validateReadsRouteToSource(t, "replica")
 	validateWritesRouteToSource(t)

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -56,7 +56,7 @@ var (
 	sourceTab, sourceReplicaTab, sourceRdonlyTab                *cluster.VttabletProcess
 
 	lastOutput          string
-	currentWorkflowType wrangler.VReplicationWorkflowType
+	currentWorkflowType binlogdatapb.VReplicationWorkflowType
 )
 
 type workflowExecOptions struct {
@@ -103,59 +103,62 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 	sourceShards, targetShards string, options *workflowExecOptions) error {
 
 	var args []string
-	if currentWorkflowType == wrangler.MoveTablesWorkflow {
+	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_MoveTables {
 		args = append(args, "MoveTables")
 	} else {
 		args = append(args, "Reshard")
 	}
 
-	args = append(args, "--")
+	args = append(args, "--workflow", workflow, "--target-keyspace", targetKs, action)
 
-	if BypassLagCheck {
-		args = append(args, "--max_replication_lag_allowed=2542087h")
-	}
-	if options.atomicCopy {
-		args = append(args, "--atomic-copy")
-	}
 	switch action {
 	case workflowActionCreate:
-		if currentWorkflowType == wrangler.MoveTablesWorkflow {
-			args = append(args, "--source", sourceKs)
+		if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_MoveTables {
+			args = append(args, "--source-keyspace", sourceKs)
 			if tables != "" {
 				args = append(args, "--tables", tables)
 			} else {
-				args = append(args, "--all")
+				args = append(args, "--all-tables")
 			}
 			if sourceShards != "" {
-				args = append(args, "--source_shards", sourceShards)
+				args = append(args, "--source-shards", sourceShards)
 			}
 		} else {
-			args = append(args, "--source_shards", sourceShards, "--target_shards", targetShards)
+			args = append(args, "--source-shards", sourceShards, "--target-shards", targetShards)
 		}
 		// Test new experimental --defer-secondary-keys flag
 		switch currentWorkflowType {
-		case wrangler.MoveTablesWorkflow, wrangler.MigrateWorkflow, wrangler.ReshardWorkflow:
-
+		case binlogdatapb.VReplicationWorkflowType_MoveTables, binlogdatapb.VReplicationWorkflowType_Migrate, binlogdatapb.VReplicationWorkflowType_Reshard:
 			if !options.atomicCopy && options.deferSecondaryKeys {
 				args = append(args, "--defer-secondary-keys")
 			}
-			args = append(args, "--initialize-target-sequences") // Only used for MoveTables
 		}
 	default:
 		if options.shardSubset != "" {
 			args = append(args, "--shards", options.shardSubset)
 		}
 	}
-	if cells != "" {
+	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_MoveTables && action == workflowActionSwitchTraffic {
+		args = append(args, "--initialize-target-sequences")
+	}
+	if action == workflowActionSwitchTraffic || action == workflowActionReverseTraffic {
+		if BypassLagCheck {
+			args = append(args, "--max-replication-lag-allowed=2542087h")
+		}
+		args = append(args, "--timeout", time.Minute.String())
+	}
+	if action == workflowActionCreate && options.atomicCopy {
+		args = append(args, "--atomic-copy")
+	}
+	if (action == workflowActionCreate || action == workflowActionSwitchTraffic || action == workflowActionReverseTraffic) && cells != "" {
 		args = append(args, "--cells", cells)
 	}
-	if tabletTypes != "" {
-		args = append(args, "--tablet_types", tabletTypes)
+	if action != workflowActionComplete && tabletTypes != "" {
+		args = append(args, "--tablet-types", tabletTypes)
 	}
-	args = append(args, "--timeout", time.Minute.String())
-	ksWorkflow := fmt.Sprintf("%s.%s", targetKs, workflow)
-	args = append(args, action, ksWorkflow)
-	output, err := vc.VtctlClient.ExecuteCommandWithOutput(args...)
+	args = append(args, "--action_timeout=2m")
+	t.Logf("Executing workflow command: vtctldclient %v", args)
+	output, err := vc.VtctldClient.ExecuteCommandWithOutput(args...)
 	lastOutput = output
 	if err != nil {
 		return fmt.Errorf("%s: %s", err, output)
@@ -285,8 +288,8 @@ func checkStates(t *testing.T, startState, endState string) {
 	require.Contains(t, lastOutput, fmt.Sprintf("Current State: %s", endState))
 }
 
-func getCurrentState(t *testing.T) string {
-	if err := tstWorkflowAction(t, "GetState", "", ""); err != nil {
+func getCurrentStatus(t *testing.T) string {
+	if err := tstWorkflowAction(t, "status", "", ""); err != nil {
 		return err.Error()
 	}
 	return strings.TrimSpace(strings.Trim(lastOutput, "\n"))
@@ -335,7 +338,7 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 	// at this point the unsharded product and sharded customer keyspaces are created by previous tests
 
 	// use MoveTables to move customer2 from product to customer using
-	currentWorkflowType = wrangler.MoveTablesWorkflow
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
 	err := tstWorkflowExec(t, defaultCellName, "wf2", sourceKs, targetKs,
 		"customer2", workflowActionCreate, "", "", "", defaultWorkflowExecOptions)
 	require.NoError(t, err)
@@ -432,7 +435,7 @@ func testReplicatingWithPKEnumCols(t *testing.T) {
 func testReshardV2Workflow(t *testing.T) {
 	vtgateConn, closeConn := getVTGateConn()
 	defer closeConn()
-	currentWorkflowType = wrangler.ReshardWorkflow
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_Reshard
 
 	// create internal tables on the original customer shards that should be
 	// ignored and not show up on the new shards
@@ -441,7 +444,7 @@ func testReshardV2Workflow(t *testing.T) {
 
 	createAdditionalCustomerShards(t, "-40,40-80,80-c0,c0-")
 	createReshardWorkflow(t, "-80,80-", "-40,40-80,80-c0,c0-")
-	if !strings.Contains(lastOutput, "Workflow started successfully") {
+	if !strings.Contains(lastOutput, "Status: Running") {
 		t.Fail()
 	}
 	validateReadsRouteToSource(t, "replica")
@@ -461,16 +464,15 @@ func testReshardV2Workflow(t *testing.T) {
 func testMoveTablesV2Workflow(t *testing.T) {
 	vtgateConn, closeConn := getVTGateConn()
 	defer closeConn()
-	currentWorkflowType = wrangler.MoveTablesWorkflow
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
 
 	// test basic forward and reverse flows
 	setupCustomerKeyspace(t)
 	// The purge table should get skipped/ignored
 	// If it's not then we'll get an error as the table doesn't exist in the vschema
 	createMoveTablesWorkflow(t, "customer,loadtest,vdiff_order,reftable,_vt_PURGE_4f9194b43b2011eb8a0104ed332e05c2_20221210194431")
-	if !strings.Contains(lastOutput, "Workflow started successfully") {
-		t.Fail()
-	}
+	require.Contains(t, lastOutput, "Status: Running")
+	waitForWorkflowState(t, vc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String())
 	validateReadsRouteToSource(t, "replica")
 	validateWritesRouteToSource(t)
 
@@ -485,26 +487,29 @@ func testMoveTablesV2Workflow(t *testing.T) {
 
 	testRestOfWorkflow(t)
 
-	listAllArgs := []string{"workflow", "customer", "listall"}
-	output, _ := vc.VtctlClient.ExecuteCommandWithOutput(listAllArgs...)
-	require.Contains(t, output, "No workflows found in keyspace customer")
+	listAllArgs := []string{"workflow", "--keyspace", "customer", "list"}
+	output, err := vc.VtctldClient.ExecuteCommandWithOutput(listAllArgs...)
+	require.NoError(t, err)
+	require.Equal(t, output, "[]")
 
 	testVSchemaForSequenceAfterMoveTables(t)
 
 	createMoveTablesWorkflow(t, "Lead,Lead-1")
-	output, _ = vc.VtctlClient.ExecuteCommandWithOutput(listAllArgs...)
-	require.Contains(t, output, "Following workflow(s) found in keyspace customer: wf1")
+	output, err = vc.VtctldClient.ExecuteCommandWithOutput(listAllArgs...)
+	require.NoError(t, err)
+	require.Contains(t, output, "wf1")
 
-	err := tstWorkflowCancel(t)
+	err = tstWorkflowCancel(t)
 	require.NoError(t, err)
 
-	output, _ = vc.VtctlClient.ExecuteCommandWithOutput(listAllArgs...)
-	require.Contains(t, output, "No workflows found in keyspace customer")
+	output, err = vc.VtctldClient.ExecuteCommandWithOutput(listAllArgs...)
+	require.NoError(t, err)
+	require.Equal(t, output, "[]")
 }
 
 func testPartialSwitches(t *testing.T) {
 	// nothing switched
-	require.Equal(t, getCurrentState(t), wrangler.WorkflowStateNotSwitched)
+	require.Contains(t, getCurrentStatus(t), wrangler.WorkflowStateNotSwitched)
 	tstWorkflowSwitchReads(t, "replica,rdonly", "zone1")
 	nextState := "Reads partially switched. Replica switched in cells: zone1. Rdonly switched in cells: zone1. Writes Not Switched"
 	checkStates(t, wrangler.WorkflowStateNotSwitched, nextState)
@@ -526,7 +531,7 @@ func testPartialSwitches(t *testing.T) {
 	checkStates(t, nextState, nextState) // idempotency
 
 	keyspace := "product"
-	if currentWorkflowType == wrangler.ReshardWorkflow {
+	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
 		keyspace = "customer"
 	}
 	waitForLowLag(t, keyspace, "wf1_reverse")
@@ -563,7 +568,7 @@ func testRestOfWorkflow(t *testing.T) {
 
 	// this function is called for both MoveTables and Reshard, so the reverse workflows exist in different keyspaces
 	keyspace := "product"
-	if currentWorkflowType == wrangler.ReshardWorkflow {
+	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
 		keyspace = "customer"
 	}
 	waitForLowLag(t, keyspace, "wf1_reverse")

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,7 +145,7 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 		if BypassLagCheck {
 			args = append(args, "--max-replication-lag-allowed=2542087h")
 		}
-		args = append(args, "--timeout", time.Minute.String())
+		args = append(args, "--timeout=1m")
 	}
 	if action == workflowActionCreate && options.atomicCopy {
 		args = append(args, "--atomic-copy")
@@ -157,7 +156,7 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 	if action != workflowActionComplete && tabletTypes != "" {
 		args = append(args, "--tablet-types", tabletTypes)
 	}
-	args = append(args, "--action_timeout=2m")
+	args = append(args, "--action_timeout=10m") // At this point something is up so fail the test
 	if debugMode {
 		t.Logf("Executing workflow command: vtctldclient %v", strings.Join(args, " "))
 	}

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -157,7 +157,9 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 		args = append(args, "--tablet-types", tabletTypes)
 	}
 	args = append(args, "--action_timeout=2m")
-	t.Logf("Executing workflow command: vtctldclient %v", args)
+	if debugMode {
+		t.Logf("Executing workflow command: vtctldclient %v", strings.Join(args, " "))
+	}
 	output, err := vc.VtctldClient.ExecuteCommandWithOutput(args...)
 	lastOutput = output
 	if err != nil {

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -145,7 +145,7 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 		if BypassLagCheck {
 			args = append(args, "--max-replication-lag-allowed=2542087h")
 		}
-		args = append(args, "--timeout=1m")
+		args = append(args, "--timeout=90s")
 	}
 	if action == workflowActionCreate && options.atomicCopy {
 		args = append(args, "--atomic-copy")

--- a/go/test/endtoend/vreplication/wrappers_test.go
+++ b/go/test/endtoend/vreplication/wrappers_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/wrangler"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
 type iWorkflow interface {
@@ -117,7 +117,7 @@ func newVtctlMoveTables(mt *moveTablesWorkflow) *VtctlMoveTables {
 }
 
 func (vmt *VtctlMoveTables) Create() {
-	currentWorkflowType = wrangler.MoveTablesWorkflow
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
 	vmt.exec(workflowActionCreate)
 }
 
@@ -314,7 +314,7 @@ func newVtctlReshard(rs *reshardWorkflow) *VtctlReshard {
 }
 
 func (vrs *VtctlReshard) Create() {
-	currentWorkflowType = wrangler.ReshardWorkflow
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_Reshard
 	vrs.exec(workflowActionCreate)
 }
 

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -3285,14 +3285,10 @@ func (s *Server) canSwitch(ctx context.Context, ts *trafficSwitcher, state *Stat
 		log.Infof("writes already switched no need to check lag")
 		return "", nil
 	}
-	ts.Logger().Infof("Checking if we can switch traffic for workflow %s.%s with starting state: %s",
-		state.TargetKeyspace, state.Workflow, state.String())
 	wf, err := s.GetWorkflow(ctx, state.TargetKeyspace, state.Workflow, false, shards)
 	if err != nil {
 		return "", err
 	}
-	ts.Logger().Infof("Checking if we can switch traffic for workflow %s.%s with GetWorkflow result: %+v",
-		state.TargetKeyspace, state.Workflow, wf)
 	for _, stream := range wf.ShardStreams {
 		for _, st := range stream.GetStreams() {
 			if st.Message == Frozen {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -3285,10 +3285,14 @@ func (s *Server) canSwitch(ctx context.Context, ts *trafficSwitcher, state *Stat
 		log.Infof("writes already switched no need to check lag")
 		return "", nil
 	}
+	ts.Logger().Infof("Checking if we can switch traffic for workflow %s.%s with starting state: %s",
+		state.TargetKeyspace, state.Workflow, state.String())
 	wf, err := s.GetWorkflow(ctx, state.TargetKeyspace, state.Workflow, false, shards)
 	if err != nil {
 		return "", err
 	}
+	ts.Logger().Infof("Checking if we can switch traffic for workflow %s.%s with GetWorkflow result: %+v",
+		state.TargetKeyspace, state.Workflow, wf)
 	for _, stream := range wf.ShardStreams {
 		for _, st := range stream.GetStreams() {
 			if st.Message == Frozen {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -547,15 +547,12 @@ func (ts *trafficSwitcher) dropSourceShards(ctx context.Context) error {
 }
 
 func (ts *trafficSwitcher) switchShardReads(ctx context.Context, cells []string, servedTypes []topodatapb.TabletType, direction TrafficSwitchDirection) error {
-	var fromShards, toShards []*topo.ShardInfo
-	if direction == DirectionForward {
-		fromShards, toShards = ts.SourceShards(), ts.TargetShards()
-	} else {
-		fromShards, toShards = ts.TargetShards(), ts.SourceShards()
-	}
-	if err := ts.TopoServer().ValidateSrvKeyspace(ctx, ts.TargetKeyspaceName(), strings.Join(cells, ",")); err != nil {
+	cellsStr := strings.Join(cells, ",")
+	log.Infof("switchShardReads: cells: %s, tablet types: %+v, direction %d", cellsStr, servedTypes, direction)
+	fromShards, toShards := ts.SourceShards(), ts.TargetShards()
+	if err := ts.TopoServer().ValidateSrvKeyspace(ctx, ts.TargetKeyspaceName(), cellsStr); err != nil {
 		err2 := vterrors.Wrapf(err, "Before switching shard reads, found SrvKeyspace for %s is corrupt in cell %s",
-			ts.TargetKeyspaceName(), strings.Join(cells, ","))
+			ts.TargetKeyspaceName(), cellsStr)
 		log.Errorf("%w", err2)
 		return err2
 	}
@@ -571,9 +568,9 @@ func (ts *trafficSwitcher) switchShardReads(ctx context.Context, cells []string,
 			return err
 		}
 	}
-	if err := ts.TopoServer().ValidateSrvKeyspace(ctx, ts.TargetKeyspaceName(), strings.Join(cells, ",")); err != nil {
+	if err := ts.TopoServer().ValidateSrvKeyspace(ctx, ts.TargetKeyspaceName(), cellsStr); err != nil {
 		err2 := vterrors.Wrapf(err, "after switching shard reads, found SrvKeyspace for %s is corrupt in cell %s",
-			ts.TargetKeyspaceName(), strings.Join(cells, ","))
+			ts.TargetKeyspaceName(), cellsStr)
 		log.Errorf("%w", err2)
 		return err2
 	}
@@ -581,7 +578,7 @@ func (ts *trafficSwitcher) switchShardReads(ctx context.Context, cells []string,
 }
 
 func (ts *trafficSwitcher) switchTableReads(ctx context.Context, cells []string, servedTypes []topodatapb.TabletType, direction TrafficSwitchDirection) error {
-	log.Infof("switchTableReads: servedTypes: %+v, direction %t", servedTypes, direction)
+	log.Infof("switchTableReads: cells: %s, tablet types: %+v, direction %d", strings.Join(cells, ","), servedTypes, direction)
 	rules, err := topotools.GetRoutingRules(ctx, ts.TopoServer())
 	if err != nil {
 		return err
@@ -939,7 +936,7 @@ func (ts *trafficSwitcher) waitForCatchup(ctx context.Context, filteredReplicati
 	}); err != nil {
 		return err
 	}
-	// all targets have caught up, record their positions for setting up reverse workflows
+	// All targets have caught up, record their positions for setting up reverse workflows.
 	return ts.ForAllTargets(func(target *MigrationTarget) error {
 		var err error
 		target.Position, err = ts.TabletManagerClient().PrimaryPosition(ctx, target.GetPrimary().Tablet)
@@ -1005,7 +1002,7 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 		err = ts.changeShardsAccess(ctx, ts.SourceKeyspaceName(), ts.SourceShards(), allowWrites)
 	}
 	if err != nil {
-		ts.Logger().Errorf("Cancel migration failed:", err)
+		ts.Logger().Errorf("Cancel migration failed: %v", err)
 	}
 
 	sm.CancelStreamMigrations(ctx)
@@ -1369,7 +1366,7 @@ func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspa
 
 	for _, table := range ts.Tables() {
 		vs, ok := vschema.Tables[table]
-		if !ok || vs == nil || vs.AutoIncrement == nil || vs.AutoIncrement.Sequence == "" {
+		if !ok || vs.GetAutoIncrement() == nil || vs.GetAutoIncrement().GetSequence() == "" {
 			continue
 		}
 		sm := &sequenceMetadata{
@@ -1411,7 +1408,7 @@ func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspa
 // the primary tablet serving the sequence to refresh/reset its cache to
 // be sure that it does not provide a value that is less than the current max.
 func (ts *trafficSwitcher) initializeTargetSequences(ctx context.Context, sequencesByBackingTable map[string]*sequenceMetadata) error {
-	initSequenceTable := func(ictx context.Context, sequenceTableName string, sequenceMetadata *sequenceMetadata) error {
+	initSequenceTable := func(ictx context.Context, sequenceMetadata *sequenceMetadata) error {
 		// Now we need to run this query on the target shards in order
 		// to get the max value and set the next id for the sequence to
 		// a higher value.
@@ -1458,6 +1455,10 @@ func (ts *trafficSwitcher) initializeTargetSequences(ctx context.Context, sequen
 			return ictx.Err()
 		default:
 		}
+		if len(shardResults) == 0 { // This should never happen
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "did not get any results for the max used sequence value for target table %s.%s in order to initialize the backing sequence table",
+				ts.targetKeyspace, sequenceMetadata.usingTableName)
+		}
 		// Sort the values to find the max value across all shards.
 		sort.Slice(shardResults, func(i, j int) bool {
 			return shardResults[i] < shardResults[j]
@@ -1492,12 +1493,7 @@ func (ts *trafficSwitcher) initializeTargetSequences(ctx context.Context, sequen
 		)
 		// Now execute this on the primary tablet of the unsharded keyspace
 		// housing the backing table.
-		primaryTablet, ierr := ts.TopoServer().GetTablet(ictx, sequenceShard.PrimaryAlias)
-		if ierr != nil {
-			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the primary tablet for %s.%s using alias %s: %v",
-				sequenceShard.Keyspace(), sequenceShard.ShardName(), sequenceShard.PrimaryAlias, ierr)
-		}
-		qr, ierr := ts.ws.tmc.ExecuteFetchAsApp(ictx, primaryTablet.Tablet, true, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
+		qr, ierr := ts.ws.tmc.ExecuteFetchAsApp(ictx, sequenceTablet.Tablet, true, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
 			Query:   []byte(query.Query),
 			MaxRows: 1,
 		})
@@ -1532,10 +1528,9 @@ func (ts *trafficSwitcher) initializeTargetSequences(ctx context.Context, sequen
 	}
 
 	initGroup, gctx := errgroup.WithContext(ctx)
-	for sequenceTableName, sequenceMetadata := range sequencesByBackingTable {
-		sequenceTableName, sequenceMetadata := sequenceTableName, sequenceMetadata // https://golang.org/doc/faq#closures_and_goroutines
+	for _, sequenceMetadata := range sequencesByBackingTable {
 		initGroup.Go(func() error {
-			return initSequenceTable(gctx, sequenceTableName, sequenceMetadata)
+			return initSequenceTable(gctx, sequenceMetadata)
 		})
 	}
 	return initGroup.Wait()

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1366,7 +1366,7 @@ func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspa
 
 	for _, table := range ts.Tables() {
 		vs, ok := vschema.Tables[table]
-		if !ok || vs.GetAutoIncrement() == nil || vs.GetAutoIncrement().GetSequence() == "" {
+		if !ok || vs.GetAutoIncrement().GetSequence() == "" {
 			continue
 		}
 		sm := &sequenceMetadata{

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -79,7 +79,7 @@ func (tm *TabletManager) CreateVReplicationWorkflow(ctx context.Context, req *ta
 		}
 		// Use the local cell if none are specified.
 		if len(req.Cells) == 0 || strings.TrimSpace(req.Cells[0]) == "" {
-			req.Cells = append(req.Cells, tm.Tablet().Alias.Cell)
+			req.Cells = []string{tm.Tablet().Alias.Cell}
 		}
 		wfState := binlogdatapb.VReplicationWorkflowState_Stopped.String()
 		tabletTypesStr := topoproto.MakeStringTypeCSV(req.TabletTypes)

--- a/test/config.json
+++ b/test/config.json
@@ -1085,15 +1085,6 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
-		"vreplication_vtctldclient_cli": {
-			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVtctldclientCLI", "-timeout", "20m"],
-			"Command": [],
-			"Manual": false,
-			"Shard": "vreplication_basic",
-			"RetryMax": 1,
-			"Tags": []
-		},
 		"vreplication_copy_parallel": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVreplicationCopyParallel", "-timeout", "20m"],
@@ -1256,12 +1247,21 @@
                         "RetryMax": 1,
                         "Tags": []
                 },
+                "vreplication_vtctldclient_cli": {
+                        "File": "unused.go",
+                        "Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVtctldclientCLI", "-timeout", "20m"],
+                        "Command": [],
+                        "Manual": false,
+			"Shard": "vreplication_cli_migrate_vdiff2_convert_tz",
+                        "RetryMax": 1,
+                        "Tags": []
+                },
 		"vreplication_vtctl_migrate": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVtctlMigrate", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "vreplication_migrate_vdiff2_convert_tz",
+			"Shard": "vreplication_cli_migrate_vdiff2_convert_tz",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -1270,7 +1270,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVtctldMigrate", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "vreplication_migrate_vdiff2_convert_tz",
+			"Shard": "vreplication_cli_migrate_vdiff2_convert_tz",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -1279,7 +1279,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVDiff2", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "vreplication_migrate_vdiff2_convert_tz",
+			"Shard": "vreplication_cli_migrate_vdiff2_convert_tz",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -1288,7 +1288,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestMoveTablesTZ"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "vreplication_migrate_vdiff2_convert_tz",
+			"Shard": "vreplication_cli_migrate_vdiff2_convert_tz",
 			"RetryMax": 1,
 			"Tags": []
 		},


### PR DESCRIPTION
## Description

This work was originally done via https://github.com/vitessio/vitess/pull/15536 as I only planned to do that work in the `vtctldclient` implementation and thus I needed to use vtctldclient in order to test the fix. In doing so, I saw other test failures when using the `vtctldclient` implementation and I fixed those there as well.

BUT, because I did not plan to backport that PR and it still remains to be seen how involved/intrusive a full fix may be and also when it will be ready, I'm moving the work not specifically related to that issue here so it can be pushed ASAP and backported to v18 (where the vreplication commands were first added to `vtctldclient`). 

I would like to backport this to v18 so that we have the traffic switching fixes and so that we have better test coverage now that we want all users to use `vtctldclient`.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required