### PR TITLE
`schemadiff`: atomic diffs for range partition `DROP PARTITION` statement

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -569,6 +569,11 @@ func TestDiffViews(t *testing.T) {
 				diff := dq.StatementString()
 				assert.Equal(t, ts.diff, diff)
 			}
+			if d != nil && !d.IsEmpty() {
+				// Validate Clone() works
+				clone := d.Clone()
+				assert.Equal(t, d.Statement(), clone.Statement())
+			}
 		})
 	}
 }
@@ -1060,6 +1065,22 @@ func TestDiffSchemas(t *testing.T) {
 				for _, s := range cstatements {
 					_, err := env.Parser().ParseStrictDDL(s)
 					assert.NoError(t, err)
+				}
+				// Validate Clone() works
+				for _, d := range diffs {
+					if d.IsEmpty() {
+						continue
+					}
+					dFrom, dTo := d.Entities()
+					clone := d.Clone()
+					clonedFrom, clonedTo := clone.Entities()
+					assert.Equal(t, d.CanonicalStatementString(), clone.CanonicalStatementString())
+					if dFrom != nil {
+						assert.Equal(t, dFrom.Name(), clonedFrom.Name())
+					}
+					if dTo != nil {
+						assert.Equal(t, dTo.Name(), clonedTo.Name())
+					}
 				}
 
 				if ts.annotated != nil {

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -139,6 +139,29 @@ func (d *AlterTableEntityDiff) InstantDDLCapability() InstantDDLCapability {
 	return d.instantDDLCapability
 }
 
+// Clone implements EntityDiff
+func (d *AlterTableEntityDiff) Clone() EntityDiff {
+	if d == nil {
+		return nil
+	}
+	ann := *d.annotations
+	clone := &AlterTableEntityDiff{
+		alterTable:           sqlparser.CloneRefOfAlterTable(d.alterTable),
+		instantDDLCapability: d.instantDDLCapability,
+		annotations:          &ann,
+	}
+	if d.from != nil {
+		clone.from = d.from.Clone().(*CreateTableEntity)
+	}
+	if d.to != nil {
+		clone.to = d.to.Clone().(*CreateTableEntity)
+	}
+	if d.subsequentDiff != nil {
+		clone.subsequentDiff = d.subsequentDiff.Clone().(*AlterTableEntityDiff)
+	}
+	return clone
+}
+
 type CreateTableEntityDiff struct {
 	to          *CreateTableEntity
 	createTable *sqlparser.CreateTable
@@ -214,6 +237,20 @@ func (d *CreateTableEntityDiff) SetSubsequentDiff(EntityDiff) {
 // InstantDDLCapability implements EntityDiff
 func (d *CreateTableEntityDiff) InstantDDLCapability() InstantDDLCapability {
 	return InstantDDLCapabilityIrrelevant
+}
+
+// Clone implements EntityDiff
+func (d *CreateTableEntityDiff) Clone() EntityDiff {
+	if d == nil {
+		return nil
+	}
+	clone := &CreateTableEntityDiff{
+		createTable: sqlparser.CloneRefOfCreateTable(d.createTable),
+	}
+	if d.to != nil {
+		clone.to = d.to.Clone().(*CreateTableEntity)
+	}
+	return clone
 }
 
 type DropTableEntityDiff struct {
@@ -293,6 +330,20 @@ func (d *DropTableEntityDiff) InstantDDLCapability() InstantDDLCapability {
 	return InstantDDLCapabilityIrrelevant
 }
 
+// Clone implements EntityDiff
+func (d *DropTableEntityDiff) Clone() EntityDiff {
+	if d == nil {
+		return nil
+	}
+	clone := &DropTableEntityDiff{
+		dropTable: sqlparser.CloneRefOfDropTable(d.dropTable),
+	}
+	if d.from != nil {
+		clone.from = d.from.Clone().(*CreateTableEntity)
+	}
+	return clone
+}
+
 type RenameTableEntityDiff struct {
 	from        *CreateTableEntity
 	to          *CreateTableEntity
@@ -369,6 +420,23 @@ func (d *RenameTableEntityDiff) SetSubsequentDiff(EntityDiff) {
 // InstantDDLCapability implements EntityDiff
 func (d *RenameTableEntityDiff) InstantDDLCapability() InstantDDLCapability {
 	return InstantDDLCapabilityIrrelevant
+}
+
+// Clone implements EntityDiff
+func (d *RenameTableEntityDiff) Clone() EntityDiff {
+	if d == nil {
+		return nil
+	}
+	clone := &RenameTableEntityDiff{
+		renameTable: sqlparser.CloneRefOfRenameTable(d.renameTable),
+	}
+	if d.from != nil {
+		clone.from = d.from.Clone().(*CreateTableEntity)
+	}
+	if d.to != nil {
+		clone.to = d.to.Clone().(*CreateTableEntity)
+	}
+	return clone
 }
 
 // CreateTableEntity stands for a TABLE construct. It contains the table's CREATE statement.

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -48,6 +48,7 @@ func TestCreateTableDiff(t *testing.T) {
 		enumreorder int
 		subsequent  int
 		textdiffs   []string
+		atomicdiffs []string
 	}{
 		{
 			name: "identical",
@@ -1365,6 +1366,10 @@ func TestCreateTableDiff(t *testing.T) {
 				"-(PARTITION `p1` VALUES LESS THAN (10),",
 				"- PARTITION `p2` VALUES LESS THAN (20),",
 			},
+			atomicdiffs: []string{
+				"ALTER TABLE `t1` DROP PARTITION `p1`",
+				"ALTER TABLE `t1` DROP PARTITION `p2`",
+			},
 		},
 		{
 			name:     "change partitioning range: statements, multiple adds",
@@ -1503,6 +1508,10 @@ func TestCreateTableDiff(t *testing.T) {
 				"+ PARTITION `p3` VALUES LESS THAN (35),",
 				"+ PARTITION `p4` VALUES LESS THAN (40))",
 			},
+			atomicdiffs: []string{
+				"ALTER TABLE `t1` DROP PARTITION `p1`",
+				"ALTER TABLE `t1` DROP PARTITION `p3`",
+			},
 		},
 		{
 			name:     "change partitioning range: complex rotate 2, ignore",
@@ -1522,6 +1531,10 @@ func TestCreateTableDiff(t *testing.T) {
 				"- PARTITION `p3` VALUES LESS THAN (30))",
 				"+ PARTITION `pX` VALUES LESS THAN (30),",
 				"+ PARTITION `p4` VALUES LESS THAN (40))",
+			},
+			atomicdiffs: []string{
+				"ALTER TABLE `t1` DROP PARTITION `p1`",
+				"ALTER TABLE `t1` DROP PARTITION `p3`",
 			},
 		},
 		{
@@ -2072,6 +2085,7 @@ func TestCreateTableDiff(t *testing.T) {
 					t.Logf("other: %v", sqlparser.CanonicalString(other.CreateTable))
 				}
 				assert.Empty(t, ts.textdiffs)
+				assert.Empty(t, AtomicDiffs(alter))
 				return
 			}
 
@@ -2125,6 +2139,18 @@ func TestCreateTableDiff(t *testing.T) {
 						applied.Create().CanonicalStatementString(),
 					)
 				}
+				// Validate atomic diffs
+				atomicDiffs := AtomicDiffs(alter)
+				if len(ts.atomicdiffs) > 0 {
+					assert.Equal(t, len(ts.atomicdiffs), len(atomicDiffs), "%+v", atomicDiffs)
+					for i := range ts.atomicdiffs {
+						assert.Equal(t, ts.atomicdiffs[i], atomicDiffs[i].CanonicalStatementString())
+					}
+				} else {
+					assert.Equal(t, 1, len(atomicDiffs))
+					assert.Equal(t, alter.CanonicalStatementString(), atomicDiffs[0].CanonicalStatementString())
+				}
+
 				{ // Validate annotations
 					alterEntityDiff, ok := alter.(*AlterTableEntityDiff)
 					require.True(t, ok)

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -69,7 +69,8 @@ type EntityDiff interface {
 	SetSubsequentDiff(EntityDiff)
 	// InstantDDLCapability returns the ability of this diff to run with ALGORITHM=INSTANT
 	InstantDDLCapability() InstantDDLCapability
-
+	// Clone returns a deep copy of the entity diff, and of all referenced entities.
+	Clone() EntityDiff
 	Annotated() (from *TextualAnnotations, to *TextualAnnotations, unified *TextualAnnotations)
 }
 

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -100,6 +100,23 @@ func (d *AlterViewEntityDiff) InstantDDLCapability() InstantDDLCapability {
 	return InstantDDLCapabilityIrrelevant
 }
 
+// Clone implements EntityDiff
+func (d *AlterViewEntityDiff) Clone() EntityDiff {
+	if d == nil {
+		return nil
+	}
+	clone := &AlterViewEntityDiff{
+		alterView: sqlparser.CloneRefOfAlterView(d.alterView),
+	}
+	if d.from != nil {
+		clone.from = d.from.Clone().(*CreateViewEntity)
+	}
+	if d.to != nil {
+		clone.to = d.to.Clone().(*CreateViewEntity)
+	}
+	return clone
+}
+
 type CreateViewEntityDiff struct {
 	createView *sqlparser.CreateView
 
@@ -177,6 +194,16 @@ func (d *CreateViewEntityDiff) InstantDDLCapability() InstantDDLCapability {
 	return InstantDDLCapabilityIrrelevant
 }
 
+// Clone implements EntityDiff
+func (d *CreateViewEntityDiff) Clone() EntityDiff {
+	if d == nil {
+		return nil
+	}
+	return &CreateViewEntityDiff{
+		createView: sqlparser.CloneRefOfCreateView(d.createView),
+	}
+}
+
 type DropViewEntityDiff struct {
 	from     *CreateViewEntity
 	dropView *sqlparser.DropView
@@ -252,6 +279,20 @@ func (d *DropViewEntityDiff) SetSubsequentDiff(EntityDiff) {
 // InstantDDLCapability implements EntityDiff
 func (d *DropViewEntityDiff) InstantDDLCapability() InstantDDLCapability {
 	return InstantDDLCapabilityIrrelevant
+}
+
+// Clone implements EntityDiff
+func (d *DropViewEntityDiff) Clone() EntityDiff {
+	if d == nil {
+		return nil
+	}
+	clone := &DropViewEntityDiff{
+		dropView: sqlparser.CloneRefOfDropView(d.dropView),
+	}
+	if d.from != nil {
+		clone.from = d.from.Clone().(*CreateViewEntity)
+	}
+	return clone
 }
 
 // CreateViewEntity stands for a VIEW construct. It contains the view's CREATE statement.

--- a/go/vt/schemadiff/view_test.go
+++ b/go/vt/schemadiff/view_test.go
@@ -196,6 +196,15 @@ func TestCreateViewDiff(t *testing.T) {
 						require.NoError(t, err)
 						assert.True(t, appliedDiff.IsEmpty(), "expected empty diff, found changes: %v", appliedDiff.CanonicalStatementString())
 					}
+					// Validate Clone() works
+					{
+						clone := alter.Clone()
+						alterClone, ok := clone.(*AlterViewEntityDiff)
+						require.True(t, ok)
+						assert.Equal(t, eFrom.Create().CanonicalStatementString(), alterClone.from.Create().CanonicalStatementString())
+						alterClone.from.CreateView.ViewName.Name = sqlparser.NewIdentifierCS("something_else")
+						assert.NotEqual(t, eFrom.Create().CanonicalStatementString(), alterClone.from.Create().CanonicalStatementString())
+					}
 				}
 				{
 					cdiff := alter.CanonicalStatementString()


### PR DESCRIPTION

## Description

Introducing a `AtomicDiffs()` function, which, given a single diff, returns a slice of diffs, as atomic as possible, which together comprises the given diff.

Right now the function only breaks down `DROP PARTITION` statements.

An an aside, this PR also adds a convenient `Clone()` function to `EntityDiff` interface, which does a deep copy of the diff and of its entities (but not necessarily other constructs such as annotations). This is useful for programs using `schemadiff` as a library as it allows some safety for data manipulation.

## Related Issue(s)

Addresses https://github.com/vitessio/vitess/issues/15842

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
