### PR TITLE
Fix the race condition during vttablet startup

### DIFF
--- a/go/test/endtoend/utils/mysql_test.go
+++ b/go/test/endtoend/utils/mysql_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,7 +130,9 @@ func TestSetSuperReadOnlyMySQL(t *testing.T) {
 func TestGetMysqlPort(t *testing.T) {
 	require.NotNil(t, mysqld)
 
-	port, err := mysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := mysqld.GetMysqlPort(ctx)
 
 	// Expected port should be one less than the port returned by GetAndReservePort
 	// As we are calling this second time to get port
@@ -161,7 +164,9 @@ func TestReplicationStatus(t *testing.T) {
 	conn, err := mysql.Connect(ctx, &mysqlParams)
 	require.NoError(t, err)
 
-	port, err := mysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := mysqld.GetMysqlPort(ctx)
 	require.NoError(t, err)
 	host := "localhost"
 
@@ -234,7 +239,9 @@ func TestSetReplicationPosition(t *testing.T) {
 func TestSetAndResetReplication(t *testing.T) {
 	require.NotNil(t, mysqld)
 
-	port, err := mysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := mysqld.GetMysqlPort(ctx)
 	require.NoError(t, err)
 	host := "localhost"
 
@@ -387,7 +394,9 @@ func TestWaitForReplicationStart(t *testing.T) {
 	err := mysqlctl.WaitForReplicationStart(mysqld, 1)
 	assert.ErrorContains(t, err, "no replication status")
 
-	port, err := mysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := mysqld.GetMysqlPort(ctx)
 	require.NoError(t, err)
 	host := "localhost"
 
@@ -407,7 +416,9 @@ func TestStartReplication(t *testing.T) {
 	err := mysqld.StartReplication(map[string]string{})
 	assert.ErrorContains(t, err, "The server is not configured as replica")
 
-	port, err := mysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := mysqld.GetMysqlPort(ctx)
 	require.NoError(t, err)
 	host := "localhost"
 
@@ -425,7 +436,9 @@ func TestStartReplication(t *testing.T) {
 func TestStopReplication(t *testing.T) {
 	require.NotNil(t, mysqld)
 
-	port, err := mysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := mysqld.GetMysqlPort(ctx)
 	require.NoError(t, err)
 	host := "localhost"
 
@@ -449,7 +462,9 @@ func TestStopReplication(t *testing.T) {
 func TestStopSQLThread(t *testing.T) {
 	require.NotNil(t, mysqld)
 
-	port, err := mysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := mysqld.GetMysqlPort(ctx)
 	require.NoError(t, err)
 	host := "localhost"
 

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -273,7 +273,7 @@ func (fmd *FakeMysqlDaemon) WaitForDBAGrants(ctx context.Context, waitTime time.
 }
 
 // GetMysqlPort is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) GetMysqlPort() (int32, error) {
+func (fmd *FakeMysqlDaemon) GetMysqlPort(ctx context.Context) (int32, error) {
 	if fmd.MysqlPort.Load() == -1 {
 		return 0, fmt.Errorf("FakeMysqlDaemon.GetMysqlPort returns an error")
 	}

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -43,7 +43,7 @@ type MysqlDaemon interface {
 	WaitForDBAGrants(ctx context.Context, waitTime time.Duration) (err error)
 
 	// GetMysqlPort returns the current port mysql is listening on.
-	GetMysqlPort() (int32, error)
+	GetMysqlPort(ctx context.Context) (int32, error)
 
 	// GetServerID returns the servers ID.
 	GetServerID(ctx context.Context) (uint32, error)

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -521,11 +521,15 @@ func (mysqld *Mysqld) WaitForDBAGrants(ctx context.Context, waitTime time.Durati
 	if waitTime == 0 {
 		return nil
 	}
+	params, err := mysqld.dbcfgs.DbaConnector().MysqlParams()
+	if err != nil {
+		return err
+	}
 	timer := time.NewTimer(waitTime)
 	ctx, cancel := context.WithTimeout(ctx, waitTime)
 	defer cancel()
 	for {
-		conn, connErr := dbconnpool.NewDBConnection(ctx, mysqld.dbcfgs.DbaConnector())
+		conn, connErr := mysql.Connect(ctx, params)
 		if connErr == nil {
 			res, fetchErr := conn.ExecuteFetch("SHOW GRANTS", 1000, false)
 			conn.Close()

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -133,12 +134,14 @@ func TestGetMysqlPort(t *testing.T) {
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
 
-	res, err := testMysqld.GetMysqlPort()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := testMysqld.GetMysqlPort(ctx)
 	assert.Equal(t, int32(12), res)
 	assert.NoError(t, err)
 
 	db.AddQuery("SHOW VARIABLES LIKE 'port'", &sqltypes.Result{})
-	res, err = testMysqld.GetMysqlPort()
+	res, err = testMysqld.GetMysqlPort(ctx)
 	assert.ErrorContains(t, err, "no port variable in mysql")
 	assert.Equal(t, int32(0), res)
 }


### PR DESCRIPTION
This avoids the problem where the connection pool is poisoned when we check for the MySQL port, by avoiding to use the pool in the first place. We only ever run this once at startup, so we can create a new connection here and then dispose of it once we've retrieved the port.

That way we know the connection pool is still clean and doesn't have any problems.

## Related Issue(s)

Fixes #15730

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required