### PR TITLE
Cleanup usage of FLUSH PRIVILEGES

### DIFF
--- a/config/init_db.sql
+++ b/config/init_db.sql
@@ -1,30 +1,22 @@
 # This file is executed immediately after initializing a fresh data directory.
 
 ###############################################################################
-# WARNING: This sql is *NOT* safe for production use,
-#          as it contains default well-known users and passwords.
-#          Care should be taken to change these users and passwords
-#          for production.
-###############################################################################
-
-###############################################################################
 # Equivalent of mysql_secure_installation
 ###############################################################################
 # We need to ensure that super_read_only is disabled so that we can execute
 # these commands. Note that disabling it does NOT disable read_only.
 # We save the current value so that we only re-enable it at the end if it was
 # enabled before.
+
 SET @original_super_read_only=IF(@@global.super_read_only=1, 'ON', 'OFF');
 SET GLOBAL super_read_only='OFF';
 
 # Changes during the init db should not make it to the binlog.
 # They could potentially create errant transactions on replicas.
 SET sql_log_bin = 0;
-# Remove anonymous users.
-DELETE FROM mysql.user WHERE User = '';
 
-# Disable remote root access (only allow UNIX socket).
-DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+# Remove anonymous users & disable remote root access (only allow UNIX socket).
+DROP USER IF EXISTS ''@'%', ''@'localhost', 'root'@'%';
 
 # Remove test database.
 DROP DATABASE IF EXISTS test;
@@ -77,8 +69,6 @@ GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD
   ON *.* TO 'vt_monitoring'@'localhost';
 GRANT SELECT, UPDATE, DELETE, DROP
   ON performance_schema.* TO 'vt_monitoring'@'localhost';
-
-FLUSH PRIVILEGES;
 
 RESET SLAVE ALL;
 RESET MASTER;

--- a/examples/compose/config/init_db.sql
+++ b/examples/compose/config/init_db.sql
@@ -12,10 +12,8 @@ SET GLOBAL super_read_only='OFF';
 # Changes during the init db should not make it to the binlog.
 # They could potentially create errant transactions on replicas.
 SET sql_log_bin = 0;
-# Remove anonymous users.
-DELETE FROM mysql.user WHERE User = '';
-# Disable remote root access (only allow UNIX socket).
-DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+# Remove anonymous users & disable remote root access (only allow UNIX socket).
+DROP USER IF EXISTS ''@'%', ''@'localhost', 'root'@'%';
 # Remove test database.
 DROP DATABASE IF EXISTS test;
 ###############################################################################
@@ -70,7 +68,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
   LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
   SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   ON *.* TO 'vt_filtered'@'localhost';
-FLUSH PRIVILEGES;
+
 RESET SLAVE ALL;
 RESET MASTER;
 

--- a/examples/compose/external_db/mysql/grant.sh
+++ b/examples/compose/external_db/mysql/grant.sh
@@ -3,5 +3,5 @@ echo '**********GRANTING PRIVILEGES START*******************'
 echo ${mysql[@]}
 # PURGE BINARY LOGS BEFORE DATE(NOW());
 mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock -p$MYSQL_ROOT_PASSWORD -e \
-"GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD'; FLUSH PRIVILEGES;"
+"GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD'"
 echo '*************GRANTING PRIVILEGES END****************'

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -68,7 +68,7 @@ if [ "$external" = "1" ]; then
   # We need a common user for the unmanaged and managed tablets else tools like orchestrator will not function correctly
   echo "Creating matching user for managed tablets..."
   echo "CREATE USER IF NOT EXISTS '$DB_USER'@'%' IDENTIFIED BY '$DB_PASS';" >> $init_db_sql_file
-  echo "GRANT ALL ON *.* TO '$DB_USER'@'%';FLUSH PRIVILEGES;" >> $init_db_sql_file
+  echo "GRANT ALL ON *.* TO '$DB_USER'@'%';" >> $init_db_sql_file
 fi
 echo "##[CUSTOM_SQL_END]##" >> $init_db_sql_file
 

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -145,11 +145,8 @@ stringData:
     # Changes during the init db should not make it to the binlog.
     # They could potentially create errant transactions on replicas.
     SET sql_log_bin = 0;
-    # Remove anonymous users.
-    DELETE FROM mysql.user WHERE User = '';
-
-    # Disable remote root access (only allow UNIX socket).
-    DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+    # Remove anonymous users & disable remote root access (only allow UNIX socket).
+    DROP USER IF EXISTS ''@'%', ''@'localhost', 'root'@'%';
 
     # Remove test database.
     DROP DATABASE IF EXISTS test;
@@ -214,8 +211,6 @@ stringData:
       LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
       SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
       ON *.* TO 'vt_filtered'@'localhost';
-
-    FLUSH PRIVILEGES;
 
     RESET SLAVE ALL;
     RESET MASTER;

--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -351,7 +351,6 @@ func GetPasswordUpdateSQL(localCluster *LocalProcessCluster) string {
 					SET PASSWORD FOR 'vt_repl'@'%' = 'VtReplPass';
 					SET PASSWORD FOR 'vt_filtered'@'localhost' = 'VtFilteredPass';
 					SET PASSWORD FOR 'vt_appdebug'@'localhost' = 'VtDebugPass';
-					FLUSH PRIVILEGES;
 					`
 	return pwdChangeCmd
 }

--- a/go/test/endtoend/vreplication/testdata/config/init_testserver_db.sql
+++ b/go/test/endtoend/vreplication/testdata/config/init_testserver_db.sql
@@ -24,11 +24,8 @@ SET GLOBAL read_only='OFF';
 # Changes during the init db should not make it to the binlog.
 # They could potentially create errant transactions on replicas.
 SET sql_log_bin = 0;
-# Remove anonymous users.
-DELETE FROM mysql.user WHERE User = '';
-
-# Disable remote root access (only allow UNIX socket).
-DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+# Remove anonymous users & disable remote root access (only allow UNIX socket).
+DROP USER IF EXISTS ''@'%', ''@'localhost', 'root'@'%';
 
 # Remove test database.
 DROP DATABASE IF EXISTS test;
@@ -81,8 +78,6 @@ GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD
       ON *.* TO 'vt_monitoring'@'localhost';
 GRANT SELECT, UPDATE, DELETE, DROP
       ON performance_schema.* TO 'vt_monitoring'@'localhost';
-
-FLUSH PRIVILEGES;
 
 RESET SLAVE ALL;
 RESET MASTER;

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -926,7 +926,5 @@ func grantAllPrivilegesToUser(t *testing.T, connParams mysql.ConnParams, testUse
 	require.NoError(t, err)
 	_, err = conn.ExecuteFetch(fmt.Sprintf(`GRANT GRANT OPTION ON *.* TO '%v'@'localhost'`, testUser), 1000, false)
 	require.NoError(t, err)
-	_, err = conn.ExecuteFetch("FLUSH PRIVILEGES", 1000, false)
-	require.NoError(t, err)
 	conn.Close()
 }

--- a/vitess-mixin/e2e/config/init_db.sql
+++ b/vitess-mixin/e2e/config/init_db.sql
@@ -12,10 +12,8 @@ SET GLOBAL super_read_only='OFF';
 # Changes during the init db should not make it to the binlog.
 # They could potentially create errant transactions on replicas.
 SET sql_log_bin = 0;
-# Remove anonymous users.
-DELETE FROM mysql.user WHERE User = '';
-# Disable remote root access (only allow UNIX socket).
-DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+# Remove anonymous users & disable remote root access (only allow UNIX socket).
+DROP USER IF EXISTS ''@'%', ''@'localhost', 'root'@'%';
 # Remove test database.
 DROP DATABASE IF EXISTS test;
 ###############################################################################
@@ -71,7 +69,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
   LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
   SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   ON *.* TO 'vt_filtered'@'localhost';
-FLUSH PRIVILEGES;
+
 RESET SLAVE ALL;
 RESET MASTER;
 # custom sql is used to add custom scripts like creating users/passwords. We use it in our tests

--- a/vitess-mixin/e2e/external_db/mysql/grant.sh
+++ b/vitess-mixin/e2e/external_db/mysql/grant.sh
@@ -3,5 +3,5 @@ echo '**********GRANTING PRIVILEGES START*******************'
 echo ${mysql[@]}
 # PURGE BINARY LOGS BEFORE DATE(NOW());
 mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock -p$MYSQL_ROOT_PASSWORD -e \
-"GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD'; FLUSH PRIVILEGES;"
+"GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD'"
 echo '*************GRANTING PRIVILEGES END****************'

--- a/vitess-mixin/e2e/vttablet-up.sh
+++ b/vitess-mixin/e2e/vttablet-up.sh
@@ -68,7 +68,7 @@ if [ "$external" = "1" ]; then
   # We need a common user for the unmanaged and managed tablets else tools like orchestrator will not function correctly
   echo "Creating matching user for managed tablets..."
   echo "CREATE USER IF NOT EXISTS '$DB_USER'@'%' IDENTIFIED BY '$DB_PASS';" >> $init_db_sql_file
-  echo "GRANT ALL ON *.* TO '$DB_USER'@'%';FLUSH PRIVILEGES;" >> $init_db_sql_file
+  echo "GRANT ALL ON *.* TO '$DB_USER'@'%';" >> $init_db_sql_file
 fi
 echo "##[CUSTOM_SQL_END]##" >> $init_db_sql_file
 


### PR DESCRIPTION
We can remove usage of `FLUSH PRIVILEGES` in many places by making sure we only use the correct SQL functionality for managing users. If we don't modify the `mysql.user` table directly, we don't need to use `FLUSH PRIVILEGES`.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required