### PR TITLE
GRPC: Address potential segfault in dedicated connection pooling

### DIFF
--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -235,8 +235,10 @@ func (client *grpcClient) dialDedicatedPool(ctx context.Context, dialPoolGroup D
 	invalidator := func() {
 		client.mu.Lock()
 		defer client.mu.Unlock()
-		m[addr].cc.Close()
-		delete(m, addr)
+		if _, exists := m[addr]; exists {
+			m[addr].cc.Close()
+			delete(m, addr)
+		}
 	}
 	return m[addr].client, invalidator, nil
 }

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -235,9 +235,9 @@ func (client *grpcClient) dialDedicatedPool(ctx context.Context, dialPoolGroup D
 	invalidator := func() {
 		client.mu.Lock()
 		defer client.mu.Unlock()
-		if m[addr] != nil {
-			if m[addr].cc != nil {
-				m[addr].cc.Close()
+		if tm, ok := m[addr]; ok {
+			if tm != nil && tm.cc != nil {
+				tm.cc.Close()
 			}
 			delete(m, addr)
 		}

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -235,8 +235,10 @@ func (client *grpcClient) dialDedicatedPool(ctx context.Context, dialPoolGroup D
 	invalidator := func() {
 		client.mu.Lock()
 		defer client.mu.Unlock()
-		if _, exists := m[addr]; exists {
-			m[addr].cc.Close()
+		if m[addr] != nil {
+			if m[addr].cc != nil {
+				m[addr].cc.Close()
+			}
 			delete(m, addr)
 		}
 	}

--- a/go/vt/vttablet/grpctmclient/client_test.go
+++ b/go/vt/vttablet/grpctmclient/client_test.go
@@ -48,6 +48,13 @@ func TestDialDedicatedPool(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, invalidator)
 		assert.NotNil(t, cli)
+		_, invalidatorTwo, err := poolDialer.dialDedicatedPool(ctx, dialPoolGroupThrottler, tablet)
+		assert.NoError(t, err)
+		// Ensure that running both the invalidators doesn't cause any issues.
+		invalidator()
+		invalidatorTwo()
+		_, _, err = poolDialer.dialDedicatedPool(ctx, dialPoolGroupThrottler, tablet)
+		assert.NoError(t, err)
 	})
 
 	var cachedTmc *tmc


### PR DESCRIPTION
## Description

This PR fixes a segmentation fault that is caused by calling the invalidator function gotten from the dedicated connection pooling more than once. The second time around, there is no map entry, so we end up dereferencing a nil pointer.

The two Vitess components that were affected by this (as they are the only dedicated connection pool users today)  are:
  - [VTOrc](https://vitess.io/docs/reference/vtorc/)
  - [Tablet throttler](https://vitess.io/docs/reference/features/tablet-throttler/)

The only Vitess release affected by this was [v19.0.3](https://github.com/vitessio/vitess/releases/tag/v19.0.3).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
  - Fixes https://github.com/vitessio/vitess/issues/15752

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
