### PR TITLE
Online DDL flow CI: Update golang version to 1.22.4

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -83,7 +83,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.3
+        go-version: 1.22.4
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'


### PR DESCRIPTION

## Description

Both https://github.com/vitessio/vitess/pull/16017 and https://github.com/vitessio/vitess/pull/16062 merged at about the same time, leading to the Online DDL flow CI test to merge with go `1.22.3` while all the rest of workflows are `1.22.4`.

This updates the go version for that CI workflow.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/16017
- https://github.com/vitessio/vitess/pull/16062

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
