### PR TITLE
Close idle conns when closing consul topo

### DIFF
--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -165,9 +165,13 @@ func parseConsulLockSessionChecks(s string) []string {
 }
 
 // Close implements topo.Server.Close.
-// It will nil out the global and cells fields, so any attempt to
-// re-use this server will panic.
+// It will close idle http connections and nil out the global
+// and cells fields, so any attempt to re-use this server
+// will panic.
 func (s *Server) Close() {
+	if consulConfig.Transport != nil {
+		consulConfig.Transport.CloseIdleConnections()
+	}
 	s.client = nil
 	s.kv = nil
 	s.mu.Lock()

--- a/go/vt/vttest/topoctl.go
+++ b/go/vt/vttest/topoctl.go
@@ -31,6 +31,7 @@ func (ctl *Topoctl) Setup() error {
 	if err != nil {
 		return err
 	}
+	defer topoServer.Close()
 
 	log.Infof("Creating cells if they don't exist in the provided topo server %s %s %s", ctl.TopoImplementation, ctl.TopoGlobalServerAddress, ctl.TopoGlobalRoot)
 	// Create cells if it doesn't exist to be idempotent. Should work when we share the same topo server across multiple local clusters.


### PR DESCRIPTION
## Description

[The `*api.Config` struct](https://pkg.go.dev/github.com/hashicorp/consul/api#Config) for the Consul client _(in `go/vt/topo/consultopo`)_ holds [a `*http.Transport`](https://pkg.go.dev/net/http#Transport) in the config, which is long-lived 😕

This object being in the "config" can cause idle connections to be left open when `.Close()` is called on the Consul topo implementation, which currently does nothing with the `*http.Transport`. This usually won't matter - the idle conn will eventually get closed, but the fact all connections are not closed on `.Close()` can cause unit test failures Slack sees on a yet-to-upstream patch

This PR:
1. Calls [`.CloseIdleConnections()`](https://pkg.go.dev/net/http#Transport.CloseIdleConnections) on the `*http.Transport` in the `.Close()` of the consul topo. This ensures that the idle connections the long-lived `*http.Transport` holds are closed
2. Add a `defer topoServer.Close()` to the `.Setup()` method in `go/vt/vttest/topoctl.go` - this `topoServer` is only used in `.Setup()` and has no `.Close()` call today

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
