### PR TITLE
mysqlctld: Remove unneeded resets in init_db.sql

### DIFF
--- a/config/init_db.sql
+++ b/config/init_db.sql
@@ -70,9 +70,6 @@ GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD
 GRANT SELECT, UPDATE, DELETE, DROP
   ON performance_schema.* TO 'vt_monitoring'@'localhost';
 
-RESET SLAVE ALL;
-RESET MASTER;
-
 # custom sql is used to add custom scripts like creating users/passwords. We use it in our tests
 # {{custom_sql}}
 

--- a/examples/compose/config/init_db.sql
+++ b/examples/compose/config/init_db.sql
@@ -69,9 +69,6 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
   SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   ON *.* TO 'vt_filtered'@'localhost';
 
-RESET SLAVE ALL;
-RESET MASTER;
-
 # custom sql is used to add custom scripts like creating users/passwords. We use it in our tests
 # {{custom_sql}}
 

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -212,9 +212,6 @@ stringData:
       SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
       ON *.* TO 'vt_filtered'@'localhost';
 
-    RESET SLAVE ALL;
-    RESET MASTER;
-
     # custom sql is used to add custom scripts like creating users/passwords. We use it in our tests
     # {{custom_sql}}
 

--- a/go/test/endtoend/vreplication/testdata/config/init_testserver_db.sql
+++ b/go/test/endtoend/vreplication/testdata/config/init_testserver_db.sql
@@ -79,8 +79,5 @@ GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD
 GRANT SELECT, UPDATE, DELETE, DROP
       ON performance_schema.* TO 'vt_monitoring'@'localhost';
 
-RESET REPLICA ALL;
-RESET MASTER;
-
 # custom sql is used to add custom scripts like creating users/passwords. We use it in our tests
 # {{custom_sql}}


### PR DESCRIPTION
This removes the resets for the startup script that we use. These were long ago added for a MariaDB 10.3 workaround which is not supported as a managed tablet anyway anymore.

It also would only needed for an existing node to join a cluster that is otherwise manually emptied. If that's the case, the reset should also be done manually anyway too.

Removing this also ensures we have no logic here that would start failing in the future on MySQL 8.4.0 which removed these statements.

## Related Issue(s)

Part of #9515
 
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required