### PR TITLE
Delete the deprecated pool size flags

### DIFF
--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -25,6 +25,7 @@
     - [Insert Row Alias Support](#insert-row-alias-support)
   - **[Query Timeout](#query-timeout)**
   - **[Flag changes](#flag-changes)**
+    - [`Pool Capacity Flags Deletion`](#pool-flags-deletion)
     - [`pprof-http` default change](#pprof-http-default)
     - [New `healthcheck-dial-concurrency` flag](#healthcheck-dial-concurrency-flag)
     - [New minimum for `--buffer_min_time_between_failovers`](#buffer_min_time_between_failovers-flag)
@@ -217,6 +218,10 @@ which is not desirable in some cases. To avoid this, Vitess now uses the `kill q
 This will only cancel the query and does not terminate the connection.
 
 ### <a id="flag-changes"/>Flag Changes
+
+#### <a id="pool-flags-deletion"/>Pool Capacity Flags Deletion
+
+The previously deprecated flags `--queryserver-config-query-pool-waiter-cap`, `--queryserver-config-stream-pool-waiter-cap` and `--queryserver-config-txpool-waiter-cap` have been deleted.
 
 #### <a id="pprof-http-default"/> `pprof-http` Default Change
 

--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -4,6 +4,7 @@
 
 - **[Major Changes](#major-changes)**
   - **[Deletions](#deletions)** 
+    - [`Pool Capacity Flags Deletion`](#pool-flags-deletion)
     - [MySQL binaries in the vitess/lite Docker images](#vitess-lite)
     - [vitess/base and vitess/k8s Docker images](#base-k8s-images)
     - [`gh-ost` binary and endtoend tests](#gh-ost-binary-tests-removal)
@@ -25,7 +26,6 @@
     - [Insert Row Alias Support](#insert-row-alias-support)
   - **[Query Timeout](#query-timeout)**
   - **[Flag changes](#flag-changes)**
-    - [`Pool Capacity Flags Deletion`](#pool-flags-deletion)
     - [`pprof-http` default change](#pprof-http-default)
     - [New `healthcheck-dial-concurrency` flag](#healthcheck-dial-concurrency-flag)
     - [New minimum for `--buffer_min_time_between_failovers`](#buffer_min_time_between_failovers-flag)
@@ -40,6 +40,10 @@
 ## <a id="major-changes"/>Major Changes
 
 ### <a id="deletions"/>Deletion
+
+#### <a id="pool-flags-deletion"/>Pool Capacity Flags Deletion
+
+The previously deprecated flags `--queryserver-config-query-pool-waiter-cap`, `--queryserver-config-stream-pool-waiter-cap` and `--queryserver-config-txpool-waiter-cap` have been deleted.
 
 #### <a id="vitess-lite"/>MySQL binaries in the `vitess/lite` Docker images
 
@@ -218,10 +222,6 @@ which is not desirable in some cases. To avoid this, Vitess now uses the `kill q
 This will only cancel the query and does not terminate the connection.
 
 ### <a id="flag-changes"/>Flag Changes
-
-#### <a id="pool-flags-deletion"/>Pool Capacity Flags Deletion
-
-The previously deprecated flags `--queryserver-config-query-pool-waiter-cap`, `--queryserver-config-stream-pool-waiter-cap` and `--queryserver-config-txpool-waiter-cap` have been deleted.
 
 #### <a id="pprof-http-default"/> `pprof-http` Default Change
 

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -146,14 +146,6 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&currentConfig.OltpReadPool.IdleTimeout, "queryserver-config-idle-timeout", defaultConfig.OltpReadPool.IdleTimeout, "query server idle timeout, vttablet manages various mysql connection pools. This config means if a connection has not been used in given idle timeout, this connection will be removed from pool. This effectively manages number of connection objects and optimize the pool performance.")
 	fs.DurationVar(&currentConfig.OltpReadPool.MaxLifetime, "queryserver-config-pool-conn-max-lifetime", defaultConfig.OltpReadPool.MaxLifetime, "query server connection max lifetime, vttablet manages various mysql connection pools. This config means if a connection has lived at least this long, it connection will be removed from pool upon the next time it is returned to the pool.")
 
-	var unused int
-	fs.IntVar(&unused, "queryserver-config-query-pool-waiter-cap", 0, "query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection")
-	fs.IntVar(&unused, "queryserver-config-stream-pool-waiter-cap", 0, "query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection")
-	fs.IntVar(&unused, "queryserver-config-txpool-waiter-cap", 0, "query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection")
-	fs.MarkDeprecated("queryserver-config-query-pool-waiter-cap", "The new connection pool in v19 does not limit waiter capacity. This flag will be removed in a future release.")
-	fs.MarkDeprecated("queryserver-config-stream-pool-waiter-cap", "The new connection pool in v19 does not limit waiter capacity. This flag will be removed in a future release.")
-	fs.MarkDeprecated("queryserver-config-txpool-waiter-cap", "The new connection pool in v19 does not limit waiter capacity. This flag will be removed in a future release.")
-
 	// tableacl related configurations.
 	fs.BoolVar(&currentConfig.StrictTableACL, "queryserver-config-strict-table-acl", defaultConfig.StrictTableACL, "only allow queries that pass table acl checks")
 	fs.BoolVar(&currentConfig.EnableTableACLDryRun, "queryserver-config-enable-table-acl-dry-run", defaultConfig.EnableTableACLDryRun, "If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR deletes the deprecated pool size flags.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
