### PR TITLE
fix: handle info_schema routing

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/other_read_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/other_read_cases.json
@@ -146,5 +146,26 @@
         "user.music"
       ]
     }
+  },
+  {
+    "comment": "describe info_schema table",
+    "query": "describe information_schema.administrable_role_authorizations",
+    "plan": {
+      "QueryType": "EXPLAIN",
+      "Original": "describe information_schema.administrable_role_authorizations",
+      "Instructions": {
+        "OperatorType": "Send",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetDestination": "AnyShard()",
+        "Query": "explain information_schema.administrable_role_authorizations",
+        "SingleShardOnly": true
+      },
+      "TablesUsed": [
+        "main.administrable_role_authorizations"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/vexplain.go
+++ b/go/vt/vtgate/planbuilder/vexplain.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -42,22 +44,35 @@ func buildVExplainPlan(ctx context.Context, vexplainStmt *sqlparser.VExplainStmt
 }
 
 func explainTabPlan(explain *sqlparser.ExplainTab, vschema plancontext.VSchema) (*planResult, error) {
-	_, _, ks, _, destination, err := vschema.FindTableOrVindex(explain.Table)
-	if err != nil {
-		return nil, err
+	var keyspace *vindexes.Keyspace
+	var destination key.Destination
+
+	if sqlparser.SystemSchema(explain.Table.Qualifier.String()) {
+		var err error
+		keyspace, err = vschema.AnyKeyspace()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		var ks string
+		_, _, ks, _, destination, err = vschema.FindTableOrVindex(explain.Table)
+		if err != nil {
+			return nil, err
+		}
+		explain.Table.Qualifier = sqlparser.NewIdentifierCS("")
+
+		keyspace, err = vschema.FindKeyspace(ks)
+		if err != nil {
+			return nil, err
+		}
+		if keyspace == nil {
+			return nil, vterrors.VT14004(ks)
+		}
 	}
-	explain.Table.Qualifier = sqlparser.NewIdentifierCS("")
 
 	if destination == nil {
 		destination = key.DestinationAnyShard{}
-	}
-
-	keyspace, err := vschema.FindKeyspace(ks)
-	if err != nil {
-		return nil, err
-	}
-	if keyspace == nil {
-		return nil, vterrors.VT14004(ks)
 	}
 
 	return newPlanResult(&engine.Send{
@@ -114,7 +129,6 @@ func buildExplainStmtPlan(stmt sqlparser.Statement, reservedVars *sqlparser.Rese
 	default:
 		return buildOtherReadAndAdmin(sqlparser.String(explain), vschema)
 	}
-
 }
 
 func explainPlan(explain *sqlparser.ExplainStmt, reservedVars *sqlparser.ReservedVars, vschema plancontext.VSchema) (*planResult, error) {


### PR DESCRIPTION
## Description
In order to handle `I_S` tables/views correctly, we have to do thing different than we do for normal tables.
These queries can be sent to any shard on any keyspace.

## Backports
This is a relatively low-risk change to backport, so I suggest we backport it at least to v18 and v19.

## Related Issue(s)
Fixes #15900

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
