### PR TITLE
Adding Distributed Transaction Test

### DIFF
--- a/go/test/endtoend/vtgate/transaction/twopc/main_test.go
+++ b/go/test/endtoend/vtgate/transaction/twopc/main_test.go
@@ -80,6 +80,7 @@ func TestMain(m *testing.M) {
 			"--twopc_enable",
 			"--twopc_coordinator_address", fmt.Sprintf("localhost:%d", clusterInstance.VtgateGrpcPort),
 			"--twopc_abandon_age", "3600",
+			"--queryserver-config-transaction-cap", "3",
 		)
 
 		// Start keyspace

--- a/go/test/endtoend/vtgate/transaction/twopc/main_test.go
+++ b/go/test/endtoend/vtgate/transaction/twopc/main_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transaction
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	keyspaceName    = "ks"
+	cell            = "zone1"
+	hostname        = "localhost"
+
+	//go:embed schema.sql
+	SchemaSQL string
+
+	//go:embed vschema.json
+	VSchema string
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitcode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Reserve vtGate port in order to pass it to vtTablet
+		clusterInstance.VtgateGrpcPort = clusterInstance.GetAndReservePort()
+
+		// Set extra args for twopc
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+			"--transaction_mode", "TWOPC",
+		)
+		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs,
+			"--twopc_enable",
+			"--twopc_coordinator_address", fmt.Sprintf("localhost:%d", clusterInstance.VtgateGrpcPort),
+			"--twopc_abandon_age", "3600",
+		)
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: SchemaSQL,
+			VSchema:   VSchema,
+		}
+		if err := clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 1, false); err != nil {
+			return 1
+		}
+
+		// Start Vtgate
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+		vtParams = clusterInstance.GetVTParams(keyspaceName)
+
+		return m.Run()
+	}()
+	os.Exit(exitcode)
+}
+
+func start(t *testing.T) (*mysql.Conn, func()) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+
+	deleteAll := func() {
+		tables := []string{"twopc_user"}
+		for _, table := range tables {
+			_, _ = utils.ExecAllowError(t, conn, "delete from "+table)
+		}
+	}
+
+	deleteAll()
+
+	return conn, func() {
+		deleteAll()
+		conn.Close()
+		cluster.PanicHandler(t)
+	}
+}

--- a/go/test/endtoend/vtgate/transaction/twopc/schema.sql
+++ b/go/test/endtoend/vtgate/transaction/twopc/schema.sql
@@ -1,0 +1,12 @@
+create table twopc_user (
+    id bigint,
+    name varchar(64),
+    primary key (id)
+) Engine=InnoDB;
+
+create table twopc_music (
+    id varchar(64),
+    user_id bigint,
+    title varchar(64),
+    primary key (id)
+) Engine=InnoDB;

--- a/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transaction
+
+import (
+	_ "embed"
+	"testing"
+
+	"vitess.io/vitess/go/test/endtoend/utils"
+)
+
+// TestDTCommit tests transaction commit using twopc mode
+func TestDTCommit(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	// Insert into multiple shards
+	utils.Exec(t, conn, "begin")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(7,'foo')")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(8,'bar')")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(9,'baz')")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(10,'apa')")
+	utils.Exec(t, conn, "commit")
+
+	// Verify the values are present in multiple shards
+	utils.Exec(t, conn, "use `ks/-80`")
+	utils.AssertMatches(t, conn,
+		"select id, name from twopc_user order by id",
+		`[[INT64(8) VARCHAR("bar")] [INT64(10) VARCHAR("apa")]]`)
+	utils.Exec(t, conn, "use `ks/80-`")
+	utils.AssertMatches(t, conn,
+		"select id, name from twopc_user order by id",
+		`[[INT64(7) VARCHAR("foo")] [INT64(9) VARCHAR("baz")]]`)
+	utils.Exec(t, conn, "use `ks`")
+
+	// Update from multiple shard
+	utils.Exec(t, conn, "begin")
+	utils.Exec(t, conn, "update twopc_user set name='newfoo' where id in (7,8)")
+	utils.Exec(t, conn, "commit")
+
+	// VERIFY that values are updated
+	utils.AssertMatches(t, conn,
+		"select id, name from twopc_user order by id",
+		`[[INT64(7) VARCHAR("newfoo")] [INT64(8) VARCHAR("newfoo")] [INT64(9) VARCHAR("baz")] [INT64(10) VARCHAR("apa")]]`)
+
+	// DELETE from multiple shard
+	utils.Exec(t, conn, "begin")
+	utils.Exec(t, conn, "delete from twopc_user")
+	utils.Exec(t, conn, "commit")
+
+	// VERIFY that values are deleted
+	utils.AssertMatches(t, conn, "select id, name from twopc_user order by id", `[]`)
+}

--- a/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
@@ -19,25 +19,20 @@ package transaction
 import (
 	"context"
 	_ "embed"
-	"fmt"
-	"io"
-	"sync"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
-	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
 
 // TestDTCommit tests transaction commit using twopc mode
+// It tests commit for insert, update and delete operations
+// It verifies the binlog events for the same with transaction state changes and redo statements.
 func TestDTCommit(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()
@@ -60,16 +55,39 @@ func TestDTCommit(t *testing.T) {
 	utils.Exec(t, conn, "insert into twopc_user(id, name) values(10,'apa')")
 	utils.Exec(t, conn, "commit")
 
-	// Verify the values are present in multiple shards
-	utils.Exec(t, conn, "use `ks/-80`")
-	utils.AssertMatches(t, conn,
-		"select id, name from twopc_user order by id",
-		`[[INT64(8) VARCHAR("bar")] [INT64(10) VARCHAR("apa")]]`)
-	utils.Exec(t, conn, "use `ks/80-`")
-	utils.AssertMatches(t, conn,
-		"select id, name from twopc_user order by id",
-		`[[INT64(7) VARCHAR("foo")] [INT64(9) VARCHAR("baz")]]`)
-	utils.Exec(t, conn, "use `ks`")
+	tableMap := make(map[string][]*querypb.Field)
+	logTable := retrieveTransitions(t, ch, tableMap)
+	expectations := map[string][]string{
+		"ks.dt_state:80-": {
+			`insert:[VARCHAR("PREPARE")]`,
+			`update:[VARCHAR("COMMIT")]`,
+			`delete:[VARCHAR("COMMIT")]`,
+		},
+		"ks.dt_participant:80-": {
+			`insert:[INT64(1) VARCHAR("ks") VARCHAR("-80")]`,
+			`delete:[INT64(1) VARCHAR("ks") VARCHAR("-80")]`,
+		},
+		"ks.redo_state:-80": {
+			`insert:[VARCHAR("PREPARE")]`,
+			`delete:[VARCHAR("PREPARE")]`,
+		},
+		"ks.redo_statement:-80": {
+			"insert:[INT64(1) BLOB(\"insert into twopc_user(id, `name`) values (8, 'bar')\")]",
+			"insert:[INT64(2) BLOB(\"insert into twopc_user(id, `name`) values (10, 'apa')\")]",
+			"delete:[INT64(1) BLOB(\"insert into twopc_user(id, `name`) values (8, 'bar')\")]",
+			"delete:[INT64(2) BLOB(\"insert into twopc_user(id, `name`) values (10, 'apa')\")]",
+		},
+		"ks.twopc_user:-80": {
+			`insert:[INT64(8) VARCHAR("bar")]`,
+			`insert:[INT64(10) VARCHAR("apa")]`,
+		},
+		"ks.twopc_user:80-": {
+			`insert:[INT64(7) VARCHAR("foo")]`,
+			`insert:[INT64(9) VARCHAR("baz")]`,
+		},
+	}
+	assert.Equal(t, len(expectations), len(logTable),
+		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
 
 	// Update from multiple shard
 	utils.Exec(t, conn, "begin")
@@ -77,10 +95,30 @@ func TestDTCommit(t *testing.T) {
 	utils.Exec(t, conn, "update twopc_user set name='newfoo' where id = 8")
 	utils.Exec(t, conn, "commit")
 
-	// VERIFY that values are updated
-	utils.AssertMatches(t, conn,
-		"select id, name from twopc_user order by id",
-		`[[INT64(7) VARCHAR("newfoo")] [INT64(8) VARCHAR("newfoo")] [INT64(9) VARCHAR("baz")] [INT64(10) VARCHAR("apa")]]`)
+	logTable = retrieveTransitions(t, ch, tableMap)
+	expectations = map[string][]string{
+		"ks.dt_state:80-": {
+			"insert:[VARCHAR(\"PREPARE\")]",
+			"update:[VARCHAR(\"COMMIT\")]",
+			"delete:[VARCHAR(\"COMMIT\")]",
+		},
+		"ks.dt_participant:80-": {
+			"insert:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
+			"delete:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
+		},
+		"ks.redo_state:-80": {
+			"insert:[VARCHAR(\"PREPARE\")]",
+			"delete:[VARCHAR(\"PREPARE\")]",
+		},
+		"ks.redo_statement:-80": {
+			"insert:[INT64(1) BLOB(\"update twopc_user set `name` = 'newfoo' where id = 8 limit 10001 /* INT64 */\")]",
+			"delete:[INT64(1) BLOB(\"update twopc_user set `name` = 'newfoo' where id = 8 limit 10001 /* INT64 */\")]",
+		},
+		"ks.twopc_user:-80": {"update:[INT64(8) VARCHAR(\"newfoo\")]"},
+		"ks.twopc_user:80-": {"update:[INT64(7) VARCHAR(\"newfoo\")]"},
+	}
+	assert.Equal(t, len(expectations), len(logTable),
+		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
 
 	// DELETE from multiple shard
 	utils.Exec(t, conn, "begin")
@@ -88,120 +126,81 @@ func TestDTCommit(t *testing.T) {
 	utils.Exec(t, conn, "delete from twopc_user where id = 10")
 	utils.Exec(t, conn, "commit")
 
-	// VERIFY that values are deleted
-	utils.AssertMatches(t, conn, "select id, name from twopc_user order by id", `[[INT64(7) VARCHAR("newfoo")] [INT64(8) VARCHAR("newfoo")]]`)
-
-	logTable := retrieveTransitions(t, ch)
-	expectations := map[string][]string{
-		"ks.twopc_user:-80": {
-			`inserted:[INT64(8) VARCHAR("bar")]`,
-			`inserted:[INT64(10) VARCHAR("apa")]`,
-			`updated:[INT64(8) VARCHAR("newfoo")]`,
-			`deleted:[INT64(10) VARCHAR("apa")]`,
+	logTable = retrieveTransitions(t, ch, tableMap)
+	expectations = map[string][]string{
+		"ks.dt_state:80-": {
+			"insert:[VARCHAR(\"PREPARE\")]",
+			"update:[VARCHAR(\"COMMIT\")]",
+			"delete:[VARCHAR(\"COMMIT\")]",
 		},
-		"ks.twopc_user:80-": {
-			`inserted:[INT64(7) VARCHAR("foo")]`,
-			`inserted:[INT64(9) VARCHAR("baz")]`,
-			`updated:[INT64(7) VARCHAR("newfoo")]`,
-			`deleted:[INT64(9) VARCHAR("baz")]`,
+		"ks.dt_participant:80-": {
+			"insert:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
+			"delete:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
 		},
+		"ks.redo_state:-80": {
+			"insert:[VARCHAR(\"PREPARE\")]",
+			"delete:[VARCHAR(\"PREPARE\")]",
+		},
+		"ks.redo_statement:-80": {
+			"insert:[INT64(1) BLOB(\"delete from twopc_user where id = 10 limit 10001 /* INT64 */\")]",
+			"delete:[INT64(1) BLOB(\"delete from twopc_user where id = 10 limit 10001 /* INT64 */\")]",
+		},
+		"ks.twopc_user:-80": {"delete:[INT64(10) VARCHAR(\"apa\")]"},
+		"ks.twopc_user:80-": {"delete:[INT64(9) VARCHAR(\"baz\")]"},
 	}
-	validateTransitions(t, logTable, expectations)
-
-	log.Errorf("logTable: %+v", logTable)
-
+	assert.Equal(t, len(expectations), len(logTable),
+		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
 }
 
-func validateTransitions(t *testing.T, logTable map[string][]string, expectations map[string][]string) {
-	for key, exp := range expectations {
-		actual, exists := logTable[key]
-		require.Truef(t, exists, "key %s not found in logTable", key)
-		require.Equal(t, exp, actual)
-	}
-}
+// TestDTRollback tests transaction rollback using twopc mode
+// It tests rollback for insert, update and delete operations
+// There would not be any binlog events for rollback
+func TestDTRollback(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
 
-func retrieveTransitions(t *testing.T, ch chan *binlogdatapb.VEvent) map[string][]string {
-	logTable := make(map[string][]string)
+	// Insert initial Data
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(7,'foo'), (8,'bar')")
+
+	// run vstream to stream binlogs
+	vtgateConn, err := cluster.DialVTGate(context.Background(), t.Name(), vtgateGrpcAddress, "fk_user", "")
+	require.NoError(t, err)
+	defer vtgateConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *binlogdatapb.VEvent)
+	runVStream(t, ctx, ch, vtgateConn)
+
+	// Insert into multiple shards
+	utils.Exec(t, conn, "begin")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(9,'baz')")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(10,'apa')")
+	utils.Exec(t, conn, "rollback")
 
 	tableMap := make(map[string][]*querypb.Field)
-	keepWaiting := true
-	for keepWaiting {
-		select {
-		case re := <-ch:
-			if re.RowEvent != nil {
-				shard := re.RowEvent.Shard
-				tableName := re.RowEvent.TableName
-				fields, ok := tableMap[tableName]
-				require.Truef(t, ok, "table %s not found in fields map", tableName)
-				for _, rc := range re.RowEvent.RowChanges {
-					logEvent(logTable, shard, tableName, fields, rc)
-				}
-			}
-			if re.FieldEvent != nil {
-				tableMap[re.FieldEvent.TableName] = re.FieldEvent.Fields
-			}
-		case <-time.After(1 * time.Second):
-			log.Errorf("%s", "stopping vstream")
-			keepWaiting = false
-		}
-	}
-	return logTable
-}
+	logTable := retrieveTransitions(t, ch, tableMap)
+	assert.Zero(t, len(logTable),
+		"no change in binlog expected: got: %s", prettyPrint(logTable))
 
-func logEvent(logTable map[string][]string, shard string, tbl string, fields []*querypb.Field, rc *binlogdatapb.RowChange) {
-	key := fmt.Sprintf("%s:%s", tbl, shard)
-	logs := logTable[key]
-	switch {
-	case rc.Before == nil && rc.After == nil:
-		panic("do not expect row event with both before and after nil")
-	case rc.Before == nil:
-		logs = append(logs, fmt.Sprintf("inserted:%v", sqltypes.MakeRowTrusted(fields, rc.After)))
-	case rc.After == nil:
-		logs = append(logs, fmt.Sprintf("deleted:%v", sqltypes.MakeRowTrusted(fields, rc.Before)))
-	default:
-		logs = append(logs, fmt.Sprintf("updated:%v", sqltypes.MakeRowTrusted(fields, rc.After)))
-	}
-	logTable[key] = logs
-}
+	// Update from multiple shard
+	utils.Exec(t, conn, "begin")
+	utils.Exec(t, conn, "update twopc_user set name='newfoo' where id = 7")
+	utils.Exec(t, conn, "update twopc_user set name='newfoo' where id = 8")
+	utils.Exec(t, conn, "rollback")
 
-func runVStream(t *testing.T, ctx context.Context, ch chan *binlogdatapb.VEvent, vtgateConn *vtgateconn.VTGateConn) {
-	vgtid := &binlogdatapb.VGtid{
-		ShardGtids: []*binlogdatapb.ShardGtid{
-			{Keyspace: keyspaceName, Shard: "-80", Gtid: "current"},
-			{Keyspace: keyspaceName, Shard: "80-", Gtid: "current"},
-		}}
-	filter := &binlogdatapb.Filter{
-		Rules: []*binlogdatapb.Rule{{
-			Match: "/.*/",
-		}},
-	}
-	vReader, err := vtgateConn.VStream(ctx, topodatapb.TabletType_PRIMARY, vgtid, filter, nil)
-	require.NoError(t, err)
+	logTable = retrieveTransitions(t, ch, tableMap)
+	assert.Zero(t, len(logTable),
+		"no change in binlog expected: got: %s", prettyPrint(logTable))
 
-	// Use a channel to signal that the first VGTID event has been processed
-	firstEventProcessed := make(chan struct{})
-	var once sync.Once
+	// DELETE from multiple shard
+	utils.Exec(t, conn, "begin")
+	utils.Exec(t, conn, "delete from twopc_user where id = 7")
+	utils.Exec(t, conn, "delete from twopc_user where id = 8")
+	utils.Exec(t, conn, "rollback")
 
-	go func() {
-		for {
-			evs, err := vReader.Recv()
-			if err == io.EOF || ctx.Err() != nil {
-				return
-			}
-			require.NoError(t, err)
-
-			for _, ev := range evs {
-				// Signal the first event has been processed using sync.Once
-				if ev.Type == binlogdatapb.VEventType_VGTID {
-					once.Do(func() { close(firstEventProcessed) })
-				}
-				if ev.Type == binlogdatapb.VEventType_ROW || ev.Type == binlogdatapb.VEventType_FIELD {
-					ch <- ev
-				}
-			}
-		}
-	}()
-
-	// Wait for the first event to be processed
-	<-firstEventProcessed
+	logTable = retrieveTransitions(t, ch, tableMap)
+	assert.Zero(t, len(logTable),
+		"no change in binlog expected: got: %s", prettyPrint(logTable))
 }

--- a/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
@@ -17,16 +17,40 @@ limitations under the License.
 package transaction
 
 import (
+	"context"
 	_ "embed"
+	"fmt"
+	"io"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
+	"vitess.io/vitess/go/vt/log"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
 
 // TestDTCommit tests transaction commit using twopc mode
 func TestDTCommit(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()
+
+	vtgateConn, err := cluster.DialVTGate(context.Background(), t.Name(), vtgateGrpcAddress, "fk_user", "")
+	require.NoError(t, err)
+	defer vtgateConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *binlogdatapb.VEvent)
+	runVStream(t, ctx, ch, vtgateConn)
 
 	// Insert into multiple shards
 	utils.Exec(t, conn, "begin")
@@ -49,7 +73,8 @@ func TestDTCommit(t *testing.T) {
 
 	// Update from multiple shard
 	utils.Exec(t, conn, "begin")
-	utils.Exec(t, conn, "update twopc_user set name='newfoo' where id in (7,8)")
+	utils.Exec(t, conn, "update twopc_user set name='newfoo' where id = 7")
+	utils.Exec(t, conn, "update twopc_user set name='newfoo' where id = 8")
 	utils.Exec(t, conn, "commit")
 
 	// VERIFY that values are updated
@@ -59,9 +84,124 @@ func TestDTCommit(t *testing.T) {
 
 	// DELETE from multiple shard
 	utils.Exec(t, conn, "begin")
-	utils.Exec(t, conn, "delete from twopc_user")
+	utils.Exec(t, conn, "delete from twopc_user where id = 9")
+	utils.Exec(t, conn, "delete from twopc_user where id = 10")
 	utils.Exec(t, conn, "commit")
 
 	// VERIFY that values are deleted
-	utils.AssertMatches(t, conn, "select id, name from twopc_user order by id", `[]`)
+	utils.AssertMatches(t, conn, "select id, name from twopc_user order by id", `[[INT64(7) VARCHAR("newfoo")] [INT64(8) VARCHAR("newfoo")]]`)
+
+	logTable := retrieveTransitions(t, ch)
+	expectations := map[string][]string{
+		"ks.twopc_user:-80": {
+			`inserted:[INT64(8) VARCHAR("bar")]`,
+			`inserted:[INT64(10) VARCHAR("apa")]`,
+			`updated:[INT64(8) VARCHAR("newfoo")]`,
+			`deleted:[INT64(10) VARCHAR("apa")]`,
+		},
+		"ks.twopc_user:80-": {
+			`inserted:[INT64(7) VARCHAR("foo")]`,
+			`inserted:[INT64(9) VARCHAR("baz")]`,
+			`updated:[INT64(7) VARCHAR("newfoo")]`,
+			`deleted:[INT64(9) VARCHAR("baz")]`,
+		},
+	}
+	validateTransitions(t, logTable, expectations)
+
+	log.Errorf("logTable: %+v", logTable)
+
+}
+
+func validateTransitions(t *testing.T, logTable map[string][]string, expectations map[string][]string) {
+	for key, exp := range expectations {
+		actual, exists := logTable[key]
+		require.Truef(t, exists, "key %s not found in logTable", key)
+		require.Equal(t, exp, actual)
+	}
+}
+
+func retrieveTransitions(t *testing.T, ch chan *binlogdatapb.VEvent) map[string][]string {
+	logTable := make(map[string][]string)
+
+	tableMap := make(map[string][]*querypb.Field)
+	keepWaiting := true
+	for keepWaiting {
+		select {
+		case re := <-ch:
+			if re.RowEvent != nil {
+				shard := re.RowEvent.Shard
+				tableName := re.RowEvent.TableName
+				fields, ok := tableMap[tableName]
+				require.Truef(t, ok, "table %s not found in fields map", tableName)
+				for _, rc := range re.RowEvent.RowChanges {
+					logEvent(logTable, shard, tableName, fields, rc)
+				}
+			}
+			if re.FieldEvent != nil {
+				tableMap[re.FieldEvent.TableName] = re.FieldEvent.Fields
+			}
+		case <-time.After(1 * time.Second):
+			log.Errorf("%s", "stopping vstream")
+			keepWaiting = false
+		}
+	}
+	return logTable
+}
+
+func logEvent(logTable map[string][]string, shard string, tbl string, fields []*querypb.Field, rc *binlogdatapb.RowChange) {
+	key := fmt.Sprintf("%s:%s", tbl, shard)
+	logs := logTable[key]
+	switch {
+	case rc.Before == nil && rc.After == nil:
+		panic("do not expect row event with both before and after nil")
+	case rc.Before == nil:
+		logs = append(logs, fmt.Sprintf("inserted:%v", sqltypes.MakeRowTrusted(fields, rc.After)))
+	case rc.After == nil:
+		logs = append(logs, fmt.Sprintf("deleted:%v", sqltypes.MakeRowTrusted(fields, rc.Before)))
+	default:
+		logs = append(logs, fmt.Sprintf("updated:%v", sqltypes.MakeRowTrusted(fields, rc.After)))
+	}
+	logTable[key] = logs
+}
+
+func runVStream(t *testing.T, ctx context.Context, ch chan *binlogdatapb.VEvent, vtgateConn *vtgateconn.VTGateConn) {
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{
+			{Keyspace: keyspaceName, Shard: "-80", Gtid: "current"},
+			{Keyspace: keyspaceName, Shard: "80-", Gtid: "current"},
+		}}
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "/.*/",
+		}},
+	}
+	vReader, err := vtgateConn.VStream(ctx, topodatapb.TabletType_PRIMARY, vgtid, filter, nil)
+	require.NoError(t, err)
+
+	// Use a channel to signal that the first VGTID event has been processed
+	firstEventProcessed := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		for {
+			evs, err := vReader.Recv()
+			if err == io.EOF || ctx.Err() != nil {
+				return
+			}
+			require.NoError(t, err)
+
+			for _, ev := range evs {
+				// Signal the first event has been processed using sync.Once
+				if ev.Type == binlogdatapb.VEventType_VGTID {
+					once.Do(func() { close(firstEventProcessed) })
+				}
+				if ev.Type == binlogdatapb.VEventType_ROW || ev.Type == binlogdatapb.VEventType_FIELD {
+					ch <- ev
+				}
+			}
+		}
+	}()
+
+	// Wait for the first event to be processed
+	<-firstEventProcessed
 }

--- a/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/vtgate/transaction/twopc/twopc_test.go
@@ -19,19 +19,20 @@ package transaction
 import (
 	"context"
 	_ "embed"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-// TestDTCommit tests transaction commit using twopc mode
-// It tests commit for insert, update and delete operations
+// TestDTCommit tests distributed transaction commit for insert, update and delete operations
 // It verifies the binlog events for the same with transaction state changes and redo statements.
 func TestDTCommit(t *testing.T) {
 	conn, closer := start(t)
@@ -152,8 +153,7 @@ func TestDTCommit(t *testing.T) {
 		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
 }
 
-// TestDTRollback tests transaction rollback using twopc mode
-// It tests rollback for insert, update and delete operations
+// TestDTRollback tests distributed transaction rollback for insert, update and delete operations
 // There would not be any binlog events for rollback
 func TestDTRollback(t *testing.T) {
 	conn, closer := start(t)
@@ -205,8 +205,7 @@ func TestDTRollback(t *testing.T) {
 		"no change in binlog expected: got: %s", prettyPrint(logTable))
 }
 
-// TestDTCommitMultiShardTxSingleShardDML tests transaction commit using twopc mode
-// It tests commit for insert, update and delete operations
+// TestDTCommitMultiShardTxSingleShardDML tests distributed transaction commit for insert, update and delete operations
 // There is DML operation only on single shard but transaction open on multiple shards.
 // Metdata Manager is the one which executed the DML operation on the shard.
 func TestDTCommitDMLOnlyOnMM(t *testing.T) {
@@ -291,8 +290,7 @@ func TestDTCommitDMLOnlyOnMM(t *testing.T) {
 		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
 }
 
-// TestDTCommitMultiShardTxSingleShardDML tests transaction commit using twopc mode
-// It tests commit for insert, update and delete operations
+// TestDTCommitMultiShardTxSingleShardDML tests distributed transaction commit for insert, update and delete operations
 // There is DML operation only on single shard but transaction open on multiple shards.
 // Resource Manager is the one which executed the DML operation on the shard.
 func TestDTCommitDMLOnlyOnRM(t *testing.T) {
@@ -396,6 +394,82 @@ func TestDTCommitDMLOnlyOnRM(t *testing.T) {
 			"delete:[INT64(1) BLOB(\"delete from twopc_user where id = 7 limit 10001 /* INT64 */\")]",
 		},
 		"ks.twopc_user:80-": {"delete:[INT64(7) VARCHAR(\"newfoo\")]"},
+	}
+	assert.Equal(t, len(expectations), len(logTable),
+		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
+}
+
+// TestDTPrepareFail tests distributed transaction prepare failure
+func TestDTPrepareFail(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	vtgateConn, err := cluster.DialVTGate(context.Background(), t.Name(), vtgateGrpcAddress, "fk_user", "")
+	require.NoError(t, err)
+	defer vtgateConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *binlogdatapb.VEvent)
+	runVStream(t, ctx, ch, vtgateConn)
+
+	// Insert into multiple shards
+	utils.Exec(t, conn, "begin")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(7,'foo')")
+	utils.Exec(t, conn, "insert into twopc_user(id, name) values(8,'bar')")
+
+	ctx2 := context.Background()
+	conn2, err := mysql.Connect(ctx2, &vtParams)
+	require.NoError(t, err)
+
+	utils.Exec(t, conn2, "begin")
+	utils.Exec(t, conn2, "insert into twopc_user(id, name) values(9,'baz')")
+	utils.Exec(t, conn2, "insert into twopc_user(id, name) values(10,'apa')")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		utils.ExecAllowError(t, conn, "commit")
+		wg.Done()
+	}()
+	go func() {
+		utils.ExecAllowError(t, conn2, "commit")
+		wg.Done()
+	}()
+	wg.Wait()
+
+	tableMap := make(map[string][]*querypb.Field)
+	logTable := retrieveTransitions(t, ch, tableMap)
+	expectations := map[string][]string{
+		"ks.dt_participant:80-": {
+			"insert:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
+			"insert:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
+			"delete:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
+			"delete:[INT64(1) VARCHAR(\"ks\") VARCHAR(\"-80\")]",
+		},
+		"ks.dt_state:80-": {
+			"insert:[VARCHAR(\"PREPARE\")]",
+			"insert:[VARCHAR(\"PREPARE\")]",
+			"update:[VARCHAR(\"COMMIT\")]",
+			"update:[VARCHAR(\"ROLLBACK\")]",
+			"delete:[VARCHAR(\"COMMIT\")]",
+			"delete:[VARCHAR(\"ROLLBACK\")]",
+		},
+		"ks.redo_state:-80": {
+			"insert:[VARCHAR(\"PREPARE\")]",
+			"delete:[VARCHAR(\"PREPARE\")]",
+		},
+		"ks.redo_statement:-80": {
+			"insert:[INT64(1) BLOB(\"insert into twopc_user(id, `name`) values (8, 'bar')\")]",
+			"delete:[INT64(1) BLOB(\"insert into twopc_user(id, `name`) values (8, 'bar')\")]",
+		},
+		"ks.twopc_user:-80": {
+			"insert:[INT64(8) VARCHAR(\"bar\")]",
+		},
+		"ks.twopc_user:80-": {
+			"insert:[INT64(7) VARCHAR(\"foo\")]",
+		},
 	}
 	assert.Equal(t, len(expectations), len(logTable),
 		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))

--- a/go/test/endtoend/vtgate/transaction/twopc/vschema.json
+++ b/go/test/endtoend/vtgate/transaction/twopc/vschema.json
@@ -1,0 +1,26 @@
+{
+  "sharded":true,
+  "vindexes": {
+    "xxhash": {
+      "type": "xxhash"
+    }
+  },
+  "tables": {
+    "twopc_user":{
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "twopc_music": {
+      "column_vindexes": [
+        {
+          "column": "user_id",
+          "name": "xxhash"
+        }
+      ]
+    }
+  }
+}

--- a/test/config.json
+++ b/test/config.json
@@ -824,6 +824,15 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"vtgate_transaction_twopc": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/transaction/twopc"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_transaction",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtgate_transaction_partial_exec": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/partialfailure"],


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds some basic tests when transaction_mode is set to `twopc`. 
This PR also fixes an issue on query initialization related to twopc on vttablet startup.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

