### PR TITLE
Add `release-20.0` to the list of branches to upgrade the Go version on

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-20.0, release-19.0, release-18.0, release-17.0, release-16.0 ]
+        branch: [ main, release-20.0, release-19.0, release-18.0, release-17.0 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-19.0, release-18.0, release-17.0, release-16.0 ]
+        branch: [ main, release-20.0, release-19.0, release-18.0, release-17.0, release-16.0 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

This is probably something we should automate with the vitess-releaser.

Just adding `release-20.0` to the list of branches so we get the go upgrade there too automatically.