### PR TITLE
Fix the email in `pom.xml`

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,7 +35,7 @@
   <developers>
     <developer>
       <name>Placeholder entry representing all developers. Please reach out to our mailing list for questions.</name>
-      <email>vitess@googlegroups.com</email>
+      <email>cncf-vitess-maintainers@lists.cncf.io</email>
       <organization>Vitess</organization>
       <organizationUrl>http://vitess.io</organizationUrl>
     </developer>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -59,7 +59,7 @@
   </issueManagement>
   <mailingLists>
     <mailingList>
-      <archive>https://groups.google.com/forum/#!forum/vitess</archive>
+      <archive>cncf-vitess-maintainers@lists.cncf.io</archive>
     </mailingList>
   </mailingLists>
 


### PR DESCRIPTION
## Description

The Google Group email is no longer valid, let's use the maintainers mailing list.

Fixes https://github.com/vitessio/vitess/issues/16077