### PR TITLE
vtctldclient: Apply (Shard | Keyspace| Table) Routing Rules commands don't work

### DIFF
--- a/go/cmd/vtctldclient/command/keyspace_routing_rules.go
+++ b/go/cmd/vtctldclient/command/keyspace_routing_rules.go
@@ -82,7 +82,7 @@ func commandApplyKeyspaceRoutingRules(cmd *cobra.Command, args []string) error {
 	}
 
 	krr := &vschemapb.KeyspaceRoutingRules{}
-	if err := json2.Unmarshal(rulesBytes, krr); err != nil {
+	if err := json2.UnmarshalPB(rulesBytes, krr); err != nil {
 		return err
 	}
 

--- a/go/cmd/vtctldclient/command/keyspace_routing_rules.go
+++ b/go/cmd/vtctldclient/command/keyspace_routing_rules.go
@@ -82,7 +82,7 @@ func commandApplyKeyspaceRoutingRules(cmd *cobra.Command, args []string) error {
 	}
 
 	krr := &vschemapb.KeyspaceRoutingRules{}
-	if err := json2.Unmarshal(rulesBytes, &krr); err != nil {
+	if err := json2.Unmarshal(rulesBytes, krr); err != nil {
 		return err
 	}
 

--- a/go/cmd/vtctldclient/command/routing_rules.go
+++ b/go/cmd/vtctldclient/command/routing_rules.go
@@ -82,7 +82,7 @@ func commandApplyRoutingRules(cmd *cobra.Command, args []string) error {
 	}
 
 	rr := &vschemapb.RoutingRules{}
-	if err := json2.Unmarshal(rulesBytes, &rr); err != nil {
+	if err := json2.Unmarshal(rulesBytes, rr); err != nil {
 		return err
 	}
 

--- a/go/cmd/vtctldclient/command/routing_rules.go
+++ b/go/cmd/vtctldclient/command/routing_rules.go
@@ -82,7 +82,7 @@ func commandApplyRoutingRules(cmd *cobra.Command, args []string) error {
 	}
 
 	rr := &vschemapb.RoutingRules{}
-	if err := json2.Unmarshal(rulesBytes, rr); err != nil {
+	if err := json2.UnmarshalPB(rulesBytes, rr); err != nil {
 		return err
 	}
 

--- a/go/cmd/vtctldclient/command/shard_routing_rules.go
+++ b/go/cmd/vtctldclient/command/shard_routing_rules.go
@@ -87,7 +87,7 @@ func commandApplyShardRoutingRules(cmd *cobra.Command, args []string) error {
 	}
 
 	srr := &vschemapb.ShardRoutingRules{}
-	if err := json2.Unmarshal(rulesBytes, &srr); err != nil {
+	if err := json2.Unmarshal(rulesBytes, srr); err != nil {
 		return err
 	}
 	// Round-trip so when we display the result it's readable.

--- a/go/cmd/vtctldclient/command/shard_routing_rules.go
+++ b/go/cmd/vtctldclient/command/shard_routing_rules.go
@@ -87,7 +87,7 @@ func commandApplyShardRoutingRules(cmd *cobra.Command, args []string) error {
 	}
 
 	srr := &vschemapb.ShardRoutingRules{}
-	if err := json2.Unmarshal(rulesBytes, srr); err != nil {
+	if err := json2.UnmarshalPB(rulesBytes, srr); err != nil {
 		return err
 	}
 	// Round-trip so when we display the result it's readable.

--- a/go/json2/marshal_test.go
+++ b/go/json2/marshal_test.go
@@ -36,6 +36,12 @@ func TestMarshalPB(t *testing.T) {
 	require.NoErrorf(t, err, "MarshalPB(%+v) error", col)
 	want := "{\"name\":\"c1\",\"type\":\"VARCHAR\"}"
 	assert.Equalf(t, want, string(b), "MarshalPB(%+v)", col)
+
+	// Test MarshalPB with nil proto.
+	b, err = MarshalPB(nil)
+	require.NoErrorf(t, err, "MarshalPB(nil) error")
+	want = "{}"
+	assert.Equalf(t, want, string(b), "MarshalPB(nil)")
 }
 
 func TestMarshalIndentPB(t *testing.T) {

--- a/go/json2/marshal_test.go
+++ b/go/json2/marshal_test.go
@@ -36,12 +36,6 @@ func TestMarshalPB(t *testing.T) {
 	require.NoErrorf(t, err, "MarshalPB(%+v) error", col)
 	want := "{\"name\":\"c1\",\"type\":\"VARCHAR\"}"
 	assert.Equalf(t, want, string(b), "MarshalPB(%+v)", col)
-
-	// Test MarshalPB with nil proto.
-	b, err = MarshalPB(nil)
-	require.NoErrorf(t, err, "MarshalPB(nil) error")
-	want = "{}"
-	assert.Equalf(t, want, string(b), "MarshalPB(nil)")
 }
 
 func TestMarshalIndentPB(t *testing.T) {

--- a/go/json2/unmarshal.go
+++ b/go/json2/unmarshal.go
@@ -33,8 +33,7 @@ var carriageReturn = []byte("\n")
 // efficient and should not be used for high QPS operations.
 func Unmarshal(data []byte, v any) error {
 	if pb, ok := v.(proto.Message); ok {
-		opts := protojson.UnmarshalOptions{DiscardUnknown: true}
-		return annotate(data, opts.Unmarshal(data, pb))
+		return UnmarshalPB(data, pb)
 	}
 	return annotate(data, json.Unmarshal(data, v))
 }

--- a/go/json2/unmarshal.go
+++ b/go/json2/unmarshal.go
@@ -53,3 +53,9 @@ func annotate(data []byte, err error) error {
 
 	return fmt.Errorf("line: %d, position %d: %v", line, pos, err)
 }
+
+// UnmarshalPB is similar to Unmarshal but specifically for proto.Message to add type safety.
+func UnmarshalPB(data []byte, pb proto.Message) error {
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	return annotate(data, opts.Unmarshal(data, pb))
+}

--- a/go/json2/unmarshal_test.go
+++ b/go/json2/unmarshal_test.go
@@ -91,3 +91,14 @@ func TestAnnotate(t *testing.T) {
 		require.Equal(t, tcase.err, err, "annotate(%s, %v) error", string(tcase.data), tcase.err)
 	}
 }
+
+func TestUnmarshalPB(t *testing.T) {
+	protoData := &emptypb.Empty{}
+	protoJSONData, err := protojson.Marshal(protoData)
+	require.Nil(t, err)
+
+	var pb emptypb.Empty
+	err = UnmarshalPB(protoJSONData, &pb)
+	require.Nil(t, err)
+	require.Equal(t, protoData, &pb)
+}

--- a/go/json2/unmarshal_test.go
+++ b/go/json2/unmarshal_test.go
@@ -95,10 +95,10 @@ func TestAnnotate(t *testing.T) {
 func TestUnmarshalPB(t *testing.T) {
 	want := &emptypb.Empty{}
 	json, err := protojson.Marshal(want)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var got emptypb.Empty
 	err = UnmarshalPB(json, &got)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, want, &got)
 }

--- a/go/json2/unmarshal_test.go
+++ b/go/json2/unmarshal_test.go
@@ -93,12 +93,12 @@ func TestAnnotate(t *testing.T) {
 }
 
 func TestUnmarshalPB(t *testing.T) {
-	protoData := &emptypb.Empty{}
-	protoJSONData, err := protojson.Marshal(protoData)
+	want := &emptypb.Empty{}
+	json, err := protojson.Marshal(want)
 	require.Nil(t, err)
 
-	var pb emptypb.Empty
-	err = UnmarshalPB(protoJSONData, &pb)
+	var got emptypb.Empty
+	err = UnmarshalPB(json, &got)
 	require.Nil(t, err)
-	require.Equal(t, protoData, &pb)
+	require.Equal(t, want, &got)
 }

--- a/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
+++ b/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
@@ -509,7 +509,7 @@ func testRoutingRulesApplyCommands(t *testing.T) {
 				require.EqualValues(t, wantRules, gotRules)
 			}
 		default:
-			t.Fatalf("Unknown type %s", typ)
+			require.FailNow(t, "Unknown type %s", typ)
 		}
 		testOneRoutingRulesCommand(t, typ, string(rulesBytes), validateRules)
 	}
@@ -536,7 +536,7 @@ func testOneRoutingRulesCommand(t *testing.T, typ string, rules string, validate
 			useFile: true,
 		},
 		{
-			name:  "empty", // finally, dcleanup rules
+			name:  "empty", // finally, cleanup rules
 			rules: "{}",
 		},
 	}


### PR DESCRIPTION
## Description

The Apply cli commands were incorrectly migrated to `vtctldclient`. This PR fixes them and adds and e2e test for validating the Apply commands for table, shard and keyspace routing rule types. 


### Backports
The root cause has been there since the first port of the `ApplyRoutingRules` command to vtctldclient. So part of this PR will need to be backported to all supported versions depending on which commands were migrated for each. Also the e2e test may not be portable in older versions since it uses some commands migrated much later. 


## Related Issue(s)

#16095

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
