### PR TITLE
`schemadiff`: adding charset/collation tests

### DIFF
--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -295,6 +295,18 @@ func TestSchemaDiff(t *testing.T) {
 			instantCapability: InstantDDLCapabilityPossible,
 		},
 		{
+			name: "two identical tables, one with explicit charset, one without",
+			fromQueries: []string{
+				"create table foobar (id int primary key, foo varchar(64) character set utf8mb3 collate utf8mb3_bin)",
+			},
+			toQueries: []string{
+				"create table foobar (id int primary key, foo varchar(64) collate utf8mb3_bin)",
+			},
+			entityOrder:       []string{},
+			instantCapability: InstantDDLCapabilityIrrelevant,
+		},
+
+		{
 			name: "instant DDL possible on 8.0.32",
 			toQueries: []string{
 				"create table t1 (id int primary key, ts timestamp, info int not null);",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1879,6 +1879,11 @@ func TestCreateTableDiff(t *testing.T) {
 			cdiff: "ALTER TABLE `t` COLLATE utf8mb4_0900_bin",
 		},
 		{
+			name: "ignore identical implicit charset",
+			from: "create table t (id int primary key, v varchar(64) character set utf8mb3 collate utf8mb3_bin)",
+			to:   "create table t (id int primary key, v varchar(64) collate utf8mb3_bin)",
+		},
+		{
 			name:  "normalized unsigned attribute",
 			from:  "create table t1 (id int primary key)",
 			to:    "create table t1 (id int unsigned primary key)",
@@ -2888,6 +2893,11 @@ func TestNormalize(t *testing.T) {
 			name: "drops existing collation if it matches table default at column level for non default charset",
 			from: "create table t (id int signed primary key, v varchar(255) charset utf8mb3 collate utf8_unicode_ci) charset utf8mb3 collate utf8_unicode_ci",
 			to:   "CREATE TABLE `t` (\n\t`id` int,\n\t`v` varchar(255),\n\tPRIMARY KEY (`id`)\n) CHARSET utf8mb3,\n  COLLATE utf8mb3_unicode_ci",
+		},
+		{
+			name: "remove column charset if collation is explicit and implies specified charset",
+			from: "create table t (id int primary key, v varchar(255) charset utf8mb4 collate utf8mb4_german2_ci)",
+			to:   "CREATE TABLE `t` (\n\t`id` int,\n\t`v` varchar(255) COLLATE utf8mb4_german2_ci,\n\tPRIMARY KEY (`id`)\n)",
 		},
 		{
 			name: "correct case table options for engine",


### PR DESCRIPTION

## Description

Just adding a couple test cases. No particular issue, though this is inspired by https://github.com/vitessio/vitess/pull/15859

## Related Issue(s)

https://github.com/vitessio/vitess/pull/15859

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
