### PR TITLE
evalengine: Ensure to pass down the precision

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -631,6 +631,10 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `REPLACE('www.mysql.com', '', 'Ww')`,
 			result:     `VARCHAR("www.mysql.com")`,
 		},
+		{
+			expression: `1 * unix_timestamp(utc_timestamp(1))`,
+			result:     `DECIMAL(1698134400.1)`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")

--- a/go/vt/vtgate/evalengine/fn_time.go
+++ b/go/vt/vtgate/evalengine/fn_time.go
@@ -222,7 +222,7 @@ func (call *builtinNow) compile(c *compiler) (ctype, error) {
 		t = sqltypes.Datetime
 		c.asm.Fn_Now(call.prec, call.utc)
 	}
-	return ctype{Type: t, Col: collationBinary}, nil
+	return ctype{Type: t, Col: collationBinary, Size: int32(call.prec)}, nil
 }
 
 func (call *builtinNow) constant() bool {
@@ -239,7 +239,7 @@ func (call *builtinSysdate) eval(env *ExpressionEnv) (eval, error) {
 
 func (call *builtinSysdate) compile(c *compiler) (ctype, error) {
 	c.asm.Fn_Sysdate(call.prec)
-	return ctype{Type: sqltypes.Datetime, Col: collationBinary}, nil
+	return ctype{Type: sqltypes.Datetime, Col: collationBinary, Size: int32(call.prec)}, nil
 }
 
 func (call *builtinSysdate) constant() bool {


### PR DESCRIPTION
We were failing to pass down the precision correctly in the compiler which would lead to a panic because we'd see an unexpected type downstream.

Marked for backporting as this triggers an internal panic inside `vtgate`. 

## Related Issue(s)

Fixes #15610 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required