### PR TITLE
SchemaEngine: Ensure GetTableForPos returns table schema for "current" position by default

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -39,7 +39,10 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-const appendEntry = -1
+const (
+	appendEntry = -1
+	useQuery    = "use `fakesqldb`"
+)
 
 // DB is a fake database and all its methods are thread safe.  It
 // creates a mysql.Listener and implements the mysql.Handler
@@ -201,7 +204,7 @@ func New(t testing.TB) *DB {
 		db.listener.Accept()
 	}()
 
-	db.AddQuery("use `fakesqldb`", &sqltypes.Result{})
+	db.AddQuery(useQuery, &sqltypes.Result{})
 	// Return the db.
 	return db
 }
@@ -628,9 +631,7 @@ func (db *DB) DeleteAllQueries() {
 	clear(db.patternData)
 	clear(db.queryCalled)
 	// Use is always expected to be present.
-	useQuery := "use `fakesqldb`"
 	db.data[useQuery] = &ExpectedResult{&sqltypes.Result{}, nil}
-	db.queryCalled[useQuery] = 0
 }
 
 // AddRejectedQuery adds a query which will be rejected at execution time.

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -33,9 +33,10 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
-	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtenv"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 const appendEntry = -1
@@ -598,6 +599,8 @@ func (db *DB) RejectQueryPattern(queryPattern, error string) {
 
 // ClearQueryPattern removes all query patterns set up
 func (db *DB) ClearQueryPattern() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	db.patternData = make(map[string]exprResult)
 }
 
@@ -615,6 +618,19 @@ func (db *DB) DeleteQuery(query string) {
 	key := strings.ToLower(query)
 	delete(db.data, key)
 	delete(db.queryCalled, key)
+}
+
+// DeleteAllQueries deletes all expected queries from the fake DB.
+func (db *DB) DeleteAllQueries() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	clear(db.data)
+	clear(db.patternData)
+	clear(db.queryCalled)
+	// Use is always expected to be present.
+	useQuery := "use `fakesqldb`"
+	db.data[useQuery] = &ExpectedResult{&sqltypes.Result{}, nil}
+	db.queryCalled[useQuery] = 0
 }
 
 // AddRejectedQuery adds a query which will be rejected at execution time.

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -519,10 +519,9 @@ func (vc *VitessCluster) AddTablet(t testing.TB, cell *Cell, keyspace *Keyspace,
 	tablet := &Tablet{}
 
 	options := []string{
-		"--queryserver-config-schema-reload-time", "5s",
 		"--heartbeat_on_demand_duration", "5s",
 		"--heartbeat_interval", "250ms",
-	} // FIXME: for multi-cell initial schema doesn't seem to load without "--queryserver-config-schema-reload-time"
+	}
 	options = append(options, extraVTTabletArgs...)
 
 	if mainClusterConfig.vreplicationCompressGTID {

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -505,8 +505,6 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 		execVtgateQuery(t, vtgateConn, "product", "insert into customer2(name) values('a')")
 	}
 	waitForRowCount(t, vtgateConn, "product", "customer2", 3+num+num)
-	//want = fmt.Sprintf("[[INT32(%d)]]", 100+num+num-1)
-	//waitForQueryResult(t, vtgateConn, "product", "select max(cid) from customer2", want)
 	res := execVtgateQuery(t, vtgateConn, "product", "select max(cid) from customer2")
 	cid, err := res.Rows[0][0].ToInt()
 	require.NoError(t, err)

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -505,8 +505,12 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 		execVtgateQuery(t, vtgateConn, "product", "insert into customer2(name) values('a')")
 	}
 	waitForRowCount(t, vtgateConn, "product", "customer2", 3+num+num)
-	want = fmt.Sprintf("[[INT32(%d)]]", 100+num+num-1)
-	waitForQueryResult(t, vtgateConn, "product", "select max(cid) from customer2", want)
+	//want = fmt.Sprintf("[[INT32(%d)]]", 100+num+num-1)
+	//waitForQueryResult(t, vtgateConn, "product", "select max(cid) from customer2", want)
+	res := execVtgateQuery(t, vtgateConn, "product", "select max(cid) from customer2")
+	cid, err := res.Rows[0][0].ToInt()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, cid, 100+num+num-1)
 }
 
 // testReplicatingWithPKEnumCols ensures that we properly apply binlog events

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -24,18 +24,16 @@ import (
 	"sync/atomic"
 	"time"
 
-	"vitess.io/vitess/go/vt/vttablet"
-
 	"google.golang.org/protobuf/encoding/prototext"
-
-	"vitess.io/vitess/go/vt/discovery"
-	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/tb"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -256,7 +256,6 @@ func addTablet(id int) *topodatapb.Tablet {
 	if err := env.TopoServ.CreateTablet(context.Background(), tablet); err != nil {
 		panic(err)
 	}
-	env.SchemaEngine.Reload(context.Background())
 	return tablet
 }
 
@@ -277,7 +276,6 @@ func addOtherTablet(id int, keyspace, shard string) *topodatapb.Tablet {
 	if err := env.TopoServ.CreateTablet(context.Background(), tablet); err != nil {
 		panic(err)
 	}
-	env.SchemaEngine.Reload(context.Background())
 	return tablet
 }
 
@@ -285,7 +283,6 @@ func deleteTablet(tablet *topodatapb.Tablet) {
 	env.TopoServ.DeleteTablet(context.Background(), tablet.Alias)
 	// This is not automatically removed from shard replication, which results in log spam.
 	topo.DeleteTabletReplicationData(context.Background(), env.TopoServ, tablet)
-	env.SchemaEngine.Reload(context.Background())
 }
 
 // fakeTabletConn implement TabletConn interface. We only care about the

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	"context"
-
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 )
@@ -38,7 +36,6 @@ func TestJournalOneToOne(t *testing.T) {
 		"drop table t",
 		fmt.Sprintf("drop table %s.t", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -98,7 +95,6 @@ func TestJournalOneToMany(t *testing.T) {
 		"drop table t",
 		fmt.Sprintf("drop table %s.t", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -164,7 +160,6 @@ func TestJournalTablePresent(t *testing.T) {
 		"drop table t",
 		fmt.Sprintf("drop table %s.t", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -223,7 +218,6 @@ func TestJournalTableNotPresent(t *testing.T) {
 		"drop table t",
 		fmt.Sprintf("drop table %s.t", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -278,7 +272,6 @@ func TestJournalTableMixed(t *testing.T) {
 		fmt.Sprintf("drop table %s.t", vrepldb),
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -116,7 +116,6 @@ func testPlayerCopyCharPK(t *testing.T) {
 		"drop table src",
 		fmt.Sprintf("drop table %s.dst", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	count := 0
 	vstreamRowsSendHook = func(ctx context.Context) {
@@ -223,7 +222,6 @@ func testPlayerCopyVarcharPKCaseInsensitive(t *testing.T) {
 		"drop table src",
 		fmt.Sprintf("drop table %s.dst", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	count := 0
 	vstreamRowsSendHook = func(ctx context.Context) {
@@ -453,7 +451,6 @@ func testPlayerCopyTablesWithFK(t *testing.T) {
 		"drop table src2",
 		fmt.Sprintf("drop table %s.dst2", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -581,7 +578,6 @@ func testPlayerCopyTables(t *testing.T) {
 		fmt.Sprintf("drop table %s.yes", vrepldb),
 		"drop table no",
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -708,7 +704,6 @@ func testPlayerCopyBigTable(t *testing.T) {
 		"drop table src",
 		fmt.Sprintf("drop table %s.dst", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	count := 0
 	vstreamRowsSendHook = func(ctx context.Context) {
@@ -839,7 +834,6 @@ func testPlayerCopyWildcardRule(t *testing.T) {
 		"drop table src",
 		fmt.Sprintf("drop table %s.src", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	count := 0
 	vstreamRowsSendHook = func(ctx context.Context) {
@@ -968,7 +962,6 @@ func testPlayerCopyTableContinuation(t *testing.T) {
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1135,7 +1128,6 @@ func testPlayerCopyWildcardTableContinuation(t *testing.T) {
 		"drop table src",
 		fmt.Sprintf("drop table %s.dst", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1232,7 +1224,6 @@ func TestPlayerCopyWildcardTableContinuationWithOptimizeInserts(t *testing.T) {
 		"drop table src",
 		fmt.Sprintf("drop table %s.dst", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1358,7 +1349,6 @@ func testPlayerCopyTablesStopAfterCopy(t *testing.T) {
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1444,7 +1434,6 @@ func testPlayerCopyTablesGIPK(t *testing.T) {
 		"drop table src2",
 		fmt.Sprintf("drop table %s.dst2", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1535,7 +1524,6 @@ func testPlayerCopyTableCancel(t *testing.T) {
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	saveTimeout := vttablet.CopyPhaseDuration
 	vttablet.CopyPhaseDuration = 1 * time.Millisecond
@@ -1626,7 +1614,6 @@ func testPlayerCopyTablesWithGeneratedColumn(t *testing.T) {
 		"drop table src2",
 		fmt.Sprintf("drop table %s.dst2", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1714,7 +1701,6 @@ func testCopyTablesWithInvalidDates(t *testing.T) {
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -66,7 +66,6 @@ func TestPlayerGeneratedInvisiblePrimaryKey(t *testing.T) {
 		"drop table t2",
 		fmt.Sprintf("drop table %s.t2", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -144,7 +143,6 @@ func TestPlayerInvisibleColumns(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -241,7 +239,6 @@ func TestVReplicationTimeUpdated(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -308,7 +305,6 @@ func TestCharPK(t *testing.T) {
 		"drop table t4",
 		fmt.Sprintf("drop table %s.t4", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -423,7 +419,6 @@ func TestRollup(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -480,7 +475,6 @@ func TestPlayerSavepoint(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -548,8 +542,6 @@ func TestPlayerForeignKeyCheck(t *testing.T) {
 		fmt.Sprintf("drop table %s.parent", vrepldb),
 	})
 
-	env.SchemaEngine.Reload(context.Background())
-
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
 			Match: "/.*",
@@ -593,7 +585,6 @@ func TestPlayerStatementModeWithFilter(t *testing.T) {
 	defer execStatements(t, []string{
 		"drop table src1",
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -638,7 +629,6 @@ func TestPlayerStatementMode(t *testing.T) {
 		"drop table src1",
 		fmt.Sprintf("drop table %s.src1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -713,7 +703,6 @@ func TestPlayerFilters(t *testing.T) {
 		"drop table src_charset",
 		fmt.Sprintf("drop table %s.dst_charset", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1030,7 +1019,6 @@ func TestPlayerKeywordNames(t *testing.T) {
 		"drop table `commit`",
 		fmt.Sprintf("drop table %s.`commit`", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1216,7 +1204,6 @@ func TestPlayerKeyspaceID(t *testing.T) {
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	if err := env.SetVSchema(shardedVSchema); err != nil {
 		t.Fatal(err)
@@ -1278,7 +1265,6 @@ func TestUnicode(t *testing.T) {
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1351,7 +1337,6 @@ func TestPlayerUpdates(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1467,7 +1452,6 @@ func TestPlayerRowMove(t *testing.T) {
 		"drop table src",
 		fmt.Sprintf("drop table %s.dst", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1560,8 +1544,6 @@ func TestPlayerTypes(t *testing.T) {
 		"drop table vitess_json",
 		fmt.Sprintf("drop table %s.vitess_json", vrepldb),
 	})
-
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1689,7 +1671,6 @@ func TestPlayerDDL(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1880,7 +1861,6 @@ func TestPlayerStopPos(t *testing.T) {
 		fmt.Sprintf("drop table %s.yes", vrepldb),
 		"drop table no",
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -1980,7 +1960,6 @@ func TestPlayerStopAtOther(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	// Insert a source row.
 	execStatements(t, []string{
@@ -2090,7 +2069,6 @@ func TestPlayerIdleUpdate(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2144,7 +2122,6 @@ func TestPlayerSplitTransaction(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2188,7 +2165,6 @@ func TestPlayerLockErrors(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2268,7 +2244,6 @@ func TestPlayerCancelOnLock(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2346,7 +2321,6 @@ func TestPlayerTransactions(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2452,7 +2426,6 @@ func TestPlayerRelayLogMaxSize(t *testing.T) {
 				"drop table t1",
 				fmt.Sprintf("drop table %s.t1", vrepldb),
 			})
-			env.SchemaEngine.Reload(context.Background())
 
 			filter := &binlogdatapb.Filter{
 				Rules: []*binlogdatapb.Rule{{
@@ -2547,7 +2520,6 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2602,7 +2574,6 @@ func TestTimestamp(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2654,8 +2625,6 @@ func TestPlayerJSONDocs(t *testing.T) {
 		"drop table vitess_json",
 		fmt.Sprintf("drop table %s.vitess_json", vrepldb),
 	})
-
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2729,8 +2698,6 @@ func TestPlayerJSONTwoColumns(t *testing.T) {
 		"drop table vitess_json2",
 		fmt.Sprintf("drop table %s.vitess_json2", vrepldb),
 	})
-
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2823,7 +2790,6 @@ func TestGeneratedColumns(t *testing.T) {
 		"drop table t2",
 		fmt.Sprintf("drop table %s.t2", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -2900,7 +2866,6 @@ func TestPlayerInvalidDates(t *testing.T) {
 	})
 	pos := primaryPosition(t)
 	execStatements(t, []string{"set sql_mode=''", "insert into src1 values(1, '0000-00-00')", "set sql_mode='STRICT_TRANS_TABLES'"})
-	env.SchemaEngine.Reload(context.Background())
 
 	// default mysql flavor allows invalid dates: so disallow explicitly for this test
 	if err := env.Mysqld.ExecuteSuperQuery(context.Background(), "SET @@global.sql_mode=REPLACE(REPLACE(@@session.sql_mode, 'NO_ZERO_DATE', ''), 'NO_ZERO_IN_DATE', '')"); err != nil {
@@ -2986,7 +2951,6 @@ func TestPlayerNoBlob(t *testing.T) {
 		"drop table t2",
 		fmt.Sprintf("drop table %s.t2", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -3124,7 +3088,6 @@ func TestPlayerBatchMode(t *testing.T) {
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
-	env.SchemaEngine.Reload(context.Background())
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -670,7 +670,8 @@ func (se *Engine) RegisterVersionEvent() error {
 	return se.historian.RegisterVersionEvent()
 }
 
-// GetTableForPos returns a best-effort schema for a specific gtid
+// GetTableForPos returns a best-effort schema for a specific gtid. If it cannot get
+// the table schema for the gtid, it returns the latest table schema available.
 func (se *Engine) GetTableForPos(ctx context.Context, tableName sqlparser.IdentifierCS, gtid string) (*binlogdatapb.MinimalTable, error) {
 	mt, err := se.historian.GetTableForPos(tableName, gtid)
 	if err != nil {
@@ -680,18 +681,27 @@ func (se *Engine) GetTableForPos(ctx context.Context, tableName sqlparser.Identi
 	if mt != nil {
 		return mt, nil
 	}
-	// We got nothing from the historian, which generally means that it's not enabled.
-	// Whatever the reason, we should get the latest schema for the "current" position.
-	// In order to ensure this, we need to reload the latest schema first so that our
-	// cache is up to date and we do in fact return the latest/current table schema.
 	se.mu.Lock()
 	defer se.mu.Unlock()
-	if err := se.reload(ctx, true); err != nil {
-		return nil, err
-	}
 	tableNameStr := tableName.String()
 	st, ok := se.tables[tableNameStr]
 	if !ok {
+		// We got nothing from the historian, which generally means that it's not enabled.
+		// We also don't currently have the table in the cache. This can happen when a table
+		// was created after the last schema reload (which happens at least every
+		// --queryserver-config-schema-reload-time).
+		// Whatever the reason, we should ensure that our cache is able to get the latest
+		// table schema for the "current" position IF the table exists in the database.
+		// In order to ensure this, we need to reload the latest schema so that our cache
+		// is up to date. This effectively turns our in-memory cache into a read-through
+		// cache for VReplication related needs (this function is only used by vstreamers).
+		// This adds an additional cost, but for VReplication it should be rare that we are
+		// trying to replicate a table that doesn't actually exist.
+		if se.conns != nil { // Test Engines (NewEngineForTests()) don't have a conns pool
+			if err := se.reload(ctx, true); err != nil {
+				return nil, err
+			}
+		}
 		if schema.IsInternalOperationTableName(tableNameStr) {
 			log.Infof("internal table %v found in vttablet schema: skipping for GTID search", tableNameStr)
 		} else {

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -702,15 +702,16 @@ func (se *Engine) GetTableForPos(ctx context.Context, tableName sqlparser.Identi
 			return nil, err
 		}
 		defer conn.Recycle()
-		cst := *st // Make a copy
+		cst := *st       // Make a copy
+		cst.Fields = nil // We're going to refresh the columns/fields
 		if err := fetchColumns(&cst, conn, se.cp.DBName(), tableNameStr); err != nil {
 			return nil, err
 		}
-		// Update the PK columns for the table as well as that may have changed.
+		// Update the PK columns for the table as well as they may have changed.
+		cst.PKColumns = nil // We're going to repopulate the PK columns
 		if err := se.populatePrimaryKeys(ctx, conn.Conn, map[string]*Table{tableNameStr: &cst}); err != nil {
 			return nil, err
 		}
-		log.Errorf("DEBUG: updating cache entry for table %v, pk column(s): %v", tableNameStr, cst.PKColumns)
 		se.tables[tableNameStr] = &cst
 		return newMinimalTable(&cst), nil
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -1422,8 +1422,8 @@ func TestGetTableForPos(t *testing.T) {
 			name:              "GetTableForPos with cache initialized, table found",
 			initialCacheState: map[string]*Table{table.String(): {Name: table}},
 			expectedQueriesFunc: func(db *fakesqldb.DB) {
-				// We only reload the columns for the table in our cache. A new column called
-				// col2 has been added to the table schema and it is the new PK.
+				// We only reload the column and PK info for the table in our cache. A new column
+				// called col2 has been added to the table schema and it is the new PK.
 				newTableSchema := "create table t1 (id int, col2 varchar, primary key(col2))"
 				db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{
 					Fields: mysql.ShowPrimaryFields,

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -41,12 +42,14 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/dbconfigs"
-	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema/schematest"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 const baseShowTablesPattern = `SELECT t\.table_name.*`
@@ -1298,4 +1301,179 @@ func TestEngineReload(t *testing.T) {
 	err = se.reload(context.Background(), false)
 	require.NoError(t, err)
 	require.NoError(t, db.LastError())
+}
+
+// TestEngineReload tests the vreplication specific GetTableForPos function to ensure
+// that it conforms to the intended/expected behavior in various scenarios.
+// This more specifically tests the behavior of the function when the historian is
+// disabled or otherwise unable to get a table schema for the given position. When it
+// CAN, that is tested indepenently in the historian tests.
+func TestGetTableForPos(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fakedb := fakesqldb.New(t)
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = newDBConfigs(fakedb)
+	table := sqlparser.NewIdentifierCS("t1")
+	column := "col1"
+	tableSchema := "create table t1 (col1 varchar(50), primary key(col1))"
+
+	// Don't do any auto cache refreshes.
+	se := newEngine(1*time.Hour, 1*time.Hour, 0, fakedb)
+	se.conns.Open(se.cp, se.cp, se.cp)
+	se.isOpen = true
+	se.notifiers = make(map[string]notifier)
+	se.MakePrimary(true)
+	se.historian.enabled = false
+
+	addExpectedReloadQueries := func(db *fakesqldb.DB) {
+		db.AddQuery("SELECT UNIX_TIMESTAMP()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+			"UNIX_TIMESTAMP()",
+			"int64"),
+			fmt.Sprintf("%d", time.Now().Unix()),
+		))
+		db.AddQuery(fmt.Sprintf(detectViewChange, sidecar.GetIdentifier()), sqltypes.MakeTestResult(sqltypes.MakeTestFields("table_name", "varchar")))
+		db.AddQuery(fmt.Sprintf(readTableCreateTimes, sidecar.GetIdentifier()), sqltypes.MakeTestResult(sqltypes.MakeTestFields("table_name|create_time", "varchar|int64")))
+		db.AddQuery(fmt.Sprintf(detectUdfChange, sidecar.GetIdentifier()), &sqltypes.Result{})
+		db.AddQueryPattern(baseShowTablesPattern,
+			&sqltypes.Result{
+				Fields:       mysql.BaseShowTablesFields,
+				RowsAffected: 0,
+				InsertID:     0,
+				Rows: [][]sqltypes.Value{
+					{
+						sqltypes.MakeTrusted(sqltypes.VarChar, []byte(table.String())),                          // table_name
+						sqltypes.MakeTrusted(sqltypes.VarChar, []byte("BASE TABLE")),                            // table_type
+						sqltypes.MakeTrusted(sqltypes.Int64, []byte(fmt.Sprintf("%d", time.Now().Unix()-1000))), // unix_timestamp(t.create_time)
+						sqltypes.MakeTrusted(sqltypes.VarChar, []byte("")),                                      // table_comment
+						sqltypes.MakeTrusted(sqltypes.Int64, []byte("128")),                                     // file_size
+						sqltypes.MakeTrusted(sqltypes.Int64, []byte("256")),                                     // allocated_size
+					},
+				},
+				SessionStateChanges: "",
+				StatusFlags:         0,
+			},
+		)
+		db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{
+			Fields: mysql.ShowPrimaryFields,
+			Rows: [][]sqltypes.Value{
+				mysql.ShowPrimaryRow(table.String(), column),
+			},
+		})
+		db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, table.String()),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("column_name", "varchar"), column))
+		db.AddQuery(fmt.Sprintf("SELECT `%s` FROM `fakesqldb`.`%v` WHERE 1 != 1", column, table.String()), sqltypes.MakeTestResult(sqltypes.MakeTestFields(column, "varchar")))
+		db.AddQuery(fmt.Sprintf(`show create table %s`, table.String()),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("Table|Create Table", "varchar|varchar"), table.String(), tableSchema))
+		db.AddQuery("begin", &sqltypes.Result{})
+		db.AddQuery(fmt.Sprintf("delete from %s.`tables` where TABLE_SCHEMA = database() and TABLE_NAME in ('%s')", sidecar.GetIdentifier(), table.String()), &sqltypes.Result{})
+		db.AddQuery(fmt.Sprintf("insert into %s.`tables`(TABLE_SCHEMA, TABLE_NAME, CREATE_STATEMENT, CREATE_TIME) values (database(), '%s', '%s', %d)",
+			sidecar.GetIdentifier(), table.String(), tableSchema, time.Now().Unix()), &sqltypes.Result{RowsAffected: 1})
+		db.AddQuery("rollback", &sqltypes.Result{})
+	}
+
+	type testcase struct {
+		name                string
+		initialCacheState   map[string]*Table
+		expectedQueriesFunc func(db *fakesqldb.DB)
+		expectFunc          func()
+	}
+	tests := []testcase{
+		{
+			name:              "GetTableForPos with cache uninitialized",
+			initialCacheState: make(map[string]*Table), // empty
+			expectedQueriesFunc: func(db *fakesqldb.DB) {
+				// We do a reload to initialize the cache.
+				addExpectedReloadQueries(db)
+			},
+			expectFunc: func() {
+				tbl, err := se.GetTableForPos(ctx, table, "")
+				require.NoError(t, err)
+				require.NotNil(t, tbl)
+			},
+		},
+		{
+			name:              "GetTableForPos with cache uninitialized, table not found",
+			initialCacheState: make(map[string]*Table), // empty
+			expectedQueriesFunc: func(db *fakesqldb.DB) {
+				// We do a reload to initialize the cache and in doing so get the missing table.
+				addExpectedReloadQueries(db)
+			},
+			expectFunc: func() {
+				tbl, err := se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("nobueno"), "")
+				require.EqualError(t, err, "table nobueno not found in vttablet schema")
+				require.Nil(t, tbl)
+			},
+		},
+		{
+			name:              "GetTableForPos with cache initialized, table not found",
+			initialCacheState: map[string]*Table{"t2": {Name: sqlparser.NewIdentifierCS("t2")}},
+			expectedQueriesFunc: func(db *fakesqldb.DB) {
+				// We do a reload to try and get this missing table and any other recently created ones.
+				addExpectedReloadQueries(db)
+			},
+			expectFunc: func() {
+				tbl, err := se.GetTableForPos(ctx, table, "")
+				require.NoError(t, err)
+				require.NotNil(t, tbl)
+			},
+		},
+		{
+			name:              "GetTableForPos with cache initialized, table found",
+			initialCacheState: map[string]*Table{table.String(): {Name: table}},
+			expectedQueriesFunc: func(db *fakesqldb.DB) {
+				// We only reload the columns for the table in our cache. A new column called
+				// col2 has been added to the table schema and it is the new PK.
+				newTableSchema := "create table t1 (id int, col2 varchar, primary key(col2))"
+				db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{
+					Fields: mysql.ShowPrimaryFields,
+					Rows: [][]sqltypes.Value{
+						mysql.ShowPrimaryRow(table.String(), "col2"),
+					},
+				})
+				db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, table.String()),
+					sqltypes.MakeTestResult(sqltypes.MakeTestFields("column_name", "varchar"), column, "col2"))
+				db.AddQuery(fmt.Sprintf("SELECT `%s`, `%s` FROM `fakesqldb`.`%v` WHERE 1 != 1",
+					column, "col2", table.String()), sqltypes.MakeTestResult(sqltypes.MakeTestFields(fmt.Sprintf("%s|%s", column, "col2"), "varchar|varchar")))
+				db.AddQuery(fmt.Sprintf(`show create table %s`, table.String()),
+					sqltypes.MakeTestResult(sqltypes.MakeTestFields("Table|Create Table", "varchar|varchar"), table.String(), newTableSchema))
+				db.AddQuery("begin", &sqltypes.Result{})
+				db.AddQuery(fmt.Sprintf("delete from %s.`tables` where TABLE_SCHEMA = database() and TABLE_NAME in ('%s')", sidecar.GetIdentifier(), table.String()), &sqltypes.Result{})
+				db.AddQuery(fmt.Sprintf("insert into %s.`tables`(TABLE_SCHEMA, TABLE_NAME, CREATE_STATEMENT, CREATE_TIME) values (database(), '%s', '%s', %d)",
+					sidecar.GetIdentifier(), table.String(), newTableSchema, time.Now().Unix()), &sqltypes.Result{})
+				db.AddQuery("rollback", &sqltypes.Result{})
+			},
+			expectFunc: func() {
+				tbl, err := se.GetTableForPos(ctx, table, "MySQL56/1497ddb0-7cb9-11ed-a1eb-0242ac120002:1-891")
+				require.NoError(t, err)
+				require.NotNil(t, tbl)
+				require.Equal(t, &binlogdatapb.MinimalTable{
+					Name: table.String(),
+					Fields: []*querypb.Field{
+						{
+							Name: column,
+							Type: sqltypes.VarChar,
+						},
+						{
+							Name: "col2",
+							Type: sqltypes.VarChar,
+						},
+					},
+					PKColumns: []int64{1}, // Second column: col2
+				}, tbl)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakedb.DeleteAllQueries()
+			AddFakeInnoDBReadRowsResult(fakedb, int(rand.Int32N(1000000)))
+			tc.expectedQueriesFunc(fakedb)
+			se.tables = tc.initialCacheState
+			tc.expectFunc()
+			fakedb.VerifyAllExecutedOrFail()
+			require.NoError(t, fakedb.LastError())
+		})
+	}
 }

--- a/go/vt/vttablet/tabletserver/schema/historian_test.go
+++ b/go/vt/vttablet/tabletserver/schema/historian_test.go
@@ -26,11 +26,11 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
-
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/sqlparser"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 func getTable(name string, fieldNames []string, fieldTypes []querypb.Type, pks []int64) *binlogdatapb.MinimalTable {

--- a/go/vt/vttablet/tabletserver/schema/historian_test.go
+++ b/go/vt/vttablet/tabletserver/schema/historian_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package schema
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -78,6 +79,7 @@ func getDbSchemaBlob(t *testing.T, tables map[string]*binlogdatapb.MinimalTable)
 }
 
 func TestHistorian(t *testing.T) {
+	ctx := context.Background()
 	se, db, cancel := getTestSchemaEngine(t, 0)
 	defer cancel()
 
@@ -88,13 +90,13 @@ func TestHistorian(t *testing.T) {
 	ddl1 := "create table tracker_test (id int)"
 	ts1 := int64(1427325876)
 	_, _, _ = ddl1, ts1, db
-	_, err := se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	_, err := se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid1)
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
-	tab, err := se.GetTableForPos(sqlparser.NewIdentifierCS("dual"), gtid1)
+	tab, err := se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("dual"), gtid1)
 	require.NoError(t, err)
 	require.Equal(t, `name:"dual"`, fmt.Sprintf("%v", tab))
 	se.EnableHistorian(true)
-	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	_, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid1)
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
 	var blob1 string
 
@@ -127,11 +129,11 @@ func TestHistorian(t *testing.T) {
 	})
 	require.Nil(t, se.RegisterVersionEvent())
 	exp1 := `name:"t1" fields:{name:"id1" type:INT32 table:"t1" charset:63 flags:32768} fields:{name:"id2" type:INT32 table:"t1" charset:63 flags:32768} p_k_columns:0`
-	tab, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	tab, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid1)
 	require.NoError(t, err)
 	require.Equal(t, exp1, fmt.Sprintf("%v", tab))
 	gtid2 := gtidPrefix + "1-20"
-	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid2)
+	_, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid2)
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
 
 	table = getTable("t1", []string{"id1", "id2"}, []querypb.Type{querypb.Type_INT32, querypb.Type_VARBINARY}, []int64{0})
@@ -147,11 +149,11 @@ func TestHistorian(t *testing.T) {
 	})
 	require.Nil(t, se.RegisterVersionEvent())
 	exp2 := `name:"t1" fields:{name:"id1" type:INT32 table:"t1" charset:63 flags:32768} fields:{name:"id2" type:VARBINARY table:"t1" charset:63 flags:128} p_k_columns:0`
-	tab, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid2)
+	tab, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid2)
 	require.NoError(t, err)
 	require.Equal(t, exp2, fmt.Sprintf("%v", tab))
 	gtid3 := gtidPrefix + "1-30"
-	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid3)
+	_, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid3)
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
 
 	table = getTable("t1", []string{"id1", "id2", "id3"}, []querypb.Type{querypb.Type_INT32, querypb.Type_VARBINARY, querypb.Type_INT32}, []int64{0})
@@ -167,22 +169,23 @@ func TestHistorian(t *testing.T) {
 	})
 	require.Nil(t, se.RegisterVersionEvent())
 	exp3 := `name:"t1" fields:{name:"id1" type:INT32 table:"t1" charset:63 flags:32768} fields:{name:"id2" type:VARBINARY table:"t1" charset:63 flags:128} fields:{name:"id3" type:INT32 table:"t1" charset:63 flags:32768} p_k_columns:0`
-	tab, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid3)
+	tab, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid3)
 	require.NoError(t, err)
 	require.Equal(t, exp3, fmt.Sprintf("%v", tab))
 
-	tab, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	tab, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid1)
 	require.NoError(t, err)
 	require.Equal(t, exp1, fmt.Sprintf("%v", tab))
-	tab, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid2)
+	tab, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid2)
 	require.NoError(t, err)
 	require.Equal(t, exp2, fmt.Sprintf("%v", tab))
-	tab, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid3)
+	tab, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid3)
 	require.NoError(t, err)
 	require.Equal(t, exp3, fmt.Sprintf("%v", tab))
 }
 
 func TestHistorianPurgeOldSchemas(t *testing.T) {
+	ctx := context.Background()
 	schemaVersionMaxAgeSeconds := 3600 // 1 hour
 	se, db, cancel := getTestSchemaEngine(t, int64(schemaVersionMaxAgeSeconds))
 	defer cancel()
@@ -194,7 +197,7 @@ func TestHistorianPurgeOldSchemas(t *testing.T) {
 	ts1 := time.Now().Add(time.Duration(-24) * time.Hour)
 	_, _, _ = ddl1, ts1, db
 	se.EnableHistorian(true)
-	_, err := se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	_, err := se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid1)
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
 	var blob1 string
 
@@ -226,14 +229,14 @@ func TestHistorianPurgeOldSchemas(t *testing.T) {
 		},
 	})
 	require.Nil(t, se.RegisterVersionEvent())
-	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	_, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid1)
 	// validate the old schema has been purged
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
 	require.Equal(t, 0, len(se.historian.schemas))
 
 	// add a second schema record row with a time_updated that won't be purged
 	gtid2 := gtidPrefix + "1-20"
-	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid2)
+	_, err = se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid2)
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
 
 	table = getTable("t1", []string{"id1", "id2"}, []querypb.Type{querypb.Type_INT32, querypb.Type_VARBINARY}, []int64{0})
@@ -250,7 +253,7 @@ func TestHistorianPurgeOldSchemas(t *testing.T) {
 	})
 	require.Nil(t, se.RegisterVersionEvent())
 	exp2 := `name:"t1" fields:{name:"id1" type:INT32 table:"t1" charset:63 flags:32768} fields:{name:"id2" type:VARBINARY table:"t1" charset:63 flags:128} p_k_columns:0`
-	tab, err := se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid2)
+	tab, err := se.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid2)
 	require.NoError(t, err)
 	require.Equal(t, exp2, fmt.Sprintf("%v", tab))
 	require.Equal(t, 1, len(se.historian.schemas))

--- a/go/vt/vttablet/tabletserver/vstreamer/resultstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/resultstreamer_test.go
@@ -43,7 +43,6 @@ func TestStreamResults(t *testing.T) {
 	defer execStatements(t, []string{
 		"drop table t1",
 	})
-	engine.se.Reload(context.Background())
 
 	query := "select id, val from t1 order by id"
 	wantStream := []string{

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
-	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
@@ -147,22 +146,7 @@ func (rs *rowStreamer) buildPlan() error {
 		return err
 	}
 
-	st, err := rs.se.GetTableForPos(fromTable, "")
-	if err != nil {
-		// There is a scenario where vstreamer's table state can be out-of-date, and this happens
-		// with vitess migrations, based on vreplication.
-		// Vitess migrations use an elaborate cut-over flow where tables are swapped away while traffic is
-		// being blocked. The RENAME flow is such that at some point the table is renamed away, leaving a
-		// "puncture"; this is an event that is captured by vstreamer. The completion of the flow fixes the
-		// puncture, and places a new table under the original table's name, but the way it is done does not
-		// cause vstreamer to refresh schema state.
-		// There is therefore a reproducible valid sequence of events where vstreamer thinks a table does not
-		// exist, where it in fact does exist.
-		// For this reason we give vstreamer a "second chance" to review the up-to-date state of the schema.
-		// In the future, we will reduce this operation to reading a single table rather than the entire schema.
-		rs.se.ReloadAt(context.Background(), replication.Position{})
-		st, err = rs.se.GetTableForPos(fromTable, "")
-	}
+	st, err := rs.se.GetTableForPos(rs.ctx, fromTable, "")
 	if err != nil {
 		return err
 	}
@@ -179,6 +163,7 @@ func (rs *rowStreamer) buildPlan() error {
 	// This is because the row format of a read is identical
 	// to the row format of a binlog event. So, the same
 	// filtering will work.
+	log.Errorf("DEBUG: rowStreamer building table plan for %v", rs.query)
 	rs.plan, err = buildTablePlan(rs.se.Environment(), ti, rs.vschema, rs.query)
 	if err != nil {
 		log.Errorf("%s", err.Error())

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -163,7 +163,6 @@ func (rs *rowStreamer) buildPlan() error {
 	// This is because the row format of a read is identical
 	// to the row format of a binlog event. So, the same
 	// filtering will work.
-	log.Errorf("DEBUG: rowStreamer building table plan for %v", rs.query)
 	rs.plan, err = buildTablePlan(rs.se.Environment(), ti, rs.vschema, rs.query)
 	if err != nil {
 		log.Errorf("%s", err.Error())

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer_test.go
@@ -51,8 +51,6 @@ func TestTableStreamer(t *testing.T) {
 		"drop table t4",
 	})
 
-	engine.se.Reload(context.Background())
-
 	wantStream := []string{
 		"table_name:\"t1\" fields:{name:\"id\" type:INT32 table:\"t1\" org_table:\"t1\" database:\"vttest\" org_name:\"id\" column_length:11 charset:63 flags:53251} fields:{name:\"val\" type:VARBINARY table:\"t1\" org_table:\"t1\" database:\"vttest\" org_name:\"val\" column_length:128 charset:63 flags:128} pkfields:{name:\"id\" type:INT32 charset:63 flags:53251}",
 		"table_name:\"t1\" rows:{lengths:1 lengths:3 values:\"1aaa\"} rows:{lengths:1 lengths:3 values:\"2bbb\"} lastpk:{lengths:1 values:\"2\"}",

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer_flaky_test.go
@@ -174,7 +174,6 @@ func TestVStreamCopyCompleteFlow(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	engine.se.Reload(context.Background())
 
 	defer execStatements(t, []string{
 		"drop table t1",

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -805,7 +805,7 @@ func (vs *vstreamer) buildTableColumns(tm *mysql.TableMap) ([]*querypb.Field, er
 			Flags:   mysql.FlagsForColumn(t, coll),
 		})
 	}
-	st, err := vs.se.GetTableForPos(sqlparser.NewIdentifierCS(tm.Name), replication.EncodePosition(vs.pos))
+	st, err := vs.se.GetTableForPos(vs.ctx, sqlparser.NewIdentifierCS(tm.Name), replication.EncodePosition(vs.pos))
 	if err != nil {
 		if vs.filter.FieldEventMode == binlogdatapb.Filter_ERR_ON_MISMATCH {
 			log.Infof("No schema found for table %s", tm.Name)

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -312,6 +312,7 @@ func TestVersion(t *testing.T) {
 		engine = oldEngine
 	}()
 
+	ctx := context.Background()
 	err := env.SchemaEngine.EnableHistorian(true)
 	require.NoError(t, err)
 	defer env.SchemaEngine.EnableHistorian(false)
@@ -348,7 +349,7 @@ func TestVersion(t *testing.T) {
 			`commit`}},
 	}}
 	runCases(t, nil, testcases, "", nil)
-	mt, err := env.SchemaEngine.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid)
+	mt, err := env.SchemaEngine.GetTableForPos(ctx, sqlparser.NewIdentifierCS("t1"), gtid)
 	require.NoError(t, err)
 	assert.True(t, proto.Equal(mt, dbSchema.Tables[0]))
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -224,7 +224,6 @@ func TestSetStatement(t *testing.T) {
 		log.Info("Cannot test SetStatement on this flavor")
 		return
 	}
-	engine.se.Reload(context.Background())
 
 	execStatements(t, []string{
 		"create table t1(id int, val varbinary(128), primary key(id))",
@@ -232,7 +231,6 @@ func TestSetStatement(t *testing.T) {
 	defer execStatements(t, []string{
 		"drop table t1",
 	})
-	engine.se.Reload(context.Background())
 	queries := []string{
 		"begin",
 		"insert into t1 values (1, 'aaa')",
@@ -335,7 +333,6 @@ func TestVersion(t *testing.T) {
 		}},
 	}
 	blob, _ := dbSchema.MarshalVT()
-	engine.se.Reload(context.Background())
 	gtid := "MariaDB/0-41983-20"
 	testcases := []testcase{{
 		input: []string{
@@ -374,7 +371,6 @@ func TestMissingTables(t *testing.T) {
 		"insert into shortlived values (1,1), (2,2)",
 		"alter table shortlived rename to _shortlived",
 	})
-	engine.se.Reload(context.Background())
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
 			Match:  "t1",
@@ -1060,7 +1056,6 @@ func TestREKeyRange(t *testing.T) {
   }
 }`
 	setVSchema(t, altVSchema)
-	engine.se.Reload(context.Background())
 	ts.Reset()
 	// Only the first insert should be sent.
 	ts.tests = [][]*TestQuery{{
@@ -1290,7 +1285,6 @@ func TestDDLAddColumn(t *testing.T) {
 }
 
 func TestDDLDropColumn(t *testing.T) {
-	env.SchemaEngine.Reload(context.Background())
 	execStatement(t, "create table ddl_test2(id int, val1 varbinary(128), val2 varbinary(128), primary key(id))")
 	defer execStatement(t, "drop table ddl_test2")
 
@@ -1302,8 +1296,6 @@ func TestDDLDropColumn(t *testing.T) {
 		"alter table ddl_test2 drop column val2",
 		"insert into ddl_test2 values(2, 'bbb')",
 	})
-	engine.se.Reload(context.Background())
-	env.SchemaEngine.Reload(context.Background())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1441,7 +1433,6 @@ func TestBestEffortNameInFieldEvent(t *testing.T) {
 	defer execStatements(t, []string{
 		"drop table vitess_test_new",
 	})
-	engine.se.Reload(context.Background())
 	testcases := []testcase{{
 		input: []string{
 			"insert into vitess_test_new values(2, 'abc')",
@@ -1501,7 +1492,6 @@ func TestInternalTables(t *testing.T) {
 		"drop table _vt_PURGE_1f9194b43b2011eb8a0104ed332e05c2_20201210194431",
 		"drop table _product_old",
 	})
-	engine.se.Reload(context.Background())
 	testcases := []testcase{{
 		input: []string{
 			"insert into vitess_test values(2, 'abc')",
@@ -1544,7 +1534,6 @@ func TestTypes(t *testing.T) {
 		"drop table vitess_null",
 		"drop table vitess_decimal",
 	})
-	engine.se.Reload(context.Background())
 
 	testcases := []testcase{{
 		input: []string{
@@ -1659,7 +1648,6 @@ func TestJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer execStatement(t, "drop table vitess_json")
-	engine.se.Reload(context.Background())
 	jsonValues := []string{"{}", "123456", `"vtTablet"`, `{"foo": "bar"}`, `["abc", 3.14, true]`}
 
 	var inputs, outputs []string
@@ -1701,7 +1689,6 @@ func TestExternalTable(t *testing.T) {
 	defer execStatements(t, []string{
 		"drop database external",
 	})
-	engine.se.Reload(context.Background())
 
 	testcases := []testcase{{
 		input: []string{
@@ -1727,7 +1714,6 @@ func TestJournal(t *testing.T) {
 	defer execStatements(t, []string{
 		"drop table _vt.resharding_journal",
 	})
-	engine.se.Reload(context.Background())
 
 	journal1 := &binlogdatapb.Journal{
 		Id:            1,
@@ -1786,8 +1772,6 @@ func TestStatementMode(t *testing.T) {
 		"create table stream2(id int, val varbinary(128), primary key(id))",
 	})
 
-	engine.se.Reload(context.Background())
-
 	defer execStatements(t, []string{
 		"drop table stream1",
 		"drop table stream2",
@@ -1837,7 +1821,6 @@ func TestNoFutureGTID(t *testing.T) {
 	defer execStatements(t, []string{
 		"drop table stream1",
 	})
-	engine.se.Reload(context.Background())
 
 	pos := primaryPosition(t)
 	t.Logf("current position: %v", pos)


### PR DESCRIPTION
## Description

In `SchemaEngine`'s `GetTableForPos` function, we would not find a table schema for a given GTID position when the [historian](https://vitess.io/docs/reference/vreplication/internal/tracker/) is disabled and we would then return the "current" table schema *from the cache*. The problem there is that the cache can be quite stale (up to 30 minutes by default, see `--queryserver-config-schema-reload-time` ). Similarly, if you want to get the current schema for a table that was recently created (within up to the last 30 minutes by default) then `GetTableForPos` would return a `table not found` error as it wasn't yet in the cache. So if you're e.g. doing a fair amount of schema changes/migrations then this function's results can be out of date and block subsequent schema changes/migrations. 

This PR changes `GetTableForPos` so that it ensures we get the table schema for the "current" position. If we *do* have the table in our cache, then we refresh the schema for that table from the database to be sure that it's up to date (and we update the entry in the cache). If we *do not* have the table in our cache then we refresh the schema cache from the database in full. This then also serves as a way to initialize the cache if it hasn't yet been done (recently started `vttablet` process).

Refreshing the schema cache is an expensive operation, which is why `--queryserver-config-schema-reload-time` defaults to 30m. But this change *only* affects VReplication as the only users of `GetTableForPos()` are vstreamers. And we only reload the schema cache there if the requested table is not *already* in the cache and it should be rare that you're trying to replicate a table that doesn't exist (we get the table schema during the planning step). This effectively turns the table schema cache — _for VReplication_ — into a read-through cache.

This aims to be a more complete fix for: https://github.com/vitessio/vitess/pull/9832

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/15852
  - Related to: https://github.com/vitessio/vitess/pull/9324
  - Related to: https://github.com/vitessio/vitess/pull/9832 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required