### PR TITLE
Add CODEOWNERS for tablet throttler and schemadiff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/cmd @ajm188 @deepthi @mattlord
 /go/cmd/vtadmin @ajm188 @notfelineit
 /go/cmd/vtctldclient @ajm188 @mattlord
+/go/cmd/vtctldclient/command/throttler.go @shlomi-noach @mattlord
 /go/cmd/vtctldclient/command/vreplication @mattlord @rohit-nayak-ps
 /go/internal/flag @ajm188 @rohit-nayak-ps
 /go/mysql @harshit-gangal @systay @mattlord
@@ -26,6 +27,8 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/sqltypes @harshit-gangal @shlomi-noach @vmg
 /go/test/endtoend/onlineddl @rohit-nayak-ps @shlomi-noach
 /go/test/endtoend/messaging @mattlord @rohit-nayak-ps @derekperkins
+/go/test/endtoend/schemadiff @shlomi-noach @mattlord
+/go/test/endtoend/*throttler* @shlomi-noach @mattlord
 /go/test/endtoend/vtgate @harshit-gangal @systay @frouioui
 /go/test/endtoend/vtorc @deepthi @shlomi-noach @GuptaManan100
 /go/tools/ @frouioui @systay
@@ -37,6 +40,7 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/vt/proto/vtadmin @ajm188 @notfelineit
 /go/vt/schema @mattlord @shlomi-noach
 /go/vt/servenv @deepthi @ajm188
+/go/vt/schemadiff @shlomi-noach @mattlord
 /go/vt/sqlparser @harshit-gangal @systay @GuptaManan100
 /go/vt/srvtopo @deepthi @mattlord
 /go/vt/sysvars @harshit-gangal @systay
@@ -64,6 +68,8 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/vt/vttablet/onlineddl @mattlord @rohit-nayak-ps @shlomi-noach
 /go/vt/vttablet/queryservice @harshit-gangal @systay
 /go/vt/vttablet/tabletmanager @deepthi @GuptaManan100 @rohit-nayak-ps @shlomi-noach
+/go/vt/vttablet/tabletmanager/rpc_throttler.go @shlomi-noach @mattlord
+/go/vt/vttablet/tabletserver/throttle @shlomi-noach @mattlord
 /go/vt/vttablet/tabletmanager/vreplication @rohit-nayak-ps @mattlord
 /go/vt/vttablet/tabletmanager/vstreamer @rohit-nayak-ps @mattlord
 /go/vt/vttablet/tabletserver* @harshit-gangal @systay @shlomi-noach @rohit-nayak-ps


### PR DESCRIPTION
## Description

This adds @shlomi-noach and myself as code owners for the tablet throttler and the schemadiff library/tool. This way we have at least 2 people (in addition to Deepthi) that are automatically added as reviewers on related PRs.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required