### PR TITLE
`schemadiff`: `DROP COLUMN` not eligible for `INSTANT` algorithm if covered by an index

### DIFF
--- a/go/vt/schemadiff/capability_test.go
+++ b/go/vt/schemadiff/capability_test.go
@@ -92,6 +92,12 @@ func TestAlterTableCapableOfInstantDDL(t *testing.T) {
 			expectCapableOfInstantDDL: false,
 		},
 		{
+			name:                      "drop column fail due to multicolumn index",
+			create:                    "create table t(id int, i1 int not null, i2 int not null, primary key(id), key i21_idx (i2, i1))",
+			alter:                     "alter table t drop column i1",
+			expectCapableOfInstantDDL: false,
+		},
+		{
 			name:                      "add two columns",
 			create:                    "create table t(id int, i1 int not null, primary key(id))",
 			alter:                     "alter table t add column i2 int not null after id, add column i3 int not null",

--- a/go/vt/schemadiff/capability_test.go
+++ b/go/vt/schemadiff/capability_test.go
@@ -86,6 +86,12 @@ func TestAlterTableCapableOfInstantDDL(t *testing.T) {
 			expectCapableOfInstantDDL: false,
 		},
 		{
+			name:                      "drop column fail due to index",
+			create:                    "create table t(id int, i1 int not null, i2 int not null, primary key(id), key i1_idx (i1))",
+			alter:                     "alter table t drop column i1",
+			expectCapableOfInstantDDL: false,
+		},
+		{
 			name:                      "add two columns",
 			create:                    "create table t(id int, i1 int not null, primary key(id))",
 			alter:                     "alter table t add column i2 int not null after id, add column i3 int not null",


### PR DESCRIPTION

## Description

Context: https://github.com/vitessio/vitess/issues/14877
In evaluating whether a `DROP COLUMN` is eligible to `ALGORITHM=INSTANT`, we must make sure that the column is not covered by any existing index. If it is, then dropping the column implies modifying the index, which is a non-`INSTANT` operation in MySQL.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/14877
- https://github.com/vitessio/vitess/pull/14878
- https://github.com/vitessio/vitess/pull/14883

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
