### PR TITLE
VStreamer unit tests: refactor pending test

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
@@ -552,7 +552,7 @@ func (ts *TestSpec) getFieldEvent(table *schemadiff.CreateTableEntity) *TestFiel
 			tc.len = lengthJSON
 			tc.collationID = collations.CollationBinaryID
 		default:
-			ts.t.Fatalf("unknown sqlTypeString %s", tc.dataTypeLowered)
+			require.FailNowf(ts.t, "unknown sqlTypeString %s", tc.dataTypeLowered)
 		}
 		tfe.cols = append(tfe.cols, &tc)
 	}
@@ -603,7 +603,7 @@ func (ts *TestSpec) getRowEvent(table string, bv map[string]string, fe *TestFiel
 			}
 		case "json":
 			sval := strings.Trim(string(val), "'")
-			sval = strings.Replace(sval, "\\", "", -1)
+			sval = strings.ReplaceAll(sval, "\\", "")
 			val = []byte(sval)
 			l = int64(len(val))
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
@@ -66,8 +66,7 @@ const (
 	// This is the expected length of the only SET column using a binary collation
 	// in the test schema.
 	lengthSetBinary = 428
-	lengthSet  = 56
-	lengthJSON = 4294967295
+	lengthJSON      = 4294967295
 )
 
 var (

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -1415,7 +1415,6 @@ func TestBuffering(t *testing.T) {
 // collation information, however, in the binlog_row_metadata in 8.0 but
 // not in 5.7. So in 5.7 our best effort uses varchar with its default
 // collation for text fields.
-// todo: migrate to new framework
 func TestBestEffortNameInFieldEvent(t *testing.T) {
 	bestEffortCollation := collations.ID(collations.CollationBinaryID)
 	if strings.HasPrefix(testenv.MySQLVersion, "5.7") {
@@ -1524,7 +1523,6 @@ func TestInternalTables(t *testing.T) {
 	runCases(t, filter, testcases, position, nil)
 }
 
-// todo: migrate to new framework
 func TestTypes(t *testing.T) {
 	// Modeled after vttablet endtoend compatibility tests.
 	execStatements(t, []string{


### PR DESCRIPTION
## Description

Final PR on porting over the vstreamer unit tests. Only one test `TestJSON` has been ported. Remaining ones are too specific and will require disproportional changes in the test framework for each test and those have been left as-is. 

## Related Issue(s)

https://github.com/vitessio/vitess/pull/14903

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
