### PR TITLE
Use for:range in go test files

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -213,7 +213,7 @@ func LaunchCluster(setupType int, streamMode string, stripes int, cDetails *Comp
 		shard.Vttablets = append(shard.Vttablets, tablet)
 		return nil
 	}
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		tabletType := tabletTypes[i]
 		if err := createTablet(tabletType); err != nil {
 			return 1, err
@@ -833,7 +833,7 @@ func terminatedRestore(t *testing.T) {
 func checkTabletType(t *testing.T, alias string, tabletType topodata.TabletType) {
 	t.Helper()
 	// for loop for 15 seconds to check if tablet type is correct
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		output, err := localCluster.VtctldClientProcess.ExecuteCommandWithOutput("GetTablet", alias)
 		require.Nil(t, err)
 		var tabletPB topodata.Tablet
@@ -1169,7 +1169,7 @@ func ReadRowsFromReplica(t *testing.T, replicaIndex int) (msgs []string) {
 func FlushBinaryLogsOnReplica(t *testing.T, replicaIndex int, count int) {
 	replica := getReplica(t, replicaIndex)
 	query := "flush binary logs"
-	for i := 0; i < count; i++ {
+	for range count {
 		_, err := replica.VttabletProcess.QueryTablet(query, keyspaceName, true)
 		require.NoError(t, err)
 	}

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -381,7 +381,7 @@ func (cluster *LocalProcessCluster) startKeyspace(keyspace Keyspace, shardNames 
 		}
 		log.Infof("Starting shard: %v", shardName)
 		var mysqlctlProcessList []*exec.Cmd
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := cluster.GetAndReserveTabletUID()
 			tablet := &Vttablet{
@@ -534,7 +534,7 @@ func (cluster *LocalProcessCluster) StartKeyspaceLegacy(keyspace Keyspace, shard
 		}
 		log.Infof("Starting shard: %v", shardName)
 		mysqlctlProcessList = []*exec.Cmd{}
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := cluster.GetAndReserveTabletUID()
 			tablet := &Vttablet{

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -531,7 +531,7 @@ func executeQuery(dbConn *mysql.Conn, query string) (*sqltypes.Result, error) {
 	)
 	retries := 10
 	retryDelay := 1 * time.Second
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		if i > 0 {
 			// We only audit from 2nd attempt and onwards, otherwise this is just too verbose.
 			log.Infof("Executing query %s (attempt %d of %d)", query, (i + 1), retries)
@@ -551,7 +551,7 @@ func executeQuery(dbConn *mysql.Conn, query string) (*sqltypes.Result, error) {
 func executeMultiQuery(dbConn *mysql.Conn, query string) (err error) {
 	retries := 10
 	retryDelay := 1 * time.Second
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		if i > 0 {
 			// We only audit from 2nd attempt and onwards, otherwise this is just too verbose.
 			log.Infof("Executing query %s (attempt %d of %d)", query, (i + 1), retries)

--- a/go/test/endtoend/docker/vttestserver_test.go
+++ b/go/test/endtoend/docker/vttestserver_test.go
@@ -155,7 +155,7 @@ func TestLargeNumberOfKeyspaces(t *testing.T) {
 		t.Run(image, func(t *testing.T) {
 			var keyspaces []string
 			var numShards []int
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				keyspaces = append(keyspaces, fmt.Sprintf("unsharded_ks%d", i))
 				numShards = append(numShards, 1)
 			}

--- a/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
+++ b/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
@@ -137,7 +137,7 @@ func initializeCluster(t *testing.T) (int, error) {
 		shard := &cluster.Shard{
 			Name: shardName,
 		}
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			// instantiate vttablet object with reserved ports
 			tabletUID := clusterInstance.GetAndReserveTabletUID()
 			tablet := clusterInstance.NewVttabletInstance("replica", tabletUID, cell)

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -356,7 +356,7 @@ func clusterSetUp(t *testing.T) (int, error) {
 		shard := &cluster.Shard{
 			Name: shardName,
 		}
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			// instantiate vttablet object with reserved ports
 			tablet := clusterInstance.NewVttabletInstance("replica", 0, cell)
 

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -83,7 +83,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 			Name: shardName,
 		}
 		var mysqlCtlProcessList []*exec.Cmd
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := clusterInstance.GetAndReserveTabletUID()
 			tablet := &cluster.Vttablet{

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -88,7 +88,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) error {
 		shard := &cluster.Shard{
 			Name: shardName,
 		}
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := clusterInstance.GetAndReserveTabletUID()
 			tablet := &cluster.Vttablet{

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -843,7 +843,7 @@ func testRevert(t *testing.T) {
 	// If they fail, it has nothing to do with revert.
 	// We run these tests because we expect their functionality to work in the next step.
 	var alterHints []string
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		testName := fmt.Sprintf("online ALTER TABLE %d", i)
 		hint := fmt.Sprintf("hint-alter-%d", i)
 		alterHints = append(alterHints, hint)
@@ -1388,7 +1388,7 @@ func runMultipleConnections(ctx context.Context, t *testing.T) {
 	require.True(t, checkTable(t, tableName, true))
 	var done int64
 	var wg sync.WaitGroup
-	for i := 0; i < maxConcurrency; i++ {
+	for range maxConcurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1415,13 +1415,13 @@ func initTable(t *testing.T) {
 	_, err = conn.ExecuteFetch(truncateStatement, 1000, true)
 	require.Nil(t, err)
 
-	for i := 0; i < maxTableRows/2; i++ {
+	for range maxTableRows / 2 {
 		generateInsert(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateUpdate(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateDelete(t, conn)
 	}
 }

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -1698,13 +1698,13 @@ func testDeclarative(t *testing.T) {
 		_, err = conn.ExecuteFetch(truncateStatement, 1000, true)
 		require.Nil(t, err)
 
-		for i := 0; i < maxTableRows/2; i++ {
+		for range maxTableRows / 2 {
 			generateInsert(t, conn)
 		}
-		for i := 0; i < maxTableRows/4; i++ {
+		for range maxTableRows / 4 {
 			generateUpdate(t, conn)
 		}
-		for i := 0; i < maxTableRows/4; i++ {
+		for range maxTableRows / 4 {
 			generateDelete(t, conn)
 		}
 	}

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -469,7 +469,7 @@ func TestSchemaChange(t *testing.T) {
 		// spawn n migrations; cancel them via cancel-all
 		var wg sync.WaitGroup
 		count := 4
-		for i := 0; i < count; i++ {
+		for range count {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -487,8 +487,7 @@ func TestSchemaChange(t *testing.T) {
 
 		// spawn n migrations; cancel them via cancel-all
 		var wg sync.WaitGroup
-		count := 4
-		for i := 0; i < count; i++ {
+		for range 4 {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -867,7 +866,7 @@ func insertRow(t *testing.T) {
 }
 
 func insertRows(t *testing.T, count int) {
-	for i := 0; i < count; i++ {
+	for range count {
 		insertRow(t)
 	}
 }
@@ -903,7 +902,7 @@ func testMigrationRowCount(t *testing.T, uuid string) {
 func testWithInitialSchema(t *testing.T) {
 	// Create 4 tables
 	var sqlQuery = "" //nolint
-	for i := 0; i < totalTableCount; i++ {
+	for i := range totalTableCount {
 		sqlQuery = fmt.Sprintf(createTable, fmt.Sprintf("vt_onlineddl_test_%02d", i))
 		err := clusterInstance.VtctldClientProcess.ApplySchema(keyspaceName, sqlQuery)
 		require.Nil(t, err)

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -243,7 +243,7 @@ func TestSchemaChange(t *testing.T) {
 		assert.Equal(t, 1, len(clusterInstance.Keyspaces[0].Shards))
 		testWithInitialSchema(t)
 	})
-	for i := 0; i < countIterations; i++ {
+	for i := range countIterations {
 		// This first tests the general functionality of initializing the table with data,
 		// no concurrency involved. Just counting.
 		testName := fmt.Sprintf("init table %d/%d", (i + 1), countIterations)
@@ -252,7 +252,7 @@ func TestSchemaChange(t *testing.T) {
 			testSelectTableMetrics(t)
 		})
 	}
-	for i := 0; i < countIterations; i++ {
+	for i := range countIterations {
 		// This tests running a workload on the table, then comparing expected metrics with
 		// actual table metrics. All this without any ALTER TABLE: this is to validate
 		// that our testing/metrics logic is sound in the first place.
@@ -284,7 +284,7 @@ func TestSchemaChange(t *testing.T) {
 		testSelectTableMetrics(t)
 	})
 
-	for i := 0; i < countIterations; i++ {
+	for i := range countIterations {
 		// Finally, this is the real test:
 		// We populate a table, and begin a concurrent workload (this is the "mini stress")
 		// We then ALTER TABLE via vreplication.
@@ -546,7 +546,7 @@ func runMultipleConnections(ctx context.Context, t *testing.T) {
 
 	log.Infof("Running multiple connections: maxConcurrency=%v, sleep interval=%v", maxConcurrency, sleepInterval)
 	var wg sync.WaitGroup
-	for i := 0; i < maxConcurrency; i++ {
+	for range maxConcurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -579,13 +579,13 @@ func initTable(t *testing.T) {
 	_, err = conn.ExecuteFetch(truncateStatement, 1000, true)
 	require.Nil(t, err)
 
-	for i := 0; i < maxTableRows/2; i++ {
+	for range maxTableRows / 2 {
 		generateInsert(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateUpdate(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateDelete(t, conn)
 	}
 }

--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -738,7 +738,7 @@ func runMultipleConnections(ctx context.Context, t *testing.T, autoIncInsert boo
 	log.Infof("Running multiple connections")
 	var done int64
 	var wg sync.WaitGroup
-	for i := 0; i < maxConcurrency; i++ {
+	for range maxConcurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -766,13 +766,13 @@ func initTable(t *testing.T) {
 	_, err = conn.ExecuteFetch(truncateStatement, 1000, true)
 	require.Nil(t, err)
 
-	for i := 0; i < maxTableRows/2; i++ {
+	for range maxTableRows / 2 {
 		generateInsert(t, conn, false)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateUpdate(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateDelete(t, conn)
 	}
 	{

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -114,7 +114,7 @@ func TestMainImpl(m *testing.M) {
 		}
 
 		var mysqlProcs []*exec.Cmd
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			tabletType := "replica"
 			if i == 0 {
 				tabletType = "primary"

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -381,7 +381,7 @@ func TestERSForInitialization(t *testing.T) {
 	require.NoError(t, err)
 	err = clusterInstance.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+"zone1")
 	require.NoError(t, err)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		tablet := clusterInstance.NewVttabletInstance("replica", 100+i, "zone1")
 		tablets = append(tablets, tablet)
 	}

--- a/go/test/endtoend/reparent/prscomplex/main_test.go
+++ b/go/test/endtoend/reparent/prscomplex/main_test.go
@@ -131,7 +131,7 @@ func TestAcquireSameConnID(t *testing.T) {
 	totalErrCount := 0
 	// run through 100 times to acquire new connection, this might override the original connection id.
 	var conn2 *mysql.Conn
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		conn2, err = mysql.Connect(ctx, &vtParams)
 		require.NoError(t, err)
 

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -202,7 +202,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 
 		var mysqlCtlProcessList []*exec.Cmd
 
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := clusterInstance.GetAndReserveTabletUID()
 			tablet := &cluster.Vttablet{

--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -296,7 +296,7 @@ func TestStreamingRPCStuck(t *testing.T) {
 	// We want the table to have enough rows such that a streaming call returns multiple packets.
 	// Therefore, we insert one row and keep doubling it.
 	utils.Exec(t, vtConn, "insert into customer(email) values('testemail')")
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		// Double the number of rows in customer table.
 		utils.Exec(t, vtConn, "insert into customer (email) select email from customer")
 	}

--- a/go/test/endtoend/tabletmanager/qps_test.go
+++ b/go/test/endtoend/tabletmanager/qps_test.go
@@ -56,7 +56,7 @@ func TestQPS(t *testing.T) {
 	//       after that we'll see 0.0 QPS rates again. If this becomes actually
 	//       flaky, we need to read continuously in a separate thread.
 
-	for n := 0; n < 15; n++ {
+	for range 15 {
 		// Run queries via vtGate so that they are counted.
 		utils.Exec(t, vtGateConn, "select * from t1")
 	}

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -154,7 +154,7 @@ func populateTable(t *testing.T) {
 	require.NoError(t, err)
 	_, err = primaryTablet.VttabletProcess.QueryTablet("insert into t1 (id, value) values (null, md5(rand()))", keyspaceName, true)
 	require.NoError(t, err)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, err = primaryTablet.VttabletProcess.QueryTablet("insert into t1 (id, value) select null, md5(rand()) from t1", keyspaceName, true)
 		require.NoError(t, err)
 	}

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -517,7 +517,7 @@ func TestCustomQuery(t *testing.T) {
 		sleepDuration := 20 * time.Second
 		var wg sync.WaitGroup
 		t.Run("generate running queries", func(t *testing.T) {
-			for i := 0; i < customThreshold+1; i++ {
+			for i := range customThreshold + 1 {
 				// Generate different Sleep() calls, all at minimum sleepDuration.
 				wg.Add(1)
 				go func(i int) {

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -110,7 +110,7 @@ func TestVaultAuth(t *testing.T) {
 	defer vs.stop()
 
 	// Wait for Vault server to come up
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		time.Sleep(250 * time.Millisecond)
 		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", hostname, vs.port1))
 		if err != nil {
@@ -164,7 +164,7 @@ func startVaultServer(t *testing.T) *Server {
 }
 
 // Setup everything we need in the Vault server
-func setupVaultServer(t *testing.T, vs *Server) (string, string) {
+func setupVaultServer(_ *testing.T, vs *Server) (string, string) {
 	// The setup script uses these environment variables
 	//   We also reuse VAULT_ADDR and VAULT_CACERT later on
 	os.Setenv("VAULT", vs.execPath)

--- a/go/test/endtoend/versionupgrade/upgrade_test.go
+++ b/go/test/endtoend/versionupgrade/upgrade_test.go
@@ -143,7 +143,7 @@ func TestDeploySchema(t *testing.T) {
 		return
 	}
 	// Create n tables, populate
-	for i := 0; i < totalTableCount; i++ {
+	for i := range totalTableCount {
 		tableName := fmt.Sprintf("vt_upgrade_test_%02d", i)
 
 		{
@@ -186,7 +186,7 @@ func checkTablesCount(t *testing.T, tablet *cluster.Vttablet, showTableName stri
 // TestTablesData checks the data in tables
 func TestTablesData(t *testing.T) {
 	// Create n tables, populate
-	for i := 0; i < totalTableCount; i++ {
+	for i := range totalTableCount {
 		tableName := fmt.Sprintf("vt_upgrade_test_%02d", i)
 
 		for i := range clusterInstance.Keyspaces[0].Shards {

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -291,7 +291,7 @@ func downloadDBTypeVersion(dbType string, majorVersion string, path string) erro
 	}
 	retries := 5
 	var dlerr error
-	for i := 0; i < retries; i++ {
+	for range retries {
 		if dlerr = downloadFile(); dlerr == nil {
 			break
 		}
@@ -615,7 +615,7 @@ func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspa
 				primary.Vttablet.IsPrimary = true
 			}
 
-			for i := 0; i < numReplicas; i++ {
+			for range numReplicas {
 				log.Infof("Adding Replica tablet")
 				tablet, proc, err := vc.AddTablet(t, cell, keyspace, shard, "replica", tabletID+tabletIndex)
 				require.NoError(t, err)
@@ -626,7 +626,7 @@ func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspa
 			}
 			// Only create RDONLY tablets in the default cell
 			if cell.Name == cluster.DefaultCell {
-				for i := 0; i < numRdonly; i++ {
+				for range numRdonly {
 					log.Infof("Adding RdOnly tablet")
 					tablet, proc, err := vc.AddTablet(t, cell, keyspace, shard, "rdonly", tabletID+tabletIndex)
 					require.NoError(t, err)

--- a/go/test/endtoend/vreplication/fk_ext_load_generator_test.go
+++ b/go/test/endtoend/vreplication/fk_ext_load_generator_test.go
@@ -388,7 +388,7 @@ func (lg *SimpleLoadGenerator) insert() {
 	require.NoError(t, err)
 	require.NotNil(t, qr)
 	// Insert one or more children, some with valid foreign keys, some without.
-	for i := 0; i < rand.IntN(4)+1; i++ {
+	for i := range rand.IntN(4) + 1 {
 		currentChildId++
 		if i == 3 && lg.overrideConstraints {
 			query = fmt.Sprintf(insertChildQueryOverrideConstraints, lg.keyspace, currentChildId, currentParentId+1000000)

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -257,7 +257,7 @@ func (ls *fkLoadSimulator) insert() {
 	qr := ls.exec(insertQuery)
 	require.NotNil(t, qr)
 	// insert one or more children, some with valid foreign keys, some without.
-	for i := 0; i < rand.IntN(4)+1; i++ {
+	for i := range rand.IntN(4) + 1 {
 		currentChildId++
 		if i == 3 {
 			insertQuery = fmt.Sprintf("INSERT /*+ SET_VAR(foreign_key_checks=0) */ INTO child (id, parent_id) VALUES (%d, %d)", currentChildId, currentParentId+1000000)

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -376,7 +376,7 @@ func waitForWorkflowState(t *testing.T, vc *VitessCluster, ksWorkflow string, wa
 						// we need to wait for all streams to have the desired state
 						state = attributeValue.Get("State").String()
 						if state == wantState {
-							for i := 0; i < len(fieldEqualityChecks); i++ {
+							for i := range len(fieldEqualityChecks) {
 								if kvparts := strings.Split(fieldEqualityChecks[i], "=="); len(kvparts) == 2 {
 									key := kvparts[0]
 									val := kvparts[1]
@@ -702,7 +702,7 @@ func getShardRoutingRules(t *testing.T) string {
 		return shardI < shardJ
 	})
 	sb := strings.Builder{}
-	for i := 0; i < len(rules); i++ {
+	for i := range len(rules) {
 		if i > 0 {
 			sb.WriteString(",")
 		}

--- a/go/test/endtoend/vreplication/performance_test.go
+++ b/go/test/endtoend/vreplication/performance_test.go
@@ -61,7 +61,7 @@ create table customer(cid int, name varbinary(128), meta json default null, typ 
 
 	tablet := defaultCell.Keyspaces[sourceKs].Shards["0"].Tablets["zone1-100"].Vttablet
 	tablet.BulkLoad(t, "stress_src", "largebin", func(w io.Writer) {
-		for i := 0; i < insertCount; i++ {
+		for i := range insertCount {
 			fmt.Fprintf(w, "\"%d\",%q\n", i, "foobar")
 		}
 	})

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -468,7 +468,7 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 
 	// ensure sequence is available to vtgate
 	num := 5
-	for i := 0; i < num; i++ {
+	for range num {
 		execVtgateQuery(t, vtgateConn, "customer", "insert into customer2(name) values('a')")
 	}
 	waitForRowCount(t, vtgateConn, "customer", "customer2", 3+num)
@@ -500,7 +500,7 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 	assert.Contains(t, output, "\"sequence\": \"customer_seq2\"", "customer2 still found in keyspace product")
 
 	// ensure sequence is available to vtgate
-	for i := 0; i < num; i++ {
+	for range num {
 		execVtgateQuery(t, vtgateConn, "product", "insert into customer2(name) values('a')")
 	}
 	waitForRowCount(t, vtgateConn, "product", "customer2", 3+num+num)

--- a/go/test/endtoend/vreplication/vstream_test.go
+++ b/go/test/endtoend/vreplication/vstream_test.go
@@ -252,7 +252,7 @@ func testVStreamStopOnReshardFlag(t *testing.T, stopOnReshard bool, baseTabletID
 	verifyClusterHealth(t, vc)
 
 	// some initial data
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		insertRow("sharded", "customer", i)
 	}
 

--- a/go/test/endtoend/vtgate/foreignkey/fk_fuzz_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_fuzz_test.go
@@ -261,7 +261,7 @@ func (fz *fuzzer) start(t *testing.T, keyspace string) {
 	// We mark the fuzzer thread to be running now.
 	fz.shouldStop.Store(false)
 	fz.wg.Add(fz.concurrency)
-	for i := 0; i < fz.concurrency; i++ {
+	for i := range fz.concurrency {
 		fuzzerThreadId := i
 		go func() {
 			fz.runFuzzerThread(t, keyspace, fuzzerThreadId)
@@ -776,7 +776,7 @@ func BenchmarkFkFuzz(b *testing.B) {
 	numQueries := 1000
 	// Wait for schema-tracking to be complete.
 	waitForSchemaTrackingForFkTables(b)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		queries, mysqlConn, vtConn, vtUnmanagedConn := setupBenchmark(b, maxValForId, maxValForCol, insertShare, deleteShare, updateShare, numQueries)
 
 		// Now we run the benchmarks!

--- a/go/test/endtoend/vtgate/foreignkey/fk_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/fk_test.go
@@ -288,7 +288,7 @@ func runVStream(t *testing.T, ctx context.Context, ch chan *binlogdatapb.VEvent,
 
 func drainEvents(t *testing.T, ch chan *binlogdatapb.VEvent, count int) []string {
 	var rowEvents []string
-	for i := 0; i < count; i++ {
+	for i := range count {
 		select {
 		case re := <-ch:
 			rowEvents = append(rowEvents, re.RowEvent.String())

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -566,7 +566,7 @@ func ExecuteFKTest(t *testing.T, tcase *testCase) {
 				defer cancel()
 
 				var wg sync.WaitGroup
-				for i := 0; i < maxConcurrency; i++ {
+				for i := range maxConcurrency {
 					tableName := tableNames[i%len(tableNames)]
 					wg.Add(1)
 					go func() {
@@ -1159,13 +1159,13 @@ func populateTables(t *testing.T, tcase *testCase) {
 			t.Run(tableName, func(t *testing.T) {
 				t.Run("populating", func(t *testing.T) {
 					// populate parent, then child, child2, then grandchild
-					for i := 0; i < maxTableRows/2; i++ {
+					for range maxTableRows / 2 {
 						generateInsert(t, tableName, conn)
 					}
-					for i := 0; i < maxTableRows/4; i++ {
+					for range maxTableRows / 4 {
 						generateUpdate(t, tableName, conn)
 					}
-					for i := 0; i < maxTableRows/4; i++ {
+					for range maxTableRows / 4 {
 						generateDelete(t, tableName, conn)
 					}
 				})

--- a/go/test/endtoend/vtgate/foreignkey/utils_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/utils_test.go
@@ -285,7 +285,7 @@ func setupBenchmark(b *testing.B, maxValForId int, maxValForCol int, insertShare
 	fz := newFuzzer(1, maxValForId, maxValForCol, insertShare, deleteShare, updateShare, SQLQueries, nil)
 	fz.noFkSetVar = true
 	var queries []string
-	for j := 0; j < numQueries; j++ {
+	for range numQueries {
 		genQueries := fz.generateQuery()
 		require.Len(b, genQueries, 1)
 		queries = append(queries, genQueries[0])

--- a/go/test/endtoend/vtgate/grpc_api/execute_test.go
+++ b/go/test/endtoend/vtgate/grpc_api/execute_test.go
@@ -44,7 +44,7 @@ func TestTransactionsWithGRPCAPI(t *testing.T) {
 
 	vtSession := vtgateConn.Session(keyspaceName, nil)
 	workload := []string{"OLTP", "OLAP"}
-	for i := 0; i < 4; i++ { // running all switch combinations.
+	for i := range 4 { // running all switch combinations.
 		index := i % len(workload)
 		_, session, err := exec(ctx, vtSession, fmt.Sprintf("set workload = %s", workload[index]), nil)
 		require.NoError(t, err)

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -788,7 +788,7 @@ func TestRowCountExceed(t *testing.T) {
 		conn.Close()
 	}()
 
-	for i := 0; i < 250; i++ {
+	for i := range 250 {
 		utils.Exec(t, conn, fmt.Sprintf("insert into t1 (id1, id2) values (%d, %d)", i, i+1))
 	}
 

--- a/go/test/endtoend/vtgate/mysql80/misc_test.go
+++ b/go/test/endtoend/vtgate/mysql80/misc_test.go
@@ -206,9 +206,9 @@ func BenchmarkReservedConnWhenSettingSysVar(b *testing.B) {
 	f(0)
 
 	benchmarkName := "Use SET_VAR"
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		b.Run(benchmarkName, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for i := range b.N {
 				f(i)
 			}
 		})

--- a/go/test/endtoend/vtgate/queries/benchmark/benchmark_test.go
+++ b/go/test/endtoend/vtgate/queries/benchmark/benchmark_test.go
@@ -34,7 +34,7 @@ type testQuery struct {
 
 func (tq *testQuery) getInsertQuery(rows int) string {
 	var allRows []string
-	for i := 0; i < rows; i++ {
+	for i := range rows {
 		var row []string
 		for _, isInt := range tq.intTyp {
 			if isInt {
@@ -61,7 +61,7 @@ func (tq *testQuery) getUpdateQuery(rows int) string {
 	allRows = append(allRows, strings.Join(row, ","))
 
 	var ids []string
-	for i := 0; i <= rows; i++ {
+	for i := range rows {
 		ids = append(ids, strconv.Itoa(i))
 	}
 	return fmt.Sprintf("update %s set %s where id in (%s)", tq.tableName, strings.Join(allRows, ","), strings.Join(ids, ","))
@@ -69,7 +69,7 @@ func (tq *testQuery) getUpdateQuery(rows int) string {
 
 func (tq *testQuery) getDeleteQuery(rows int) string {
 	var ids []string
-	for i := 0; i <= rows; i++ {
+	for i := range rows {
 		ids = append(ids, strconv.Itoa(i))
 	}
 	return fmt.Sprintf("delete from %s where id in (%s)", tq.tableName, strings.Join(ids, ","))
@@ -78,7 +78,7 @@ func (tq *testQuery) getDeleteQuery(rows int) string {
 func getRandomString(size int) string {
 	var str strings.Builder
 
-	for i := 0; i < size; i++ {
+	for range size {
 		str.WriteByte(byte(rand.IntN(27) + 97))
 	}
 	return str.String()
@@ -99,7 +99,7 @@ func BenchmarkShardedTblNoLookup(b *testing.B) {
 	for _, rows := range []int{1, 10, 100, 500, 1000, 5000, 10000} {
 		insStmt := tq.getInsertQuery(rows)
 		b.Run(fmt.Sprintf("16-shards-%d-rows", rows), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = utils.Exec(b, conn, insStmt)
 			}
 		})
@@ -122,7 +122,7 @@ func BenchmarkShardedTblUpdateIn(b *testing.B) {
 	for _, rows := range []int{1, 10, 100, 500, 1000, 5000, 10000} {
 		updStmt := tq.getUpdateQuery(rows)
 		b.Run(fmt.Sprintf("16-shards-%d-rows", rows), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = utils.Exec(b, conn, updStmt)
 			}
 		})
@@ -140,7 +140,7 @@ func BenchmarkShardedTblDeleteIn(b *testing.B) {
 		_ = utils.Exec(b, conn, insStmt)
 		delStmt := tq.getDeleteQuery(rows)
 		b.Run(fmt.Sprintf("16-shards-%d-rows", rows), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = utils.Exec(b, conn, delStmt)
 			}
 		})

--- a/go/test/endtoend/vtgate/queries/kill/main_test.go
+++ b/go/test/endtoend/vtgate/queries/kill/main_test.go
@@ -109,7 +109,7 @@ func setupData(t *testing.T, huge bool) {
 	r3 := getRandomString(30)
 	r4 := getRandomString(40)
 
-	for i := 0; i < initialRow; i += 4 {
+	for i := range initialRow {
 		utils.Exec(t, conn, fmt.Sprintf("insert into test(id, msg, extra) values (%d, '%s', '%s'),(%d, '%s', '%s'),(%d, '%s', '%s'),(%d, '%s', '%s')",
 			i, r1, r2,
 			i+1, r2, r3,
@@ -141,7 +141,7 @@ func dropData(t *testing.T) {
 func getRandomString(size int) string {
 	var str strings.Builder
 
-	for i := 0; i < size; i++ {
+	for range size {
 		str.WriteByte(byte((rand.Int() % 26) + 97))
 	}
 

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -204,7 +204,7 @@ func TestHighNumberOfParams(t *testing.T) {
 	// create the value and argument slices used to build the prepare stmt
 	var vals []any
 	var params []string
-	for i := 0; i < paramCount; i++ {
+	for i := range paramCount {
 		vals = append(vals, strconv.Itoa(i))
 		params = append(params, "?")
 	}

--- a/go/test/endtoend/vtgate/queries/random/query_gen.go
+++ b/go/test/endtoend/vtgate/queries/random/query_gen.go
@@ -357,7 +357,7 @@ func (sg *selectGenerator) createTablesAndJoin() ([]tableT, bool) {
 	sg.sel.From = append(sg.sel.From, newAliasedTable(tables[0], "tbl0"))
 
 	numTables := rand.IntN(sg.maxTables)
-	for i := 0; i < numTables; i++ {
+	for i := range numTables {
 		tables = append(tables, randomEl(sg.schemaTables))
 		alias := fmt.Sprintf("tbl%d", i+1)
 		sg.sel.From = append(sg.sel.From, newAliasedTable(tables[i+1], alias))
@@ -416,7 +416,7 @@ func (sg *selectGenerator) createGroupBy(tables []tableT) (grouping []column) {
 		return
 	}
 	numGBs := rand.IntN(sg.maxGBs + 1)
-	for i := 0; i < numGBs; i++ {
+	for range numGBs {
 		tblIdx := rand.IntN(len(tables))
 		col := randomEl(tables[tblIdx].cols)
 		// TODO: grouping by a date column sometimes errors
@@ -532,7 +532,7 @@ func (sg *selectGenerator) createRandomExprs(minExprs, maxExprs int, generators 
 		return
 	}
 	numPredicates := rand.IntN(maxExprs-minExprs+1) + minExprs
-	for i := 0; i < numPredicates; i++ {
+	for range numPredicates {
 		predicates = append(predicates, sg.getRandomExpr(generators...))
 	}
 

--- a/go/test/endtoend/vtgate/queries/random/random_expr_test.go
+++ b/go/test/endtoend/vtgate/queries/random/random_expr_test.go
@@ -46,7 +46,7 @@ func TestRandomExprWithTables(t *testing.T) {
 		{name: "loc", typ: "varchar"},
 	}...)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		genConfig := sqlparser.NewExprGeneratorConfig(sqlparser.CanAggregate, "", 0, false)
 		g := sqlparser.NewGenerator(3, slice.Map(schemaTables, func(t tableT) sqlparser.ExprGenerator { return &t })...)
 		g.Expression(genConfig)

--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -74,7 +74,7 @@ func TestQueryTimeoutWithTables(t *testing.T) {
 
 	// unsharded
 	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into uks.unsharded(id1) values (1),(2),(3),(4),(5)")
-	for i := 0; i < 12; i++ {
+	for range 12 {
 		utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=2000 */ into uks.unsharded(id1) select id1+5 from uks.unsharded")
 	}
 

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -113,7 +113,7 @@ func TestUnionAll(t *testing.T) {
 			// this test is quite good at uncovering races in the Concatenate engine primitive. make it run many times
 			// see: https://github.com/vitessio/vitess/issues/15434
 			if utils.BinaryIsAtLeastAtVersion(20, "vtgate") {
-				for i := 0; i < 100; i++ {
+				for range 100 {
 					// union all between two select unique in tables
 					mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
 						"[[INT64(1)] [INT64(2)] [INT64(1)] [INT64(2)]]")

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -284,7 +284,7 @@ func BenchmarkReservedConnFieldQuery(b *testing.B) {
 	utils.Exec(b, conn, "set sql_mode = ''")
 	utils.AssertMatches(b, conn, "select 	@@sql_mode", `[[VARCHAR("")]]`)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		utils.Exec(b, conn, "select id, val1 from test")
 	}
 }

--- a/go/test/endtoend/vtgate/schema/schema_test.go
+++ b/go/test/endtoend/vtgate/schema/schema_test.go
@@ -119,7 +119,7 @@ func TestSchemaChange(t *testing.T) {
 func testWithInitialSchema(t *testing.T) {
 	// Create 4 tables
 	var sqlQuery = "" // nolint
-	for i := 0; i < totalTableCount; i++ {
+	for i := range totalTableCount {
 		sqlQuery = fmt.Sprintf(createTable, fmt.Sprintf("vt_select_test_%02d", i))
 		err := clusterInstance.VtctldClientProcess.ApplySchema(keyspaceName, sqlQuery)
 		require.Nil(t, err)
@@ -295,7 +295,7 @@ func testCopySchemaShards(t *testing.T, source string, shard int) {
 	checkTablesCount(t, clusterInstance.Keyspaces[0].Shards[shard].Vttablets[0], 0)
 	checkTablesCount(t, clusterInstance.Keyspaces[0].Shards[shard].Vttablets[1], 0)
 	// Run the command twice to make sure it's idempotent.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		err := clusterInstance.VtctlclientProcess.ExecuteCommand("CopySchemaShard", source, fmt.Sprintf("%s/%d", keyspaceName, shard))
 		require.Nil(t, err)
 	}

--- a/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
+++ b/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
@@ -147,7 +147,7 @@ func TestVSchemaTrackerKeyspaceReInit(t *testing.T) {
 	assert.NotNil(t, originalResults)
 
 	// restart the primary tablet so that the vschema gets reloaded for the keyspace
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		err := primaryTablet.VttabletProcess.TearDownWithTimeout(30 * time.Second)
 		require.NoError(t, err)
 		err = primaryTablet.VttabletProcess.Setup()

--- a/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
+++ b/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
@@ -149,7 +149,7 @@ func TestHealthCheckCacheWithTabletChurn(t *testing.T) {
 	qr, _ := vtgateConn.ExecuteFetch(query, 100, true)
 	assert.Equal(t, expectedTabletHCcacheEntries, len(qr.Rows), "wrong number of tablet records in healthcheck cache, expected %d but had %d. Results: %v", expectedTabletHCcacheEntries, len(qr.Rows), qr.Rows)
 
-	for i := 0; i < tries; i++ {
+	for range tries {
 		tablet := addTablet(t, churnTabletUID, churnTabletType)
 		expectedTabletHCcacheEntries++
 

--- a/go/test/endtoend/vtgate/transaction/single/main_test.go
+++ b/go/test/endtoend/vtgate/transaction/single/main_test.go
@@ -226,7 +226,7 @@ func TestNoRecordInTableNotFail(t *testing.T) {
 	utils.AssertMatches(t, conn, `select @@transaction_mode`, `[[VARCHAR("SINGLE")]]`)
 	// Need to run this test multiple times as shards are picked randomly for Impossible query.
 	// After the fix it is not random if a shard session already exists then it reuses that same shard session.
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		utils.Exec(t, conn, `begin`)
 		utils.Exec(t, conn, `INSERT INTO t1(id, txn_id) VALUES (1, "t1")`)
 		utils.Exec(t, conn, `SELECT * FROM t2 WHERE id = 1`)

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -118,13 +118,13 @@ func createVttablets(clusterInstance *cluster.LocalProcessCluster, cellInfos []*
 	// creating tablets by hand instead of using StartKeyspace because we don't want to call InitShardPrimary
 	var tablets []*cluster.Vttablet
 	for _, cellInfo := range cellInfos {
-		for i := 0; i < cellInfo.NumReplicas; i++ {
+		for range cellInfo.NumReplicas {
 			vttabletInstance := clusterInstance.NewVttabletInstance("replica", cellInfo.UIDBase, cellInfo.CellName)
 			cellInfo.UIDBase++
 			tablets = append(tablets, vttabletInstance)
 			cellInfo.ReplicaTablets = append(cellInfo.ReplicaTablets, vttabletInstance)
 		}
-		for i := 0; i < cellInfo.NumRdonly; i++ {
+		for range cellInfo.NumRdonly {
 			vttabletInstance := clusterInstance.NewVttabletInstance("rdonly", cellInfo.UIDBase, cellInfo.CellName)
 			cellInfo.UIDBase++
 			tablets = append(tablets, vttabletInstance)
@@ -234,7 +234,7 @@ func resetShardPrimary(ts *topo.Server) (err error) {
 func StartVTOrcs(t *testing.T, clusterInfo *VTOrcClusterInfo, orcExtraArgs []string, config cluster.VTOrcConfiguration, count int) {
 	t.Helper()
 	// Start vtorc
-	for i := 0; i < count; i++ {
+	for range count {
 		vtorcProcess := clusterInfo.ClusterInstance.NewVTOrcProcess(config)
 		vtorcProcess.ExtraArgs = orcExtraArgs
 		err := vtorcProcess.Setup()
@@ -763,7 +763,7 @@ func SetupNewClusterSemiSync(t *testing.T) *VTOrcClusterInfo {
 	err = clusterInstance.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+Cell1)
 	require.NoError(t, err, "Error managing topo: %v", err)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		tablet := clusterInstance.NewVttabletInstance("replica", 100+i, Cell1)
 		tablets = append(tablets, tablet)
 	}
@@ -836,7 +836,7 @@ func AddSemiSyncKeyspace(t *testing.T, clusterInfo *VTOrcClusterInfo) {
 	keyspaceSemiSyncName := "ks2"
 	keyspace := &cluster.Keyspace{Name: keyspaceSemiSyncName}
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		tablet := clusterInfo.ClusterInstance.NewVttabletInstance("replica", 300+i, Cell1)
 		tablets = append(tablets, tablet)
 	}

--- a/go/test/fuzzing/autogenerate/convert_grep_to_fuzzer.go
+++ b/go/test/fuzzing/autogenerate/convert_grep_to_fuzzer.go
@@ -194,7 +194,7 @@ func createMainFuzzer(functionList, harnesses []string) {
 	mainFuzzer.WriteString(fmt.Sprintf("\tfuncOp := int(data[0])%%%d\n", maxOps))
 	mainFuzzer.WriteString("\tdata2 := data[1:]\n")
 	mainFuzzer.WriteString("\tswitch funcOp {\n")
-	for i := 0; i < len(functionList); i++ {
+	for i := range len(functionList) {
 		mainFuzzer.WriteString(fmt.Sprintf("\tcase %d:\n", i))
 		mainFuzzer.WriteString(fmt.Sprintf("\t%s\n", functionList[i]))
 	}
@@ -203,7 +203,7 @@ func createMainFuzzer(functionList, harnesses []string) {
 	mainFuzzer.WriteString("}")
 
 	// add all the internal harnesses
-	for i := 0; i < len(harnesses); i++ {
+	for i := range len(harnesses) {
 		mainFuzzer.WriteString(harnesses[i])
 	}
 

--- a/go/test/fuzzing/vttablet_fuzzer.go
+++ b/go/test/fuzzing/vttablet_fuzzer.go
@@ -49,7 +49,7 @@ func (fs *fuzzStore) createTablets(f *fuzz.ConsumeFuzzer) error {
 		return fmt.Errorf("We don't need a nil-len list")
 	}
 	tablets := make([]*topodatapb.Tablet, 0)
-	for i := 0; i < tabletCount; i++ {
+	for range tabletCount {
 		tablet := &topodatapb.Tablet{}
 		err = f.GenerateStruct(tablet)
 		if err != nil {
@@ -73,7 +73,7 @@ func (fs *fuzzStore) createTabletAliases(f *fuzz.ConsumeFuzzer) error {
 		return fmt.Errorf("We don't need a nil-len list")
 	}
 	tabletAliases := make([]*topodatapb.TabletAlias, 0)
-	for i := 0; i < tabletAliasCount; i++ {
+	for range tabletAliasCount {
 		tabletAlias := &topodatapb.TabletAlias{}
 		err = f.GenerateStruct(tabletAlias)
 		if err != nil {
@@ -97,7 +97,7 @@ func (fs *fuzzStore) createStrings(f *fuzz.ConsumeFuzzer) error {
 		return fmt.Errorf("We don't need a nil-len list")
 	}
 	stringSlice := make([]string, 0)
-	for i := 0; i < stringCount; i++ {
+	for range stringCount {
 		newString, err := f.GetString()
 		if err != nil {
 			return err
@@ -120,7 +120,7 @@ func (fs *fuzzStore) createBytes(f *fuzz.ConsumeFuzzer) error {
 		return fmt.Errorf("We don't need a nil-len list")
 	}
 	byteSlice := make([][]byte, 0)
-	for i := 0; i < bytesCount; i++ {
+	for range bytesCount {
 		newBytes, err := f.GetBytes()
 		if err != nil {
 			return err
@@ -143,7 +143,7 @@ func (fs *fuzzStore) createInts(f *fuzz.ConsumeFuzzer) error {
 		return fmt.Errorf("We don't need a nil-len list")
 	}
 	intSlice := make([]int, 0)
-	for i := 0; i < intCount; i++ {
+	for range intCount {
 		newInt, err := f.GetInt()
 		if err != nil {
 			return err
@@ -166,7 +166,7 @@ func (fs *fuzzStore) createExecutionOrder(f *fuzz.ConsumeFuzzer) error {
 		return fmt.Errorf("We don't need a nil-len list")
 	}
 	executionOrder := make([]int, 0)
-	for i := 0; i < intCount; i++ {
+	for range intCount {
 		newInt, err := f.GetInt()
 		if err != nil {
 			return err

--- a/go/test/stress/stress.go
+++ b/go/test/stress/stress.go
@@ -236,7 +236,7 @@ func (s *Stresser) Start() *Stresser {
 
 func generateNewTables(prefix string, nb int) []*table {
 	tbls := make([]*table, 0, nb)
-	for i := 0; i < nb; i++ {
+	for i := range nb {
 		tbls = append(tbls, &table{
 			name: fmt.Sprintf("%s%d", prefix, i),
 		})
@@ -263,13 +263,13 @@ func (s *Stresser) startClients() {
 	resultCh := make(chan result, maxClient)
 
 	// Start the concurrent clients.
-	for i := 0; i < maxClient; i++ {
+	for range maxClient {
 		go s.startStressClient(resultCh)
 	}
 
 	// Wait for the different clients to publish their results.
 	perClientResults := make([]result, 0, maxClient)
-	for i := 0; i < maxClient; i++ {
+	for range maxClient {
 		newResult := <-resultCh
 		perClientResults = append(perClientResults, newResult)
 	}

--- a/go/test/utils/noleak.go
+++ b/go/test/utils/noleak.go
@@ -85,7 +85,7 @@ func ensureNoGoroutines() error {
 	}
 
 	var err error
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		err = goleak.Find(ignored...)
 		if err == nil {
 			return nil

--- a/test.go
+++ b/test.go
@@ -475,7 +475,7 @@ func main() {
 	}()
 
 	// Start the requested number of parallel runners.
-	for i := 0; i < *parallel; i++ {
+	for range *parallel {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -53,7 +53,7 @@ func main() {
 
 	// Insert some messages on random pages.
 	fmt.Println("Inserting into primary...")
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		tx, err := db.Begin()
 		if err != nil {
 			fmt.Printf("begin failed: %v\n", err)


### PR DESCRIPTION
## Description

Go 1.22 introduced the ability to range over integers in a more concise manner, e.g.

`for i := 0; i < n; i++`

becomes

`for i := range n`

Did the change for all go test files. 

My first commit on this repo.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15193

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required

## Deployment Notes
N/A
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
