### PR TITLE
Remove legacy `EmergencyReparentShard` stats

### DIFF
--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -107,6 +107,8 @@ These counters are replaced by the following stats _(introduced in Vitess 18.0)_
 - `emergency_reparent_counts` - Number of times `EmergencyReparentShard` has been run. It is further subdivided by the keyspace, shard and the result of the operation.
 - `planned_reparent_counts` - Number of times `PlannedReparentShard` has been run. It is further subdivided by the keyspace, shard and the result of the operation.
 
+Also, the `reparent_shard_operation_timings` stat was added to provide per-operation timings of reparent operations.
+
 ### <a id="breaking-changes"/>Breaking Changes
 
 #### <a id="shutdown-grace-period-default"/>`shutdown_grace_period` Default Change

--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -7,6 +7,7 @@
     - [MySQL binaries in the vitess/lite Docker images](#vitess-lite)
     - [vitess/base and vitess/k8s Docker images](#base-k8s-images)
     - [`gh-ost` binary and endtoend tests](#gh-ost-binary-tests-removal)
+    - [Legacy `EmergencyReparentShard` stats](#legacy-emergencyshardreparent-stats)
   - **[Breaking changes](#breaking-changes)**
     - [`shutdown_grace_period` Default Change](#shutdown-grace-period-default)
     - [New `unmanaged` Flag and `disable_active_reparents` deprecation](#unmanaged-flag)
@@ -94,6 +95,17 @@ Vitess 20.0 drops support for `gh-ost` DDL strategy.
 `vttablet` binary no longer embeds a `gh-ost` binary. Users of `gh-ost` DDL strategy will need to supply a `gh-ost` binary on the `vttablet` host or pod. Vitess will look for the `gh-ost` binary in the system `PATH`; otherwise the user should supply `vttablet --gh-ost-path`.
 
 Vitess' endtoend tests no longer use nor test `gh-ost` migrations.
+
+#### <a id="legacy-emergencyshardreparent-stats"/>Legacy `EmergencyReparentShard` stats
+
+The following `EmergencyReparentShard` stats were deprecated in Vitess 18.0 and are removed in Vitess 20.0:
+- `ers_counter`
+- `ers_success_counter`
+- `ers_failure_counter`
+
+These counters are replaced by the following stats _(introduced in Vitess 18.0)_:
+- `emergency_reparent_counts` - Number of times `EmergencyReparentShard` has been run. It is further subdivided by the keyspace, shard and the result of the operation.
+- `planned_reparent_counts` - Number of times `PlannedReparentShard` has been run. It is further subdivided by the keyspace, shard and the result of the operation.
 
 ### <a id="breaking-changes"/>Breaking Changes
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -68,15 +68,8 @@ type EmergencyReparentOptions struct {
 }
 
 // counters for Emergency Reparent Shard
-var (
-	// TODO(timvaillancourt): remove legacyERS* gauges in v19+.
-	legacyERSCounter        = stats.NewGauge("ers_counter", "Number of times Emergency Reparent Shard has been run")
-	legacyERSSuccessCounter = stats.NewGauge("ers_success_counter", "Number of times Emergency Reparent Shard has succeeded")
-	legacyERSFailureCounter = stats.NewGauge("ers_failure_counter", "Number of times Emergency Reparent Shard has failed")
-
-	ersCounter = stats.NewCountersWithMultiLabels("emergency_reparent_counts", "Number of times Emergency Reparent Shard has been run",
-		[]string{"Keyspace", "Shard", "Result"},
-	)
+var ersCounter = stats.NewCountersWithMultiLabels("emergency_reparent_counts", "Number of times Emergency Reparent Shard has been run",
+	[]string{"Keyspace", "Shard", "Result"},
 )
 
 // NewEmergencyReparenter returns a new EmergencyReparenter object, ready to
@@ -125,11 +118,9 @@ func (erp *EmergencyReparenter) ReparentShard(ctx context.Context, keyspace stri
 		reparentShardOpTimings.Add("EmergencyReparentShard", time.Since(startTime))
 		switch err {
 		case nil:
-			legacyERSSuccessCounter.Add(1)
 			ersCounter.Add(append(statsLabels, successResult), 1)
 			event.DispatchUpdate(ev, "finished EmergencyReparentShard")
 		default:
-			legacyERSFailureCounter.Add(1)
 			ersCounter.Add(append(statsLabels, failureResult), 1)
 			event.DispatchUpdate(ev, "failed EmergencyReparentShard: "+err.Error())
 		}
@@ -154,7 +145,6 @@ func (erp *EmergencyReparenter) getLockAction(newPrimaryAlias *topodatapb.Tablet
 func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *events.Reparent, keyspace, shard string, opts EmergencyReparentOptions) (err error) {
 	// log the starting of the operation and increment the counter
 	erp.logger.Infof("will initiate emergency reparent shard in keyspace - %s, shard - %s", keyspace, shard)
-	legacyERSCounter.Add(1)
 
 	var (
 		stoppedReplicationSnapshot *replicationSnapshot

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -2725,9 +2725,6 @@ func TestEmergencyReparenter_waitForAllRelayLogsToApply(t *testing.T) {
 
 func TestEmergencyReparenterStats(t *testing.T) {
 	ersCounter.ResetAll()
-	legacyERSCounter.Reset()
-	legacyERSSuccessCounter.Reset()
-	legacyERSFailureCounter.Reset()
 	reparentShardOpTimings.Reset()
 
 	emergencyReparentOps := EmergencyReparentOptions{}
@@ -2860,11 +2857,6 @@ func TestEmergencyReparenterStats(t *testing.T) {
 	require.EqualValues(t, map[string]int64{"testkeyspace.-.success": 1}, ersCounter.Counts())
 	require.EqualValues(t, map[string]int64{"All": 1, "EmergencyReparentShard": 1}, reparentShardOpTimings.Counts())
 
-	// check the legacy counter values
-	require.EqualValues(t, 1, legacyERSCounter.Get())
-	require.EqualValues(t, 1, legacyERSSuccessCounter.Get())
-	require.EqualValues(t, 0, legacyERSFailureCounter.Get())
-
 	// set emergencyReparentOps to request a non existent tablet
 	emergencyReparentOps.NewPrimaryAlias = &topodatapb.TabletAlias{
 		Cell: "bogus",
@@ -2878,11 +2870,6 @@ func TestEmergencyReparenterStats(t *testing.T) {
 	// check the counter values
 	require.EqualValues(t, map[string]int64{"testkeyspace.-.success": 1, "testkeyspace.-.failure": 1}, ersCounter.Counts())
 	require.EqualValues(t, map[string]int64{"All": 2, "EmergencyReparentShard": 2}, reparentShardOpTimings.Counts())
-
-	// check the legacy counter values
-	require.EqualValues(t, 2, legacyERSCounter.Get())
-	require.EqualValues(t, 1, legacyERSSuccessCounter.Get())
-	require.EqualValues(t, 1, legacyERSFailureCounter.Get())
 }
 
 func TestEmergencyReparenter_findMostAdvanced(t *testing.T) {


### PR DESCRIPTION
## Description

This PR removes legacy ERS stats that were deprecated [by a PR I wrote in Vitess 18.0](https://github.com/vitessio/vitess/pull/13723). Replacement metrics with labels were added in the same release

## Related Issue(s)

https://github.com/vitessio/vitess/pull/13723

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
