### PR TITLE
Fix Data race in tests introduced in #15934

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -3002,8 +3002,6 @@ func TestEmergencyReparenter_findMostAdvanced(t *testing.T) {
 }
 
 func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name                  string
 		emergencyReparentOps  EmergencyReparentOptions


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes a data race introduced in https://github.com/vitessio/vitess/pull/15934. The test in question is changing the `topo.RemoteOperationTimeout`. Since that value is used while running ERS and PRS, we cannot run that test in parallel with anyother test running a reparent operation. This PR fixes this by removign the test from running parallely with other tests.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes a race introduced in https://github.com/vitessio/vitess/pull/15934 which was caught in the tests in https://github.com/vitessio/vitess/pull/15991#issuecomment-2123858289

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
