### PR TITLE
Handle single sharded keyspaces for analysis

### DIFF
--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -415,6 +415,16 @@ func TestSchemaDiff(t *testing.T) {
 			instantCapability: InstantDDLCapabilityIrrelevant,
 		},
 		{
+			name: "add view with over",
+			toQueries: append(
+				createQueries,
+				"create view v2 as SELECT *, ROW_NUMBER() OVER(PARTITION BY info) AS row_num1, ROW_NUMBER() OVER(PARTITION BY info ORDER BY id) AS row_num2 FROM t1;\n",
+			),
+			expectDiffs:       1,
+			entityOrder:       []string{"v2"},
+			instantCapability: InstantDDLCapabilityIrrelevant,
+		},
+		{
 			name: "add view, alter table",
 			toQueries: []string{
 				"create table t1 (id int primary key, info int not null);",
@@ -1050,7 +1060,7 @@ func TestSchemaDiff(t *testing.T) {
 				return
 			}
 			if tc.conflictingDiffs > 0 {
-				assert.Error(t, err)
+				require.Error(t, err)
 				impossibleOrderErr, ok := err.(*ImpossibleApplyDiffOrderError)
 				assert.True(t, ok)
 				conflictingDiffsStatements := []string{}

--- a/go/vt/vtgate/semantics/check_invalid.go
+++ b/go/vt/vtgate/semantics/check_invalid.go
@@ -49,11 +49,13 @@ func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
 			return vterrors.VT12001("recursive common table expression")
 		}
 	case *sqlparser.Insert:
-		if node.Action == sqlparser.ReplaceAct {
+		if !a.singleUnshardedKeyspace && node.Action == sqlparser.ReplaceAct {
 			return ShardedError{Inner: &UnsupportedConstruct{errString: "REPLACE INTO with sharded keyspace"}}
 		}
 	case *sqlparser.OverClause:
-		return ShardedError{Inner: &UnsupportedConstruct{errString: "OVER CLAUSE with sharded keyspace"}}
+		if !a.singleUnshardedKeyspace {
+			return ShardedError{Inner: &UnsupportedConstruct{errString: "OVER CLAUSE with sharded keyspace"}}
+		}
 	}
 
 	return nil

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -821,7 +821,7 @@ func singleUnshardedKeyspace(tableInfos []TableInfo) (ks *vindexes.Keyspace, tab
 	return ks, tables
 }
 
-// SingleUnshardedKeyspace returns the single keyspace if all tables in the query are in the same keyspace
+// SingleKeyspace returns the single keyspace if all tables in the query are in the same keyspace
 func (st *SemTable) SingleKeyspace() (ks *vindexes.Keyspace) {
 	validKS := func(this *vindexes.Keyspace) bool {
 		if this == nil {


### PR DESCRIPTION
This fixes the problem where we would throw an error for a query on a single unsharded keyspace, even though the limitation only exists for sharded queries.

The issue here was that the previous `singleUnshardedKeyspace` field was really the field indicating if we could short circuit analysis. `schemadiff` doesn't want to short cut full analysis though, since it does want to know table & column dependencies etc. which would not be computed if analysis can be shortcutted.

Since the `singleUnshardedKeyspace` field was overloaded and really was "can we shortcut" (either because of being in a single sharded keyspace or because of non-strict analysis being requested), we couldn't use that field as a fix to guard the error thrown.

Instead, we now have a proper explicit field `canShortcut` that we use to handle existing shortcut logic.

`singleUnshardedKeyspace` still exists, but now means what it actually implies, which is if this query runs against a single unsharded keyspace, irrespective of whether we can shortcut or not and is correctly set when doing full analysis.

With those changes, we can use `singleUnshardedKeyspace` to guard the error throw for unsupported sharded queries and `schemadiff` works properly as well.

## Related Issue(s)

Fixes #16067 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required