### PR TITLE
fix: insert on duplicate update to add list argument in the bind variables map

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/insert_test.go
@@ -54,6 +54,27 @@ func TestSimpleInsertSelect(t *testing.T) {
 	utils.AssertMatches(t, mcmp.VtConn, `select num from num_vdx_tbl order by num`, `[[INT64(2)] [INT64(4)] [INT64(40)] [INT64(42)] [INT64(80)] [INT64(84)]]`)
 }
 
+// TestInsertOnDup test the insert on duplicate key update feature with argument and list argument.
+func TestInsertOnDup(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into order_tbl(oid, region_id, cust_no) values (1,2,3),(3,4,5)")
+
+	for _, mode := range []string{"oltp", "olap"} {
+		mcmp.Run(mode, func(mcmp *utils.MySQLCompare) {
+			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", mode))
+
+			mcmp.Exec(`insert into order_tbl(oid, region_id, cust_no) values (2,2,3),(4,4,5) on duplicate key update cust_no = if(values(cust_no) in (1, 2, 3), region_id, values(cust_no))`)
+			mcmp.Exec(`select oid, region_id, cust_no from order_tbl order by oid, region_id`)
+			mcmp.Exec(`insert into order_tbl(oid, region_id, cust_no) values (7,2,2) on duplicate key update cust_no = 10 + values(cust_no)`)
+			mcmp.Exec(`select oid, region_id, cust_no from order_tbl order by oid, region_id`)
+		})
+	}
+}
+
 func TestFailureInsertSelect(t *testing.T) {
 	if clusterInstance.HasPartialKeyspaces {
 		t.Skip("don't run on partial keyspaces")

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -402,6 +402,15 @@ func TestNormalize(t *testing.T) {
 			"bv2": sqltypes.Int64BindVariable(2),
 			"bv3": sqltypes.Int64BindVariable(3),
 		},
+	}, {
+		// list in on duplicate key update
+		in:      "insert into t(a, b) values (1, 2) on duplicate key update b = if(values(b) in (1, 2), b, values(b))",
+		outstmt: "insert into t(a, b) values (:bv1 /* INT64 */, :bv2 /* INT64 */) on duplicate key update b = if(values(b) in ::bv3, b, values(b))",
+		outbv: map[string]*querypb.BindVariable{
+			"bv1": sqltypes.Int64BindVariable(1),
+			"bv2": sqltypes.Int64BindVariable(2),
+			"bv3": sqltypes.TestBindVariable([]any{1, 2}),
+		},
 	}}
 	parser := NewTestParser()
 	for _, tc := range testcases {

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -268,13 +268,20 @@ func (ins *Insert) getInsertShardedQueries(
 			index, _ := strconv.ParseInt(string(indexValue.Value), 0, 64)
 			if keyspaceIDs[index] != nil {
 				walkFunc := func(node sqlparser.SQLNode) (kontinue bool, err error) {
-					if arg, ok := node.(*sqlparser.Argument); ok {
-						bv, exists := bindVars[arg.Name]
-						if !exists {
-							return false, vterrors.VT03026(arg.Name)
-						}
-						shardBindVars[arg.Name] = bv
+					var arg string
+					switch argType := node.(type) {
+					case *sqlparser.Argument:
+						arg = argType.Name
+					case sqlparser.ListArg:
+						arg = string(argType)
+					default:
+						return true, nil
 					}
+					bv, exists := bindVars[arg]
+					if !exists {
+						return false, vterrors.VT03026(arg)
+					}
+					shardBindVars[arg] = bv
 					return true, nil
 				}
 				mids = append(mids, sqlparser.String(ins.Mid[index]))

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -356,13 +356,23 @@ func TestInsertShardWithONDuplicateKey(t *testing.T) {
 			{&sqlparser.Argument{Name: "_id_0", Type: sqltypes.Int64}},
 		},
 		sqlparser.OnDup{
-			&sqlparser.UpdateExpr{Name: sqlparser.NewColName("suffix"), Expr: &sqlparser.Argument{Name: "_id_0", Type: sqltypes.Int64}},
-		},
+			&sqlparser.UpdateExpr{Name: sqlparser.NewColName("suffix1"), Expr: &sqlparser.Argument{Name: "_id_0", Type: sqltypes.Int64}},
+			&sqlparser.UpdateExpr{Name: sqlparser.NewColName("suffix2"), Expr: &sqlparser.FuncExpr{
+				Name: sqlparser.NewIdentifierCI("if"),
+				Exprs: sqlparser.Exprs{
+					sqlparser.NewComparisonExpr(sqlparser.InOp, &sqlparser.ValuesFuncExpr{Name: sqlparser.NewColName("col")}, sqlparser.ListArg("_id_1"), nil),
+					sqlparser.NewColName("col"),
+					&sqlparser.ValuesFuncExpr{Name: sqlparser.NewColName("col")},
+				},
+			}}},
 	)
 	vc := newDMLTestVCursor("-20", "20-")
 	vc.shardForKsid = []string{"20-", "-20", "20-"}
 
-	_, err := ins.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	tupleVar, _ := sqltypes.BuildBindVariable([]int{1, 2})
+	_, err := ins.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{
+		"_id_1": tupleVar,
+	}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +381,10 @@ func TestInsertShardWithONDuplicateKey(t *testing.T) {
 		`ResolveDestinations sharded [value:"0"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
 		// Row 2 will go to -20, rows 1 & 3 will go to 20-
 		`ExecuteMultiShard ` +
-			`sharded.20-: prefix(:_id_0 /* INT64 */) on duplicate key update suffix = :_id_0 /* INT64 */ {_id_0: type:INT64 value:"1"} ` +
+			`sharded.20-: prefix(:_id_0 /* INT64 */) on duplicate key update ` +
+			`suffix1 = :_id_0 /* INT64 */, suffix2 = if(values(col) in ::_id_1, col, values(col)) ` +
+			`{_id_0: type:INT64 value:"1" ` +
+			`_id_1: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"}} ` +
 			`true true`,
 	})
 

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -369,9 +369,8 @@ func TestInsertShardWithONDuplicateKey(t *testing.T) {
 	vc := newDMLTestVCursor("-20", "20-")
 	vc.shardForKsid = []string{"20-", "-20", "20-"}
 
-	tupleVar, _ := sqltypes.BuildBindVariable([]int{1, 2})
 	_, err := ins.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{
-		"_id_1": tupleVar,
+		"_id_1": sqltypes.TestBindVariable([]int{1, 2}),
 	}, false)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the issue with `insert on duplicate key update`. When there is a `list argument` in the on duplicate key update expressions it was missed in sending down to vttablet.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15965

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [X] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required

