### PR TITLE
CI: Upgrade/Downgrade use N+1 version of vtctld when testing with N+1 of vttablet

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -202,6 +202,12 @@ jobs:
 
         rm -f $PWD/bin/vtgate $PWD/bin/vttablet $PWD/bin/mysqlctl $PWD/bin/mysqlctld
         cp /tmp/vitess-build-current/bin/vtgate $PWD/bin/vtgate
+
+        cp /tmp/vitess-build-other/bin/vtctld $PWD/bin
+        cp /tmp/vitess-build-other/bin/vtctldclient $PWD/bin
+        cp /tmp/vitess-build-other/bin/vtctl $PWD/bin
+        cp /tmp/vitess-build-other/bin/vtctlclient $PWD/bin
+
         cp /tmp/vitess-build-other/bin/vttablet $PWD/bin/vttablet
         cp /tmp/vitess-build-other/bin/mysqlctl $PWD/bin/mysqlctl
         cp /tmp/vitess-build-other/bin/mysqlctld $PWD/bin/mysqlctld


### PR DESCRIPTION
## Description

Makes a similar change done in the multi-tenant PR at https://github.com/vitessio/vitess/pull/15503/files#diff-79c61525895b1e17d0cc49054a0d19f9264073042bbe75a8f5997092f02a3c92R203-R210

We need to use the same version of vtctld as vttablets.

Otherwise this workflow fails since it cannot insert into `_vt.vreplication` which now has a json column for which we cannot specify a default at the table schema level.

This is being done directly on v19 since the versions of vttablet/vtctlds  of upgrade/downgrade are reversed as compared to main (v20) and v19.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
