### PR TITLE
connpool: Allow time out during shutdown

### DIFF
--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -870,7 +870,7 @@ func TestTimeout(t *testing.T) {
 		newctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 		_, err = p.Get(newctx, setting)
 		cancel()
-		assert.EqualError(t, err, "resource pool timed out")
+		assert.EqualError(t, err, "connection pool timed out")
 
 	}
 
@@ -894,7 +894,7 @@ func TestExpired(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 		_, err := p.Get(ctx, setting)
 		cancel()
-		require.EqualError(t, err, "resource pool context already expired")
+		require.EqualError(t, err, "connection pool context already expired")
 	}
 }
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -208,13 +208,15 @@ func TestOpen(t *testing.T) {
 	assert.EqualValues(t, 6, state.lastID.Load())
 
 	// SetCapacity
-	p.SetCapacity(3)
+	err = p.SetCapacity(ctx, 3)
+	require.NoError(t, err)
 	assert.EqualValues(t, 3, state.open.Load())
 	assert.EqualValues(t, 6, state.lastID.Load())
 	assert.EqualValues(t, 3, p.Capacity())
 	assert.EqualValues(t, 3, p.Available())
 
-	p.SetCapacity(6)
+	err = p.SetCapacity(ctx, 6)
+	require.NoError(t, err)
 	assert.EqualValues(t, 6, p.Capacity())
 	assert.EqualValues(t, 6, p.Available())
 
@@ -265,7 +267,9 @@ func TestShrinking(t *testing.T) {
 	}
 	done := make(chan bool)
 	go func() {
-		p.SetCapacity(3)
+		err := p.SetCapacity(ctx, 3)
+		require.NoError(t, err)
+
 		done <- true
 	}()
 	expected := map[string]any{
@@ -335,7 +339,8 @@ func TestShrinking(t *testing.T) {
 
 	// This will also wait
 	go func() {
-		p.SetCapacity(2)
+		err := p.SetCapacity(ctx, 2)
+		require.NoError(t, err)
 		done <- true
 	}()
 	time.Sleep(10 * time.Millisecond)
@@ -353,7 +358,8 @@ func TestShrinking(t *testing.T) {
 	assert.EqualValues(t, 2, state.open.Load())
 
 	// Test race condition of SetCapacity with itself
-	p.SetCapacity(3)
+	err = p.SetCapacity(ctx, 3)
+	require.NoError(t, err)
 	for i := 0; i < 3; i++ {
 		var r *Pooled[*TestConn]
 		var err error
@@ -375,9 +381,15 @@ func TestShrinking(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// This will wait till we Put
-	go p.SetCapacity(2)
+	go func() {
+		err := p.SetCapacity(ctx, 2)
+		require.NoError(t, err)
+	}()
 	time.Sleep(10 * time.Millisecond)
-	go p.SetCapacity(4)
+	go func() {
+		err := p.SetCapacity(ctx, 4)
+		require.NoError(t, err)
+	}()
 	time.Sleep(10 * time.Millisecond)
 
 	// This should not hang
@@ -387,7 +399,7 @@ func TestShrinking(t *testing.T) {
 	<-done
 
 	assert.Panics(t, func() {
-		p.SetCapacity(-1)
+		_ = p.SetCapacity(ctx, -1)
 	})
 
 	assert.EqualValues(t, 4, p.Capacity())
@@ -528,6 +540,46 @@ func TestReopen(t *testing.T) {
 	assert.Equal(t, expected, stats)
 	assert.EqualValues(t, 5, state.lastID.Load())
 	assert.EqualValues(t, 0, state.open.Load())
+}
+
+func TestUserClosing(t *testing.T) {
+	var state TestState
+
+	ctx := context.Background()
+	p := NewPool(&Config[*TestConn]{
+		Capacity:    5,
+		IdleTimeout: time.Second,
+		LogWait:     state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	var resources [5]*Pooled[*TestConn]
+	for i := 0; i < 5; i++ {
+		var err error
+		resources[i], err = p.Get(ctx, nil)
+		require.NoError(t, err)
+	}
+
+	for _, r := range resources[:4] {
+		r.Recycle()
+	}
+
+	ch := make(chan error)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		err := p.CloseWithContext(ctx)
+		ch <- err
+		close(ch)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Pool did not shutdown after 5s")
+	case err := <-ch:
+		require.Error(t, err)
+		t.Logf("Shutdown error: %v", err)
+	}
 }
 
 func TestIdleTimeout(t *testing.T) {

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -261,8 +261,10 @@ func TestSidecarTables(t *testing.T) {
 }
 
 func TestConsolidation(t *testing.T) {
-	defer framework.Server.SetPoolSize(framework.Server.PoolSize())
-	framework.Server.SetPoolSize(1)
+	defer framework.Server.SetPoolSize(context.Background(), framework.Server.PoolSize())
+
+	err := framework.Server.SetPoolSize(context.Background(), 1)
+	require.NoError(t, err)
 
 	const tag = "Waits/Histograms/Consolidations/Count"
 

--- a/go/vt/vttablet/endtoend/stream_test.go
+++ b/go/vt/vttablet/endtoend/stream_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package endtoend
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -98,11 +99,13 @@ func TestStreamConsolidation(t *testing.T) {
 
 	defaultPoolSize := framework.Server.StreamPoolSize()
 
-	framework.Server.SetStreamPoolSize(4)
+	err = framework.Server.SetStreamPoolSize(context.Background(), 4)
+	require.NoError(t, err)
+
 	framework.Server.SetStreamConsolidationBlocking(true)
 
 	defer func() {
-		framework.Server.SetStreamPoolSize(defaultPoolSize)
+		_ = framework.Server.SetStreamPoolSize(context.Background(), defaultPoolSize)
 		framework.Server.SetStreamConsolidationBlocking(false)
 	}()
 

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -31,14 +31,8 @@ import (
 	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
-
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
-
-// ErrConnPoolClosed is returned when the connection pool is closed.
-var ErrConnPoolClosed = vterrors.New(vtrpcpb.Code_INTERNAL, "internal error: unexpected: conn pool is closed")
 
 const (
 	getWithoutS = "GetWithoutSettings"

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -126,9 +126,9 @@ func TestConnPoolSetCapacity(t *testing.T) {
 	defer connPool.Close()
 
 	assert.Panics(t, func() {
-		connPool.SetCapacity(-10)
+		_ = connPool.SetCapacity(context.Background(), -10)
 	})
-	connPool.SetCapacity(10)
+	_ = connPool.SetCapacity(context.Background(), 10)
 	if connPool.Capacity() != 10 {
 		t.Fatalf("capacity should be 10")
 	}

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -67,7 +67,7 @@ func TestConnPoolTimeout(t *testing.T) {
 	require.NoError(t, err)
 	defer dbConn.Recycle()
 	_, err = connPool.Get(context.Background(), nil)
-	assert.EqualError(t, err, "resource pool timed out")
+	assert.EqualError(t, err, "connection pool timed out")
 }
 
 func TestConnPoolGetEmptyDebugConfig(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -128,7 +128,8 @@ func TestConnPoolSetCapacity(t *testing.T) {
 	assert.Panics(t, func() {
 		_ = connPool.SetCapacity(context.Background(), -10)
 	})
-	_ = connPool.SetCapacity(context.Background(), 10)
+	err := connPool.SetCapacity(context.Background(), 10)
+	assert.NoError(t, err)
 	if connPool.Capacity() != 10 {
 		t.Fatalf("capacity should be 10")
 	}

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tabletserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -82,6 +83,17 @@ func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) 
 			f(ival)
 			msg = fmt.Sprintf("Setting %v to: %v", varname, value)
 		}
+		setIntValCtx := func(f func(context.Context, int) error) {
+			ival, err := strconv.Atoi(value)
+			if err == nil {
+				err = f(r.Context(), ival)
+				if err == nil {
+					msg = fmt.Sprintf("Setting %v to: %v", varname, value)
+					return
+				}
+			}
+			msg = fmt.Sprintf("Failed setting value for %v: %v", varname, err)
+		}
 		setInt64Val := func(f func(int64)) {
 			ival, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
@@ -111,11 +123,11 @@ func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) 
 		}
 		switch varname {
 		case "PoolSize":
-			setIntVal(tsv.SetPoolSize)
+			setIntValCtx(tsv.SetPoolSize)
 		case "StreamPoolSize":
-			setIntVal(tsv.SetStreamPoolSize)
+			setIntValCtx(tsv.SetStreamPoolSize)
 		case "TxPoolSize":
-			setIntVal(tsv.SetTxPoolSize)
+			setIntValCtx(tsv.SetTxPoolSize)
 		case "MaxResultSize":
 			setIntVal(tsv.SetMaxResultSize)
 		case "WarnResultSize":

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -780,15 +780,7 @@ func (qre *QueryExecutor) getConn() (*connpool.PooledConn, error) {
 	defer func(start time.Time) {
 		qre.logStats.WaitingForConnection += time.Since(start)
 	}(time.Now())
-	conn, err := qre.tsv.qe.conns.Get(ctx, qre.setting)
-
-	switch err {
-	case nil:
-		return conn, nil
-	case connpool.ErrConnPoolClosed:
-		return nil, err
-	}
-	return nil, err
+	return qre.tsv.qe.conns.Get(ctx, qre.setting)
 }
 
 func (qre *QueryExecutor) getStreamConn() (*connpool.PooledConn, error) {
@@ -798,15 +790,7 @@ func (qre *QueryExecutor) getStreamConn() (*connpool.PooledConn, error) {
 	defer func(start time.Time) {
 		qre.logStats.WaitingForConnection += time.Since(start)
 	}(time.Now())
-	conn, err := qre.tsv.qe.streamConns.Get(ctx, qre.setting)
-
-	switch err {
-	case nil:
-		return conn, nil
-	case connpool.ErrConnPoolClosed:
-		return nil, err
-	}
-	return nil, err
+	return qre.tsv.qe.streamConns.Get(ctx, qre.setting)
 }
 
 // txFetch fetches from a TxConnection.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2000,7 +2000,7 @@ func (tsv *TabletServer) SetPoolSize(val int) {
 	if val <= 0 {
 		return
 	}
-	tsv.qe.conns.SetCapacity(int64(val))
+	_ = tsv.qe.conns.SetCapacity(context.Background(), int64(val))
 }
 
 // PoolSize returns the pool size.
@@ -2010,7 +2010,7 @@ func (tsv *TabletServer) PoolSize() int {
 
 // SetStreamPoolSize changes the pool size to the specified value.
 func (tsv *TabletServer) SetStreamPoolSize(val int) {
-	tsv.qe.streamConns.SetCapacity(int64(val))
+	_ = tsv.qe.streamConns.SetCapacity(context.Background(), int64(val))
 }
 
 // SetStreamConsolidationBlocking sets whether the stream consolidator should wait for slow clients
@@ -2025,7 +2025,7 @@ func (tsv *TabletServer) StreamPoolSize() int {
 
 // SetTxPoolSize changes the tx pool size to the specified value.
 func (tsv *TabletServer) SetTxPoolSize(val int) {
-	tsv.te.txPool.scp.conns.SetCapacity(int64(val))
+	_ = tsv.te.txPool.scp.conns.SetCapacity(context.Background(), int64(val))
 }
 
 // TxPoolSize returns the tx pool size.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1996,11 +1996,11 @@ func (tsv *TabletServer) EnableHistorian(enabled bool) {
 }
 
 // SetPoolSize changes the pool size to the specified value.
-func (tsv *TabletServer) SetPoolSize(val int) {
+func (tsv *TabletServer) SetPoolSize(ctx context.Context, val int) error {
 	if val <= 0 {
-		return
+		return nil
 	}
-	_ = tsv.qe.conns.SetCapacity(context.Background(), int64(val))
+	return tsv.qe.conns.SetCapacity(ctx, int64(val))
 }
 
 // PoolSize returns the pool size.
@@ -2009,8 +2009,8 @@ func (tsv *TabletServer) PoolSize() int {
 }
 
 // SetStreamPoolSize changes the pool size to the specified value.
-func (tsv *TabletServer) SetStreamPoolSize(val int) {
-	_ = tsv.qe.streamConns.SetCapacity(context.Background(), int64(val))
+func (tsv *TabletServer) SetStreamPoolSize(ctx context.Context, val int) error {
+	return tsv.qe.streamConns.SetCapacity(ctx, int64(val))
 }
 
 // SetStreamConsolidationBlocking sets whether the stream consolidator should wait for slow clients
@@ -2024,8 +2024,8 @@ func (tsv *TabletServer) StreamPoolSize() int {
 }
 
 // SetTxPoolSize changes the tx pool size to the specified value.
-func (tsv *TabletServer) SetTxPoolSize(val int) {
-	_ = tsv.te.txPool.scp.conns.SetCapacity(context.Background(), int64(val))
+func (tsv *TabletServer) SetTxPoolSize(ctx context.Context, val int) error {
+	return tsv.te.txPool.scp.conns.SetCapacity(ctx, int64(val))
 }
 
 // TxPoolSize returns the tx pool size.

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2133,7 +2133,9 @@ func TestConfigChanges(t *testing.T) {
 	newSize := 10
 	newDuration := time.Duration(10 * time.Millisecond)
 
-	tsv.SetPoolSize(newSize)
+	err := tsv.SetPoolSize(context.Background(), newSize)
+	require.NoError(t, err)
+
 	if val := tsv.PoolSize(); val != newSize {
 		t.Errorf("PoolSize: %d, want %d", val, newSize)
 	}
@@ -2141,7 +2143,9 @@ func TestConfigChanges(t *testing.T) {
 		t.Errorf("tsv.qe.connPool.Capacity: %d, want %d", val, newSize)
 	}
 
-	tsv.SetStreamPoolSize(newSize)
+	err = tsv.SetStreamPoolSize(context.Background(), newSize)
+	require.NoError(t, err)
+
 	if val := tsv.StreamPoolSize(); val != newSize {
 		t.Errorf("StreamPoolSize: %d, want %d", val, newSize)
 	}
@@ -2149,7 +2153,9 @@ func TestConfigChanges(t *testing.T) {
 		t.Errorf("tsv.qe.streamConnPool.Capacity: %d, want %d", val, newSize)
 	}
 
-	tsv.SetTxPoolSize(newSize)
+	err = tsv.SetTxPoolSize(context.Background(), newSize)
+	require.NoError(t, err)
+
 	if val := tsv.TxPoolSize(); val != newSize {
 		t.Errorf("TxPoolSize: %d, want %d", val, newSize)
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -216,7 +216,7 @@ func primeTxPoolWithConnection(t *testing.T, ctx context.Context) (*fakesqldb.DB
 	db := fakesqldb.New(t)
 	txPool, _ := newTxPool()
 	// Set the capacity to 1 to ensure that the db connection is reused.
-	txPool.scp.conns.SetCapacity(1)
+	_ = txPool.scp.conns.SetCapacity(context.Background(), 1)
 	params := dbconfigs.New(db.ConnParams())
 	txPool.Open(params, params, params)
 

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -216,7 +216,8 @@ func primeTxPoolWithConnection(t *testing.T, ctx context.Context) (*fakesqldb.DB
 	db := fakesqldb.New(t)
 	txPool, _ := newTxPool()
 	// Set the capacity to 1 to ensure that the db connection is reused.
-	_ = txPool.scp.conns.SetCapacity(context.Background(), 1)
+	err := txPool.scp.conns.SetCapacity(context.Background(), 1)
+	require.NoError(t, err)
 	params := dbconfigs.New(db.ConnParams())
 	txPool.Open(params, params, params)
 


### PR DESCRIPTION
## Description

Since rolling out the new connection pool in Vitess 18, we've seen in production some cases were the connection pool fails to shutdown properly. I've spotted the following issues:

- The new connection pool is very strict when it comes to shutting down: it won't finish the shutdown operation until every single connection has been returned to the pool and cleanly closed. The previous connection pool was not this strict, so this behavior is new and seems to be causing issues.
- The new connection pool returns the wrong Error when trying to fetch a connection from the pool while the pool is already closed or during the process of closing. The old connection pool had a specific `ErrConnPoolClosed`, whilst the new pool returns a generic `ErrTimeout` that was causing very confusing messages to appear in the logs.
- The combination of the pool waiting indefinitely to shutdown and the wrong error message being reported caused logs to be spammed with a confusing error message.

I believe the most reliable approach here is to time-out the connection pool shutdown process and log a meaningful error to the logs. Of course, it's also fundamental to figure out the cause for the missing connections which are not being returned to the pool.

I've detected two likely culprits:

- Some connections that have been fetched from the pool are not being properly Recycled (i.e. returned) from the caller. This usually happens when the connection errors out; the most likely scenario is when a connection panics and the `Recycle` method on the collection was not called inside a `defer`. A similar leak can happen during normal error handling, if the connection is simply not being `Recycle`d during the error handling path. 

- Re-opening or refreshing a connection pool can race with a normal Shutdown, causing the shutdown to never finish. This would be very unlikely but very possible. The fix for this is straightforward by locking the shutdown process.

cc @harshit-gangal @deepthi 

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15745 (shutdown lockup; confusing error message in logs)
- TODO @aquarapid (detected case where a connection leaks after an error)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
