### PR TITLE
fix: don't forget DISTINCT for derived tables

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -603,6 +603,7 @@ func buildDerivedSelect(op *Horizon, qb *queryBuilder, sel *sqlparser.Select) {
 	sel.GroupBy = opQuery.GroupBy
 	sel.Having = mergeHaving(sel.Having, opQuery.Having)
 	sel.SelectExprs = opQuery.SelectExprs
+	sel.Distinct = opQuery.Distinct
 	qb.addTableExpr(op.Alias, op.Alias, TableID(op), &sqlparser.DerivedTable{
 		Select: sel,
 	}, nil, op.ColumnAliases)

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -410,6 +410,28 @@
     }
   },
   {
+    "comment": "DISTINCT inside derived table",
+    "query": "select * from (select distinct name from user) as t",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select * from (select distinct name from user) as t",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `name` from (select `name` from `user` where 1 != 1) as t where 1 != 1",
+        "Query": "select `name` from (select distinct `name` from `user`) as t",
+        "Table": "`user`"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "',' join unsharded",
     "query": "select u1.a, u2.a from unsharded u1, unsharded u2",
     "plan": {


### PR DESCRIPTION
## Description
When the planner is able to push down a derived table and everything that goes with it under a route, we were not copying over whether the SELECT was distinct or not.

## Related Issue(s)
Fixes #13578

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
