### PR TITLE
Copy `v19.0.3` release notes on `main`

### DIFF
--- a/changelog/19.0/19.0.3/changelog.md
+++ b/changelog/19.0/19.0.3/changelog.md
@@ -1,0 +1,9 @@
+# Changelog of Vitess v19.0.3
+
+### Internal Cleanup 
+#### General
+ * Update dependencies for golang.org/x/net to latest [#15651](https://github.com/vitessio/vitess/pull/15651)
+### Release 
+#### General
+ * [release-19.0] Bump to `v19.0.3-SNAPSHOT` after the `v19.0.2` release [#15648](https://github.com/vitessio/vitess/pull/15648)
+

--- a/changelog/19.0/19.0.3/release_notes.md
+++ b/changelog/19.0/19.0.3/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v19.0.3
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/19.0/19.0.3/changelog.md).
+
+The release includes 2 merged Pull Requests.
+
+Thanks to all our contributors: @systay
+

--- a/changelog/19.0/README.md
+++ b/changelog/19.0/README.md
@@ -1,4 +1,8 @@
 ## v19.0
+* **[19.0.3](19.0.3)**
+	* [Changelog](19.0.3/changelog.md)
+	* [Release Notes](19.0.3/release_notes.md)
+
 * **[19.0.2](19.0.2)**
 	* [Changelog](19.0.2/changelog.md)
 	* [Release Notes](19.0.2/release_notes.md)


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-19.0` to keep release notes up-to-date after the `v19.0.3` release.