### PR TITLE
Fix `docker_build_images` CI workflow

### DIFF
--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -76,7 +76,6 @@ jobs:
           tags: ${{ env.DOCKER_TAG }}
 
   build_and_push_components:
-    needs: build_and_push_k8s
     name: Build and push vitess components Docker images
     runs-on: gh-hosted-runners-16cores-1
     if: github.repository == 'vitessio/vitess'


### PR DESCRIPTION
## Description

I broke the action `docker_build_images` in https://github.com/vitessio/vitess/pull/15620 as seen in https://github.com/vitessio/vitess/actions/runs/8546027282. This fixes it.