### PR TITLE
test: Replace `t.fatalf` with testify `require` in `go/vt/schemamanager`

### DIFF
--- a/go/vt/schemamanager/plain_controller_test.go
+++ b/go/vt/schemamanager/plain_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"context"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPlainController(t *testing.T) {
@@ -28,50 +30,31 @@ func TestPlainController(t *testing.T) {
 	controller := NewPlainController([]string{sql}, "test_keyspace")
 	ctx := context.Background()
 	err := controller.Open(ctx)
-	if err != nil {
-		t.Fatalf("controller.Open should succeed, but got error: %v", err)
-	}
+	require.NoError(t, err)
 
 	keyspace := controller.Keyspace()
-	if keyspace != "test_keyspace" {
-		t.Fatalf("expect to get keyspace: 'test_keyspace', but got keyspace: '%s'", keyspace)
-	}
+	require.Equal(t, "test_keyspace", keyspace)
 
 	sqls, err := controller.Read(ctx)
-	if err != nil {
-		t.Fatalf("controller.Read should succeed, but got error: %v", err)
-	}
-	if len(sqls) != 1 {
-		t.Fatalf("controller should only get one sql, but got: %v", sqls)
-	}
-	if sqls[0] != sql {
-		t.Fatalf("expect to get sql: '%s', but got: '%s'", sql, sqls[0])
-	}
+	require.NoError(t, err)
+	require.Len(t, sqls, 1, "controller should only get one sql")
+	require.Equal(t, sql, sqls[0])
+
 	defer controller.Close()
 	err = controller.OnReadSuccess(ctx)
-	if err != nil {
-		t.Fatalf("OnDataSourcerReadSuccess should succeed")
-	}
+	require.NoError(t, err)
 
 	errReadFail := fmt.Errorf("read fail")
 	err = controller.OnReadFail(ctx, errReadFail)
-	if err != errReadFail {
-		t.Fatalf("should get error:%v, but get: %v", errReadFail, err)
-	}
+	require.ErrorIs(t, err, errReadFail)
 
 	err = controller.OnValidationSuccess(ctx)
-	if err != nil {
-		t.Fatalf("OnValidationSuccess should succeed")
-	}
+	require.NoError(t, err)
 
 	errValidationFail := fmt.Errorf("validation fail")
 	err = controller.OnValidationFail(ctx, errValidationFail)
-	if err != errValidationFail {
-		t.Fatalf("should get error:%v, but get: %v", errValidationFail, err)
-	}
+	require.ErrorIs(t, err, errValidationFail)
 
 	err = controller.OnExecutorComplete(ctx, &ExecuteResult{})
-	if err != nil {
-		t.Fatalf("OnExecutorComplete should succeed")
-	}
+	require.NoError(t, err)
 }

--- a/go/vt/schemamanager/tablet_executor_test.go
+++ b/go/vt/schemamanager/tablet_executor_test.go
@@ -19,11 +19,11 @@ package schemamanager
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -43,15 +43,13 @@ func TestTabletExecutorOpen(t *testing.T) {
 	executor := newFakeExecutor(t)
 	ctx := context.Background()
 
-	if err := executor.Open(ctx, "test_keyspace"); err != nil {
-		t.Fatalf("executor.Open should succeed")
-	}
+	err := executor.Open(ctx, "test_keyspace")
+	require.NoError(t, err)
 
 	defer executor.Close()
 
-	if err := executor.Open(ctx, "test_keyspace"); err != nil {
-		t.Fatalf("open an opened executor should also succeed")
-	}
+	err = executor.Open(ctx, "test_keyspace")
+	require.NoError(t, err, "open an opened executor should also succeed")
 }
 
 func TestTabletExecutorOpenWithEmptyPrimaryAlias(t *testing.T) {
@@ -69,13 +67,12 @@ func TestTabletExecutorOpenWithEmptyPrimaryAlias(t *testing.T) {
 	}
 	// This will create the Keyspace, Shard and Tablet record.
 	// Since this is a replica tablet, the Shard will have no primary.
-	if err := ts.InitTablet(ctx, tablet, false /*allowPrimaryOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
-		t.Fatalf("InitTablet failed: %v", err)
-	}
+	err := ts.InitTablet(ctx, tablet, false /*allowPrimaryOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/)
+	require.NoError(t, err)
+
 	executor := NewTabletExecutor("TestTabletExecutorOpenWithEmptyPrimaryAlias", ts, newFakeTabletManagerClient(), logutil.NewConsoleLogger(), testWaitReplicasTimeout, 0, sqlparser.NewTestParser())
-	if err := executor.Open(ctx, "test_keyspace"); err == nil || !strings.Contains(err.Error(), "does not have a primary") {
-		t.Fatalf("executor.Open() = '%v', want error", err)
-	}
+	err = executor.Open(ctx, "test_keyspace")
+	require.ErrorContains(t, err, "does not have a primary")
 	executor.Close()
 }
 
@@ -115,42 +112,37 @@ func TestTabletExecutorValidate(t *testing.T) {
 		"ALTER SCHEMA db_name CHARACTER SET = utf8mb4",
 	}
 
-	if err := executor.Validate(ctx, sqls); err == nil {
-		t.Fatalf("validate should fail because executor is closed")
-	}
+	err := executor.Validate(ctx, sqls)
+	require.Error(t, err, "validate should fail because executor is closed")
 
 	executor.Open(ctx, "test_keyspace")
 	defer executor.Close()
 
 	// schema changes with DMLs should fail
-	if err := executor.Validate(ctx, []string{
-		"INSERT INTO test_table VALUES(1)"}); err == nil {
-		t.Fatalf("schema changes are for DDLs")
-	}
+	err = executor.Validate(ctx, []string{
+		"INSERT INTO test_table VALUES(1)",
+	})
+	require.Error(t, err, "schema changes are for DDLs")
 
 	// validates valid ddls
-	if err := executor.Validate(ctx, sqls); err != nil {
-		t.Fatalf("executor.Validate should succeed, but got error: %v", err)
-	}
+	err = executor.Validate(ctx, sqls)
+	require.NoError(t, err)
 
 	// alter a table with more than 100,000 rows
-	if err := executor.Validate(ctx, []string{
+	err = executor.Validate(ctx, []string{
 		"ALTER TABLE test_table_03 ADD COLUMN new_id bigint(20)",
-	}); err != nil {
-		t.Fatalf("executor.Validate should not fail, even for a table with more than 100,000 rows")
-	}
+	})
+	require.NoError(t, err, "executor.Validate should not fail, even for a table with more than 100,000 rows")
 
-	if err := executor.Validate(ctx, []string{
+	err = executor.Validate(ctx, []string{
 		"TRUNCATE TABLE test_table_04",
-	}); err != nil {
-		t.Fatalf("executor.Validate should succeed, drop a table with more than 2,000,000 rows is allowed")
-	}
+	})
+	require.NoError(t, err, "executor.Validate should succeed, truncate a table with more than 2,000,000 rows is allowed")
 
-	if err := executor.Validate(ctx, []string{
+	err = executor.Validate(ctx, []string{
 		"DROP TABLE test_table_04",
-	}); err != nil {
-		t.Fatalf("executor.Validate should succeed, drop a table with more than 2,000,000 rows is allowed")
-	}
+	})
+	require.NoError(t, err, "executor.Validate should succeed, drop a table with more than 2,000,000 rows is allowed")
 }
 
 func TestTabletExecutorDML(t *testing.T) {
@@ -186,10 +178,10 @@ func TestTabletExecutorDML(t *testing.T) {
 	defer executor.Close()
 
 	// schema changes with DMLs should fail
-	if err := executor.Validate(ctx, []string{
-		"INSERT INTO test_table VALUES(1)"}); err != nil {
-		t.Fatalf("executor.Validate should succeed, for DML to unsharded keyspace")
-	}
+	err := executor.Validate(ctx, []string{
+		"INSERT INTO test_table VALUES(1)",
+	})
+	require.NoError(t, err, "executor.Validate should succeed, for DML to unsharded keyspace")
 }
 
 func TestTabletExecutorExecute(t *testing.T) {
@@ -199,9 +191,7 @@ func TestTabletExecutorExecute(t *testing.T) {
 	sqls := []string{"DROP TABLE unknown_table"}
 
 	result := executor.Execute(ctx, sqls)
-	if result.ExecutorErr == "" {
-		t.Fatalf("execute should fail, call execute.Open first")
-	}
+	require.NotEmpty(t, result.ExecutorErr, "execute should fail, call execute.Open first")
 }
 
 func TestIsOnlineSchemaDDL(t *testing.T) {

--- a/go/vt/schemamanager/ui_controller_test.go
+++ b/go/vt/schemamanager/ui_controller_test.go
@@ -19,10 +19,11 @@ package schemamanager
 import (
 	"fmt"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"context"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUIController(t *testing.T) {
@@ -32,68 +33,37 @@ func TestUIController(t *testing.T) {
 	ctx := context.Background()
 
 	err := controller.Open(ctx)
-	if err != nil {
-		t.Fatalf("controller.Open should succeed, but got error: %v", err)
-	}
+	require.NoError(t, err)
 
 	keyspace := controller.Keyspace()
-	if keyspace != "test_keyspace" {
-		t.Fatalf("expect to get keyspace: 'test_keyspace', but got keyspace: '%s'", keyspace)
-	}
+	require.Equal(t, "test_keyspace", keyspace)
 
 	sqls, err := controller.Read(ctx)
-	if err != nil {
-		t.Fatalf("controller.Read should succeed, but got error: %v", err)
-	}
-	if len(sqls) != 1 {
-		t.Fatalf("controller should only get one sql, but got: %v", sqls)
-	}
-	if sqls[0] != sql {
-		t.Fatalf("expect to get sql: '%s', but got: '%s'", sql, sqls[0])
-	}
+	require.NoError(t, err)
+	require.Len(t, sqls, 1, "controller should only get one sql")
+	require.Equal(t, sql, sqls[0])
+
 	defer controller.Close()
+
 	err = controller.OnReadSuccess(ctx)
-	if err != nil {
-		t.Fatalf("OnDataSourcerReadSuccess should succeed")
-	}
-	if !strings.Contains(response.Body.String(), "OnReadSuccess, sqls") {
-		t.Fatalf("controller.OnReadSuccess should write to http response")
-	}
+	require.NoError(t, err)
+	require.Contains(t, response.Body.String(), "OnReadSuccess, sqls", "controller.OnReadSuccess should write to http response")
+
 	errReadFail := fmt.Errorf("read fail")
 	err = controller.OnReadFail(ctx, errReadFail)
-	if err != errReadFail {
-		t.Fatalf("should get error:%v, but get: %v", errReadFail, err)
-	}
-
-	if !strings.Contains(response.Body.String(), "OnReadFail, error") {
-		t.Fatalf("controller.OnReadFail should write to http response")
-	}
+	require.ErrorIs(t, err, errReadFail)
+	require.Contains(t, response.Body.String(), "OnReadFail, error", "controller.OnReadFail should write to http response")
 
 	err = controller.OnValidationSuccess(ctx)
-	if err != nil {
-		t.Fatalf("OnValidationSuccess should succeed")
-	}
-
-	if !strings.Contains(response.Body.String(), "OnValidationSuccess, sqls") {
-		t.Fatalf("controller.OnValidationSuccess should write to http response")
-	}
+	require.NoError(t, err)
+	require.Contains(t, response.Body.String(), "OnValidationSuccess, sqls", "controller.OnValidationSuccess should write to http response")
 
 	errValidationFail := fmt.Errorf("validation fail")
 	err = controller.OnValidationFail(ctx, errValidationFail)
-	if err != errValidationFail {
-		t.Fatalf("should get error:%v, but get: %v", errValidationFail, err)
-	}
-
-	if !strings.Contains(response.Body.String(), "OnValidationFail, error") {
-		t.Fatalf("controller.OnValidationFail should write to http response")
-	}
+	require.ErrorIs(t, err, errValidationFail)
+	require.Contains(t, response.Body.String(), "OnValidationFail, error", "controller.OnValidationFail should write to http response")
 
 	err = controller.OnExecutorComplete(ctx, &ExecuteResult{})
-	if err != nil {
-		t.Fatalf("OnExecutorComplete should succeed")
-	}
-
-	if !strings.Contains(response.Body.String(), "Executor succeeds") {
-		t.Fatalf("controller.OnExecutorComplete should write to http response")
-	}
+	require.NoError(t, err)
+	require.Contains(t, response.Body.String(), "Executor succeeds", "controller.OnExecutorComplete should write to http response")
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR replaces some `t.fatalf` instances with testify's `require` in `go/vt/schemamanager`
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #15182
- #14931 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
