### PR TITLE
fix: make sure string literals as columns are handled well

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2194,8 +2194,13 @@ func (ae *AliasedExpr) ColumnName() string {
 		return ae.As.String()
 	}
 
-	if col, ok := ae.Expr.(*ColName); ok {
-		return col.Name.String()
+	switch node := ae.Expr.(type) {
+	case *ColName:
+		return node.Name.String()
+	case *Literal:
+		if node.Type == StrVal {
+			return node.Val
+		}
 	}
 
 	return String(ae.Expr)

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -601,8 +601,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select dt.c0 as `'b'`, dt.c1 as `'c'`, weight_string(dt.c0), weight_string(dt.c1) from (select 'b', 'c' from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
-                "Query": "select dt.c0 as `'b'`, dt.c1 as `'c'`, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)",
+                "FieldQuery": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select 'b', 'c' from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
+                "Query": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)",
                 "Table": "`user`"
               }
             ]
@@ -639,8 +639,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select dt.c0 as `'b'`, dt.c1 as `'c'`, weight_string(dt.c0), weight_string(dt.c1) from (select 'b', 'c' from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
-                "Query": "select dt.c0 as `'b'`, dt.c1 as `'c'`, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)",
+                "FieldQuery": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select 'b', 'c' from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
+                "Query": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)",
                 "Table": "`user`"
               },
               {


### PR DESCRIPTION
## Description
When using pure literals without column alias, Vitess is getting the column names a little wrong. 

## Related Issue(s)
Fixes #15819

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
