### PR TITLE
Local Examples: Add --binary-as-hex=false flag to mysql alias

### DIFF
--- a/examples/common/env.sh
+++ b/examples/common/env.sh
@@ -76,7 +76,7 @@ mkdir -p "${VTDATAROOT}/tmp"
 # In your own environment you may prefer to use config files,
 # such as ~/.my.cnf
 
-alias mysql="command mysql --no-defaults -h 127.0.0.1 -P 15306"
+alias mysql="command mysql --no-defaults -h 127.0.0.1 -P 15306 --binary-as-hex=false"
 alias vtctldclient="command vtctldclient --server localhost:15999"
 
 # If using bash, make sure aliases are expanded in non-interactive shell


### PR DESCRIPTION
## Description

The [Vitess local examples](https://vitess.io/docs/get-started/local/) ([source](https://github.com/vitessio/vitess/tree/main/examples/local)) are a common first touch experience for users. They are regularly confused or curious as to why many of the columns in the examples show up as HEX in the query results. The reason for this is that we use [`VARBINARY`](https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html) types throughout — in some rare cases like `keyspace_id` it makes sense, but most like `customer.email` are pure text. This makes understanding what's happening and quickly confirming at-a-glance results as expected more difficult and poses a minor hurdle when it's already quite a lot to get started with Vitess.

In this PR, we add the [`--binary-as-hex=false`](https://dev.mysql.com/doc/refman/8.0/en/mysql-command-options.html#option_mysql_binary-as-hex) mysql client flag to the [`mysql` alias we setup](https://github.com/vitessio/vitess/blob/0d8ca1be54ec50feda41b75e750619df15c5b747/examples/common/env.sh#L79) to both increase awareness of that flag and so that more people are using it by default (source [../common/env.sh](https://github.com/vitessio/vitess/blob/main/examples/common/env.sh)). 

The bigger effort would be to move most of our `VARBINARY` usage under [`./examples`](https://github.com/vitessio/vitess/tree/main/examples) to `VARCHAR`. This offers a more intuitive/expected experience while also more closely matching what users will be using for similar types of data. I can only guess that `VARBINARY` was used initially (many years ago now) because at the time Vitess did not have MySQL collation support. Vitess now has MySQL compatible collations so I think it's worth doing this work. For that I've created [an issue](https://github.com/vitessio/vitess/issues/15997) and marked it as a good `first issue` for anyone that's interested in a relatively simple and straightforward first contribution to Vitess.

## Related Issue(s)

  - https://github.com/vitessio/vitess/issues/15997

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required