### PR TITLE
Add `no_scatter` flag to vttestserver

### DIFF
--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -224,6 +224,8 @@ func New() (cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&config.VtgateTabletRefreshInterval, "tablet_refresh_interval", 10*time.Second, "Interval at which vtgate refreshes tablet information from topology server.")
 
 	cmd.Flags().BoolVar(&doCreateTCPUser, "initialize-with-vt-dba-tcp", false, "If this flag is enabled, MySQL will be initialized with an additional user named vt_dba_tcp, who will have access via TCP/IP connection.")
+
+	cmd.Flags().BoolVar(&config.NoScatter, "no_scatter", false, "when set to true, the planner will fail instead of producing a plan that includes scatter queries")
 	acl.RegisterFlags(cmd.Flags())
 
 	return cmd

--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -186,6 +186,21 @@ func TestForeignKeysAndDDLModes(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNoScatter(t *testing.T) {
+	conf := config
+	defer resetConfig(conf)
+
+	cluster, err := startCluster("--no_scatter")
+	assert.NoError(t, err)
+	defer cluster.TearDown()
+
+	_ = execOnCluster(cluster, "app_customer", func(conn *mysql.Conn) error {
+		_, err = conn.ExecuteFetch("SELECT * FROM customers", 100, false)
+		require.ErrorContains(t, err, "plan includes scatter, which is disallowed")
+		return nil
+	})
+}
+
 // TestCreateDbaTCPUser tests that the vt_dba_tcp user is created and can connect through TCP/IP connection
 // when --initialize-with-vt-dba-tcp is set to true.
 func TestCreateDbaTCPUser(t *testing.T) {

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -92,6 +92,7 @@ Flags:
       --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
+      --no_scatter                                                       when set to true, the planner will fail instead of producing a plan that includes scatter queries
       --null_probability float                                           The probability to initialize a field with 'NULL'  if --initialize_with_random_data is true. Only applies to fields that can contain NULL values. (default 0.1)
       --num_shards strings                                               Comma separated shard count (one per keyspace) (default [2])
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -156,6 +156,9 @@ type Config struct {
 	ExternalTopoGlobalRoot string
 
 	VtgateTabletRefreshInterval time.Duration
+
+	// Set the planner to fail on scatter queries
+	NoScatter bool
 }
 
 // InitSchemas is a shortcut for tests that just want to setup a single

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -235,6 +235,7 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 		fmt.Sprintf("--enable_online_ddl=%t", args.EnableOnlineDDL),
 		fmt.Sprintf("--enable_direct_ddl=%t", args.EnableDirectDDL),
 		fmt.Sprintf("--enable_system_settings=%t", args.EnableSystemSettings),
+		fmt.Sprintf("--no_scatter=%t", args.NoScatter),
 	}...)
 
 	// If topo tablet refresh interval is not defined then we will give it value of 10s. Please note


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds the flag `no_scatter` to `vttestserver`, which will cause scatter queries to automatically fail when set. This behavior is useful for detecting / preventing scatter queries early in a test environment.

Note that this flag already exists in [vtcombo](https://github.com/aparajon/vitess/blob/b3d45fdb5be936f3815ff8e3efcb3af4c1afe06d/go/flags/endtoend/vtcombo.txt#L252).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes https://github.com/vitessio/vitess/issues/15683

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
