### PR TITLE
Match MySQL's `LAST_INSERT_ID` behaviour

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
@@ -87,3 +87,13 @@ create table lkp_mixed_idx
     keyspace_id varbinary(20),
     primary key (lkp_key)
 ) Engine = InnoDB;
+
+create table last_insert_id_test
+(
+    id bigint NOT NULL AUTO_INCREMENT,
+    user_id bigint,
+    reason varchar(20),
+    sharding_key varchar(20),
+    primary key (id),
+    unique (user_id, sharding_key)
+)

--- a/go/test/endtoend/vtgate/queries/dml/unsharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/unsharded_schema.sql
@@ -29,9 +29,19 @@ create table u_tbl
     primary key (id)
 ) Engine = InnoDB;
 
+create table last_insert_id_test_seq
+(
+    id      int    default 0,
+    next_id bigint default null,
+    cache   bigint default null,
+    primary key (id)
+) comment 'vitess_sequence' Engine = InnoDB;
+
 insert into user_seq(id, next_id, cache)
 values (0, 1, 1000);
 insert into auto_seq(id, next_id, cache)
 values (0, 666, 1000);
 insert into mixed_seq(id, next_id, cache)
+values (0, 1, 1000);
+insert into last_insert_id_test_seq(id, next_id, cache)
 values (0, 1, 1000);

--- a/go/test/endtoend/vtgate/queries/dml/vschema.json
+++ b/go/test/endtoend/vtgate/queries/dml/vschema.json
@@ -4,6 +4,9 @@
     "hash": {
       "type": "hash"
     },
+    "xxhash": {
+      "type": "xxhash"
+    },
     "num_vdx": {
       "type": "consistent_lookup_unique",
       "params": {
@@ -186,6 +189,18 @@
         {
           "column": "lkp_key",
           "name": "hash"
+        }
+      ]
+    },
+    "last_insert_id_test": {
+      "auto_increment": {
+        "column": "id",
+        "sequence": "uks.last_insert_id_test_seq"
+      },
+      "column_vindexes": [
+        {
+          "column": "sharding_key",
+          "name": "xxhash"
         }
       ]
     }


### PR DESCRIPTION
## Description

TODO

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/15696

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
