### PR TITLE
Docker: Update node vtadmin version

### DIFF
--- a/docker/binaries/vtadmin/Dockerfile
+++ b/docker/binaries/vtadmin/Dockerfile
@@ -17,7 +17,7 @@ ARG DEBIAN_VER=bullseye-slim
 
 FROM vitess/lite:${VT_BASE_VER} AS lite
 
-FROM node:18-${DEBIAN_VER} as node
+FROM node:20-${DEBIAN_VER} as node
 
 # Prepare directory structure.
 RUN mkdir -p /vt/web

--- a/docker/local/install_local_dependencies.sh
+++ b/docker/local/install_local_dependencies.sh
@@ -22,4 +22,4 @@ mkdir -p /var/run/etcd && chown -R vitess:vitess /var/run/etcd
 rm -rf /var/lib/apt/lists/*
 
 # Install npm and node dependencies for vtadmin
-curl -fsSL https://deb.nodesource.com/setup_19.x |  bash - && apt-get install -y nodejs
+curl -fsSL https://deb.nodesource.com/setup_20.x |  bash - && apt-get install -y nodejs


### PR DESCRIPTION

## Description

One of the vtadmin packages requires node 20 (otherwise docker builds fail).
This is a reverse backport from https://github.com/vitessio/vitess/pull/16145

- To be backported to `release-20.0`. 
- No need to backport to `release-20.0-rc` because it already contains this fix.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16010

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
