### PR TITLE
Tablet throttler: remove `LowPriority` logic

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_throttler.go
+++ b/go/vt/vttablet/tabletmanager/rpc_throttler.go
@@ -34,7 +34,6 @@ func (tm *TabletManager) CheckThrottler(ctx context.Context, req *tabletmanagerd
 		req.AppName = throttlerapp.VitessName.String()
 	}
 	flags := &throttle.CheckFlags{
-		LowPriority:           false,
 		SkipRequestHeartbeats: true,
 	}
 	checkResult := tm.QueryServiceControl.CheckThrottler(ctx, req.AppName, flags)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1896,7 +1896,6 @@ func (tsv *TabletServer) registerThrottlerCheckHandlers() {
 				appName = throttlerapp.DefaultName.String()
 			}
 			flags := &throttle.CheckFlags{
-				LowPriority:           (r.URL.Query().Get("p") == "low"),
 				SkipRequestHeartbeats: (r.URL.Query().Get("s") == "true"),
 			}
 			checkResult := tsv.lagThrottler.CheckByType(ctx, appName, remoteAddr, flags, checkType)

--- a/go/vt/vttablet/tabletserver/throttle/client.go
+++ b/go/vt/vttablet/tabletserver/throttle/client.go
@@ -56,30 +56,14 @@ type Client struct {
 	lastSuccessfulThrottle   int64
 }
 
-// NewProductionClient creates a client suitable for foreground/production jobs, which have normal priority.
-func NewProductionClient(throttler *Throttler, appName throttlerapp.Name, checkType ThrottleCheckType) *Client {
-	initThrottleTicker()
-	return &Client{
-		throttler: throttler,
-		appName:   appName,
-		checkType: checkType,
-		flags: CheckFlags{
-			LowPriority: false,
-		},
-	}
-}
-
-// NewBackgroundClient creates a client suitable for background jobs, which have low priority over production traffic,
-// e.g. migration, table pruning, vreplication
+// NewBackgroundClient creates a client
 func NewBackgroundClient(throttler *Throttler, appName throttlerapp.Name, checkType ThrottleCheckType) *Client {
 	initThrottleTicker()
 	return &Client{
 		throttler: throttler,
 		appName:   appName,
 		checkType: checkType,
-		flags: CheckFlags{
-			LowPriority: true,
-		},
+		flags:     CheckFlags{},
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -93,8 +93,6 @@ const (
 	aggregatedMetricsExpiration = 5 * time.Second
 	recentAppsExpiration        = time.Hour * 24
 
-	nonDeprioritizedAppMapExpiration = time.Second
-
 	dormantPeriod              = time.Minute // How long since last check to be considered dormant
 	DefaultAppThrottleDuration = time.Hour
 	DefaultThrottleRatio       = 1.0
@@ -207,8 +205,7 @@ type Throttler struct {
 
 	readSelfThrottleMetric func(context.Context, *mysql.Probe) *mysql.MySQLThrottleMetric // overwritten by unit test
 
-	nonLowPriorityAppRequestsThrottled *cache.Cache
-	httpClient                         *http.Client
+	httpClient *http.Client
 }
 
 // ThrottlerStatus published some status values from the throttler
@@ -254,7 +251,6 @@ func NewThrottler(env tabletenv.Env, srvTopoServer srvtopo.Server, ts *topo.Serv
 	throttler.aggregatedMetrics = cache.New(aggregatedMetricsExpiration, 0)
 	throttler.recentApps = cache.New(recentAppsExpiration, 0)
 	throttler.metricsHealth = cache.New(cache.NoExpiration, 0)
-	throttler.nonLowPriorityAppRequestsThrottled = cache.New(nonDeprioritizedAppMapExpiration, 0)
 
 	throttler.httpClient = base.SetupHTTPClient(2 * mysqlCollectInterval)
 	throttler.initThrottleTabletTypes()
@@ -711,7 +707,6 @@ func (throttler *Throttler) Operate(ctx context.Context, wg *sync.WaitGroup) {
 			primaryStimulatorRateLimiter.Stop()
 			throttler.aggregatedMetrics.Flush()
 			throttler.recentApps.Flush()
-			throttler.nonLowPriorityAppRequestsThrottled.Flush()
 			wg.Done()
 		}()
 		// we do not flush throttler.throttledApps because this is data submitted by the user; the user expects the data to survive a disable+enable

--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -157,7 +157,6 @@ func newTestThrottler() *Throttler {
 	throttler.aggregatedMetrics = cache.New(10*aggregatedMetricsExpiration, 0)
 	throttler.recentApps = cache.New(recentAppsExpiration, 0)
 	throttler.metricsHealth = cache.New(cache.NoExpiration, 0)
-	throttler.nonLowPriorityAppRequestsThrottled = cache.New(nonDeprioritizedAppMapExpiration, 0)
 	throttler.metricsQuery.Store(metricsQuery)
 	throttler.initThrottleTabletTypes()
 	throttler.check = NewThrottlerCheck(throttler)


### PR DESCRIPTION
## Description

This is a cleanup PR for a functionality we've never used. While these changes are extracted from https://github.com/vitessio/vitess/pull/15988, this PR is against `main` and not as part of the multi-metrics PR series.

The "low priority" mechanism is a relic we inherited from `freno`, where production client apps competed with background apps over the throttler. We have never used this in `vitess`, to date, and I therefore wish to remove it. It only adds more boilerplate, more considerations, and as a matter in fact I spent the better half of a day chasing down a recurring CI failure that was caused due to a (bug? misconfiguration?) related to prioritization.

In vitess, all existing throttler clients have the same priority and nothing externally to vitess gets any precedence.

The priority flag & usage were never documented in the first place and users were not instructed to use it. Priorities were mentioned in the docs but without any actionable guidance.

Moreover, this functionality did not enjoy any specific unit testing. 

**Doc updates**: https://github.com/vitessio/vitess/pull/16013

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15624

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
