### PR TITLE
Fix AVG() sharded planning 

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -91,6 +91,10 @@ func TestAggregateTypes(t *testing.T) {
 		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches("select avg(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	})
+	mcmp.Run("Average with group by without selecting the grouped columns", func(mcmp *utils.MySQLCompare) {
+		mcmp.SkipIfBinaryIsBelowVersion(20, "vtgate")
+		mcmp.AssertMatches("select avg(val2) from aggr_test group by val1 order by val1", `[[DECIMAL(1.0000)] [DECIMAL(1.0000)] [DECIMAL(3.5000)] [NULL] [DECIMAL(1.0000)]]`)
+	})
 }
 
 func TestGroupBy(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -182,12 +182,12 @@ var _ selectExpressions = (*Projection)(nil)
 
 // createSimpleProjection returns a projection where all columns are offsets.
 // used to change the name and order of the columns in the final output
-func createSimpleProjection(ctx *plancontext.PlanningContext, qp *QueryProjection, src Operator) *Projection {
+func createSimpleProjection(ctx *plancontext.PlanningContext, selExprs []sqlparser.SelectExpr, src Operator) *Projection {
 	p := newAliasedProjection(src)
-	for _, e := range qp.SelectExprs {
-		ae, err := e.GetAliasedExpr()
-		if err != nil {
-			panic(err)
+	for _, e := range selExprs {
+		ae, isAe := e.(*sqlparser.AliasedExpr)
+		if !isAe {
+			panic(vterrors.VT09015())
 		}
 		offset := p.Source.AddColumn(ctx, true, false, ae)
 		expr := newProjExpr(ae)

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -26,6 +26,12 @@ import (
 )
 
 func planQuery(ctx *plancontext.PlanningContext, root Operator) Operator {
+	var selExpr sqlparser.SelectExprs
+	if horizon, isHorizon := root.(*Horizon); isHorizon {
+		sel := sqlparser.GetFirstSelect(horizon.Query)
+		selExpr = sqlparser.CloneSelectExprs(sel.SelectExprs)
+	}
+
 	output := runPhases(ctx, root)
 	output = planOffsets(ctx, output)
 
@@ -36,7 +42,7 @@ func planQuery(ctx *plancontext.PlanningContext, root Operator) Operator {
 
 	output = compact(ctx, output)
 
-	return addTruncationOrProjectionToReturnOutput(ctx, root, output)
+	return addTruncationOrProjectionToReturnOutput(ctx, selExpr, output)
 }
 
 // runPhases is the process of figuring out how to perform the operations in the Horizon
@@ -571,24 +577,21 @@ func tryPushUnion(ctx *plancontext.PlanningContext, op *Union) (Operator, *Apply
 }
 
 // addTruncationOrProjectionToReturnOutput uses the original Horizon to make sure that the output columns line up with what the user asked for
-func addTruncationOrProjectionToReturnOutput(ctx *plancontext.PlanningContext, oldHorizon Operator, output Operator) Operator {
-	horizon, ok := oldHorizon.(*Horizon)
-	if !ok {
+func addTruncationOrProjectionToReturnOutput(ctx *plancontext.PlanningContext, selExprs sqlparser.SelectExprs, output Operator) Operator {
+	if len(selExprs) == 0 {
 		return output
 	}
 
 	cols := output.GetSelectExprs(ctx)
-	sel := sqlparser.GetFirstSelect(horizon.Query)
-	if len(sel.SelectExprs) == len(cols) {
+	if len(selExprs) == len(cols) {
 		return output
 	}
 
-	if tryTruncateColumnsAt(output, len(sel.SelectExprs)) {
+	if tryTruncateColumnsAt(output, len(selExprs)) {
 		return output
 	}
 
-	qp := horizon.getQP(ctx)
-	proj := createSimpleProjection(ctx, qp, output)
+	proj := createSimpleProjection(ctx, selExprs, output)
 	return proj
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1696,6 +1696,58 @@
     }
   },
   {
+    "comment": "avg in sharded keyspace with group by without selecting the group by columns",
+    "query": "select avg(intcol) as avg_col from user group by textcol1, textcol2 order by textcol1, textcol2;",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select avg(intcol) as avg_col from user group by textcol1, textcol2 order by textcol1, textcol2;",
+      "Instructions": {
+        "OperatorType": "SimpleProjection",
+        "ColumnNames": [
+          "avg_col"
+        ],
+        "Columns": [
+          0
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Projection",
+            "Expressions": [
+              "sum(intcol) / count(intcol) as avg_col",
+              ":1 as textcol1",
+              ":2 as textcol2"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Aggregate",
+                "Variant": "Ordered",
+                "Aggregates": "sum(0) AS avg_col, sum_count(3) AS count(intcol)",
+                "GroupBy": "1 COLLATE latin1_swedish_ci, (2|4) COLLATE ",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select sum(intcol) as avg_col, textcol1, textcol2, count(intcol), weight_string(textcol2) from `user` where 1 != 1 group by textcol1, textcol2, weight_string(textcol2)",
+                    "OrderBy": "1 ASC COLLATE latin1_swedish_ci, (2|4) ASC COLLATE ",
+                    "Query": "select sum(intcol) as avg_col, textcol1, textcol2, count(intcol), weight_string(textcol2) from `user` group by textcol1, textcol2, weight_string(textcol2) order by textcol1 asc, textcol2 asc",
+                    "Table": "`user`"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "don't filter on the vtgate",
     "query": "select 42 from dual where false",
     "plan": {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the average planning bug found in https://github.com/vitessio/vitess/issues/15625. The issue was with the simple projector, wherein we were creating a new incorrect field instead of reusing an already existing one.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15625

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
