### PR TITLE
[18.x] Fix `schemacopy` collation issues

### DIFF
--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -39,13 +39,13 @@ const (
 	DetectSchemaChange = `
 SELECT DISTINCT table_name
 FROM (
-	SELECT table_name, column_name, ordinal_position, character_set_name, collation_name, data_type, column_key
+	SELECT table_name COLLATE utf8mb3_bin AS table_name, column_name COLLATE utf8mb3_general_ci AS column_name, ordinal_position, character_set_name COLLATE utf8mb3_general_ci AS character_set_name, collation_name COLLATE utf8mb3_general_ci AS collation_name, data_type COLLATE utf8mb3_bin AS data_type, column_key COLLATE utf8mb3_bin AS column_key
 	FROM information_schema.columns
 	WHERE table_schema = database()
 
 	UNION ALL
 
-	SELECT table_name, column_name, ordinal_position, character_set_name, collation_name, data_type, column_key
+	SELECT table_name COLLATE utf8mb3_bin AS table_name, column_name COLLATE utf8mb3_general_ci AS column_name, ordinal_position, character_set_name COLLATE utf8mb3_general_ci AS character_set_name, collation_name COLLATE utf8mb3_general_ci AS collation_name, data_type COLLATE utf8mb3_bin AS data_type, column_key COLLATE utf8mb3_bin AS column_key
 	FROM %s.schemacopy
 	WHERE table_schema = database()
 ) _inner

--- a/go/vt/sidecardb/schema/schematracker/schemacopy.sql
+++ b/go/vt/sidecardb/schema/schematracker/schemacopy.sql
@@ -16,13 +16,13 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS schemacopy
 (
-    `table_schema`          varchar(64) COLLATE utf8_bin         NOT NULL,
-    `table_name`            varchar(64) COLLATE utf8_bin         NOT NULL,
-    `column_name`           varchar(64) COLLATE utf8_general_ci  NOT NULL,
-    `ordinal_position`      bigint unsigned                      NOT NULL,
-    `character_set_name`    varchar(32) COLLATE utf8_general_ci  DEFAULT NULL,
-    `collation_name`        varchar(32) COLLATE utf8_general_ci  DEFAULT NULL,
-    `data_type`             varchar(64) COLLATE utf8_bin         NOT NULL,
-    `column_key`            varchar(3)  COLLATE utf8_bin         NOT NULL,
+    `table_schema`          varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
+    `table_name`            varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
+    `column_name`           varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci  NOT NULL,
+    `ordinal_position`      bigint unsigned                                               NOT NULL,
+    `character_set_name`    varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci  DEFAULT NULL,
+    `collation_name`        varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci  DEFAULT NULL,
+    `data_type`             varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
+    `column_key`            varchar(3)  CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
     PRIMARY KEY (`table_schema`, `table_name`, `ordinal_position`)
 ) ENGINE = InnoDB

--- a/go/vt/sidecardb/schema/schematracker/schemacopy.sql
+++ b/go/vt/sidecardb/schema/schematracker/schemacopy.sql
@@ -16,13 +16,13 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS schemacopy
 (
-    `table_schema`       varchar(64)     NOT NULL,
-    `table_name`         varchar(64)     NOT NULL,
-    `column_name`        varchar(64)     NOT NULL,
-    `ordinal_position`   bigint unsigned NOT NULL,
-    `character_set_name` varchar(32) DEFAULT NULL,
-    `collation_name`     varchar(32) DEFAULT NULL,
-    `data_type`          varchar(64)     NOT NULL,
-    `column_key`         varchar(3)      NOT NULL,
+    `table_schema`          varchar(64) COLLATE utf8_bin         NOT NULL,
+    `table_name`            varchar(64) COLLATE utf8_bin         NOT NULL,
+    `column_name`           varchar(64) COLLATE utf8_general_ci  NOT NULL,
+    `ordinal_position`      bigint unsigned                      NOT NULL,
+    `character_set_name`    varchar(32) COLLATE utf8_general_ci  DEFAULT NULL,
+    `collation_name`        varchar(32) COLLATE utf8_general_ci  DEFAULT NULL,
+    `data_type`             varchar(64) COLLATE utf8_bin         NOT NULL,
+    `column_key`            varchar(3)  COLLATE utf8_bin         NOT NULL,
     PRIMARY KEY (`table_schema`, `table_name`, `ordinal_position`)
 ) ENGINE = InnoDB

--- a/go/vt/sidecardb/schema/schematracker/schemacopy.sql
+++ b/go/vt/sidecardb/schema/schematracker/schemacopy.sql
@@ -25,4 +25,4 @@ CREATE TABLE IF NOT EXISTS schemacopy
     `data_type`             varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
     `column_key`            varchar(3)  CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
     PRIMARY KEY (`table_schema`, `table_name`, `ordinal_position`)
-) ENGINE = InnoDB
+) ENGINE = InnoDB, CHARACTER SET = utf8mb3


### PR DESCRIPTION
## Description

This fixes a collation error caused by a query run during health check in `vttablet`.

The same issue exists in v17.x, so a backport is required once this has been merged to v18.x.

## Related Issue(s)

* https://github.com/vitessio/vitess/issues/11003
* https://github.com/vitessio/vitess/issues/15858

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
