### PR TITLE
Multi-tenant MoveTables: allow switching replica/rdonly traffic separately before switching primary traffic

### DIFF
--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -285,6 +285,7 @@ func waitForRowCountInTablet(t *testing.T, vttablet *cluster.VttabletProcess, da
 		require.NoError(t, err)
 		require.NotNil(t, qr)
 		if wantRes == fmt.Sprintf("%v", qr.Rows) {
+			log.Infof("waitForRowCountInTablet: found %d rows in table %s on tablet %s", want, table, vttablet.Name)
 			return
 		}
 		select {

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -991,17 +991,17 @@ func getCellNames(cells []*Cell) string {
 
 // VExplainPlan is the struct that represents the json output of a vexplain query.
 type VExplainPlan struct {
-	OperatorType string           `json:"OperatorType"`
-	Variant      string           `json:"Variant"`
-	Keyspace     VExplainKeyspace `json:"Keyspace"`
-	FieldQuery   string           `json:"FieldQuery"`
-	Query        string           `json:"Query"`
-	Table        string           `json:"Table"`
+	OperatorType string
+	Variant      string
+	Keyspace     VExplainKeyspace
+	FieldQuery   string
+	Query        string
+	Table        string
 }
 
 type VExplainKeyspace struct {
-	Name    string `json:"Name"`
-	Sharded bool   `json:"Sharded"`
+	Name    string
+	Sharded bool
 }
 
 // vexplain runs vexplain on the given query and returns the plan. Useful for validating routing rules.

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -1020,15 +1020,13 @@ func vexplain(t *testing.T, database, query string) *VExplainPlan {
 }
 
 // confirmKeyspacesRoutedTo confirms that the given keyspaces are routed as expected for the given tablet types, using vexplain.
-func confirmKeyspacesRoutedTo(t *testing.T, keyspaces []string, routedKeyspace, table string, tabletTypes []string) {
+func confirmKeyspacesRoutedTo(t *testing.T, keyspace string, routedKeyspace, table string, tabletTypes []string) {
 	if len(tabletTypes) == 0 {
 		tabletTypes = []string{"primary", "replica", "rdonly"}
 	}
-	for _, ks := range keyspaces {
-		for _, tt := range tabletTypes {
-			database := fmt.Sprintf("%s@%s", ks, tt)
-			plan := vexplain(t, database, fmt.Sprintf("select * from %s.%s", ks, table))
-			require.Equalf(t, routedKeyspace, plan.Keyspace.Name, "for database %s, keyspaces %v, tabletType %s", database, keyspaces, tt)
-		}
+	for _, tt := range tabletTypes {
+		database := fmt.Sprintf("%s@%s", keyspace, tt)
+		plan := vexplain(t, database, fmt.Sprintf("select * from %s.%s", keyspace, table))
+		require.Equalf(t, routedKeyspace, plan.Keyspace.Name, "for database %s, keyspace %v, tabletType %s", database, keyspace, tt)
 	}
 }

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -34,13 +34,12 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/json2"
-
 	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqlescape"
@@ -989,6 +988,7 @@ func getCellNames(cells []*Cell) string {
 	return strings.Join(cellNames, ",")
 }
 
+// VExplainPlan is the struct that represents the json output of a vexplain query.
 type VExplainPlan struct {
 	OperatorType string           `json:"OperatorType"`
 	Variant      string           `json:"Variant"`
@@ -1003,18 +1003,22 @@ type VExplainKeyspace struct {
 	Sharded bool   `json:"Sharded"`
 }
 
+// vexplain runs vexplain on the given query and returns the plan. Useful for validating routing rules.
 func vexplain(t *testing.T, database, query string) *VExplainPlan {
 	vtgateConn := vc.GetVTGateConn(t)
 	defer vtgateConn.Close()
+
 	qr := execVtgateQuery(t, vtgateConn, database, fmt.Sprintf("vexplain %s", query))
 	require.NotNil(t, qr)
 	require.Equal(t, 1, len(qr.Rows))
 	json := qr.Rows[0][0].ToString()
+
 	var plan VExplainPlan
 	require.NoError(t, json2.Unmarshal([]byte(json), &plan))
 	return &plan
 }
 
+// confirmKeyspacesRoutedTo confirms that the given keyspaces are routed as expected for the given tablet types, using vexplain.
 func confirmKeyspacesRoutedTo(t *testing.T, keyspaces []string, routedKeyspace, table string, tabletTypes []string) {
 	if len(tabletTypes) == 0 {
 		tabletTypes = []string{"primary", "replica", "rdonly"}

--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -174,10 +174,10 @@ func TestMultiTenantSimple(t *testing.T) {
 	waitForWorkflowState(t, vc, fmt.Sprintf("%s.%s", targetKeyspace, mt.workflowName), binlogdatapb.VReplicationWorkflowState_Running.String())
 
 	mt.SwitchReads()
-	confirmReadsSwitched(t)
+	confirmOnlyReadsSwitched(t)
 
 	mt.SwitchWrites()
-	confirmReadsAndWritesSwitched(t)
+	confirmBothReadsAndWritesSwitched(t)
 
 	// Note: here we have already switched, and we can insert into the target keyspace, and it should get reverse
 	// replicated to the source keyspace. The source keyspace is routed to the target keyspace at this point.
@@ -198,7 +198,7 @@ func TestMultiTenantSimple(t *testing.T) {
 
 }
 
-func confirmReadsSwitched(t *testing.T) {
+func confirmOnlyReadsSwitched(t *testing.T) {
 	confirmKeyspacesRoutedTo(t, "s1", "mt", "t1", []string{"rdonly", "replica"})
 	confirmKeyspacesRoutedTo(t, "s1", "s1", "t1", []string{"primary"})
 	rules := &vschemapb.KeyspaceRoutingRules{
@@ -211,7 +211,7 @@ func confirmReadsSwitched(t *testing.T) {
 	validateKeyspaceRoutingRules(t, vc, rules)
 }
 
-func confirmWritesSwitched(t *testing.T) {
+func confirmOnlyWritesSwitched(t *testing.T) {
 	confirmKeyspacesRoutedTo(t, "s1", "s1", "t1", []string{"rdonly", "replica"})
 	confirmKeyspacesRoutedTo(t, "s1", "mt", "t1", []string{"primary"})
 	rules := &vschemapb.KeyspaceRoutingRules{
@@ -224,7 +224,7 @@ func confirmWritesSwitched(t *testing.T) {
 	validateKeyspaceRoutingRules(t, vc, rules)
 }
 
-func confirmReadsAndWritesSwitched(t *testing.T) {
+func confirmBothReadsAndWritesSwitched(t *testing.T) {
 	confirmKeyspacesRoutedTo(t, "s1", "mt", "t1", []string{"rdonly", "replica"})
 	confirmKeyspacesRoutedTo(t, "s1", "mt", "t1", []string{"primary"})
 	rules := &vschemapb.KeyspaceRoutingRules{

--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -298,7 +298,7 @@ func TestMultiTenantComplex(t *testing.T) {
 	vtgateConn, closeConn := getVTGateConn()
 	defer closeConn()
 	t.Run("Verify all rows have been migrated", func(t *testing.T) {
-		numAdditionalInsertSets := 2 // during the SwitchTraffic stop
+		numAdditionalInsertSets := 2 /* during the SwitchTraffic stop */ + 1 /* after Complete */
 		totalRowsInsertedPerTenant := numInitialRowsPerTenant + numAdditionalRowsPerTenant*numAdditionalInsertSets
 		totalRowsInserted := totalRowsInsertedPerTenant * numTenants
 		totalActualRowsInserted := getRowCount(t, vtgateConn, fmt.Sprintf("%s.%s", mtm.targetKeyspace, "t1"))
@@ -416,6 +416,7 @@ func (mtm *multiTenantMigration) switchTraffic(tenantId int64) {
 func (mtm *multiTenantMigration) complete(tenantId int64) {
 	mt := mtm.getActiveMoveTables(tenantId)
 	mt.Complete()
+	mtm.insertSomeData(mtm.t, tenantId, mtm.targetKeyspace, numAdditionalRowsPerTenant)
 	vtgateConn := vc.GetVTGateConn(mtm.t)
 	defer vtgateConn.Close()
 	waitForQueryResult(mtm.t, vtgateConn, "",

--- a/go/test/endtoend/vreplication/wrappers_test.go
+++ b/go/test/endtoend/vreplication/wrappers_test.go
@@ -134,7 +134,7 @@ func (vmt *VtctlMoveTables) ReverseReadsAndWrites() {
 }
 
 func (vmt *VtctlMoveTables) Show() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -148,12 +148,12 @@ func (vmt *VtctlMoveTables) exec(action string) {
 	require.NoError(vmt.vc.t, err)
 }
 func (vmt *VtctlMoveTables) SwitchReads() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (vmt *VtctlMoveTables) SwitchWrites() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -232,13 +232,15 @@ func (v VtctldMoveTables) Show() {
 }
 
 func (v VtctldMoveTables) SwitchReads() {
-	//TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic", "--tablet-types=rdonly,replica"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldMoveTables) SwitchWrites() {
-	//TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic", "--tablet-types=primary"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldMoveTables) Cancel() {
@@ -327,7 +329,7 @@ func (vrs *VtctlReshard) ReverseReadsAndWrites() {
 }
 
 func (vrs *VtctlReshard) Show() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -339,12 +341,12 @@ func (vrs *VtctlReshard) exec(action string) {
 }
 
 func (vrs *VtctlReshard) SwitchReads() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (vrs *VtctlReshard) SwitchWrites() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -421,12 +423,12 @@ func (v VtctldReshard) Show() {
 }
 
 func (v VtctldReshard) SwitchReads() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (v VtctldReshard) SwitchWrites() {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1586,10 +1586,12 @@ func (s *Server) setupInitialRoutingRules(ctx context.Context, req *vtctldatapb.
 		var keyspaces []string
 		// Note that you can never point the target keyspace to the source keyspace in a multi-tenant migration
 		// since the target takes write traffic for all tenants!
-		keyspaces = append(keyspaces, sourceKeyspace)
+		keyspaces = append(keyspaces, sourceKeyspace, targetKeyspace)
 		routes := make(map[string]string)
 		for _, ks := range keyspaces {
-			routes[ks] = sourceKeyspace
+			for _, tt := range tabletTypeSuffixes {
+				routes[ks+tt] = sourceKeyspace
+			}
 		}
 		if err := updateKeyspaceRoutingRule(ctx, s.ts, routes); err != nil {
 			return err

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -3139,7 +3139,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 		if err != nil {
 			return nil, err
 		}
-		if len(req.GetCells()) != len(allCells) {
+		if len(req.GetCells()) != 0 && len(req.GetCells()) != len(allCells) {
 			return handleError("invalid request", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "requesting read traffic for multi-tenant migrations must include all cells"))
 		}
 	}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1566,15 +1566,11 @@ func (s *Server) setupInitialRoutingRules(ctx context.Context, req *vtctldatapb.
 
 	if mz.IsMultiTenantMigration() {
 		log.Infof("Setting up keyspace routing rules for workflow %s.%s", targetKeyspace, req.Workflow)
-		var keyspaces []string
 		// Note that you can never point the target keyspace to the source keyspace in a multi-tenant migration
 		// since the target takes write traffic for all tenants!
-		keyspaces = append(keyspaces, sourceKeyspace, targetKeyspace)
 		routes := make(map[string]string)
-		for _, ks := range keyspaces {
-			for _, tt := range tabletTypeSuffixes {
-				routes[ks+tt] = sourceKeyspace
-			}
+		for _, tt := range tabletTypeSuffixes {
+			routes[sourceKeyspace+tt] = sourceKeyspace
 		}
 		if err := updateKeyspaceRoutingRule(ctx, s.ts, routes); err != nil {
 			return err

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -3139,7 +3139,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 		if err != nil {
 			return nil, err
 		}
-		if req.Cells != nil && len(req.Cells) != len(allCells) {
+		if len(req.GetCells()) != len(allCells) {
 			return handleError("invalid request", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "requesting read traffic for multi-tenant migrations must include all cells"))
 		}
 	}
@@ -3199,8 +3199,8 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 		case ts.IsMultiTenantMigration():
 			err := sw.switchKeyspaceReads(ctx, roTabletTypes)
 			if err != nil {
-				return handleError(fmt.Sprintf("failed to switch read traffic for keyspace %s, workflow %s",
-					ts.SourceKeyspaceName(), ts.WorkflowName()), err)
+				return handleError(fmt.Sprintf("failed to switch read traffic, from source keyspace %s to target keyspace %s, workflow %s",
+					ts.SourceKeyspaceName(), ts.TargetKeyspaceName(), ts.WorkflowName()), err)
 			}
 		case ts.isPartialMigration:
 			ts.Logger().Infof("Partial migration, skipping switchTableReads as traffic is all or nothing per shard and overridden for reads AND writes in the ShardRoutingRule created when switching writes.")

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -67,7 +67,12 @@ func (r *switcher) dropSourceShards(ctx context.Context) error {
 }
 
 func (r *switcher) switchKeyspaceReads(ctx context.Context, servedTypes []topodatapb.TabletType) error {
-	return r.ts.switchKeyspaceReads(ctx, servedTypes)
+	if err := changeKeyspaceRoute(ctx, r.ts.TopoServer(), servedTypes,
+		[]string{r.ts.SourceKeyspaceName(), r.ts.TargetKeyspaceName()},
+		r.ts.TargetKeyspaceName()); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *switcher) switchShardReads(ctx context.Context, cells []string, servedTypes []topodatapb.TabletType, direction TrafficSwitchDirection) error {

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -68,8 +68,7 @@ func (r *switcher) dropSourceShards(ctx context.Context) error {
 
 func (r *switcher) switchKeyspaceReads(ctx context.Context, servedTypes []topodatapb.TabletType) error {
 	if err := changeKeyspaceRoute(ctx, r.ts.TopoServer(), servedTypes,
-		[]string{r.ts.SourceKeyspaceName(), r.ts.TargetKeyspaceName()},
-		r.ts.TargetKeyspaceName()); err != nil {
+		r.ts.SourceKeyspaceName() /* from */, r.ts.TargetKeyspaceName() /* to */); err != nil {
 		return err
 	}
 	return nil

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -67,7 +67,7 @@ func (r *switcher) dropSourceShards(ctx context.Context) error {
 }
 
 func (r *switcher) switchKeyspaceReads(ctx context.Context, servedTypes []topodatapb.TabletType) error {
-	if err := changeKeyspaceRoute(ctx, r.ts.TopoServer(), servedTypes,
+	if err := changeKeyspaceRouting(ctx, r.ts.TopoServer(), servedTypes,
 		r.ts.SourceKeyspaceName() /* from */, r.ts.TargetKeyspaceName() /* to */); err != nil {
 		return err
 	}

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -66,6 +66,10 @@ func (r *switcher) dropSourceShards(ctx context.Context) error {
 	return r.ts.dropSourceShards(ctx)
 }
 
+func (r *switcher) switchKeyspaceReads(ctx context.Context, servedTypes []topodatapb.TabletType) error {
+	return r.ts.switchKeyspaceReads(ctx, servedTypes)
+}
+
 func (r *switcher) switchShardReads(ctx context.Context, cells []string, servedTypes []topodatapb.TabletType, direction TrafficSwitchDirection) error {
 	return r.ts.switchShardReads(ctx, cells, servedTypes, direction)
 }

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -63,6 +63,16 @@ func (dr *switcherDryRun) deleteKeyspaceRoutingRules(ctx context.Context) error 
 	return nil
 }
 
+func (dr *switcherDryRun) switchKeyspaceReads(ctx context.Context, types []topodatapb.TabletType) error {
+	var tabletTypes []string
+	for _, servedType := range types {
+		tabletTypes = append(tabletTypes, servedType.String())
+	}
+	dr.drLog.Logf("Switch reads for keyspace %s to keyspace %s for tablet types [%s]",
+		dr.ts.SourceKeyspaceName(), dr.ts.TargetKeyspaceName(), strings.Join(tabletTypes, ","))
+	return nil
+}
+
 func (dr *switcherDryRun) switchShardReads(ctx context.Context, cells []string, servedTypes []topodatapb.TabletType, direction TrafficSwitchDirection) error {
 	sourceShards := make([]string, 0)
 	targetShards := make([]string, 0)

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -68,7 +68,7 @@ func (dr *switcherDryRun) switchKeyspaceReads(ctx context.Context, types []topod
 	for _, servedType := range types {
 		tabletTypes = append(tabletTypes, servedType.String())
 	}
-	dr.drLog.Logf("Switch reads for keyspace %s to keyspace %s for tablet types [%s]",
+	dr.drLog.Logf("Switch reads from keyspace %s to keyspace %s for tablet types [%s]",
 		dr.ts.SourceKeyspaceName(), dr.ts.TargetKeyspaceName(), strings.Join(tabletTypes, ","))
 	return nil
 }

--- a/go/vt/vtctl/workflow/switcher_interface.go
+++ b/go/vt/vtctl/workflow/switcher_interface.go
@@ -36,6 +36,7 @@ type iswitcher interface {
 	changeRouting(ctx context.Context) error
 	streamMigraterfinalize(ctx context.Context, ts *trafficSwitcher, workflows []string) error
 	startReverseVReplication(ctx context.Context) error
+	switchKeyspaceReads(ctx context.Context, types []topodatapb.TabletType) error
 	switchTableReads(ctx context.Context, cells []string, servedType []topodatapb.TabletType, rebuildSrvVSchema bool, direction TrafficSwitchDirection) error
 	switchShardReads(ctx context.Context, cells []string, servedType []topodatapb.TabletType, direction TrafficSwitchDirection) error
 	validateWorkflowHasCompleted(ctx context.Context) error

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -739,7 +739,7 @@ func (ts *trafficSwitcher) changeWriteRoute(ctx context.Context) error {
 		// For multi-tenant migrations, we can only move forward and not backwards.
 		ts.Logger().Infof("Pointing keyspace routing rules for primary to %s for workflow %s", ts.TargetKeyspaceName(), ts.workflow)
 		if err := changeKeyspaceRoute(ctx, ts.TopoServer(), []topodatapb.TabletType{topodatapb.TabletType_PRIMARY},
-			[]string{ts.SourceKeyspaceName(), ts.TargetKeyspaceName()}, ts.TargetKeyspaceName()); err != nil {
+			ts.SourceKeyspaceName() /* from */, ts.TargetKeyspaceName() /* to */); err != nil {
 			return err
 		}
 	} else if ts.isPartialMigration {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -450,7 +450,6 @@ func (ts *trafficSwitcher) deleteKeyspaceRoutingRules(ctx context.Context) error
 	}
 	for _, suffix := range tabletTypeSuffixes {
 		delete(krr, ts.SourceKeyspaceName()+suffix)
-		delete(krr, ts.TargetKeyspaceName()+suffix)
 	}
 	if err := topotools.SaveKeyspaceRoutingRules(ctx, ts.TopoServer(), krr); err != nil {
 		return err
@@ -738,7 +737,7 @@ func (ts *trafficSwitcher) changeWriteRoute(ctx context.Context) error {
 	if ts.IsMultiTenantMigration() {
 		// For multi-tenant migrations, we can only move forward and not backwards.
 		ts.Logger().Infof("Pointing keyspace routing rules for primary to %s for workflow %s", ts.TargetKeyspaceName(), ts.workflow)
-		if err := changeKeyspaceRoute(ctx, ts.TopoServer(), []topodatapb.TabletType{topodatapb.TabletType_PRIMARY},
+		if err := changeKeyspaceRouting(ctx, ts.TopoServer(), []topodatapb.TabletType{topodatapb.TabletType_PRIMARY},
 			ts.SourceKeyspaceName() /* from */, ts.TargetKeyspaceName() /* to */); err != nil {
 			return err
 		}

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -850,13 +850,11 @@ func getTenantClause(vrOptions *vtctldatapb.WorkflowOptions,
 	return &sel.Where.Expr, nil
 }
 
-func changeKeyspaceRoute(ctx context.Context, ts *topo.Server, tabletTypes []topodatapb.TabletType, keyspaces []string, routedKeyspace string) error {
+func changeKeyspaceRoute(ctx context.Context, ts *topo.Server, tabletTypes []topodatapb.TabletType, sourceKeyspace string, routedKeyspace string) error {
 	routes := make(map[string]string)
-	for _, keyspace := range keyspaces {
-		for _, tabletType := range tabletTypes {
-			suffix := getTabletTypeSuffix(tabletType)
-			routes[keyspace+suffix] = routedKeyspace
-		}
+	for _, tabletType := range tabletTypes {
+		suffix := getTabletTypeSuffix(tabletType)
+		routes[sourceKeyspace+suffix] = routedKeyspace
 	}
 	if err := updateKeyspaceRoutingRule(ctx, ts, routes); err != nil {
 		return err

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -850,11 +850,12 @@ func getTenantClause(vrOptions *vtctldatapb.WorkflowOptions,
 	return &sel.Where.Expr, nil
 }
 
-func changeKeyspaceRoute(ctx context.Context, ts *topo.Server, tabletTypes []topodatapb.TabletType, sourceKeyspace string, routedKeyspace string) error {
+func changeKeyspaceRouting(ctx context.Context, ts *topo.Server, tabletTypes []topodatapb.TabletType,
+	sourceKeyspace string, targetKeyspace string) error {
 	routes := make(map[string]string)
 	for _, tabletType := range tabletTypes {
 		suffix := getTabletTypeSuffix(tabletType)
-		routes[sourceKeyspace+suffix] = routedKeyspace
+		routes[sourceKeyspace+suffix] = targetKeyspace
 	}
 	if err := updateKeyspaceRoutingRule(ctx, ts, routes); err != nil {
 		return err

--- a/go/vt/vtctl/workflow/workflow_test.go
+++ b/go/vt/vtctl/workflow/workflow_test.go
@@ -1,0 +1,1 @@
+package workflow

--- a/go/vt/vtctl/workflow/workflow_test.go
+++ b/go/vt/vtctl/workflow/workflow_test.go
@@ -1,1 +1,0 @@
-package workflow

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/vt/log"
 
 	"vitess.io/vitess/go/ptr"
 	"vitess.io/vitess/go/vt/topotools"
@@ -1134,34 +1133,27 @@ func (vschema *VSchema) FirstKeyspace() *Keyspace {
 	return ks.Keyspace
 }
 
-// FIXME: remove logs before merging
 // findRoutedKeyspace checks if there is a keyspace routing rule for the given keyspace and tablet type.
 func (vschema *VSchema) findRoutedKeyspace(keyspace string, tabletType topodatapb.TabletType) string {
-	log.Infof("findRoutedKeyspace called with keyspace %s, tabletType %s", keyspace, tabletType)
 	if len(vschema.KeyspaceRoutingRules) == 0 {
-		log.Infof("findRoutedKeyspace: no keyspace routing rules found")
 		return keyspace
 	}
-
 	tabletTypeSuffix := TabletTypeSuffix[tabletType]
 	if tabletTypeSuffix == "@primary" {
 		tabletTypeSuffix = ""
 	}
 	routedKeyspace, ok := vschema.KeyspaceRoutingRules[keyspace+tabletTypeSuffix]
 	if ok {
-		log.Infof("findRoutedKeyspace: found routed keyspace %s for key %s", routedKeyspace, keyspace+tabletTypeSuffix)
 		return routedKeyspace
 	} else {
 		if tabletTypeSuffix != "" {
 			// if it was @replica or @rdonly and had no route, default to the route for @primary
 			routedKeyspace, ok = vschema.KeyspaceRoutingRules[keyspace]
 			if ok {
-				log.Infof("findRoutedKeyspace: found routed keyspace %s for key %s", routedKeyspace, keyspace)
 				return routedKeyspace
 			}
 		}
 	}
-	log.Infof("findRoutedKeyspace: no routed keyspace found")
 	return keyspace
 }
 

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-
 	"vitess.io/vitess/go/ptr"
 	"vitess.io/vitess/go/vt/topotools"
 

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1138,17 +1138,28 @@ func (vschema *VSchema) FirstKeyspace() *Keyspace {
 // findRoutedKeyspace checks if there is a keyspace routing rule for the given keyspace and tablet type.
 func (vschema *VSchema) findRoutedKeyspace(keyspace string, tabletType topodatapb.TabletType) string {
 	log.Infof("findRoutedKeyspace called with keyspace %s, tabletType %s", keyspace, tabletType)
-	tabletTypeSuffix := TabletTypeSuffix[tabletType]
-	if tabletTypeSuffix == "@primary" {
-		tabletTypeSuffix = ""
-	}
 	if len(vschema.KeyspaceRoutingRules) == 0 {
 		log.Infof("findRoutedKeyspace: no keyspace routing rules found")
 		return keyspace
 	}
-	if routedKeyspace, ok := vschema.KeyspaceRoutingRules[keyspace+tabletTypeSuffix]; ok {
+
+	tabletTypeSuffix := TabletTypeSuffix[tabletType]
+	if tabletTypeSuffix == "@primary" {
+		tabletTypeSuffix = ""
+	}
+	routedKeyspace, ok := vschema.KeyspaceRoutingRules[keyspace+tabletTypeSuffix]
+	if ok {
 		log.Infof("findRoutedKeyspace: found routed keyspace %s for key %s", routedKeyspace, keyspace+tabletTypeSuffix)
 		return routedKeyspace
+	} else {
+		if tabletTypeSuffix != "" {
+			// if it was @replica or @rdonly and had no route, default to the route for @primary
+			routedKeyspace, ok = vschema.KeyspaceRoutingRules[keyspace]
+			if ok {
+				log.Infof("findRoutedKeyspace: found routed keyspace %s for key %s", routedKeyspace, keyspace)
+				return routedKeyspace
+			}
+		}
 	}
 	log.Infof("findRoutedKeyspace: no routed keyspace found")
 	return keyspace


### PR DESCRIPTION
## Description

As part of #15403 we had assumed it was fine to switch all traffic at the same time. However it turns out there are use cases where we may want to allow switching replica/rdonly and primary traffic separately, similar to other workflows.

This PR adds that support.

## Related Issue(s)

#15403 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
