### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters will much better

### DIFF
--- a/go/vt/hook/hook.go
+++ b/go/vt/hook/hook.go
@@ -100,7 +100,7 @@ func NewHookWithEnv(name string, params []string, env map[string]string) *Hook {
 func (hook *Hook) findHook(ctx context.Context) (*exec.Cmd, int, error) {
 	// Check the hook path.
 	if strings.Contains(hook.Name, "/") {
-		return nil, HOOK_INVALID_NAME, fmt.Errorf("hook cannot contain '/'")
+		return nil, HOOK_INVALID_NAME, errors.New("hook cannot contain '/'")
 	}
 
 	// Find our root.

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -18,6 +18,7 @@ package topo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"sort"
@@ -547,7 +548,7 @@ func (ts *Server) InitTablet(ctx context.Context, tablet *topodatapb.Tablet, all
 	} else {
 		si, err = ts.GetShard(ctx, tablet.Keyspace, tablet.Shard)
 		if IsErrType(err, NoNode) {
-			return fmt.Errorf("missing parent shard, use -parent option to create it, or CreateKeyspace / CreateShard")
+			return errors.New("missing parent shard, use -parent option to create it, or CreateKeyspace / CreateShard")
 		}
 	}
 

--- a/go/vt/topo/zk2topo/file.go
+++ b/go/vt/topo/zk2topo/file.go
@@ -18,7 +18,7 @@ package zk2topo
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"path"
 
 	"context"
@@ -46,7 +46,7 @@ func (zs *Server) Create(ctx context.Context, filePath string, contents []byte) 
 		return nil, convertError(err, zkPath)
 	}
 	if !bytes.Equal(data, contents) {
-		return nil, fmt.Errorf("file contents changed between zk.Create and zk.Get")
+		return nil, errors.New("file contents changed between zk.Create and zk.Get")
 	}
 
 	return ZKVersion(stat.Version), nil

--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
+	"errors"
 	"math/rand/v2"
 	"net"
 	"os"
@@ -411,7 +411,7 @@ func dialZk(ctx context.Context, addr string) (*zk.Conn, <-chan zk.Event, error)
 			case zk.StateAuthFailed:
 				// fast fail this one
 				zconn.Close()
-				return nil, nil, fmt.Errorf("zk connect failed: StateAuthFailed")
+				return nil, nil, errors.New("zk connect failed: StateAuthFailed")
 			}
 		}
 	}


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters will much better
