### PR TITLE
GetTablets from Vtctldclient

### DIFF
--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -3639,6 +3639,22 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 						},
 					},
 				},
+				GetTabletsResults: &struct {
+					Tablets []*topodatapb.Tablet
+					Error   error
+				}{
+					Tablets: []*topodatapb.Tablet{
+						{
+							Alias: &topodatapb.TabletAlias{
+								Cell: "zone1",
+								Uid:  100,
+							},
+							Keyspace: "test",
+							Type:     topodatapb.TabletType_REPLICA,
+						},
+					},
+					Error: nil,
+				},
 				GetVSchemaResults: map[string]struct {
 					Response *vtctldatapb.GetVSchemaResponse
 					Error    error
@@ -3881,6 +3897,22 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 							SrvVSchema: &vschemapb.SrvVSchema{},
 						},
 					},
+				},
+				GetTabletsResults: &struct {
+					Tablets []*topodatapb.Tablet
+					Error   error
+				}{
+					Tablets: []*topodatapb.Tablet{
+						{
+							Alias: &topodatapb.TabletAlias{
+								Cell: "other1",
+								Uid:  100,
+							},
+							Keyspace: "otherks",
+							Type:     topodatapb.TabletType_REPLICA,
+						},
+					},
+					Error: nil,
 				},
 				GetVSchemaResults: map[string]struct {
 					Response *vtctldatapb.GetVSchemaResponse

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -3954,6 +3954,9 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 							Events: []*logutilpb.Event{{}}},
 					},
 				},
+				RunHealthCheckResults: map[string]error{
+					"other1-0000000100": nil,
+				},
 			},
 			Tablets: []*vtadminpb.Tablet{
 				{

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -126,6 +126,25 @@ func TestFindSchema(t *testing.T) {
 								},
 							},
 						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone1",
+										Uid:  100,
+									},
+									Keyspace: "testkeyspace",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone1-0000000100": nil,
+						},
 					},
 					Tablets: []*vtadminpb.Tablet{
 						{
@@ -181,6 +200,13 @@ func TestFindSchema(t *testing.T) {
 								{Name: "testkeyspace"},
 							},
 						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: nil,
+							Error:   assert.AnError,
+						},
 					},
 				},
 			},
@@ -203,6 +229,25 @@ func TestFindSchema(t *testing.T) {
 							Error     error
 						}{
 							Error: fmt.Errorf("GetKeyspaces: %w", assert.AnError),
+						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone1",
+										Uid:  100,
+									},
+									Keyspace: "testkeyspace",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone1-0000000100": nil,
 						},
 					},
 					Tablets: []*vtadminpb.Tablet{
@@ -250,6 +295,25 @@ func TestFindSchema(t *testing.T) {
 							"zone1-0000000100": {
 								Error: fmt.Errorf("GetSchema: %w", assert.AnError),
 							},
+						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone1",
+										Uid:  100,
+									},
+									Keyspace: "testkeyspace",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone1-0000000100": nil,
 						},
 					},
 					Tablets: []*vtadminpb.Tablet{
@@ -306,6 +370,25 @@ func TestFindSchema(t *testing.T) {
 								},
 							},
 						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone1",
+										Uid:  100,
+									},
+									Keyspace: "testkeyspace",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone1-0000000100": nil,
+						},
 					},
 					Tablets: []*vtadminpb.Tablet{
 						{
@@ -361,6 +444,25 @@ func TestFindSchema(t *testing.T) {
 								},
 							},
 						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone1",
+										Uid:  100,
+									},
+									Keyspace: "testkeyspace",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone1-0000000100": nil,
+						},
 					},
 					Tablets: []*vtadminpb.Tablet{
 						{
@@ -406,6 +508,25 @@ func TestFindSchema(t *testing.T) {
 									},
 								},
 							},
+						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone2",
+										Uid:  200,
+									},
+									Keyspace: "testkeyspace",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone2-0000000200": nil,
 						},
 					},
 					Tablets: []*vtadminpb.Tablet{
@@ -462,6 +583,25 @@ func TestFindSchema(t *testing.T) {
 								},
 							},
 						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone1",
+										Uid:  100,
+									},
+									Keyspace: "testkeyspace1",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone1-0000000100": nil,
+						},
 					},
 					Tablets: []*vtadminpb.Tablet{
 						{
@@ -507,6 +647,25 @@ func TestFindSchema(t *testing.T) {
 									},
 								},
 							},
+						},
+						GetTabletsResults: &struct {
+							Tablets []*topodatapb.Tablet
+							Error   error
+						}{
+							Tablets: []*topodatapb.Tablet{
+								{
+									Alias: &topodatapb.TabletAlias{
+										Cell: "zone2",
+										Uid:  200,
+									},
+									Keyspace: "testkeyspace2",
+									Shard:    "-",
+								},
+							},
+							Error: nil,
+						},
+						RunHealthCheckResults: map[string]error{
+							"zone2-0000000200": nil,
 						},
 					},
 					Tablets: []*vtadminpb.Tablet{
@@ -675,6 +834,34 @@ func TestFindSchema(t *testing.T) {
 						},
 					},
 				},
+				GetTabletsResults: &struct {
+					Tablets []*topodatapb.Tablet
+					Error   error
+				}{
+					Tablets: []*topodatapb.Tablet{
+						{
+							Alias: &topodatapb.TabletAlias{
+								Cell: "c1zone1",
+								Uid:  100,
+							},
+							Keyspace: "testkeyspace",
+							Shard:    "-80",
+						},
+						{
+							Alias: &topodatapb.TabletAlias{
+								Cell: "c1zone1",
+								Uid:  200,
+							},
+							Keyspace: "testkeyspace",
+							Shard:    "80-",
+						},
+					},
+					Error: nil,
+				},
+				RunHealthCheckResults: map[string]error{
+					"c1zone1-0000000100": nil,
+					"c1zone1-0000000200": nil,
+				},
 			},
 			Tablets: []*vtadminpb.Tablet{
 				{
@@ -746,6 +933,25 @@ func TestFindSchema(t *testing.T) {
 					"c2z1-0000000100": {
 						Response: &vtctldatapb.GetSchemaResponse{},
 					},
+				},
+				GetTabletsResults: &struct {
+					Tablets []*topodatapb.Tablet
+					Error   error
+				}{
+					Tablets: []*topodatapb.Tablet{
+						{
+							Alias: &topodatapb.TabletAlias{
+								Cell: "c2z1",
+								Uid:  100,
+							},
+							Keyspace: "ks2",
+							Shard:    "-",
+						},
+					},
+					Error: nil,
+				},
+				RunHealthCheckResults: map[string]error{
+					"c2z1-0000000100": nil,
 				},
 			},
 			Tablets: []*vtadminpb.Tablet{

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -1320,12 +1320,13 @@ func (c *Cluster) getTablets(ctx context.Context) ([]*vtadminpb.Tablet, error) {
 	}
 
 	var (
-		m       sync.Mutex
-		wg      sync.WaitGroup
-		tablets []*vtadminpb.Tablet
+		m  sync.Mutex
+		wg sync.WaitGroup
 	)
 
-	for _, t := range res.Tablets {
+	tablets := make([]*vtadminpb.Tablet, len(res.Tablets))
+
+	for i, t := range res.Tablets {
 		wg.Add(1)
 
 		go func(tablet *topodatapb.Tablet) {
@@ -1343,16 +1344,15 @@ func (c *Cluster) getTablets(ctx context.Context) ([]*vtadminpb.Tablet, error) {
 			m.Lock()
 			defer m.Unlock()
 
-			tablets = append(tablets, &vtadminpb.Tablet{
+			tablets[i] = &vtadminpb.Tablet{
 				Cluster: c.ToProto(),
 				Tablet:  tablet,
 				State:   state,
-			})
+			}
 		}(t)
 	}
 
 	wg.Wait()
-
 	return tablets, nil
 }
 

--- a/go/vt/vtadmin/cluster/cluster_internal_test.go
+++ b/go/vt/vtadmin/cluster/cluster_internal_test.go
@@ -1546,6 +1546,44 @@ func Test_reloadTabletSchemas(t *testing.T) {
 				ID:   "test",
 				Name: "test",
 				Vtctld: &fakevtctldclient.VtctldClient{
+					GetTabletsResults: &struct {
+						Tablets []*topodatapb.Tablet
+						Error   error
+					}{
+						Tablets: []*topodatapb.Tablet{
+							{
+								Alias: &topodatapb.TabletAlias{
+									Cell: "zone1",
+									Uid:  100,
+								},
+							},
+							{
+								Alias: &topodatapb.TabletAlias{
+									Cell: "zone1",
+									Uid:  101,
+								},
+							},
+							{
+								Alias: &topodatapb.TabletAlias{
+									Cell: "zone2",
+									Uid:  200,
+								},
+							},
+							{
+								Alias: &topodatapb.TabletAlias{
+									Cell: "zone5",
+									Uid:  500,
+								},
+							},
+						},
+						Error: nil,
+					},
+					RunHealthCheckResults: map[string]error{
+						"zone1-0000000100": nil,
+						"zone1-0000000101": nil,
+						"zone2-0000000200": nil,
+						"zone5-0000000500": nil,
+					},
 					ReloadSchemaResults: map[string]struct {
 						Response *vtctldatapb.ReloadSchemaResponse
 						Error    error

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -87,6 +87,11 @@
                     "comment": "this structure exists primarily to support the VTExplain test cases; for GetSrvVSchema(s) itself, an empty but non-nil map is sufficient"
                 },
                 {
+                    "field": "GetTabletsResults",
+                    "type": "&struct{\nTablets []*topodatapb.Tablet\nError error}",
+                    "value": "Tablets: []*topodatapb.Tablet{\n{\nAlias: &topodatapb.TabletAlias{\nCell: \"zone1\",\nUid: 100,\n},\nKeyspace: \"test\",\nType: topodatapb.TabletType_REPLICA,\n},\n},\nError: nil,"
+                },
+                {
                     "field": "GetVSchemaResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetVSchemaResponse\nError error}",
                     "value": "\"test\": {\nResponse: &vtctldatapb.GetVSchemaResponse{\nVSchema: &vschemapb.Keyspace{},\n},\n},"
@@ -231,6 +236,11 @@
                     "field": "GetSrvVSchemaResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetSrvVSchemaResponse\nError error}",
                     "value": "\"other1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
+                },
+                {
+                    "field": "GetTabletsResults",
+                    "type": "&struct{\nTablets []*topodatapb.Tablet\nError error}",
+                    "value": "Tablets: []*topodatapb.Tablet{\n{\nAlias: &topodatapb.TabletAlias{\nCell: \"other1\",\nUid: 100,\n},\nKeyspace: \"otherks\",\nType: topodatapb.TabletType_REPLICA,\n},\n},\nError: nil,"
                 },
                 {
                     "field": "GetVSchemaResults",

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -261,6 +261,11 @@
                     "field": "ReloadSchemaKeyspaceResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.ReloadSchemaKeyspaceResponse\nError error\n}",
                     "value": "\"otherks\": {\nResponse: &vtctldatapb.ReloadSchemaKeyspaceResponse{\nEvents: []*logutilpb.Event{{}}},\n},"
+                },
+                {
+                    "field": "RunHealthCheckResults",
+                    "type": "map[string]error",
+                    "value": "\"other1-0000000100\": nil,"
                 }
             ],
             "db_tablet_list": [

--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -105,6 +105,10 @@ type VtctldClient struct {
 		Response *vtctldatapb.GetSrvVSchemaResponse
 		Error    error
 	}
+	GetTabletsResults *struct {
+		Tablets []*topodatapb.Tablet
+		Error   error
+	}
 	GetVSchemaResults map[string]struct {
 		Response *vtctldatapb.GetVSchemaResponse
 		Error    error
@@ -502,6 +506,21 @@ func (fake *VtctldClient) GetSrvVSchemas(ctx context.Context, req *vtctldatapb.G
 	}
 
 	return resp, nil
+}
+
+// GetTablets is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) GetTablets(ctx context.Context, req *vtctldatapb.GetTabletsRequest, opts ...grpc.CallOption) (*vtctldatapb.GetTabletsResponse, error) {
+	if fake.GetTabletsResults == nil {
+		return nil, fmt.Errorf("%w: GetTabletsResults not set on fake vtctldclient", assert.AnError)
+	}
+
+	if fake.GetTabletsResults.Error != nil {
+		return nil, fake.GetTabletsResults.Error
+	}
+
+	return &vtctldatapb.GetTabletsResponse{
+		Tablets: fake.GetTabletsResults.Tablets,
+	}, nil
 }
 
 // GetVSchema is part of the vtctldclient.VtctldClient interface.


### PR DESCRIPTION
## Description
A newer version of https://github.com/vitessio/vitess/pull/14342

Addresses https://github.com/vitessio/vitess/issues/14152 by fetching tablets from Vtctld instead of a single VTGate instance. `State` (serving state) will be supplemented by results from `Vtctld.RunHealthCheck`. 
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
https://github.com/vitessio/vitess/issues/14152

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

