### PR TITLE
Improve `mcmp` type comparison

### DIFF
--- a/go/test/endtoend/utils/mysql.go
+++ b/go/test/endtoend/utils/mysql.go
@@ -242,7 +242,7 @@ func compareVitessAndMySQLResults(t TestingT, query string, vtConn *mysql.Conn, 
 	return errors.New(errStr)
 }
 
-var checkFeildsRegExpr = regexp.MustCompile(`(.*)(\d*)`)
+var checkFeildsRegExpr = regexp.MustCompile(`([a-zA-Z]*)(\d*)`)
 
 func checkFields(t TestingT, columnName string, vtField, myField *querypb.Field) {
 	t.Helper()
@@ -257,14 +257,17 @@ func checkFields(t TestingT, columnName string, vtField, myField *querypb.Field)
 
 		if len(vtMatches) != 3 || len(vtMatches) != len(myMatches) || vtMatches[1] != myMatches[1] {
 			fail()
+			return
 		}
 		vtVal, vtErr := strconv.Atoi(vtMatches[2])
-		myVal, myErr := strconv.Atoi(vtMatches[2])
+		myVal, myErr := strconv.Atoi(myMatches[2])
 		if vtErr != nil || myErr != nil {
 			fail()
+			return
 		}
 		if vtVal <= myVal {
 			fail()
+			return
 		}
 	}
 


### PR DESCRIPTION
## Description

This Pull Request enhances how we compare types with `mcmp`. If the type is the same between MySQL and Vitess but the size is bigger on Vitess than on MySQL, we let the test pass.

Related to https://github.com/vitessio/vitess/issues/15818, it won't fix it but it will allow test to pass.
