### PR TITLE
Fix panic in aggregation

### DIFF
--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -244,7 +244,7 @@ func AssertMatchesWithTimeout(t *testing.T, conn *mysql.Conn, query, expected st
 }
 
 // WaitForAuthoritative waits for a table to become authoritative
-func WaitForAuthoritative(t *testing.T, ks, tbl string, readVSchema func() (*interface{}, error)) error {
+func WaitForAuthoritative(t TestingT, ks, tbl string, readVSchema func() (*interface{}, error)) error {
 	timeout := time.After(60 * time.Second)
 	for {
 		select {
@@ -320,7 +320,7 @@ func WaitForTableDeletions(t *testing.T, vtgateProcess cluster.VtgateProcess, ks
 }
 
 // WaitForColumn waits for a table's column to be present
-func WaitForColumn(t testing.TB, vtgateProcess cluster.VtgateProcess, ks, tbl, col string) error {
+func WaitForColumn(t TestingT, vtgateProcess cluster.VtgateProcess, ks, tbl, col string) error {
 	timeout := time.After(60 * time.Second)
 	for {
 		select {
@@ -355,7 +355,7 @@ func WaitForColumn(t testing.TB, vtgateProcess cluster.VtgateProcess, ks, tbl, c
 				if !isMap {
 					break
 				}
-				if colName, exists := colDef["name"]; exists && colName == col {
+				if colName, exists := colDef["name"]; exists && strings.EqualFold(colName.(string), col) {
 					return nil
 				}
 			}

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -249,7 +249,7 @@ func WaitForAuthoritative(t TestingT, ks, tbl string, readVSchema func() (*inter
 	for {
 		select {
 		case <-timeout:
-			return fmt.Errorf("schema tracking didn't mark table t2 as authoritative until timeout")
+			return fmt.Errorf("schema tracking didn't mark table %v.%v as authoritative until timeout", ks, tbl)
 		default:
 			res, err := readVSchema()
 			require.NoError(t, err, res)

--- a/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
+++ b/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
@@ -131,6 +131,36 @@ order by
 	l_returnflag,
 	l_linestatus;`,
 		},
+		{
+			name: "Q11",
+			query: `select
+	ps_partkey,
+	sum(ps_supplycost * ps_availqty) as value
+from
+	partsupp,
+	supplier,
+	nation
+where
+	ps_suppkey = s_suppkey
+	and s_nationkey = n_nationkey
+	and n_name = 'MOZAMBIQUE'
+group by
+	ps_partkey having
+		sum(ps_supplycost * ps_availqty) > (
+			select
+				sum(ps_supplycost * ps_availqty) * 0.0001000000
+			from
+				partsupp,
+				supplier,
+				nation
+			where
+				ps_suppkey = s_suppkey
+				and s_nationkey = n_nationkey
+				and n_name = 'MOZAMBIQUE'
+		)
+order by
+	value desc;`,
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -80,7 +80,7 @@ func (sa *ScalarAggregate) NeedsTransaction() bool {
 
 // TryExecute implements the Primitive interface
 func (sa *ScalarAggregate) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	result, err := vcursor.ExecutePrimitive(ctx, sa.Input, bindVars, wantfields)
+	result, err := vcursor.ExecutePrimitive(ctx, sa.Input, bindVars, true)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (sa *ScalarAggregate) TryStreamExecute(ctx context.Context, vcursor VCursor
 	var fields []*querypb.Field
 	fieldsSent := !wantfields
 
-	err := vcursor.StreamExecutePrimitive(ctx, sa.Input, bindVars, wantfields, func(result *sqltypes.Result) error {
+	err := vcursor.StreamExecutePrimitive(ctx, sa.Input, bindVars, true, func(result *sqltypes.Result) error {
 		// as the underlying primitive call is not sync
 		// and here scalar aggregate is using shared variables we have to sync the callback
 		// for correct aggregation.


### PR DESCRIPTION
## Description
When using the aggregation engine, we need to have full field information from the inputs to calculate things correctly.

This PR makes sure that the aggregator always asks for fields. When it was running inside of some other operators that don't need fields, we failed to ask for the fields, and this could lead to panics.

## Related Issue(s)
- Fixes https://github.com/vitessio/vitess/issues/15729

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
