### PR TITLE
evalengine: Fix additional time type handling

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -635,6 +635,42 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `1 * unix_timestamp(utc_timestamp(1))`,
 			result:     `DECIMAL(1698134400.1)`,
 		},
+		{
+			expression: `1 * unix_timestamp(CONVERT_TZ(20040101120000.10e0,'+00:00','+10:00'))`,
+			result:     `DECIMAL(1072990800.101563)`,
+		},
+		{
+			expression: `1 * unix_timestamp(CONVERT_TZ(20040101120000.10,'+00:00','+10:00'))`,
+			result:     `DECIMAL(1072990800.10)`,
+		},
+		{
+			expression: `1 * unix_timestamp(CONVERT_TZ(timestamp'2004-01-01 12:00:00.10','+00:00','+10:00'))`,
+			result:     `DECIMAL(1072990800.10)`,
+		},
+		{
+			expression: `1 * unix_timestamp(CONVERT_TZ('2004-01-01 12:00:00.10','+00:00','+10:00'))`,
+			result:     `DECIMAL(1072990800.10)`,
+		},
+		{
+			expression: `1 * unix_timestamp('2004-01-01 12:00:00.10')`,
+			result:     `DECIMAL(1072954800.10)`,
+		},
+		{
+			expression: `1 * unix_timestamp(from_unixtime(1447430881.123))`,
+			result:     `DECIMAL(1447430881.123)`,
+		},
+		{
+			expression: `1 * unix_timestamp(from_unixtime('1447430881.123'))`,
+			result:     `DECIMAL(1447430881.123000)`,
+		},
+		{
+			expression: `1 * unix_timestamp(from_unixtime(time '31:34:58'))`,
+			result:     `INT64(313458)`,
+		},
+		{
+			expression: `1 * unix_timestamp(from_unixtime(time '31:34:58.123'))`,
+			result:     `DECIMAL(313458.123)`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")

--- a/go/vt/vtgate/evalengine/fn_info.go
+++ b/go/vt/vtgate/evalengine/fn_info.go
@@ -51,7 +51,7 @@ func (call *builtinVersion) eval(env *ExpressionEnv) (eval, error) {
 
 func (*builtinVersion) compile(c *compiler) (ctype, error) {
 	c.asm.Fn_Version()
-	return ctype{Type: sqltypes.Datetime, Col: collationUtf8mb3}, nil
+	return ctype{Type: sqltypes.VarChar, Col: collationUtf8mb3}, nil
 }
 
 type builtinDatabase struct {
@@ -70,7 +70,7 @@ func (call *builtinDatabase) eval(env *ExpressionEnv) (eval, error) {
 
 func (*builtinDatabase) compile(c *compiler) (ctype, error) {
 	c.asm.Fn_Database()
-	return ctype{Type: sqltypes.Datetime, Col: collationUtf8mb3}, nil
+	return ctype{Type: sqltypes.VarChar, Col: collationUtf8mb3}, nil
 }
 
 func (call *builtinDatabase) constant() bool {


### PR DESCRIPTION
This fixes a number of other cases where we didn't propagate the type sizing properly, mostly for datetime related functions. Also fixes some plain wrong types for other functions.

Also backported for v19 since it suffers from similar potential panics as #15610 

## Related Issue(s)

Fixes #15613 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required