### PR TITLE
[release-19.0] Backport testing for new semi-sync plugin

### DIFF
--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -301,7 +301,14 @@ func TestPullFromRdonly(t *testing.T) {
 	require.NoError(t, err)
 
 	// stop semi-sync on the primary so that any transaction now added does not require an ack
-	utils.RunSQL(ctx, t, "SET GLOBAL rpl_semi_sync_master_enabled = false", tablets[0])
+	semisyncType, err := tablets[0].VttabletProcess.SemiSyncExtensionLoaded()
+	require.NoError(t, err)
+	switch semisyncType {
+	case cluster.SemiSyncTypeSource:
+		utils.RunSQL(ctx, t, "SET GLOBAL rpl_semi_sync_source_enabled = false", tablets[0])
+	case cluster.SemiSyncTypeMaster:
+		utils.RunSQL(ctx, t, "SET GLOBAL rpl_semi_sync_master_enabled = false", tablets[0])
+	}
 
 	// confirm that rdonly is able to replicate from our primary
 	// This will also introduce a new transaction into the rdonly tablet which the other 2 replicas don't have

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -354,38 +354,38 @@ func TestChangeTypeSemiSync(t *testing.T) {
 	// The flag is only an indication of the value to use next time
 	// we turn replication on, so also check the status.
 	// rdonly1 is not replicating, so its status is off.
-	utils.CheckSemisyncEnabled(ctx, t, replica, true)
-	utils.CheckSemisyncEnabled(ctx, t, rdonly1, false)
-	utils.CheckSemisyncEnabled(ctx, t, rdonly2, false)
-	utils.CheckSemisyncStatus(ctx, t, replica, true)
-	utils.CheckSemisyncStatus(ctx, t, rdonly1, false)
-	utils.CheckSemisyncStatus(ctx, t, rdonly2, false)
+	utils.CheckSemiSyncEnabled(ctx, t, replica, true)
+	utils.CheckSemiSyncEnabled(ctx, t, rdonly1, false)
+	utils.CheckSemiSyncEnabled(ctx, t, rdonly2, false)
+	utils.CheckSemiSyncStatus(ctx, t, replica, true)
+	utils.CheckSemiSyncStatus(ctx, t, rdonly1, false)
+	utils.CheckSemiSyncStatus(ctx, t, rdonly2, false)
 
 	// Change replica to rdonly while replicating, should turn off semi-sync, and restart replication.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", replica.Alias, "rdonly")
 	require.NoError(t, err)
-	utils.CheckSemisyncEnabled(ctx, t, replica, false)
-	utils.CheckSemisyncStatus(ctx, t, replica, false)
+	utils.CheckSemiSyncEnabled(ctx, t, replica, false)
+	utils.CheckSemiSyncStatus(ctx, t, replica, false)
 
 	// Change rdonly1 to replica, should turn on semi-sync, and not start replication.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", rdonly1.Alias, "replica")
 	require.NoError(t, err)
-	utils.CheckSemisyncEnabled(ctx, t, rdonly1, true)
-	utils.CheckSemisyncStatus(ctx, t, rdonly1, false)
+	utils.CheckSemiSyncEnabled(ctx, t, rdonly1, true)
+	utils.CheckSemiSyncStatus(ctx, t, rdonly1, false)
 	utils.CheckReplicaStatus(ctx, t, rdonly1)
 
 	// Now change from replica back to rdonly, make sure replication is still not enabled.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", rdonly1.Alias, "rdonly")
 	require.NoError(t, err)
-	utils.CheckSemisyncEnabled(ctx, t, rdonly1, false)
-	utils.CheckSemisyncStatus(ctx, t, rdonly1, false)
+	utils.CheckSemiSyncEnabled(ctx, t, rdonly1, false)
+	utils.CheckSemiSyncStatus(ctx, t, rdonly1, false)
 	utils.CheckReplicaStatus(ctx, t, rdonly1)
 
 	// Change rdonly2 to replica, should turn on semi-sync, and restart replication.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", rdonly2.Alias, "replica")
 	require.NoError(t, err)
-	utils.CheckSemisyncEnabled(ctx, t, rdonly2, true)
-	utils.CheckSemisyncStatus(ctx, t, rdonly2, true)
+	utils.CheckSemiSyncEnabled(ctx, t, rdonly2, true)
+	utils.CheckSemiSyncStatus(ctx, t, rdonly2, true)
 }
 
 // TestCrossCellDurability tests 2 things -

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -26,11 +26,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/mysql/replication"
-
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/reparent/utils"
 	"vitess.io/vitess/go/vt/log"
@@ -356,38 +354,38 @@ func TestChangeTypeSemiSync(t *testing.T) {
 	// The flag is only an indication of the value to use next time
 	// we turn replication on, so also check the status.
 	// rdonly1 is not replicating, so its status is off.
-	utils.CheckDBvar(ctx, t, replica, "rpl_semi_sync_slave_enabled", "ON")
-	utils.CheckDBvar(ctx, t, rdonly1, "rpl_semi_sync_slave_enabled", "OFF")
-	utils.CheckDBvar(ctx, t, rdonly2, "rpl_semi_sync_slave_enabled", "OFF")
-	utils.CheckDBstatus(ctx, t, replica, "Rpl_semi_sync_slave_status", "ON")
-	utils.CheckDBstatus(ctx, t, rdonly1, "Rpl_semi_sync_slave_status", "OFF")
-	utils.CheckDBstatus(ctx, t, rdonly2, "Rpl_semi_sync_slave_status", "OFF")
+	utils.CheckSemisyncEnabled(ctx, t, replica, true)
+	utils.CheckSemisyncEnabled(ctx, t, rdonly1, false)
+	utils.CheckSemisyncEnabled(ctx, t, rdonly2, false)
+	utils.CheckSemisyncStatus(ctx, t, replica, true)
+	utils.CheckSemisyncStatus(ctx, t, rdonly1, false)
+	utils.CheckSemisyncStatus(ctx, t, rdonly2, false)
 
 	// Change replica to rdonly while replicating, should turn off semi-sync, and restart replication.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", replica.Alias, "rdonly")
 	require.NoError(t, err)
-	utils.CheckDBvar(ctx, t, replica, "rpl_semi_sync_slave_enabled", "OFF")
-	utils.CheckDBstatus(ctx, t, replica, "Rpl_semi_sync_slave_status", "OFF")
+	utils.CheckSemisyncEnabled(ctx, t, replica, false)
+	utils.CheckSemisyncStatus(ctx, t, replica, false)
 
 	// Change rdonly1 to replica, should turn on semi-sync, and not start replication.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", rdonly1.Alias, "replica")
 	require.NoError(t, err)
-	utils.CheckDBvar(ctx, t, rdonly1, "rpl_semi_sync_slave_enabled", "ON")
-	utils.CheckDBstatus(ctx, t, rdonly1, "Rpl_semi_sync_slave_status", "OFF")
+	utils.CheckSemisyncEnabled(ctx, t, rdonly1, true)
+	utils.CheckSemisyncStatus(ctx, t, rdonly1, false)
 	utils.CheckReplicaStatus(ctx, t, rdonly1)
 
 	// Now change from replica back to rdonly, make sure replication is still not enabled.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", rdonly1.Alias, "rdonly")
 	require.NoError(t, err)
-	utils.CheckDBvar(ctx, t, rdonly1, "rpl_semi_sync_slave_enabled", "OFF")
-	utils.CheckDBstatus(ctx, t, rdonly1, "Rpl_semi_sync_slave_status", "OFF")
+	utils.CheckSemisyncEnabled(ctx, t, rdonly1, false)
+	utils.CheckSemisyncStatus(ctx, t, rdonly1, false)
 	utils.CheckReplicaStatus(ctx, t, rdonly1)
 
 	// Change rdonly2 to replica, should turn on semi-sync, and restart replication.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeTabletType", rdonly2.Alias, "replica")
 	require.NoError(t, err)
-	utils.CheckDBvar(ctx, t, rdonly2, "rpl_semi_sync_slave_enabled", "ON")
-	utils.CheckDBstatus(ctx, t, rdonly2, "Rpl_semi_sync_slave_status", "ON")
+	utils.CheckSemisyncEnabled(ctx, t, rdonly2, true)
+	utils.CheckSemisyncStatus(ctx, t, rdonly2, true)
 }
 
 // TestCrossCellDurability tests 2 things -

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -680,7 +680,7 @@ func assertNodeCount(t *testing.T, result string, want int) {
 	assert.Equal(t, want, got)
 }
 
-func CheckSemisyncEnabled(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, enabled bool) {
+func CheckSemiSyncEnabled(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, enabled bool) {
 	tabletParams := getMysqlConnParam(tablet)
 	conn, err := mysql.Connect(ctx, &tabletParams)
 	require.NoError(t, err)
@@ -707,7 +707,7 @@ func CheckSemisyncEnabled(ctx context.Context, t *testing.T, tablet *cluster.Vtt
 	}
 }
 
-func CheckSemisyncStatus(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, enabled bool) {
+func CheckSemiSyncStatus(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, enabled bool) {
 	tabletParams := getMysqlConnParam(tablet)
 	conn, err := mysql.Connect(ctx, &tabletParams)
 	require.NoError(t, err)


### PR DESCRIPTION
There are upgrade / downgrade tests that run against a newer version from `main` on the `release-19.0` branch. That means those have the new plugin loaded and these endtoend tests need to be able to check both also for the `release-19.0` branch.

## Related Issue(s)

See also the failures in #15804

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
