### PR TITLE
Use the legacy name for timeouts

### DIFF
--- a/config/mycnf/mysql80.cnf
+++ b/config/mycnf/mysql80.cnf
@@ -33,5 +33,5 @@ loose_rpl_semi_sync_master_wait_no_slave = 1
 super-read-only
 
 # Replication parameters to ensure reparents are fast.
-replica_net_timeout = 8
+slave_net_timeout = 8
 


### PR DESCRIPTION
We still want to be able to work with older MySQL 8.0 releases that don't have the new names yet, so keep using the old one for now.

## Related Issue(s)

This was added as setting in https://github.com/vitessio/vitess/pull/15663. Part of https://github.com/vitessio/vitess/issues/15664

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required