### PR TITLE
VReplication: refactor denied tables unit test, add couple more tests

### DIFF
--- a/go/vt/topo/shard_test.go
+++ b/go/vt/topo/shard_test.go
@@ -140,70 +140,155 @@ func TestUpdateSourcePrimaryDeniedTables(t *testing.T) {
 
 func TestUpdateSourceDeniedTables(t *testing.T) {
 	si := NewShardInfo("ks", "sh", &topodatapb.Shard{}, nil)
-
-	// check we enforce the keyspace lock
 	ctx := context.Background()
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, nil, false, nil); err == nil || err.Error() != "keyspace ks is not locked (no locksInfo)" {
-		t.Fatalf("unlocked keyspace produced wrong error: %v", err)
-	}
-	ctx = lockedKeyspaceContext("ks")
+	ctxWithLock := lockedKeyspaceContext("ks")
 
-	// add one cell
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"first"}, false, []string{"t1", "t2"}); err != nil || !reflect.DeepEqual(si.TabletControls, []*topodatapb.Shard_TabletControl{
+	type testCase struct {
+		name       string
+		ctx        context.Context
+		tabletType topodatapb.TabletType
+		cells      []string
+		remove     bool
+		tables     []string
+
+		wantError         string
+		wantTabletControl *topodatapb.Shard_TabletControl
+	}
+
+	testCases := []testCase{
 		{
-			TabletType:   topodatapb.TabletType_RDONLY,
-			Cells:        []string{"first"},
-			DeniedTables: []string{"t1", "t2"},
+			name:       "enforce keyspace lock",
+			ctx:        ctx,
+			tabletType: topodatapb.TabletType_RDONLY,
+
+			wantError: "keyspace ks is not locked (no locksInfo)",
 		},
-	}) {
-		t.Fatalf("one cell add failed: %v", si)
-	}
-
-	// remove that cell, going back
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"first"}, true, nil); err != nil || len(si.TabletControls) != 0 {
-		t.Fatalf("going back should have remove the record: %v", si)
-	}
-
-	// re-add a cell, then another with different table list to
-	// make sure it fails
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"first"}, false, []string{"t1", "t2"}); err != nil {
-		t.Fatalf("one cell add failed: %v", si)
-	}
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"second"}, false, []string{"t2", "t3"}); err == nil || err.Error() != "trying to use two different sets of denied tables for shard ks/sh: [t1 t2] and [t2 t3]" {
-		t.Fatalf("different table list should fail: %v", err)
-	}
-	// add another cell, see the list grow
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"second"}, false, []string{"t1", "t2"}); err != nil || !reflect.DeepEqual(si.TabletControls, []*topodatapb.Shard_TabletControl{
 		{
-			TabletType:   topodatapb.TabletType_RDONLY,
-			Cells:        []string{"first", "second"},
-			DeniedTables: []string{"t1", "t2"},
+			name:       "add one cell",
+			tabletType: topodatapb.TabletType_RDONLY,
+			cells:      []string{"first"},
+			tables:     []string{"t1", "t2"},
+			wantTabletControl: &topodatapb.Shard_TabletControl{
+				TabletType:   topodatapb.TabletType_RDONLY,
+				Cells:        []string{"first"},
+				DeniedTables: []string{"t1", "t2"},
+			},
 		},
-	}) {
-		t.Fatalf("second cell add failed: %v", si)
+		{
+			name:       "remove the only cell",
+			tabletType: topodatapb.TabletType_RDONLY,
+			cells:      []string{"first"},
+			remove:     true,
+		},
+		{
+			name:       "re-add cell",
+			tabletType: topodatapb.TabletType_RDONLY,
+			cells:      []string{"first"},
+			tables:     []string{"t1", "t2"},
+			wantTabletControl: &topodatapb.Shard_TabletControl{
+				TabletType:   topodatapb.TabletType_RDONLY,
+				Cells:        []string{"first"},
+				DeniedTables: []string{"t1", "t2"},
+			},
+		},
+		{
+			name:       "re-add existing cell, different tables, should fail",
+			tabletType: topodatapb.TabletType_RDONLY,
+			cells:      []string{"first"},
+			tables:     []string{"t3"},
+			wantError:  "trying to use two different sets of denied tables for shard",
+		},
+		{
+			name:       "add all cells, see cell list grow to all",
+			tabletType: topodatapb.TabletType_RDONLY,
+			cells:      []string{"first", "second", "third"},
+			tables:     []string{"t1", "t2"},
+			wantTabletControl: &topodatapb.Shard_TabletControl{
+				TabletType:   topodatapb.TabletType_RDONLY,
+				Cells:        []string{"first", "second", "third"},
+				DeniedTables: []string{"t1", "t2"},
+			},
+		},
+		{
+			name:       "remove one cell",
+			tabletType: topodatapb.TabletType_RDONLY,
+			cells:      []string{"second"},
+			remove:     true,
+			tables:     []string{"t1", "t2"},
+			wantTabletControl: &topodatapb.Shard_TabletControl{
+				TabletType:   topodatapb.TabletType_RDONLY,
+				Cells:        []string{"first", "third"},
+				DeniedTables: []string{"t1", "t2"},
+			},
+		},
 	}
 
-	// add all cells, see the list grow to all
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"first", "second", "third"}, false, []string{"t1", "t2"}); err != nil || !reflect.DeepEqual(si.TabletControls, []*topodatapb.Shard_TabletControl{
-		{
-			TabletType:   topodatapb.TabletType_RDONLY,
-			Cells:        []string{"first", "second", "third"},
-			DeniedTables: []string{"t1", "t2"},
-		},
-	}) {
-		t.Fatalf("all cells add failed: %v", si)
-	}
+	for _, tcase := range testCases {
+		t.Run(tcase.name, func(t *testing.T) {
+			if tcase.ctx == nil {
+				tcase.ctx = ctxWithLock
+			}
 
-	// remove one cell from the full list
-	if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"second"}, true, []string{"t1", "t2"}); err != nil || !reflect.DeepEqual(si.TabletControls, []*topodatapb.Shard_TabletControl{
-		{
-			TabletType:   topodatapb.TabletType_RDONLY,
-			Cells:        []string{"first", "third"},
-			DeniedTables: []string{"t1", "t2"},
-		},
-	}) {
-		t.Fatalf("one cell removal from all failed: %v", si)
+			err := si.UpdateDeniedTables(tcase.ctx, tcase.tabletType, tcase.cells, tcase.remove, tcase.tables)
+			if tcase.wantError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tcase.wantError)
+				return
+			}
+			require.NoError(t, err)
+			if tcase.wantTabletControl == nil {
+				require.Nil(t, si.GetTabletControl(tcase.tabletType))
+			} else {
+				require.Truef(t, reflect.DeepEqual(tcase.wantTabletControl, si.GetTabletControl(tcase.tabletType)),
+					"want: %v, got: %v", tcase.wantTabletControl, si.GetTabletControl(tcase.tabletType))
+			}
+		})
 	}
+	/*
+
+
+
+		// re-add a cell, then another with different table list to
+		// make sure it fails
+		if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"first"}, false, []string{"t1", "t2"}); err != nil {
+			t.Fatalf("one cell add failed: %v", si)
+		}
+		if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"second"}, false, []string{"t2", "t3"}); err == nil || err.Error() != "trying to use two different sets of denied tables for shard ks/sh: [t1 t2] and [t2 t3]" {
+			t.Fatalf("different table list should fail: %v", err)
+		}
+		// add another cell, see the list grow
+		if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"second"}, false, []string{"t1", "t2"}); err != nil || !reflect.DeepEqual(si.TabletControls, []*topodatapb.Shard_TabletControl{
+			{
+				TabletType:   topodatapb.TabletType_RDONLY,
+				Cells:        []string{"first", "second"},
+				DeniedTables: []string{"t1", "t2"},
+			},
+		}) {
+			t.Fatalf("second cell add failed: %v", si)
+		}
+
+		// add all cells, see the list grow to all
+		if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"first", "second", "third"}, false, []string{"t1", "t2"}); err != nil || !reflect.DeepEqual(si.TabletControls, []*topodatapb.Shard_TabletControl{
+			{
+				TabletType:   topodatapb.TabletType_RDONLY,
+				Cells:        []string{"first", "second", "third"},
+				DeniedTables: []string{"t1", "t2"},
+			},
+		}) {
+			t.Fatalf("all cells add failed: %v", si)
+		}
+
+		// remove one cell from the full list
+		if err := si.UpdateDeniedTables(ctx, topodatapb.TabletType_RDONLY, []string{"second"}, true, []string{"t1", "t2"}); err != nil || !reflect.DeepEqual(si.TabletControls, []*topodatapb.Shard_TabletControl{
+			{
+				TabletType:   topodatapb.TabletType_RDONLY,
+				Cells:        []string{"first", "third"},
+				DeniedTables: []string{"t1", "t2"},
+			},
+		}) {
+			t.Fatalf("one cell removal from all failed: %v", si)
+		}
+	*/
 }
 
 func TestValidateShardName(t *testing.T) {


### PR DESCRIPTION
## Description

While debugging an issue reported around denied tables, I ended up refactoring a unit test. It turned out the report was on an older version which had been fixed. But thought it worthwhile to push the test changes.

## Related Issue(s)


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
