### PR TITLE
evalengine: Implement `TO_SECONDS`

### DIFF
--- a/go/mysql/datetime/datetime.go
+++ b/go/mysql/datetime/datetime.go
@@ -599,6 +599,11 @@ func (dt DateTime) toDuration() time.Duration {
 	return dur
 }
 
+func (dt DateTime) ToSeconds() int64 {
+	numDays := MysqlDayNumber(dt.Date.Year(), dt.Date.Month(), dt.Date.Day())
+	return int64(numDays*24*3600) + dt.Time.ToSeconds()
+}
+
 func (dt *DateTime) addInterval(itv *Interval) bool {
 	switch {
 	case itv.unit.HasTimeParts():

--- a/go/mysql/datetime/datetime_test.go
+++ b/go/mysql/datetime/datetime_test.go
@@ -552,10 +552,21 @@ func TestToSeconds(t *testing.T) {
 	assert.Equal(t, 45020, int(res))
 
 	// Neg Time Case
-	tt.hour = 1<<15 | tt.hour
+	tt.hour |= 1 << 15
 	res = tt.ToSeconds()
 
 	assert.Equal(t, -45020, int(res))
+
+	dt := NewDateTimeFromStd(testGoTime)
+
+	res = dt.ToSeconds()
+	assert.Equal(t, 63877465820, int(res))
+
+	// Neg Time Case
+	dt.Time.hour |= 1 << 15
+	res = dt.ToSeconds()
+
+	assert.Equal(t, 63877375780, int(res))
 }
 
 func TestToStdTime(t *testing.T) {

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1679,6 +1679,18 @@ func (cached *builtinToDays) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinToSeconds) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinTrim) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3927,6 +3927,17 @@ func (asm *assembler) Fn_TIME_TO_SEC() {
 	}, "FN TIME_TO_SEC TIME(SP-1)")
 }
 
+func (asm *assembler) Fn_TO_SECONDS() {
+	asm.emit(func(env *ExpressionEnv) int {
+		if env.vm.stack[env.vm.sp-1] == nil {
+			return 1
+		}
+		arg := env.vm.stack[env.vm.sp-1].(*evalTemporal)
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalInt64(arg.dt.ToSeconds())
+		return 1
+	}, "FN TO_SECONDS DATETIME(SP-1)")
+}
+
 func (asm *assembler) Fn_QUARTER() {
 	asm.emit(func(env *ExpressionEnv) int {
 		if env.vm.stack[env.vm.sp-1] == nil {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -2022,10 +2022,9 @@ func FnToSeconds(yield Query) {
 	}
 
 	mysqlDocSamples := []string{
-		`SELECT TO_SECONDS(950501)`,
-		`SELECT TO_SECONDS('2009-11-29')`,
-		`SELECT TO_SECONDS('2009-11-29 13:43:32')`,
-		`SELECT TO_SECONDS( NOW() )`,
+		`TO_SECONDS(950501)`,
+		`TO_SECONDS('2009-11-29')`,
+		`TO_SECONDS('2009-11-29 13:43:32')`,
 	}
 
 	for _, q := range mysqlDocSamples {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -142,6 +142,7 @@ var Cases = []TestCase{
 	{Run: FnToDays},
 	{Run: FnFromDays},
 	{Run: FnTimeToSec},
+	{Run: FnToSeconds},
 	{Run: FnQuarter},
 	{Run: FnSecond},
 	{Run: FnTime},
@@ -1994,6 +1995,41 @@ func FnTimeToSec(yield Query) {
 
 	for _, t := range time {
 		yield(fmt.Sprintf("TIME_TO_SEC(%s)", t), nil)
+	}
+}
+
+func FnToSeconds(yield Query) {
+	for _, t := range inputConversions {
+		yield(fmt.Sprintf("TO_SECONDS(%s)", t), nil)
+	}
+
+	timeInputs := []string{
+		`DATE'0000-00-00'`,
+		`0`,
+		`'0000-00-00'`,
+		`'00:00:00'`,
+		`DATE'2023-09-03 00:00:00'`,
+		`DATE'0000-00-00 00:00:00'`,
+		`950501`,
+		`'2007-10-07'`,
+		`'0000-01-01'`,
+		`TIME'00:00:00'`,
+		`TIME'120:01:12'`,
+	}
+
+	for _, t := range timeInputs {
+		yield(fmt.Sprintf("TO_SECONDS(%s)", t), nil)
+	}
+
+	mysqlDocSamples := []string{
+		`SELECT TO_SECONDS(950501)`,
+		`SELECT TO_SECONDS('2009-11-29')`,
+		`SELECT TO_SECONDS('2009-11-29 13:43:32')`,
+		`SELECT TO_SECONDS( NOW() )`,
+	}
+
+	for _, q := range mysqlDocSamples {
+		yield(q, nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -457,6 +457,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinTimeToSec{CallExpr: call}, nil
+	case "to_seconds":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinToSeconds{CallExpr: call}, nil
 	case "quarter":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds implementation of [TO_SECONDS](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_to-seconds) func in evalengine.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #9647
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
