### PR TITLE
[VTAdmin] Remove vtctld web link, improve local example

### DIFF
--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -24,6 +24,8 @@ web_dir="${script_dir}/../../../web/vtadmin"
 vtadmin_api_port=14200
 vtadmin_web_port=14201
 
+echo "vtadmin-api http-origin set to \"http://${hostname}:${vtadmin_web_port}\""
+
 vtadmin \
   --addr "${hostname}:${vtadmin_api_port}" \
   --http-origin "http://${hostname}:${vtadmin_web_port}" \
@@ -48,9 +50,12 @@ vtadmin-api is running!
   - PID: ${vtadmin_api_pid}
 "
 
+echo "Building vtadmin-web..."
+source "${web_dir}/build.sh"
+
 # Wait for vtadmin to successfully discover the cluster
 expected_cluster_result="{\"result\":{\"clusters\":[{\"id\":\"${cluster_name}\",\"name\":\"${cluster_name}\"}]},\"ok\":true}"
-for _ in {0..300}; do
+for _ in {0..100}; do
   result=$(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters")
   if [[ ${result} == "${expected_cluster_result}" ]]; then
     break

--- a/web/vtadmin/build.sh
+++ b/web/vtadmin/build.sh
@@ -24,6 +24,12 @@ web_dir="${script_dir}"
 
 vtadmin_api_port=14200
 
+if [ -z "${hostname}" ]
+then
+  hostname=$(hostname -f)
+  output "\n\033[1;32mhostname was empty, set it to \"${hostname}\"\033[0m"
+fi
+
 # Download nvm and node
 if [[ -z ${NVM_DIR} ]]; then
     export NVM_DIR="$HOME/.nvm"
@@ -49,6 +55,9 @@ nvm install "$NODE_VERSION" || fail "Could not install and use nvm $NODE_VERSION
 npm --prefix "$web_dir" --silent install
 
 export PATH=$PATH:$web_dir/node_modules/.bin/
+
+vite_vtadmin_api_address="http://${hostname}:${vtadmin_api_port}"
+output "\n\033[1;32mSetting VITE_VTADMIN_API_ADDRESS to \"${vite_vtadmin_api_address}\"\033[0m"
 
 VITE_VTADMIN_API_ADDRESS="http://${hostname}:${vtadmin_api_port}" \
   VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \

--- a/web/vtadmin/src/components/routes/Vtctlds.tsx
+++ b/web/vtadmin/src/components/routes/Vtctlds.tsx
@@ -27,65 +27,58 @@ import { WorkspaceTitle } from '../layout/WorkspaceTitle';
 import { QueryLoadingPlaceholder } from '../placeholders/QueryLoadingPlaceholder';
 
 export const Vtctlds = () => {
-    const vtctldsQuery = useVtctlds();
-    const { data: vtctlds = [] } = vtctldsQuery;
+  const vtctldsQuery = useVtctlds();
+  const { data: vtctlds = [] } = vtctldsQuery;
 
-    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
+  const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
 
-    const data = useMemo(() => {
-        const mapped = vtctlds.map((v) => ({
-            cluster: v.cluster?.name,
-            clusterID: v.cluster?.id,
-            hostname: v.hostname,
-            fqdn: v.FQDN,
-        }));
+  const data = useMemo(() => {
+    const mapped = vtctlds.map((v) => ({
+      cluster: v.cluster?.name,
+      clusterID: v.cluster?.id,
+      hostname: v.hostname,
+    }));
 
-        const filtered = filterNouns(filter, mapped);
+    const filtered = filterNouns(filter, mapped);
 
-        return orderBy(filtered, ['cluster', 'hostname']);
-    }, [filter, vtctlds]);
+    return orderBy(filtered, ['cluster', 'hostname']);
+  }, [filter, vtctlds]);
 
-    const renderRows = (rows: typeof data) => {
-        return rows.map((row) => {
-            return (
-                <tr key={row.hostname}>
-                    <DataCell>
-                        <div className="font-bold">
-                            {row.fqdn ? (
-                                <a href={`//${row.fqdn}`} rel="noopener noreferrer" target="_blank">
-                                    {row.hostname}
-                                </a>
-                            ) : (
-                                row.hostname
-                            )}
-                        </div>
-                    </DataCell>
-                    <DataCell>
-                        {row.cluster}
-                        <div className="text-sm text-secondary">{row.clusterID}</div>
-                    </DataCell>
-                </tr>
-            );
-        });
-    };
+  const renderRows = (rows: typeof data) => {
+    return rows.map((row) => {
+      return (
+        <tr key={row.hostname}>
+          <DataCell>
+            <div className="font-bold">
+              {row.hostname}
+            </div>
+          </DataCell>
+          <DataCell>
+            {row.cluster}
+            <div className="text-sm text-secondary">{row.clusterID}</div>
+          </DataCell>
+        </tr>
+      );
+    });
+  };
 
-    return (
-        <div>
-            <WorkspaceHeader>
-                <WorkspaceTitle>vtctlds</WorkspaceTitle>
-            </WorkspaceHeader>
+  return (
+    <div>
+      <WorkspaceHeader>
+        <WorkspaceTitle>vtctlds</WorkspaceTitle>
+      </WorkspaceHeader>
 
-            <ContentContainer>
-                <DataFilter
-                    autoFocus
-                    onChange={(e) => updateFilter(e.target.value)}
-                    onClear={() => updateFilter('')}
-                    placeholder="Filter vtctlds"
-                    value={filter || ''}
-                />
-                <DataTable columns={['Hostname', 'Cluster']} data={data} renderRows={renderRows} />
-                <QueryLoadingPlaceholder query={vtctldsQuery} />
-            </ContentContainer>
-        </div>
-    );
+      <ContentContainer>
+        <DataFilter
+          autoFocus
+          onChange={(e) => updateFilter(e.target.value)}
+          onClear={() => updateFilter('')}
+          placeholder="Filter vtctlds"
+          value={filter || ''}
+        />
+        <DataTable columns={['Hostname', 'Cluster']} data={data} renderRows={renderRows} />
+        <QueryLoadingPlaceholder query={vtctldsQuery} />
+      </ContentContainer>
+    </div>
+  );
 };

--- a/web/vtadmin/src/components/routes/Vtctlds.tsx
+++ b/web/vtadmin/src/components/routes/Vtctlds.tsx
@@ -27,58 +27,56 @@ import { WorkspaceTitle } from '../layout/WorkspaceTitle';
 import { QueryLoadingPlaceholder } from '../placeholders/QueryLoadingPlaceholder';
 
 export const Vtctlds = () => {
-  const vtctldsQuery = useVtctlds();
-  const { data: vtctlds = [] } = vtctldsQuery;
+    const vtctldsQuery = useVtctlds();
+    const { data: vtctlds = [] } = vtctldsQuery;
 
-  const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
+    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
 
-  const data = useMemo(() => {
-    const mapped = vtctlds.map((v) => ({
-      cluster: v.cluster?.name,
-      clusterID: v.cluster?.id,
-      hostname: v.hostname,
-    }));
+    const data = useMemo(() => {
+        const mapped = vtctlds.map((v) => ({
+            cluster: v.cluster?.name,
+            clusterID: v.cluster?.id,
+            hostname: v.hostname,
+        }));
 
-    const filtered = filterNouns(filter, mapped);
+        const filtered = filterNouns(filter, mapped);
 
-    return orderBy(filtered, ['cluster', 'hostname']);
-  }, [filter, vtctlds]);
+        return orderBy(filtered, ['cluster', 'hostname']);
+    }, [filter, vtctlds]);
 
-  const renderRows = (rows: typeof data) => {
-    return rows.map((row) => {
-      return (
-        <tr key={row.hostname}>
-          <DataCell>
-            <div className="font-bold">
-              {row.hostname}
-            </div>
-          </DataCell>
-          <DataCell>
-            {row.cluster}
-            <div className="text-sm text-secondary">{row.clusterID}</div>
-          </DataCell>
-        </tr>
-      );
-    });
-  };
+    const renderRows = (rows: typeof data) => {
+        return rows.map((row) => {
+            return (
+                <tr key={row.hostname}>
+                    <DataCell>
+                        <div className="font-bold">{row.hostname}</div>
+                    </DataCell>
+                    <DataCell>
+                        {row.cluster}
+                        <div className="text-sm text-secondary">{row.clusterID}</div>
+                    </DataCell>
+                </tr>
+            );
+        });
+    };
 
-  return (
-    <div>
-      <WorkspaceHeader>
-        <WorkspaceTitle>vtctlds</WorkspaceTitle>
-      </WorkspaceHeader>
+    return (
+        <div>
+            <WorkspaceHeader>
+                <WorkspaceTitle>vtctlds</WorkspaceTitle>
+            </WorkspaceHeader>
 
-      <ContentContainer>
-        <DataFilter
-          autoFocus
-          onChange={(e) => updateFilter(e.target.value)}
-          onClear={() => updateFilter('')}
-          placeholder="Filter vtctlds"
-          value={filter || ''}
-        />
-        <DataTable columns={['Hostname', 'Cluster']} data={data} renderRows={renderRows} />
-        <QueryLoadingPlaceholder query={vtctldsQuery} />
-      </ContentContainer>
-    </div>
-  );
+            <ContentContainer>
+                <DataFilter
+                    autoFocus
+                    onChange={(e) => updateFilter(e.target.value)}
+                    onClear={() => updateFilter('')}
+                    placeholder="Filter vtctlds"
+                    value={filter || ''}
+                />
+                <DataTable columns={['Hostname', 'Cluster']} data={data} renderRows={renderRows} />
+                <QueryLoadingPlaceholder query={vtctldsQuery} />
+            </ContentContainer>
+        </div>
+    );
 };


### PR DESCRIPTION
## Description
This PR:
- Removes the link to vtctld web, since we deprecated it in v17
- Improves `vtadmin-up.sh` by 1) outputting the variables that are being set and 2) shortening the wait time for cluster discovery
- Improves `web/vtadmin/build.sh` by 1) outputting the variables set and 2) when no hostname is set, uses the local machine's hostname

The last bullet point made it so that I could run `./101_initial_clusters.sh` without any extra steps, and get vtadmin-web/vtadmin-api working:

![Screenshot 2024-04-01 at 6 14 19 PM](https://github.com/vitessio/vitess/assets/31225471/24da7f89-1d1c-4e8f-9bc5-3fc376d3329a)

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/15597
- https://github.com/vitessio/vitess/issues/15587

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
