### PR TITLE
Fix Context returned from LockShard

### DIFF
--- a/go/vt/topo/locks.go
+++ b/go/vt/topo/locks.go
@@ -339,11 +339,7 @@ func (ts *Server) internalLockShard(ctx context.Context, keyspace, shard, action
 	l := newLock(action)
 	var lockDescriptor LockDescriptor
 	var err error
-	if isBlocking {
-		lockDescriptor, err = l.lockShard(ctx, ts, keyspace, shard)
-	} else {
-		lockDescriptor, err = l.tryLockShard(ctx, ts, keyspace, shard)
-	}
+	lockDescriptor, err = l.internalLockShard(ctx, ts, keyspace, shard, isBlocking)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -399,18 +395,6 @@ func CheckShardLocked(ctx context.Context, keyspace, shard string) error {
 
 	// Check the lock server implementation still holds the lock.
 	return li.lockDescriptor.Check(ctx)
-}
-
-// lockShard will lock the shard in the topology server.
-// UnlockShard should be called if this returns no error.
-func (l *Lock) lockShard(ctx context.Context, ts *Server, keyspace, shard string) (LockDescriptor, error) {
-	return l.internalLockShard(ctx, ts, keyspace, shard, true)
-}
-
-// tryLockShard will lock the shard in the topology server but unlike `lockShard` it fail-fast if not able to get lock
-// UnlockShard should be called if this returns no error.
-func (l *Lock) tryLockShard(ctx context.Context, ts *Server, keyspace, shard string) (LockDescriptor, error) {
-	return l.internalLockShard(ctx, ts, keyspace, shard, false)
 }
 
 func (l *Lock) internalLockShard(ctx context.Context, ts *Server, keyspace, shard string, isBlocking bool) (LockDescriptor, error) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the context returned from LockShard. As described in https://github.com/vitessio/vitess/issues/15925, we aren't sending the correct context back from LockShard. This PR fixes this problem.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/15925

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
