### PR TITLE
Flaky test TestOnlineDDLVDiff: add additional check for vreplication workflow to exist

### DIFF
--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -350,10 +350,7 @@ func assertQueryDoesNotExecutesOnTablet(t *testing.T, conn *mysql.Conn, tablet *
 func waitForWorkflowToBeCreated(t *testing.T, vc *VitessCluster, ksWorkflow string) {
 	require.NoError(t, waitForCondition("workflow to be created", func() bool {
 		_, err := vc.VtctlClient.ExecuteCommandWithOutput("Workflow", ksWorkflow, "show")
-		if err == nil {
-			return true
-		}
-		return false
+		return err == nil
 	}, defaultTimeout))
 }
 

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -347,6 +347,16 @@ func assertQueryDoesNotExecutesOnTablet(t *testing.T, conn *mysql.Conn, tablet *
 	assert.Equalf(t, count0, count1, "query %q executed in target;\ntried to match %q\nbefore:\n%s\n\nafter:\n%s\n\n", query, matchQuery, body0, body1)
 }
 
+func waitForWorkflowToBeCreated(t *testing.T, vc *VitessCluster, ksWorkflow string) {
+	require.NoError(t, waitForCondition("workflow to be created", func() bool {
+		_, err := vc.VtctlClient.ExecuteCommandWithOutput("Workflow", ksWorkflow, "show")
+		if err == nil {
+			return true
+		}
+		return false
+	}, defaultTimeout))
+}
+
 // waitForWorkflowState waits for all of the given workflow's
 // streams to reach the provided state. You can pass optional
 // key value pairs of the form "key==value" to also wait for

--- a/go/test/endtoend/vreplication/vdiff_online_ddl_test.go
+++ b/go/test/endtoend/vreplication/vdiff_online_ddl_test.go
@@ -102,7 +102,9 @@ func execOnlineDDL(t *testing.T, strategy, keyspace, query string) string {
 			return false
 		}, defaultTimeout)
 		require.NoError(t, err)
-
+		// The online ddl migration is set to SchemaMigration_RUNNING before it creates the
+		// _vt.vreplication records. Hence wait for the vreplication workflow to be created as well.
+		waitForWorkflowToBeCreated(t, vc, fmt.Sprintf("%s.%s", keyspace, uuid))
 	}
 	return uuid
 }


### PR DESCRIPTION

## Description

We were checking for the Online DDL to reach `OnlineDDLStatusRunning` before checking for the status of the underlying VReplication workflow. However in  `executor.ExecuteWithVReplication()`  `OnlineDDLStatusRunning`  is set before the VReplication records are created, resulting in flakiness in subsequent checks where we wait for the workflow to reach `Running` status.

This PR adds another wait for the VReplication Workflow to be created.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
