### PR TITLE
Add DCO workflow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,24 @@
+name: DCO
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Check DCO
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install -U dco-check
+          dco-check --verbose


### PR DESCRIPTION
## Description

As described in https://github.com/dcoapp/app/issues/211, the DCO GitHub app we have been using is down and will remain down for at least a week. This workflow is a temporary workaround to ensure DCO on our PRs and not have to manually verify each commit.

Once merged, we will be able to add the `DCO` workflow to the `required` checks and we will be able to unlock the `main` branch along with all the branches we backport this to.

We must backport this to all branches: `release-17.0`, `release-18.0`, `release-19.0`, `release-20.0`, `release-20.0-rc`.

## Related Issue(s)

- This workaround was found on https://github.com/anchore/syft/pull/2926

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
