### PR TITLE
Online DDL: fix flaky `onlineddl_scheduler` CI test

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -248,6 +248,7 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
+			"--migration_check_interval", "5s",
 			"--watch_replication_stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{}


### PR DESCRIPTION

## Description

This PR fixes a flakiness in `onlineddl_scheduler` CI. It seems to have been lurking for quite a while, but I only encountered it severely in https://github.com/vitessio/vitess/pull/15988, though after a long investigation, I found it's unrelated to the throttler.

It's a really simple race condition between VReplication and a `SELECT FOR UPDATE` query the test runs (validating the behavior of `FORCE_CUTOVER`). The race is that the test can issue said select query before VReplication has even had the chance to start running, in which case VReplication never gets to the point of cutting over, in which case the migration cannot cut-over. This is unrealistic (or rather, not _interesting_) in production, and not the purpose of the test.

The fix is to ensure VReplication has had chance to run before validating the cutover behavior.

On top of that change, we also use `"--migration_check_interval", "5s",` which is standard across all Online DDL CI jobs, and overall reduces runtime of this CI job.


## Related Issue(s)

No related issue. See for example [this CI failure](https://github.com/vitessio/vitess/actions/runs/9240401390/job/25420920851).


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
