### PR TITLE
Decouple topotools from vschema

### DIFF
--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/ptr"
-	"vitess.io/vitess/go/vt/topotools"
 
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql/collations"
@@ -1015,10 +1014,14 @@ func buildShardRoutingRule(source *vschemapb.SrvVSchema, vschema *VSchema) {
 
 func buildKeyspaceRoutingRule(source *vschemapb.SrvVSchema, vschema *VSchema) {
 	vschema.KeyspaceRoutingRules = nil
-	if len(source.GetKeyspaceRoutingRules().GetRules()) == 0 {
+	sourceRules := source.GetKeyspaceRoutingRules().GetRules()
+	if len(sourceRules) == 0 {
 		return
 	}
-	rulesMap := topotools.GetKeyspaceRoutingRulesMap(source.KeyspaceRoutingRules)
+	rulesMap := make(map[string]string, len(sourceRules))
+	for _, rr := range sourceRules {
+		rulesMap[rr.FromKeyspace] = rr.ToKeyspace
+	}
 	vschema.KeyspaceRoutingRules = rulesMap
 }
 


### PR DESCRIPTION
This removes the coupling between vschema and topotools just for a single helper function.

With this change, we don't end up pulling a large dependency tree for other utilities like schemadiff.

See also https://go-proverbs.github.io, "A little copying is better than a little dependency.".

Also see https://github.com/planetscale/schemadiff/pull/22#issuecomment-2131055714

## Related Issue(s)

Part of #14717

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
