### PR TITLE
`schemadiff`: `SubsequentDiffStrategy`: allow/reject multiple changes on same entity

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -453,3 +453,18 @@ type UnknownColumnCollationCharsetError struct {
 func (e *UnknownColumnCollationCharsetError) Error() string {
 	return fmt.Sprintf("unable to determine charset for column %s with collation %q", sqlescape.EscapeID(e.Column), e.Collation)
 }
+
+type SubsequentDiffRejectedError struct {
+	Table string
+	Diffs []EntityDiff
+}
+
+func (e *SubsequentDiffRejectedError) Error() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("multiple changes not allowed on table %s. Found:", sqlescape.EscapeID(e.Table)))
+	for _, d := range e.Diffs {
+		b.WriteString("\n")
+		b.WriteString(d.CanonicalStatementString())
+	}
+	return b.String()
+}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -946,6 +946,12 @@ func (c *CreateTableEntity) TableDiff(other *CreateTableEntity, hints *DiffHints
 	}
 	sortAlterOptions(parentAlterTableEntityDiff)
 
+	if hints.SubsequentDiffStrategy == SubsequentDiffStrategyReject {
+		if allSubsequent := AllSubsequent(parentAlterTableEntityDiff); len(allSubsequent) > 1 {
+			return nil, &SubsequentDiffRejectedError{Table: c.Name(), Diffs: allSubsequent}
+		}
+	}
+
 	return parentAlterTableEntityDiff, nil
 }
 

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -134,6 +134,11 @@ const (
 	ForeignKeyCheckStrategyIgnore
 )
 
+const (
+	SubsequentDiffStrategyAllow int = iota
+	SubsequentDiffStrategyReject
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering         bool
@@ -148,6 +153,7 @@ type DiffHints struct {
 	AlterTableAlgorithmStrategy int
 	EnumReorderStrategy         int
 	ForeignKeyCheckStrategy     int
+	SubsequentDiffStrategy      int
 }
 
 func EmptyDiffHints() *DiffHints {


### PR DESCRIPTION

## Description

Some diffs between two tables, cannot be applied in MySQL in a single `ALTER TABLE` statement. Examples:

- Adding a column and dropping a partition.
- Adding and dropping a partition.
- Some other partitioning change scenarios.
- Adding two `FULLTEXT` keys.

These are MySQL limitations. Specifically for `FULLTEXT`, `schemadiff` offers a flag to tolerate multiple changes (and `vitess`  Online DDL can then work with that).

This PR adds a more general diff hint: whether to at all allow multiple changes per table (default: allow, for backwards compatibility), or to outright reject such diff.

This can only ever apply to `ALTER TABLE` as no other supported change has this problem (e.g. `ALTER VIEW` is just one sweep atomic change anyway ; `DROP TABLE` obviously has nothing to apply twice, etc.)

The new hint flag will be used in followup PRs. This PR is worth being standalone.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15674

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
