### PR TITLE
`schemadiff`: assume default collation for textual column when collation is undefined

### DIFF
--- a/go/vt/schemadiff/column.go
+++ b/go/vt/schemadiff/column.go
@@ -104,11 +104,15 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 ) (*ModifyColumnDiff, error) {
 	if c.IsTextual() || other.IsTextual() {
 		// We will now denormalize the columns charset & collate as needed (if empty, populate from table.)
+		// This column definition
 		if c.columnDefinition.Type.Charset.Name != "" && c.columnDefinition.Type.Options.Collate == "" {
 			collation := env.CollationEnv().DefaultCollationForCharset(c.columnDefinition.Type.Charset.Name)
 			if collation == collations.Unknown {
 				return nil, &UnknownColumnCharsetCollationError{Column: c.columnDefinition.Name.String(), Charset: t1cc.charset}
 			}
+			defer func() {
+				c.columnDefinition.Type.Options.Collate = ""
+			}()
 			c.columnDefinition.Type.Options.Collate = env.CollationEnv().LookupName(collation)
 		}
 		if c.columnDefinition.Type.Charset.Name == "" && c.columnDefinition.Type.Options.Collate != "" {
@@ -143,11 +147,15 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 				c.columnDefinition.Type.Options.Collate = env.CollationEnv().LookupName(collation)
 			}
 		}
+		// other column definition
 		if other.columnDefinition.Type.Charset.Name != "" && other.columnDefinition.Type.Options.Collate == "" {
 			collation := env.CollationEnv().DefaultCollationForCharset(other.columnDefinition.Type.Charset.Name)
 			if collation == collations.Unknown {
-				return nil, &UnknownColumnCharsetCollationError{Column: other.columnDefinition.Name.String(), Charset: t1cc.charset}
+				return nil, &UnknownColumnCharsetCollationError{Column: other.columnDefinition.Name.String(), Charset: t2cc.charset}
 			}
+			defer func() {
+				other.columnDefinition.Type.Options.Collate = ""
+			}()
 			other.columnDefinition.Type.Options.Collate = env.CollationEnv().LookupName(collation)
 		}
 		if other.columnDefinition.Type.Charset.Name == "" && other.columnDefinition.Type.Options.Collate != "" {

--- a/go/vt/schemadiff/column.go
+++ b/go/vt/schemadiff/column.go
@@ -104,8 +104,9 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 ) (*ModifyColumnDiff, error) {
 	if c.IsTextual() || other.IsTextual() {
 		// We will now denormalize the columns charset & collate as needed (if empty, populate from table.)
-		// This column definition
+		// Normalizing _this_ column definition:
 		if c.columnDefinition.Type.Charset.Name != "" && c.columnDefinition.Type.Options.Collate == "" {
+			// Charset defined without collation. Assign the default collation for that charset.
 			collation := env.CollationEnv().DefaultCollationForCharset(c.columnDefinition.Type.Charset.Name)
 			if collation == collations.Unknown {
 				return nil, &UnknownColumnCharsetCollationError{Column: c.columnDefinition.Name.String(), Charset: t1cc.charset}
@@ -128,6 +129,7 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 			c.columnDefinition.Type.Charset.Name = charset
 		}
 		if c.columnDefinition.Type.Charset.Name == "" {
+			// Still nothing? Assign the table's charset/collation.
 			defer func() {
 				c.columnDefinition.Type.Charset.Name = ""
 				c.columnDefinition.Type.Options.Collate = ""
@@ -147,8 +149,9 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 				c.columnDefinition.Type.Options.Collate = env.CollationEnv().LookupName(collation)
 			}
 		}
-		// other column definition
+		// Normalizing _the other_ column definition:
 		if other.columnDefinition.Type.Charset.Name != "" && other.columnDefinition.Type.Options.Collate == "" {
+			// Charset defined without collation. Assign the default collation for that charset.
 			collation := env.CollationEnv().DefaultCollationForCharset(other.columnDefinition.Type.Charset.Name)
 			if collation == collations.Unknown {
 				return nil, &UnknownColumnCharsetCollationError{Column: other.columnDefinition.Name.String(), Charset: t2cc.charset}
@@ -172,6 +175,7 @@ func (c *ColumnDefinitionEntity) ColumnDiff(
 		}
 
 		if other.columnDefinition.Type.Charset.Name == "" {
+			// Still nothing? Assign the table's charset/collation.
 			defer func() {
 				other.columnDefinition.Type.Charset.Name = ""
 				other.columnDefinition.Type.Options.Collate = ""

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1897,6 +1897,26 @@ func TestCreateTableDiff(t *testing.T) {
 			to:   "create table t (id int primary key, v varchar(64) collate utf8mb3_bin)",
 		},
 		{
+			name: "ignore identical implicit ascii charset",
+			from: "create table t (id int primary key, v varchar(64) character set ascii collate ascii_general_ci)",
+			to:   "create table t (id int primary key, v varchar(64) collate ascii_general_ci)",
+		},
+		{
+			name: "ignore identical implicit collation",
+			from: "create table t (id int primary key, v varchar(64) character set utf8mb3 collate utf8mb3_general_ci)",
+			to:   "create table t (id int primary key, v varchar(64) character set utf8mb3)",
+		},
+		{
+			name: "ignore identical implicit collation, reverse",
+			from: "create table t (id int primary key, v varchar(64) character set utf8mb3)",
+			to:   "create table t (id int primary key, v varchar(64) character set utf8mb3 collate utf8mb3_general_ci)",
+		},
+		{
+			name: "ignore identical implicit ascii collation",
+			from: "create table t (id int primary key, v varchar(64) character set ascii collate ascii_general_ci)",
+			to:   "create table t (id int primary key, v varchar(64) character set ascii)",
+		},
+		{
 			name:  "normalized unsigned attribute",
 			from:  "create table t1 (id int primary key)",
 			to:    "create table t1 (id int unsigned primary key)",
@@ -2924,6 +2944,11 @@ func TestNormalize(t *testing.T) {
 			name: "remove column charset if collation is explicit and implies specified charset",
 			from: "create table t (id int primary key, v varchar(255) charset utf8mb4 collate utf8mb4_german2_ci)",
 			to:   "CREATE TABLE `t` (\n\t`id` int,\n\t`v` varchar(255) COLLATE utf8mb4_german2_ci,\n\tPRIMARY KEY (`id`)\n)",
+		},
+		{
+			name: "ascii charset and collation",
+			from: "create table t (id int primary key, v varchar(255) charset ascii collate ascii_general_ci) charset utf8mb3 collate utf8_general_ci",
+			to:   "CREATE TABLE `t` (\n\t`id` int,\n\t`v` varchar(255) CHARACTER SET ascii COLLATE ascii_general_ci,\n\tPRIMARY KEY (`id`)\n) CHARSET utf8mb3,\n  COLLATE utf8mb3_general_ci",
 		},
 		{
 			name: "correct case table options for engine",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1912,8 +1912,18 @@ func TestCreateTableDiff(t *testing.T) {
 			to:   "create table t (id int primary key, v varchar(64) character set utf8mb3 collate utf8mb3_general_ci)",
 		},
 		{
+			name: "implicit charset and implciit collation",
+			from: "create table t (id int primary key, v varchar(64) character set utf8mb3)",
+			to:   "create table t (id int primary key, v varchar(64) collate utf8mb3_general_ci)",
+		},
+		{
 			name: "ignore identical implicit ascii collation",
 			from: "create table t (id int primary key, v varchar(64) character set ascii collate ascii_general_ci)",
+			to:   "create table t (id int primary key, v varchar(64) character set ascii)",
+		},
+		{
+			name: "implicit charset and implciit collation, ascii",
+			from: "create table t (id int primary key, v varchar(64) collate ascii_general_ci)",
 			to:   "create table t (id int primary key, v varchar(64) character set ascii)",
 		},
 		{


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/15999. When looking at textual columns, if the character set is defined and the collation is not, `schemadiff` assumes the default collation for that character set.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15999

cc @lizztheblizz 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
