### PR TITLE
allow query timeout hints on shard targeting

### DIFF
--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -100,23 +100,30 @@ func TestQueryTimeoutWithTables(t *testing.T) {
 
 // TestQueryTimeoutWithShardTargeting tests the query timeout with shard targeting.
 func TestQueryTimeoutWithShardTargeting(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+
 	mcmp, closer := start(t)
 	defer closer()
-
-	queries := []string{
-		"insert /*vt+ QUERY_TIMEOUT_MS=1 */ into t1(id1, id2) values (1,2)",
-		"update /*vt+ QUERY_TIMEOUT_MS=1 */ t1 set id2 = 5",
-		"delete /*vt+ QUERY_TIMEOUT_MS=1 */ from t1 where id2 = 5",
-		"select /*vt+ QUERY_TIMEOUT_MS=1 */ 1 from t1 where sleep(100)",
-	}
 
 	// shard targeting to -80 shard.
 	utils.Exec(t, mcmp.VtConn, "use `ks_misc/-80`")
 
-	for _, query := range queries {
-		t.Run(query, func(t *testing.T) {
-			_, err := utils.ExecAllowError(t, mcmp.VtConn, query)
-			assert.ErrorContains(t, err, "context deadline exceeded (errno 1317) (sqlstate 70100)")
-		})
-	}
+	// insert some data
+	utils.Exec(t, mcmp.VtConn, "insert into t1(id1, id2) values (1,2),(3,4),(4,5),(5,6)")
+
+	// insert
+	_, err := utils.ExecAllowError(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1 */ into t1(id1, id2) values (6,sleep(5))")
+	assert.ErrorContains(t, err, "context deadline exceeded (errno 1317) (sqlstate 70100)")
+
+	// update
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "update /*vt+ QUERY_TIMEOUT_MS=1 */ t1 set id2 = sleep(5)")
+	assert.ErrorContains(t, err, "context deadline exceeded (errno 1317) (sqlstate 70100)")
+
+	// delete
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "delete /*vt+ QUERY_TIMEOUT_MS=1 */ from t1 where id2 = sleep(5)")
+	assert.ErrorContains(t, err, "context deadline exceeded (errno 1317) (sqlstate 70100)")
+
+	// select
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=1 */ 1 from t1 where id2 = 5 and sleep(100)")
+	assert.ErrorContains(t, err, "context deadline exceeded (errno 1317) (sqlstate 70100)")
 }

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -1091,7 +1091,7 @@ func (cached *Send) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(48)
+		size += int64(64)
 	}
 	// field Keyspace *vitess.io/vitess/go/vt/vtgate/vindexes.Keyspace
 	size += cached.Keyspace.CachedSize(true)

--- a/go/vt/vtgate/engine/send.go
+++ b/go/vt/vtgate/engine/send.go
@@ -57,6 +57,9 @@ type Send struct {
 	MultishardAutocommit bool
 
 	ReservedConnectionNeeded bool
+
+	// QueryTimeout contains the optional timeout (in milliseconds) to apply to this query
+	QueryTimeout int
 }
 
 // ShardName as key for setting shard name in bind variables map
@@ -88,7 +91,7 @@ func (s *Send) GetTableName() string {
 
 // TryExecute implements Primitive interface
 func (s *Send) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	ctx, cancelFunc := addQueryTimeout(ctx, vcursor, 0)
+	ctx, cancelFunc := addQueryTimeout(ctx, vcursor, s.QueryTimeout)
 	defer cancelFunc()
 
 	rss, err := s.checkAndReturnShards(ctx, vcursor)
@@ -192,6 +195,7 @@ func (s *Send) description() PrimitiveDescription {
 		"ShardNameNeeded":          s.ShardNameNeeded,
 		"MultishardAutocommit":     s.MultishardAutocommit,
 		"ReservedConnectionNeeded": s.ReservedConnectionNeeded,
+		"QueryTimeout":             s.QueryTimeout,
 	}
 	return PrimitiveDescription{
 		OperatorType:      "Send",

--- a/go/vt/vtgate/planbuilder/testdata/bypass_shard_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/bypass_shard_cases.json
@@ -123,6 +123,7 @@
     }
   },
   {
+    "comment": "load data from s3 'x.txt' into table x",
     "query": "load data from s3 'x.txt' into table x",
     "plan": {
       "QueryType": "OTHER",
@@ -141,6 +142,7 @@
     }
   },
   {
+    "comment": "load data from s3 'x.txt'",
     "query": "load data from s3 'x.txt'",
     "plan": {
       "QueryType": "OTHER",
@@ -172,6 +174,81 @@
         },
         "TargetDestination": "Shard(-80)",
         "Query": "create /* test */ table t1(id bigint, primary key(id)) /* comments */"
+      }
+    }
+  },
+  {
+    "comment": "select bypass with query timeout hint",
+    "query": "select /*vt+ QUERY_TIMEOUT_MS=100 */ count(*), col from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select /*vt+ QUERY_TIMEOUT_MS=100 */ count(*), col from user",
+      "Instructions": {
+        "OperatorType": "Send",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetDestination": "Shard(-80)",
+        "Query": "select /*vt+ QUERY_TIMEOUT_MS=100 */ count(*), col from `user`",
+        "QueryTimeout": 100
+      }
+    }
+  },
+  {
+    "comment": "update bypass with query timeout hint",
+    "query": "update /*vt+ QUERY_TIMEOUT_MS=100 */ user set val = 1 where id = 1",
+    "plan": {
+      "QueryType": "UPDATE",
+      "Original": "update /*vt+ QUERY_TIMEOUT_MS=100 */ user set val = 1 where id = 1",
+      "Instructions": {
+        "OperatorType": "Send",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetDestination": "Shard(-80)",
+        "IsDML": true,
+        "Query": "update /*vt+ QUERY_TIMEOUT_MS=100 */ `user` set val = 1 where id = 1",
+        "QueryTimeout": 100
+      }
+    }
+  },
+  {
+    "comment": "delete bypass with query timeout hint",
+    "query": "DELETE /*vt+ QUERY_TIMEOUT_MS=100 */ FROM USER WHERE ID = 42",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "DELETE /*vt+ QUERY_TIMEOUT_MS=100 */ FROM USER WHERE ID = 42",
+      "Instructions": {
+        "OperatorType": "Send",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetDestination": "Shard(-80)",
+        "IsDML": true,
+        "Query": "delete /*vt+ QUERY_TIMEOUT_MS=100 */ from `USER` where ID = 42",
+        "QueryTimeout": 100
+      }
+    }
+  },
+  {
+    "comment": "insert bypass with query timeout hint",
+    "query": "INSERT /*vt+ QUERY_TIMEOUT_MS=100 */ INTO USER (ID, NAME) VALUES (42, 'ms X')",
+    "plan": {
+      "QueryType": "INSERT",
+      "Original": "INSERT /*vt+ QUERY_TIMEOUT_MS=100 */ INTO USER (ID, NAME) VALUES (42, 'ms X')",
+      "Instructions": {
+        "OperatorType": "Send",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetDestination": "Shard(-80)",
+        "IsDML": true,
+        "Query": "insert /*vt+ QUERY_TIMEOUT_MS=100 */ into `USER`(ID, `NAME`) values (42, 'ms X')",
+        "QueryTimeout": 100
       }
     }
   }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds support for query timeout hint in shard targeting.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes https://github.com/vitessio/vitess/issues/7031

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required