### PR TITLE
Use Kill Query for Non-Transaction Query Execution and Update Query Timeout / Cancelled Error Message

### DIFF
--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -22,6 +22,7 @@
     - [Delete with Subquery Support](#delete-subquery)
     - [Delete with Multi Target Support](#delete-multi-target)
     - [User Defined Functions Support](#udf-support)
+  - **[Query Timeout](#query-timeout)**
   - **[Flag changes](#flag-changes)**
     - [`pprof-http` default change](#pprof-http-default)
     - [New `healthcheck-dial-concurrency` flag](#healthcheck-dial-concurrency-flag)
@@ -192,6 +193,11 @@ User Defined Functions (UDFs) should be directly loaded in the underlying MySQL.
 It should be enabled in VTGate with the `--enable-udfs` flag.
 
 More details about how to load UDFs is available in [MySQL Docs](https://dev.mysql.com/doc/extending-mysql/8.0/en/adding-loadable-function.html)
+
+### <a id="query-timeout"/>Query Timeout
+On a query timeout, Vitess closed the connection using the `kill connection` statement. This leads to connection churn 
+which is not desirable in some cases. To avoid this, Vitess now uses the `kill query` statement to cancel the query. 
+This will only cancel the query and does not terminate the connection.
 
 ### <a id="flag-changes"/>Flag Changes
 

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -583,7 +583,7 @@ func testScheduler(t *testing.T) {
 				onlineddl.CheckCompleteMigration(t, &vtParams, shards, t1uuid, true)
 			})
 			t.Run("cut-over fail due to timeout", func(t *testing.T) {
-				waitForMessage(t, t1uuid, "due to context deadline exceeded")
+				waitForMessage(t, t1uuid, "(errno 3024) (sqlstate HY000): Query execution was interrupted, maximum statement execution time exceeded")
 				status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, t1uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed, schema.OnlineDDLStatusRunning)
 				fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 				onlineddl.CheckMigrationStatus(t, &vtParams, shards, t1uuid, schema.OnlineDDLStatusRunning)
@@ -606,7 +606,7 @@ func testScheduler(t *testing.T) {
 			})
 			t.Run("expect transaction failure", func(t *testing.T) {
 				select {
-				case commitTransactionChan <- true: //good
+				case commitTransactionChan <- true: // good
 				case <-ctx.Done():
 					assert.Fail(t, ctx.Err().Error())
 				}
@@ -1445,7 +1445,7 @@ DROP TABLE IF EXISTS stress_test
 		}
 	})
 
-	//DROP
+	// DROP
 
 	t.Run("online DROP TABLE", func(t *testing.T) {
 		uuid := testOnlineDDLStatement(t, createParams(dropStatement, onlineSingletonDDLStrategy, "vtgate", "", "", "", false))

--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -276,7 +276,7 @@ func TestQueryTimeout(t *testing.T) {
 	assert.Equal(t, vtrpcpb.Code_ABORTED, vterrors.Code(err))
 	vend := framework.DebugVars()
 	verifyIntValue(t, vend, "QueryTimeout", int(100*time.Millisecond))
-	compareIntDiff(t, vend, "Kills/Queries", vstart, 1)
+	compareIntDiff(t, vend, "Kills/Connections", vstart, 1)
 }
 
 func changeVar(t *testing.T, name, value string) (revert func()) {

--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -195,7 +195,7 @@ func TestConsolidatorReplicasOnly(t *testing.T) {
 func TestQueryPlanCache(t *testing.T) {
 	var cachedPlanSize = int((&tabletserver.TabletPlan{}).CachedSize(true))
 
-	//sleep to avoid race between SchemaChanged event clearing out the plans cache which breaks this test
+	// sleep to avoid race between SchemaChanged event clearing out the plans cache which breaks this test
 	framework.Server.WaitForSchemaReset(2 * time.Second)
 
 	bindVars := map[string]*querypb.BindVariable{
@@ -276,7 +276,7 @@ func TestQueryTimeout(t *testing.T) {
 	assert.Equal(t, vtrpcpb.Code_ABORTED, vterrors.Code(err))
 	vend := framework.DebugVars()
 	verifyIntValue(t, vend, "QueryTimeout", int(100*time.Millisecond))
-	compareIntDiff(t, vend, "Kills/Queries", vstart, 1)
+	compareIntDiff(t, vend, "Kills/Connections", vstart, 1)
 }
 
 func changeVar(t *testing.T, name, value string) (revert func()) {

--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -276,7 +276,7 @@ func TestQueryTimeout(t *testing.T) {
 	assert.Equal(t, vtrpcpb.Code_ABORTED, vterrors.Code(err))
 	vend := framework.DebugVars()
 	verifyIntValue(t, vend, "QueryTimeout", int(100*time.Millisecond))
-	compareIntDiff(t, vend, "Kills/Connections", vstart, 1)
+	compareIntDiff(t, vend, "Kills/Queries", vstart, 1)
 }
 
 func changeVar(t *testing.T, name, value string) (revert func()) {

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -974,7 +974,10 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream, sh
 	defer renameConn.Recycle()
 	defer func() {
 		if !renameWasSuccessful {
-			renameConn.Conn.Kill("premature exit while renaming tables", 0)
+			err := renameConn.Conn.Kill("premature exit while renaming tables", 0)
+			if err != nil {
+				log.Warningf("failed to kill rename connection: %v", err)
+			}
 		}
 	}()
 	// See if backend MySQL server supports 'rename_table_preserve_foreign_key' variable

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -976,7 +976,7 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream, sh
 		if !renameWasSuccessful {
 			err := renameConn.Conn.Kill("premature exit while renaming tables", 0)
 			if err != nil {
-				log.Warningf("failed to kill rename connection: %v", err)
+				log.Warningf("Failed to kill connection being used to rename tables in OnlineDDL migration %s: %v", onlineDDL.UUID, err)
 			}
 		}
 	}()

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -184,7 +184,7 @@ func (dbc *Conn) execOnce(ctx context.Context, query string, maxrows int, wantfi
 
 	select {
 	case <-ctx.Done():
-		_ = dbc.Kill(ctx.Err().Error(), time.Since(now))
+		_ = dbc.KillQuery(ctx.Err().Error(), time.Since(now))
 		return nil, dbc.Err()
 	case r := <-ch:
 		if dbcErr := dbc.Err(); dbcErr != nil {
@@ -280,7 +280,7 @@ func (dbc *Conn) streamOnce(ctx context.Context, query string, callback func(*sq
 
 	select {
 	case <-ctx.Done():
-		_ = dbc.Kill(ctx.Err().Error(), time.Since(now))
+		_ = dbc.KillQuery(ctx.Err().Error(), time.Since(now))
 		return dbc.Err()
 	case err := <-ch:
 		if dbcErr := dbc.Err(); dbcErr != nil {

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -607,6 +607,10 @@ func TestDBExecOnceKillTimeout(t *testing.T) {
 	require.Nil(t, result)
 	timeQuery := time.UnixMicro(timestampQuery.Load())
 	timeKill := time.UnixMicro(timestampKill.Load())
+	// In this unit test, the execution of `select 1` is blocked for 1000ms.
+	// The kill query gets executed after 100ms but waits for the query to return which will happen after 1000ms due to the test framework.
+	// In real scenario mysql will kill the query immediately and return the error.
+	// Here, kill call happens after 100ms but took 1000ms to complete.
 	require.WithinDuration(t, timeQuery, timeKill, 150*time.Millisecond)
-	require.WithinDuration(t, timeKill, timeDone, 150*time.Millisecond)
+	require.WithinDuration(t, timeKill, timeDone, 1000*time.Millisecond)
 }

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -320,11 +320,11 @@ func TestDBKillWithContext(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+	// set a lower timeout value
+	dbConn.killTimeout = 100 * time.Millisecond
 
-	// KillWithContext should return context.DeadlineExceeded
-	err = dbConn.KillWithContext(ctx, "test kill", 0)
+	// Kill should return context.DeadlineExceeded
+	err = dbConn.Kill("test kill", 0)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -590,7 +590,7 @@ func TestDBExecOnceKillTimeout(t *testing.T) {
 	// It should also run into a timeout.
 	var timestampKill atomic.Int64
 	dbConn.killTimeout = 100 * time.Millisecond
-	db.AddQueryPatternWithCallback(`kill \d+`, &sqltypes.Result{}, func(string) {
+	db.AddQueryPatternWithCallback(`kill query \d+`, &sqltypes.Result{}, func(string) {
 		timestampKill.Store(time.Now().UnixMicro())
 		// should take longer than the configured kill timeout above.
 		time.Sleep(200 * time.Millisecond)

--- a/go/vt/vttablet/tabletserver/query_list.go
+++ b/go/vt/vttablet/tabletserver/query_list.go
@@ -26,6 +26,7 @@ import (
 
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callinfo"
+	"vitess.io/vitess/go/vt/log"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -139,7 +140,10 @@ func (ql *QueryList) Terminate(connID int64) bool {
 		return false
 	}
 	for _, qd := range qds {
-		_ = qd.conn.Kill("QueryList.Terminate()", time.Since(qd.start))
+		err := qd.conn.Kill("QueryList.Terminate()", time.Since(qd.start))
+		if err != nil {
+			log.Warningf("Error terminating query on connection id: %d, error: %v", qd.conn.ID(), err)
+		}
 	}
 	return true
 }
@@ -150,7 +154,10 @@ func (ql *QueryList) TerminateAll() {
 	defer ql.mu.Unlock()
 	for _, qds := range ql.queryDetails {
 		for _, qd := range qds {
-			_ = qd.conn.Kill("QueryList.TerminateAll()", time.Since(qd.start))
+			err := qd.conn.Kill("QueryList.TerminateAll()", time.Since(qd.start))
+			if err != nil {
+				log.Warningf("Error terminating query on connection id: %d, error: %v", qd.conn.ID(), err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR changes the error message returned on the context error.
On context timeout: `ERROR 3024 (HY000): Query execution was interrupted, maximum statement execution time exceeded`
On context cancelled: `ERROR 1317 (70100): Query execution was interrupted`

This PR also executed `kill query` instead of `kill connection` on context error to reduce the connection churn. This is only performed on non-transactional queries.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes https://github.com/vitessio/vitess/issues/10059

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
