### PR TITLE
Changelog 20.0: Fix broken links

### DIFF
--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -183,7 +183,7 @@ This makes reparenting in Vitess resilient to client errors, and prevents Planne
 
 In order to preserve the old behaviour, the users can set the flag back to `0 seconds` causing open transactions to never be shutdown, but in that case, they run the risk of PlannedReparentShard calls timing out.
 
-#### <a id="unmanaged-tablet"/> New `unmanaged` Flag and `disable_active_reparents` deprecation
+#### <a id="unmanaged-flag"/> New `unmanaged` Flag and `disable_active_reparents` deprecation
 
 New flag `--unmanaged` has been introduced in this release to make it easier to flag unmanaged tablets. It also runs validations to make sure the unmanaged tablets are configured properly. `--disable_active_reparents` flag has been deprecated for `vttablet`, `vtcombo` and `vttestserver` binaries and will be removed in future releases. Specifying the `--unmanaged` flag will also block replication commands and replication repairs.
 
@@ -338,7 +338,7 @@ VTTablet exposes two new counter stats:
  * `QueryCacheHits`: Query engine query cache hits
  * `QueryCacheMisses`: Query engine query cache misses
 
-### <a id="#vttablet-query-text-characters-processed"/>VTTablet Query Text Characters Processed
+### <a id="vttablet-query-text-characters-processed"/>VTTablet Query Text Characters Processed
 
 VTGate and VTTablet expose a new counter stat `QueryTextCharactersProcessed` to reflect the number of query text characters processed.
 


### PR DESCRIPTION
## Description

Somewhat late seeing that we code-freezed, this PR fixes a couple broken links in the `20.0` changelog.

I've also reviewed the PR for spell checking, it looks good.

**To be backported to `release-20.0` and then to `release-20.0-rc`**

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16010

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
