### PR TITLE
modify error message when transaction not found in numbered pool

### DIFF
--- a/go/pools/numbered.go
+++ b/go/pools/numbered.go
@@ -108,7 +108,7 @@ func (nu *Numbered) Get(id int64, purpose string) (val any, err error) {
 		if unreg, ok := nu.recentlyUnregistered.Get(fmt.Sprintf("%v", id)); ok {
 			return nil, fmt.Errorf("ended at %v (%v)", unreg.timeUnregistered.Format("2006-01-02 15:04:05.000 MST"), unreg.reason)
 		}
-		return nil, fmt.Errorf("not found")
+		return nil, fmt.Errorf("not found (potential transaction timeout)")
 	}
 	if nw.inUse {
 		return nil, fmt.Errorf("in use: %s", nw.purpose)

--- a/go/pools/numbered_test.go
+++ b/go/pools/numbered_test.go
@@ -45,7 +45,7 @@ func TestNumberedGeneral(t *testing.T) {
 
 	p.Put(id)
 	_, err = p.Get(1, "test2")
-	assert.Contains(t, "not found", err.Error())
+	assert.ErrorContains(t, err, "not found (potential transaction timeout)")
 	p.Unregister(1, "test") // Should not fail
 	p.Unregister(0, "test")
 	// p is now empty


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR modified the error message when a transaction ID is not found in the active pool and evicted from the unregisted cache. When there is a high QPS system, it can land in this situation. So, modified the message to give some potential reason for it i.e. a transaction timeout.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
