### PR TITLE
Update env.sh so that is does not error when running on Mac

### DIFF
--- a/examples/common/env.sh
+++ b/examples/common/env.sh
@@ -80,5 +80,7 @@ alias mysql="command mysql --no-defaults -h 127.0.0.1 -P 15306"
 alias vtctldclient="command vtctldclient --server localhost:15999"
 
 # Make sure aliases are expanded in non-interactive shell
-shopt -s expand_aliases
+if [[ "${SHELL##*/}" == "bash" ]]; then
+    shopt -s expand_aliases
+fi
 

--- a/examples/common/env.sh
+++ b/examples/common/env.sh
@@ -79,8 +79,8 @@ mkdir -p "${VTDATAROOT}/tmp"
 alias mysql="command mysql --no-defaults -h 127.0.0.1 -P 15306"
 alias vtctldclient="command vtctldclient --server localhost:15999"
 
-# Make sure aliases are expanded in non-interactive shell
-if [[ "${SHELL##*/}" == "bash" ]]; then
+# If using bash, make sure aliases are expanded in non-interactive shell
+if [[ -n ${BASH} ]]; then
     shopt -s expand_aliases
 fi
 


### PR DESCRIPTION
## Description

This is a minor fix to `examples/common/env.sh` so that it does not error out on mac where `zsh` is the default shell. `shopt` is bash-specific and does not work on `zsh`. This fix was suggested by @mattlord while reviewing and discussing this other PR for the docs on the website: https://github.com/vitessio/website/pull/1736 

This is my first PR to `vitessio/vitess` so not sure about other procedures such as backports, etc.

## Related Issue(s)

No issue for this.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required