### PR TITLE
Run more test on release-19 branch

### DIFF
--- a/go/test/endtoend/utils/mysql.go
+++ b/go/test/endtoend/utils/mysql.go
@@ -237,8 +237,8 @@ func checkFields(t *testing.T, columnName string, vtField, myField *querypb.Fiel
 		t.Errorf("for column %s field types do not match\nNot equal: \nMySQL: %v\nVitess: %v\n", columnName, myField.Type.String(), vtField.Type.String())
 	}
 
-	// starting in Vitess 20, decimal types are properly sized in their field information
-	if BinaryIsAtLeastAtVersion(20, "vtgate") && vtField.Type == sqltypes.Decimal {
+	// starting in Vitess 19, decimal types are properly sized in their field information
+	if BinaryIsAtLeastAtVersion(19, "vtgate") && vtField.Type == sqltypes.Decimal {
 		if vtField.Decimals != myField.Decimals {
 			t.Errorf("for column %s field decimals count do not match\nNot equal: \nMySQL: %v\nVitess: %v\n", columnName, myField.Decimals, vtField.Decimals)
 		}

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -573,7 +573,7 @@ func TestComplexAggregation(t *testing.T) {
 
 func TestJoinAggregation(t *testing.T) {
 	// This is new functionality in Vitess 20
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/queries/reference/reference_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/reference_test.go
@@ -84,7 +84,7 @@ func TestReferenceRouting(t *testing.T) {
 	)
 
 	t.Run("Complex reference query", func(t *testing.T) {
-		utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+		utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 		// Verify a complex query using reference tables with a left join having a derived table with an order by clause works as intended.
 		utils.AssertMatches(
 			t,

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -180,7 +180,7 @@ func TestSubqueryInAggregation(t *testing.T) {
 // TestSubqueryInDerivedTable tests that subqueries and derived tables
 // are handled correctly when there are joins inside the derived table
 func TestSubqueryInDerivedTable(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
+++ b/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
@@ -48,7 +48,7 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 }
 
 func TestTPCHQueries(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 	err := utils.WaitForColumn(t, clusterInstance.VtgateProcess, keyspaceName, "region", `R_COMMENT`)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Post backport of PRs it is missed to enable some e2e test that do not run on release-19. They should be enabled now as the PRs are backported to it.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
