### PR TITLE
Fix flaky test `TestCanGetKeyspaces`

### DIFF
--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -464,7 +464,7 @@ func assertGetKeyspaces(ctx context.Context, t *testing.T, cluster vttest.LocalC
 		},
 		30*time.Second,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	resp, err := consumeEventStream(stream)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
