### PR TITLE
Switch to use semisync source / replica plugins

### DIFF
--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -136,7 +136,7 @@ jobs:
 
         set -exo pipefail
 
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -136,7 +136,7 @@ jobs:
 
         set -exo pipefail
 
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -136,7 +136,7 @@ jobs:
 
         set -exo pipefail
 
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -136,7 +136,7 @@ jobs:
 
         set -exo pipefail
 
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -136,7 +136,7 @@ jobs:
 
         set -exo pipefail
 
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -153,7 +153,7 @@ jobs:
         slow-query-log=OFF
         EOF
         
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -137,7 +137,7 @@ jobs:
 
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF

--- a/config/embed.go
+++ b/config/embed.go
@@ -16,3 +16,9 @@ var MycnfMySQL57 string
 
 //go:embed mycnf/mysql80.cnf
 var MycnfMySQL80 string
+
+//go:embed mycnf/mysql8026.cnf
+var MycnfMySQL8026 string
+
+//go:embed mycnf/mysql84.cnf
+var MycnfMySQL84 string

--- a/config/mycnf/mysql8026.cnf
+++ b/config/mycnf/mysql8026.cnf
@@ -1,0 +1,37 @@
+# This file is auto-included when MySQL 8.0.26 or later is detected.
+
+# MySQL 8.0 enables binlog by default with sync_binlog and TABLE info repositories
+# It does not enable GTIDs or enforced GTID consistency
+
+gtid_mode = ON
+enforce_gtid_consistency
+relay_log_recovery = 1
+binlog_expire_logs_seconds = 259200
+
+# disable mysqlx
+mysqlx = 0
+
+# 8.0 changes the default auth-plugin to caching_sha2_password
+default_authentication_plugin = mysql_native_password
+
+# Semi-sync replication is required for automated unplanned failover
+# (when the primary goes away). Here we just load the plugin so it's
+# available if desired, but it's disabled at startup.
+#
+# VTTablet will enable semi-sync at the proper time when replication is set up,
+# or when a primary is promoted or demoted based on the durability policy configured.
+plugin-load = rpl_semi_sync_source=semisync_source.so;rpl_semi_sync_replica=semisync_replica.so
+
+# MySQL 8.0.26 and later will not load plugins during --initialize
+# which makes these options unknown. Prefixing with --loose
+# tells the server it's fine if they are not understood.
+loose_rpl_semi_sync_source_timeout = 1000000000000000000
+loose_rpl_semi_sync_source_wait_no_replica = 1
+
+# In order to protect against any errand GTIDs we will start the mysql instance
+# in super-read-only mode.
+super-read-only
+
+# Replication parameters to ensure reparents are fast.
+replica_net_timeout = 8
+

--- a/config/mycnf/mysql84.cnf
+++ b/config/mycnf/mysql84.cnf
@@ -1,0 +1,39 @@
+# This file is auto-included when MySQL 8.4.0 or later is detected.
+
+# MySQL 8.0 enables binlog by default with sync_binlog and TABLE info repositories
+# It does not enable GTIDs or enforced GTID consistency
+
+gtid_mode = ON
+enforce_gtid_consistency
+relay_log_recovery = 1
+binlog_expire_logs_seconds = 259200
+
+# disable mysqlx
+mysqlx = 0
+
+# 8.4 changes the default auth-plugin to caching_sha2_password and
+# disables mysql_native_password by default.
+mysql_native_password = ON
+default_authentication_plugin = mysql_native_password
+
+# Semi-sync replication is required for automated unplanned failover
+# (when the primary goes away). Here we just load the plugin so it's
+# available if desired, but it's disabled at startup.
+#
+# VTTablet will enable semi-sync at the proper time when replication is set up,
+# or when a primary is promoted or demoted based on the durability policy configured.
+plugin-load = rpl_semi_sync_source=semisync_source.so;rpl_semi_sync_replica=semisync_replica.so
+
+# MySQL 8.0.26 and later will not load plugins during --initialize
+# which makes these options unknown. Prefixing with --loose
+# tells the server it's fine if they are not understood.
+loose_rpl_semi_sync_source_timeout = 1000000000000000000
+loose_rpl_semi_sync_source_wait_no_replica = 1
+
+# In order to protect against any errand GTIDs we will start the mysql instance
+# in super-read-only mode.
+super-read-only
+
+# Replication parameters to ensure reparents are fast.
+replica_net_timeout = 8
+

--- a/go/cmd/vtcombo/cli/main.go
+++ b/go/cmd/vtcombo/cli/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -216,7 +217,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		servenv.OnClose(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), mysqlctl.DefaultShutdownTimeout+10*time.Second)
+			ctx, cancel := context.WithTimeout(cmd.Context(), mysqlctl.DefaultShutdownTimeout+10*time.Second)
 			defer cancel()
 			mysqld.Shutdown(ctx, cnf, true, mysqlctl.DefaultShutdownTimeout)
 		})
@@ -240,7 +241,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		// ensure we start mysql in the event we fail here
 		if startMysql {
-			ctx, cancel := context.WithTimeout(context.Background(), mysqlctl.DefaultShutdownTimeout+10*time.Second)
+			ctx, cancel := context.WithTimeout(cmd.Context(), mysqlctl.DefaultShutdownTimeout+10*time.Second)
 			defer cancel()
 			mysqld.Shutdown(ctx, cnf, true, mysqlctl.DefaultShutdownTimeout)
 		}
@@ -387,11 +388,11 @@ func (mysqld *vtcomboMysqld) StopReplication(hookExtraEnv map[string]string) err
 }
 
 // SetSemiSyncEnabled implements the MysqlDaemon interface
-func (mysqld *vtcomboMysqld) SetSemiSyncEnabled(source, replica bool) error {
+func (mysqld *vtcomboMysqld) SetSemiSyncEnabled(ctx context.Context, source, replica bool) error {
 	return nil
 }
 
 // SemiSyncExtensionLoaded implements the MysqlDaemon interface
-func (mysqld *vtcomboMysqld) SemiSyncExtensionLoaded() (bool, error) {
-	return true, nil
+func (mysqld *vtcomboMysqld) SemiSyncExtensionLoaded(ctx context.Context) (mysql.SemiSyncType, error) {
+	return mysql.SemiSyncTypeSource, nil
 }

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -144,7 +144,8 @@ func (mariadbFlavor) resetReplicationCommands(c *Conn) []string {
 		"RESET MASTER",
 		"SET GLOBAL gtid_slave_pos = ''",
 	}
-	if c.SemiSyncExtensionLoaded() {
+	semisyncType, _ := c.SemiSyncExtensionLoaded()
+	if semisyncType == SemiSyncTypeMaster {
 		resetCommands = append(resetCommands, "SET GLOBAL rpl_semi_sync_master_enabled = false, GLOBAL rpl_semi_sync_slave_enabled = false") // semi-sync will be enabled if needed when replica is started.
 	}
 	return resetCommands

--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -85,10 +85,10 @@ func TestTabletInitialBackup(t *testing.T) {
 	// TabletExternallyReparented
 	err = localCluster.VtctldClientProcess.ExecuteCommand(
 		"SetWritable", primary.Alias, "true")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = localCluster.VtctldClientProcess.ExecuteCommand(
 		"TabletExternallyReparented", primary.Alias)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	restore(t, replica1, "replica", "SERVING")
 
 	// Run the entire backup test
@@ -134,14 +134,14 @@ func firstBackupTest(t *testing.T, tabletType string) {
 
 	// Store initial backup counts
 	backups, err := listBackups(shardKsName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// insert data on primary, wait for replica to get it
 	_, err = primary.VttabletProcess.QueryTablet(vtInsertTest, keyspaceName, true)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// Add a single row with value 'test1' to the primary tablet
 	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test1')", keyspaceName, true)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Check that the specified tablet has the expected number of rows
 	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 1)
@@ -158,7 +158,7 @@ func firstBackupTest(t *testing.T, tabletType string) {
 
 	// insert more data on the primary
 	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test2')", keyspaceName, true)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 2)
 
 	// even though we change the value of compression it won't affect
@@ -168,7 +168,7 @@ func firstBackupTest(t *testing.T, tabletType string) {
 	defer func() { mysqlctl.CompressionEngineName = "pgzip" }()
 	// now bring up the other replica, letting it restore from backup.
 	err = localCluster.InitTablet(replica2, keyspaceName, shardName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	restore(t, replica2, "replica", "SERVING")
 	// Replica2 takes time to serve. Sleeping for 5 sec.
 	time.Sleep(5 * time.Second)
@@ -181,7 +181,7 @@ func firstBackupTest(t *testing.T, tabletType string) {
 
 func vtBackup(t *testing.T, initialBackup bool, restartBeforeBackup, disableRedoLog bool) *opentsdb.DataPointReader {
 	mysqlSocket, err := os.CreateTemp("", "vtbackup_test_mysql.sock")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(mysqlSocket.Name())
 
 	// Prepare opentsdb stats file path.
@@ -214,7 +214,7 @@ func vtBackup(t *testing.T, initialBackup bool, restartBeforeBackup, disableRedo
 
 	log.Infof("starting backup tablet %s", time.Now())
 	err = localCluster.StartVtbackup(newInitDBFile, initialBackup, keyspaceName, shardName, cell, extraArgs...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	f, err := os.OpenFile(statsPath, os.O_RDONLY, 0)
 	require.NoError(t, err)
@@ -223,7 +223,7 @@ func vtBackup(t *testing.T, initialBackup bool, restartBeforeBackup, disableRedo
 
 func verifyBackupCount(t *testing.T, shardKsName string, expected int) []string {
 	backups, err := listBackups(shardKsName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equalf(t, expected, len(backups), "invalid number of backups")
 	return backups
 }
@@ -251,7 +251,7 @@ func listBackups(shardKsName string) ([]string, error) {
 func removeBackups(t *testing.T) {
 	// Remove all the backups from the shard
 	backups, err := listBackups(shardKsName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	for _, backup := range backups {
 		_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput(
 			"--backup_storage_implementation", "file",
@@ -259,7 +259,7 @@ func removeBackups(t *testing.T) {
 			path.Join(os.Getenv("VTDATAROOT"), "tmp", "backupstorage"),
 			"RemoveBackup", shardKsName, backup,
 		)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -267,18 +267,18 @@ func initTablets(t *testing.T, startTablet bool, initShardPrimary bool) {
 	// Initialize tablets
 	for _, tablet := range []cluster.Vttablet{*primary, *replica1} {
 		err := localCluster.InitTablet(&tablet, keyspaceName, shardName)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		if startTablet {
 			err = tablet.VttabletProcess.Setup()
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 	}
 
 	if initShardPrimary {
 		// choose primary and start replication
 		err := localCluster.VtctldClientProcess.InitShardPrimary(keyspaceName, shardName, cell, primary.TabletUID)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -293,7 +293,7 @@ func restore(t *testing.T, tablet *cluster.Vttablet, tabletType string, waitForS
 	tablet.VttabletProcess.ServingStatus = waitForState
 	tablet.VttabletProcess.SupportsBackup = true
 	err := tablet.VttabletProcess.Setup()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func resetTabletDirectory(t *testing.T, tablet cluster.Vttablet, initMysql bool) {
@@ -302,11 +302,11 @@ func resetTabletDirectory(t *testing.T, tablet cluster.Vttablet, initMysql bool)
 
 	// Teardown Tablet
 	err := tablet.VttabletProcess.TearDown()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Shutdown Mysql
 	err = tablet.MysqlctlProcess.Stop()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Clear out the previous data
 	tablet.MysqlctlProcess.CleanupFiles(tablet.TabletUID)
@@ -315,7 +315,7 @@ func resetTabletDirectory(t *testing.T, tablet cluster.Vttablet, initMysql bool)
 		// Init the Mysql
 		tablet.MysqlctlProcess.InitDBFile = newInitDBFile
 		err = tablet.MysqlctlProcess.Start()
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -323,24 +323,36 @@ func tearDown(t *testing.T, initMysql bool) {
 	// reset replication
 	for _, db := range []string{"_vt", "vt_insert_test"} {
 		_, err := primary.VttabletProcess.QueryTablet(fmt.Sprintf("drop database if exists %s", db), keyspaceName, true)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	caughtUp := waitForReplicationToCatchup([]cluster.Vttablet{*replica1, *replica2})
 	require.True(t, caughtUp, "Timed out waiting for all replicas to catch up")
 	promoteCommands := []string{"STOP SLAVE", "RESET SLAVE ALL", "RESET MASTER"}
-	disableSemiSyncCommands := []string{"SET GLOBAL rpl_semi_sync_master_enabled = false", " SET GLOBAL rpl_semi_sync_slave_enabled = false"}
+
+	disableSemiSyncCommandsSource := []string{"SET GLOBAL rpl_semi_sync_source_enabled = false", " SET GLOBAL rpl_semi_sync_replica_enabled = false"}
+	disableSemiSyncCommandsMaster := []string{"SET GLOBAL rpl_semi_sync_master_enabled = false", " SET GLOBAL rpl_semi_sync_slave_enabled = false"}
+
 	for _, tablet := range []cluster.Vttablet{*primary, *replica1, *replica2} {
 		err := tablet.VttabletProcess.QueryTabletMultiple(promoteCommands, keyspaceName, true)
-		require.Nil(t, err)
-		err = tablet.VttabletProcess.QueryTabletMultiple(disableSemiSyncCommands, keyspaceName, true)
-		require.Nil(t, err)
+		require.NoError(t, err)
+		semisyncType, err := tablet.VttabletProcess.SemiSyncExtensionLoaded()
+		require.NoError(t, err)
+
+		switch semisyncType {
+		case mysql.SemiSyncTypeSource:
+			err = tablet.VttabletProcess.QueryTabletMultiple(disableSemiSyncCommandsSource, keyspaceName, true)
+			require.NoError(t, err)
+		case mysql.SemiSyncTypeMaster:
+			err = tablet.VttabletProcess.QueryTabletMultiple(disableSemiSyncCommandsMaster, keyspaceName, true)
+			require.NoError(t, err)
+		}
 	}
 
 	for _, tablet := range []cluster.Vttablet{*primary, *replica1, *replica2} {
 		resetTabletDirectory(t, tablet, initMysql)
 		// DeleteTablet on a primary will cause tablet to shutdown, so should only call it after tablet is already shut down
 		err := localCluster.VtctldClientProcess.ExecuteCommand("DeleteTablets", "--allow-primary", tablet.Alias)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -359,7 +371,7 @@ func verifyDisableEnableRedoLogs(ctx context.Context, t *testing.T, mysqlSocket 
 
 			// Check if server supports disable/enable redo log.
 			qr, err := conn.ExecuteFetch("SELECT 1 FROM performance_schema.global_status WHERE variable_name = 'innodb_redo_log_enabled'", 1, false)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			// If not, there's nothing to test.
 			if len(qr.Rows) == 0 {
 				return
@@ -368,7 +380,7 @@ func verifyDisableEnableRedoLogs(ctx context.Context, t *testing.T, mysqlSocket 
 			// MY-013600
 			// https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_ib_wrn_redo_disabled
 			qr, err = conn.ExecuteFetch("SELECT 1 FROM performance_schema.error_log WHERE error_code = 'MY-013600'", 1, false)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			if len(qr.Rows) != 1 {
 				// Keep trying, possible we haven't disabled yet.
 				continue
@@ -377,7 +389,7 @@ func verifyDisableEnableRedoLogs(ctx context.Context, t *testing.T, mysqlSocket 
 			// MY-013601
 			// https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_ib_wrn_redo_enabled
 			qr, err = conn.ExecuteFetch("SELECT 1 FROM performance_schema.error_log WHERE error_code = 'MY-013601'", 1, false)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			if len(qr.Rows) != 1 {
 				// Keep trying, possible we haven't disabled yet.
 				continue

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -457,6 +457,16 @@ func (vttablet *VttabletProcess) QueryTablet(query string, keyspace string, useD
 	return executeQuery(conn, query)
 }
 
+// SemiSyncExtensionLoaded returns what type of semi-sync extension is loaded
+func (vttablet *VttabletProcess) SemiSyncExtensionLoaded() (mysql.SemiSyncType, error) {
+	conn, err := vttablet.TabletConn("", false)
+	if err != nil {
+		return mysql.SemiSyncTypeUnknown, err
+	}
+	defer conn.Close()
+	return conn.SemiSyncExtensionLoaded()
+}
+
 // QueryTabletMultiple lets you execute multiple queries -- without any
 // results -- against the tablet.
 func (vttablet *VttabletProcess) QueryTabletMultiple(queries []string, keyspace string, useDb bool) error {

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -476,9 +476,20 @@ func CheckInsertedValues(ctx context.Context, t *testing.T, tablet *cluster.Vtta
 }
 
 func CheckSemiSyncSetupCorrectly(t *testing.T, tablet *cluster.Vttablet, semiSyncVal string) {
-	dbVar, err := tablet.VttabletProcess.GetDBVar("rpl_semi_sync_slave_enabled", "")
+	semisyncType, err := tablet.VttabletProcess.SemiSyncExtensionLoaded()
 	require.NoError(t, err)
-	require.Equal(t, semiSyncVal, dbVar)
+	switch semisyncType {
+	case mysql.SemiSyncTypeSource:
+		dbVar, err := tablet.VttabletProcess.GetDBVar("rpl_semi_sync_replica_enabled", "")
+		require.NoError(t, err)
+		require.Equal(t, semiSyncVal, dbVar)
+	case mysql.SemiSyncTypeMaster:
+		dbVar, err := tablet.VttabletProcess.GetDBVar("rpl_semi_sync_slave_enabled", "")
+		require.NoError(t, err)
+		require.Equal(t, semiSyncVal, dbVar)
+	default:
+		require.Fail(t, "Unknown semi sync type")
+	}
 }
 
 // CheckCountOfInsertedValues checks that the number of inserted values matches the given count on the given tablet
@@ -679,30 +690,70 @@ func positionAtLeast(t *testing.T, tablet *cluster.Vttablet, a string, b string)
 	return isAtleast
 }
 
-// CheckDBvar checks the db var
-func CheckDBvar(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, variable string, status string) {
+func CheckSemisyncEnabled(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, enabled bool) {
 	tabletParams := getMysqlConnParam(tablet)
 	conn, err := mysql.Connect(ctx, &tabletParams)
 	require.NoError(t, err)
 	defer conn.Close()
 
-	qr := execute(t, conn, fmt.Sprintf("show variables like '%s'", variable))
-	got := fmt.Sprintf("%v", qr.Rows)
-	want := fmt.Sprintf("[[VARCHAR(\"%s\") VARCHAR(\"%s\")]]", variable, status)
-	assert.Equal(t, want, got)
+	status := "OFF"
+	if enabled {
+		status = "ON"
+	}
+
+	semisyncType, err := SemiSyncExtensionLoaded(ctx, tablet)
+	require.NoError(t, err)
+	switch semisyncType {
+	case mysql.SemiSyncTypeSource:
+		qr := execute(t, conn, "show variables like 'rpl_semi_sync_replica_enabled'")
+		got := fmt.Sprintf("%v", qr.Rows)
+		want := fmt.Sprintf("[[VARCHAR(\"%s\") VARCHAR(\"%s\")]]", "rpl_semi_sync_replica_enabled", status)
+		assert.Equal(t, want, got)
+	case mysql.SemiSyncTypeMaster:
+		qr := execute(t, conn, "show variables like 'rpl_semi_sync_slave_enabled'")
+		got := fmt.Sprintf("%v", qr.Rows)
+		want := fmt.Sprintf("[[VARCHAR(\"%s\") VARCHAR(\"%s\")]]", "rpl_semi_sync_slave_enabled", status)
+		assert.Equal(t, want, got)
+	}
 }
 
-// CheckDBstatus checks the db status
-func CheckDBstatus(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, variable string, status string) {
+func CheckSemisyncStatus(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, enabled bool) {
 	tabletParams := getMysqlConnParam(tablet)
 	conn, err := mysql.Connect(ctx, &tabletParams)
 	require.NoError(t, err)
 	defer conn.Close()
 
-	qr := execute(t, conn, fmt.Sprintf("show status like '%s'", variable))
-	got := fmt.Sprintf("%v", qr.Rows)
-	want := fmt.Sprintf("[[VARCHAR(\"%s\") VARCHAR(\"%s\")]]", variable, status)
-	assert.Equal(t, want, got)
+	status := "OFF"
+	if enabled {
+		status = "ON"
+	}
+
+	semisyncType, err := SemiSyncExtensionLoaded(ctx, tablet)
+	require.NoError(t, err)
+	switch semisyncType {
+	case mysql.SemiSyncTypeSource:
+		qr := execute(t, conn, "show status like 'Rpl_semi_sync_replica_status'")
+		got := fmt.Sprintf("%v", qr.Rows)
+		want := fmt.Sprintf("[[VARCHAR(\"%s\") VARCHAR(\"%s\")]]", "Rpl_semi_sync_replica_status", status)
+		assert.Equal(t, want, got)
+	case mysql.SemiSyncTypeMaster:
+		qr := execute(t, conn, "show status like 'Rpl_semi_sync_slave_status'")
+		got := fmt.Sprintf("%v", qr.Rows)
+		want := fmt.Sprintf("[[VARCHAR(\"%s\") VARCHAR(\"%s\")]]", "Rpl_semi_sync_slave_status", status)
+		assert.Equal(t, want, got)
+	default:
+		assert.Fail(t, "unknown semi-sync type")
+	}
+}
+
+func SemiSyncExtensionLoaded(ctx context.Context, tablet *cluster.Vttablet) (mysql.SemiSyncType, error) {
+	tabletParams := getMysqlConnParam(tablet)
+	conn, err := mysql.Connect(ctx, &tabletParams)
+	if err != nil {
+		return mysql.SemiSyncTypeUnknown, err
+	}
+	defer conn.Close()
+	return conn.SemiSyncExtensionLoaded()
 }
 
 // SetReplicationSourceFailed returns true if the given output from PRS had failed because the given tablet was

--- a/go/test/endtoend/utils/mysql_test.go
+++ b/go/test/endtoend/utils/mysql_test.go
@@ -373,17 +373,17 @@ func TestGetPreviousGTIDs(t *testing.T) {
 func TestSemiSyncEnabled(t *testing.T) {
 	require.NotNil(t, mysqld)
 
-	err := mysqld.SetSemiSyncEnabled(true, false)
+	err := mysqld.SetSemiSyncEnabled(context.Background(), true, false)
 	assert.NoError(t, err)
 
-	p, r := mysqld.SemiSyncEnabled()
+	p, r := mysqld.SemiSyncEnabled(context.Background())
 	assert.True(t, p)
 	assert.False(t, r)
 
-	err = mysqld.SetSemiSyncEnabled(false, true)
+	err = mysqld.SetSemiSyncEnabled(context.Background(), false, true)
 	assert.NoError(t, err)
 
-	p, r = mysqld.SemiSyncEnabled()
+	p, r = mysqld.SemiSyncEnabled(context.Background())
 	assert.False(t, p)
 	assert.True(t, r)
 }

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -404,7 +404,7 @@ func (be *BuiltinBackupEngine) executeFullBackup(ctx context.Context, params Bac
 	superReadOnly := true //nolint
 	readOnly := true      //nolint
 	var replicationPosition replication.Position
-	semiSyncSource, semiSyncReplica := params.Mysqld.SemiSyncEnabled()
+	semiSyncSource, semiSyncReplica := params.Mysqld.SemiSyncEnabled(ctx)
 
 	// See if we need to restart replication after backup.
 	params.Logger.Infof("getting current replication status")
@@ -519,7 +519,7 @@ func (be *BuiltinBackupEngine) executeFullBackup(ctx context.Context, params Bac
 		// the plugin isn't even loaded, and the server variables don't exist.
 		params.Logger.Infof("restoring semi-sync settings from before backup: primary=%v, replica=%v",
 			semiSyncSource, semiSyncReplica)
-		err := params.Mysqld.SetSemiSyncEnabled(semiSyncSource, semiSyncReplica)
+		err := params.Mysqld.SetSemiSyncEnabled(ctx, semiSyncSource, semiSyncReplica)
 		if err != nil {
 			return backupResult, err
 		}

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
@@ -171,9 +172,9 @@ type FakeMysqlDaemon struct {
 	// FetchSuperQueryResults is used by FetchSuperQuery.
 	FetchSuperQueryMap map[string]*sqltypes.Result
 
-	// SemiSyncPrimaryEnabled represents the state of rpl_semi_sync_master_enabled.
+	// SemiSyncPrimaryEnabled represents the state of rpl_semi_sync_source_enabled.
 	SemiSyncPrimaryEnabled bool
-	// SemiSyncReplicaEnabled represents the state of rpl_semi_sync_slave_enabled.
+	// SemiSyncReplicaEnabled represents the state of rpl_semi_sync_replica_enabled.
 	SemiSyncReplicaEnabled bool
 
 	// TimeoutHook is a func that can be called at the beginning of
@@ -667,19 +668,19 @@ func (fmd *FakeMysqlDaemon) GetAllPrivsConnection(ctx context.Context) (*dbconnp
 }
 
 // SetSemiSyncEnabled is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SetSemiSyncEnabled(primary, replica bool) error {
+func (fmd *FakeMysqlDaemon) SetSemiSyncEnabled(ctx context.Context, primary, replica bool) error {
 	fmd.SemiSyncPrimaryEnabled = primary
 	fmd.SemiSyncReplicaEnabled = replica
 	return nil
 }
 
 // SemiSyncEnabled is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SemiSyncEnabled() (primary, replica bool) {
+func (fmd *FakeMysqlDaemon) SemiSyncEnabled(ctx context.Context) (primary, replica bool) {
 	return fmd.SemiSyncPrimaryEnabled, fmd.SemiSyncReplicaEnabled
 }
 
 // SemiSyncStatus is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SemiSyncStatus() (bool, bool) {
+func (fmd *FakeMysqlDaemon) SemiSyncStatus(ctx context.Context) (bool, bool) {
 	// The fake assumes the status worked.
 	if fmd.SemiSyncPrimaryEnabled {
 		return true, false
@@ -688,22 +689,22 @@ func (fmd *FakeMysqlDaemon) SemiSyncStatus() (bool, bool) {
 }
 
 // SemiSyncClients is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SemiSyncClients() uint32 {
+func (fmd *FakeMysqlDaemon) SemiSyncClients(ctx context.Context) uint32 {
 	return 0
 }
 
 // SemiSyncExtensionLoaded is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SemiSyncExtensionLoaded() (bool, error) {
-	return true, nil
+func (fmd *FakeMysqlDaemon) SemiSyncExtensionLoaded(ctx context.Context) (mysql.SemiSyncType, error) {
+	return mysql.SemiSyncTypeSource, nil
 }
 
 // SemiSyncSettings is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SemiSyncSettings() (timeout uint64, numReplicas uint32) {
+func (fmd *FakeMysqlDaemon) SemiSyncSettings(ctx context.Context) (timeout uint64, numReplicas uint32) {
 	return 10000000, 1
 }
 
 // SemiSyncReplicationStatus is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SemiSyncReplicationStatus() (bool, error) {
+func (fmd *FakeMysqlDaemon) SemiSyncReplicationStatus(ctx context.Context) (bool, error) {
 	// The fake assumes the status worked.
 	return fmd.SemiSyncReplicaEnabled, nil
 }

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconnpool"
@@ -60,13 +61,13 @@ type MysqlDaemon interface {
 	ReplicationStatus() (replication.ReplicationStatus, error)
 	PrimaryStatus(ctx context.Context) (replication.PrimaryStatus, error)
 	GetGTIDPurged(ctx context.Context) (replication.Position, error)
-	SetSemiSyncEnabled(source, replica bool) error
-	SemiSyncEnabled() (source, replica bool)
-	SemiSyncExtensionLoaded() (bool, error)
-	SemiSyncStatus() (source, replica bool)
-	SemiSyncClients() (count uint32)
-	SemiSyncSettings() (timeout uint64, numReplicas uint32)
-	SemiSyncReplicationStatus() (bool, error)
+	SetSemiSyncEnabled(ctx context.Context, source, replica bool) error
+	SemiSyncEnabled(ctx context.Context) (source, replica bool)
+	SemiSyncExtensionLoaded(ctx context.Context) (mysql.SemiSyncType, error)
+	SemiSyncStatus(ctx context.Context) (source, replica bool)
+	SemiSyncClients(ctx context.Context) (count uint32)
+	SemiSyncSettings(ctx context.Context) (timeout uint64, numReplicas uint32)
+	SemiSyncReplicationStatus(ctx context.Context) (bool, error)
 	ResetReplicationParameters(ctx context.Context) error
 	GetBinlogInformation(ctx context.Context) (binlogFormat string, logEnabled bool, logReplicaUpdate bool, binlogRowImage string, err error)
 	GetGTIDMode(ctx context.Context) (gtidMode string, err error)

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -118,6 +118,8 @@ type Mysqld struct {
 	mutex         sync.Mutex
 	onTermFuncs   []func()
 	cancelWaitCmd chan struct{}
+
+	semiSyncType mysql.SemiSyncType
 }
 
 func init() {
@@ -928,7 +930,13 @@ func (mysqld *Mysqld) getMycnfTemplate() string {
 				log.Infof("this version of Vitess does not include built-in support for %v %v", mysqld.capabilities.flavor, mysqld.capabilities.version)
 			}
 		case 8:
-			versionConfig = config.MycnfMySQL80
+			if mysqld.capabilities.version.Minor >= 4 {
+				versionConfig = config.MycnfMySQL84
+			} else if mysqld.capabilities.version.Minor >= 1 || mysqld.capabilities.version.Patch >= 26 {
+				versionConfig = config.MycnfMySQL8026
+			} else {
+				versionConfig = config.MycnfMySQL80
+			}
 		default:
 			log.Infof("this version of Vitess does not include built-in support for %v %v", mysqld.capabilities.flavor, mysqld.capabilities.version)
 		}

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -612,9 +612,48 @@ func (mysqld *Mysqld) GetPreviousGTIDs(ctx context.Context, binlog string) (prev
 	return previousGtids, nil
 }
 
+var ErrNoSemiSync = errors.New("semi-sync plugin not loaded")
+
+func (mysqld *Mysqld) SemiSyncType(ctx context.Context) mysql.SemiSyncType {
+	if mysqld.semiSyncType == mysql.SemiSyncTypeUnknown {
+		mysqld.semiSyncType, _ = mysqld.SemiSyncExtensionLoaded(ctx)
+	}
+	return mysqld.semiSyncType
+}
+
+func (mysqld *Mysqld) enableSemiSyncQuery(ctx context.Context) (string, error) {
+	switch mysqld.SemiSyncType(ctx) {
+	case mysql.SemiSyncTypeSource:
+		return "SET GLOBAL rpl_semi_sync_source_enabled = %v, GLOBAL rpl_semi_sync_replica_enabled = %v", nil
+	case mysql.SemiSyncTypeMaster:
+		return "SET GLOBAL rpl_semi_sync_master_enabled = %v, GLOBAL rpl_semi_sync_slave_enabled = %v", nil
+	}
+	return "", ErrNoSemiSync
+}
+
+func (mysqld *Mysqld) semiSyncClientsQuery(ctx context.Context) (string, error) {
+	switch mysqld.SemiSyncType(ctx) {
+	case mysql.SemiSyncTypeSource:
+		return "SHOW STATUS LIKE 'Rpl_semi_sync_source_clients'", nil
+	case mysql.SemiSyncTypeMaster:
+		return "SHOW STATUS LIKE 'Rpl_semi_sync_master_clients'", nil
+	}
+	return "", ErrNoSemiSync
+}
+
+func (mysqld *Mysqld) semiSyncReplicationStatusQuery(ctx context.Context) (string, error) {
+	switch mysqld.SemiSyncType(ctx) {
+	case mysql.SemiSyncTypeSource:
+		return "SHOW STATUS LIKE 'rpl_semi_sync_replica_status'", nil
+	case mysql.SemiSyncTypeMaster:
+		return "SHOW STATUS LIKE 'rpl_semi_sync_slave_status'", nil
+	}
+	return "", ErrNoSemiSync
+}
+
 // SetSemiSyncEnabled enables or disables semi-sync replication for
 // primary and/or replica mode.
-func (mysqld *Mysqld) SetSemiSyncEnabled(primary, replica bool) error {
+func (mysqld *Mysqld) SetSemiSyncEnabled(ctx context.Context, primary, replica bool) error {
 	log.Infof("Setting semi-sync mode: primary=%v, replica=%v", primary, replica)
 
 	// Convert bool to int.
@@ -626,9 +665,11 @@ func (mysqld *Mysqld) SetSemiSyncEnabled(primary, replica bool) error {
 		s = 1
 	}
 
-	err := mysqld.ExecuteSuperQuery(context.TODO(), fmt.Sprintf(
-		"SET GLOBAL rpl_semi_sync_master_enabled = %v, GLOBAL rpl_semi_sync_slave_enabled = %v",
-		p, s))
+	query, err := mysqld.enableSemiSyncQuery(ctx)
+	if err != nil {
+		return err
+	}
+	err = mysqld.ExecuteSuperQuery(ctx, fmt.Sprintf(query, p, s))
 	if err != nil {
 		return fmt.Errorf("can't set semi-sync mode: %v; make sure plugins are loaded in my.cnf", err)
 	}
@@ -637,30 +678,46 @@ func (mysqld *Mysqld) SetSemiSyncEnabled(primary, replica bool) error {
 
 // SemiSyncEnabled returns whether semi-sync is enabled for primary or replica.
 // If the semi-sync plugin is not loaded, we assume semi-sync is disabled.
-func (mysqld *Mysqld) SemiSyncEnabled() (primary, replica bool) {
-	vars, err := mysqld.fetchVariables(context.TODO(), "rpl_semi_sync_%_enabled")
+func (mysqld *Mysqld) SemiSyncEnabled(ctx context.Context) (primary, replica bool) {
+	vars, err := mysqld.fetchVariables(ctx, "rpl_semi_sync_%_enabled")
 	if err != nil {
 		return false, false
 	}
-	primary = vars["rpl_semi_sync_master_enabled"] == "ON"
-	replica = vars["rpl_semi_sync_slave_enabled"] == "ON"
+	switch mysqld.SemiSyncType(ctx) {
+	case mysql.SemiSyncTypeSource:
+		primary = vars["rpl_semi_sync_source_enabled"] == "ON"
+		replica = vars["rpl_semi_sync_replica_enabled"] == "ON"
+	case mysql.SemiSyncTypeMaster:
+		primary = vars["rpl_semi_sync_master_enabled"] == "ON"
+		replica = vars["rpl_semi_sync_slave_enabled"] == "ON"
+	}
 	return primary, replica
 }
 
 // SemiSyncStatus returns the current status of semi-sync for primary and replica.
-func (mysqld *Mysqld) SemiSyncStatus() (primary, replica bool) {
-	vars, err := mysqld.fetchStatuses(context.TODO(), "Rpl_semi_sync_%_status")
+func (mysqld *Mysqld) SemiSyncStatus(ctx context.Context) (primary, replica bool) {
+	vars, err := mysqld.fetchStatuses(ctx, "Rpl_semi_sync_%_status")
 	if err != nil {
 		return false, false
 	}
-	primary = vars["Rpl_semi_sync_master_status"] == "ON"
-	replica = vars["Rpl_semi_sync_slave_status"] == "ON"
+	switch mysqld.SemiSyncType(ctx) {
+	case mysql.SemiSyncTypeSource:
+		primary = vars["Rpl_semi_sync_source_status"] == "ON"
+		replica = vars["Rpl_semi_sync_replica_status"] == "ON"
+	case mysql.SemiSyncTypeMaster:
+		primary = vars["Rpl_semi_sync_master_status"] == "ON"
+		replica = vars["Rpl_semi_sync_slave_status"] == "ON"
+	}
 	return primary, replica
 }
 
 // SemiSyncClients returns the number of semi-sync clients for the primary.
-func (mysqld *Mysqld) SemiSyncClients() uint32 {
-	qr, err := mysqld.FetchSuperQuery(context.TODO(), "SHOW STATUS LIKE 'Rpl_semi_sync_master_clients'")
+func (mysqld *Mysqld) SemiSyncClients(ctx context.Context) uint32 {
+	query, err := mysqld.semiSyncClientsQuery(ctx)
+	if err != nil {
+		return 0
+	}
+	qr, err := mysqld.FetchSuperQuery(ctx, query)
 	if err != nil {
 		return 0
 	}
@@ -673,24 +730,35 @@ func (mysqld *Mysqld) SemiSyncClients() uint32 {
 }
 
 // SemiSyncSettings returns the settings of semi-sync which includes the timeout and the number of replicas to wait for.
-func (mysqld *Mysqld) SemiSyncSettings() (timeout uint64, numReplicas uint32) {
-	vars, err := mysqld.fetchVariables(context.TODO(), "rpl_semi_sync_%")
+func (mysqld *Mysqld) SemiSyncSettings(ctx context.Context) (timeout uint64, numReplicas uint32) {
+	vars, err := mysqld.fetchVariables(ctx, "rpl_semi_sync_%")
 	if err != nil {
 		return 0, 0
 	}
-	timeout, _ = strconv.ParseUint(vars["rpl_semi_sync_master_timeout"], 10, 64)
-	numReplicasUint, _ := strconv.ParseUint(vars["rpl_semi_sync_master_wait_for_slave_count"], 10, 32)
+	var numReplicasUint uint64
+	switch mysqld.SemiSyncType(ctx) {
+	case mysql.SemiSyncTypeSource:
+		timeout, _ = strconv.ParseUint(vars["rpl_semi_sync_source_timeout"], 10, 64)
+		numReplicasUint, _ = strconv.ParseUint(vars["rpl_semi_sync_source_wait_for_replica_count"], 10, 32)
+	case mysql.SemiSyncTypeMaster:
+		timeout, _ = strconv.ParseUint(vars["rpl_semi_sync_master_timeout"], 10, 64)
+		numReplicasUint, _ = strconv.ParseUint(vars["rpl_semi_sync_master_wait_for_slave_count"], 10, 32)
+	}
 	return timeout, uint32(numReplicasUint)
 }
 
 // SemiSyncReplicationStatus returns whether semi-sync is currently used by replication.
-func (mysqld *Mysqld) SemiSyncReplicationStatus() (bool, error) {
-	qr, err := mysqld.FetchSuperQuery(context.TODO(), "SHOW STATUS LIKE 'rpl_semi_sync_slave_status'")
+func (mysqld *Mysqld) SemiSyncReplicationStatus(ctx context.Context) (bool, error) {
+	query, err := mysqld.semiSyncReplicationStatusQuery(ctx)
+	if err != nil {
+		return false, err
+	}
+	qr, err := mysqld.FetchSuperQuery(ctx, query)
 	if err != nil {
 		return false, err
 	}
 	if len(qr.Rows) != 1 {
-		return false, errors.New("no rpl_semi_sync_slave_status variable in mysql")
+		return false, errors.New("no rpl_semi_sync_replica_status variable in mysql")
 	}
 	if qr.Rows[0][1].ToString() == "ON" {
 		return true, nil
@@ -699,14 +767,12 @@ func (mysqld *Mysqld) SemiSyncReplicationStatus() (bool, error) {
 }
 
 // SemiSyncExtensionLoaded returns whether semi-sync plugins are loaded.
-func (mysqld *Mysqld) SemiSyncExtensionLoaded() (bool, error) {
-	qr, err := mysqld.FetchSuperQuery(context.Background(), "SELECT COUNT(*) > 0 AS plugin_loaded FROM information_schema.plugins WHERE plugin_name LIKE 'rpl_semi_sync%'")
-	if err != nil {
-		return false, err
+func (mysqld *Mysqld) SemiSyncExtensionLoaded(ctx context.Context) (mysql.SemiSyncType, error) {
+	conn, connErr := getPoolReconnect(ctx, mysqld.dbaPool)
+	if connErr != nil {
+		return mysql.SemiSyncTypeUnknown, connErr
 	}
-	pluginPresent, err := qr.Rows[0][0].ToBool()
-	if err != nil {
-		return false, err
-	}
-	return pluginPresent, nil
+	defer conn.Recycle()
+
+	return conn.Conn.SemiSyncExtensionLoaded()
 }

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
@@ -556,16 +557,16 @@ func TestSetSemiSyncEnabled(t *testing.T) {
 	defer testMysqld.Close()
 
 	// We expect this query to be executed
-	err := testMysqld.SetSemiSyncEnabled(true, true)
-	assert.ErrorContains(t, err, "SET GLOBAL rpl_semi_sync_master_enabled = 1, GLOBAL rpl_semi_sync_slave_enabled = 1")
+	err := testMysqld.SetSemiSyncEnabled(context.Background(), true, true)
+	assert.ErrorContains(t, err, "semisync plugin not loaded")
 
 	// We expect this query to be executed
-	err = testMysqld.SetSemiSyncEnabled(true, false)
-	assert.ErrorContains(t, err, "SET GLOBAL rpl_semi_sync_master_enabled = 1, GLOBAL rpl_semi_sync_slave_enabled = 0")
+	err = testMysqld.SetSemiSyncEnabled(context.Background(), true, false)
+	assert.ErrorContains(t, err, "semisync plugin not loaded")
 
 	// We expect this query to be executed
-	err = testMysqld.SetSemiSyncEnabled(false, true)
-	assert.ErrorContains(t, err, "SET GLOBAL rpl_semi_sync_master_enabled = 0, GLOBAL rpl_semi_sync_slave_enabled = 1")
+	err = testMysqld.SetSemiSyncEnabled(context.Background(), false, true)
+	assert.ErrorContains(t, err, "semisync plugin not loaded")
 }
 
 func TestSemiSyncEnabled(t *testing.T) {
@@ -577,12 +578,12 @@ func TestSemiSyncEnabled(t *testing.T) {
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
 
 	db.AddQuery("SELECT 1", &sqltypes.Result{})
-	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "rpl_semi_sync_master_enabled|OFF", "rpl_semi_sync_slave_enabled|ON"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "rpl_semi_sync_source_enabled|OFF", "rpl_semi_sync_replica_enabled|ON"))
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
 
-	p, r := testMysqld.SemiSyncEnabled()
+	p, r := testMysqld.SemiSyncEnabled(context.Background())
 	assert.False(t, p)
 	assert.True(t, r)
 }
@@ -596,12 +597,13 @@ func TestSemiSyncStatus(t *testing.T) {
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
 
 	db.AddQuery("SELECT 1", &sqltypes.Result{})
-	db.AddQuery("SHOW STATUS LIKE 'Rpl_semi_sync_%_status'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "Rpl_semi_sync_master_status|ON", "Rpl_semi_sync_slave_status|OFF"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "rpl_semi_sync_source_enabled|ON", "rpl_semi_sync_replica_enabled|ON"))
+	db.AddQuery("SHOW STATUS LIKE 'Rpl_semi_sync_%_status'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "Rpl_semi_sync_source_status|ON", "Rpl_semi_sync_replica_status|OFF"))
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
 
-	p, r := testMysqld.SemiSyncStatus()
+	p, r := testMysqld.SemiSyncStatus(context.Background())
 	assert.True(t, p)
 	assert.False(t, r)
 }
@@ -615,12 +617,13 @@ func TestSemiSyncClients(t *testing.T) {
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
 
 	db.AddQuery("SELECT 1", &sqltypes.Result{})
-	db.AddQuery("SHOW STATUS LIKE 'Rpl_semi_sync_master_clients'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "val1|12"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "rpl_semi_sync_source_enabled|ON", "rpl_semi_sync_replica_enabled|ON"))
+	db.AddQuery("SHOW STATUS LIKE 'Rpl_semi_sync_source_clients'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "val1|12"))
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
 
-	res := testMysqld.SemiSyncClients()
+	res := testMysqld.SemiSyncClients(context.Background())
 	assert.Equal(t, uint32(12), res)
 }
 
@@ -633,12 +636,13 @@ func TestSemiSyncSettings(t *testing.T) {
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
 
 	db.AddQuery("SELECT 1", &sqltypes.Result{})
-	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "rpl_semi_sync_master_timeout|123", "rpl_semi_sync_master_wait_for_slave_count|80"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "rpl_semi_sync_source_enabled|ON", "rpl_semi_sync_replica_enabled|ON"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "rpl_semi_sync_source_timeout|123", "rpl_semi_sync_source_wait_for_replica_count|80"))
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
 
-	timeout, replicas := testMysqld.SemiSyncSettings()
+	timeout, replicas := testMysqld.SemiSyncSettings(context.Background())
 	assert.Equal(t, uint64(123), timeout)
 	assert.Equal(t, uint32(80), replicas)
 }
@@ -652,18 +656,19 @@ func TestSemiSyncReplicationStatus(t *testing.T) {
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
 
 	db.AddQuery("SELECT 1", &sqltypes.Result{})
-	db.AddQuery("SHOW STATUS LIKE 'rpl_semi_sync_slave_status'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "rpl_semi_sync_slave_status|ON"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "rpl_semi_sync_source_enabled|ON", "rpl_semi_sync_replica_enabled|ON"))
+	db.AddQuery("SHOW STATUS LIKE 'rpl_semi_sync_replica_status'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "rpl_semi_sync_replica_status|ON"))
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
 
-	res, err := testMysqld.SemiSyncReplicationStatus()
+	res, err := testMysqld.SemiSyncReplicationStatus(context.Background())
 	assert.NoError(t, err)
 	assert.True(t, res)
 
-	db.AddQuery("SHOW STATUS LIKE 'rpl_semi_sync_slave_status'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "rpl_semi_sync_slave_status|OFF"))
+	db.AddQuery("SHOW STATUS LIKE 'rpl_semi_sync_replica_status'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|uint64"), "rpl_semi_sync_replica_status|OFF"))
 
-	res, err = testMysqld.SemiSyncReplicationStatus()
+	res, err = testMysqld.SemiSyncReplicationStatus(context.Background())
 	assert.NoError(t, err)
 	assert.False(t, res)
 }
@@ -675,20 +680,22 @@ func TestSemiSyncExtensionLoaded(t *testing.T) {
 	params := db.ConnParams()
 	cp := *params
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	db.AddQuery("SELECT 1", &sqltypes.Result{})
-	db.AddQuery("SELECT COUNT(*) > 0 AS plugin_loaded FROM information_schema.plugins WHERE plugin_name LIKE 'rpl_semi_sync%'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1", "int64"), "1"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1|field2", "varchar|varchar"), "rpl_semi_sync_source_enabled|ON", "rpl_semi_sync_replica_enabled|ON"))
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
 
-	res, err := testMysqld.SemiSyncExtensionLoaded()
+	res, err := testMysqld.SemiSyncExtensionLoaded(ctx)
 	assert.NoError(t, err)
-	assert.True(t, res)
+	assert.Contains(t, []mysql.SemiSyncType{mysql.SemiSyncTypeSource, mysql.SemiSyncTypeMaster}, res)
 
-	db.AddQuery("SELECT COUNT(*) > 0 AS plugin_loaded FROM information_schema.plugins WHERE plugin_name LIKE 'rpl_semi_sync%'", sqltypes.MakeTestResult(sqltypes.MakeTestFields("field1", "int64"), "0"))
+	db.AddQuery("SHOW VARIABLES LIKE 'rpl_semi_sync_%_enabled'", &sqltypes.Result{})
 
-	res, err = testMysqld.SemiSyncExtensionLoaded()
+	res, err = testMysqld.SemiSyncExtensionLoaded(ctx)
 	assert.NoError(t, err)
-	assert.False(t, res)
+	assert.Equal(t, mysql.SemiSyncTypeOff, res)
 }

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -558,15 +558,15 @@ func TestSetSemiSyncEnabled(t *testing.T) {
 
 	// We expect this query to be executed
 	err := testMysqld.SetSemiSyncEnabled(context.Background(), true, true)
-	assert.ErrorContains(t, err, "semisync plugin not loaded")
+	assert.ErrorIs(t, err, ErrNoSemiSync)
 
 	// We expect this query to be executed
 	err = testMysqld.SetSemiSyncEnabled(context.Background(), true, false)
-	assert.ErrorContains(t, err, "semisync plugin not loaded")
+	assert.ErrorIs(t, err, ErrNoSemiSync)
 
 	// We expect this query to be executed
 	err = testMysqld.SetSemiSyncEnabled(context.Background(), false, true)
-	assert.ErrorContains(t, err, "semisync plugin not loaded")
+	assert.ErrorIs(t, err, ErrNoSemiSync)
 }
 
 func TestSemiSyncEnabled(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/rpc_actions.go
+++ b/go/vt/vttablet/tabletmanager/rpc_actions.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/hook"
@@ -82,7 +83,7 @@ func (tm *TabletManager) ChangeType(ctx context.Context, tabletType topodatapb.T
 	}
 	defer tm.unlock()
 
-	semiSyncAction, err := tm.convertBoolToSemiSyncAction(semiSync)
+	semiSyncAction, err := tm.convertBoolToSemiSyncAction(ctx, semiSync)
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func (tm *TabletManager) changeTypeLocked(ctx context.Context, tabletType topoda
 	}
 
 	// Let's see if we need to fix semi-sync acking.
-	if err := tm.fixSemiSyncAndReplication(tm.Tablet().Type, semiSync); err != nil {
+	if err := tm.fixSemiSyncAndReplication(ctx, tm.Tablet().Type, semiSync); err != nil {
 		return vterrors.Wrap(err, "fixSemiSyncAndReplication failed, may not ack correctly")
 	}
 	return nil
@@ -147,19 +148,20 @@ func (tm *TabletManager) RunHealthCheck(ctx context.Context) {
 	tm.QueryServiceControl.BroadcastHealth()
 }
 
-func (tm *TabletManager) convertBoolToSemiSyncAction(semiSync bool) (SemiSyncAction, error) {
-	semiSyncExtensionLoaded, err := tm.MysqlDaemon.SemiSyncExtensionLoaded()
+func (tm *TabletManager) convertBoolToSemiSyncAction(ctx context.Context, semiSync bool) (SemiSyncAction, error) {
+	semiSyncExtensionLoaded, err := tm.MysqlDaemon.SemiSyncExtensionLoaded(ctx)
 	if err != nil {
 		return SemiSyncActionNone, err
 	}
 
-	if semiSyncExtensionLoaded {
+	switch semiSyncExtensionLoaded {
+	case mysql.SemiSyncTypeSource, mysql.SemiSyncTypeMaster:
 		if semiSync {
 			return SemiSyncActionSet, nil
 		} else {
 			return SemiSyncActionUnset, nil
 		}
-	} else {
+	default:
 		if semiSync {
 			return SemiSyncActionNone, vterrors.VT09013()
 		} else {

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -136,7 +136,7 @@ func (tm *TabletManager) Backup(ctx context.Context, logger logutil.Logger, req 
 			}
 
 			isSemiSync := reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tabletInfo.Tablet)
-			semiSyncAction, err := tm.convertBoolToSemiSyncAction(isSemiSync)
+			semiSyncAction, err := tm.convertBoolToSemiSyncAction(bgCtx, isSemiSync)
 			if err != nil {
 				l.Errorf("Failed to convert bool to semisync action, error: %v", err)
 				return

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -974,12 +974,12 @@ func (tm *TabletManager) initializeReplication(ctx context.Context, tabletType t
 
 	tablet.Type = tabletType
 
-	semiSyncAction, err := tm.convertBoolToSemiSyncAction(reparentutil.IsReplicaSemiSync(durability, currentPrimary.Tablet, tablet))
+	semiSyncAction, err := tm.convertBoolToSemiSyncAction(ctx, reparentutil.IsReplicaSemiSync(durability, currentPrimary.Tablet, tablet))
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tm.fixSemiSync(tabletType, semiSyncAction); err != nil {
+	if err := tm.fixSemiSync(ctx, tabletType, semiSyncAction); err != nil {
 		return nil, err
 	}
 

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -183,7 +183,7 @@ jobs:
         {{if .LimitResourceUsage}}
         # Increase our open file descriptor limit as we could hit this
         ulimit -n 65536
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         innodb_buffer_pool_dump_at_shutdown=OFF
         innodb_buffer_pool_in_core_file=OFF
         innodb_buffer_pool_load_at_startup=OFF
@@ -201,7 +201,7 @@ jobs:
         {{end}}
 
         {{if .EnableBinlogTransactionCompression}}
-        cat <<-EOF>>./config/mycnf/mysql80.cnf
+        cat <<-EOF>>./config/mycnf/mysql8026.cnf
         binlog-transaction-compression=ON
         EOF
         {{end}}

--- a/test/vtop_example.sh
+++ b/test/vtop_example.sh
@@ -36,7 +36,7 @@ unset VTROOT # ensure that the examples can run without VTROOT now.
 function checkSemiSyncSetup() {
   for vttablet in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" | grep "vttablet") ; do
     echo "Checking semi-sync in $vttablet"
-    kubectl exec "$vttablet" -c mysqld -- mysql -S "/vt/socket/mysql.sock" -u root -e "show variables like 'rpl_semi_sync_slave_enabled'" | grep "OFF"
+    kubectl exec "$vttablet" -c mysqld -- mysql -S "/vt/socket/mysql.sock" -u root -e "show variables like 'rpl_semi_sync_replica_enabled'" | grep "OFF"
     if [ $? -ne 0 ]; then
       echo "Semi Sync setup on $vttablet"
       exit 1


### PR DESCRIPTION
The plugins with the old terminology are deprecated and will be removed in the future. In MySQL 8.4.0 also the old terminology for regular replication is removed.

This starts the move to use the new style. Since MySQL 8.0.26 the new semisync plugin is available, so we should start using it from that version on.

This means we also need new default MySQL cnf files to set up things correctly. We add here a mysql8026.cnf and also a pre-emptive mysql84.cnf. The latter is needed to start the work in the future for MySQL 8.4.0. The main change here is that the deprecated mysql_native_password plugin needs to be explicitly enabled.

Removing our usage of mysql_native_password is another separate significant effort. The main issue there is how we want to deal with certificates etc. which end up being required for replication if you want to use caching_sha2_password which adds a whole layer of complexity we've never had to deal with.

## Related Issue(s)

Part of https://github.com/vitessio/vitess/issues/11716

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required