### PR TITLE
Install linux generic libc2.12 `mysqlbinlog` binary and libraries

### DIFF
--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -55,19 +55,19 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess
 RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
-ENV VTROOT /vt/src/vitess.io/vitess
-ENV VTDATAROOT /vt/vtdataroot
+ENV VTROOT /vt
+ENV VTDATAROOT $VTROOT/vtdataroot
 ENV PATH $VTROOT/bin:$PATH
 
 # Copy artifacts from builder layer.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder --chown=vitess:vitess /vt/install /vt
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/web/vtadmin /vt/web/vtadmin
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/init_db.sql /vt/config/
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/mycnf /vt/config/
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/bin/mysqlbinlog /vt/bin/mysqlbinlog
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/lib/private/libcrypto.so.3 /vt/lib/libcrypto.so.3
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/lib/private/libssl.so.3 /vt/lib/libssl.so.3
+COPY --from=builder --chown=vitess:vitess /vt/install $VTROOT
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/web/vtadmin $VTROOT/web/vtadmin
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/init_db.sql $VTROOT/config/
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/mycnf $VTROOT/config/
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/bin/mysqlbinlog $VTROOT/bin/mysqlbinlog
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/lib/private/libcrypto.so.3 $VTROOT/lib/private/libcrypto.so.3
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/lib/private/libssl.so.3 $VTROOT/lib/private/libssl.so.3
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot

--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -25,7 +25,7 @@ FROM "${image}" AS builder
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
-# Install mysql
+# Download linux generic mysql
 USER root
 RUN apt-get update && apt-get install -y xz-utils
 RUN wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.37-linux-glibc2.12-x86_64.tar.xz

--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -18,12 +18,19 @@
 
 # Use a temporary layer for the build stage.
 ARG bootstrap_version=31
-ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
+ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM "${image}" AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
+
+# Install mysql
+USER root
+RUN apt-get update && apt-get install -y xz-utils
+RUN wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.37-linux-glibc2.12-x86_64.tar.xz
+RUN tar -xf mysql-8.0.37-linux-glibc2.12-x86_64.tar.xz
+RUN mv mysql-8.0.37-linux-glibc2.12-x86_64 mysql-generic-binaries
 
 # Re-copy sources from working tree.
 COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
@@ -34,13 +41,10 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:bullseye-slim
-
-# Install mysqlbinglog
-RUN apt-get update && apt-get -y install libssl1.1 gnupg
-COPY --from=builder /usr/bin/mysqlbinlog /usr/bin/mysqlbinlog
+FROM --platform=linux/amd64 debian:bullseye-slim
 
 # Install xtrabackup
+RUN apt-get update && apt-get -y install gnupg
 RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 9334A25F8507EFA5
 RUN echo 'deb http://repo.percona.com/apt bullseye main' > /etc/apt/sources.list.d/percona.list
 RUN apt-get update -y
@@ -61,6 +65,9 @@ COPY --from=builder --chown=vitess:vitess /vt/install /vt
 COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/web/vtadmin /vt/web/vtadmin
 COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/init_db.sql /vt/config/
 COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/mycnf /vt/config/
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/bin/mysqlbinlog /vt/bin/mysqlbinlog
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/lib/private/libcrypto.so.3 /vt/lib/libcrypto.so.3
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/mysql-generic-binaries/lib/private/libssl.so.3 /vt/lib/libssl.so.3
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot


### PR DESCRIPTION
## Description

After merging https://github.com/vitessio/vitess/pull/15620 we realized that `mysqlbinlog` was missing from the `vitess/lite` image, we decided to add it back to the image with https://github.com/vitessio/vitess/pull/15775. However, we realized that `mysqlbinlog` is used by the `mysqld` container in K8S, and the image of this container is defined by the user (official MySQL image, Percona image, custom build, etc...), meaning that the when executing `mysqlbinlog` in the `mysqld` container we had 0 guarantee that all the required libraries were installed. For this reason, we are now installing a generic linux version of `mysql` based on libc2.12 (from 2010) in the base image of `vitess/lite`, this binary and libraries are going to be compatible with most x86_64 environments where Vitess will run.

The `mysqlbinlog` binary has two libraries that we need to copy from the downloaded tarball to the final Docker image: `libcrypto.so.3` and `libssl.so.3`. The binary expect to find both libraries in the `../lib/private/` folder from where the binary is found. For this reason, in the final image, the libraries are copied into `/vt/lib/private` and `mysqlbinlog` to `/vt/bin`. The goal here, is for the vitess-operator to modify the `vtRootInitScript` to copy `mysqlbinlog` and the libraries. @mattlord is already working on this in https://github.com/planetscale/vitess-operator/pull/541.

## Docker Image tests

```
~/vitess# docker build -f docker/lite/Dockerfile -t frouioui/lite:test . 
[+] Building 85.9s (31/31) FINISHED                                                                                                             

~/vitess# docker run -it frouioui/lite:test bash 
vitess@4f6240a178e1:/$ mysqlbinlog -V
mysqlbinlog  Ver 8.0.37 for Linux on x86_64 (MySQL Community Server - GPL)
vitess@4f6240a178e1:/$ ldd /vt/bin/mysqlbinlog 
        linux-vdso.so.1 (0x00007fff6f5fa000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f2210cd5000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f2210ccf000)
        libcrypto.so.3 => /vt/bin/../lib/private/libcrypto.so.3 (0x00007f22106b7000)
        libssl.so.3 => /vt/bin/../lib/private/libssl.so.3 (0x00007f2210413000)
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007f22103f9000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f22103ef000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f2210220000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f22100dc000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f22100c2000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f220feee000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2210cfc000)
```

## Vitess-operator deployment tests

```
$> minikube start --kubernetes-version=v1.28.5 --cpus=4 --memory=11000 --disk-size=32g
$> cd examples/operator
$> kubectl apply -f operator.yaml
$> kubectl apply -f 101_initial_cluster.yaml
$> kubectl get pods
NAME                                                         READY   STATUS    RESTARTS        AGE
example-commerce-x-x-zone1-vtorc-c13ef6ff-5fd499c7db-2dp9n   1/1     Running   0               4m39s
example-etcd-faf13de3-1                                      1/1     Running   0               4m40s
example-etcd-faf13de3-2                                      1/1     Running   0               4m40s
example-etcd-faf13de3-3                                      1/1     Running   0               4m40s
example-vttablet-zone1-2469782763-bfadd780                   3/3     Running   1 (2m29s ago)   4m39s
example-vttablet-zone1-2548885007-46a852d0                   3/3     Running   1 (2m29s ago)   4m39s
example-zone1-vtadmin-c03d7eae-5dfd76fb6-5x2vx               2/2     Running   0               4m40s
example-zone1-vtctld-1d4dcad0-7744455bd6-dn8gd               1/1     Running   0               4m40s
example-zone1-vtgate-bc6cde92-7974f87944-szqf5               1/1     Running   0               4m39s
vitess-operator-6fcb7977c-mjr77                              1/1     Running   0               5m20s


```
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
