### PR TITLE
Update VTAdmin build script

### DIFF
--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -28,11 +28,13 @@ web_dir="${script_dir}/../../../web/vtadmin"
 vtadmin_api_port=14200
 vtadmin_web_port=14201
 
-output "\n\033[1;32mvtadmin-api expects vtadmin-web at, and set http-origin to \"http://${hostname}:${vtadmin_web_port}\"\033[0m"
+case_insensitive_hostname=$(echo "$hostname" | tr '[:upper:]' '[:lower:]')
+
+output "\n\033[1;32mvtadmin-api expects vtadmin-web at, and set http-origin to \"http://${case_insensitive_hostname}:${vtadmin_web_port}\"\033[0m"
 
 vtadmin \
-  --addr "${hostname}:${vtadmin_api_port}" \
-  --http-origin "http://${hostname}:${vtadmin_web_port}" \
+  --addr "${case_insensitive_hostname}:${vtadmin_api_port}" \
+  --http-origin "http://${case_insensitive_hostname}:${vtadmin_web_port}" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   --tracer "opentracing-jaeger" \
   --grpc-tracing \
@@ -49,7 +51,7 @@ echo ${vtadmin_api_pid} > "${log_dir}/vtadmin-api.pid"
 
 echo "\
 vtadmin-api is running!
-  - API: http://${hostname}:${vtadmin_api_port}
+  - API: http://${case_insensitive_hostname}:${vtadmin_api_port}
   - Logs: ${log_dir}/vtadmin-api.out
   - PID: ${vtadmin_api_pid}
 "
@@ -60,7 +62,7 @@ source "${web_dir}/build.sh"
 # Wait for vtadmin to successfully discover the cluster
 expected_cluster_result="{\"result\":{\"clusters\":[{\"id\":\"${cluster_name}\",\"name\":\"${cluster_name}\"}]},\"ok\":true}"
 for _ in {0..100}; do
-  result=$(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters")
+  result=$(curl -s "http://${case_insensitive_hostname}:${vtadmin_api_port}/api/clusters")
   if [[ ${result} == "${expected_cluster_result}" ]]; then
     break
   fi
@@ -68,7 +70,7 @@ for _ in {0..100}; do
 done
 
 # Check one last time
-[[ $(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters") == "${expected_cluster_result}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
+[[ $(curl -s "http://${case_insensitive_hostname}:${vtadmin_api_port}/api/clusters") == "${expected_cluster_result}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
 
 [[ ! -d "$web_dir/build" ]] && fail "Please make sure the VTAdmin files are built in $web_dir/build, using 'make build'"
 
@@ -80,7 +82,7 @@ echo ${vtadmin_web_pid} > "${log_dir}/vtadmin-web.pid"
 
 echo "\
 vtadmin-web is running!
-  - Browser: http://${hostname}:${vtadmin_web_port}
+  - Browser: http://${case_insensitive_hostname}:${vtadmin_web_port}
   - Logs: ${log_dir}/vtadmin-web.out
   - PID: ${vtadmin_web_pid}
 "

--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+function output() {
+  echo -e "$@"
+}
+
 script_dir="$(dirname "${BASH_SOURCE[0]:-$0}")"
 source "${script_dir}/../env.sh"
 
@@ -24,7 +28,7 @@ web_dir="${script_dir}/../../../web/vtadmin"
 vtadmin_api_port=14200
 vtadmin_web_port=14201
 
-echo "vtadmin-api http-origin set to \"http://${hostname}:${vtadmin_web_port}\""
+output "\n\033[1;32mvtadmin-api expects vtadmin-web at, and set http-origin to \"http://${hostname}:${vtadmin_web_port}\"\033[0m"
 
 vtadmin \
   --addr "${hostname}:${vtadmin_api_port}" \

--- a/web/vtadmin/build.sh
+++ b/web/vtadmin/build.sh
@@ -32,6 +32,8 @@ then
   output "\n\033[1;32mhostname was empty, set it to \"${hostname}\"\033[0m"
 fi
 
+case_insensitive_hostname=$(echo "$hostname" | tr '[:upper:]' '[:lower:]')
+
 # Download nvm and node
 if [[ -z ${NVM_DIR} ]]; then
     export NVM_DIR="$HOME/.nvm"
@@ -58,9 +60,9 @@ npm --prefix "$web_dir" --silent install
 
 export PATH=$PATH:$web_dir/node_modules/.bin/
 
-vite_vtadmin_api_address="http://${hostname}:${vtadmin_api_port}"
+vite_vtadmin_api_address="http://${case_insensitive_hostname}:${vtadmin_api_port}"
 output "\n\033[1;32mSetting VITE_VTADMIN_API_ADDRESS to \"${vite_vtadmin_api_address}\"\033[0m"
 
-VITE_VTADMIN_API_ADDRESS="http://${hostname}:${vtadmin_api_port}" \
+VITE_VTADMIN_API_ADDRESS="http://${case_insensitive_hostname}:${vtadmin_api_port}" \
   VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
   npm run --prefix "$web_dir" build

--- a/web/vtadmin/build.sh
+++ b/web/vtadmin/build.sh
@@ -19,7 +19,9 @@ function output() {
 }
 
 script_dir="$(dirname "${BASH_SOURCE[0]:-$0}")"
-source "${script_dir}/../../build.env"
+pushd ${VTROOT}
+source "./build.env"
+popd
 web_dir="${script_dir}"
 
 vtadmin_api_port=14200


### PR DESCRIPTION
## Description
This PR:
- updates the build.sh script to reference `build.env` in the same directory
- ensures that the vtadmin-up.sh build scripts work with different formats of `hostname`

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/15833

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes
N/A