### PR TITLE
refactor: cleaner cloning API

### DIFF
--- a/go/test/endtoend/vtgate/queries/random/query_gen.go
+++ b/go/test/endtoend/vtgate/queries/random/query_gen.go
@@ -132,7 +132,7 @@ func (t *tableT) addColumns(col ...column) {
 
 func (t *tableT) clone() *tableT {
 	return &tableT{
-		tableExpr: sqlparser.CloneSimpleTableExpr(t.tableExpr),
+		tableExpr: sqlparser.Clone(t.tableExpr),
 		alias:     t.alias,
 		cols:      slices.Clone(t.cols),
 	}

--- a/go/test/fuzzing/ast_fuzzer.go
+++ b/go/test/fuzzing/ast_fuzzer.go
@@ -61,7 +61,7 @@ func FuzzEqualsSQLNode(data []byte) int {
 	}
 
 	// Target 2:
-	newSQLNode := sqlparser.CloneSQLNode(inA)
+	newSQLNode := sqlparser.Clone(inA)
 	if !sqlparser.EqualsSQLNode(inA, newSQLNode) {
 		panic("These two nodes should be identical")
 	}

--- a/go/vt/schema/online_ddl.go
+++ b/go/vt/schema/online_ddl.go
@@ -288,7 +288,7 @@ func OnlineDDLFromCommentedStatement(stmt sqlparser.Statement) (onlineDDL *Onlin
 	// We clone the comments because they will end up being cached by the query planner. Then, the Directive() function actually modifies the comments.
 	// If comments are shared in cache, and Directive() modifies it, then we have a concurrency issue when someone else wants to read the comments.
 	// By cloning the comments we remove the concurrency problem.
-	comments = sqlparser.CloneRefOfParsedComments(comments)
+	comments = sqlparser.Clone(comments)
 	comments.ResetDirectives()
 
 	if comments.Length() == 0 {

--- a/go/vt/schemadiff/capability.go
+++ b/go/vt/schemadiff/capability.go
@@ -74,7 +74,7 @@ func alterOptionCapableOfInstantDDL(alterOption sqlparser.AlterOption, createTab
 		return true, col.Type.Options.Storage
 	}
 	colStringStrippedDown := func(col *sqlparser.ColumnDefinition, stripDefault bool, stripEnum bool) string {
-		strippedCol := sqlparser.CloneRefOfColumnDefinition(col)
+		strippedCol := sqlparser.Clone(col)
 		if stripDefault {
 			strippedCol.Type.Options.Default = nil
 			strippedCol.Type.Options.DefaultLiteral = false

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1079,8 +1079,8 @@ func (s *Schema) getViewColumnNames(v *CreateViewEntity, schemaInformation *decl
 		case *sqlparser.StarExpr:
 			if tableName := node.TableName.Name.String(); tableName != "" {
 				for _, col := range schemaInformation.Tables[tableName].Columns {
-					name := sqlparser.Clone(&col.Name)
-					columnNames = append(columnNames, name)
+					name := sqlparser.Clone(col.Name)
+					columnNames = append(columnNames, &name)
 				}
 			} else {
 				dependentNames := getViewDependentTableNames(v.CreateView)
@@ -1088,8 +1088,8 @@ func (s *Schema) getViewColumnNames(v *CreateViewEntity, schemaInformation *decl
 				for _, entityName := range dependentNames {
 					if schemaInformation.Tables[entityName] != nil { // is nil for dual/DUAL
 						for _, col := range schemaInformation.Tables[entityName].Columns {
-							name := sqlparser.Clone(&col.Name)
-							columnNames = append(columnNames, name)
+							name := sqlparser.Clone(col.Name)
+							columnNames = append(columnNames, &name)
 						}
 					}
 				}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1014,7 +1014,7 @@ func (s *Schema) ValidateViewReferences() error {
 	schemaInformation.addTable("dual")
 
 	for _, view := range s.Views() {
-		sel := sqlparser.CloneSelectStatement(view.CreateView.Select) // Analyze(), below, rewrites the select; we don't want to actually modify the schema
+		sel := sqlparser.Clone(view.CreateView.Select) // Analyze(), below, rewrites the select; we don't want to actually modify the schema
 		_, err := semantics.AnalyzeStrict(sel, semanticKS.Name, schemaInformation)
 		formalizeErr := func(err error) error {
 			if err == nil {
@@ -1079,7 +1079,7 @@ func (s *Schema) getViewColumnNames(v *CreateViewEntity, schemaInformation *decl
 		case *sqlparser.StarExpr:
 			if tableName := node.TableName.Name.String(); tableName != "" {
 				for _, col := range schemaInformation.Tables[tableName].Columns {
-					name := sqlparser.CloneRefOfIdentifierCI(&col.Name)
+					name := sqlparser.Clone(&col.Name)
 					columnNames = append(columnNames, name)
 				}
 			} else {
@@ -1088,7 +1088,7 @@ func (s *Schema) getViewColumnNames(v *CreateViewEntity, schemaInformation *decl
 				for _, entityName := range dependentNames {
 					if schemaInformation.Tables[entityName] != nil { // is nil for dual/DUAL
 						for _, col := range schemaInformation.Tables[entityName].Columns {
-							name := sqlparser.CloneRefOfIdentifierCI(&col.Name)
+							name := sqlparser.Clone(&col.Name)
 							columnNames = append(columnNames, name)
 						}
 					}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -146,7 +146,7 @@ func (d *AlterTableEntityDiff) Clone() EntityDiff {
 	}
 	ann := *d.annotations
 	clone := &AlterTableEntityDiff{
-		alterTable:           sqlparser.CloneRefOfAlterTable(d.alterTable),
+		alterTable:           sqlparser.Clone(d.alterTable),
 		instantDDLCapability: d.instantDDLCapability,
 		annotations:          &ann,
 	}
@@ -245,7 +245,7 @@ func (d *CreateTableEntityDiff) Clone() EntityDiff {
 		return nil
 	}
 	clone := &CreateTableEntityDiff{
-		createTable: sqlparser.CloneRefOfCreateTable(d.createTable),
+		createTable: sqlparser.Clone(d.createTable),
 	}
 	if d.to != nil {
 		clone.to = d.to.Clone().(*CreateTableEntity)
@@ -336,7 +336,7 @@ func (d *DropTableEntityDiff) Clone() EntityDiff {
 		return nil
 	}
 	clone := &DropTableEntityDiff{
-		dropTable: sqlparser.CloneRefOfDropTable(d.dropTable),
+		dropTable: sqlparser.Clone(d.dropTable),
 	}
 	if d.from != nil {
 		clone.from = d.from.Clone().(*CreateTableEntity)
@@ -428,7 +428,7 @@ func (d *RenameTableEntityDiff) Clone() EntityDiff {
 		return nil
 	}
 	clone := &RenameTableEntityDiff{
-		renameTable: sqlparser.CloneRefOfRenameTable(d.renameTable),
+		renameTable: sqlparser.Clone(d.renameTable),
 	}
 	if d.from != nil {
 		clone.from = d.from.Clone().(*CreateTableEntity)
@@ -526,7 +526,7 @@ func (c *CreateTableEntity) GetCollation() string {
 }
 
 func (c *CreateTableEntity) Clone() Entity {
-	return &CreateTableEntity{CreateTable: sqlparser.CloneRefOfCreateTable(c.CreateTable), Env: c.Env}
+	return &CreateTableEntity{CreateTable: sqlparser.Clone(c.CreateTable), Env: c.Env}
 }
 
 func getTableCharsetCollate(env *Environment, tableOptions *sqlparser.TableOptions) *charsetCollate {
@@ -1601,8 +1601,8 @@ func (c *CreateTableEntity) diffKeys(alterTable *sqlparser.AlterTable,
 // Returns if this is a visibility only change and if true, whether
 // the new visibility is invisible or not.
 func indexOnlyVisibilityChange(t1Key, t2Key *sqlparser.IndexDefinition) (bool, bool) {
-	t1KeyCopy := sqlparser.CloneRefOfIndexDefinition(t1Key)
-	t2KeyCopy := sqlparser.CloneRefOfIndexDefinition(t2Key)
+	t1KeyCopy := sqlparser.Clone(t1Key)
+	t2KeyCopy := sqlparser.Clone(t2Key)
 	t1KeyKeptOptions := make([]*sqlparser.IndexOption, 0, len(t1KeyCopy.Options))
 	t2KeyInvisible := false
 	for _, opt := range t1KeyCopy.Options {

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -106,7 +106,7 @@ func (d *AlterViewEntityDiff) Clone() EntityDiff {
 		return nil
 	}
 	clone := &AlterViewEntityDiff{
-		alterView: sqlparser.CloneRefOfAlterView(d.alterView),
+		alterView: sqlparser.Clone(d.alterView),
 	}
 	if d.from != nil {
 		clone.from = d.from.Clone().(*CreateViewEntity)
@@ -200,7 +200,7 @@ func (d *CreateViewEntityDiff) Clone() EntityDiff {
 		return nil
 	}
 	return &CreateViewEntityDiff{
-		createView: sqlparser.CloneRefOfCreateView(d.createView),
+		createView: sqlparser.Clone(d.createView),
 	}
 }
 
@@ -287,7 +287,7 @@ func (d *DropViewEntityDiff) Clone() EntityDiff {
 		return nil
 	}
 	clone := &DropViewEntityDiff{
-		dropView: sqlparser.CloneRefOfDropView(d.dropView),
+		dropView: sqlparser.Clone(d.dropView),
 	}
 	if d.from != nil {
 		clone.from = d.from.Clone().(*CreateViewEntity)
@@ -402,7 +402,7 @@ func (c *CreateViewEntity) Apply(diff EntityDiff) (Entity, error) {
 }
 
 func (c *CreateViewEntity) Clone() Entity {
-	return &CreateViewEntity{CreateView: sqlparser.CloneRefOfCreateView(c.CreateView)}
+	return &CreateViewEntity{CreateView: sqlparser.Clone(c.CreateView)}
 }
 
 func (c *CreateViewEntity) identicalOtherThanName(other *CreateViewEntity) bool {

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2776,3 +2776,8 @@ func (lock Lock) GetHighestOrderLock(newLock Lock) Lock {
 	}
 	return lock
 }
+
+// Clone returns a deep copy of the SQLNode, typed as the original type
+func Clone[K SQLNode](x K) K {
+	return CloneSQLNode(x).(K)
+}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1592,7 +1592,7 @@ func (e *Executor) planPrepareStmt(ctx context.Context, vcursor *vcursorImpl, qu
 		ctx,
 		vcursor,
 		query,
-		sqlparser.CloneStatement(stmt),
+		sqlparser.Clone(stmt),
 		vcursor.marginComments,
 		map[string]*querypb.BindVariable{},
 		reservedVars, /* normalize */

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -210,7 +210,7 @@ func buildCreateViewCommon(
 	// because we don't trust the schema tracker to have up-to-date info, we don't want to expand any SELECT * here
 	var expressions []sqlparser.SelectExprs
 	_ = sqlparser.VisitAllSelects(ddlSelect, func(p *sqlparser.Select, idx int) error {
-		expressions = append(expressions, sqlparser.CloneSelectExprs(p.SelectExprs))
+		expressions = append(expressions, sqlparser.Clone(p.SelectExprs))
 		return nil
 	})
 	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddlSelect), ddlSelect, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -628,7 +628,7 @@ func splitAvgAggregations(ctx *plancontext.PlanningContext, aggr *Aggregator) (O
 
 		outputColumn := aeWrap(col.Expr)
 		outputColumn.As = sqlparser.NewIdentifierCI(col.ColumnName())
-		proj.addUnexploredExpr(sqlparser.CloneRefOfAliasedExpr(col), calcExpr)
+		proj.addUnexploredExpr(sqlparser.Clone(col), calcExpr)
 		col.Expr = sumExpr
 		found := false
 		for aggrOffset, aggregation := range aggr.Aggregations {

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
@@ -266,7 +266,7 @@ func (p *joinPusher) countStar(ctx *plancontext.PlanningContext) (*sqlparser.Ali
 // It returns the expression of the aggregation as it should be used in the parent Aggregator.
 func (p *joinPusher) addAggr(ctx *plancontext.PlanningContext, aggr Aggr) sqlparser.Expr {
 	copyAggr := aggr
-	expr := sqlparser.CloneExpr(aggr.Original.Expr)
+	expr := sqlparser.Clone(aggr.Original.Expr)
 	copyAggr.Original = aeWrap(expr)
 	// copy dependencies so we can keep track of which side expressions need to be pushed to
 	ctx.SemTable.Direct[expr] = p.tableID
@@ -291,7 +291,7 @@ func (p *joinPusher) pushThroughAggr(aggr Aggr) {
 // It returns the expression of the GroupBy as it should be used in the parent Aggregator.
 func (p *joinPusher) addGrouping(ctx *plancontext.PlanningContext, gb GroupBy) sqlparser.Expr {
 	copyGB := gb
-	expr := sqlparser.CloneExpr(gb.Inner)
+	expr := sqlparser.Clone(gb.Inner)
 	// copy dependencies so we can keep track of which side expressions need to be pushed to
 	ctx.SemTable.CopyDependencies(gb.Inner, expr)
 	// if the column exists in the selection then copy it down to the pushed aggregator operator.

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -73,7 +73,7 @@ func createOperatorFromDelete(ctx *plancontext.PlanningContext, deleteStmt *sqlp
 		return createDeleteWithInputOp(ctx, deleteStmt)
 	}
 
-	delClone := sqlparser.CloneRefOfDelete(deleteStmt)
+	delClone := sqlparser.Clone(deleteStmt)
 	var vTbl *vindexes.Table
 	op, vTbl = createDeleteOperator(ctx, deleteStmt)
 
@@ -315,7 +315,7 @@ func addOrdering(ctx *plancontext.PlanningContext, orderBy sqlparser.OrderBy, op
 			continue
 		}
 		ordering.Order = append(ordering.Order, OrderBy{
-			Inner:          sqlparser.CloneRefOfOrder(order),
+			Inner:          sqlparser.Clone(order),
 			SimplifiedExpr: order.Expr,
 		})
 	}

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -59,7 +59,7 @@ func newHorizon(src Operator, query sqlparser.SelectStatement) *Horizon {
 func (h *Horizon) Clone(inputs []Operator) Operator {
 	klone := *h
 	klone.Source = inputs[0]
-	klone.ColumnAliases = sqlparser.CloneColumns(h.ColumnAliases)
+	klone.ColumnAliases = sqlparser.Clone(h.ColumnAliases)
 	klone.Columns = slices.Clone(h.Columns)
 	klone.ColumnsOffset = slices.Clone(h.ColumnsOffset)
 	klone.QP = h.QP

--- a/go/vt/vtgate/planbuilder/operators/insert.go
+++ b/go/vt/vtgate/planbuilder/operators/insert.go
@@ -135,7 +135,7 @@ func createOperatorFromInsert(ctx *plancontext.PlanningContext, ins *sqlparser.I
 
 	delStmt := &sqlparser.Delete{
 		Comments:   ins.Comments,
-		TableExprs: sqlparser.TableExprs{sqlparser.CloneRefOfAliasedTableExpr(ins.Table)},
+		TableExprs: sqlparser.TableExprs{sqlparser.Clone(ins.Table)},
 		Where:      sqlparser.NewWhere(sqlparser.WhereClause, whereExpr),
 	}
 	delOp := createOpFromStmt(ctx, delStmt, false, "")

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -36,7 +36,7 @@ type Limit struct {
 func (l *Limit) Clone(inputs []Operator) Operator {
 	return &Limit{
 		Source: inputs[0],
-		AST:    sqlparser.CloneRefOfLimit(l.AST),
+		AST:    sqlparser.Clone(l.AST),
 		Top:    l.Top,
 		Pushed: l.Pushed,
 	}

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -176,8 +176,8 @@ func createDMLWithInput(ctx *plancontext.PlanningContext, op, src Operator, in *
 	targetQT := targetTable.QTable
 	qt := &QueryTable{
 		ID:         targetQT.ID,
-		Alias:      sqlparser.CloneRefOfAliasedTableExpr(targetQT.Alias),
-		Table:      sqlparser.CloneTableName(targetQT.Table),
+		Alias:      sqlparser.Clone(targetQT.Alias),
+		Table:      sqlparser.Clone(targetQT.Table),
 		Predicates: []sqlparser.Expr{compExpr},
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -111,7 +111,7 @@ type (
 
 func newProjExpr(ae *sqlparser.AliasedExpr) *ProjExpr {
 	return &ProjExpr{
-		Original: sqlparser.CloneRefOfAliasedExpr(ae),
+		Original: sqlparser.Clone(ae),
 		EvalExpr: ae.Expr,
 		ColExpr:  ae.Expr,
 	}

--- a/go/vt/vtgate/planbuilder/operators/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/projection_pushing.go
@@ -327,7 +327,7 @@ func splitUnexploredExpression(
 	alias string,
 	dt *DerivedTable,
 ) applyJoinColumn {
-	original := sqlparser.CloneRefOfAliasedExpr(pe.Original)
+	original := sqlparser.Clone(pe.Original)
 	expr := pe.ColExpr
 
 	var colName *sqlparser.ColName

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -34,7 +34,7 @@ func planQuery(ctx *plancontext.PlanningContext, root Operator) Operator {
 	var selExpr sqlparser.SelectExprs
 	if horizon, isHorizon := root.(*Horizon); isHorizon {
 		sel := sqlparser.GetFirstSelect(horizon.Query)
-		selExpr = sqlparser.CloneSelectExprs(sel.SelectExprs)
+		selExpr = sqlparser.Clone(sel.SelectExprs)
 	}
 
 	output := runPhases(ctx, root)
@@ -252,7 +252,7 @@ func tryPushLimit(ctx *plancontext.PlanningContext, in *Limit) (Operator, *Apply
 }
 
 func createPushedLimit(ctx *plancontext.PlanningContext, src Operator, orig *Limit) Operator {
-	pushedLimit := sqlparser.CloneRefOfLimit(orig.AST)
+	pushedLimit := sqlparser.Clone(orig.AST)
 	if pushedLimit.Offset != nil {
 		// we can't push down an offset, so we need to convert it to a rowcount
 		// by adding it to the already existing rowcount, and then let the LIMIT running on the vtgate do the rest

--- a/go/vt/vtgate/planbuilder/operators/querygraph.go
+++ b/go/vt/vtgate/planbuilder/operators/querygraph.go
@@ -190,8 +190,8 @@ func (qg *QueryGraph) AddPredicate(ctx *plancontext.PlanningContext, expr sqlpar
 func (qt *QueryTable) Clone() *QueryTable {
 	return &QueryTable{
 		ID:          qt.ID,
-		Alias:       sqlparser.CloneRefOfAliasedTableExpr(qt.Alias),
-		Table:       sqlparser.CloneTableName(qt.Table),
+		Alias:       sqlparser.Clone(qt.Alias),
+		Table:       sqlparser.Clone(qt.Table),
 		Predicates:  qt.Predicates,
 		IsInfSchema: qt.IsInfSchema,
 	}

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -124,7 +124,7 @@ func (sq *SubQuery) Clone(inputs []Operator) Operator {
 	}
 	klone.JoinColumns = slices.Clone(sq.JoinColumns)
 	klone.Vars = maps.Clone(sq.Vars)
-	klone.Predicates = sqlparser.CloneExprs(sq.Predicates)
+	klone.Predicates = sqlparser.Clone(sq.Predicates)
 	return &klone
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -297,7 +297,7 @@ func (sqb *SubQueryBuilder) pullOutValueSubqueries(
 	outerID semantics.TableSet,
 	isDML bool,
 ) (sqlparser.Expr, []*SubQuery) {
-	original := sqlparser.CloneExpr(expr)
+	original := sqlparser.Clone(expr)
 	sqe := extractSubQueries(ctx, expr, isDML)
 	if sqe == nil {
 		return nil, nil

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -45,7 +45,7 @@ type (
 func (to *Table) Clone([]Operator) Operator {
 	var columns []*sqlparser.ColName
 	for _, name := range to.Columns {
-		columns = append(columns, sqlparser.CloneRefOfColName(name))
+		columns = append(columns, sqlparser.Clone(name))
 	}
 	return &Table{
 		QTable:  to.QTable,

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -338,7 +338,7 @@ func createUpdateOperator(ctx *plancontext.PlanningContext, updStmt *sqlparser.U
 	// updClone is used in foreign key planning to create the selection statements to be used for verification and selection.
 	// If we encounter subqueries, we want to fix the updClone to use the replaced expression, so that the pulled out subquery's
 	// result is used everywhere instead of running the subquery multiple times, which is wasteful.
-	updClone := sqlparser.CloneRefOfUpdate(updStmt)
+	updClone := sqlparser.Clone(updStmt)
 	var tblInfo semantics.TableInfo
 	var err error
 	for idx, updExpr := range updStmt.Exprs {
@@ -346,7 +346,7 @@ func createUpdateOperator(ctx *plancontext.PlanningContext, updStmt *sqlparser.U
 		if len(subqs) == 0 {
 			expr = updExpr.Expr
 		} else {
-			updClone.Exprs[idx].Expr = sqlparser.CloneExpr(expr)
+			updClone.Exprs[idx].Expr = sqlparser.Clone(expr)
 			ctx.SemTable.UpdateChildFKExpr(updExpr, expr)
 		}
 		proj := newProjExpr(aeWrap(expr))

--- a/go/vt/vtgate/planbuilder/operators/upsert.go
+++ b/go/vt/vtgate/planbuilder/operators/upsert.go
@@ -129,7 +129,7 @@ func createUpsertOperator(ctx *plancontext.PlanningContext, ins *sqlparser.Inser
 		updOp := createOpFromStmt(ctx, upd, false, "")
 
 		// replan insert statement without on duplicate key update.
-		newInsert := sqlparser.CloneRefOfInsert(ins)
+		newInsert := sqlparser.Clone(ins)
 		newInsert.OnDup = nil
 		newInsert.Rows = sqlparser.Values{row}
 		insOp = createOpFromStmt(ctx, newInsert, false, "")

--- a/go/vt/vtgate/planbuilder/simplifier_test.go
+++ b/go/vt/vtgate/planbuilder/simplifier_test.go
@@ -45,7 +45,7 @@ func TestSimplifyBuggyQuery(t *testing.T) {
 	}
 	stmt, reserved, err := sqlparser.NewTestParser().Parse2(query)
 	require.NoError(t, err)
-	rewritten, _ := sqlparser.RewriteAST(sqlparser.CloneStatement(stmt), vschema.CurrentDb(), sqlparser.SQLSelectLimitUnset, "", nil, nil, nil)
+	rewritten, _ := sqlparser.RewriteAST(sqlparser.Clone(stmt), vschema.CurrentDb(), sqlparser.SQLSelectLimitUnset, "", nil, nil, nil)
 	reservedVars := sqlparser.NewReservedVars("vtg", reserved)
 
 	simplified := simplifier.SimplifyStatement(
@@ -68,7 +68,7 @@ func TestSimplifyPanic(t *testing.T) {
 	}
 	stmt, reserved, err := sqlparser.NewTestParser().Parse2(query)
 	require.NoError(t, err)
-	rewritten, _ := sqlparser.RewriteAST(sqlparser.CloneStatement(stmt), vschema.CurrentDb(), sqlparser.SQLSelectLimitUnset, "", nil, nil, nil)
+	rewritten, _ := sqlparser.RewriteAST(sqlparser.Clone(stmt), vschema.CurrentDb(), sqlparser.SQLSelectLimitUnset, "", nil, nil, nil)
 	reservedVars := sqlparser.NewReservedVars("vtg", reserved)
 
 	simplified := simplifier.SimplifyStatement(

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -493,7 +493,7 @@ func (r *earlyRewriter) rewriteAliasesInGroupBy(node sqlparser.Expr, sel *sqlpar
 				return
 			}
 
-			cursor.Replace(sqlparser.CloneExpr(item.expr))
+			cursor.Replace(sqlparser.Clone(item.expr))
 		}
 	}, nil)
 

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -966,7 +966,7 @@ func (st *SemTable) Clone(n sqlparser.SQLNode) sqlparser.SQLNode {
 		if !isExpr {
 			return
 		}
-		cursor.Replace(sqlparser.CloneExpr(expr))
+		cursor.Replace(sqlparser.Clone(expr))
 	}, st.CopySemanticInfo)
 }
 

--- a/go/vt/vtgate/simplifier/expression_simplifier.go
+++ b/go/vt/vtgate/simplifier/expression_simplifier.go
@@ -29,14 +29,14 @@ type CheckF = func(sqlparser.Expr) bool
 
 func SimplifyExpr(in sqlparser.Expr, test CheckF) sqlparser.Expr {
 	// since we can't rewrite the top level, wrap the expr in an Exprs object
-	smallestKnown := sqlparser.Exprs{sqlparser.CloneExpr(in)}
+	smallestKnown := sqlparser.Exprs{sqlparser.Clone(in)}
 
 	alwaysVisit := func(node, parent sqlparser.SQLNode) bool {
 		return true
 	}
 
 	up := func(cursor *sqlparser.Cursor) bool {
-		node := sqlparser.CloneSQLNode(cursor.Node())
+		node := sqlparser.Clone(cursor.Node())
 		s := &shrinker{orig: node}
 		expr := s.Next()
 		for expr != nil {
@@ -57,7 +57,7 @@ func SimplifyExpr(in sqlparser.Expr, test CheckF) sqlparser.Expr {
 
 	// loop until rewriting introduces no more changes
 	for {
-		prevSmallest := sqlparser.CloneExprs(smallestKnown)
+		prevSmallest := sqlparser.Clone(smallestKnown)
 		sqlparser.SafeRewrite(smallestKnown, alwaysVisit, up)
 		if sqlparser.Equals.Exprs(prevSmallest, smallestKnown) {
 			break
@@ -185,7 +185,7 @@ func (s *shrinker) fillQueue() bool {
 			s.queue = append(s.queue, ae)
 		}
 
-		clone := sqlparser.CloneAggrFunc(e)
+		clone := sqlparser.Clone(e)
 		if da, ok := clone.(sqlparser.DistinctableAggr); ok {
 			if da.IsDistinct() {
 				da.SetDistinct(false)

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1242,7 +1242,7 @@ func (vschema *VSchema) FindView(keyspace, name string) sqlparser.SelectStatemen
 	}
 
 	// We do this to make sure there is no shared state between uses of this AST
-	statement = sqlparser.CloneSelectStatement(statement)
+	statement = sqlparser.Clone(statement)
 	sqlparser.SafeRewrite(statement, nil, func(cursor *sqlparser.Cursor) bool {
 		col, ok := cursor.Node().(*sqlparser.ColName)
 		if ok {

--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -213,7 +213,7 @@ func (vm *VSchemaManager) updateViewInfo(ks *vindexes.KeyspaceSchema, ksName str
 	if views != nil {
 		ks.Views = make(map[string]sqlparser.SelectStatement, len(views))
 		for name, def := range views {
-			ks.Views[name] = sqlparser.CloneSelectStatement(def)
+			ks.Views[name] = sqlparser.Clone(def)
 		}
 	}
 }

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1402,7 +1402,7 @@ func (e *Executor) duplicateCreateTable(ctx context.Context, onlineDDL *schema.O
 	if !ok {
 		return nil, nil, nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "expected CreateTable statement, got: %v", sqlparser.CanonicalString(stmt))
 	}
-	newCreateTable = sqlparser.CloneRefOfCreateTable(originalCreateTable)
+	newCreateTable = sqlparser.Clone(originalCreateTable)
 	newCreateTable.SetTable(newCreateTable.GetTable().Qualifier.CompliantName(), newTableName)
 	// manipulate CreateTable statement: take care of constraints names which have to be
 	// unique across the schema
@@ -3033,7 +3033,7 @@ func (e *Executor) executeCreateDDLActionMigration(ctx context.Context, onlineDD
 		}
 	}
 	if originalCreateTable, ok := ddlStmt.(*sqlparser.CreateTable); ok {
-		newCreateTable := sqlparser.CloneRefOfCreateTable(originalCreateTable)
+		newCreateTable := sqlparser.Clone(originalCreateTable)
 		// Rewrite this CREATE TABLE statement such that CONSTRAINT names are edited,
 		// specifically removing any <tablename> prefix.
 		if _, err := e.validateAndEditCreateTableStatement(onlineDDL, newCreateTable); err != nil {
@@ -3117,7 +3117,7 @@ func (e *Executor) executeAlterViewOnline(ctx context.Context, onlineDDL *schema
 			Select:      viewStmt.Select,
 			CheckOption: viewStmt.CheckOption,
 			IsReplace:   true,
-			Comments:    sqlparser.CloneRefOfParsedComments(viewStmt.Comments),
+			Comments:    sqlparser.Clone(viewStmt.Comments),
 		}
 		stmt.SetTable("", artifactViewName)
 	default:


### PR DESCRIPTION
### Refactor: Simplify Clone Usage with Generics

#### Summary
This PR refactors the codebase to use a more generic `Clone` method, eliminating the need to specify exact types when cloning various structures. This makes the code cleaner and more maintainable.

#### Changes
- Updated various usages of specific clone methods (e.g., `CloneSimpleTableExpr`, `CloneSQLNode`, `CloneRefOfParsedComments`, `CloneRefOfColumnDefinition`, etc.) to use the generic `sqlparser.Clone`.

#### Rationale
Using a generic `Clone` method reduces redundancy and potential for errors. It also enhances the maintainability of the code by centralizing cloning logic.

#### Impact
This refactor should have no functional impact on existing features but will make the code easier to work with.
