### PR TITLE
Validate go versions in Static Code Checks CI

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -149,6 +149,11 @@ jobs:
         run: |
           make minimaltools
 
+      - name: check_go_versions
+        if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
+        run:
+          tools/check_go_versions.sh || exit 1
+
       - name: check_make_parser
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && (steps.changes.outputs.parser_changes == 'true' || steps.changes.outputs.go_files == 'true')
         run: |

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -150,7 +150,7 @@ jobs:
           make minimaltools
 
       - name: check_go_versions
-        if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
+        if: steps.skip-workflow.outputs.skip-workflow == 'false'
         run:
           tools/check_go_versions.sh || exit 1
 

--- a/tools/check_go_versions.sh
+++ b/tools/check_go_versions.sh
@@ -7,30 +7,32 @@
 
 set -e
 
+# go.mod
 GO_MOD_VERSION="$(awk '/^go [0-9].[0-9]+/{print $(NF-0)}' go.mod)"
 if [ -z "${GO_MOD_VERSION}" ]; then
   echo "cannot find go version in go.mod"
   exit 1
 fi
 
+# ci workflows
 TPL_GO_VERSIONS="$(awk '/go-version: /{print $(NF-0)}' .github/workflows/*.yml test/templates/*.tpl | sort -u)"
 TPL_GO_VERSIONS_COUNT=$(echo "$TPL_GO_VERSIONS" | wc -l | tr -d [:space:])
 if [ "${TPL_GO_VERSIONS_COUNT}" -gt 1 ]; then
   echo -e "expected a consistent 'go-version:' in CI workflow files/templates, found versions:\n${TPL_GO_VERSIONS}"
   exit 1
 fi
-
 TPL_GO_VERSION="${TPL_GO_VERSIONS}"
 if [[ ! "${TPL_GO_VERSION}" =~ "${GO_MOD_VERSION}" ]]; then
   echo "expected go-version in test/templates/* to be equal to go.mod: '${TPL_GO_VERSION}' != '${GO_MOD_VERSION}'"
   exit 1
 fi
 
+# docker/bootstrap/Dockerfile.common
 BOOTSTRAP_GO_VERSION="$(awk -F ':' '/golang:/{print $(NF-0)}' docker/bootstrap/Dockerfile.common | cut -d- -f1)"
 if [[ ! "${BOOTSTRAP_GO_VERSION}" =~ "${GO_MOD_VERSION}" ]]; then
   echo "expected golang docker version in docker/bootstrap/Dockerfile.common to be equal to go.mod: '${TPL_GO_VERSION}' != '${GO_MOD_VERSION}'"
   exit 1
 elif [ "${TPL_GO_VERSION}" != "${BOOTSTRAP_GO_VERSION}" ]; then
-  echo "expected equal go version in bootstrap Dockerfile: '${TPL_GO_VERSIONS}' != '${BOOTSTRAP_GO_VERSION}'"
+  echo "expected equal go version in CI workflow files/templates and bootstrap Dockerfile: '${TPL_GO_VERSIONS}' != '${BOOTSTRAP_GO_VERSION}'"
   exit 1
 fi

--- a/tools/check_go_versions.sh
+++ b/tools/check_go_versions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Validate that the go versions in go.mod, CI test workflows
+# and docker/bootstrap/Dockerfile.common are compatible.
+#
+# This is called from the Static Code Checks CI workflow.
+
+set -e
+
+GO_MOD_VERSION="$(awk '/^go [0-9].[0-9]+/{print $(NF-0)}' go.mod)"
+if [ -z "${GO_MOD_VERSION}" ]; then
+  echo "cannot find go version in go.mod"
+  exit 1
+fi
+
+TPL_GO_VERSIONS="$(awk '/go-version: /{print $(NF-0)}' .github/workflows/*.yml test/templates/*.tpl | sort -u)"
+TPL_GO_VERSIONS_COUNT=$(echo "$TPL_GO_VERSIONS" | wc -l | tr -d [:space:])
+if [ "${TPL_GO_VERSIONS_COUNT}" -gt 1 ]; then
+  echo -e "expected a consistent 'go-version:' in CI workflow files/templates, found versions:\n${TPL_GO_VERSIONS}"
+  exit 1
+fi
+
+TPL_GO_VERSION="${TPL_GO_VERSIONS}"
+if [[ ! "${TPL_GO_VERSION}" =~ "${GO_MOD_VERSION}" ]]; then
+  echo "expected go-version in test/templates/* to be equal to go.mod: '${TPL_GO_VERSION}' != '${GO_MOD_VERSION}'"
+  exit 1
+fi
+
+BOOTSTRAP_GO_VERSION="$(awk -F ':' '/golang:/{print $(NF-0)}' docker/bootstrap/Dockerfile.common | cut -d- -f1)"
+if [[ ! "${BOOTSTRAP_GO_VERSION}" =~ "${GO_MOD_VERSION}" ]]; then
+  echo "expected golang docker version in docker/bootstrap/Dockerfile.common to be equal to go.mod: '${TPL_GO_VERSION}' != '${GO_MOD_VERSION}'"
+  exit 1
+elif [ "${TPL_GO_VERSION}" != "${BOOTSTRAP_GO_VERSION}" ]; then
+  echo "expected equal go version in bootstrap Dockerfile: '${TPL_GO_VERSIONS}' != '${BOOTSTRAP_GO_VERSION}'"
+  exit 1
+fi


### PR DESCRIPTION
## Description

This PR validates that the go versions in the project are compatible as discussed in https://github.com/vitessio/vitess/issues/15494

Real CI result for https://github.com/vitessio/vitess/pull/15932/commits/d412182c4ea02c649bd99c601c4c68de0feb9682:
<img width="500" alt="Screenshot 2024-05-14 at 01 10 12" src="https://github.com/vitessio/vitess/assets/3202797/c51878a9-f67b-43e9-99b2-7ed23b3af838">

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/15494

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
