### PR TITLE
`schemadiff`: adding a FK dependency unit test

### DIFF
--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -988,7 +988,7 @@ func TestSchemaDiff(t *testing.T) {
 				"create table t3 (id int primary key, p int, key p_idx (p));",
 			},
 			expectDiffs:       3,
-			expectDeps:        2,
+			expectDeps:        2, // [alter t2]/[drop t1], [alter t2]/[create t3]
 			sequential:        true,
 			entityOrder:       []string{"t3", "t2", "t1"},
 			instantCapability: InstantDDLCapabilityImpossible,

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -978,6 +978,22 @@ func TestSchemaDiff(t *testing.T) {
 			instantCapability: InstantDDLCapabilityImpossible,
 		},
 		{
+			name: "add and drop FK, add and drop respective tables",
+			fromQueries: []string{
+				"create table t1 (id int primary key, p int, key p_idx (p));",
+				"create table t2 (id int primary key, p int, key p_idx (p), foreign key (p) references t1 (p) on delete no action);",
+			},
+			toQueries: []string{
+				"create table t2 (id int primary key, p int, key p_idx (p), foreign key (p) references t3 (p) on delete no action);",
+				"create table t3 (id int primary key, p int, key p_idx (p));",
+			},
+			expectDiffs:       3,
+			expectDeps:        2,
+			sequential:        true,
+			entityOrder:       []string{"t3", "t2", "t1"},
+			instantCapability: InstantDDLCapabilityImpossible,
+		},
+		{
 			name: "two identical foreign keys in table, drop one",
 			fromQueries: []string{
 				"create table parent (id int primary key)",
@@ -1051,7 +1067,7 @@ func TestSchemaDiff(t *testing.T) {
 			for _, dep := range deps {
 				depsKeys = append(depsKeys, dep.hashKey())
 			}
-			assert.Equalf(t, tc.expectDeps, len(deps), "found deps: %v", depsKeys)
+			assert.Equalf(t, tc.expectDeps, len(deps), "found %v deps: %v", len(depsKeys), depsKeys)
 			assert.Equal(t, tc.sequential, schemaDiff.HasSequentialExecutionDependencies())
 
 			orderedDiffs, err := schemaDiff.OrderedDiffs(ctx)


### PR DESCRIPTION
## Description

This PR adds a `schemadiff` unit test for a multi-table add/alter/drop scenario, where we expect a specific sequential ordering of statements.

## Related Issue(s)

No related issue in particular. This is a test of interest.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
