### PR TITLE
VIndexes: Stop recommending md5 based vindex types as md5 is considered insecure

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/lookupvindex/lookupvindex.go
+++ b/go/cmd/vtctldclient/command/vreplication/lookupvindex/lookupvindex.go
@@ -291,7 +291,7 @@ func registerCommands(root *cobra.Command) {
 	create.Flags().StringSliceVar(&createOptions.TableOwnerColumns, "table-owner-columns", nil, "The columns to read from the owner table. These will be used to build the hash which gets stored as the keyspace_id value in the lookup table.")
 	create.MarkFlagRequired("table-owner-columns")
 	create.Flags().StringVar(&createOptions.TableName, "table-name", "", "The name of the lookup table. If not specified, then it will be created using the same name as the Lookup Vindex.")
-	create.Flags().StringVar(&createOptions.TableVindexType, "table-vindex-type", "", "The primary vindex name/type to use for the lookup table, if the table-keyspace is sharded. This must match the name of a vindex defined in the table-keyspace. If no value is provided then the default type will be used based on the table-owner-columns types.")
+	create.Flags().StringVar(&createOptions.TableVindexType, "table-vindex-type", "", "The primary vindex name/type to use for the lookup table, if the table-keyspace is sharded. If no value is provided then the default type will be used based on the table-owner-columns types.")
 	create.Flags().BoolVar(&createOptions.IgnoreNulls, "ignore-nulls", false, "Do not add corresponding records in the lookup table if any of the owner table's 'from' fields are NULL.")
 	create.Flags().BoolVar(&createOptions.ContinueAfterCopyWithOwner, "continue-after-copy-with-owner", true, "Vindex will continue materialization after the backfill completes when an owner is provided.")
 	// VReplication specific flags.

--- a/go/vt/vtctl/workflow/materializer_test.go
+++ b/go/vt/vtctl/workflow/materializer_test.go
@@ -1367,15 +1367,15 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"unicode_loose_md5": {
-					Type: "unicode_loose_md5",
+				"unicode_loose_xxhash": {
+					Type: "unicode_loose_xxhash",
 				},
 			},
 			Tables: map[string]*vschemapb.Table{
 				"lkp": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
 						Column: "c1",
-						Name:   "unicode_loose_md5",
+						Name:   "unicode_loose_xxhash",
 					}},
 				},
 			},
@@ -1417,7 +1417,7 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 			Vindexes: map[string]*vschemapb.Vindex{
 				// Create a misleading vindex name.
 				"xxhash": {
-					Type: "unicode_loose_md5",
+					Type: "unicode_loose_xxhash",
 				},
 			},
 		},
@@ -1639,7 +1639,7 @@ func TestCreateCustomizedVindex(t *testing.T) {
 			},
 			"lookup": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Name:   "unicode_loose_md5",
+					Name:   "unicode_loose_xxhash",
 					Column: "c1",
 				}},
 			},
@@ -1659,8 +1659,8 @@ func TestCreateCustomizedVindex(t *testing.T) {
 			"xxhash": {
 				Type: "xxhash",
 			},
-			"unicode_loose_md5": { // Non default vindex type for the column.
-				Type: "unicode_loose_md5",
+			"unicode_loose_xxhash": { // Non default vindex type for the column.
+				Type: "unicode_loose_xxhash",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
@@ -1678,8 +1678,8 @@ func TestCreateCustomizedVindex(t *testing.T) {
 			"xxhash": {
 				Type: "xxhash",
 			},
-			"unicode_loose_md5": {
-				Type: "unicode_loose_md5",
+			"unicode_loose_xxhash": {
+				Type: "unicode_loose_xxhash",
 			},
 			"v": {
 				Type: "lookup_unique",
@@ -1705,7 +1705,7 @@ func TestCreateCustomizedVindex(t *testing.T) {
 			"lookup": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "c1",
-					Name:   "unicode_loose_md5",
+					Name:   "unicode_loose_xxhash",
 				}},
 			},
 		},

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1378,12 +1378,10 @@ func LoadFormalKeyspace(filename string) (*vschemapb.Keyspace, error) {
 // the given SQL data type.
 func ChooseVindexForType(typ querypb.Type) (string, error) {
 	switch {
-	case sqltypes.IsIntegral(typ):
+	case sqltypes.IsIntegral(typ) || sqltypes.IsBinary(typ):
 		return "xxhash", nil
 	case sqltypes.IsText(typ):
-		return "unicode_loose_md5", nil
-	case sqltypes.IsBinary(typ):
-		return "binary_md5", nil
+		return "unicode_loose_xxhash", nil
 	}
 	return "", vterrors.Errorf(
 		vtrpcpb.Code_INVALID_ARGUMENT,

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -960,22 +960,22 @@ func TestChooseVindexForType(t *testing.T) {
 		out: "",
 	}, {
 		in:  sqltypes.Text,
-		out: "unicode_loose_md5",
+		out: "unicode_loose_xxhash",
 	}, {
 		in:  sqltypes.Blob,
-		out: "binary_md5",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.VarChar,
-		out: "unicode_loose_md5",
+		out: "unicode_loose_xxhash",
 	}, {
 		in:  sqltypes.VarBinary,
-		out: "binary_md5",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Char,
-		out: "unicode_loose_md5",
+		out: "unicode_loose_xxhash",
 	}, {
 		in:  sqltypes.Binary,
-		out: "binary_md5",
+		out: "xxhash",
 	}, {
 		in:  sqltypes.Bit,
 		out: "",

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -952,15 +952,15 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 		out: &vschemapb.Keyspace{
 			Sharded: true,
 			Vindexes: map[string]*vschemapb.Vindex{
-				"unicode_loose_md5": {
-					Type: "unicode_loose_md5",
+				"unicode_loose_xxhash": {
+					Type: "unicode_loose_xxhash",
 				},
 			},
 			Tables: map[string]*vschemapb.Table{
 				"lkp": {
 					ColumnVindexes: []*vschemapb.ColumnVindex{{
 						Column: "c1",
-						Name:   "unicode_loose_md5",
+						Name:   "unicode_loose_xxhash",
 					}},
 				},
 			},
@@ -1002,7 +1002,7 @@ func TestCreateLookupVindexTargetVSchema(t *testing.T) {
 			Vindexes: map[string]*vschemapb.Vindex{
 				// Create a misleading vindex name.
 				"xxhash": {
-					Type: "unicode_loose_md5",
+					Type: "unicode_loose_xxhash",
 				},
 			},
 		},


### PR DESCRIPTION
## Description

When creating the `vtctldclient` implementation of the [`LookupVindex` command](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_lookupvindex/) in https://github.com/vitessio/vitess/pull/14086, I added the ability to specify which vindex type to use with the `--table-vindex-type` flag. The `vtctlclient` client and its behavior is now frozen as it's deprecated and slated for removal so that will not be modified.

By default, however, we would still use `md5` by default for text based column types (we had changed the default/recommended vindex type for integral column types in #13955 and #13956). This PR moves the md5 based recommendations to `xxhash` based ones as `md5` for passwords is considered insecure ([1](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5351), [2](https://docs.datadoghq.com/code_analysis/static_analysis_rules/go-security/import-md5/#), [3](https://nvd.nist.gov/vuln/detail/CVE-2020-5229), ...) so any usage of it in your fleet — even though with Vindexes it is NOT used for passwords — can trigger security warnings on audits. Beyond that, `xxhash` should generally be faster as well. So we should recommend it as the default instead.

## Related Issue(s)

  - Follow-up to:
    - https://github.com/vitessio/vitess/issues/13955
    - https://github.com/vitessio/vitess/issues/13956
  - Fixes: https://github.com/vitessio/vitess/issues/14155

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation: https://github.com/vitessio/website/pull/1772