### PR TITLE
Match MySQL's `LAST_INSERT_ID` behaviour when no rows are inserted / updated

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/insert_test.go
@@ -431,7 +431,9 @@ func TestInsertShardedWithOnDuplicateKeyNoInserts(t *testing.T) {
 
 	vitessResult = utils.Exec(t, mcmp.VtConn, query)
 	assert.Equal(t, mysqlResult.RowsAffected, vitessResult.RowsAffected)
-	assert.Equal(t, mysqlResult.InsertID, vitessResult.InsertID)
+	// Vitess can't return the `auto_increment` value of the last updated row, but it returns a value larger than 0.
+	assert.Greater(t, vitessResult.InsertID, uint64(0))
+	assert.NotEqual(t, mysqlResult.InsertID, vitessResult.InsertID)
 
 	// Second test case, insert multiple rows, all of which already exist, and change a column on existing rows.
 	query = "insert into last_insert_id_test (sharding_key, user_id, reason) values ('2:2:2', 2, 'qux'), ('1:1:1', 1, 'baz') on duplicate key update reason = VALUES(reason)"
@@ -444,7 +446,9 @@ func TestInsertShardedWithOnDuplicateKeyNoInserts(t *testing.T) {
 
 	vitessResult = utils.Exec(t, mcmp.VtConn, query)
 	assert.Equal(t, mysqlResult.RowsAffected, vitessResult.RowsAffected)
-	assert.Equal(t, mysqlResult.InsertID, vitessResult.InsertID)
+	// Vitess can't return the `auto_increment` value of the last updated row, but it returns a value larger than 0.
+	assert.Greater(t, vitessResult.InsertID, uint64(0))
+	assert.NotEqual(t, mysqlResult.InsertID, vitessResult.InsertID)
 
 	// Third test case, insert multiple rows, some of which already exist, and change a column on existing rows.
 	query = "insert into last_insert_id_test (sharding_key, user_id, reason) values ('3:3:3', 3, 'apa'), ('2:2:2', 2, 'bpa'), ('1:1:1', 1, 'cpa') on duplicate key update reason = VALUES(reason)"

--- a/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
@@ -87,3 +87,13 @@ create table lkp_mixed_idx
     keyspace_id varbinary(20),
     primary key (lkp_key)
 ) Engine = InnoDB;
+
+create table last_insert_id_test
+(
+    id bigint NOT NULL AUTO_INCREMENT,
+    user_id bigint,
+    reason varchar(20),
+    sharding_key varchar(20),
+    primary key (id),
+    unique (user_id, sharding_key)
+)

--- a/go/test/endtoend/vtgate/queries/dml/unsharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/unsharded_schema.sql
@@ -29,9 +29,19 @@ create table u_tbl
     primary key (id)
 ) Engine = InnoDB;
 
+create table last_insert_id_test_seq
+(
+    id      int    default 0,
+    next_id bigint default null,
+    cache   bigint default null,
+    primary key (id)
+) comment 'vitess_sequence' Engine = InnoDB;
+
 insert into user_seq(id, next_id, cache)
 values (0, 1, 1000);
 insert into auto_seq(id, next_id, cache)
 values (0, 666, 1000);
 insert into mixed_seq(id, next_id, cache)
+values (0, 1, 1000);
+insert into last_insert_id_test_seq(id, next_id, cache)
 values (0, 1, 1000);

--- a/go/test/endtoend/vtgate/queries/dml/vschema.json
+++ b/go/test/endtoend/vtgate/queries/dml/vschema.json
@@ -4,6 +4,9 @@
     "hash": {
       "type": "hash"
     },
+    "xxhash": {
+      "type": "xxhash"
+    },
     "num_vdx": {
       "type": "consistent_lookup_unique",
       "params": {
@@ -186,6 +189,18 @@
         {
           "column": "lkp_key",
           "name": "hash"
+        }
+      ]
+    },
+    "last_insert_id_test": {
+      "auto_increment": {
+        "column": "id",
+        "sequence": "uks.last_insert_id_test_seq"
+      },
+      "column_vindexes": [
+        {
+          "column": "sharding_key",
+          "name": "xxhash"
         }
       ]
     }

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -176,10 +176,16 @@ func (ins *Insert) executeInsertQueries(
 
 	// If this insert used auto increment values from a sequence, we need to set the `last_insert_id` value.
 	if insertID != 0 {
-		// If no rows were inserted or updated, clear the `last_insert_id` value.
 		if result.RowsAffected > 0 {
+			// If at least one row was affected, we set the `last_insert_id` value to the highest reserved sequence id.
+			// Note that this is not the same behavior as MySQL, which sets the `last_insert_id` value to
+			// highest actually inserted auto increment value.
+			//
+			// Unfortunately, we don't have a way to get the actual inserted auto increment value in a multi-shard
+			// insert, so we have to settle for the highest reserved sequence id.
 			result.InsertID = insertID
 		} else {
+			// If no rows were inserted or updated, clear the `last_insert_id` value.
 			result.InsertID = 0
 		}
 	}

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -174,9 +174,16 @@ func (ins *Insert) executeInsertQueries(
 		return nil, vterrors.Aggregate(errs)
 	}
 
+	// If this insert used auto increment values from a sequence, we need to set the `last_insert_id` value.
 	if insertID != 0 {
-		result.InsertID = insertID
+		// If no rows were inserted or updated, clear the `last_insert_id` value.
+		if result.RowsAffected > 0 {
+			result.InsertID = insertID
+		} else {
+			result.InsertID = 0
+		}
 	}
+
 	return result, nil
 }
 

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -177,12 +177,10 @@ func (ins *Insert) executeInsertQueries(
 	// If this insert used auto increment values from a sequence, we need to set the `last_insert_id` value.
 	if insertID != 0 {
 		if result.RowsAffected > 0 {
-			// If at least one row was affected, we set the `last_insert_id` value to the highest reserved sequence id.
-			// Note that this is not the same behavior as MySQL, which sets the `last_insert_id` value to
-			// highest actually inserted auto increment value.
+			// If at least one row was affected, we set the `last_insert_id` value to the lowest reserved sequence id.
 			//
-			// Unfortunately, we don't have a way to get the actual inserted auto increment value in a multi-shard
-			// insert, so we have to settle for the highest reserved sequence id.
+			// This does not match the behaviour of MySQL in case where no new rows where inserted (but one or more rows were updated
+			// via `ON DUPLICATE KEY UPDATE`), where the `last_insert_id` value is set to the `auto_increment` column value.
 			result.InsertID = insertID
 		} else {
 			// If no rows were inserted or updated, clear the `last_insert_id` value.


### PR DESCRIPTION
## Description

This pull request fixes the behaviour of `LAST_INSERT_ID` when inserting into a sharded table that uses a sequence to fill an auto increment column.

In case an `INSERT ... ON DUPLICATE KEY UPDATE ...` statement does neither insert nor update any rows in the target table, Vitess should set `LAST_INSERT_ID` to `0`.

Note: I think this will only work on connections that don't specify the `CLIENT_FOUND_ROWS` flag. 🤔 I will add some additional test cases to verify this.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/15696

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
