### PR TITLE
test: Use testify require/assert instead of t.Fatal/Error in `go/vt/throttler`

### DIFF
--- a/go/vt/throttler/aggregated_interval_history_test.go
+++ b/go/vt/throttler/aggregated_interval_history_test.go
@@ -19,6 +19,8 @@ package throttler
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAggregatedIntervalHistory(t *testing.T) {
@@ -26,7 +28,6 @@ func TestAggregatedIntervalHistory(t *testing.T) {
 	h.addPerThread(0, record{sinceZero(0 * time.Second), 1000})
 	h.addPerThread(1, record{sinceZero(0 * time.Second), 2000})
 
-	if got, want := h.average(sinceZero(250*time.Millisecond), sinceZero(750*time.Millisecond)), 3000.0; got != want {
-		t.Errorf("average(0.25s, 0.75s) across both threads = %v, want = %v", got, want)
-	}
+	got := h.average(sinceZero(250*time.Millisecond), sinceZero(750*time.Millisecond))
+	assert.Equal(t, 3000.0, got)
 }

--- a/go/vt/throttler/replication_lag_cache_test.go
+++ b/go/vt/throttler/replication_lag_cache_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/vt/discovery"
 )
 
@@ -33,44 +35,39 @@ func TestReplicationLagCache(t *testing.T) {
 
 	// If there is no entry yet, a zero struct is returned.
 	zeroEntry := c.atOrAfter(r1Key, sinceZero(0*time.Second))
-	if !zeroEntry.isZero() {
-		t.Fatalf("atOrAfter(<non existent key>) should have returned a zero entry but did not: %v", zeroEntry)
-	}
+	require.True(t, zeroEntry.isZero(), "atOrAfter(<non existent key>) should have returned a zero entry")
 
 	// First entry at 1s.
 	c.add(lagRecord(sinceZero(1*time.Second), r1, 1))
-	if got, want := c.latest(r1Key).time, sinceZero(1*time.Second); got != want {
-		t.Fatalf("latest(r1) = %v, want = %v", got, want)
-	}
+	got, want := c.latest(r1Key).time, sinceZero(1*time.Second)
+	require.Equal(t, want, got)
 
 	// Second entry at 2s makes the cache full.
 	c.add(lagRecord(sinceZero(2*time.Second), r1, 2))
-	if got, want := c.latest(r1Key).time, sinceZero(2*time.Second); got != want {
-		t.Fatalf("latest(r1) = %v, want = %v", got, want)
-	}
-	if got, want := c.atOrAfter(r1Key, sinceZero(1*time.Second)).time, sinceZero(1*time.Second); got != want {
-		t.Fatalf("atOrAfter(r1) = %v, want = %v", got, want)
-	}
+	got, want = c.latest(r1Key).time, sinceZero(2*time.Second)
+	require.Equal(t, want, got)
+
+	got, want = c.atOrAfter(r1Key, sinceZero(1*time.Second)).time, sinceZero(1*time.Second)
+	require.Equal(t, want, got)
 
 	// Third entry at 3s evicts the 1s entry.
 	c.add(lagRecord(sinceZero(3*time.Second), r1, 3))
-	if got, want := c.latest(r1Key).time, sinceZero(3*time.Second); got != want {
-		t.Fatalf("latest(r1) = %v, want = %v", got, want)
-	}
+	got, want = c.latest(r1Key).time, sinceZero(3*time.Second)
+	require.Equal(t, want, got)
+
 	// Requesting an entry at 1s or after gets us the entry for 2s.
-	if got, want := c.atOrAfter(r1Key, sinceZero(1*time.Second)).time, sinceZero(2*time.Second); got != want {
-		t.Fatalf("atOrAfter(r1) = %v, want = %v", got, want)
-	}
+	got, want = c.atOrAfter(r1Key, sinceZero(1*time.Second)).time, sinceZero(2*time.Second)
+	require.Equal(t, want, got)
 
 	// Wrap around one more time. Entries at 4s and 5s should be left.
 	c.add(lagRecord(sinceZero(4*time.Second), r1, 4))
 	c.add(lagRecord(sinceZero(5*time.Second), r1, 5))
-	if got, want := c.latest(r1Key).time, sinceZero(5*time.Second); got != want {
-		t.Fatalf("latest(r1) = %v, want = %v", got, want)
-	}
-	if got, want := c.atOrAfter(r1Key, sinceZero(1*time.Second)).time, sinceZero(4*time.Second); got != want {
-		t.Fatalf("atOrAfter(r1) = %v, want = %v", got, want)
-	}
+
+	got, want = c.latest(r1Key).time, sinceZero(5*time.Second)
+	require.Equal(t, want, got)
+
+	got, want = c.atOrAfter(r1Key, sinceZero(1*time.Second)).time, sinceZero(4*time.Second)
+	require.Equal(t, want, got)
 }
 
 func TestReplicationLagCache_SortByLag(t *testing.T) {
@@ -80,14 +77,10 @@ func TestReplicationLagCache_SortByLag(t *testing.T) {
 	c.add(lagRecord(sinceZero(1*time.Second), r1, 30))
 	c.sortByLag(1 /* ignoreNSlowestReplicas */, 30 /* minimumReplicationLag */)
 
-	if c.slowReplicas[r1Key] {
-		t.Fatal("the only replica tracked should not get ignored")
-	}
+	require.False(t, c.slowReplicas[r1Key], "the only replica tracked should not get ignored")
 
 	c.add(lagRecord(sinceZero(1*time.Second), r2, 1))
 	c.sortByLag(1 /* ignoreNSlowestReplicas */, 1 /* minimumReplicationLag */)
 
-	if !c.slowReplicas[r1Key] {
-		t.Fatal("r1 should be tracked as a slow replica")
-	}
+	require.True(t, c.slowReplicas[r1Key], "r1 should be tracked as a slow replica")
 }

--- a/go/vt/throttler/result_test.go
+++ b/go/vt/throttler/result_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package throttler
 
 import (
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -127,9 +128,7 @@ reason: emergency state decreased the rate`,
 
 	for _, tc := range testcases {
 		got := tc.r.String()
-		if got != tc.want {
-			t.Fatalf("record.String() = %v, want = %v for full record: %#v", got, tc.want, tc.r)
-		}
+		require.Equal(t, tc.want, got)
 	}
 }
 
@@ -143,19 +142,16 @@ func TestResultRing(t *testing.T) {
 
 	// Use the ring partially.
 	rr.add(r1)
-	if got, want := rr.latestValues(), []result{r1}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("items not correctly added to resultRing. got = %v, want = %v", got, want)
-	}
+	got, want := rr.latestValues(), []result{r1}
+	require.Equal(t, want, got, "items not correctly added to resultRing")
 
 	// Use it fully.
 	rr.add(r2)
-	if got, want := rr.latestValues(), []result{r2, r1}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("items not correctly added to resultRing. got = %v, want = %v", got, want)
-	}
+	got, want = rr.latestValues(), []result{r2, r1}
+	require.Equal(t, want, got, "items not correctly added to resultRing")
 
 	// Let it wrap.
 	rr.add(r3)
-	if got, want := rr.latestValues(), []result{r3, r2}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("resultRing did not wrap correctly. got = %v, want = %v", got, want)
-	}
+	got, want = rr.latestValues(), []result{r3, r2}
+	require.Equal(t, want, got, "resultRing did not wrap correctly")
 }

--- a/go/vt/throttler/thread_throttler_test.go
+++ b/go/vt/throttler/thread_throttler_test.go
@@ -19,6 +19,8 @@ package throttler
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestThrottle_NoBurst(t *testing.T) {
@@ -28,11 +30,10 @@ func TestThrottle_NoBurst(t *testing.T) {
 	// 1. This means that in any time interval of length t seconds, the throttler should
 	// not allow more than floor(2*t+1) requests. For example, in the interval [1500ms, 1501ms], of
 	// length 1ms, we shouldn't be able to send more than floor(2*10^-3+1)=1 requests.
-	if gotBackoff := tt.throttle(sinceZero(1500 * time.Millisecond)); gotBackoff != NotThrottled {
-		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
-	}
+	gotBackoff := tt.throttle(sinceZero(1500 * time.Millisecond))
+	require.Equal(t, NotThrottled, gotBackoff, "throttler should not have throttled us")
+
 	wantBackoff := 499 * time.Millisecond
-	if gotBackoff := tt.throttle(sinceZero(1501 * time.Millisecond)); gotBackoff != wantBackoff {
-		t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff)
-	}
+	gotBackoff = tt.throttle(sinceZero(1501 * time.Millisecond))
+	require.Equal(t, wantBackoff, gotBackoff, "throttler should have throttled us")
 }

--- a/go/vt/throttler/throttlerlogz_test.go
+++ b/go/vt/throttler/throttlerlogz_test.go
@@ -19,8 +19,9 @@ package throttler
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestThrottlerlogzHandler_MissingSlash(t *testing.T) {
@@ -30,9 +31,8 @@ func TestThrottlerlogzHandler_MissingSlash(t *testing.T) {
 
 	throttlerlogzHandler(response, request, m)
 
-	if got, want := response.Body.String(), "invalid /throttlerlogz path"; !strings.Contains(got, want) {
-		t.Fatalf("/throttlerlogz without the slash does not work (the Go HTTP server does automatically redirect in practice though). got = %v, want = %v", got, want)
-	}
+	got := response.Body.String()
+	require.Contains(t, got, "invalid /throttlerlogz path", "/throttlerlogz without the slash does not work (the Go HTTP server does automatically redirect in practice though)")
 }
 
 func TestThrottlerlogzHandler_NonExistantThrottler(t *testing.T) {
@@ -41,9 +41,8 @@ func TestThrottlerlogzHandler_NonExistantThrottler(t *testing.T) {
 
 	throttlerlogzHandler(response, request, newManager())
 
-	if got, want := response.Body.String(), `throttler not found`; !strings.Contains(got, want) {
-		t.Fatalf("/throttlerlogz page for non-existent t1 should not succeed. got = %v, want = %v", got, want)
-	}
+	got := response.Body.String()
+	require.Contains(t, got, "throttler not found", "/throttlerlogz page for non-existent t1 should not succeed")
 }
 
 func TestThrottlerlogzHandler(t *testing.T) {
@@ -152,8 +151,6 @@ func TestThrottlerlogzHandler(t *testing.T) {
 		throttlerlogzHandler(response, request, f.m)
 
 		got := response.Body.String()
-		if !strings.Contains(got, tc.want) {
-			t.Fatalf("testcase '%v': result not shown in log. got = %v, want = %v", tc.desc, got, tc.want)
-		}
+		require.Containsf(t, got, tc.want, "testcase '%v': result not shown in log", tc.desc)
 	}
 }

--- a/go/vt/throttler/throttlerz_test.go
+++ b/go/vt/throttler/throttlerz_test.go
@@ -19,8 +19,9 @@ package throttler
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestThrottlerzHandler_MissingSlash(t *testing.T) {
@@ -30,9 +31,8 @@ func TestThrottlerzHandler_MissingSlash(t *testing.T) {
 
 	throttlerzHandler(response, request, m)
 
-	if got, want := response.Body.String(), "invalid /throttlerz path"; !strings.Contains(got, want) {
-		t.Fatalf("/throttlerz without the slash does not work (the Go HTTP server does automatically redirect in practice though). got = %v, want = %v", got, want)
-	}
+	got := response.Body.String()
+	require.Contains(t, got, "invalid /throttlerz path", "/throttlerz without the slash does not work (the Go HTTP server does automatically redirect in practice though)")
 }
 
 func TestThrottlerzHandler_List(t *testing.T) {
@@ -47,12 +47,9 @@ func TestThrottlerzHandler_List(t *testing.T) {
 
 	throttlerzHandler(response, request, f.m)
 
-	if got, want := response.Body.String(), `<a href="/throttlerz/t1">t1</a>`; !strings.Contains(got, want) {
-		t.Fatalf("list does not include 't1'. got = %v, want = %v", got, want)
-	}
-	if got, want := response.Body.String(), `<a href="/throttlerz/t2">t2</a>`; !strings.Contains(got, want) {
-		t.Fatalf("list does not include 't1'. got = %v, want = %v", got, want)
-	}
+	got := response.Body.String()
+	require.Contains(t, got, `<a href="/throttlerz/t1">t1</a>`, "list does not include 't1'")
+	require.Contains(t, got, `<a href="/throttlerz/t2">t2</a>`, "list does not include 't2'")
 }
 
 func TestThrottlerzHandler_Details(t *testing.T) {
@@ -67,7 +64,6 @@ func TestThrottlerzHandler_Details(t *testing.T) {
 
 	throttlerzHandler(response, request, f.m)
 
-	if got, want := response.Body.String(), `<title>Details for Throttler 't1'</title>`; !strings.Contains(got, want) {
-		t.Fatalf("details for 't1' not shown. got = %v, want = %v", got, want)
-	}
+	got := response.Body.String()
+	require.Contains(t, got, `<title>Details for Throttler 't1'</title>`, "details for 't1' not shown")
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR replaces some t.fatalf/errorf instances with testify's require in `go/vt/throttler`

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #15182
- #14931 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
