### PR TITLE
Tablet throttler: recent check diff fix

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -271,6 +271,9 @@ func NewThrottler(env tabletenv.Env, srvTopoServer srvtopo.Server, ts *topo.Serv
 	throttler.dormantPeriod = dormantPeriod
 	throttler.recentCheckDormantDiff = int64(throttler.dormantPeriod / recentCheckRateLimiterInterval)
 	throttler.recentCheckDiff = int64(1 * time.Second / recentCheckRateLimiterInterval)
+	if throttler.recentCheckDiff < 1 {
+		throttler.recentCheckDiff = 1
+	}
 
 	throttler.StoreMetricsThreshold(defaultThrottleLagThreshold.Seconds()) //default
 	throttler.readSelfThrottleMetric = func(ctx context.Context, p *mysql.Probe) *mysql.MySQLThrottleMetric {

--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -185,6 +185,13 @@ func newTestThrottler() *Throttler {
 	return throttler
 }
 
+func TestInitThrottler(t *testing.T) {
+	throttler := newTestThrottler()
+	assert.Equal(t, 5*time.Second, throttler.dormantPeriod)
+	assert.EqualValues(t, 5, throttler.recentCheckDormantDiff)
+	assert.EqualValues(t, 3, throttler.recentCheckDiff)
+}
+
 func TestIsAppThrottled(t *testing.T) {
 	throttler := Throttler{
 		throttledApps:   cache.New(cache.NoExpiration, 0),

--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -171,6 +171,7 @@ func newTestThrottler() *Throttler {
 	throttler.throttledAppsSnapshotInterval = 10 * time.Millisecond
 	throttler.dormantPeriod = 5 * time.Second
 	throttler.recentCheckDormantDiff = int64(throttler.dormantPeriod / recentCheckRateLimiterInterval)
+	throttler.recentCheckDiff = int64(3 * time.Second / recentCheckRateLimiterInterval)
 
 	throttler.readSelfThrottleMetric = func(ctx context.Context, p *mysql.Probe) *mysql.MySQLThrottleMetric {
 		return &mysql.MySQLThrottleMetric{
@@ -555,7 +556,11 @@ func TestReplica(t *testing.T) {
 	runThrottler(t, ctx, throttler, time.Minute, func(t *testing.T, ctx context.Context) {
 		assert.Empty(t, tmClient.AppNames())
 		flags := &CheckFlags{}
-		throttler.CheckByType(ctx, throttlerapp.VitessName.String(), "", flags, ThrottleCheckSelf)
+		{
+			checkResult := throttler.CheckByType(ctx, throttlerapp.VitessName.String(), "", flags, ThrottleCheckSelf)
+			assert.False(t, checkResult.RecentlyChecked) // "vitess" app does not mark the throttler as recently checked
+			assert.False(t, throttler.recentlyChecked()) // "vitess" app does not mark the throttler as recently checked
+		}
 		go func() {
 			select {
 			case <-ctx.Done():
@@ -573,7 +578,17 @@ func TestReplica(t *testing.T) {
 				assert.Containsf(t, appNames, throttlerapp.ThrottlerStimulatorName.String(), "%+v", appNames)
 				assert.Equalf(t, 1, len(appNames), "%+v", appNames)
 			}
-			throttler.CheckByType(ctx, throttlerapp.OnlineDDLName.String(), "", flags, ThrottleCheckSelf)
+			{
+				checkResult := throttler.CheckByType(ctx, throttlerapp.OnlineDDLName.String(), "", flags, ThrottleCheckSelf)
+				assert.True(t, checkResult.RecentlyChecked)
+				assert.True(t, throttler.recentlyChecked())
+			}
+			{
+				checkResult := throttler.CheckByType(ctx, throttlerapp.VitessName.String(), "", flags, ThrottleCheckSelf)
+				assert.True(t, checkResult.RecentlyChecked) // due to previous "online-ddl" check
+				assert.True(t, throttler.recentlyChecked()) // due to previous "online-ddl" check
+			}
+
 			select {
 			case <-ctx.Done():
 				require.FailNow(t, "context expired before testing completed")


### PR DESCRIPTION
## Description

Followup to https://github.com/vitessio/vitess/issues/15397 and https://github.com/vitessio/vitess/pull/15398

When the `Primary` throttler probes a replica throttler, the replica's `CheckResult` includes a `RecentlyChecked` boolean field.
That field was not set correctly, and was `false` in almost all internal vitess probing situations. The stimulation introduced in #15398 thankfully prevents a complete starvation of the throttler. However, with `RecentlyChecked` reported as `false` more than it should, the `Primary` will not renew the heartbeat lease as much as it should, leading to more throttling scenarios.

In this PR we ensure to return a `RecentlyChecked = true` value when the throttler has, in fact, been recently checked in the past second-or-so, by any other check.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15397

Found while working/testing https://github.com/vitessio/vitess/pull/15988

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required