### PR TITLE
discovery: Fix tablets removed from healthcheck when topo server GetTablet call fails

### DIFF
--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -18,6 +18,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"math/rand/v2"
 	"testing"
 	"time"
@@ -575,4 +576,85 @@ func TestFilterByKeyspaceSkipsIgnoredTablets(t *testing.T) {
 	assert.Empty(t, fhc.GetAllTablets())
 
 	tw.Stop()
+}
+
+func TestGetTabletErrorDoesNotRemoveFromHealthcheck(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+
+	ts, factory := memorytopo.NewServerAndFactory(ctx, "aa")
+	defer ts.Close()
+	fhc := NewFakeHealthCheck(nil)
+	defer fhc.Close()
+	topologyWatcherOperations.ZeroAll()
+	counts := topologyWatcherOperations.Counts()
+	tw := NewTopologyWatcher(context.Background(), ts, fhc, nil, "aa", 10*time.Minute, true, 5)
+	defer tw.Stop()
+
+	// Force fallback to getting tablets individually.
+	factory.AddOperationError(memorytopo.List, ".*", topo.NewError(topo.NoImplementation, "List not supported"))
+
+	counts = checkOpCounts(t, counts, map[string]int64{})
+	checkChecksum(t, tw, 0)
+
+	// Add a tablet to the topology.
+	tablet1 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: "aa",
+			Uid:  0,
+		},
+		Hostname: "host1",
+		PortMap: map[string]int32{
+			"vt": 123,
+		},
+		Keyspace: "keyspace",
+		Shard:    "shard",
+	}
+	require.NoError(t, ts.CreateTablet(ctx, tablet1), "CreateTablet failed for %v", tablet1.Alias)
+
+	tw.loadTablets()
+	counts = checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "AddTablet": 1})
+	checkChecksum(t, tw, 3238442862)
+
+	// Check the tablet is returned by GetAllTablets().
+	allTablets := fhc.GetAllTablets()
+	key1 := TabletToMapKey(tablet1)
+	assert.Len(t, allTablets, 1)
+	assert.Contains(t, allTablets, key1)
+	assert.True(t, proto.Equal(tablet1, allTablets[key1]))
+
+	// Add a second tablet to the topology.
+	tablet2 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: "aa",
+			Uid:  2,
+		},
+		Hostname: "host2",
+		PortMap: map[string]int32{
+			"vt": 789,
+		},
+		Keyspace: "keyspace",
+		Shard:    "shard",
+	}
+	require.NoError(t, ts.CreateTablet(ctx, tablet2), "CreateTablet failed for %v", tablet2.Alias)
+
+	// Cause the Get for the first tablet to fail.
+	factory.AddOperationError(memorytopo.Get, "tablets/aa-0000000000/Tablet", errors.New("fake error"))
+
+	// Ensure that a topo Get error results in a partial results error. If not, the rest of this test is invalid.
+	_, err := ts.GetTabletsByCell(ctx, "aa", &topo.GetTabletsByCellOptions{})
+	require.ErrorContains(t, err, "partial result")
+
+	// Now force the error during loadTablets.
+	tw.loadTablets()
+	checkOpCounts(t, counts, map[string]int64{"ListTablets": 1, "AddTablet": 1})
+	checkChecksum(t, tw, 2762153755)
+
+	// Ensure the first tablet is still returned by GetAllTablets() and the second tablet has been added.
+	allTablets = fhc.GetAllTablets()
+	key2 := TabletToMapKey(tablet2)
+	assert.Len(t, allTablets, 2)
+	assert.Contains(t, allTablets, key1)
+	assert.Contains(t, allTablets, key2)
+	assert.True(t, proto.Equal(tablet1, allTablets[key1]))
+	assert.True(t, proto.Equal(tablet2, allTablets[key2]))
 }

--- a/go/vt/topo/keyspace_external_test.go
+++ b/go/vt/topo/keyspace_external_test.go
@@ -142,7 +142,7 @@ func TestServerGetServingShards(t *testing.T) {
 			require.NotNil(t, stats)
 
 			if tt.fallback {
-				factory.SetListError(errNoListImpl)
+				factory.AddOperationError(memorytopo.List, ".*", errNoListImpl)
 			}
 
 			err := ts.CreateKeyspace(ctx, keyspace, &topodatapb.Keyspace{})

--- a/go/vt/topo/memorytopo/directory.go
+++ b/go/vt/topo/memorytopo/directory.go
@@ -39,6 +39,9 @@ func (c *Conn) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.D
 	if c.factory.err != nil {
 		return nil, c.factory.err
 	}
+	if err := c.factory.getOperationError(ListDir, dirPath); err != nil {
+		return nil, err
+	}
 
 	isRoot := false
 	if dirPath == "" || dirPath == "/" {

--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -35,6 +35,10 @@ func (c *Conn) NewLeaderParticipation(name, id string) (topo.LeaderParticipation
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
 
+	if err := c.factory.getOperationError(NewLeaderParticipation, id); err != nil {
+		return nil, err
+	}
+
 	// Make sure the global path exists.
 	electionPath := path.Join(electionsPath, name)
 	if n := c.factory.getOrCreatePath(c.cell, electionPath); n == nil {

--- a/go/vt/topo/memorytopo/file.go
+++ b/go/vt/topo/memorytopo/file.go
@@ -46,6 +46,9 @@ func (c *Conn) Create(ctx context.Context, filePath string, contents []byte) (to
 	if c.factory.err != nil {
 		return nil, c.factory.err
 	}
+	if err := c.factory.getOperationError(Create, filePath); err != nil {
+		return nil, err
+	}
 
 	// Get the parent dir.
 	dir, file := path.Split(filePath)
@@ -91,6 +94,9 @@ func (c *Conn) Update(ctx context.Context, filePath string, contents []byte, ver
 
 	if c.factory.err != nil {
 		return nil, c.factory.err
+	}
+	if err := c.factory.getOperationError(Update, filePath); err != nil {
+		return nil, err
 	}
 
 	// Get the parent dir, we'll need it in case of creation.
@@ -168,6 +174,9 @@ func (c *Conn) Get(ctx context.Context, filePath string) ([]byte, topo.Version, 
 	if c.factory.err != nil {
 		return nil, nil, c.factory.err
 	}
+	if err := c.factory.getOperationError(Get, filePath); err != nil {
+		return nil, nil, err
+	}
 
 	// Get the node.
 	n := c.factory.nodeByPath(c.cell, filePath)
@@ -195,8 +204,8 @@ func (c *Conn) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, 
 	if c.factory.err != nil {
 		return nil, c.factory.err
 	}
-	if c.factory.listErr != nil {
-		return nil, c.factory.listErr
+	if err := c.factory.getOperationError(List, filePathPrefix); err != nil {
+		return nil, err
 	}
 
 	dir, file := path.Split(filePathPrefix)
@@ -258,6 +267,9 @@ func (c *Conn) Delete(ctx context.Context, filePath string, version topo.Version
 
 	if c.factory.err != nil {
 		return c.factory.err
+	}
+	if err := c.factory.getOperationError(Delete, filePath); err != nil {
+		return err
 	}
 
 	// Get the parent dir.

--- a/go/vt/topo/memorytopo/lock.go
+++ b/go/vt/topo/memorytopo/lock.go
@@ -44,12 +44,26 @@ type memoryTopoLockDescriptor struct {
 func (c *Conn) TryLock(ctx context.Context, dirPath, contents string) (topo.LockDescriptor, error) {
 	c.factory.callstats.Add([]string{"TryLock"}, 1)
 
+	c.factory.mu.Lock()
+	err := c.factory.getOperationError(TryLock, dirPath)
+	c.factory.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+
 	return c.Lock(ctx, dirPath, contents)
 }
 
 // Lock is part of the topo.Conn interface.
 func (c *Conn) Lock(ctx context.Context, dirPath, contents string) (topo.LockDescriptor, error) {
 	c.factory.callstats.Add([]string{"Lock"}, 1)
+
+	c.factory.mu.Lock()
+	err := c.factory.getOperationError(Lock, dirPath)
+	c.factory.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
 
 	return c.lock(ctx, dirPath, contents)
 }

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -37,6 +37,9 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 	if c.factory.err != nil {
 		return nil, nil, c.factory.err
 	}
+	if err := c.factory.getOperationError(Watch, filePath); err != nil {
+		return nil, nil, err
+	}
 
 	n := c.factory.nodeByPath(c.cell, filePath)
 	if n == nil {
@@ -88,6 +91,9 @@ func (c *Conn) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.Watc
 
 	if c.factory.err != nil {
 		return nil, nil, c.factory.err
+	}
+	if err := c.factory.getOperationError(WatchRecursive, dirpath); err != nil {
+		return nil, nil, err
 	}
 
 	n := c.factory.getOrCreatePath(c.cell, dirpath)

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -240,6 +240,7 @@ type GetTabletsByCellOptions struct {
 
 // GetTabletsByCell returns all the tablets in the cell.
 // It returns ErrNoNode if the cell doesn't exist.
+// It returns ErrPartialResult if some tablets couldn't be read. The results in the slice are incomplete.
 // It returns (nil, nil) if the cell exists, but there are no tablets in it.
 func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string, opt *GetTabletsByCellOptions) ([]*TabletInfo, error) {
 	// If the cell doesn't exist, this will return ErrNoNode.
@@ -277,6 +278,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string, opt *G
 // GetTabletsIndividuallyByCell returns a sorted list of tablets for topo servers that do not
 // directly support the topoConn.List() functionality.
 // It returns ErrNoNode if the cell doesn't exist.
+// It returns ErrPartialResult if some tablets couldn't be read. The results in the slice are incomplete.
 // It returns (nil, nil) if the cell exists, but there are no tablets in it.
 func (ts *Server) GetTabletsIndividuallyByCell(ctx context.Context, cell string, opt *GetTabletsByCellOptions) ([]*TabletInfo, error) {
 	// If the cell doesn't exist, this will return ErrNoNode.
@@ -286,10 +288,14 @@ func (ts *Server) GetTabletsIndividuallyByCell(ctx context.Context, cell string,
 	}
 	sort.Sort(topoproto.TabletAliasList(aliases))
 
+	var partialResultErr error
 	tabletMap, err := ts.GetTabletMap(ctx, aliases, opt)
 	if err != nil {
-		// we got another error than topo.ErrNoNode
-		return nil, err
+		if IsErrType(err, PartialResult) {
+			partialResultErr = err
+		} else {
+			return nil, err
+		}
 	}
 	tablets := make([]*TabletInfo, 0, len(aliases))
 	for _, tabletAlias := range aliases {
@@ -303,7 +309,7 @@ func (ts *Server) GetTabletsIndividuallyByCell(ctx context.Context, cell string,
 		}
 	}
 
-	return tablets, nil
+	return tablets, partialResultErr
 }
 
 // UpdateTablet updates the tablet data only - not associated replication paths.


### PR DESCRIPTION
## Description

This PR fixes two bugs that can appear when using Zookeeper as the topo server
1. topo.Server GetTabletsIndividuallyByCell will return an empty slice on a partial result error from GetTabletMap, which causes TopologyWatcher to remove all tablets from the healthcheck.
2. After fixing the first bug, TopologyWatcher will still remove any tablets not present in the partial results list.

In order to test these fixes this PR also introduces a more flexible way to return fake errors from memorytopo.

Since the impact of this bug could be pretty disruptive, I think it should be backported to v19.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/15632

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

n/a