### PR TITLE
Revert the removal of the MySQL binaries in the `vitess/lite` image

### DIFF
--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        branch: [ latest ]
+        branch: [ latest, percona80 ]
 
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-docker/base/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+docker/lite/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -318,12 +318,18 @@ define build_docker_image
 	fi
 endef
 
-docker_lite:
-	${call build_docker_image,docker/lite/Dockerfile,vitess/lite}
+DOCKER_LITE_SUFFIX = percona80
+DOCKER_LITE_TARGETS = $(addprefix docker_lite_,$(DOCKER_LITE_SUFFIX))
+$(DOCKER_LITE_TARGETS): docker_lite_%:
+	${call build_docker_image,docker/lite/Dockerfile.$*,vitess/lite:$*}
 
 docker_lite_push:
-	echo "pushing lite image: latest"
-	docker push vitess/lite:latest
+	for i in $(DOCKER_LITE_SUFFIX); do echo "pushing lite image: $$i"; docker push vitess/lite:$$i || exit 1; done
+
+docker_lite_all: docker_lite $(DOCKER_LITE_TARGETS)
+
+docker_lite:
+	${call build_docker_image,docker/lite/Dockerfile,vitess/lite}
 
 docker_local:
 	${call build_docker_image,docker/local/Dockerfile,vitess/local}

--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -7,7 +7,6 @@
   - **[Deletions](#deletions)** 
     - [`--vreplication_tablet_type` flag](#vreplication-tablet-type-deletion)
     - [Pool Capacity Flags](#pool-flags-deletion)
-    - [MySQL binaries in the vitess/lite Docker images](#vitess-lite)
     - [vitess/base and vitess/k8s Docker images](#base-k8s-images)
     - [`gh-ost` binary and endtoend tests](#gh-ost-binary-tests-removal)
     - [Legacy `EmergencyReparentShard` stats](#legacy-emergencyshardreparent-stats)
@@ -55,47 +54,6 @@ The previously deprecated flag `--vreplication_tablet_type` has been deleted.
 #### <a id="pool-flags-deletion"/>Pool Capacity Flags
 
 The previously deprecated flags `--queryserver-config-query-pool-waiter-cap`, `--queryserver-config-stream-pool-waiter-cap` and `--queryserver-config-txpool-waiter-cap` have been deleted.
-
-#### <a id="vitess-lite"/>MySQL binaries in the `vitess/lite` Docker images
-
-In `v19.0.0` we had deprecated the `mysqld` binary in the `vitess/lite` Docker image.
-Making MySQL/Percona version specific image tags also deprecated.
-
-Starting in `v20.0.0` we no longer build the MySQL/Percona version specific image tags.
-Moreover, the `mysqld` binary is no longer present on the `vitess/lite` image.
-
-Here are the images we will no longer build and push:
-
-| Image                           | Available | 
-|---------------------------------|-----------|
-| `vitess/lite:v20.0.0`           | YES       |
-| `vitess/lite:v20.0.0-mysql57`   | NO        |
-| `vitess/lite:v20.0.0-mysql80`   | NO        |
-| `vitess/lite:v20.0.0-percona57` | NO        |
-| `vitess/lite:v20.0.0-percona80` | NO        |
-
-
-If you have not done it yet, you can use an official MySQL Docker image for your `mysqld` container now such as: `mysql:8.0.30`.
-Below is an example of a kubernetes yaml file before and after upgrading to an official MySQL image:
-
-```yaml
-# before:
-
-# you are still on v19 and are looking to upgrade to v20
-# the image used here includes MySQL 8.0.30 and its binaries
-
-    mysqld:
-      mysql80Compatible: vitess/lite:v19.0.0-mysql80
-```
-```yaml
-# after:
-
-# if we still want to use MySQL 8.0.30, we now have to use the
-# official MySQL image with the 8.0.30 tag as shown below 
-
-    mysqld:
-      mysql80Compatible: mysql:8.0.30 # or even mysql:8.0.34 for instance
-```
 
 #### <a id="base-k8s-images"/>`vitess/base` and `vitess/k8s` Docker images
 

--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -36,15 +36,9 @@ RUN make install PREFIX=/vt/install
 # Start over and build the final image.
 FROM debian:bullseye-slim
 
-# Install mysqlbinglog
-RUN apt-get update && apt-get -y install libssl1.1 gnupg
-COPY --from=builder /usr/bin/mysqlbinlog /usr/bin/mysqlbinlog
-
-# Install xtrabackup
-RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 9334A25F8507EFA5
-RUN echo 'deb http://repo.percona.com/apt bullseye main' > /etc/apt/sources.list.d/percona.list
-RUN apt-get update -y
-RUN apt-get install -y percona-xtrabackup-80
+# Install dependencies
+COPY docker/utils/install_dependencies.sh /vt/dist/install_dependencies.sh
+RUN /vt/dist/install_dependencies.sh mysql80
 
 # Set up Vitess user and directory tree.
 RUN groupadd -r vitess && useradd -r -g vitess vitess

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -1,0 +1,61 @@
+# Copyright 2019 The Vitess Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We have to build the Vitess binaries from scratch instead of sharing
+#       a base image because Docker Hub dropped the feature we relied upon to
+#       ensure images contain the right binaries.
+
+# Use a temporary layer for the build stage.
+ARG bootstrap_version=32
+ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
+
+FROM "${image}" AS builder
+
+# Allows docker builds to set the BUILD_NUMBER
+ARG BUILD_NUMBER
+
+# Re-copy sources from working tree.
+COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
+
+# Build and install Vitess in a temporary output directory.
+USER vitess
+
+RUN make install PREFIX=/vt/install
+
+# Start over and build the final image.
+FROM debian:bullseye-slim
+
+# Install dependencies
+COPY docker/utils/install_dependencies.sh /vt/dist/install_dependencies.sh
+RUN /vt/dist/install_dependencies.sh mysql80
+
+# Set up Vitess user and directory tree.
+RUN groupadd -r vitess && useradd -r -g vitess vitess
+RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt/src/vitess.io/vitess
+ENV VTDATAROOT /vt/vtdataroot
+ENV PATH $VTROOT/bin:$PATH
+
+# Copy artifacts from builder layer.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder --chown=vitess:vitess /vt/install /vt
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/web/vtadmin /vt/web/vtadmin
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/init_db.sql /vt/config/
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/mycnf /vt/config/
+
+# Create mount point for actual data (e.g. MySQL data dir)
+VOLUME /vt/vtdataroot
+USER vitess

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -1,4 +1,4 @@
-# Copyright 2019 The Vitess Authors.
+# Copyright 2024 The Vitess Authors.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 # Use a temporary layer for the build stage.
 ARG bootstrap_version=32
-ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
+ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}" AS builder
 
@@ -30,7 +30,6 @@ COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
 
 # Build and install Vitess in a temporary output directory.
 USER vitess
-
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
@@ -38,7 +37,7 @@ FROM debian:bullseye-slim
 
 # Install dependencies
 COPY docker/utils/install_dependencies.sh /vt/dist/install_dependencies.sh
-RUN /vt/dist/install_dependencies.sh mysql80
+RUN /vt/dist/install_dependencies.sh percona80
 
 # Set up Vitess user and directory tree.
 RUN groupadd -r vitess && useradd -r -g vitess vitess
@@ -50,11 +49,8 @@ ENV VTDATAROOT /vt/vtdataroot
 ENV PATH $VTROOT/bin:$PATH
 
 # Copy artifacts from builder layer.
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder --chown=vitess:vitess /vt/install /vt
 COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/web/vtadmin /vt/web/vtadmin
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/init_db.sql /vt/config/
-COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/mycnf /vt/config/
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot


### PR DESCRIPTION
## Description

We have been facing multiple issues after we merged https://github.com/vitessio/vitess/pull/15620. Mainly, the `xtrabackup` and `mysqlbinlog` binaries were missing and thus we could not use certain features of vitess. There was several attempts to fix this: https://github.com/vitessio/vitess/pull/15775 and https://github.com/vitessio/vitess/pull/15854, which both failed. We have a plan internally on how to make this work, but as of today (1 day before the code freeze of v20) I have not been able to make that plan work, hence the revert.
