### PR TITLE
[release-18.0] Update go.mod go version to 1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.21
+go 1.21.9
 
 require (
 	cloud.google.com/go/storage v1.39.0


### PR DESCRIPTION

## Description

Followup to https://github.com/vitessio/vitess/pull/15639, we were missing the updated go version in `go.mod`.


## Related Issue(s)

#15639 
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
