### PR TITLE
Make -grpc_prometheus work when not using a grpc server

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -273,13 +273,14 @@ func interceptors() []grpc.ServerOption {
 }
 
 func serveGRPC() {
-	if grpccommon.EnableGRPCPrometheus() {
-		grpc_prometheus.Register(GRPCServer)
-		grpc_prometheus.EnableHandlingTimeHistogram()
-	}
 	// skip if not registered
 	if gRPCPort == 0 {
 		return
+	}
+
+	if grpccommon.EnableGRPCPrometheus {
+		grpc_prometheus.Register(GRPCServer)
+		grpc_prometheus.EnableHandlingTimeHistogram()
 	}
 
 	// register reflection to support list calls :)


### PR DESCRIPTION
--grpc_prometheus enables server and client gRPC metrics. But if we don't have a gRPC server, but call `servenv.Run()` (which we are doing in some internal tools to have the `servenv` utilities available but without a gRPC server) the process will crash because of some uninitialized server state. Fix by moving the prom enable logic after the check to see if we actually have a server.