### PR TITLE
VReplication Workflows (RowStreamer): explicitly set read only when creating snapshots in the copy phase

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -136,7 +136,7 @@ func (conn *snapshotConn) startSnapshot(ctx context.Context, table string) (gtid
 	if _, err := conn.ExecuteFetch("set transaction isolation level repeatable read", 1, false); err != nil {
 		return "", err
 	}
-	if _, err := conn.ExecuteFetch("start transaction with consistent snapshot", 1, false); err != nil {
+	if _, err := conn.ExecuteFetch("start transaction with consistent snapshot, read only", 1, false); err != nil {
 		return "", err
 	}
 	if _, err := conn.ExecuteFetch("set @@session.time_zone = '+00:00'", 1, false); err != nil {
@@ -152,7 +152,7 @@ func (conn *snapshotConn) startSnapshotWithConsistentGTID(ctx context.Context) (
 	if _, err := conn.ExecuteFetch("set transaction isolation level repeatable read", 1, false); err != nil {
 		return "", err
 	}
-	result, err := conn.ExecuteFetch("start transaction with consistent snapshot", 1, false)
+	result, err := conn.ExecuteFetch("start transaction with consistent snapshot, read only", 1, false)
 	if err != nil {
 		return "", err
 	}
@@ -290,7 +290,7 @@ func (conn *snapshotConn) startSnapshotAllTables(ctx context.Context) (gtid stri
 	if _, err := conn.ExecuteFetch("set transaction isolation level repeatable read", 1, false); err != nil {
 		return "", err
 	}
-	if _, err := conn.ExecuteFetch("start transaction with consistent snapshot", 1, false); err != nil {
+	if _, err := conn.ExecuteFetch("start transaction with consistent snapshot, read only", 1, false); err != nil {
 		return "", err
 	}
 	if _, err := conn.ExecuteFetch("set @@session.time_zone = '+00:00'", 1, false); err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
@@ -53,7 +53,7 @@ func TestStartSnapshot(t *testing.T) {
 		Rows: [][]sqltypes.Value{
 			{sqltypes.NewInt32(1), sqltypes.NewVarBinary("aaa")},
 		},
-		StatusFlags: sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit | sqltypes.ServerStatusInTrans,
+		StatusFlags: sqltypes.ServerStatusInTransReadonly | sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit | sqltypes.ServerStatusInTrans,
 	}
 	qr, err := conn.ExecuteFetch("select * from t1", 10, false)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

On a high write qps cluster, while copying a huge table, we noticed that the copy phase of a MoveTables workflow was significantly increasing replica lag. The workflow was streaming from replicas. Reducing the copy phase duration to 10 minutes did not help.

While auditing `INNODB_TRX` It was noticed that `trx_is_read_only` is set to `0`. We expected it to be `1` since we do this
```
if _, err := conn.ExecuteFetch("set transaction isolation level repeatable read", 1, false); err != nil {
		return "", err
}
if _, err := conn.ExecuteFetch("start transaction with consistent snapshot", 1, false); err != nil {
		return "", err
}
```

This PR modifies the second query to explicitly set `read only`: like `start transaction with consistent snapshot, read only`. A unit test confirms that this works.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/8056

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
