### PR TITLE
[VTAdmin] Output warning log if cluster ID has invalid characters

### DIFF
--- a/go/vt/vtadmin/cluster/config.go
+++ b/go/vt/vtadmin/cluster/config.go
@@ -22,6 +22,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -49,6 +50,8 @@ var (
 	// read-only RPC pools if a config has no wait timeout set.
 	DefaultReadPoolWaitTimeout = time.Millisecond * 100
 )
+
+var ClusterIDPattern = regexp.MustCompile("^[a-zA-Z0-9+.-]*$")
 
 // Config represents the options to configure a vtadmin cluster.
 type Config struct {
@@ -147,6 +150,10 @@ func LoadConfig(r io.Reader, configType string) (cfg *Config, id string, err err
 	id = v.GetString("id")
 	if id == "" {
 		return nil, "", ErrNoConfigID
+	}
+
+	if !ClusterIDPattern.MatchString(id) {
+		log.Warning("cluster id must only contain alphanumeric characters, +, ., or -")
 	}
 
 	tmp := map[string]string{}


### PR DESCRIPTION
## Description
In VTAdmin, Cluster IDs are used as part of the gRPC resolver name. As such, they need to follow a specific URI scheme, as specified in https://datatracker.ietf.org/doc/html/rfc3986#section-3.1

Namely, Cluster IDs can only have alphanumeric characters, a `+`, `.`, or `-` and nothing else. 

The first step of Cluster ID validation is simply outputting a warning when bad characters are detected. VTAdmin simply will not work if someone passes an invalid Cluster ID (current behavior). This PR adds that warning.

## Related Issue(s)
First part of https://github.com/vitessio/vitess/issues/15721

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
