### PR TITLE
Remove the default for replica-net-timeout

### DIFF
--- a/config/mycnf/mysql80.cnf
+++ b/config/mycnf/mysql80.cnf
@@ -32,6 +32,3 @@ loose_rpl_semi_sync_master_wait_no_slave = 1
 # in super-read-only mode.
 super-read-only
 
-# Replication parameters to ensure reparents are fast.
-slave_net_timeout = 8
-


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
As described in https://github.com/vitessio/vitess/issues/15937#issuecomment-2109779208, this PR needs to revert the changes in https://github.com/vitessio/vitess/pull/15663 and https://github.com/vitessio/vitess/pull/15689. We'll reintroduce the default change in next release.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15937

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
