### PR TITLE
Point in time recovery and restore: assume (and validate) MySQL56 flavor in position arguments

### DIFF
--- a/go/mysql/replication/mysql56_gtid.go
+++ b/go/mysql/replication/mysql56_gtid.go
@@ -29,6 +29,10 @@ import (
 // Mysql56FlavorID is the string identifier for the Mysql56 flavor.
 const Mysql56FlavorID = "MySQL56"
 
+var (
+	ErrExpectMysql56Flavor = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "Expecting MySQL56 position flavor")
+)
+
 // parseMysql56GTID is registered as a GTID parser.
 func parseMysql56GTID(s string) (GTID, error) {
 	// Split into parts.
@@ -127,4 +131,33 @@ func (gtid Mysql56GTID) GTIDSet() GTIDSet {
 
 func init() {
 	gtidParsers[Mysql56FlavorID] = parseMysql56GTID
+}
+
+// DecodePositionMySQL56 converts a string into a Position value with the MySQL56 flavor. The function returns an error if the given
+// string does not translate to a MySQL56 GTID set.
+// The prefix "MySQL56/" is optional in the input string. Examples of inputs strings that produce valid result:
+// - "MySQL56/16b1039f-22b6-11ed-b765-0a43f95f28a3:1-615"
+// - "16b1039f-22b6-11ed-b765-0a43f95f28a3:1-615"
+func DecodePositionMySQL56(s string) (rp Position, gtidSet Mysql56GTIDSet, err error) {
+	if s == "" {
+		return rp, nil, nil
+	}
+
+	flav, gtid, ok := strings.Cut(s, "/")
+	if !ok {
+		gtid = s
+		flav = Mysql56FlavorID
+	}
+	rp, err = ParsePosition(flav, gtid)
+	if err != nil {
+		return rp, nil, err
+	}
+	if !rp.MatchesFlavor(Mysql56FlavorID) {
+		return rp, nil, vterrors.Wrapf(ErrExpectMysql56Flavor, s)
+	}
+	gtidSet, ok = rp.GTIDSet.(Mysql56GTIDSet)
+	if !ok {
+		return rp, nil, vterrors.Wrapf(ErrExpectMysql56Flavor, s)
+	}
+	return rp, gtidSet, nil
 }

--- a/go/mysql/replication/mysql56_gtid.go
+++ b/go/mysql/replication/mysql56_gtid.go
@@ -30,7 +30,7 @@ import (
 const Mysql56FlavorID = "MySQL56"
 
 var (
-	ErrExpectMysql56Flavor = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "Expecting MySQL56 position flavor")
+	ErrExpectMysql56Flavor = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "expected MySQL GTID position but found a different or invalid format.")
 )
 
 // parseMysql56GTID is registered as a GTID parser.

--- a/go/mysql/replication/mysql56_gtid_test.go
+++ b/go/mysql/replication/mysql56_gtid_test.go
@@ -153,3 +153,40 @@ func TestMysql56ParseGTID(t *testing.T) {
 	require.NoError(t, err, "unexpected error: %v", err)
 	assert.Equal(t, want, got, "(&mysql56{}).ParseGTID(%#v) = %#v, want %#v", input, got, want)
 }
+
+func TestDecodePositionMySQL56(t *testing.T) {
+	{
+		pos, gtidSet, err := DecodePositionMySQL56("")
+		assert.NoError(t, err)
+		assert.True(t, pos.IsZero())
+		assert.Nil(t, gtidSet)
+	}
+	{
+		pos, gtidSet, err := DecodePositionMySQL56("MySQL56/16b1039f-22b6-11ed-b765-0a43f95f28a3:1-615")
+		assert.NoError(t, err)
+		assert.False(t, pos.IsZero())
+		assert.NotNil(t, gtidSet)
+	}
+	{
+		pos, gtidSet, err := DecodePositionMySQL56("16b1039f-22b6-11ed-b765-0a43f95f28a3:1-615")
+		assert.NoError(t, err)
+		assert.False(t, pos.IsZero())
+		assert.NotNil(t, gtidSet)
+	}
+	{
+		_, _, err := DecodePositionMySQL56("q-22b6-11ed-b765-0a43f95f28a3:1-615")
+		assert.Error(t, err)
+	}
+	{
+		_, _, err := DecodePositionMySQL56("16b1039f-22b6-11ed-b765-0a43f95f28a3")
+		assert.Error(t, err)
+	}
+	{
+		_, _, err := DecodePositionMySQL56("FilePos/mysql-bin.000001:234")
+		assert.Error(t, err)
+	}
+	{
+		_, _, err := DecodePositionMySQL56("mysql-bin.000001:234")
+		assert.Error(t, err)
+	}
+}

--- a/go/mysql/replication/mysql56_gtid_test.go
+++ b/go/mysql/replication/mysql56_gtid_test.go
@@ -162,16 +162,26 @@ func TestDecodePositionMySQL56(t *testing.T) {
 		assert.Nil(t, gtidSet)
 	}
 	{
-		pos, gtidSet, err := DecodePositionMySQL56("MySQL56/16b1039f-22b6-11ed-b765-0a43f95f28a3:1-615")
+		pos, gtidSet, err := DecodePositionMySQL56("MySQL56/00010203-0405-0607-0809-0A0B0C0D0E0F:1-615")
 		assert.NoError(t, err)
 		assert.False(t, pos.IsZero())
 		assert.NotNil(t, gtidSet)
+		expectGTID := Mysql56GTIDSet{
+			SID{
+				0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
+			}: []interval{{start: 1, end: 615}}}
+		assert.Equal(t, expectGTID, gtidSet)
 	}
 	{
-		pos, gtidSet, err := DecodePositionMySQL56("16b1039f-22b6-11ed-b765-0a43f95f28a3:1-615")
+		pos, gtidSet, err := DecodePositionMySQL56("00010203-0405-0607-0809-0A0B0C0D0E0F:1-615")
 		assert.NoError(t, err)
 		assert.False(t, pos.IsZero())
 		assert.NotNil(t, gtidSet)
+		expectGTID := Mysql56GTIDSet{
+			SID{
+				0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
+			}: []interval{{start: 1, end: 615}}}
+		assert.Equal(t, expectGTID, gtidSet)
 	}
 	{
 		_, _, err := DecodePositionMySQL56("q-22b6-11ed-b765-0a43f95f28a3:1-615")

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
@@ -1299,6 +1300,13 @@ func TestReplicaRestoreToPos(t *testing.T, replicaIndex int, restoreToPos replic
 
 	require.False(t, restoreToPos.IsZero())
 	restoreToPosArg := replication.EncodePosition(restoreToPos)
+	assert.Contains(t, restoreToPosArg, "MySQL56/")
+	if rand.Intn(2) == 0 {
+		// Verify that restore works whether or not the MySQL56/ prefix is present.
+		restoreToPosArg = strings.Replace(restoreToPosArg, "MySQL56/", "", 1)
+		assert.NotContains(t, restoreToPosArg, "MySQL56/")
+	}
+
 	output, err := localCluster.VtctldClientProcess.ExecuteCommandWithOutput("RestoreFromBackup", "--restore-to-pos", restoreToPosArg, replica.Alias)
 	if expectError != "" {
 		require.Errorf(t, err, "expected: %v", expectError)

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -415,7 +415,7 @@ func getTabletPosition(t *testing.T, tablet *cluster.Vttablet) replication.Posit
 	require.NotNil(t, row)
 	gtidExecuted := row.AsString("gtid_executed", "")
 	require.NotEmpty(t, gtidExecuted)
-	pos, err := replication.DecodePositionDefaultFlavor(gtidExecuted, replication.Mysql56FlavorID)
+	pos, _, err := replication.DecodePositionMySQL56(gtidExecuted)
 	assert.NoError(t, err)
 	return pos
 }

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -36,7 +36,6 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
-	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/proto/vttime"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
@@ -238,15 +237,9 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "--restore-to-pos and --restore-to-timestamp are mutually exclusive")
 	}
 	if request.RestoreToPos != "" {
-		pos, err := replication.DecodePositionDefaultFlavor(request.RestoreToPos, replication.Mysql56FlavorID)
+		pos, _, err := replication.DecodePositionMySQL56(request.RestoreToPos)
 		if err != nil {
 			return vterrors.Wrapf(err, "restore failed: unable to decode --restore-to-pos: %s", request.RestoreToPos)
-		}
-		if !pos.MatchesFlavor(replication.Mysql56FlavorID) {
-			return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "restore to position only supports MySQL GTID positions. Got: %v", request.RestoreToPos)
-		}
-		if _, ok := pos.GTIDSet.(replication.Mysql56GTIDSet); !ok {
-			return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "cannot get MySQL GTID value: %v", pos)
 		}
 		params.RestoreToPos = pos
 	}


### PR DESCRIPTION

## Description

Incremental backup and point-in-time recoveries assume a MySQL 5.6 flavor GTID. To that effect, both now:

- Do not require the `"MySQL56/"` prefix in position argument
- Validate that with or without said `"MySQL56/"` prefix, the positiion must be in MySQL 5.6 GTID format

This PR consolidated the logic into a new `DecodePositionMySQL56()` function in `go/mysql/replication`. We retire  `DecodePositionDefaultFlavor()` though we still keep the function as it may yet prove useful.

Added unit tests, and updated endtoend tests to use positions with/out  `"MySQL56/"` prefix.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/15592
- Followup to https://github.com/vitessio/vitess/pull/13474

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
