### PR TITLE
Add more fields to the marshal output of column

### DIFF
--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -203,16 +203,22 @@ type Column struct {
 // MarshalJSON returns a JSON representation of Column.
 func (col *Column) MarshalJSON() ([]byte, error) {
 	cj := struct {
-		Name      string `json:"name"`
-		Type      string `json:"type,omitempty"`
-		Invisible bool   `json:"invisible,omitempty"`
-		Default   string `json:"default,omitempty"`
+		Name      string   `json:"name"`
+		Type      string   `json:"type,omitempty"`
+		Invisible bool     `json:"invisible,omitempty"`
+		Default   string   `json:"default,omitempty"`
+		Size      int32    `json:"size,omitempty"`
+		Scale     int32    `json:"scale,omitempty"`
+		Nullable  bool     `json:"nullable,omitempty"`
+		Values    []string `json:"values,omitempty"`
 	}{
-		Name: col.Name.String(),
-		Type: querypb.Type_name[int32(col.Type)],
-	}
-	if col.Invisible {
-		cj.Invisible = true
+		Name:      col.Name.String(),
+		Type:      querypb.Type_name[int32(col.Type)],
+		Invisible: col.Invisible,
+		Size:      col.Size,
+		Scale:     col.Scale,
+		Nullable:  col.Nullable,
+		Values:    col.Values,
 	}
 	if col.Default != nil {
 		cj.Default = sqlparser.String(col.Default)


### PR DESCRIPTION
## Description
We were not adding a few fields for the column type information in the vschema, which made it hard to use them in other parts of our code base.

## Related Issue(s)


## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
