### PR TITLE
Add support for sampling rate in `streamlog`

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -272,7 +272,7 @@ Flags:
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
-      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -272,6 +272,7 @@ Flags:
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -174,6 +174,7 @@ Flags:
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --retry-count int                                                  retry count (default 2)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -174,7 +174,7 @@ Flags:
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
-      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --retry-count int                                                  retry count (default 2)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -263,6 +263,7 @@ Flags:
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -263,7 +263,7 @@ Flags:
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
-      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -265,7 +265,7 @@ func shouldSampleQuery() bool {
 	} else if sampleRate > 1.0 {
 		sampleRate = 1.0
 	}
-	return rand.IntN(100) <= int(sampleRate*100)
+	return rand.Float64() <= sampleRate
 }
 
 // ShouldEmitLog returns whether the log with the given SQL query

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -264,7 +264,7 @@ func shouldSampleQuery() bool {
 	} else if queryLogSampleRate >= 1 {
 		return true
 	}
-	return rand.Float64() < queryLogSampleRate
+	return rand.Float64() <= queryLogSampleRate
 }
 
 // ShouldEmitLog returns whether the log with the given SQL query

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -265,8 +265,7 @@ func shouldSampleQuery() bool {
 	} else if sampleRate > 1.0 {
 		sampleRate = 1.0
 	}
-	randMax := int(sampleRate * 100)
-	return rand.IntN(randMax) <= randMax
+	return rand.IntN(100) <= int(sampleRate * 100)
 }
 
 // ShouldEmitLog returns whether the log with the given SQL query

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -265,7 +265,7 @@ func shouldSampleQuery() bool {
 	} else if sampleRate > 1.0 {
 		sampleRate = 1.0
 	}
-	return rand.IntN(100) <= int(sampleRate * 100)
+	return rand.IntN(100) <= int(sampleRate*100)
 }
 
 // ShouldEmitLog returns whether the log with the given SQL query

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -259,13 +259,12 @@ func GetFormatter[T any](logger *StreamLogger[T]) LogFormatter {
 
 // shouldSampleQuery returns true if a query should be sampled based on queryLogSampleRate
 func shouldSampleQuery() bool {
-	sampleRate := queryLogSampleRate
-	if sampleRate <= 0 {
+	if queryLogSampleRate <= 0 {
 		return false
-	} else if sampleRate > 1.0 {
-		sampleRate = 1.0
+	} else if queryLogSampleRate >= 1.0 {
+		return true
 	}
-	return rand.Float64() <= sampleRate
+	return rand.Float64() <= queryLogSampleRate
 }
 
 // ShouldEmitLog returns whether the log with the given SQL query

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -261,10 +261,10 @@ func GetFormatter[T any](logger *StreamLogger[T]) LogFormatter {
 func shouldSampleQuery() bool {
 	if queryLogSampleRate <= 0 {
 		return false
-	} else if queryLogSampleRate >= 1.0 {
+	} else if queryLogSampleRate >= 1 {
 		return true
 	}
-	return rand.Float64() <= queryLogSampleRate
+	return rand.Float64() < queryLogSampleRate
 }
 
 // ShouldEmitLog returns whether the log with the given SQL query

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -20,6 +20,7 @@ package streamlog
 import (
 	"fmt"
 	"io"
+	rand "math/rand/v2"
 	"net/http"
 	"net/url"
 	"os"
@@ -51,6 +52,7 @@ var (
 	queryLogFilterTag    string
 	queryLogRowThreshold uint64
 	queryLogFormat       = "text"
+	queryLogSampleRate   float64
 )
 
 func GetRedactDebugUIQueries() bool {
@@ -67,6 +69,10 @@ func SetQueryLogFilterTag(newQueryLogFilterTag string) {
 
 func SetQueryLogRowThreshold(newQueryLogRowThreshold uint64) {
 	queryLogRowThreshold = newQueryLogRowThreshold
+}
+
+func SetQueryLogSampleRate(sampleRate float64) {
+	queryLogSampleRate = sampleRate
 }
 
 func GetQueryLogFormat() string {
@@ -96,6 +102,8 @@ func registerStreamLogFlags(fs *pflag.FlagSet) {
 	// QueryLogRowThreshold only log queries returning or affecting this many rows
 	fs.Uint64Var(&queryLogRowThreshold, "querylog-row-threshold", queryLogRowThreshold, "Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.")
 
+	// QueryLogSampleRate causes a sample of queries to be logged
+	fs.Float64Var(&queryLogSampleRate, "querylog-sample-rate", queryLogSampleRate, "Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)")
 }
 
 const (
@@ -249,9 +257,24 @@ func GetFormatter[T any](logger *StreamLogger[T]) LogFormatter {
 	}
 }
 
+// shouldSampleQuery returns true if a query should be sampled based on queryLogSampleRate
+func shouldSampleQuery() bool {
+	sampleRate := queryLogSampleRate
+	if sampleRate <= 0 {
+		return false
+	} else if sampleRate > 1.0 {
+		sampleRate = 1.0
+	}
+	randMax := int(sampleRate * 100)
+	return rand.IntN(randMax) <= randMax
+}
+
 // ShouldEmitLog returns whether the log with the given SQL query
 // should be emitted or filtered
 func ShouldEmitLog(sql string, rowsAffected, rowsReturned uint64) bool {
+	if shouldSampleQuery() {
+		return true
+	}
 	if queryLogRowThreshold > max(rowsAffected, rowsReturned) && queryLogFilterTag == "" {
 		return false
 	}

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -103,7 +103,7 @@ func registerStreamLogFlags(fs *pflag.FlagSet) {
 	fs.Uint64Var(&queryLogRowThreshold, "querylog-row-threshold", queryLogRowThreshold, "Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.")
 
 	// QueryLogSampleRate causes a sample of queries to be logged
-	fs.Float64Var(&queryLogSampleRate, "querylog-sample-rate", queryLogSampleRate, "Sample rate for logging queries. Value must be between 0.01 (1% of queries) and 1.0 (all queries)")
+	fs.Float64Var(&queryLogSampleRate, "querylog-sample-rate", queryLogSampleRate, "Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)")
 }
 
 const (

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -369,6 +369,30 @@ func TestShouldEmitLog(t *testing.T) {
 	}
 }
 
+func BenchmarkShouldEmitLog(b *testing.B) {
+	b.Run("default", func(b *testing.B) {
+		SetQueryLogSampleRate(0.0)
+		for i := 0; i < b.N; i++ {
+			ShouldEmitLog("select * from test where user='someone'", 0, 123)
+		}
+	})
+	b.Run("filter_tag", func(b *testing.B) {
+		SetQueryLogSampleRate(0.0)
+		SetQueryLogFilterTag("LOG_QUERY")
+		defer SetQueryLogFilterTag("")
+		for i := 0; i < b.N; i++ {
+			ShouldEmitLog("select /* LOG_QUERY=1 */ * from test where user='someone'", 0, 123)
+		}
+	})
+	b.Run("50%_sample_rate", func(b *testing.B) {
+		SetQueryLogSampleRate(0.5)
+		defer SetQueryLogSampleRate(0.0)
+		for i := 0; i < b.N; i++ {
+			ShouldEmitLog("select * from test where user='someone'", 0, 123)
+		}
+	})
+}
+
 func TestGetFormatter(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -272,6 +272,10 @@ func TestShouldSampleQuery(t *testing.T) {
 	queryLogSampleRate = 0
 	assert.False(t, shouldSampleQuery())
 
+	// for test coverage, can't test a random result
+	queryLogSampleRate = 0.5
+	shouldSampleQuery()
+
 	queryLogSampleRate = 1.0
 	assert.True(t, shouldSampleQuery())
 

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -348,15 +348,6 @@ func TestShouldEmitLog(t *testing.T) {
 			ok:               true,
 		},
 		{
-			sql:              "this contains out-of-bounds querySampleRate: 123.0",
-			qLogFilterTag:    "",
-			qLogRowThreshold: 0,
-			qLogSampleRate:   123.0,
-			rowsAffected:     7,
-			rowsReturned:     17,
-			ok:               true,
-		},
-		{
 			sql:              "this contains querySampleRate: 1.0 without expected queryFilterTag",
 			qLogFilterTag:    "TAG",
 			qLogRowThreshold: 0,

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/servenv"
@@ -262,6 +263,20 @@ func TestFile(t *testing.T) {
 	if want != string(got) {
 		t.Errorf("streamlog file: want %q got %q", want, got)
 	}
+}
+
+func TestShouldSampleQuery(t *testing.T) {
+	queryLogSampleRate = -1
+	assert.False(t, shouldSampleQuery())
+
+	queryLogSampleRate = 0
+	assert.False(t, shouldSampleQuery())
+
+	queryLogSampleRate = 1.0
+	assert.True(t, shouldSampleQuery())
+
+	queryLogSampleRate = 100.0
+	assert.True(t, shouldSampleQuery())
 }
 
 func TestShouldEmitLog(t *testing.T) {


### PR DESCRIPTION
## Description

This PR implements the RFC https://github.com/vitessio/vitess/issues/15909 by adding a flag `--querylog-sample-rate float` to `vtcombo`, `vtgate` and `vttablet` in order for queries to be sampled randomly without the need for the client to trigger query logging via a query directive/comment == `--querylog-filter-tag string`

This flag supports values between `0.0` (no logging) and `1.0` (log all queries) to match other `0.0-1.0` float "sample" flags

`math/rand/v2` was used because it sounds better

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/15909

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
