### PR TITLE
Fix schemadiff semantics handling

### DIFF
--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -415,13 +415,15 @@ func TestSchemaDiff(t *testing.T) {
 			instantCapability: InstantDDLCapabilityIrrelevant,
 		},
 		{
-			name: "add view with over",
+			name: "add view with over and keyword table",
 			toQueries: append(
 				createQueries,
-				"create view v2 as SELECT *, ROW_NUMBER() OVER(PARTITION BY info) AS row_num1, ROW_NUMBER() OVER(PARTITION BY info ORDER BY id) AS row_num2 FROM t1;\n",
+				"create table `order` (id int primary key, info int not null);",
+				"create view v2 as SELECT *, ROW_NUMBER() OVER(PARTITION BY info) AS row_num1, ROW_NUMBER() OVER(PARTITION BY info ORDER BY id) AS row_num2 FROM `order`;",
 			),
-			expectDiffs:       1,
-			entityOrder:       []string{"v2"},
+			expectDiffs:       2,
+			expectDeps:        1,
+			entityOrder:       []string{"order", "v2"},
 			instantCapability: InstantDDLCapabilityIrrelevant,
 		},
 		{

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -125,6 +125,15 @@ func TestNewSchemaFromQueriesUnresolved(t *testing.T) {
 	assert.Equal(t, "CREATE VIEW `v7` AS SELECT * FROM `v8`, `t2`", v.Create().CanonicalStatementString())
 }
 
+func TestNewSchemaFromQueriesWithSQLKeyword(t *testing.T) {
+	queries := []string{
+		"create table `order` (id int primary key, info int not null)",
+		"create view v2 as SELECT *, ROW_NUMBER() OVER(PARTITION BY info) AS row_num1, ROW_NUMBER() OVER(PARTITION BY info ORDER BY id) AS row_num2 FROM `order`;",
+	}
+	_, err := NewSchemaFromQueries(NewTestEnv(), queries)
+	assert.NoError(t, err)
+}
+
 func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
 	// v8 does not exist
 	queries := append(schemaTestCreateQueries,

--- a/go/vt/schemadiff/semantics.go
+++ b/go/vt/schemadiff/semantics.go
@@ -51,7 +51,7 @@ func newDeclarativeSchemaInformation(env *Environment) *declarativeSchemaInforma
 
 // FindTableOrVindex implements the SchemaInformation interface
 func (si *declarativeSchemaInformation) FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, string, topodatapb.TabletType, key.Destination, error) {
-	table := si.Tables[sqlparser.String(tablename)]
+	table := si.Tables[tablename.Name.String()]
 	return table, nil, "", 0, nil, nil
 }
 


### PR DESCRIPTION
The problem here is that we store entries in `.Tables` with their unescaped names, which is entirely safe to do here.

However, we would use `sqlparser.String` to retrieve them. Now that normally works for table names, unless a table name is a SQL keyword. In that case, it turns into the escaped version with backticks and the whole table can't be found for semantic analysis.

This can happen for example if you name a table `Order`.

## Related Issue(s)

Fixes #16072 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
