### PR TITLE
[VTAdmin API] Fix schema cache flag, add documentation

### DIFF
--- a/doc/vtadmin/clusters.yaml
+++ b/doc/vtadmin/clusters.yaml
@@ -69,8 +69,8 @@ defaults:
   schema-cache-default-expiration: 1m
   # How many outstanding backfil requests to permit in schema cache.
   # If the queue is full, calls backfill schemas will return false, and those requests will be discarded.
-  # Defaults to 1.
-  schema-cache-backfill-queue-size: 1
+  # Defaults to 0 if a negative value is passed.
+  schema-cache-backfill-queue-size: 0
   # How often expired values are removed from schema cache.
   schema-cache-cleanup-interval: 5m
   # How long a backfill request is considered valid.

--- a/doc/vtadmin/clusters.yaml
+++ b/doc/vtadmin/clusters.yaml
@@ -63,3 +63,24 @@ defaults:
   # - schema-read-pool => for GetSchema, GetSchemas, and FindSchema api methods
   # - topo-read-pool => for generic topo methods (e.g. GetKeyspace, FindAllShardsInKeyspace)
   # - workflow-read-pool => for GetWorkflow/GetWorkflows api methods.
+
+  # How long to keep values in schema cache by default (duration passed to Add takes precedence).
+  # Defaults to the sentinal NoExpiration to make values never expire by default.
+  schema-cache-default-expiration: 1m
+  # How many outstanding backfil requests to permit in schema cache.
+  # If the queue is full, calls backfill schemas will return false, and those requests will be discarded.
+  # Defaults to 1.
+  schema-cache-backfill-queue-size: 1
+  # How often expired values are removed from schema cache.
+  schema-cache-cleanup-interval: 5m
+  # How long a backfill request is considered valid.
+  # If the backfill goroutin encounters a request older than this, it is discarded.
+  # Defaults to 100ms.
+  schema-cache-backfill-request-ttl: 100ms
+  # How much time must pass before the backfill goroutin will re-backfill the same key.
+  # Used to prevent multiple callers from queueing up too many requests for the same key,
+  # when one backfill would satisfy all of them.
+  schema-cache-backfill-request-duplicate-interval: 1m
+  # How long to wait whe attempting to enqueue a backfill request before giving up.
+  # Defaults to 50ms.
+  schema-cache-backfill-enqueue-wait-time: 50ms

--- a/doc/vtadmin/clusters.yaml
+++ b/doc/vtadmin/clusters.yaml
@@ -65,22 +65,22 @@ defaults:
   # - workflow-read-pool => for GetWorkflow/GetWorkflows api methods.
 
   # How long to keep values in schema cache by default (duration passed to Add takes precedence).
-  # Defaults to the sentinal NoExpiration to make values never expire by default.
+  # A value of "0m" means values will never be cached, a positive duration "1m" means items will be cached
+  # for that duration, and passing nothing will default to "NoExpiration".
   schema-cache-default-expiration: 1m
   # How many outstanding backfil requests to permit in schema cache.
   # If the queue is full, calls backfill schemas will return false, and those requests will be discarded.
-  # Defaults to 0 if a negative value is passed.
+  # A value of "0" means that the underlying channel will have a size of 0, 
+  # and every send to the backfill queue will block until the queue is "empty" again.
   schema-cache-backfill-queue-size: 0
   # How often expired values are removed from schema cache.
   schema-cache-cleanup-interval: 5m
   # How long a backfill request is considered valid.
   # If the backfill goroutin encounters a request older than this, it is discarded.
-  # Defaults to 100ms.
   schema-cache-backfill-request-ttl: 100ms
-  # How much time must pass before the backfill goroutin will re-backfill the same key.
+  # How much time must pass before the backfill goroutine will re-backfill the same key.
   # Used to prevent multiple callers from queueing up too many requests for the same key,
   # when one backfill would satisfy all of them.
   schema-cache-backfill-request-duplicate-interval: 1m
   # How long to wait whe attempting to enqueue a backfill request before giving up.
-  # Defaults to 50ms.
   schema-cache-backfill-enqueue-wait-time: 50ms

--- a/go/vt/vtadmin/cache/cache.go
+++ b/go/vt/vtadmin/cache/cache.go
@@ -54,6 +54,9 @@ const (
 	// backfill requests to still process, if a config is passed with a
 	// non-positive BackfillRequestTTL.
 	DefaultBackfillRequestTTL = time.Millisecond * 100
+	// DefaultBackfillQueueSize is the default value used for the size of the
+	// backfill queue, if a config is passed with a non-positive BackfillQueueSize.
+	DefaultBackfillQueueSize = 1
 )
 
 // Config is the configuration for a cache.
@@ -123,6 +126,11 @@ func New[Key Keyer, Value any](fillFunc func(ctx context.Context, req Key) (Valu
 	if cfg.BackfillRequestTTL <= 0 {
 		log.Warningf("BackfillRequestTTL (%v) must be positive, defaulting to %v", cfg.BackfillRequestTTL, DefaultBackfillRequestTTL)
 		cfg.BackfillRequestTTL = DefaultBackfillRequestTTL
+	}
+
+	if cfg.BackfillQueueSize <= 0 {
+		log.Warningf("BackfillQueueSize (%v) must be positive, defaulting to %v", cfg.BackfillQueueSize, DefaultBackfillQueueSize)
+		cfg.BackfillQueueSize = DefaultBackfillQueueSize
 	}
 
 	c := &Cache[Key, Value]{

--- a/go/vt/vtadmin/cache/cache.go
+++ b/go/vt/vtadmin/cache/cache.go
@@ -56,7 +56,7 @@ const (
 	DefaultBackfillRequestTTL = time.Millisecond * 100
 	// DefaultBackfillQueueSize is the default value used for the size of the
 	// backfill queue, if a config is passed with a non-positive BackfillQueueSize.
-	DefaultBackfillQueueSize = 1
+	DefaultBackfillQueueSize = 0
 )
 
 // Config is the configuration for a cache.
@@ -128,7 +128,7 @@ func New[Key Keyer, Value any](fillFunc func(ctx context.Context, req Key) (Valu
 		cfg.BackfillRequestTTL = DefaultBackfillRequestTTL
 	}
 
-	if cfg.BackfillQueueSize <= 0 {
+	if cfg.BackfillQueueSize < 0 {
 		log.Warningf("BackfillQueueSize (%v) must be positive, defaulting to %v", cfg.BackfillQueueSize, DefaultBackfillQueueSize)
 		cfg.BackfillQueueSize = DefaultBackfillQueueSize
 	}

--- a/go/vt/vtadmin/cache/cache_test.go
+++ b/go/vt/vtadmin/cache/cache_test.go
@@ -92,6 +92,43 @@ func TestBackfillDuplicates(t *testing.T) {
 	}
 }
 
+func TestBackfillQueueSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                        string
+		configuredBackfillQueueSize int
+		expectedBackfillQueueSize   int
+	}{
+		{
+			name:                        "configured negative backfill queue size",
+			configuredBackfillQueueSize: -1,
+			expectedBackfillQueueSize:   0,
+		}, {
+			name:                        "configured 0 backfill queue size",
+			configuredBackfillQueueSize: 0,
+			expectedBackfillQueueSize:   0,
+		}, {
+			name:                        "configured positive backfill queue size",
+			configuredBackfillQueueSize: 1,
+			expectedBackfillQueueSize:   1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := cache.New(func(ctx context.Context, req intkey) (any, error) {
+				return nil, nil
+			}, cache.Config{
+				BackfillQueueSize: tt.configuredBackfillQueueSize,
+			})
+			var config cache.Config = c.Debug()["config"].(cache.Config)
+			assert.Equal(t, tt.expectedBackfillQueueSize, config.BackfillQueueSize)
+		})
+	}
+}
+
 func TestBackfillTTL(t *testing.T) {
 	t.Parallel()
 

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -1490,7 +1490,10 @@ func (c *Cluster) GetSchemas(ctx context.Context, opts GetSchemaOptions) ([]*vta
 
 		span.Annotate("cache_hit", ok)
 		if ok {
+			log.Infof("GetSchemas(cluster = %s) fetching schemas from schema cache", c.ID)
 			return schemas, err
+		} else {
+			log.Infof("GetSchemas(cluster = %s) bypassing schema cache", c.ID)
 		}
 	}
 


### PR DESCRIPTION
## Description
Currently, when a user passes any schema cache flags, but does not pass `backfill-queue-size`, vtadmin-api crashes because `backfill-queue-size` is defaulted to `-1` and crashes with:
```
panic: makechan: size out of range

goroutine 1 [running]:
vitess.io/vitess/go/vt/vtadmin/cache.New[...](0xc000375570, {0xdf8475800, 0xffffffffffffffff, 0x5f5e100, 0xffffffffffffffff, 0xffffffffffffffff, 0x2faf080})
	vitess.io/vitess/go/vt/vtadmin/cache/cache.go:131 +0x20d
```
at https://github.com/vitessio/vitess/blob/main/go/vt/vtadmin/cache/cache.go#L131

This PR makes it so that `backfill-queue-size` is defaulted to 0 if the value is negative. It also adds the `schema-cache-*` flags to the example `cluster.yml`, and adds some logs.

A subsequent PR will make it so that the debug endpoint returns the cache values as they are actually set. (currently shows -1 if the user didn't pass configuration, even if defaults are different).

### Backport reason
This is a bug that breaks vtadmin-api usage.

## Related Issue(s)
https://github.com/vitessio/vitess/issues/15717

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes
None