### PR TITLE
VTCombo: Ensure VSchema exists when creating keyspace

### DIFF
--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -168,7 +168,7 @@ func assertVSchemaExists(t *testing.T, grpcAddress string) {
 	log.Infof("Running vtctldclient with command: %v", tmpCmd.Args)
 
 	output, err := tmpCmd.CombinedOutput()
-	require.Nil(t, err, fmt.Sprintf("Output:\n%v", string(output)))
+	require.NoError(t, err, fmt.Sprintf("Output:\n%v", string(output)))
 
 	assert.Equal(t, "{}\n", string(output))
 }

--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -130,6 +130,8 @@ func TestStandalone(t *testing.T) {
 	tmp, _ := cmd.([]any)
 	require.Contains(t, tmp[0], "vtcombo")
 
+	assertVSchemaExists(t, grpcAddress)
+
 	ctx := context.Background()
 	conn, err := vtgateconn.Dial(ctx, grpcAddress)
 	require.NoError(t, err)
@@ -158,6 +160,17 @@ func TestStandalone(t *testing.T) {
 	assertInsertedRowsExist(ctx, t, conn, idStart, rowCount)
 	assertTabletsPresent(t)
 	assertTransactionalityAndRollbackObeyed(ctx, t, conn, idStart)
+}
+
+func assertVSchemaExists(t *testing.T, grpcAddress string) {
+	tmpCmd := exec.Command("vtctldclient", "--server", grpcAddress, "--compact", "GetVSchema", "routed")
+
+	log.Infof("Running vtctldclient with command: %v", tmpCmd.Args)
+
+	output, err := tmpCmd.CombinedOutput()
+	require.Nil(t, err, fmt.Sprintf("Output:\n%v", string(output)))
+
+	assert.Equal(t, "{}\n", string(output))
 }
 
 func assertInsertedRowsExist(ctx context.Context, t *testing.T, conn *vtgateconn.VTGateConn, idStart, rowCount int) {

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -322,6 +322,11 @@ func CreateKs(
 		return 0, fmt.Errorf("CreateKeyspace(%v) failed: %v", keyspace, err)
 	}
 
+	// make sure a valid vschema has been loaded
+	if err := ts.EnsureVSchema(ctx, keyspace); err != nil {
+		return 0, fmt.Errorf("EnsureVSchema(%v) failed: %v", keyspace, err)
+	}
+
 	// iterate through the shards
 	for _, spb := range kpb.Shards {
 		shard := spb.Name


### PR DESCRIPTION
## Description

Ensures that a VSchema exists whenever a keyspace is created by VTCombo

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/16088

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None