### PR TITLE
Fix derived table bug

### DIFF
--- a/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
+++ b/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
@@ -197,29 +197,6 @@ where l_partkey = p_partkey
   and l_shipdate < date_add('1996-12-01', interval '1' month);`,
 		},
 		{
-			name: "Q7",
-			query: `select supp_nation, cust_nation, l_year, sum(volume) as revenue
-from (select n1.n_name                          as supp_nation,
-             n2.n_name                          as cust_nation,
-             extract(year from l_shipdate)      as l_year,
-             l_extendedprice * (1 - l_discount) as volume
-      from supplier,
-           lineitem,
-           orders,
-           customer,
-           nation n1,
-           nation n2
-      where s_suppkey = l_suppkey
-        and o_orderkey = l_orderkey
-        and c_custkey = o_custkey
-        and s_nationkey = n1.n_nationkey
-        and c_nationkey = n2.n_nationkey
-        and ((n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE'))
-        and l_shipdate between date ('1995-01-01') and date('1996-12-31')) as shipping
-group by supp_nation, cust_nation, l_year
-order by supp_nation, cust_nation, l_year`,
-		},
-		{
 			name: "Q8",
 			query: `select o_year, sum(case when nation = 'BRAZIL' then volume else 0 end) / sum(volume) as mkt_share
 from (select extract(year from o_orderdate) as o_year, l_extendedprice * (1 - l_discount) as volume, n2.n_name as nation
@@ -242,28 +219,6 @@ from (select extract(year from o_orderdate) as o_year, l_extendedprice * (1 - l_
         and o_orderdate between date '1995-01-01' and date ('1996-12-31') and p_type = 'ECONOMY ANODIZED STEEL' ) as all_nations
 group by o_year
 order by o_year`,
-		},
-		{
-			name: "Q9",
-			query: `select nation, o_year, sum(amount) as sum_profit
-from (select n_name                                                          as nation,
-             extract(year from o_orderdate)                                  as o_year,
-             l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
-      from part,
-           supplier,
-           lineitem,
-           partsupp,
-           orders,
-           nation
-      where s_suppkey = l_suppkey
-        and ps_suppkey = l_suppkey
-        and ps_partkey = l_partkey
-        and p_partkey = l_partkey
-        and o_orderkey = l_orderkey
-        and s_nationkey = n_nationkey
-        and p_name like '%green%') as profit
-group by nation, o_year
-order by nation, o_year desc`,
 		},
 		{
 			name: "simple derived table",

--- a/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
+++ b/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
@@ -196,6 +196,82 @@ where l_partkey = p_partkey
   and l_shipdate >= '1996-12-01'
   and l_shipdate < date_add('1996-12-01', interval '1' month);`,
 		},
+		{
+			name: "Q7",
+			query: `select supp_nation, cust_nation, l_year, sum(volume) as revenue
+from (select n1.n_name                          as supp_nation,
+             n2.n_name                          as cust_nation,
+             extract(year from l_shipdate)      as l_year,
+             l_extendedprice * (1 - l_discount) as volume
+      from supplier,
+           lineitem,
+           orders,
+           customer,
+           nation n1,
+           nation n2
+      where s_suppkey = l_suppkey
+        and o_orderkey = l_orderkey
+        and c_custkey = o_custkey
+        and s_nationkey = n1.n_nationkey
+        and c_nationkey = n2.n_nationkey
+        and ((n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE'))
+        and l_shipdate between date ('1995-01-01') and date('1996-12-31')) as shipping
+group by supp_nation, cust_nation, l_year
+order by supp_nation, cust_nation, l_year`,
+		},
+		{
+			name: "Q8",
+			query: `select o_year, sum(case when nation = 'BRAZIL' then volume else 0 end) / sum(volume) as mkt_share
+from (select extract(year from o_orderdate) as o_year, l_extendedprice * (1 - l_discount) as volume, n2.n_name as nation
+      from part,
+           supplier,
+           lineitem,
+           orders,
+           customer,
+           nation n1,
+           nation n2,
+           region
+      where p_partkey = l_partkey
+        and s_suppkey = l_suppkey
+        and l_orderkey = o_orderkey
+        and o_custkey = c_custkey
+        and c_nationkey = n1.n_nationkey
+        and n1.n_regionkey = r_regionkey
+        and r_name = 'AMERICA'
+        and s_nationkey = n2.n_nationkey
+        and o_orderdate between date '1995-01-01' and date ('1996-12-31') and p_type = 'ECONOMY ANODIZED STEEL' ) as all_nations
+group by o_year
+order by o_year`,
+		},
+		{
+			name: "Q9",
+			query: `select nation, o_year, sum(amount) as sum_profit
+from (select n_name                                                          as nation,
+             extract(year from o_orderdate)                                  as o_year,
+             l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+      from part,
+           supplier,
+           lineitem,
+           partsupp,
+           orders,
+           nation
+      where s_suppkey = l_suppkey
+        and ps_suppkey = l_suppkey
+        and ps_partkey = l_partkey
+        and p_partkey = l_partkey
+        and o_orderkey = l_orderkey
+        and s_nationkey = n_nationkey
+        and p_name like '%green%') as profit
+group by nation, o_year
+order by nation, o_year desc`,
+		},
+		{
+			name: "simple derived table",
+			query: `select *
+from (select l.l_extendedprice * o.o_totalprice
+      from lineitem l
+               join orders o) as dt`,
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2883,7 +2883,7 @@ func TestCrossShardSubquery(t *testing.T) {
 	result, err := executorExec(ctx, executor, session, "select id1 from (select u1.id id1, u2.id from user u1 join user u2 on u2.id = u1.col where u1.id = 1) as t", nil)
 	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select id1, t.`u1.col` from (select u1.id as id1, u1.col as `u1.col` from `user` as u1 where u1.id = 1) as t",
+		Sql:           "select t.id1, t.`u1.col` from (select u1.id as id1, u1.col as `u1.col` from `user` as u1 where u1.id = 1) as t",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	utils.MustMatch(t, wantQueries, sbc1.Queries)
@@ -2959,7 +2959,7 @@ func TestCrossShardSubqueryStream(t *testing.T) {
 	result, err := executorStream(ctx, executor, "select id1 from (select u1.id id1, u2.id from user u1 join user u2 on u2.id = u1.col where u1.id = 1) as t")
 	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select id1, t.`u1.col` from (select u1.id as id1, u1.col as `u1.col` from `user` as u1 where u1.id = 1) as t",
+		Sql:           "select t.id1, t.`u1.col` from (select u1.id as id1, u1.col as `u1.col` from `user` as u1 where u1.id = 1) as t",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	utils.MustMatch(t, wantQueries, sbc1.Queries)

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -310,6 +310,10 @@ func (aj *ApplyJoin) planOffsetFor(ctx *plancontext.PlanningContext, col applyJo
 			offset := aj.LHS.AddColumn(ctx, true, col.GroupBy, aeWrap(col.DTColName))
 			aj.addOffset(ToLeftOffset(offset))
 		} else {
+			for _, lhsExpr := range col.LHSExprs {
+				offset := aj.LHS.AddColumn(ctx, true, col.GroupBy, aeWrap(lhsExpr.Expr))
+				aj.Vars[lhsExpr.Name] = offset
+			}
 			offset := aj.RHS.AddColumn(ctx, true, col.GroupBy, aeWrap(col.DTColName))
 			aj.addOffset(ToRightOffset(offset))
 		}

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -71,10 +71,11 @@ type (
 	//     so they can be used for the result of this expression that is using data from both sides.
 	//     All fields will be used for these
 	applyJoinColumn struct {
-		Original sqlparser.Expr // this is the original expression being passed through
-		LHSExprs []BindVarExpr
-		RHSExpr  sqlparser.Expr
-		GroupBy  bool // if this is true, we need to push this down to our inputs with addToGroupBy set to true
+		Original  sqlparser.Expr     // this is the original expression being passed through
+		LHSExprs  []BindVarExpr      // These are the expressions we are pushing to the left hand side which we'll receive as bind variables
+		RHSExpr   sqlparser.Expr     // This the expression that we'll evaluate on the right hand side. This is nil, if the right hand side has nothing.
+		DTColName *sqlparser.ColName // This is the output column name that the parent of JOIN will be seeing. If this is unset, then the colname is the String(Original). We set this when we push Projections with derived tables underneath a Join.
+		GroupBy   bool               // if this is true, we need to push this down to our inputs with addToGroupBy set to true
 	}
 
 	// BindVarExpr is an expression needed from one side of a join/subquery, and the argument name for it.
@@ -211,7 +212,8 @@ func (aj *ApplyJoin) getJoinColumnFor(ctx *plancontext.PlanningContext, orig *sq
 
 func applyJoinCompare(ctx *plancontext.PlanningContext, expr sqlparser.Expr) func(e applyJoinColumn) bool {
 	return func(e applyJoinColumn) bool {
-		return ctx.SemTable.EqualsExprWithDeps(e.Original, expr)
+		// e.DTColName is how the outside world will be using this expression. So we should check for an equality with that too.
+		return ctx.SemTable.EqualsExprWithDeps(e.Original, expr) || ctx.SemTable.EqualsExprWithDeps(e.DTColName, expr)
 	}
 }
 
@@ -301,6 +303,18 @@ func (aj *ApplyJoin) planOffsets(ctx *plancontext.PlanningContext) Operator {
 }
 
 func (aj *ApplyJoin) planOffsetFor(ctx *plancontext.PlanningContext, col applyJoinColumn) {
+	if col.DTColName != nil {
+		// If DTColName is set, then we already pushed the parts of the expression down while planning.
+		// We need to use this name and ask the correct side of the join for it. Nothing else is required.
+		if col.IsPureLeft() {
+			offset := aj.LHS.AddColumn(ctx, true, col.GroupBy, aeWrap(col.DTColName))
+			aj.addOffset(ToLeftOffset(offset))
+		} else {
+			offset := aj.RHS.AddColumn(ctx, true, col.GroupBy, aeWrap(col.DTColName))
+			aj.addOffset(ToRightOffset(offset))
+		}
+		return
+	}
 	for _, lhsExpr := range col.LHSExprs {
 		offset := aj.LHS.AddColumn(ctx, true, col.GroupBy, aeWrap(lhsExpr.Expr))
 		if col.RHSExpr == nil {

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -147,10 +147,10 @@ func createDMLWithInput(ctx *plancontext.PlanningContext, op, src Operator, in *
 	dm.cols = make([][]*sqlparser.ColName, 1)
 	for _, col := range in.Target.VTable.PrimaryKey {
 		colName := sqlparser.NewColNameWithQualifier(col.String(), in.Target.Name)
+		ctx.SemTable.Recursive[colName] = in.Target.ID
 		proj.AddColumn(ctx, true, false, aeWrap(colName))
 		dm.cols[0] = append(dm.cols[0], colName)
 		leftComp = append(leftComp, colName)
-		ctx.SemTable.Recursive[colName] = in.Target.ID
 	}
 
 	dm.Source = proj

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -1053,7 +1053,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1",
+            "JoinColumnIndexes": "L:1,L:0",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1063,8 +1063,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select t.col1, t.id from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.col1, t.id from (select `user`.id, `user`.col1 from `user`) as t",
+                "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
                 "Table": "`user`"
               },
               {
@@ -1111,7 +1111,7 @@
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
         "JoinVars": {
-          "user_col": 1
+          "user_col": 2
         },
         "TableName": "`user`_user_extra",
         "Inputs": [
@@ -1122,8 +1122,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select t.id, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t",
+            "FieldQuery": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t",
             "Table": "`user`"
           },
           {
@@ -1171,7 +1171,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0",
+            "JoinColumnIndexes": "L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1181,8 +1181,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
+                "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
                 "Table": "`user`"
               },
               {
@@ -1236,7 +1236,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0",
+            "JoinColumnIndexes": "L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1246,8 +1246,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.col1 from (select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id) as t",
+                "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id) as t",
                 "Table": "`user`",
                 "Values": [
                   ":ua_id"
@@ -1295,8 +1295,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, t.id from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select id, t.id from (select `user`.id from `user`) as t",
+            "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id from (select `user`.id from `user`) as t",
             "Table": "`user`"
           },
           {
@@ -1388,8 +1388,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select id from (select `user`.id, `user`.col from `user` where `user`.id = 5) as t",
+            "FieldQuery": "select t.id, t.col from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id, t.col from (select `user`.id, `user`.col from `user` where `user`.id = 5) as t",
             "Table": "`user`",
             "Values": [
               "5"

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -1843,7 +1843,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1",
+            "JoinColumnIndexes": "L:1,L:0",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1853,8 +1853,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select t.col1, t.id from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.col1, t.id from (select `user`.id, `user`.col1 from `user`) as t",
+                "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
                 "Table": "`user`"
               },
               {
@@ -1901,7 +1901,7 @@
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
         "JoinVars": {
-          "user_col": 1
+          "user_col": 2
         },
         "TableName": "`user`_user_extra",
         "Inputs": [
@@ -1912,8 +1912,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select t.id, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t",
+            "FieldQuery": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t",
             "Table": "`user`"
           },
           {
@@ -1961,7 +1961,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0",
+            "JoinColumnIndexes": "L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1971,8 +1971,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
+                "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
                 "Table": "`user`"
               },
               {
@@ -2026,7 +2026,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0",
+            "JoinColumnIndexes": "L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -2036,8 +2036,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.col1 from (select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id) as t",
+                "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id) as t",
                 "Table": "`user`",
                 "Values": [
                   ":ua_id"
@@ -2477,8 +2477,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, t.id from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select id, t.id from (select `user`.id from `user`) as t",
+            "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id from (select `user`.id from `user`) as t",
             "Table": "`user`"
           },
           {
@@ -2911,8 +2911,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select id from (select `user`.id, `user`.col from `user` where `user`.id = 5) as t",
+            "FieldQuery": "select t.id, t.col from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id, t.col from (select `user`.id, `user`.col from `user` where `user`.id = 5) as t",
             "Table": "`user`",
             "Values": [
               "5"
@@ -4443,6 +4443,9 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "u_foo": 0
+        },
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -4452,8 +4455,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select 1 from (select u.foo from `user` as u where 1 != 1) as dt where 1 != 1",
-            "Query": "select 1 from (select u.foo from `user` as u) as dt",
+            "FieldQuery": "select dt.foo from (select u.foo from `user` as u where 1 != 1) as dt where 1 != 1",
+            "Query": "select dt.foo from (select u.foo from `user` as u) as dt",
             "Table": "`user`"
           },
           {
@@ -4463,8 +4466,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select `u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue where 1 != 1) as dt where 1 != 1",
-            "Query": "select `u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue) as dt",
+            "FieldQuery": "select dt.`u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue where 1 != 1) as dt where 1 != 1",
+            "Query": "select dt.`u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue) as dt",
             "Table": "user_extra"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4432,5 +4432,47 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "Select everything from a derived table having a cross-shard join",
+    "query": "select * from (select u.foo * ue.bar from user u join user_extra ue) as dt",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select * from (select u.foo * ue.bar from user u join user_extra ue) as dt",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "TableName": "`user`_user_extra",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from (select u.foo from `user` as u where 1 != 1) as dt where 1 != 1",
+            "Query": "select 1 from (select u.foo from `user` as u) as dt",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue where 1 != 1) as dt where 1 != 1",
+            "Query": "select `u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue) as dt",
+            "Table": "user_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -257,9 +257,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
-            "OrderBy": "(0|1) ASC",
-            "Query": "select id, weight_string(id) from (select `user`.id, `user`.col from `user`) as t order by t.id asc",
+            "FieldQuery": "select t.id, t.col, weight_string(t.id) from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
+            "OrderBy": "(0|2) ASC",
+            "Query": "select t.id, t.col, weight_string(t.id) from (select `user`.id, `user`.col from `user`) as t order by t.id asc",
             "Table": "`user`"
           },
           {
@@ -681,8 +681,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select foo, weight_string(foo) from (select u.foo from `user` as u where 1 != 1) as tbl where 1 != 1",
-                "Query": "select foo, weight_string(foo) from (select u.foo from `user` as u) as tbl",
+                "FieldQuery": "select tbl.foo, weight_string(tbl.foo) from (select u.foo from `user` as u where 1 != 1) as tbl where 1 != 1",
+                "Query": "select tbl.foo, weight_string(tbl.foo) from (select u.foo from `user` as u) as tbl",
                 "Table": "`user`"
               },
               {
@@ -692,8 +692,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select bar, weight_string(bar) from (select ue.bar from user_extra as ue where 1 != 1) as tbl where 1 != 1",
-                "Query": "select bar, weight_string(bar) from (select ue.bar from user_extra as ue) as tbl",
+                "FieldQuery": "select tbl.bar, weight_string(tbl.bar) from (select ue.bar from user_extra as ue where 1 != 1) as tbl where 1 != 1",
+                "Query": "select tbl.bar, weight_string(tbl.bar) from (select ue.bar from user_extra as ue) as tbl",
                 "Table": "user_extra"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1406,8 +1406,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id1 from (select `user`.id as id1 from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select id1 from (select `user`.id as id1 from `user`) as t",
+            "FieldQuery": "select t.id1 from (select `user`.id as id1 from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id1 from (select `user`.id as id1 from `user`) as t",
             "Table": "`user`"
           },
           {
@@ -1417,8 +1417,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id2 from (select user_extra.id as id2 from user_extra where 1 != 1) as t where 1 != 1",
-            "Query": "select id2 from (select user_extra.id as id2 from user_extra) as t",
+            "FieldQuery": "select t.id2 from (select user_extra.id as id2 from user_extra where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id2 from (select user_extra.id as id2 from user_extra) as t",
             "Table": "user_extra"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -998,17 +998,17 @@
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "L:0,R:0,L:1,L:3",
+                    "JoinColumnIndexes": "L:0,R:0,L:4,L:6",
                     "JoinVars": {
-                      "l_partkey": 2,
-                      "l_suppkey": 1
+                      "l_partkey": 5,
+                      "l_suppkey": 4
                     },
                     "TableName": "orders_lineitem_part_partsupp",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "L:0,R:0,R:1,L:2",
+                        "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,L:2",
                         "JoinVars": {
                           "o_orderkey": 1
                         },
@@ -1028,9 +1028,9 @@
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,L:1",
+                            "JoinColumnIndexes": "L:0,L:1,L:2,L:3,L:4",
                             "JoinVars": {
-                              "l_partkey": 1
+                              "l_partkey": 4
                             },
                             "TableName": "lineitem_part",
                             "Inputs": [
@@ -1068,8 +1068,8 @@
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select profit.l_suppkey, profit.l_partkey from (select l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as profit where 1 != 1",
-                                    "Query": "select profit.l_suppkey, profit.l_partkey from (select l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit",
+                                    "FieldQuery": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as profit where 1 != 1",
+                                    "Query": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit",
                                     "Table": "lineitem"
                                   }
                                 ]
@@ -1127,8 +1127,8 @@
                               "Name": "main",
                               "Sharded": true
                             },
-                            "FieldQuery": "select profit.amount from (select l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount from partsupp where 1 != 1) as profit where 1 != 1",
-                            "Query": "select profit.amount from (select l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount from partsupp where ps_partkey = :l_partkey and ps_suppkey = :l_suppkey) as profit",
+                            "FieldQuery": "select profit.amount from (select :l_extendedprice * (1 - :l_discount) - ps_supplycost * :l_quantity as amount from partsupp where 1 != 1) as profit where 1 != 1",
+                            "Query": "select profit.amount from (select :l_extendedprice * (1 - :l_discount) - ps_supplycost * :l_quantity as amount from partsupp where ps_partkey = :l_partkey and ps_suppkey = :l_suppkey) as profit",
                             "Table": "partsupp"
                           }
                         ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -1000,7 +1000,10 @@
                     "Variant": "Join",
                     "JoinColumnIndexes": "L:0,R:0,L:4,L:6",
                     "JoinVars": {
+                      "l_discount": 2,
+                      "l_extendedprice": 1,
                       "l_partkey": 5,
+                      "l_quantity": 3,
                       "l_suppkey": 4
                     },
                     "TableName": "orders_lineitem_part_partsupp",


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the issue described in https://github.com/vitessio/vitess/issues/15830.
While working on fixing the derived table query, it was noticed that `select * from (select u.foo * ue.bar from user u join user_extra ue) as dt` wasn't working on main even before https://github.com/vitessio/vitess/pull/15588 was merged but still #15588 made it worse (as in the plan became even more wrong if that makes sense).

This PR fixes this issue and after the changes in this PR, that query works as intended. There are 2 changes in this PR - 

1. We can't override the original expression when we see a derived table, because overriding the original with a column name causes issues with breaking the expression since a column name can't be split. At the same time, we don't want to lose the information about the column name either. So we now store this information in a newly introduced field called `DTColumn`. We further change planning of offsets to check for the `DTColumn` value. Since we know the underlying source has a field with this name, we get it from there.

2. The other bug present in `main` even before #15588 was merged, was around projection pushing wherein a new projection would totally override the join columns. This led to the information about the splitting of columns being forgotten and then the same problem wherein we can't split an aliased expression. The fix is to just reuse the joinColumns if they're already populated.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15830

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
