### PR TITLE
`schemadiff`: only compare column collations if of textual type

### DIFF
--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -444,6 +444,13 @@ func colTypeEqualForForeignKey(env *Environment, ct, pt *sqlparser.TableSpec, ch
 }
 
 func colCollationEqualForForeignKey(env *Environment, ct, pt *sqlparser.TableSpec, child, parent *sqlparser.ColumnType) bool {
+	isTextual := func(col *sqlparser.ColumnType) bool {
+		return charsetTypes[strings.ToLower(col.Type)]
+	}
+	if !isTextual(child) || !isTextual(parent) {
+		// irrelevant if columns are not textual
+		return true
+	}
 	return *colCollation(env, ct, child) == *colCollation(env, pt, parent)
 }
 

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -431,7 +431,7 @@ func TestInvalidSchema(t *testing.T) {
 					t1id int NOT NULL,
 					primary key (id),
 					CONSTRAINT fk1_en9z857fmvhhyrzb1p7lr751o FOREIGN KEY (t1id) REFERENCES t1 (id) ON DELETE CASCADE
-				) CHARSET utf8mb4, COLLATE utf8mb4_0900_ai_ci;;
+				) CHARSET utf8mb4, COLLATE utf8mb4_0900_ai_ci;
 			`,
 		},
 		{

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -413,6 +413,28 @@ func TestInvalidSchema(t *testing.T) {
 			`,
 		},
 		{
+			schema: `
+				CREATE TABLE t1 (id int NOT NULL AUTO_INCREMENT, primary key (id));
+				CREATE TABLE t2 (
+					id int NOT NULL AUTO_INCREMENT,
+					t1id int NOT NULL,
+					primary key (id),
+					CONSTRAINT fk1_en9z857fmvhhyrzb1p7lr751o FOREIGN KEY (t1id) REFERENCES t1 (id) ON DELETE CASCADE
+				);
+			`,
+		},
+		{
+			schema: `
+				CREATE TABLE t1 (id int NOT NULL AUTO_INCREMENT, primary key (id)) CHARSET utf8mb4, COLLATE utf8mb4_unicode_ci;
+				CREATE TABLE t2 (
+					id int NOT NULL AUTO_INCREMENT,
+					t1id int NOT NULL,
+					primary key (id),
+					CONSTRAINT fk1_en9z857fmvhhyrzb1p7lr751o FOREIGN KEY (t1id) REFERENCES t1 (id) ON DELETE CASCADE
+				) CHARSET utf8mb4, COLLATE utf8mb4_0900_ai_ci;;
+			`,
+		},
+		{
 			schema:    "create table t11 (id int primary key, i int, key ix(i), constraint f11 foreign key (i) references t11(id2) on delete restrict)",
 			expectErr: &InvalidReferencedColumnInForeignKeyConstraintError{Table: "t11", Constraint: "f11", ReferencedTable: "t11", ReferencedColumn: "id2"},
 		},


### PR DESCRIPTION

## Description

Followup to https://github.com/vitessio/vitess/pull/16109. #16109 introduced a bug where comparing `int` column types in tables that have different collations, inadvertently caused a `ForeignKeyColumnTypeMismatchError`.

This PR fixes that and adds a test to show it.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16108

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
