### PR TITLE
Update `operator.yaml` and add schedule backup example

### DIFF
--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -24,9 +24,11 @@ spec:
         jobTimeoutMinute: 5
         strategies:
           - name: BackupShard
-            keyspaceShard: "customer/-80"
+            keyspace: "customer"
+            shard: "-80"
           - name: BackupShard
-            keyspaceShard: "customer/80-"
+            keyspace: "customer"
+            shard: "80-"
       - name: "every-minute-commerce"
         schedule: "* * * * *"
         resources:
@@ -40,7 +42,8 @@ spec:
         jobTimeoutMinute: 5
         strategies:
           - name: BackupShard
-            keyspaceShard: "commerce/-"
+            keyspace: "customer"
+            shard: "-"
   images:
     vtctld: vitess/lite:latest
     vtadmin: vitess/vtadmin:latest

--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -1,0 +1,187 @@
+apiVersion: planetscale.com/v2
+kind: VitessCluster
+metadata:
+  name: example
+spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /tmp
+            type: Directory
+    schedules:
+      - name: "every-minute-customer"
+        schedule: "* * * * *"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1024Mi
+          limits:
+            memory: 1024Mi
+        successfulJobsHistoryLimit: 2
+        failedJobsHistoryLimit: 3
+        jobTimeoutMinute: 5
+        strategies:
+          - name: BackupShard
+            keyspaceShard: "customer/-80"
+          - name: BackupShard
+            keyspaceShard: "customer/80-"
+      - name: "every-minute-commerce"
+        schedule: "* * * * *"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1024Mi
+          limits:
+            memory: 1024Mi
+        successfulJobsHistoryLimit: 2
+        failedJobsHistoryLimit: 3
+        jobTimeoutMinute: 5
+        strategies:
+          - name: BackupShard
+            keyspaceShard: "commerce/-"
+  images:
+    vtctld: vitess/lite:latest
+    vtadmin: vitess/vtadmin:latest
+    vtgate: vitess/lite:latest
+    vttablet: vitess/lite:latest
+    vtbackup: vitess/lite:latest
+    vtorc: vitess/lite:latest
+    mysqld:
+      mysql80Compatible: mysql:8.0.30
+    mysqldExporter: prom/mysqld-exporter:v0.11.0
+  cells:
+  - name: zone1
+    gateway:
+      authentication:
+        static:
+          secret:
+            name: example-cluster-config
+            key: users.json
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+  vitessDashboard:
+    cells:
+    - zone1
+    extraFlags:
+      security_policy: read-only
+    replicas: 1
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+  vtadmin:
+    rbac:
+      name: example-cluster-config
+      key: rbac.yaml
+    cells:
+      - zone1
+    apiAddresses:
+      - http://localhost:14001
+    replicas: 1
+    readOnly: false
+    apiResources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    webResources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  keyspaces:
+  - name: commerce
+    durabilityPolicy: none
+    turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
+    partitionings:
+    - equal:
+        parts: 1
+        shardTemplate:
+          databaseInitScriptSecret:
+            name: example-cluster-config
+            key: init_db.sql
+          tabletPools:
+          - cell: zone1
+            type: replica
+            replicas: 2
+            vttablet:
+              extraFlags:
+                db_charset: utf8mb4
+                wait_for_backup_interval: "0"
+              resources:
+                limits:
+                  memory: 1024Mi
+                requests:
+                  cpu: 100m
+                  memory: 1024Mi
+            mysqld:
+              resources:
+                limits:
+                  memory: 1024Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+            dataVolumeClaimTemplate:
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 10Gi
+  - name: customer
+    durabilityPolicy: none
+    turndownPolicy: Immediate
+    partitionings:
+    - equal:
+        parts: 2
+        shardTemplate:
+          databaseInitScriptSecret:
+            name: example-cluster-config
+            key: init_db.sql
+          tabletPools:
+          - cell: zone1
+            type: replica
+            replicas: 2
+            vttablet:
+              extraFlags:
+                db_charset: utf8mb4
+                wait_for_backup_interval: "0"
+              resources:
+                limits:
+                  memory: 1024Mi
+                requests:
+                  cpu: 100m
+                  memory: 1024Mi
+            mysqld:
+              resources:
+                limits:
+                  memory: 1024Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+            dataVolumeClaimTemplate:
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 10Gi
+  updateStrategy:
+    type: Immediate

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -407,14 +407,21 @@ spec:
               type: object
             spec:
               properties:
+                affinity:
+                  x-kubernetes-preserve-unknown-fields: true
                 allowedMissedRun:
                   minimum: 0
                   type: integer
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                cluster:
+                  type: string
                 concurrencyPolicy:
                   enum:
                     - Allow
                     - Forbid
-                    - Replace
                   example: Forbid
                   type: string
                 failedJobsHistoryLimit:
@@ -431,7 +438,7 @@ spec:
                   minimum: 0
                   type: integer
                 name:
-                  example: every-minute
+                  example: every-day
                   minLength: 1
                   pattern: ^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$
                   type: string
@@ -467,7 +474,7 @@ spec:
                       type: object
                   type: object
                 schedule:
-                  example: '* * * * *'
+                  example: 0 0 * * *
                   minLength: 0
                   type: string
                 startingDeadlineSeconds:
@@ -481,19 +488,20 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      keyspaceShard:
-                        example: commerce/-
+                      keyspace:
+                        example: commerce
                         type: string
                       name:
                         enum:
-                          - BackupTablet
                           - BackupShard
                         type: string
-                      tabletAlias:
-                        example: zone1-0000000102
+                      shard:
+                        example: '-'
                         type: string
                     required:
+                      - keyspace
                       - name
+                      - shard
                     type: object
                   minItems: 1
                   type: array
@@ -504,6 +512,7 @@ spec:
                 suspend:
                   type: boolean
               required:
+                - cluster
                 - name
                 - resources
                 - schedule
@@ -1634,14 +1643,19 @@ spec:
                     schedules:
                       items:
                         properties:
+                          affinity:
+                            x-kubernetes-preserve-unknown-fields: true
                           allowedMissedRun:
                             minimum: 0
                             type: integer
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
                           concurrencyPolicy:
                             enum:
                               - Allow
                               - Forbid
-                              - Replace
                             example: Forbid
                             type: string
                           failedJobsHistoryLimit:
@@ -1654,7 +1668,7 @@ spec:
                             minimum: 0
                             type: integer
                           name:
-                            example: every-minute
+                            example: every-day
                             minLength: 1
                             pattern: ^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$
                             type: string
@@ -1690,7 +1704,7 @@ spec:
                                 type: object
                             type: object
                           schedule:
-                            example: '* * * * *'
+                            example: 0 0 * * *
                             minLength: 0
                             type: string
                           startingDeadlineSeconds:
@@ -1704,19 +1718,20 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                                keyspaceShard:
-                                  example: commerce/-
+                                keyspace:
+                                  example: commerce
                                   type: string
                                 name:
                                   enum:
-                                    - BackupTablet
                                     - BackupShard
                                   type: string
-                                tabletAlias:
-                                  example: zone1-0000000102
+                                shard:
+                                  example: '-'
                                   type: string
                               required:
+                                - keyspace
                                 - name
+                                - shard
                               type: object
                             minItems: 1
                             type: array

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -386,6 +385,167 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
+  name: vitessbackupschedules.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessBackupSchedule
+    listKind: VitessBackupScheduleList
+    plural: vitessbackupschedules
+    singular: vitessbackupschedule
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                allowedMissedRun:
+                  minimum: 0
+                  type: integer
+                concurrencyPolicy:
+                  enum:
+                    - Allow
+                    - Forbid
+                    - Replace
+                  example: Forbid
+                  type: string
+                failedJobsHistoryLimit:
+                  format: int32
+                  minimum: 0
+                  type: integer
+                image:
+                  type: string
+                imagePullPolicy:
+                  type: string
+                jobTimeoutMinute:
+                  format: int32
+                  minimum: 0
+                  type: integer
+                name:
+                  example: every-minute
+                  minLength: 1
+                  pattern: ^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$
+                  type: string
+                resources:
+                  properties:
+                    claims:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                schedule:
+                  example: '* * * * *'
+                  minLength: 0
+                  type: string
+                startingDeadlineSeconds:
+                  format: int64
+                  minimum: 0
+                  type: integer
+                strategies:
+                  items:
+                    properties:
+                      extraFlags:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      keyspaceShard:
+                        example: commerce/-
+                        type: string
+                      name:
+                        enum:
+                          - BackupTablet
+                          - BackupShard
+                        type: string
+                      tabletAlias:
+                        example: zone1-0000000102
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  minItems: 1
+                  type: array
+                successfulJobsHistoryLimit:
+                  format: int32
+                  minimum: 0
+                  type: integer
+                suspend:
+                  type: boolean
+              required:
+                - name
+                - resources
+                - schedule
+                - strategies
+              type: object
+            status:
+              properties:
+                active:
+                  items:
+                    properties:
+                      apiVersion:
+                        type: string
+                      fieldPath:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                      resourceVersion:
+                        type: string
+                      uid:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                lastScheduledTime:
+                  format: date-time
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: vitessbackupstorages.planetscale.com
 spec:
   group: planetscale.com
@@ -705,6 +865,109 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     initContainers:
                       x-kubernetes-preserve-unknown-fields: true
+                    lifecycle:
+                      properties:
+                        postStart:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                          type: object
+                        preStop:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                          type: object
+                      type: object
                     replicas:
                       format: int32
                       minimum: 0
@@ -792,6 +1055,9 @@ spec:
                       type: object
                     sidecarContainers:
                       x-kubernetes-preserve-unknown-fields: true
+                    terminationGracePeriodSeconds:
+                      format: int64
+                      type: integer
                     tolerations:
                       x-kubernetes-preserve-unknown-fields: true
                     topologySpreadConstraints:
@@ -1364,6 +1630,107 @@ spec:
                         type: object
                       minItems: 1
                       type: array
+                    schedules:
+                      items:
+                        properties:
+                          allowedMissedRun:
+                            minimum: 0
+                            type: integer
+                          concurrencyPolicy:
+                            enum:
+                              - Allow
+                              - Forbid
+                              - Replace
+                            example: Forbid
+                            type: string
+                          failedJobsHistoryLimit:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          jobTimeoutMinute:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          name:
+                            example: every-minute
+                            minLength: 1
+                            pattern: ^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$
+                            type: string
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          schedule:
+                            example: '* * * * *'
+                            minLength: 0
+                            type: string
+                          startingDeadlineSeconds:
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          strategies:
+                            items:
+                              properties:
+                                extraFlags:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                keyspaceShard:
+                                  example: commerce/-
+                                  type: string
+                                name:
+                                  enum:
+                                    - BackupTablet
+                                    - BackupShard
+                                  type: string
+                                tabletAlias:
+                                  example: zone1-0000000102
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            minItems: 1
+                            type: array
+                          successfulJobsHistoryLimit:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          suspend:
+                            type: boolean
+                        required:
+                          - name
+                          - resources
+                          - schedule
+                          - strategies
+                        type: object
+                      type: array
                     subcontroller:
                       properties:
                         serviceAccountName:
@@ -1496,6 +1863,109 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                           initContainers:
                             x-kubernetes-preserve-unknown-fields: true
+                          lifecycle:
+                            properties:
+                              postStart:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                type: object
+                              preStop:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                type: object
+                            type: object
                           replicas:
                             format: int32
                             minimum: 0
@@ -1583,6 +2053,9 @@ spec:
                             type: object
                           sidecarContainers:
                             x-kubernetes-preserve-unknown-fields: true
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
                           tolerations:
                             x-kubernetes-preserve-unknown-fields: true
                           topologySpreadConstraints:
@@ -2278,6 +2751,16 @@ spec:
                         type: string
                       durabilityPolicy:
                         type: string
+                      images:
+                        properties:
+                          mysqld:
+                            properties:
+                              mysql56Compatible:
+                                type: string
+                              mysql80Compatible:
+                                type: string
+                            type: object
+                        type: object
                       name:
                         maxLength: 63
                         minLength: 1
@@ -2607,6 +3090,45 @@ spec:
                                               required:
                                                 - resources
                                               type: object
+                                            mysqldExporter:
+                                              properties:
+                                                resources:
+                                                  properties:
+                                                    claims:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                        required:
+                                                          - name
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                        - name
+                                                      x-kubernetes-list-type: map
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - resources
+                                              type: object
+                                            name:
+                                              default: ""
+                                              type: string
                                             replicas:
                                               format: int32
                                               minimum: 0
@@ -2664,6 +3186,9 @@ spec:
                                                         x-kubernetes-int-or-string: true
                                                       type: object
                                                   type: object
+                                                terminationGracePeriodSeconds:
+                                                  format: int64
+                                                  type: integer
                                               required:
                                                 - resources
                                               type: object
@@ -2677,6 +3202,7 @@ spec:
                                         x-kubernetes-list-map-keys:
                                           - type
                                           - cell
+                                          - name
                                         x-kubernetes-list-type: map
                                     required:
                                       - databaseInitScriptSecret
@@ -3002,6 +3528,45 @@ spec:
                                             required:
                                               - resources
                                             type: object
+                                          mysqldExporter:
+                                            properties:
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                      - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                            required:
+                                              - resources
+                                            type: object
+                                          name:
+                                            default: ""
+                                            type: string
                                           replicas:
                                             format: int32
                                             minimum: 0
@@ -3059,6 +3624,9 @@ spec:
                                                       x-kubernetes-int-or-string: true
                                                     type: object
                                                 type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
                                             required:
                                               - resources
                                             type: object
@@ -3072,6 +3640,7 @@ spec:
                                       x-kubernetes-list-map-keys:
                                         - type
                                         - cell
+                                        - name
                                       x-kubernetes-list-type: map
                                   required:
                                     - databaseInitScriptSecret
@@ -4309,6 +4878,45 @@ spec:
                                         required:
                                           - resources
                                         type: object
+                                      mysqldExporter:
+                                        properties:
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                        required:
+                                          - resources
+                                        type: object
+                                      name:
+                                        default: ""
+                                        type: string
                                       replicas:
                                         format: int32
                                         minimum: 0
@@ -4366,6 +4974,9 @@ spec:
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                             type: object
+                                          terminationGracePeriodSeconds:
+                                            format: int64
+                                            type: integer
                                         required:
                                           - resources
                                         type: object
@@ -4379,6 +4990,7 @@ spec:
                                   x-kubernetes-list-map-keys:
                                     - type
                                     - cell
+                                    - name
                                   x-kubernetes-list-type: map
                               required:
                                 - databaseInitScriptSecret
@@ -4704,6 +5316,45 @@ spec:
                                       required:
                                         - resources
                                       type: object
+                                    mysqldExporter:
+                                      properties:
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                                - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                      required:
+                                        - resources
+                                      type: object
+                                    name:
+                                      default: ""
+                                      type: string
                                     replicas:
                                       format: int32
                                       minimum: 0
@@ -4761,6 +5412,9 @@ spec:
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
                                       required:
                                         - resources
                                       type: object
@@ -4774,6 +5428,7 @@ spec:
                                 x-kubernetes-list-map-keys:
                                   - type
                                   - cell
+                                  - name
                                 x-kubernetes-list-type: map
                             required:
                               - databaseInitScriptSecret
@@ -5641,6 +6296,45 @@ spec:
                         required:
                           - resources
                         type: object
+                      mysqldExporter:
+                        properties:
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                        required:
+                          - resources
+                        type: object
+                      name:
+                        default: ""
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -5698,6 +6392,9 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
                         required:
                           - resources
                         type: object
@@ -5711,6 +6408,7 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                     - cell
+                    - name
                   x-kubernetes-list-type: map
                 topologyReconciliation:
                   properties:
@@ -6091,6 +6789,15 @@ rules:
       - vitessbackupstorages
       - vitessbackupstorages/status
       - vitessbackupstorages/finalizers
+      - vitessbackupschedules
+      - vitessbackupschedules/status
+      - vitessbackupschedules/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
     verbs:
       - '*'
 ---
@@ -6105,6 +6812,22 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: vitess-operator
+---
+apiVersion: scheduling.k8s.io/v1
+description: Vitess components (vttablet, vtgate, vtctld, etcd)
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: vitess
+value: 1000
+---
+apiVersion: scheduling.k8s.io/v1
+description: The vitess-operator control plane.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: vitess-operator-control-plane
+value: 5000
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -6145,7 +6868,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:latest
+          image: frouioui/vitess-operator:latest
           name: vitess-operator
           resources:
             limits:
@@ -6155,19 +6878,3 @@ spec:
               memory: 128Mi
       priorityClassName: vitess-operator-control-plane
       serviceAccountName: vitess-operator
----
-apiVersion: scheduling.k8s.io/v1
-description: The vitess-operator control plane.
-globalDefault: false
-kind: PriorityClass
-metadata:
-  name: vitess-operator-control-plane
-value: 5000
----
-apiVersion: scheduling.k8s.io/v1
-description: Vitess components (vttablet, vtgate, vtctld, etcd)
-globalDefault: false
-kind: PriorityClass
-metadata:
-  name: vitess
-value: 1000

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -426,6 +426,7 @@ spec:
                 imagePullPolicy:
                   type: string
                 jobTimeoutMinute:
+                  default: 10
                   format: int32
                   minimum: 0
                   type: integer
@@ -1648,6 +1649,7 @@ spec:
                             minimum: 0
                             type: integer
                           jobTimeoutMinute:
+                            default: 10
                             format: int32
                             minimum: 0
                             type: integer
@@ -6868,7 +6870,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: frouioui/vitess-operator:latest
+          image: planetscale/vitess-operator:latest
           name: vitess-operator
           resources:
             limits:


### PR DESCRIPTION
## Description

This Pull Request adds one more step to the operator example: schedule backup. It comes at the very end of the guide, after `Resharding`. For this a new `401_` file is added.

The `operator.yaml` file is also modified to reflect the changes brought by https://github.com/planetscale/vitess-operator/pull/553.

## Related Issue(s)

- Website PR: https://github.com/vitessio/website/pull/1746
- Vtop PR: https://github.com/planetscale/vitess-operator/pull/553
