### PR TITLE
fix: order by subquery planning

### DIFF
--- a/go/test/endtoend/vtgate/queries/subquery/schema.sql
+++ b/go/test/endtoend/vtgate/queries/subquery/schema.sql
@@ -4,18 +4,21 @@ create table t1
     id2 bigint,
     primary key (id1)
 ) Engine = InnoDB;
+
 create table t1_id2_idx
 (
     id2         bigint,
     keyspace_id varbinary(10),
     primary key (id2)
 ) Engine = InnoDB;
+
 create table t2
 (
     id3 bigint,
     id4 bigint,
     primary key (id3)
 ) Engine = InnoDB;
+
 create table t2_id4_idx
 (
     id  bigint not null auto_increment,
@@ -24,3 +27,16 @@ create table t2_id4_idx
     primary key (id),
     key idx_id4 (id4)
 ) Engine = InnoDB;
+
+CREATE TABLE user
+(
+    id   INT PRIMARY KEY,
+    name VARCHAR(100)
+);
+
+CREATE TABLE user_extra
+(
+    user_id    INT,
+    extra_info VARCHAR(100),
+    PRIMARY KEY (user_id, extra_info)
+);

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -194,7 +194,7 @@ func TestSubqueries(t *testing.T) {
 	// This method tests many types of subqueries. The queries should move to a vitess-tester test file once we have a way to run them.
 	// The commented out queries are failing because of wrong types being returned.
 	// The tests are commented out until the issue is fixed.
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 	queries := []string{

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package subquery
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -187,4 +188,47 @@ func TestSubqueryInDerivedTable(t *testing.T) {
 	mcmp.Exec("INSERT INTO t2 (id3, id4) VALUES (10, 1), (20, 2), (30, 3), (40, 4), (50, 99)")
 	mcmp.Exec(`select t.a from (select t1.id2, t2.id3, (select id2 from t1 order by id2 limit 1) as a from t1 join t2 on t1.id1 = t2.id4) t`)
 	mcmp.Exec(`SELECT COUNT(*) FROM (SELECT DISTINCT t1.id1 FROM t1 JOIN t2 ON t1.id1 = t2.id4) dt`)
+}
+
+func TestSubqueries(t *testing.T) {
+	// This method tests many types of subqueries. The queries should move to a vitess-tester test file once we have a way to run them.
+	// The commented out queries are failing because of wrong types being returned.
+	// The tests are commented out until the issue is fixed.
+	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+	mcmp, closer := start(t)
+	defer closer()
+	queries := []string{
+		`INSERT INTO user (id, name) VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie'), (4, 'David'), (5, 'Eve'), (6, 'Frank'), (7, 'Grace'), (8, 'Hannah'), (9, 'Ivy'), (10, 'Jack')`,
+		`INSERT INTO user_extra (user_id, extra_info) VALUES (1, 'info1'), (1, 'info2'), (2, 'info1'), (3, 'info1'), (3, 'info2'), (4, 'info1'), (5, 'info1'), (6, 'info1'), (7, 'info1'), (8, 'info1')`,
+		`SELECT (SELECT COUNT(*) FROM user_extra) AS order_count, id FROM user WHERE id = (SELECT COUNT(*) FROM user_extra)`,
+		`SELECT id, (SELECT COUNT(*) FROM user_extra) AS order_count FROM user ORDER BY (SELECT COUNT(*) FROM user_extra)`,
+		`SELECT id FROM user WHERE id = (SELECT COUNT(*) FROM user_extra) ORDER BY (SELECT COUNT(*) FROM user_extra)`,
+		`SELECT (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) AS extra_count, id, name FROM user WHERE (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) > 0`,
+		`SELECT id, name, (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) AS extra_count FROM user ORDER BY (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id)`,
+		`SELECT id, name FROM user WHERE (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) > 0 ORDER BY (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id)`,
+		`SELECT id, name, (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) AS extra_count FROM user GROUP BY id, name HAVING COUNT(*) > (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id)`,
+		`SELECT id, name, COUNT(*) FROM user WHERE (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) > 0 GROUP BY id, name HAVING COUNT(*) > (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id)`,
+		`SELECT id, round(MAX(id + (SELECT COUNT(*) FROM user_extra where user_id = 42))) as r FROM user WHERE id = 42 GROUP BY id ORDER BY r`,
+		`SELECT id, name, (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) * 2 AS double_extra_count FROM user`,
+		`SELECT id, name FROM user WHERE id IN (SELECT user_id FROM user_extra WHERE LENGTH(extra_info) > 4)`,
+		`SELECT id, COUNT(*) FROM user GROUP BY id HAVING COUNT(*) > (SELECT COUNT(*) FROM user_extra WHERE user_extra.user_id = user.id) + 1`,
+		`SELECT id, name FROM user ORDER BY (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) * id`,
+		`SELECT id, name, (SELECT COUNT(*) FROM user_extra WHERE user.id = user_extra.user_id) + id AS extra_count_plus_id FROM user`,
+		`SELECT id, name FROM user WHERE id IN (SELECT user_id FROM user_extra WHERE extra_info = 'info1') OR id IN (SELECT user_id FROM user_extra WHERE extra_info = 'info2')`,
+		`SELECT id, name, (SELECT COUNT(*) FROM user_extra) AS total_extra_count, SUM(id) AS sum_ids FROM user GROUP BY id, name ORDER BY (SELECT COUNT(*) FROM user_extra)`,
+		// `SELECT id, name, (SELECT SUM(LENGTH(extra_info)) FROM user_extra) AS total_length_extra_info, AVG(id) AS avg_ids FROM user GROUP BY id, name HAVING (SELECT SUM(LENGTH(extra_info)) FROM user_extra) > 10`,
+		`SELECT id, name, (SELECT AVG(LENGTH(extra_info)) FROM user_extra) AS avg_length_extra_info, MAX(id) AS max_id FROM user WHERE id IN (SELECT user_id FROM user_extra) GROUP BY id, name`,
+		`SELECT id, name, (SELECT MAX(LENGTH(extra_info)) FROM user_extra) AS max_length_extra_info, MIN(id) AS min_id FROM user GROUP BY id, name ORDER BY (SELECT MAX(LENGTH(extra_info)) FROM user_extra)`,
+		`SELECT id, name, (SELECT MIN(LENGTH(extra_info)) FROM user_extra) AS min_length_extra_info, SUM(id) AS sum_ids FROM user GROUP BY id, name HAVING (SELECT MIN(LENGTH(extra_info)) FROM user_extra) < 5`,
+		`SELECT id, name, (SELECT COUNT(*) FROM user_extra) AS total_extra_count, AVG(id) AS avg_ids FROM user WHERE id > (SELECT COUNT(*) FROM user_extra) GROUP BY id, name`,
+		// `SELECT id, name, (SELECT SUM(LENGTH(extra_info)) FROM user_extra) AS total_length_extra_info, COUNT(id) AS count_ids FROM user GROUP BY id, name ORDER BY (SELECT SUM(LENGTH(extra_info)) FROM user_extra)`,
+		// `SELECT id, name, (SELECT COUNT(*) FROM user_extra) AS total_extra_count, (SELECT SUM(LENGTH(extra_info)) FROM user_extra) AS total_length_extra_info, (SELECT AVG(LENGTH(extra_info)) FROM user_extra) AS avg_length_extra_info, (SELECT MAX(LENGTH(extra_info)) FROM user_extra) AS max_length_extra_info, (SELECT MIN(LENGTH(extra_info)) FROM user_extra) AS min_length_extra_info, SUM(id) AS sum_ids FROM user GROUP BY id, name HAVING (SELECT AVG(LENGTH(extra_info)) FROM user_extra) > 2`,
+		`SELECT id, name, (SELECT COUNT(*) FROM user_extra) + id AS total_extra_count_plus_id, AVG(id) AS avg_ids FROM user WHERE id < (SELECT MAX(user_id) FROM user_extra) GROUP BY id, name`,
+	}
+
+	for idx, query := range queries {
+		mcmp.Run(fmt.Sprintf("%d %s", idx, query), func(mcmp *utils.MySQLCompare) {
+			mcmp.Exec(query)
+		})
+	}
 }

--- a/go/test/endtoend/vtgate/queries/subquery/vschema.json
+++ b/go/test/endtoend/vtgate/queries/subquery/vschema.json
@@ -22,6 +22,9 @@
         "autocommit": "true"
       },
       "owner": "t2"
+    },
+    "xxhash": {
+      "type": "xxhash"
     }
   },
   "tables": {
@@ -64,6 +67,34 @@
           "name": "hash"
         }
       ]
+    },
+    "user_extra": {
+      "name": "user_extra",
+      "column_vindexes": [
+        {
+          "columns": [
+            "user_id",
+            "extra_info"
+          ],
+          "type": "xxhash",
+          "name": "xxhash",
+          "vindex": null
+        }
+      ]
+    },
+    "user": {
+      "name": "user",
+      "column_vindexes": [
+        {
+          "columns": [
+            "id"
+          ],
+          "type": "xxhash",
+          "name": "xxhash",
+          "vindex": null
+        }
+      ]
     }
+
   }
 }

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -3426,6 +3426,32 @@ func (varS *VarSamp) SetArg(expr Expr)              { varS.Arg = expr }
 func (variance *Variance) SetArg(expr Expr)         { variance.Arg = expr }
 func (av *AnyValue) SetArg(expr Expr)               { av.Arg = expr }
 
+func (min *Min) SetArgs(exprs Exprs) error           { return setFuncArgs(min, exprs, "MIN") }
+func (sum *Sum) SetArgs(exprs Exprs) error           { return setFuncArgs(sum, exprs, "SUM") }
+func (max *Max) SetArgs(exprs Exprs) error           { return setFuncArgs(max, exprs, "MAX") }
+func (avg *Avg) SetArgs(exprs Exprs) error           { return setFuncArgs(avg, exprs, "AVG") }
+func (*CountStar) SetArgs(Exprs) error               { return nil }
+func (bAnd *BitAnd) SetArgs(exprs Exprs) error       { return setFuncArgs(bAnd, exprs, "BIT_AND") }
+func (bOr *BitOr) SetArgs(exprs Exprs) error         { return setFuncArgs(bOr, exprs, "BIT_OR") }
+func (bXor *BitXor) SetArgs(exprs Exprs) error       { return setFuncArgs(bXor, exprs, "BIT_XOR") }
+func (std *Std) SetArgs(exprs Exprs) error           { return setFuncArgs(std, exprs, "STD") }
+func (stdD *StdDev) SetArgs(exprs Exprs) error       { return setFuncArgs(stdD, exprs, "STDDEV") }
+func (stdP *StdPop) SetArgs(exprs Exprs) error       { return setFuncArgs(stdP, exprs, "STDDEV_POP") }
+func (stdS *StdSamp) SetArgs(exprs Exprs) error      { return setFuncArgs(stdS, exprs, "STDDEV_SAMP") }
+func (varP *VarPop) SetArgs(exprs Exprs) error       { return setFuncArgs(varP, exprs, "VAR_POP") }
+func (varS *VarSamp) SetArgs(exprs Exprs) error      { return setFuncArgs(varS, exprs, "VAR_SAMP") }
+func (variance *Variance) SetArgs(exprs Exprs) error { return setFuncArgs(variance, exprs, "VARIANCE") }
+func (av *AnyValue) SetArgs(exprs Exprs) error       { return setFuncArgs(av, exprs, "ANY_VALUE") }
+
+func (count *Count) SetArgs(exprs Exprs) error {
+	count.Args = exprs
+	return nil
+}
+func (grpConcat *GroupConcatExpr) SetArgs(exprs Exprs) error {
+	grpConcat.Exprs = exprs
+	return nil
+}
+
 func (sum *Sum) IsDistinct() bool                   { return sum.Distinct }
 func (min *Min) IsDistinct() bool                   { return min.Distinct }
 func (max *Max) IsDistinct() bool                   { return max.Distinct }

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2878,6 +2878,8 @@ type (
 		Expr
 		GetArg() Expr
 		GetArgs() Exprs
+		SetArg(expr Expr)
+		SetArgs(exprs Exprs) error
 		// AggrName returns the lower case string representing this aggregation function
 		AggrName() string
 	}
@@ -3404,6 +3406,25 @@ func (varP *VarPop) GetArgs() Exprs               { return Exprs{varP.Arg} }
 func (varS *VarSamp) GetArgs() Exprs              { return Exprs{varS.Arg} }
 func (variance *Variance) GetArgs() Exprs         { return Exprs{variance.Arg} }
 func (av *AnyValue) GetArgs() Exprs               { return Exprs{av.Arg} }
+
+func (min *Min) SetArg(expr Expr)                   { min.Arg = expr }
+func (sum *Sum) SetArg(expr Expr)                   { sum.Arg = expr }
+func (max *Max) SetArg(expr Expr)                   { max.Arg = expr }
+func (avg *Avg) SetArg(expr Expr)                   { avg.Arg = expr }
+func (*CountStar) SetArg(expr Expr)                 {}
+func (count *Count) SetArg(expr Expr)               { count.Args = Exprs{expr} }
+func (grpConcat *GroupConcatExpr) SetArg(expr Expr) { grpConcat.Exprs = Exprs{expr} }
+func (bAnd *BitAnd) SetArg(expr Expr)               { bAnd.Arg = expr }
+func (bOr *BitOr) SetArg(expr Expr)                 { bOr.Arg = expr }
+func (bXor *BitXor) SetArg(expr Expr)               { bXor.Arg = expr }
+func (std *Std) SetArg(expr Expr)                   { std.Arg = expr }
+func (stdD *StdDev) SetArg(expr Expr)               { stdD.Arg = expr }
+func (stdP *StdPop) SetArg(expr Expr)               { stdP.Arg = expr }
+func (stdS *StdSamp) SetArg(expr Expr)              { stdS.Arg = expr }
+func (varP *VarPop) SetArg(expr Expr)               { varP.Arg = expr }
+func (varS *VarSamp) SetArg(expr Expr)              { varS.Arg = expr }
+func (variance *Variance) SetArg(expr Expr)         { variance.Arg = expr }
+func (av *AnyValue) SetArg(expr Expr)               { av.Arg = expr }
 
 func (sum *Sum) IsDistinct() bool                   { return sum.Distinct }
 func (min *Min) IsDistinct() bool                   { return min.Distinct }

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2184,63 +2184,6 @@ func ContainsAggregation(e SQLNode) bool {
 	return hasAggregates
 }
 
-func (min *Min) SetArgs(exprs Exprs) error {
-	return setFuncArgs(min, exprs, "MIN")
-}
-func (sum *Sum) SetArgs(exprs Exprs) error {
-	return setFuncArgs(sum, exprs, "SUM")
-}
-func (max *Max) SetArgs(exprs Exprs) error {
-	return setFuncArgs(max, exprs, "MAX")
-}
-func (avg *Avg) SetArgs(exprs Exprs) error {
-	return setFuncArgs(avg, exprs, "AVG")
-}
-func (*CountStar) SetArgs(exprs Exprs) error {
-	return nil
-}
-func (count *Count) SetArgs(exprs Exprs) error {
-	count.Args = exprs
-	return nil
-}
-func (grpConcat *GroupConcatExpr) SetArgs(exprs Exprs) error {
-	grpConcat.Exprs = exprs
-	return nil
-}
-func (bAnd *BitAnd) SetArgs(exprs Exprs) error {
-	return setFuncArgs(bAnd, exprs, "BIT_AND")
-}
-func (bOr *BitOr) SetArgs(exprs Exprs) error {
-	return setFuncArgs(bOr, exprs, "BIT_OR")
-}
-func (bXor *BitXor) SetArgs(exprs Exprs) error {
-	return setFuncArgs(bXor, exprs, "BIT_XOR")
-}
-func (std *Std) SetArgs(exprs Exprs) error {
-	return setFuncArgs(std, exprs, "STD")
-}
-func (stdD *StdDev) SetArgs(exprs Exprs) error {
-	return setFuncArgs(stdD, exprs, "STDDEV")
-}
-func (stdP *StdPop) SetArgs(exprs Exprs) error {
-	return setFuncArgs(stdP, exprs, "STDDEV_POP")
-}
-func (stdS *StdSamp) SetArgs(exprs Exprs) error {
-	return setFuncArgs(stdS, exprs, "STDDEV_SAMP")
-}
-func (varP *VarPop) SetArgs(exprs Exprs) error {
-	return setFuncArgs(varP, exprs, "VAR_POP")
-}
-func (varS *VarSamp) SetArgs(exprs Exprs) error {
-	return setFuncArgs(varS, exprs, "VAR_SAMP")
-}
-func (variance *Variance) SetArgs(exprs Exprs) error {
-	return setFuncArgs(variance, exprs, "VARIANCE")
-}
-func (av *AnyValue) SetArgs(exprs Exprs) error {
-	return setFuncArgs(av, exprs, "ANY_VALUE")
-}
-
 // setFuncArgs sets the arguments for the aggregation function, while checking that there is only one argument
 func setFuncArgs(aggr AggrFunc, exprs Exprs, name string) error {
 	if len(exprs) != 1 {

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2241,6 +2241,7 @@ func (av *AnyValue) SetArgs(exprs Exprs) error {
 	return setFuncArgs(av, exprs, "ANY_VALUE")
 }
 
+// setFuncArgs sets the arguments for the aggregation function, while checking that there is only one argument
 func setFuncArgs(aggr AggrFunc, exprs Exprs, name string) error {
 	if len(exprs) != 1 {
 		return vterrors.VT03001(name)

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2184,6 +2184,71 @@ func ContainsAggregation(e SQLNode) bool {
 	return hasAggregates
 }
 
+func (min *Min) SetArgs(exprs Exprs) error {
+	return setFuncArgs(min, exprs, "MIN")
+}
+func (sum *Sum) SetArgs(exprs Exprs) error {
+	return setFuncArgs(sum, exprs, "SUM")
+}
+func (max *Max) SetArgs(exprs Exprs) error {
+	return setFuncArgs(max, exprs, "MAX")
+}
+func (avg *Avg) SetArgs(exprs Exprs) error {
+	return setFuncArgs(avg, exprs, "AVG")
+}
+func (*CountStar) SetArgs(exprs Exprs) error {
+	return nil
+}
+func (count *Count) SetArgs(exprs Exprs) error {
+	count.Args = exprs
+	return nil
+}
+func (grpConcat *GroupConcatExpr) SetArgs(exprs Exprs) error {
+	grpConcat.Exprs = exprs
+	return nil
+}
+func (bAnd *BitAnd) SetArgs(exprs Exprs) error {
+	return setFuncArgs(bAnd, exprs, "BIT_AND")
+}
+func (bOr *BitOr) SetArgs(exprs Exprs) error {
+	return setFuncArgs(bOr, exprs, "BIT_OR")
+}
+func (bXor *BitXor) SetArgs(exprs Exprs) error {
+	return setFuncArgs(bXor, exprs, "BIT_XOR")
+}
+func (std *Std) SetArgs(exprs Exprs) error {
+	return setFuncArgs(std, exprs, "STD")
+}
+func (stdD *StdDev) SetArgs(exprs Exprs) error {
+	return setFuncArgs(stdD, exprs, "STDDEV")
+}
+func (stdP *StdPop) SetArgs(exprs Exprs) error {
+	return setFuncArgs(stdP, exprs, "STDDEV_POP")
+}
+func (stdS *StdSamp) SetArgs(exprs Exprs) error {
+	return setFuncArgs(stdS, exprs, "STDDEV_SAMP")
+}
+func (varP *VarPop) SetArgs(exprs Exprs) error {
+	return setFuncArgs(varP, exprs, "VAR_POP")
+}
+func (varS *VarSamp) SetArgs(exprs Exprs) error {
+	return setFuncArgs(varS, exprs, "VAR_SAMP")
+}
+func (variance *Variance) SetArgs(exprs Exprs) error {
+	return setFuncArgs(variance, exprs, "VARIANCE")
+}
+func (av *AnyValue) SetArgs(exprs Exprs) error {
+	return setFuncArgs(av, exprs, "ANY_VALUE")
+}
+
+func setFuncArgs(aggr AggrFunc, exprs Exprs, name string) error {
+	if len(exprs) != 1 {
+		return vterrors.VT03001(name)
+	}
+	aggr.SetArg(exprs[0])
+	return nil
+}
+
 // GetFirstSelect gets the first select statement
 func GetFirstSelect(selStmt SelectStatement) *Select {
 	if selStmt == nil {

--- a/go/vt/vtgate/planbuilder/fuzz.go
+++ b/go/vt/vtgate/planbuilder/fuzz.go
@@ -20,12 +20,12 @@ import (
 	"sync"
 	"testing"
 
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/sqltypes"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
 )
 
 var initter sync.Once

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -89,7 +89,7 @@ func reachedPhase(ctx *plancontext.PlanningContext, p Phase) bool {
 // Any columns that are needed to evaluate the subquery needs to be added as
 // grouping columns to the aggregation being pushed down, and then after the
 // subquery evaluation we are free to reassemble the total aggregation values.
-// This is very similar to how we push aggregation through an apply	-join.
+// This is very similar to how we push aggregation through an apply-join.
 func pushAggregationThroughSubquery(
 	ctx *plancontext.PlanningContext,
 	rootAggr *Aggregator,

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -89,7 +89,7 @@ func reachedPhase(ctx *plancontext.PlanningContext, p Phase) bool {
 // Any columns that are needed to evaluate the subquery needs to be added as
 // grouping columns to the aggregation being pushed down, and then after the
 // subquery evaluation we are free to reassemble the total aggregation values.
-// This is very similar to how we push aggregation through an shouldRun-join.
+// This is very similar to how we push aggregation through an apply	-join.
 func pushAggregationThroughSubquery(
 	ctx *plancontext.PlanningContext,
 	rootAggr *Aggregator,
@@ -99,10 +99,11 @@ func pushAggregationThroughSubquery(
 	for _, subQuery := range src.Inner {
 		lhsCols := subQuery.OuterExpressionsNeeded(ctx, src.Outer)
 		for _, colName := range lhsCols {
-			idx := slices.IndexFunc(pushedAggr.Columns, func(ae *sqlparser.AliasedExpr) bool {
+			findColName := func(ae *sqlparser.AliasedExpr) bool {
 				return ctx.SemTable.EqualsExpr(ae.Expr, colName)
-			})
-			if idx >= 0 {
+			}
+			if slices.IndexFunc(pushedAggr.Columns, findColName) >= 0 {
+				// we already have the column, no need to push it again
 				continue
 			}
 			pushedAggr.addColumnWithoutPushing(ctx, aeWrap(colName), true)
@@ -112,6 +113,7 @@ func pushAggregationThroughSubquery(
 	src.Outer = pushedAggr
 
 	for _, aggr := range pushedAggr.Aggregations {
+		// we rewrite columns in the aggregation to use the argument form of the subquery
 		aggr.Original.Expr = rewriteColNameToArgument(ctx, aggr.Original.Expr, aggr.SubQueryExpression, src.Inner...)
 		pushedAggr.Columns[aggr.ColOffset].Expr = rewriteColNameToArgument(ctx, pushedAggr.Columns[aggr.ColOffset].Expr, aggr.SubQueryExpression, src.Inner...)
 	}

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -380,16 +380,18 @@ func (a *Aggregator) planOffsets(ctx *plancontext.PlanningContext) Operator {
 }
 
 func (aggr Aggr) setPushColumn(exprs sqlparser.Exprs) {
-	if aggr.Func != nil {
-		err := aggr.Func.SetArgs(exprs)
-		if err != nil {
-			panic(err)
+	if aggr.Func == nil {
+		if len(exprs) > 1 {
+			panic(vterrors.VT13001(fmt.Sprintf("unexpected number of expression in an random aggregation: %s", sqlparser.String(exprs))))
 		}
+		aggr.Original.Expr = exprs[0]
+		return
 	}
-	if len(exprs) > 1 {
-		panic(vterrors.VT13001(fmt.Sprintf("unexpected number of expression in an random aggregation: %s", sqlparser.String(exprs))))
+
+	err := aggr.Func.SetArgs(exprs)
+	if err != nil {
+		panic(err)
 	}
-	aggr.Original.Expr = exprs[0]
 }
 
 func (aggr Aggr) getPushColumn() sqlparser.Expr {

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -529,6 +529,9 @@ func (a *Aggregator) SplitAggregatorBelowOperators(ctx *plancontext.PlanningCont
 	newOp.Pushed = false
 	newOp.Original = false
 	newOp.DT = nil
+
+	// We need to make sure that the columns are cloned so that the original operator is not affected
+	// by the changes we make to the new operator
 	newOp.Columns = slice.Map(a.Columns, func(from *sqlparser.AliasedExpr) *sqlparser.AliasedExpr {
 		return ctx.SemTable.Clone(from).(*sqlparser.AliasedExpr)
 	})

--- a/go/vt/vtgate/planbuilder/operators/helpers.go
+++ b/go/vt/vtgate/planbuilder/operators/helpers.go
@@ -26,13 +26,13 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
+type compactable interface {
+	// Compact implement this interface for operators that have easy to see optimisations
+	Compact(ctx *plancontext.PlanningContext) (Operator, *ApplyResult)
+}
+
 // compact will optimise the operator tree into a smaller but equivalent version
 func compact(ctx *plancontext.PlanningContext, op Operator) Operator {
-	type compactable interface {
-		// Compact implement this interface for operators that have easy to see optimisations
-		Compact(ctx *plancontext.PlanningContext) (Operator, *ApplyResult)
-	}
-
 	newOp := BottomUp(op, TableID, func(op Operator, _ semantics.TableSet, _ bool) (Operator, *ApplyResult) {
 		newOp, ok := op.(compactable)
 		if !ok {

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -128,7 +128,8 @@ func expandOrderBy(ctx *plancontext.PlanningContext, op Operator, qp *QueryProje
 		if !ok {
 			panic(vterrors.VT12001("subquery with aggregation in order by"))
 		}
-		proj.addSubqueryExpr(aeWrap(newExpr), newExpr, subqs...)
+
+		proj.addSubqueryExpr(ctx, aeWrap(newExpr), newExpr, subqs...)
 		newOrder = append(newOrder, OrderBy{
 			Inner: &sqlparser.Order{
 				Expr:      newExpr,
@@ -284,7 +285,7 @@ func createProjectionWithoutAggr(ctx *plancontext.PlanningContext, qp *QueryProj
 			// there was no subquery in this expression
 			proj.addUnexploredExpr(org, expr)
 		} else {
-			proj.addSubqueryExpr(org, newExpr, subqs...)
+			proj.addSubqueryExpr(ctx, org, newExpr, subqs...)
 		}
 	}
 	proj.Source = sqc.getRootOperator(src, nil)

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -229,11 +229,14 @@ func (p *Projection) canPush(ctx *plancontext.PlanningContext) bool {
 }
 
 func (p *Projection) GetAliasedProjections() (AliasedProjections, error) {
-	ap, ok := p.Columns.(AliasedProjections)
-	if !ok {
+	switch cols := p.Columns.(type) {
+	case AliasedProjections:
+		return cols, nil
+	case nil:
+		return nil, nil
+	default:
 		return nil, vterrors.VT09015()
 	}
-	return ap, nil
 }
 
 func (p *Projection) isDerived() bool {
@@ -274,8 +277,7 @@ func (p *Projection) addProjExpr(pe ...*ProjExpr) int {
 	}
 
 	offset := len(ap)
-	ap = append(ap, pe...)
-	p.Columns = ap
+	p.Columns = append(ap, pe...)
 
 	return offset
 }

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -286,7 +286,18 @@ func (p *Projection) addUnexploredExpr(ae *sqlparser.AliasedExpr, e sqlparser.Ex
 	return p.addProjExpr(newProjExprWithInner(ae, e))
 }
 
-func (p *Projection) addSubqueryExpr(ae *sqlparser.AliasedExpr, expr sqlparser.Expr, sqs ...*SubQuery) {
+func (p *Projection) addSubqueryExpr(ctx *plancontext.PlanningContext, ae *sqlparser.AliasedExpr, expr sqlparser.Expr, sqs ...*SubQuery) {
+	ap, err := p.GetAliasedProjections()
+	if err != nil {
+		panic(err)
+	}
+	for _, projExpr := range ap {
+		if ctx.SemTable.EqualsExprWithDeps(projExpr.EvalExpr, expr) {
+			// if we already have this column, we can just return the offset
+			return
+		}
+	}
+
 	pe := newProjExprWithInner(ae, expr)
 	pe.Info = SubQueryExpression(sqs)
 

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -405,6 +405,7 @@ func tryPushOrdering(ctx *plancontext.PlanningContext, in *Ordering) (Operator, 
 				return in, NoRewrite
 			}
 			in.Order[idx].SimplifiedExpr = src.rewriteColNameToArgument(order.SimplifiedExpr)
+			in.Order[idx].Inner.Expr = src.rewriteColNameToArgument(order.Inner.Expr)
 		}
 		src.Outer, in.Source = in, src.Outer
 		return src, Rewrote("push ordering into outer side of subquery")

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -682,6 +682,11 @@ func addTruncationOrProjectionToReturnOutput(ctx *plancontext.PlanningContext, s
 }
 
 func colNamesAlign(expected, actual sqlparser.SelectExprs) bool {
+	if len(expected) > len(actual) {
+		// if we expect more columns than we have, we can't align
+		return false
+	}
+
 	for i, seE := range expected {
 		switch se := seE.(type) {
 		case *sqlparser.AliasedExpr:
@@ -691,7 +696,7 @@ func colNamesAlign(expected, actual sqlparser.SelectExprs) bool {
 		case *sqlparser.StarExpr:
 			actualStar, isStar := actual[i].(*sqlparser.StarExpr)
 			if !isStar {
-				panic("I DONT THINK THIS CAN HAPPEN")
+				panic(vterrors.VT13001("this should not happen"))
 			}
 			if !sqlparser.Equals.RefOfStarExpr(se, actualStar) {
 				return false

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -20,12 +20,10 @@ import (
 	"fmt"
 	"io"
 
-	"vitess.io/vitess/go/vt/vtgate/engine"
-
-	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
@@ -713,7 +711,7 @@ func colNamesAlign(expected, actual sqlparser.SelectExprs) bool {
 		case *sqlparser.StarExpr:
 			actualStar, isStar := actual[i].(*sqlparser.StarExpr)
 			if !isStar {
-				panic(vterrors.VT13001("this should not happen"))
+				panic(vterrors.VT13001(fmt.Sprintf("star expression is expected here, found: %T", actual[i])))
 			}
 			if !sqlparser.Equals.RefOfStarExpr(se, actualStar) {
 				return false

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -269,7 +269,7 @@ func (qp *QueryProjection) addOrderBy(ctx *plancontext.PlanningContext, orderBy 
 	canPushSorting := true
 	es := &expressionSet{}
 	for _, order := range orderBy {
-		if notInterestingToOrderBy(ctx, order.Expr) {
+		if canIgnoreOrdering(ctx, order.Expr) {
 			continue
 		}
 		if !es.add(ctx, order.Expr) {
@@ -283,7 +283,8 @@ func (qp *QueryProjection) addOrderBy(ctx *plancontext.PlanningContext, orderBy 
 	}
 }
 
-func notInterestingToOrderBy(ctx *plancontext.PlanningContext, expr sqlparser.Expr) bool {
+// canIgnoreOrdering returns true if the ordering expression has no effect on the result.
+func canIgnoreOrdering(ctx *plancontext.PlanningContext, expr sqlparser.Expr) bool {
 	switch expr.(type) {
 	case *sqlparser.NullVal, *sqlparser.Literal, *sqlparser.Argument:
 		return true

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -69,7 +69,7 @@ type (
 	// Aggr encodes all information needed for aggregation functions
 	Aggr struct {
 		Original *sqlparser.AliasedExpr
-		Func     sqlparser.AggrFunc
+		Func     sqlparser.AggrFunc // if we are missing a Func, it means this is a AggregateAnyValue
 		OpCode   opcode.AggregateOpcode
 
 		// OriginalOpCode will contain opcode.AggregateUnassigned unless we are changing opcode while pushing them down

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -178,6 +178,7 @@ func (sq *SubQuery) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparse
 
 func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, ae *sqlparser.AliasedExpr) int {
 	ae = sqlparser.Clone(ae)
+	// we need to rewrite the column name to an argument if it's the same as the subquery column name
 	ae.Expr = rewriteColNameToArgument(ctx, ae.Expr, []*SubQuery{sq}, sq)
 	return sq.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, ae)
 }
@@ -318,6 +319,7 @@ func (sq *SubQuery) Compact(*plancontext.PlanningContext) (Operator, *ApplyResul
 		return sq, NoRewrite
 	}
 	if other.ArgName == sq.ArgName {
+		// we can remove this subquery because it's a duplicate
 		sq.Outer = other.Outer
 		return sq, Rewrote("removed duplicate subquery")
 	}

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -312,17 +312,3 @@ func (sq *SubQuery) rewriteColNameToArgument(expr sqlparser.Expr) sqlparser.Expr
 
 	return sqlparser.Rewrite(expr, pre, nil).(sqlparser.Expr)
 }
-
-func (sq *SubQuery) Compact(*plancontext.PlanningContext) (Operator, *ApplyResult) {
-	other, ok := sq.Outer.(*SubQuery)
-	if !ok {
-		return sq, NoRewrite
-	}
-	if other.ArgName == sq.ArgName {
-		// we can remove this subquery because it's a duplicate
-		sq.Outer = other.Outer
-		return sq, Rewrote("removed duplicate subquery")
-	}
-
-	return sq, NoRewrite
-}

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -309,3 +309,16 @@ func (sq *SubQuery) rewriteColNameToArgument(expr sqlparser.Expr) sqlparser.Expr
 
 	return sqlparser.Rewrite(expr, pre, nil).(sqlparser.Expr)
 }
+
+func (sq *SubQuery) Compact(*plancontext.PlanningContext) (Operator, *ApplyResult) {
+	other, ok := sq.Outer.(*SubQuery)
+	if !ok {
+		return sq, NoRewrite
+	}
+	if other.ArgName == sq.ArgName {
+		sq.Outer = other.Outer
+		return sq, Rewrote("removed duplicate subquery")
+	}
+
+	return sq, NoRewrite
+}

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -31,7 +31,7 @@ import (
 
 // SubQuery represents a subquery used for filtering rows in an
 // outer query through a join.
-type /**/ SubQuery struct {
+type SubQuery struct {
 	// Fields filled in at the time of construction:
 	Outer             Operator             // Outer query operator.
 	Subquery          Operator             // Subquery operator.
@@ -53,7 +53,8 @@ type /**/ SubQuery struct {
 	// We use this information to fail the planning if we are unable to merge the subquery with a route.
 	correlated bool
 
-	IsProjection bool
+	// IsArgument is set to true if the subquery puts the
+	IsArgument bool
 }
 
 func (sq *SubQuery) planOffsets(ctx *plancontext.PlanningContext) Operator {
@@ -156,8 +157,8 @@ func (sq *SubQuery) SetInputs(inputs []Operator) {
 
 func (sq *SubQuery) ShortDescription() string {
 	var typ string
-	if sq.IsProjection {
-		typ = "PROJ"
+	if sq.IsArgument {
+		typ = "ARGUMENT"
 	} else {
 		typ = "FILTER"
 	}
@@ -210,7 +211,7 @@ func (sq *SubQuery) settle(ctx *plancontext.PlanningContext, outer Operator) Ope
 	if sq.correlated && sq.FilterType != opcode.PulloutExists {
 		panic(correlatedSubqueryErr)
 	}
-	if sq.IsProjection {
+	if sq.IsArgument {
 		if len(sq.GetMergePredicates()) > 0 {
 			// this means that we have a correlated subquery on our hands
 			panic(correlatedSubqueryErr)

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -176,8 +176,10 @@ func (sq *SubQuery) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparse
 	return sq
 }
 
-func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, exprs *sqlparser.AliasedExpr) int {
-	return sq.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, exprs)
+func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, ae *sqlparser.AliasedExpr) int {
+	ae = sqlparser.Clone(ae)
+	ae.Expr = rewriteColNameToArgument(ctx, ae.Expr, []*SubQuery{sq}, sq)
+	return sq.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, ae)
 }
 
 func (sq *SubQuery) AddWSColumn(ctx *plancontext.PlanningContext, offset int, underRoute bool) int {

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -159,7 +159,7 @@ func createSubquery(
 	parent sqlparser.Expr,
 	argName string,
 	filterType opcode.PulloutOpcode,
-	isProjection bool,
+	isArg bool,
 ) *SubQuery {
 	topLevel := ctx.SemTable.EqualsExpr(original, parent)
 	original = cloneASTAndSemState(ctx, original)
@@ -181,7 +181,7 @@ func createSubquery(
 		Original:         original,
 		ArgName:          argName,
 		originalSubquery: originalSq,
-		IsProjection:     isProjection,
+		IsArgument:       isArg,
 		TopLevel:         topLevel,
 		JoinColumns:      joinCols,
 		correlated:       correlated,

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -43,7 +43,7 @@ func (sqc *SubQueryContainer) Clone(inputs []Operator) Operator {
 		if !ok {
 			panic("got bad input")
 		}
-		result.Inner = append(result.Inner, inner)
+		result.addInner(inner)
 	}
 	return result
 }
@@ -93,4 +93,14 @@ func (sqc *SubQueryContainer) GetColumns(ctx *plancontext.PlanningContext) []*sq
 
 func (sqc *SubQueryContainer) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
 	return sqc.Outer.GetSelectExprs(ctx)
+}
+
+func (sqc *SubQueryContainer) addInner(inner *SubQuery) {
+	for _, sq := range sqc.Inner {
+		if sq.ArgName == inner.ArgName {
+			// we already have this subquery
+			return
+		}
+	}
+	sqc.Inner = append(sqc.Inner, inner)
 }

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -100,6 +100,7 @@ func settleSubqueries(ctx *plancontext.PlanningContext, op Operator) Operator {
 				newExpr, rewritten := rewriteMergedSubqueryExpr(ctx, aggr.SubQueryExpression, aggr.Original.Expr)
 				if rewritten {
 					aggr.Original.Expr = newExpr
+					op.Columns[aggr.ColOffset].Expr = newExpr
 				}
 			}
 		case *Ordering:

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -477,7 +477,7 @@ func tryMergeSubqueryWithOuter(ctx *plancontext.PlanningContext, subQuery *SubQu
 	if op == nil {
 		return outer, NoRewrite
 	}
-	if !subQuery.IsProjection {
+	if !subQuery.IsArgument {
 		op.Source = newFilter(outer.Source, subQuery.Original)
 	}
 	ctx.MergedSubqueries = append(ctx.MergedSubqueries, subQuery.originalSubquery)
@@ -582,7 +582,7 @@ func (s *subqueryRouteMerger) merge(ctx *plancontext.PlanningContext, inner, out
 	var src Operator
 	if isSharded {
 		src = s.outer.Source
-		if !s.subq.IsProjection {
+		if !s.subq.IsArgument {
 			src = newFilter(s.outer.Source, s.original)
 		}
 	} else {
@@ -643,7 +643,7 @@ func (s *subqueryRouteMerger) rewriteASTExpression(ctx *plancontext.PlanningCont
 		panic(err)
 	}
 
-	if s.subq.IsProjection {
+	if s.subq.IsArgument {
 		ctx.SemTable.CopySemanticInfo(s.subq.originalSubquery.Select, subqStmt)
 		s.subq.originalSubquery.Select = subqStmt
 	} else {

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -157,7 +157,7 @@ func rewriteMergedSubqueryExpr(ctx *plancontext.PlanningContext, se SubQueryExpr
 							return true
 						}
 					case *sqlparser.Argument:
-						if expr.Name != sq. /**/ ArgName {
+						if expr.Name != sq.ArgName {
 							return true
 						}
 					default:

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -345,7 +345,7 @@ func addSubQuery(in Operator, inner *SubQuery) Operator {
 		}
 	}
 
-	sql.Inner = append(sql.Inner, inner)
+	sql.addInner(inner)
 	return sql
 }
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -28,10 +28,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/nsf/jsondiff"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"

--- a/go/vt/vtgate/planbuilder/planner_test.go
+++ b/go/vt/vtgate/planbuilder/planner_test.go
@@ -19,11 +19,10 @@ package planbuilder
 import (
 	"testing"
 
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )

--- a/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
-
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtenv"

--- a/go/vt/vtgate/planbuilder/rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/rewrite_test.go
@@ -19,12 +19,11 @@ package planbuilder
 import (
 	"testing"
 
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
 

--- a/go/vt/vtgate/planbuilder/set.go
+++ b/go/vt/vtgate/planbuilder/set.go
@@ -21,18 +21,14 @@ import (
 	"strconv"
 	"strings"
 
-	"vitess.io/vitess/go/vt/sysvars"
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
-	"vitess.io/vitess/go/vt/vterrors"
-
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/sysvars"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 type (

--- a/go/vt/vtgate/planbuilder/show_test.go
+++ b/go/vt/vtgate/planbuilder/show_test.go
@@ -21,15 +21,13 @@ import (
 	"fmt"
 	"testing"
 
-	"vitess.io/vitess/go/test/vschemawrapper"
-	"vitess.io/vitess/go/vt/vtenv"
-
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
-
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/vschemawrapper"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2278,98 +2278,61 @@
       "QueryType": "SELECT",
       "Original": "select (select col from user limit 1) as a from user join user_extra order by a",
       "Instructions": {
-        "OperatorType": "SimpleProjection",
-        "ColumnNames": [
-          "0:a"
-        ],
-        "Columns": "0",
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_user_extra",
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutValue",
+            "PulloutVars": [
+              "__sq1"
+            ],
             "Inputs": [
               {
-                "OperatorType": "UncorrelatedSubquery",
-                "Variant": "PulloutValue",
-                "PulloutVars": [
-                  "__sq1"
-                ],
+                "InputName": "SubQuery",
+                "OperatorType": "Limit",
+                "Count": "1",
                 "Inputs": [
                   {
-                    "InputName": "SubQuery",
-                    "OperatorType": "Limit",
-                    "Count": "1",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                        "Query": "select `user`.col from `user` limit 1",
-                        "Table": "`user`"
-                      }
-                    ]
-                  },
-                  {
-                    "InputName": "Outer",
-                    "OperatorType": "UncorrelatedSubquery",
-                    "Variant": "PulloutValue",
-                    "PulloutVars": [
-                      "__sq1"
-                    ],
-                    "Inputs": [
-                      {
-                        "InputName": "SubQuery",
-                        "OperatorType": "Limit",
-                        "Count": "1",
-                        "Inputs": [
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "Scatter",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select col from `user` where 1 != 1",
-                            "Query": "select col from `user` limit 1",
-                            "Table": "`user`"
-                          }
-                        ]
-                      },
-                      {
-                        "InputName": "Outer",
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select :__sq1 as a, :__sq1 as __sq1, :__sq1, weight_string(:__sq1) from `user` where 1 != 1",
-                        "OrderBy": "(2|3) ASC",
-                        "Query": "select :__sq1 as a, :__sq1 as __sq1, :__sq1, weight_string(:__sq1) from `user` order by __sq1 asc",
-                        "Table": "`user`"
-                      }
-                    ]
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select `user`.col from `user` where 1 != 1",
+                    "Query": "select `user`.col from `user` limit 1",
+                    "Table": "`user`"
                   }
                 ]
               },
               {
+                "InputName": "Outer",
                 "OperatorType": "Route",
                 "Variant": "Scatter",
                 "Keyspace": {
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "FieldQuery": "select :__sq1 as a, :__sq1, weight_string(:__sq1) from `user` where 1 != 1",
+                "OrderBy": "(1|2) ASC",
+                "Query": "select :__sq1 as a, :__sq1, weight_string(:__sq1) from `user` order by :__sq1 asc",
+                "Table": "`user`"
               }
             ]
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from user_extra where 1 != 1",
+            "Query": "select 1 from user_extra",
+            "Table": "user_extra"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2302,8 +2302,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                    "Query": "select `user`.col from `user` limit 1",
+                    "FieldQuery": "select col from `user` where 1 != 1",
+                    "Query": "select col from `user` limit 1",
                     "Table": "`user`"
                   }
                 ]
@@ -2316,9 +2316,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select :__sq1 as a, :__sq1, weight_string(:__sq1) from `user` where 1 != 1",
-                "OrderBy": "(1|2) ASC",
-                "Query": "select :__sq1 as a, :__sq1, weight_string(:__sq1) from `user` order by :__sq1 asc",
+                "FieldQuery": "select :__sq1 as a from `user` where 1 != 1",
+                "Query": "select :__sq1 as a from `user`",
                 "Table": "`user`"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2272,7 +2272,7 @@
     }
   },
   {
-    "comment": "select (select col from user limit 1) as a from user join user_extra order by a",
+    "comment": "ORDER BY subquery",
     "query": "select (select col from user limit 1) as a from user join user_extra order by a",
     "plan": {
       "QueryType": "SELECT",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2282,12 +2282,12 @@
         "ColumnNames": [
           "0:a"
         ],
-        "Columns": "1",
+        "Columns": "0",
         "Inputs": [
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -2309,24 +2309,52 @@
                           "Name": "user",
                           "Sharded": true
                         },
-                        "FieldQuery": "select col from `user` where 1 != 1",
-                        "Query": "select col from `user` limit 1",
+                        "FieldQuery": "select `user`.col from `user` where 1 != 1",
+                        "Query": "select `user`.col from `user` limit 1",
                         "Table": "`user`"
                       }
                     ]
                   },
                   {
                     "InputName": "Outer",
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select :__sq1 as __sq1, weight_string(:__sq1) from `user` where 1 != 1",
-                    "OrderBy": "(0|1) ASC",
-                    "Query": "select :__sq1 as __sq1, weight_string(:__sq1) from `user` order by __sq1 asc",
-                    "Table": "`user`"
+                    "OperatorType": "UncorrelatedSubquery",
+                    "Variant": "PulloutValue",
+                    "PulloutVars": [
+                      "__sq1"
+                    ],
+                    "Inputs": [
+                      {
+                        "InputName": "SubQuery",
+                        "OperatorType": "Limit",
+                        "Count": "1",
+                        "Inputs": [
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select col from `user` where 1 != 1",
+                            "Query": "select col from `user` limit 1",
+                            "Table": "`user`"
+                          }
+                        ]
+                      },
+                      {
+                        "InputName": "Outer",
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select :__sq1 as a, :__sq1 as __sq1, :__sq1, weight_string(:__sq1) from `user` where 1 != 1",
+                        "OrderBy": "(2|3) ASC",
+                        "Query": "select :__sq1 as a, :__sq1 as __sq1, :__sq1, weight_string(:__sq1) from `user` order by __sq1 asc",
+                        "Table": "`user`"
+                      }
+                    ]
                   }
                 ]
               },

--- a/go/vt/vtgate/planbuilder/vexplain.go
+++ b/go/vt/vtgate/planbuilder/vexplain.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -31,6 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 func buildVExplainPlan(ctx context.Context, vexplainStmt *sqlparser.VExplainStmt, reservedVars *sqlparser.ReservedVars, vschema plancontext.VSchema, enableOnlineDDL, enableDirectDDL bool) (*planResult, error) {

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 
 	"vitess.io/vitess/go/mysql/collations"
-	"vitess.io/vitess/go/vt/vterrors"
-
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 

--- a/go/vt/vtgate/planbuilder/vstream.go
+++ b/go/vt/vtgate/planbuilder/vstream.go
@@ -20,13 +20,12 @@ import (
 	"strconv"
 	"strings"
 
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 )
 
 const defaultLimit = 100


### PR DESCRIPTION
## Description
This PR fixes an issue in the vtgate planner where an incorrect column reference is used in ORDER BY subquery plans.

### Fix
The planner now correctly uses arguments instead of the column names for subquerie placeholders, ensuring the query works as expected on MySQL.

## Related Issue(s)
Fixes #16110
The regression was introduced in #15039.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
