### PR TITLE
vtorc: Switch to Vitess stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.5.0
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.53.0
-	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/sjmudd/stopwatch v0.1.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.14.0 h1:Lw4VdGGoKEZilJsayHf0B+9YgLGREba2C6xr+Fdfq6s=
 github.com/prometheus/procfs v0.14.0/go.mod h1:XL+Iwz8k8ZabyZfMFHPiilCniixqQarAy5Mu67pHlNQ=
-github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
-github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 h1:Qp27Idfgi6ACvFQat5+VJvlYToylpM/hcyLBI3WaKPA=

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -21,30 +21,26 @@ import (
 	"math"
 	"time"
 
-	"vitess.io/vitess/go/vt/external/golib/sqlutils"
-	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/topo/topoproto"
-
+	"github.com/patrickmn/go-cache"
 	"google.golang.org/protobuf/encoding/prototext"
 
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/external/golib/sqlutils"
+	"vitess.io/vitess/go/vt/log"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vtorc/config"
 	"vitess.io/vitess/go/vt/vtorc/db"
 	"vitess.io/vitess/go/vt/vtorc/util"
-
-	"github.com/patrickmn/go-cache"
-	"github.com/rcrowley/go-metrics"
 )
 
-var analysisChangeWriteCounter = metrics.NewCounter()
+var analysisChangeWriteCounter = stats.NewCounter("analysis.change.write", "Number of times analysis has changed")
 
 var recentInstantAnalysis *cache.Cache
 
 func init() {
-	_ = metrics.Register("analysis.change.write", analysisChangeWriteCounter)
-
 	go initializeAnalysisDaoPostConfiguration()
 }
 
@@ -717,7 +713,7 @@ func auditInstanceAnalysisInChangelog(tabletAlias string, analysisCode AnalysisC
 		tabletAlias, string(analysisCode),
 	)
 	if err == nil {
-		analysisChangeWriteCounter.Inc(1)
+		analysisChangeWriteCounter.Add(1)
 	} else {
 		log.Error(err)
 	}

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
-	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/external/golib/sqlutils"
@@ -906,7 +905,7 @@ func TestAuditInstanceAnalysisInChangelog(t *testing.T) {
 			oldAnalysisChangeWriteCounter := analysisChangeWriteCounter
 
 			recentInstantAnalysis = cache.New(tt.cacheExpiration, 100*time.Millisecond)
-			analysisChangeWriteCounter = metrics.NewCounter()
+			before := analysisChangeWriteCounter.Get()
 
 			defer func() {
 				// Set the old values back.
@@ -919,7 +918,7 @@ func TestAuditInstanceAnalysisInChangelog(t *testing.T) {
 			updates := []struct {
 				tabletAlias             string
 				analysisCode            AnalysisCode
-				writeCounterExpectation int
+				writeCounterExpectation int64
 				wantErr                 string
 			}{
 				{
@@ -950,7 +949,7 @@ func TestAuditInstanceAnalysisInChangelog(t *testing.T) {
 					continue
 				}
 				require.NoError(t, err)
-				require.EqualValues(t, upd.writeCounterExpectation, analysisChangeWriteCounter.Count())
+				require.EqualValues(t, upd.writeCounterExpectation, analysisChangeWriteCounter.Get()-before)
 			}
 		})
 	}

--- a/go/vt/vtorc/inst/audit_dao.go
+++ b/go/vt/vtorc/inst/audit_dao.go
@@ -21,18 +21,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
-
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtorc/config"
 	"vitess.io/vitess/go/vt/vtorc/db"
 )
 
-var auditOperationCounter = metrics.NewCounter()
-
-func init() {
-	_ = metrics.Register("audit.write", auditOperationCounter)
-}
+var auditOperationCounter = stats.NewCounter("audit.write", "Number of audit operations performed")
 
 // AuditOperation creates and writes a new audit entry by given params
 func AuditOperation(auditType string, tabletAlias string, message string) error {
@@ -86,7 +81,7 @@ func AuditOperation(auditType string, tabletAlias string, message string) error 
 	if !auditWrittenToFile {
 		log.Infof(logMessage)
 	}
-	auditOperationCounter.Inc(1)
+	auditOperationCounter.Add(1)
 
 	return nil
 }

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
-	"github.com/rcrowley/go-metrics"
 	"github.com/sjmudd/stopwatch"
 
 	"vitess.io/vitess/go/mysql/replication"
@@ -60,10 +59,8 @@ var (
 var forgetAliases *cache.Cache
 
 var (
-	accessDeniedCounter         = metrics.NewCounter()
-	readTopologyInstanceCounter = metrics.NewCounter()
-	readInstanceCounter         = metrics.NewCounter()
-	writeInstanceCounter        = metrics.NewCounter()
+	readTopologyInstanceCounter = stats.NewCounter("instance.read_topology", "Number of times an instance was read from the topology")
+	readInstanceCounter         = stats.NewCounter("instance.read", "Number of times an instance was read")
 	backendWrites               = collection.CreateOrReturnCollection("BACKEND_WRITES")
 	writeBufferLatency          = stopwatch.NewNamedStopwatch()
 )
@@ -74,10 +71,6 @@ var (
 )
 
 func init() {
-	_ = metrics.Register("instance.access_denied", accessDeniedCounter)
-	_ = metrics.Register("instance.read_topology", readTopologyInstanceCounter)
-	_ = metrics.Register("instance.read", readInstanceCounter)
-	_ = metrics.Register("instance.write", writeInstanceCounter)
 	_ = writeBufferLatency.AddMany([]string{"wait", "write"})
 	writeBufferLatency.Start("wait")
 
@@ -390,7 +383,7 @@ Cleanup:
 	}
 
 	latency.Stop("instance")
-	readTopologyInstanceCounter.Inc(1)
+	readTopologyInstanceCounter.Add(1)
 
 	if instanceFound {
 		instance.LastDiscoveryLatency = time.Since(readingStartTime)
@@ -621,7 +614,7 @@ func ReadInstance(tabletAlias string) (*Instance, bool, error) {
 	instances, err := readInstancesByCondition(condition, sqlutils.Args(tabletAlias), "")
 	// We know there will be at most one (alias is the PK).
 	// And we expect to find one.
-	readInstanceCounter.Inc(1)
+	readInstanceCounter.Add(1)
 	if len(instances) == 0 {
 		return nil, false, err
 	}


### PR DESCRIPTION
This moves the stats setup to the internal Vitess stats package instead of another external dependency.

With this change we can remove the external dependency.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required