### PR TITLE
Prevent adding to query details after unserve common has started

### DIFF
--- a/go/test/endtoend/vtgate/transaction/restart/main_test.go
+++ b/go/test/endtoend/vtgate/transaction/restart/main_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
@@ -113,5 +112,4 @@ func TestStreamTxRestart(t *testing.T) {
 	// query should return connection error
 	_, err = utils.ExecAllowError(t, conn, "select connection_id()")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "broken pipe (errno 2006) (sqlstate HY000)")
 }

--- a/go/vt/vttablet/tabletserver/livequeryz_test.go
+++ b/go/vt/vttablet/tabletserver/livequeryz_test.go
@@ -30,8 +30,8 @@ func TestLiveQueryzHandlerJSON(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/livequeryz/?format=json", nil)
 
 	queryList := NewQueryList("test", sqlparser.NewTestParser())
-	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
-	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
+	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
+	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
 
 	livequeryzHandler([]*QueryList{queryList}, resp, req)
 }
@@ -41,8 +41,8 @@ func TestLiveQueryzHandlerHTTP(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/livequeryz/", nil)
 
 	queryList := NewQueryList("test", sqlparser.NewTestParser())
-	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
-	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
+	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
+	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
 
 	livequeryzHandler([]*QueryList{queryList}, resp, req)
 }
@@ -64,7 +64,7 @@ func TestLiveQueryzHandlerTerminateConn(t *testing.T) {
 
 	queryList := NewQueryList("test", sqlparser.NewTestParser())
 	testConn := &testConn{id: 1}
-	queryList.Add(NewQueryDetail(context.Background(), testConn))
+	_ = queryList.Add(NewQueryDetail(context.Background(), testConn))
 	if testConn.IsKilled() {
 		t.Fatalf("conn should still be alive")
 	}

--- a/go/vt/vttablet/tabletserver/livequeryz_test.go
+++ b/go/vt/vttablet/tabletserver/livequeryz_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -30,8 +32,10 @@ func TestLiveQueryzHandlerJSON(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/livequeryz/?format=json", nil)
 
 	queryList := NewQueryList("test", sqlparser.NewTestParser())
-	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
-	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
+	err := queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
+	require.NoError(t, err)
+	err = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
+	require.NoError(t, err)
 
 	livequeryzHandler([]*QueryList{queryList}, resp, req)
 }
@@ -41,8 +45,10 @@ func TestLiveQueryzHandlerHTTP(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/livequeryz/", nil)
 
 	queryList := NewQueryList("test", sqlparser.NewTestParser())
-	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
-	_ = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
+	err := queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
+	require.NoError(t, err)
+	err = queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
+	require.NoError(t, err)
 
 	livequeryzHandler([]*QueryList{queryList}, resp, req)
 }
@@ -64,7 +70,8 @@ func TestLiveQueryzHandlerTerminateConn(t *testing.T) {
 
 	queryList := NewQueryList("test", sqlparser.NewTestParser())
 	testConn := &testConn{id: 1}
-	_ = queryList.Add(NewQueryDetail(context.Background(), testConn))
+	err := queryList.Add(NewQueryDetail(context.Background(), testConn))
+	require.NoError(t, err)
 	if testConn.IsKilled() {
 		t.Fatalf("conn should still be alive")
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -1085,7 +1085,10 @@ func (qre *QueryExecutor) execDBConn(conn *connpool.Conn, sql string, wantfields
 	defer qre.logStats.AddRewrittenSQL(sql, time.Now())
 
 	qd := NewQueryDetail(qre.logStats.Ctx, conn)
-	qre.tsv.statelessql.Add(qd)
+	err := qre.tsv.statelessql.Add(qd)
+	if err != nil {
+		return nil, err
+	}
 	defer qre.tsv.statelessql.Remove(qd)
 
 	return conn.Exec(ctx, sql, int(qre.tsv.qe.maxResultSize.Load()), wantfields)
@@ -1098,7 +1101,10 @@ func (qre *QueryExecutor) execStatefulConn(conn *StatefulConnection, sql string,
 	defer qre.logStats.AddRewrittenSQL(sql, time.Now())
 
 	qd := NewQueryDetail(qre.logStats.Ctx, conn)
-	qre.tsv.statefulql.Add(qd)
+	err := qre.tsv.statefulql.Add(qd)
+	if err != nil {
+		return nil, err
+	}
 	defer qre.tsv.statefulql.Remove(qd)
 
 	return conn.Exec(ctx, sql, int(qre.tsv.qe.maxResultSize.Load()), wantfields)
@@ -1122,11 +1128,17 @@ func (qre *QueryExecutor) execStreamSQL(conn *connpool.PooledConn, isTransaction
 	// once their grace period is over.
 	qd := NewQueryDetail(qre.logStats.Ctx, conn.Conn)
 	if isTransaction {
-		qre.tsv.statefulql.Add(qd)
+		err := qre.tsv.statefulql.Add(qd)
+		if err != nil {
+			return err
+		}
 		defer qre.tsv.statefulql.Remove(qd)
 		return conn.Conn.StreamOnce(ctx, sql, callBackClosingSpan, allocStreamResult, int(qre.tsv.qe.streamBufferSize.Load()), sqltypes.IncludeFieldsOrDefault(qre.options))
 	}
-	qre.tsv.olapql.Add(qd)
+	err := qre.tsv.olapql.Add(qd)
+	if err != nil {
+		return err
+	}
 	defer qre.tsv.olapql.Remove(qd)
 	return conn.Conn.Stream(ctx, sql, callBackClosingSpan, allocStreamResult, int(qre.tsv.qe.streamBufferSize.Load()), sqltypes.IncludeFieldsOrDefault(qre.options))
 }

--- a/go/vt/vttablet/tabletserver/query_list_test.go
+++ b/go/vt/vttablet/tabletserver/query_list_test.go
@@ -102,11 +102,16 @@ func TestClusterAction(t *testing.T) {
 	connID := int64(1)
 	qd1 := NewQueryDetail(context.Background(), &testConn{id: connID})
 
-	ql.SetClusterAction(true)
+	ql.SetClusterAction(ClusterActionInProgress)
+	ql.SetClusterAction(ClusterActionNoQueries)
 	err := ql.Add(qd1)
 	require.ErrorContains(t, err, "operation not allowed in state SHUTTING_DOWN")
 
-	ql.SetClusterAction(false)
+	ql.SetClusterAction(ClusterActionNotInProgress)
+	err = ql.Add(qd1)
+	require.NoError(t, err)
+	// If the current state is not in progress, then setting no queries, shouldn't change anything.
+	ql.SetClusterAction(ClusterActionNoQueries)
 	err = ql.Add(qd1)
 	require.NoError(t, err)
 }

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -542,6 +542,8 @@ func (sm *stateManager) connect(tabletType topodatapb.TabletType) error {
 }
 
 func (sm *stateManager) unserveCommon() {
+	sm.markClusterAction(true)
+	defer sm.markClusterAction(false)
 	// We create a wait group that tracks whether all the queries have been terminated or not.
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -849,4 +851,11 @@ func (sm *stateManager) IsServingString() string {
 
 func (sm *stateManager) SetUnhealthyThreshold(v time.Duration) {
 	sm.unhealthyThreshold.Store(v.Nanoseconds())
+}
+
+// markClusterAction marks whether a cluster action is in progress or not for all the query details.
+func (sm *stateManager) markClusterAction(inProgress bool) {
+	sm.statefulql.SetClusterAction(inProgress)
+	sm.statelessql.SetClusterAction(inProgress)
+	sm.olapql.SetClusterAction(inProgress)
 }

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -409,18 +409,20 @@ func TestStateManagerShutdownGracePeriod(t *testing.T) {
 
 	sm.te = &delayedTxEngine{}
 	kconn1 := &killableConn{id: 1}
-	sm.statelessql.Add(&QueryDetail{
+	err := sm.statelessql.Add(&QueryDetail{
 		conn:   kconn1,
 		connID: kconn1.id,
 	})
+	require.NoError(t, err)
 	kconn2 := &killableConn{id: 2}
-	sm.statefulql.Add(&QueryDetail{
+	err = sm.statefulql.Add(&QueryDetail{
 		conn:   kconn2,
 		connID: kconn2.id,
 	})
+	require.NoError(t, err)
 
 	// Transition to replica with no shutdown grace period should kill kconn2 but not kconn1.
-	err := sm.SetServingType(topodatapb.TabletType_PRIMARY, testNow, StateServing, "")
+	err = sm.SetServingType(topodatapb.TabletType_PRIMARY, testNow, StateServing, "")
 	require.NoError(t, err)
 	assert.False(t, kconn1.killed.Load())
 	assert.True(t, kconn2.killed.Load())


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the bug found in https://github.com/vitessio/vitess/issues/15685. The problem was that we were adding to the queryDetails even after unserveCommon had been called and after the kill had happened. This is troublesome and has been fixed by preventing addition to the query details right after `unserveCommon` starts.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15685

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
