### PR TITLE
Copy `v18.0.4` release notes on `main`

### DIFF
--- a/changelog/18.0/18.0.4/changelog.md
+++ b/changelog/18.0/18.0.4/changelog.md
@@ -1,0 +1,22 @@
+# Changelog of Vitess v18.0.4
+
+### Bug fixes 
+#### VReplication
+ * [release-18.0] VReplication: Fix workflow update changed handling (#15621) [#15628](https://github.com/vitessio/vitess/pull/15628)
+### CI/Build 
+#### Build/CI
+ * [release-18.0] Update to latest CodeQL (#15530) [#15533](https://github.com/vitessio/vitess/pull/15533)
+ * [release-18.0] Update go.mod go version to 1.21.9 [#15646](https://github.com/vitessio/vitess/pull/15646)
+ * [release-18.0] Updated `golang.org/x/net` [#15650](https://github.com/vitessio/vitess/pull/15650) 
+#### General
+ * [release-18.0] Upgrade to go1.21.9 [#15639](https://github.com/vitessio/vitess/pull/15639)
+### Regression 
+#### Query Serving
+ * [release-18.0] fix: remove keyspace from column during query builder (#15514) [#15516](https://github.com/vitessio/vitess/pull/15516)
+### Release 
+#### General
+ * [release-18.0] Bump to `v18.0.4-SNAPSHOT` after the `v18.0.3` release [#15489](https://github.com/vitessio/vitess/pull/15489)
+### Testing 
+#### VReplication
+ * [release-18.0] VReplication: Fix vtctldclient SwitchReads related bugs and move the TestBasicV2Workflows e2e test to vtctldclient (#15579) [#15583](https://github.com/vitessio/vitess/pull/15583)
+

--- a/changelog/18.0/18.0.4/release_notes.md
+++ b/changelog/18.0/18.0.4/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v18.0.4
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/18.0/18.0.4/changelog.md).
+
+The release includes 8 merged Pull Requests.
+
+Thanks to all our contributors: @app/vitess-bot, @frouioui, @shlomi-noach, @systay
+

--- a/changelog/18.0/README.md
+++ b/changelog/18.0/README.md
@@ -1,4 +1,8 @@
 ## v18.0
+* **[18.0.4](18.0.4)**
+	* [Changelog](18.0.4/changelog.md)
+	* [Release Notes](18.0.4/release_notes.md)
+
 * **[18.0.3](18.0.3)**
 	* [Changelog](18.0.3/changelog.md)
 	* [Release Notes](18.0.3/release_notes.md)


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-18.0` to keep release notes up-to-date after the `v18.0.4` release.