### PR TITLE
Delete the deprecated vreplication tablet type flag

### DIFF
--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -4,6 +4,7 @@
 
 - **[Major Changes](#major-changes)**
   - **[Deletions](#deletions)** 
+    - [`--vreplication_tablet_type` flag is now deleted](#vreplication-tablet-type-deletion)
     - [`Pool Capacity Flags Deletion`](#pool-flags-deletion)
     - [MySQL binaries in the vitess/lite Docker images](#vitess-lite)
     - [vitess/base and vitess/k8s Docker images](#base-k8s-images)
@@ -40,6 +41,10 @@
 ## <a id="major-changes"/>Major Changes
 
 ### <a id="deletions"/>Deletion
+
+#### <a id="vreplication-tablet-type-deletion"\>`--vreplication_tablet_type` flag is now deleted
+
+The previously deprecated flags `--vreplication_tablet_type` has been deleted.
 
 #### <a id="pool-flags-deletion"/>Pool Capacity Flags Deletion
 

--- a/go/vt/vttablet/tabletmanager/vreplication/flags.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/flags.go
@@ -59,10 +59,6 @@ func registerVReplicationFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&vreplicationStoreCompressedGTID, "vreplication_store_compressed_gtid", vreplicationStoreCompressedGTID, "Store compressed gtids in the pos column of the sidecar database's vreplication table")
 
 	fs.IntVar(&vreplicationParallelInsertWorkers, "vreplication-parallel-insert-workers", vreplicationParallelInsertWorkers, "Number of parallel insertion workers to use during copy phase. Set <= 1 to disable parallelism, or > 1 to enable concurrent insertion during copy phase.")
-
-	// Deprecated and ignored in v19.
-	fs.String("vreplication_tablet_type", tabletTypesStr, "Comma-separated list of tablet types used as a source.")
-	fs.MarkDeprecated("vreplication_tablet_type", "As of v19 this is ignored and will be removed in a future release.")
 }
 
 func init() {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR deletes the deprecated vreplication tablet type flag.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
