### PR TITLE
rewrite shuffleTablets to be clearer and more efficient

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -381,7 +381,7 @@ func (gw *TabletGateway) shuffleTablets(cell string, tablets []*discovery.Tablet
 	// Randomly shuffle the list of tablets, putting the same-cell hosts at the front
 	// of the list and the other-cell hosts at the back
 	//
-	// Only need to do n-1 swaps since the last host is always in the right place.
+	// Only need to do n-1 swaps since the last tablet is always in the right place.
 	n := len(tablets)
 	head := 0
 	tail := n - 1


### PR DESCRIPTION
## Description
Implement a simple single-pass scan through the list of tablets that both randomly shuffles the set and pulls the same-cell hosts to the front of the list.

This is the same functionality as the old code, just with a simpler algorithm that only needs to loop once through the set of tablets so it's a marginally more efficient approach.

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

