### PR TITLE
Improve WaitForPos errors, don't include Result struct in message

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -791,9 +791,9 @@ func (vre *Engine) WaitForPos(ctx context.Context, id int32, pos string) error {
 		case len(qr.Rows) == 0:
 			return fmt.Errorf("vreplication stream %d not found", id)
 		case len(qr.Rows) > 1:
-			return fmt.Errorf("vreplication stream received more rows than expected, got %v instead of 1", len(qr.Rows))
+			return fmt.Errorf("vreplication stream received more rows than expected, got %d instead of 1", len(qr.Rows))
 		case len(qr.Rows[0]) != 3:
-			return fmt.Errorf("vreplication stream received an unexpected number of columns, got %v instead of 3", len(qr.Rows[0]))
+			return fmt.Errorf("vreplication stream received an unexpected number of columns, got %d instead of 3", len(qr.Rows[0]))
 		}
 
 		// When err is not nil then we got a retryable error and will loop again.

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -790,8 +790,10 @@ func (vre *Engine) WaitForPos(ctx context.Context, id int32, pos string) error {
 			}
 		case len(qr.Rows) == 0:
 			return fmt.Errorf("vreplication stream %d not found", id)
-		case len(qr.Rows) > 1 || len(qr.Rows[0]) != 3:
-			return fmt.Errorf("unexpected result: %v", qr)
+		case len(qr.Rows) > 1:
+			return fmt.Errorf("vreplication stream received more rows than expected, got %v instead of 1", len(qr.Rows))
+		case len(qr.Rows[0]) != 3:
+			return fmt.Errorf("vreplication stream received an unexpected number of columns, got %v instead of 3", len(qr.Rows[0]))
 		}
 
 		// When err is not nil then we got a retryable error and will loop again.

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -426,7 +426,7 @@ func TestWaitForPosError(t *testing.T) {
 
 	dbClient.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{}}}, nil)
 	err = vre.WaitForPos(context.Background(), 1, "MariaDB/0-1-1084")
-	want = fmt.Sprintf("unexpected result: %v", &sqltypes.Result{Rows: [][]sqltypes.Value{{}}})
+	want = "vreplication stream received an unexpected number of columns, got 0 instead of 3"
 
 	assert.EqualError(t, err, want, "WaitForPos:")
 
@@ -436,11 +436,7 @@ func TestWaitForPosError(t *testing.T) {
 		sqltypes.NewVarBinary("MariaDB/0-1-1083"),
 	}}}, nil)
 	err = vre.WaitForPos(context.Background(), 1, "MariaDB/0-1-1084")
-	want = fmt.Sprintf("unexpected result: %v", &sqltypes.Result{Rows: [][]sqltypes.Value{{
-		sqltypes.NewVarBinary("MariaDB/0-1-1083"),
-	}, {
-		sqltypes.NewVarBinary("MariaDB/0-1-1083"),
-	}}})
+	want = "vreplication stream received more rows than expected, got 2 instead of 1"
 	assert.EqualError(t, err, want, "WaitForPos:")
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -426,7 +426,8 @@ func TestWaitForPosError(t *testing.T) {
 
 	dbClient.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{}}}, nil)
 	err = vre.WaitForPos(context.Background(), 1, "MariaDB/0-1-1084")
-	want = "unexpected result: &{[] 0 0 [[]]  0 }"
+	want = fmt.Sprintf("unexpected result: %v", &sqltypes.Result{Rows: [][]sqltypes.Value{{}}})
+
 	assert.EqualError(t, err, want, "WaitForPos:")
 
 	dbClient.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{
@@ -435,7 +436,11 @@ func TestWaitForPosError(t *testing.T) {
 		sqltypes.NewVarBinary("MariaDB/0-1-1083"),
 	}}}, nil)
 	err = vre.WaitForPos(context.Background(), 1, "MariaDB/0-1-1084")
-	want = `unexpected result: &{[] 0 0 [[VARBINARY("MariaDB/0-1-1083")] [VARBINARY("MariaDB/0-1-1083")]]  0 }`
+	want = fmt.Sprintf("unexpected result: %v", &sqltypes.Result{Rows: [][]sqltypes.Value{{
+		sqltypes.NewVarBinary("MariaDB/0-1-1083"),
+	}, {
+		sqltypes.NewVarBinary("MariaDB/0-1-1083"),
+	}}})
 	assert.EqualError(t, err, want, "WaitForPos:")
 }
 


### PR DESCRIPTION
## Description

Add more specific errors when `WaitForPos` receives an unexpected number of rows or columns. No longer prints the raw Result object (which isn't a particularly descriptive error for end users). 

Immediate motivation is to make tests less brittle when `Result` object is modified (in downstream forks).

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
