### PR TITLE
projection: Return correct collation information

### DIFF
--- a/go/vt/vtgate/engine/projection_test.go
+++ b/go/vt/vtgate/engine/projection_test.go
@@ -228,3 +228,41 @@ func TestFields(t *testing.T) {
 		})
 	}
 }
+
+func TestFieldConversion(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		expr      string
+		typ       querypb.Type
+		collation collations.ID
+	}{
+		{
+			name:      `convert different charset`,
+			expr:      `_latin1 0xFF`,
+			typ:       sqltypes.VarChar,
+			collation: collations.MySQL8().DefaultConnectionCharset(),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			arg, err := sqlparser.NewTestParser().ParseExpr(testCase.expr)
+			require.NoError(t, err)
+			bindExpr, err := evalengine.Translate(arg, &evalengine.Config{
+				Environment: vtenv.NewTestEnv(),
+				Collation:   collations.MySQL8().DefaultConnectionCharset(),
+			})
+			require.NoError(t, err)
+			proj := &Projection{
+				Cols:       []string{"col"},
+				Exprs:      []evalengine.Expr{bindExpr},
+				Input:      &SingleRow{},
+				noTxNeeded: noTxNeeded{},
+			}
+			qr, err := proj.TryExecute(context.Background(), &noopVCursor{}, nil, true)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.typ, qr.Fields[0].Type)
+			assert.Equal(t, testCase.collation, collations.ID(qr.Fields[0].Charset))
+		})
+	}
+}


### PR DESCRIPTION
When we have a project, we correctly convert the value to the connection collation using:

```go
c.Value(vcursor.ConnCollation())
```

But we then don't update / change the collation on the fields information. This needs to match the actual data, otherwise the client might corrupt the data.

This ensures we add the same rules for the resulting collation.

## Related Issue(s)

Fixes #15800 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required