### PR TITLE
Assign and tag the release team for go update/upgrade auto PRs

### DIFF
--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -41,9 +41,8 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.CREATE_PR_VITESS_BOT }}
         with:
+          token: ${{ secrets.CREATE_PR_VITESS_BOT }}
           branch: "upgrade-go-deps-on-main-test"
           commit-message: "upgrade go deps"
           signoff: true

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          branch: "upgrade-go-deps-on-main"
+          branch: "upgrade-go-deps-on-main-test"
           commit-message: "upgrade go deps"
           signoff: true
           delete-branch: true

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -1,6 +1,7 @@
 name: Update Golang Dependencies
 
 on:
+  pull_request:
   schedule:
     - cron: "0 0 1,15 * *" # Runs every month on the 1st and 15th days at midnight UTC
   workflow_dispatch:
@@ -45,9 +46,12 @@ jobs:
           commit-message: "upgrade go deps"
           signoff: true
           delete-branch: true
+          reviewers: vitessio/release
           title: "Upgrade the Golang Dependencies"
           body: |
             This Pull Request updates all the Golang dependencies to their latest version using `go get -u ./...`.
+            
+            cc @vitessio/release
           base: main
           labels: |
             go

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -1,7 +1,6 @@
 name: Update Golang Dependencies
 
 on:
-  pull_request:
   schedule:
     - cron: "0 0 1,15 * *" # Runs every month on the 1st and 15th days at midnight UTC
   workflow_dispatch:

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -42,7 +42,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.CREATE_PR_VITESS_BOT }}
-          branch: "upgrade-go-deps-on-main-test"
+          branch: "upgrade-go-deps-on-main"
           commit-message: "upgrade go deps"
           signoff: true
           delete-branch: true

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -41,12 +41,14 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.CREATE_PR_VITESS_BOT }}
         with:
           branch: "upgrade-go-deps-on-main-test"
           commit-message: "upgrade go deps"
           signoff: true
           delete-branch: true
-          reviewers: vitessio/release
+          team-reviewers: vitessio/release
           title: "Upgrade the Golang Dependencies"
           body: |
             This Pull Request updates all the Golang dependencies to their latest version using `go get -u ./...`.

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -55,6 +55,5 @@ jobs:
           base: main
           labels: |
             go
-            dependencies
             Component: General
-            Type: Internal Cleanup
+            Type: Dependencies

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -48,7 +48,7 @@ jobs:
           commit-message: "upgrade go deps"
           signoff: true
           delete-branch: true
-          team-reviewers: vitessio/release
+          team-reviewers: Release
           title: "Upgrade the Golang Dependencies"
           body: |
             This Pull Request updates all the Golang dependencies to their latest version using `go get -u ./...`.

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -65,14 +65,13 @@ jobs:
       - name: Create Pull Request
         if: steps.detect-and-update.outputs.create-pr == 'true'
         uses: peter-evans/create-pull-request@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.CREATE_PR_VITESS_BOT }}
         with:
+          token: ${{ secrets.CREATE_PR_VITESS_BOT }}
           branch: "upgrade-go-to-${{steps.detect-and-update.outputs.go-version}}-on-${{ matrix.branch }}"
           commit-message: "bump go version to go${{steps.detect-and-update.outputs.go-version}}"
           signoff: true
           delete-branch: true
-          team-reviewers: vitessio/release
+          team-reviewers: Release
           title: "[${{ matrix.branch }}] Upgrade the Golang version to `go${{steps.detect-and-update.outputs.go-version}}`"
           body: |
             This Pull Request bumps the Golang version to `go${{steps.detect-and-update.outputs.go-version}}` and the bootstrap version to `${{steps.detect-and-update.outputs.bootstrap-version}}`.

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -65,12 +65,14 @@ jobs:
       - name: Create Pull Request
         if: steps.detect-and-update.outputs.create-pr == 'true'
         uses: peter-evans/create-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.CREATE_PR_VITESS_BOT }}
         with:
           branch: "upgrade-go-to-${{steps.detect-and-update.outputs.go-version}}-on-${{ matrix.branch }}"
           commit-message: "bump go version to go${{steps.detect-and-update.outputs.go-version}}"
           signoff: true
           delete-branch: true
-          reviewers: vitessio/release
+          team-reviewers: vitessio/release
           title: "[${{ matrix.branch }}] Upgrade the Golang version to `go${{steps.detect-and-update.outputs.go-version}}`"
           body: |
             This Pull Request bumps the Golang version to `go${{steps.detect-and-update.outputs.go-version}}` and the bootstrap version to `${{steps.detect-and-update.outputs.bootstrap-version}}`.

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -70,6 +70,7 @@ jobs:
           commit-message: "bump go version to go${{steps.detect-and-update.outputs.go-version}}"
           signoff: true
           delete-branch: true
+          reviewers: vitessio/release
           title: "[${{ matrix.branch }}] Upgrade the Golang version to `go${{steps.detect-and-update.outputs.go-version}}`"
           body: |
             This Pull Request bumps the Golang version to `go${{steps.detect-and-update.outputs.go-version}}` and the bootstrap version to `${{steps.detect-and-update.outputs.bootstrap-version}}`.
@@ -81,6 +82,8 @@ jobs:
               - [ ] Build and Push the bootstrap images to Docker Hub, the bot cannot handle that.
               - [ ] Update the `./.github/workflows/*.yml` files with the newer Golang version, the bot cannot handle that due to permissions.
                 - To accomplish this, run the following: `go run ./go/tools/go-upgrade/go-upgrade.go upgrade workflows --go-to=${{steps.detect-and-update.outputs.go-version}}`
+            
+            cc @vitessio/release
           base: ${{ matrix.branch }}
           labels: |
             Skip CI


### PR DESCRIPTION
## Description

This PR changes the automatic golang deps update and version upgrade to tag the `@vitessio/release` team in the reviewers list and in the PRs' descriptions.

To do this, I have generated a PAT for the @vitess-bot account and used it in the create-pull-request action. Here is what a PR for the update dependencies looks like now: https://github.com/vitessio/vitess/pull/15743
