### PR TITLE
Gen4 Planner: support aggregate UDFs

### DIFF
--- a/go/mysql/sqlerror/sql_error.go
+++ b/go/mysql/sqlerror/sql_error.go
@@ -244,6 +244,7 @@ var stateToMysqlCode = map[vterrors.State]mysqlCode{
 	vterrors.KillDeniedError:              {num: ERKillDenied, state: SSUnknownSQLState},
 	vterrors.BadNullError:                 {num: ERBadNullError, state: SSConstraintViolation},
 	vterrors.InvalidGroupFuncUse:          {num: ERInvalidGroupFuncUse, state: SSUnknownSQLState},
+	vterrors.AggregateMustPushDown:        {num: ERNotSupportedYet, state: SSUnknownSQLState},
 }
 
 func getStateToMySQLState(state vterrors.State) mysqlCode {

--- a/go/mysql/sqlerror/sql_error.go
+++ b/go/mysql/sqlerror/sql_error.go
@@ -244,7 +244,6 @@ var stateToMysqlCode = map[vterrors.State]mysqlCode{
 	vterrors.KillDeniedError:              {num: ERKillDenied, state: SSUnknownSQLState},
 	vterrors.BadNullError:                 {num: ERBadNullError, state: SSConstraintViolation},
 	vterrors.InvalidGroupFuncUse:          {num: ERInvalidGroupFuncUse, state: SSUnknownSQLState},
-	vterrors.AggregateMustPushDown:        {num: ERNotSupportedYet, state: SSUnknownSQLState},
 }
 
 func getStateToMySQLState(state vterrors.State) mysqlCode {

--- a/go/test/vschemawrapper/vschema_wrapper.go
+++ b/go/test/vschemawrapper/vschema_wrapper.go
@@ -147,6 +147,10 @@ func (vw *VSchemaWrapper) KeyspaceError(keyspace string) error {
 	return nil
 }
 
+func (vw *VSchemaWrapper) GetAggregateUDFs() (udfs []string) {
+	return vw.V.GetAggregateUDFs()
+}
+
 func (vw *VSchemaWrapper) GetForeignKeyChecksState() *bool {
 	return vw.ForeignKeyChecksState
 }

--- a/go/vt/schemadiff/semantics.go
+++ b/go/vt/schemadiff/semantics.go
@@ -71,6 +71,10 @@ func (si *declarativeSchemaInformation) KeyspaceError(keyspace string) error {
 	return nil
 }
 
+func (si *declarativeSchemaInformation) GetAggregateUDFs() []string {
+	return nil
+}
+
 func (si *declarativeSchemaInformation) GetForeignKeyChecksState() *bool {
 	return nil
 }

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -923,6 +923,16 @@ func (node IdentifierCI) EqualString(str string) bool {
 	return node.Lowered() == strings.ToLower(str)
 }
 
+// EqualsAnyString returns true if any of these strings match
+func (node IdentifierCI) EqualsAnyString(str []string) bool {
+	for _, s := range str {
+		if node.EqualString(s) {
+			return true
+		}
+	}
+	return false
+}
+
 // MarshalJSON marshals into JSON.
 func (node IdentifierCI) MarshalJSON() ([]byte, error) {
 	return json.Marshal(node.val)

--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -58,7 +58,6 @@ var (
 	VT03030 = errorWithState("VT03030", vtrpcpb.Code_INVALID_ARGUMENT, WrongValueCountOnRow, "lookup column count does not match value count with the row (columns, count): (%v, %d)", "The number of columns you want to insert do not match the number of columns of your SELECT query.")
 	VT03031 = errorWithoutState("VT03031", vtrpcpb.Code_INVALID_ARGUMENT, "EXPLAIN is only supported for single keyspace", "EXPLAIN has to be sent down as a single query to the underlying MySQL, and this is not possible if it uses tables from multiple keyspaces")
 	VT03032 = errorWithState("VT03032", vtrpcpb.Code_INVALID_ARGUMENT, NonUpdateableTable, "the target table %s of the UPDATE is not updatable", "You cannot update a table that is not a real MySQL table.")
-	VT03033 = errorWithState("VT03033", vtrpcpb.Code_INVALID_ARGUMENT, AggregateMustPushDown, "aggregate user-defined function %s must be pushed down to mysql", "The aggregate user-defined function must be pushed down to mysql and can't be evaluated on the vtgate. The query contains aggregation that can't be fully pushed down to MySQL.")
 
 	VT05001 = errorWithState("VT05001", vtrpcpb.Code_NOT_FOUND, DbDropExists, "cannot drop database '%s'; database does not exists", "The given database does not exist; Vitess cannot drop it.")
 	VT05002 = errorWithState("VT05002", vtrpcpb.Code_NOT_FOUND, BadDb, "cannot alter database '%s'; unknown database", "The given database does not exist; Vitess cannot alter it.")

--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -57,7 +57,8 @@ var (
 	VT03029 = errorWithState("VT03029", vtrpcpb.Code_INVALID_ARGUMENT, WrongValueCountOnRow, "column count does not match value count with the row for vindex '%s'", "The number of columns you want to insert do not match the number of columns of your SELECT query.")
 	VT03030 = errorWithState("VT03030", vtrpcpb.Code_INVALID_ARGUMENT, WrongValueCountOnRow, "lookup column count does not match value count with the row (columns, count): (%v, %d)", "The number of columns you want to insert do not match the number of columns of your SELECT query.")
 	VT03031 = errorWithoutState("VT03031", vtrpcpb.Code_INVALID_ARGUMENT, "EXPLAIN is only supported for single keyspace", "EXPLAIN has to be sent down as a single query to the underlying MySQL, and this is not possible if it uses tables from multiple keyspaces")
-	VT03032 = errorWithState("VT03031", vtrpcpb.Code_INVALID_ARGUMENT, NonUpdateableTable, "the target table %s of the UPDATE is not updatable", "You cannot update a table that is not a real MySQL table.")
+	VT03032 = errorWithState("VT03032", vtrpcpb.Code_INVALID_ARGUMENT, NonUpdateableTable, "the target table %s of the UPDATE is not updatable", "You cannot update a table that is not a real MySQL table.")
+	VT03033 = errorWithState("VT03033", vtrpcpb.Code_INVALID_ARGUMENT, AggregateMustPushDown, "aggregate user-defined function %s must be pushed down to mysql", "The aggregate user-defined function must be pushed down to mysql and can't be evaluated on the vtgate. The query contains aggregation that can't be fully pushed down to MySQL.")
 
 	VT05001 = errorWithState("VT05001", vtrpcpb.Code_NOT_FOUND, DbDropExists, "cannot drop database '%s'; database does not exists", "The given database does not exist; Vitess cannot drop it.")
 	VT05002 = errorWithState("VT05002", vtrpcpb.Code_NOT_FOUND, BadDb, "cannot alter database '%s'; unknown database", "The given database does not exist; Vitess cannot alter it.")

--- a/go/vt/vterrors/state.go
+++ b/go/vt/vterrors/state.go
@@ -49,7 +49,6 @@ const (
 	WrongArguments
 	BadNullError
 	InvalidGroupFuncUse
-	AggregateMustPushDown
 
 	// failed precondition
 	NoDB

--- a/go/vt/vterrors/state.go
+++ b/go/vt/vterrors/state.go
@@ -49,6 +49,7 @@ const (
 	WrongArguments
 	BadNullError
 	InvalidGroupFuncUse
+	AggregateMustPushDown
 
 	// failed precondition
 	NoDB

--- a/go/vt/vtgate/engine/opcode/constants.go
+++ b/go/vt/vtgate/engine/opcode/constants.go
@@ -154,6 +154,8 @@ func (code AggregateOpcode) SQLType(typ querypb.Type) querypb.Type {
 		return sqltypes.Int64
 	case AggregateGtid:
 		return sqltypes.VarChar
+	case AggregateUDF:
+		return sqltypes.Unknown
 	default:
 		panic(code.String()) // we have a unit test checking we never reach here
 	}

--- a/go/vt/vtgate/engine/opcode/constants.go
+++ b/go/vt/vtgate/engine/opcode/constants.go
@@ -77,20 +77,8 @@ const (
 	AggregateCountStar
 	AggregateGroupConcat
 	AggregateAvg
+	AggregateUDF  // This is an opcode used to represent UDFs
 	_NumOfOpCodes // This line must be last of the opcodes!
-)
-
-var (
-	// OpcodeType keeps track of the known output types for different aggregate functions
-	OpcodeType = map[AggregateOpcode]querypb.Type{
-		AggregateCountDistinct: sqltypes.Int64,
-		AggregateCount:         sqltypes.Int64,
-		AggregateCountStar:     sqltypes.Int64,
-		AggregateSumDistinct:   sqltypes.Decimal,
-		AggregateSum:           sqltypes.Decimal,
-		AggregateAvg:           sqltypes.Decimal,
-		AggregateGtid:          sqltypes.VarChar,
-	}
 )
 
 // SupportedAggregates maps the list of supported aggregate

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -49,7 +49,7 @@ func gen4DeleteStmtPlanner(
 		return nil, err
 	}
 
-	err = queryRewrite(ctx.SemTable, reservedVars, deleteStmt)
+	err = queryRewrite(ctx, deleteStmt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -33,7 +33,7 @@ func gen4InsertStmtPlanner(version querypb.ExecuteOptions_PlannerVersion, insStm
 		return nil, err
 	}
 
-	err = queryRewrite(ctx.SemTable, reservedVars, insStmt)
+	err = queryRewrite(ctx, insStmt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -96,7 +96,7 @@ func (qb *queryBuilder) addPredicate(expr sqlparser.Expr) {
 
 	switch stmt := qb.stmt.(type) {
 	case *sqlparser.Select:
-		if containsAggr(expr) {
+		if ContainsAggr(qb.ctx, expr) {
 			addPred = stmt.AddHaving
 		} else {
 			addPred = stmt.AddWhere

--- a/go/vt/vtgate/planbuilder/operators/expressions.go
+++ b/go/vt/vtgate/planbuilder/operators/expressions.go
@@ -31,7 +31,7 @@ func breakExpressionInLHSandRHSForApplyJoin(
 ) (col applyJoinColumn) {
 	rewrittenExpr := sqlparser.CopyOnRewrite(expr, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
 		nodeExpr, ok := cursor.Node().(sqlparser.Expr)
-		if !ok || !mustFetchFromInput(nodeExpr) {
+		if !ok || !mustFetchFromInput(ctx, nodeExpr) {
 			return
 		}
 		deps := ctx.SemTable.RecursiveDeps(nodeExpr)

--- a/go/vt/vtgate/planbuilder/operators/hash_join.go
+++ b/go/vt/vtgate/planbuilder/operators/hash_join.go
@@ -292,7 +292,7 @@ func (hj *HashJoin) addColumn(ctx *plancontext.PlanningContext, in sqlparser.Exp
 			}
 			inOffset := op.FindCol(ctx, expr, false)
 			if inOffset == -1 {
-				if !mustFetchFromInput(expr) {
+				if !mustFetchFromInput(ctx, expr) {
 					return -1
 				}
 
@@ -398,7 +398,7 @@ func (hj *HashJoin) addSingleSidedColumn(
 			}
 			inOffset := op.FindCol(ctx, expr, false)
 			if inOffset == -1 {
-				if !mustFetchFromInput(expr) {
+				if !mustFetchFromInput(ctx, expr) {
 					return -1
 				}
 

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -100,7 +100,7 @@ func (h *Horizon) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.
 	}
 
 	newExpr := semantics.RewriteDerivedTableExpression(expr, tableInfo)
-	if sqlparser.ContainsAggregation(newExpr) {
+	if ContainsAggr(ctx, newExpr) {
 		return newFilter(h, expr)
 	}
 	h.Source = h.Source.AddPredicate(ctx, newExpr)

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -129,6 +129,8 @@ func addColumnsToInput(ctx *plancontext.PlanningContext, root Operator) Operator
 
 		return in, NoRewrite
 	}
+
+	// while we are out here walking the operator tree, if we find a UDF in an aggregation, we should fail
 	failUDFAggregation := func(in Operator, _ semantics.TableSet, _ bool) (Operator, *ApplyResult) {
 		aggrOp, ok := in.(*Aggregator)
 		if !ok {

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -139,7 +139,7 @@ func addColumnsToInput(ctx *plancontext.PlanningContext, root Operator) Operator
 		for _, aggr := range aggrOp.Aggregations {
 			if aggr.OpCode == opcode.AggregateUDF {
 				// we don't support UDFs in aggregation if it's still above a route
-				message := fmt.Sprintf("Aggregate UDF %s must be pushed down to MySQL", sqlparser.String(aggr.Original.Expr))
+				message := fmt.Sprintf("Aggregate UDF '%s' must be pushed down to MySQL", sqlparser.String(aggr.Original.Expr))
 				panic(vterrors.VT12001(message))
 			}
 		}

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -88,7 +88,7 @@ func (p Phase) shouldRun(s semantics.QuerySignature) bool {
 func (p Phase) act(ctx *plancontext.PlanningContext, op Operator) Operator {
 	switch p {
 	case pullDistinctFromUnion:
-		return pullDistinctFromUNION(ctx, op)
+		return isolateDistinctFromUnion(ctx, op)
 	case delegateAggregation:
 		return enableDelegateAggregation(ctx, op)
 	case addAggrOrdering:

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -287,7 +287,7 @@ func tryPushOrdering(ctx *plancontext.PlanningContext, in *Ordering) (Operator, 
 	case *Projection:
 		// we can move ordering under a projection if it's not introducing a column we're sorting by
 		for _, by := range in.Order {
-			if !mustFetchFromInput(by.SimplifiedExpr) {
+			if !mustFetchFromInput(ctx, by.SimplifiedExpr) {
 				return in, NoRewrite
 			}
 		}
@@ -459,7 +459,7 @@ func pushFilterUnderProjection(ctx *plancontext.PlanningContext, filter *Filter,
 	for _, p := range filter.Predicates {
 		cantPush := false
 		_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-			if !mustFetchFromInput(node) {
+			if !mustFetchFromInput(ctx, node) {
 				return true, nil
 			}
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -56,11 +56,11 @@ func isMergeable(ctx *plancontext.PlanningContext, query sqlparser.SelectStateme
 
 		// if we have grouping, we have already checked that it's safe, and don't need to check for aggregations
 		// but if we don't have groupings, we need to check if there are aggregations that will mess with us
-		if sqlparser.ContainsAggregation(node.SelectExprs) {
+		if ContainsAggr(ctx, node.SelectExprs) {
 			return false
 		}
 
-		if sqlparser.ContainsAggregation(node.Having) {
+		if ContainsAggr(ctx, node.Having) {
 			return false
 		}
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -590,19 +590,16 @@ func loadSchema(t testing.TB, filename string, setCollation bool) *vindexes.VSch
 		t.Fatal(err)
 	}
 	vschema := vindexes.BuildVSchema(formal, sqlparser.NewTestParser())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for _, ks := range vschema.Keyspaces {
-		if ks.Error != nil {
-			t.Fatal(ks.Error)
-		}
+		require.NoError(t, ks.Error)
 
 		// adding view in user keyspace
 		if ks.Keyspace.Name == "user" {
-			if err = vschema.AddView(ks.Keyspace.Name, "user_details_view", "select user.id, user_extra.col from user join user_extra on user.id = user_extra.user_id", sqlparser.NewTestParser()); err != nil {
-				t.Fatal(err)
-			}
+			err = vschema.AddView(ks.Keyspace.Name, "user_details_view", "select user.id, user_extra.col from user join user_extra on user.id = user_extra.user_id", sqlparser.NewTestParser())
+			require.NoError(t, err)
+			err = vschema.AddUDF(ks.Keyspace.Name, "udf_aggr")
+			require.NoError(t, err)
 		}
 
 		// setting a default value to all the text columns in the tables of this keyspace

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -586,9 +586,7 @@ func TestOtherPlanningFromFile(t *testing.T) {
 
 func loadSchema(t testing.TB, filename string, setCollation bool) *vindexes.VSchema {
 	formal, err := vindexes.LoadFormal(locateFile(filename))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	vschema := vindexes.BuildVSchema(formal, sqlparser.NewTestParser())
 	require.NoError(t, err)
 	for _, ks := range vschema.Keyspaces {

--- a/go/vt/vtgate/planbuilder/plancontext/vschema.go
+++ b/go/vt/vtgate/planbuilder/plancontext/vschema.go
@@ -93,6 +93,9 @@ type VSchema interface {
 
 	// StorePrepareData stores the prepared data in the session.
 	StorePrepareData(name string, v *vtgatepb.PrepareData)
+
+	// GetAggregateUDFs returns the list of aggregate UDFs.
+	GetAggregateUDFs() []string
 }
 
 // PlannerNameToVersion returns the numerical representation of the planner

--- a/go/vt/vtgate/planbuilder/planner_test.go
+++ b/go/vt/vtgate/planbuilder/planner_test.go
@@ -19,6 +19,8 @@ package planbuilder
 import (
 	"testing"
 
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -67,9 +69,13 @@ func TestBindingSubquery(t *testing.T) {
 					"foo":  {Name: sqlparser.NewIdentifierCS("foo")},
 				},
 			})
+			ctx := &plancontext.PlanningContext{
+				ReservedVars: sqlparser.NewReservedVars("vt", make(sqlparser.BindVars)),
+				SemTable:     semTable,
+			}
 			require.NoError(t, err)
 			if testcase.rewrite {
-				err = queryRewrite(semTable, sqlparser.NewReservedVars("vt", make(sqlparser.BindVars)), selStmt)
+				err = queryRewrite(ctx, selStmt)
 				require.NoError(t, err)
 			}
 			expr := testcase.extractor(selStmt)

--- a/go/vt/vtgate/planbuilder/rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/rewrite_test.go
@@ -19,6 +19,8 @@ package planbuilder
 import (
 	"testing"
 
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -74,7 +76,11 @@ func TestHavingRewrite(t *testing.T) {
 	for _, tcase := range tcases {
 		t.Run(tcase.input, func(t *testing.T) {
 			semTable, reservedVars, sel := prepTest(t, tcase.input)
-			err := queryRewrite(semTable, reservedVars, sel)
+			ctx := &plancontext.PlanningContext{
+				ReservedVars: reservedVars,
+				SemTable:     semTable,
+			}
+			err := queryRewrite(ctx, sel)
 			require.NoError(t, err)
 			assert.Equal(t, tcase.output, sqlparser.String(sel))
 		})

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -225,7 +225,7 @@ func newBuildSelectPlan(
 }
 
 func createSelectOperator(ctx *plancontext.PlanningContext, selStmt sqlparser.SelectStatement, reservedVars *sqlparser.ReservedVars) (operators.Operator, error) {
-	err := queryRewrite(ctx.SemTable, reservedVars, selStmt)
+	err := queryRewrite(ctx, selStmt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6962,7 +6962,7 @@
   {
     "comment": "Aggregate UDFs can't be handled by vtgate",
     "query": "select id from t1 group by id having udf_aggr(foo) > 1 and sum(foo) = 10",
-    "plan": "VT03033: aggregate user-defined function udf_aggr(foo) must be pushed down to mysql"
+    "plan": "VT12001: unsupported: Aggregate UDF 'udf_aggr(foo)' must be pushed down to MySQL"
   },
   {
     "comment": "Valid to run since we can push down the aggregate function because of the grouping",

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6963,5 +6963,75 @@
     "comment": "Aggregate UDFs can't be handled by vtgate",
     "query": "select id from t1 group by id having udf_aggr(foo) > 1 and sum(foo) = 10",
     "plan": "VT03033: aggregate user-defined function udf_aggr(foo) must be pushed down to mysql"
+  },
+  {
+    "comment": "Valid to run since we can push down the aggregate function because of the grouping",
+    "query": "select id from user group by id having udf_aggr(foo) > 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select id from user group by id having udf_aggr(foo) > 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1 group by id",
+        "Query": "select id from `user` group by id having udf_aggr(foo) > 1",
+        "Table": "`user`"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Valid to run since we can push down the aggregate function because it's unsharded",
+    "query": "select bar, udf_aggr(foo) from unsharded group by bar",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select bar, udf_aggr(foo) from unsharded group by bar",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select bar, udf_aggr(foo) from unsharded where 1 != 1 group by bar",
+        "Query": "select bar, udf_aggr(foo) from unsharded group by bar",
+        "Table": "unsharded"
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
+    "comment": "Valid to run since we can push down the aggregate function because the where clause using the sharding key",
+    "query": "select bar, udf_aggr(foo) from user where id = 17 group by bar",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select bar, udf_aggr(foo) from user where id = 17 group by bar",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select bar, udf_aggr(foo) from `user` where 1 != 1 group by bar",
+        "Query": "select bar, udf_aggr(foo) from `user` where id = 17 group by bar",
+        "Table": "`user`",
+        "Values": [
+          "17"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6958,5 +6958,10 @@
     "comment": "baz in the HAVING clause can't be accessed because of the GROUP BY",
     "query": "select foo, count(bar) as x from user group by foo having baz > avg(baz) order by x",
     "plan": "Unknown column 'baz' in 'having clause'"
+  },
+  {
+    "comment": "Aggregate UDFs can't be handled by vtgate",
+    "query": "select id from t1 group by id having udf_aggr(foo) > 1 and sum(foo) = 10",
+    "plan": "VT03033: aggregate user-defined function udf_aggr(foo) must be pushed down to mysql"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -5822,12 +5822,12 @@
   {
     "comment": "update with multi table reference with multi target update on a derived table",
     "query": "update ignore (select foo, col, bar from user) u, music m set u.foo = 21, u.bar = 'abc' where u.col = m.col",
-    "plan": "VT03031: the target table (select foo, col, bar from `user`) as u of the UPDATE is not updatable"
+    "plan": "VT03032: the target table (select foo, col, bar from `user`) as u of the UPDATE is not updatable"
   },
   {
     "comment": "update with derived table",
     "query": "update (select id from user) as u set id = 4",
-    "plan": "VT03031: the target table (select id from `user`) as u of the UPDATE is not updatable"
+    "plan": "VT03032: the target table (select id from `user`) as u of the UPDATE is not updatable"
   },
   {
     "comment": "Delete with routed table on music",

--- a/go/vt/vtgate/planbuilder/update.go
+++ b/go/vt/vtgate/planbuilder/update.go
@@ -41,7 +41,7 @@ func gen4UpdateStmtPlanner(
 		return nil, err
 	}
 
-	err = queryRewrite(ctx.SemTable, reservedVars, updStmt)
+	err = queryRewrite(ctx, updStmt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/vexplain.go
+++ b/go/vt/vtgate/planbuilder/vexplain.go
@@ -128,7 +128,7 @@ func explainPlan(explain *sqlparser.ExplainStmt, reservedVars *sqlparser.Reserve
 		return nil, vterrors.VT03031()
 	}
 
-	if err = queryRewrite(ctx.SemTable, reservedVars, explain.Statement); err != nil {
+	if err = queryRewrite(ctx, explain.Statement); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/vtgate/semantics/FakeSI.go
+++ b/go/vt/vtgate/semantics/FakeSI.go
@@ -36,6 +36,7 @@ type FakeSI struct {
 	VindexTables     map[string]vindexes.Vindex
 	KsForeignKeyMode map[string]vschemapb.Keyspace_ForeignKeyMode
 	KsError          map[string]error
+	UDFs             []string
 }
 
 // FindTableOrVindex implements the SchemaInformation interface
@@ -79,4 +80,8 @@ func (s *FakeSI) KeyspaceError(keyspace string) error {
 		return fkErr
 	}
 	return nil
+}
+
+func (s *FakeSI) GetAggregateUDFs() []string {
+	return s.UDFs
 }

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -78,6 +78,7 @@ func (a *analyzer) lateInit() {
 		aliasMapCache:   map[*sqlparser.Select]map[string]exprContainer{},
 		reAnalyze:       a.reAnalyze,
 		tables:          a.tables,
+		aggrUDFs:        a.si.GetAggregateUDFs(),
 	}
 	a.fk = &fkManager{
 		binder:   a.binder,

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -53,7 +53,7 @@ type analyzer struct {
 // newAnalyzer create the semantic analyzer
 func newAnalyzer(dbName string, si SchemaInformation, fullAnalysis bool) *analyzer {
 	// TODO  dependencies between these components are a little tangled. We should try to clean up
-	s := newScoper()
+	s := newScoper(si.GetAggregateUDFs())
 	a := &analyzer{
 		scoper:       s,
 		earlyTables:  newEarlyTableCollector(si, dbName),

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -53,7 +53,7 @@ type analyzer struct {
 // newAnalyzer create the semantic analyzer
 func newAnalyzer(dbName string, si SchemaInformation, fullAnalysis bool) *analyzer {
 	// TODO  dependencies between these components are a little tangled. We should try to clean up
-	s := newScoper(si.GetAggregateUDFs())
+	s := newScoper(si)
 	a := &analyzer{
 		scoper:       s,
 		earlyTables:  newEarlyTableCollector(si, dbName),

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -645,6 +645,7 @@ func getSchemaWithKnownColumns() *FakeSI {
 				ColumnListAuthoritative: true,
 			},
 		},
+		UDFs: []string{"custom_udf"},
 	}
 	return schemaInfo
 }

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -542,6 +542,10 @@ func TestHavingColumnName(t *testing.T) {
 		expDeps: TS0,
 		warning: "Column 'foo' in having clause is ambiguous",
 	}, {
+		sql:     "select id, custom_udf(t1.foo) as foo from t1 having foo > 1",
+		expSQL:  "select id, custom_udf(t1.foo) as foo from t1 having custom_udf(t1.foo) > 1",
+		expDeps: TS0,
+	}, {
 		sql:    "select id, sum(t1.foo) as XYZ from t1 having sum(XYZ) > 1",
 		expErr: "Invalid use of group function",
 	}, {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -537,6 +537,11 @@ func TestHavingColumnName(t *testing.T) {
 		expDeps: TS0,
 		warning: "Column 'foo' in having clause is ambiguous",
 	}, {
+		sql:     "select id, sum(t1.foo) as foo from t1 having custom_udf(foo) > 1",
+		expSQL:  "select id, sum(t1.foo) as foo from t1 having custom_udf(foo) > 1",
+		expDeps: TS0,
+		warning: "Column 'foo' in having clause is ambiguous",
+	}, {
 		sql:    "select id, sum(t1.foo) as XYZ from t1 having sum(XYZ) > 1",
 		expErr: "Invalid use of group function",
 	}, {

--- a/go/vt/vtgate/semantics/info_schema.go
+++ b/go/vt/vtgate/semantics/info_schema.go
@@ -1661,3 +1661,7 @@ func (i *infoSchemaWithColumns) GetForeignKeyChecksState() *bool {
 func (i *infoSchemaWithColumns) KeyspaceError(keyspace string) error {
 	return i.inner.KeyspaceError(keyspace)
 }
+
+func (i *infoSchemaWithColumns) GetAggregateUDFs() []string {
+	return i.inner.GetAggregateUDFs()
+}

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -37,7 +37,7 @@ type (
 		// These scopes are only used for rewriting ORDER BY 1 and GROUP BY 1
 		specialExprScopes map[*sqlparser.Literal]*scope
 		statementIDs      map[sqlparser.Statement]TableSet
-		aggrUDFs          []string
+		si                SchemaInformation
 	}
 
 	scope struct {
@@ -54,13 +54,13 @@ type (
 	}
 )
 
-func newScoper(udfs []string) *scoper {
+func newScoper(si SchemaInformation) *scoper {
 	return &scoper{
 		rScope:            map[*sqlparser.Select]*scope{},
 		wScope:            map[*sqlparser.Select]*scope{},
 		specialExprScopes: map[*sqlparser.Literal]*scope{},
 		statementIDs:      map[sqlparser.Statement]TableSet{},
-		aggrUDFs:          udfs,
+		si:                si,
 	}
 }
 
@@ -90,7 +90,7 @@ func (s *scoper) down(cursor *sqlparser.Cursor) error {
 		if !s.currentScope().inHaving {
 			break
 		}
-		if node.Name.EqualsAnyString(s.aggrUDFs) {
+		if node.Name.EqualsAnyString(s.si.GetAggregateUDFs()) {
 			s.currentScope().inHavingAggr = true
 		}
 	case *sqlparser.Where:

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -37,6 +37,7 @@ type (
 		// These scopes are only used for rewriting ORDER BY 1 and GROUP BY 1
 		specialExprScopes map[*sqlparser.Literal]*scope
 		statementIDs      map[sqlparser.Statement]TableSet
+		aggrUDFs          []string
 	}
 
 	scope struct {
@@ -53,12 +54,13 @@ type (
 	}
 )
 
-func newScoper() *scoper {
+func newScoper(udfs []string) *scoper {
 	return &scoper{
 		rScope:            map[*sqlparser.Select]*scope{},
 		wScope:            map[*sqlparser.Select]*scope{},
 		specialExprScopes: map[*sqlparser.Literal]*scope{},
 		statementIDs:      map[sqlparser.Statement]TableSet{},
+		aggrUDFs:          udfs,
 	}
 }
 
@@ -84,6 +86,13 @@ func (s *scoper) down(cursor *sqlparser.Cursor) error {
 			break
 		}
 		s.currentScope().inHavingAggr = true
+	case *sqlparser.FuncExpr:
+		if !s.currentScope().inHaving {
+			break
+		}
+		if node.Name.EqualsAnyString(s.aggrUDFs) {
+			s.currentScope().inHavingAggr = true
+		}
 	case *sqlparser.Where:
 		if node.Type == sqlparser.HavingClause {
 			err := s.createSpecialScopePostProjection(cursor.Parent())

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -161,6 +161,7 @@ type (
 		ForeignKeyMode(keyspace string) (vschemapb.Keyspace_ForeignKeyMode, error)
 		GetForeignKeyChecksState() *bool
 		KeyspaceError(keyspace string) error
+		GetAggregateUDFs() []string
 	}
 
 	shortCut = int

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -1075,6 +1075,10 @@ func (vc *vcursorImpl) KeyspaceError(keyspace string) error {
 	return ks.Error
 }
 
+func (vc *vcursorImpl) GetAggregateUDFs() []string {
+	return vc.vschema.GetAggregateUDFs()
+}
+
 // ParseDestinationTarget parses destination target string and sets default keyspace if possible.
 func parseDestinationTarget(targetString string, vschema *vindexes.VSchema) (string, topodatapb.TabletType, key.Destination, error) {
 	destKeyspace, destTabletType, dest, err := topoprotopb.ParseDestination(targetString, defaultTabletType)

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -425,7 +425,7 @@ func (vschema *VSchema) AddView(ksname, viewName, query string, parser *sqlparse
 	return nil
 }
 
-// AddTable adds a table to an existing keyspace in the VSchema.
+// AddUDF adds a UDF to an existing keyspace in the VSchema.
 // It's only used from tests.
 func (vschema *VSchema) AddUDF(ksname, udfName string) error {
 	ks, ok := vschema.Keyspaces[ksname]

--- a/go/vt/wrangler/vexec_plan.go
+++ b/go/vt/wrangler/vexec_plan.go
@@ -248,13 +248,7 @@ func (vx *vexec) buildUpdatePlan(ctx context.Context, planner vexecPlanner, upd 
 	if updatableColumnNames := plannerParams.updatableColumnNames; len(updatableColumnNames) > 0 {
 		// if updatableColumnNames is non empty, then we must only accept changes to columns listed there
 		for _, expr := range upd.Exprs {
-			isUpdatable := false
-			for _, updatableColName := range updatableColumnNames {
-				if expr.Name.Name.EqualString(updatableColName) {
-					isUpdatable = true
-				}
-			}
-			if !isUpdatable {
+			if !expr.Name.Name.EqualsAnyString(updatableColumnNames) {
 				return nil, fmt.Errorf("%+v cannot be changed: %v", expr.Name.Name, sqlparser.String(expr))
 			}
 		}


### PR DESCRIPTION
## Description
The schema tracker can now tell us which aggregate UDFs exist on the underlying MySQL, and with this PR the planner will now use this information when planning queries.

It changes how the column binding is done in the `HAVING` and `ORDER BY` clause in a subtle but important way.

Vtgate can only handle these functions when it's possible to entirely push down the aggregation to mysql.

At the moment there is no support for actually installing the UDFs on MySQL - for now this exercise is left to the user.

## Related Issue(s)
#15705

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
