### PR TITLE
feat: add a LIMIT 1 on EXISTS subqueries to limit network overhead

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -128,7 +128,7 @@ select name from user where id not in (select id from t1) /* non-correlated subq
 ----------------------------------------------------------------------
 select name from user where exists (select id from t1) /* non-correlated subquery as EXISTS */
 
-1 ks_unsharded/-: select 1 from t1 limit 10001 /* non-correlated subquery as EXISTS */
+1 ks_unsharded/-: select 1 from t1 limit 1 /* non-correlated subquery as EXISTS */
 2 ks_sharded/-40: select `name` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
 2 ks_sharded/40-80: select `name` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
 2 ks_sharded/80-c0: select `name` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */

--- a/go/vt/vtgate/planbuilder/operators/query_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func TestMergeOffsetExpressions(t *testing.T) {
+	tests := []struct {
+		name           string
+		offset1        sqlparser.Expr
+		offset2        sqlparser.Expr
+		expectedExpr   sqlparser.Expr
+		expectedFailed bool
+	}{
+		{
+			name:           "both offsets are integers",
+			offset1:        sqlparser.NewIntLiteral("5"),
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   sqlparser.NewIntLiteral("8"),
+			expectedFailed: false,
+		},
+		{
+			name:           "first offset is nil",
+			offset1:        nil,
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   sqlparser.NewIntLiteral("3"),
+			expectedFailed: false,
+		},
+		{
+			name:           "second offset is nil",
+			offset1:        sqlparser.NewIntLiteral("5"),
+			offset2:        nil,
+			expectedExpr:   sqlparser.NewIntLiteral("5"),
+			expectedFailed: false,
+		},
+		{
+			name:           "both offsets are nil",
+			offset1:        nil,
+			offset2:        nil,
+			expectedExpr:   nil,
+			expectedFailed: false,
+		},
+		{
+			name:           "first offset is argument",
+			offset1:        sqlparser.NewArgument("offset1"),
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   nil,
+			expectedFailed: true,
+		},
+		{
+			name:           "second offset is argument",
+			offset1:        sqlparser.NewIntLiteral("5"),
+			offset2:        sqlparser.NewArgument("offset2"),
+			expectedExpr:   nil,
+			expectedFailed: true,
+		},
+		{
+			name:           "both offsets are arguments",
+			offset1:        sqlparser.NewArgument("offset1"),
+			offset2:        sqlparser.NewArgument("offset2"),
+			expectedExpr:   nil,
+			expectedFailed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, failed := mergeOffsetExpressions(tt.offset1, tt.offset2)
+			assert.Equal(t, tt.expectedExpr, expr)
+			assert.Equal(t, tt.expectedFailed, failed, "failed")
+		})
+	}
+}
+
+func TestMergeLimitExpressions(t *testing.T) {
+	tests := []struct {
+		name           string
+		limit1         sqlparser.Expr
+		limit2         sqlparser.Expr
+		offset2        sqlparser.Expr
+		expectedExpr   sqlparser.Expr
+		expectedFailed bool
+	}{
+		{
+			name:           "valid limits and offset",
+			limit1:         sqlparser.NewIntLiteral("10"),
+			limit2:         sqlparser.NewIntLiteral("7"),
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   sqlparser.NewIntLiteral("7"),
+			expectedFailed: false,
+		},
+		{
+			name:           "remaining rows after offset2 is zero",
+			limit1:         sqlparser.NewIntLiteral("3"),
+			limit2:         sqlparser.NewIntLiteral("7"),
+			offset2:        sqlparser.NewIntLiteral("5"),
+			expectedExpr:   sqlparser.NewIntLiteral("0"),
+			expectedFailed: false,
+		},
+		{
+			name:           "first limit is nil",
+			limit1:         nil,
+			limit2:         sqlparser.NewIntLiteral("7"),
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   sqlparser.NewIntLiteral("7"),
+			expectedFailed: false,
+		},
+		{
+			name:           "second limit is nil",
+			limit1:         sqlparser.NewIntLiteral("10"),
+			limit2:         nil,
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   sqlparser.NewIntLiteral("7"),
+			expectedFailed: false,
+		},
+		{
+			name:           "offset2 is nil",
+			limit1:         sqlparser.NewIntLiteral("10"),
+			limit2:         sqlparser.NewIntLiteral("7"),
+			offset2:        nil,
+			expectedExpr:   sqlparser.NewIntLiteral("7"),
+			expectedFailed: false,
+		},
+		{
+			name:           "first limit is argument",
+			limit1:         sqlparser.NewArgument("limit1"),
+			limit2:         sqlparser.NewIntLiteral("7"),
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   nil,
+			expectedFailed: true,
+		},
+		{
+			name:           "second limit is argument",
+			limit1:         sqlparser.NewIntLiteral("10"),
+			limit2:         sqlparser.NewArgument("limit2"),
+			offset2:        sqlparser.NewIntLiteral("3"),
+			expectedExpr:   nil,
+			expectedFailed: true,
+		},
+		{
+			name:           "offset2 is argument",
+			limit1:         sqlparser.NewIntLiteral("10"),
+			limit2:         sqlparser.NewIntLiteral("7"),
+			offset2:        sqlparser.NewArgument("offset2"),
+			expectedExpr:   nil,
+			expectedFailed: true,
+		},
+		{
+			name:           "all are arguments",
+			limit1:         sqlparser.NewArgument("limit1"),
+			limit2:         sqlparser.NewArgument("limit2"),
+			offset2:        sqlparser.NewArgument("offset2"),
+			expectedExpr:   nil,
+			expectedFailed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, failed := mergeLimitExpressions(tt.limit1, tt.limit2, tt.offset2)
+			assert.Equal(t, tt.expectedExpr, expr)
+			assert.Equal(t, tt.expectedFailed, failed, "failed")
+		})
+	}
+}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -1735,7 +1735,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id",
+            "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id limit 1",
             "Table": "user_extra",
             "Values": [
               "3"
@@ -2590,15 +2590,21 @@
               },
               {
                 "InputName": "SubQuery",
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra where user_extra.bar = :user_apa",
-                "Table": "user_extra"
+                "OperatorType": "Limit",
+                "Count": "1",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1 from user_extra where 1 != 1",
+                    "Query": "select 1 from user_extra where user_extra.bar = :user_apa limit 1",
+                    "Table": "user_extra"
+                  }
+                ]
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -2014,15 +2014,21 @@
         "Inputs": [
           {
             "InputName": "SubQuery",
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select 1 from `user` where 1 != 1",
-            "Query": "select 1 from `user`",
-            "Table": "`user`"
+            "OperatorType": "Limit",
+            "Count": "1",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from `user` where 1 != 1",
+                "Query": "select 1 from `user` limit 1",
+                "Table": "`user`"
+              }
+            ]
           },
           {
             "InputName": "Outer",
@@ -2854,7 +2860,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
-            "Query": "select 1 from `user` as u2 where u2.id = 5",
+            "Query": "select 1 from `user` as u2 where u2.id = 5 limit 1",
             "Table": "`user`",
             "Values": [
               "5"
@@ -4311,7 +4317,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded as u2 where 1 != 1",
-                "Query": "select 1 from unsharded as u2 where u2.baz = :u1_bar",
+                "Query": "select 1 from unsharded as u2 where u2.baz = :u1_bar limit 1",
                 "Table": "unsharded"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -946,31 +946,37 @@
         "Inputs": [
           {
             "InputName": "SubQuery",
-            "OperatorType": "Concatenate",
+            "OperatorType": "Limit",
+            "Count": "1",
             "Inputs": [
               {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
-                "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name1 /* VARCHAR */ and table_name = :table_name1 /* VARCHAR */",
-                "SysTableTableName": "[table_name1:'Music']",
-                "Table": "information_schema.`tables`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
-                "Query": "select 1 as found from information_schema.views where table_name = :table_name2 /* VARCHAR */ and table_name = :table_name2 /* VARCHAR */ limit 1",
-                "SysTableTableName": "[table_name2:'user']",
-                "Table": "information_schema.views"
+                "OperatorType": "Concatenate",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "DBA",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": false
+                    },
+                    "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
+                    "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name1 /* VARCHAR */ and table_name = :table_name1 /* VARCHAR */ limit :__upper_limit",
+                    "SysTableTableName": "[table_name1:'Music']",
+                    "Table": "information_schema.`tables`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "DBA",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": false
+                    },
+                    "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
+                    "Query": "select 1 as found from information_schema.views where table_name = :table_name2 /* VARCHAR */ and table_name = :table_name2 /* VARCHAR */ limit :__upper_limit",
+                    "SysTableTableName": "[table_name2:'user']",
+                    "Table": "information_schema.views"
+                  }
+                ]
               }
             ]
           },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1011,31 +1011,37 @@
         "Inputs": [
           {
             "InputName": "SubQuery",
-            "OperatorType": "Concatenate",
+            "OperatorType": "Limit",
+            "Count": "1",
             "Inputs": [
               {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
-                "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name1 /* VARCHAR */ and table_name = :table_name1 /* VARCHAR */",
-                "SysTableTableName": "[table_name1:'Music']",
-                "Table": "information_schema.`tables`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
-                "Query": "select 1 as found from information_schema.views where table_name = :table_name2 /* VARCHAR */ and table_name = :table_name2 /* VARCHAR */ limit 1",
-                "SysTableTableName": "[table_name2:'user']",
-                "Table": "information_schema.views"
+                "OperatorType": "Concatenate",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "DBA",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": false
+                    },
+                    "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
+                    "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name1 /* VARCHAR */ and table_name = :table_name1 /* VARCHAR */ limit :__upper_limit",
+                    "SysTableTableName": "[table_name1:'Music']",
+                    "Table": "information_schema.`tables`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "DBA",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": false
+                    },
+                    "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
+                    "Query": "select 1 as found from information_schema.views where table_name = :table_name2 /* VARCHAR */ and table_name = :table_name2 /* VARCHAR */ limit :__upper_limit",
+                    "SysTableTableName": "[table_name2:'user']",
+                    "Table": "information_schema.views"
+                  }
+                ]
               }
             ]
           },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2723,7 +2723,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id",
+                "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id limit 1",
                 "Table": "user_extra",
                 "Values": [
                   "3"
@@ -2782,7 +2782,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id",
+                "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id limit 1",
                 "Table": "user_extra",
                 "Values": [
                   "3"
@@ -2846,15 +2846,21 @@
               },
               {
                 "InputName": "SubQuery",
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
-                "Query": "select 1 from user_extra as ue where ue.col = :u1_col and ue.col = :u2_col",
-                "Table": "user_extra"
+                "OperatorType": "Limit",
+                "Count": "1",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
+                    "Query": "select 1 from user_extra as ue where ue.col = :u1_col and ue.col = :u2_col limit 1",
+                    "Table": "user_extra"
+                  }
+                ]
               }
             ]
           }
@@ -2897,15 +2903,21 @@
               },
               {
                 "InputName": "SubQuery",
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
-                "Query": "select 1 from user_extra as ue where ue.col = :u_col and ue.col2 = :u_col",
-                "Table": "user_extra"
+                "OperatorType": "Limit",
+                "Count": "1",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
+                    "Query": "select 1 from user_extra as ue where ue.col = :u_col and ue.col2 = :u_col limit 1",
+                    "Table": "user_extra"
+                  }
+                ]
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -252,7 +252,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from lineitem where 1 != 1",
-                    "Query": "select 1 from lineitem where l_orderkey = :o_orderkey and l_commitdate < l_receiptdate",
+                    "Query": "select 1 from lineitem where l_orderkey = :o_orderkey and l_commitdate < l_receiptdate limit 1",
                     "Table": "lineitem"
                   }
                 ]


### PR DESCRIPTION

## Description

This pull request introduces an optimization to our query planner by adding a `LIMIT 1` clause to `EXISTS` subqueries. This change aims to minimize the amount of data being transferred over the wire, resulting in improved performance and reduced resource consumption.

## Changes

- **Optimization Addition**: Added a `LIMIT 1` clause to all `EXISTS` subqueries generated by the planner.
- **Impact**: The optimization reduces the amount of data sent over the network and processed by the database, improving overall query performance.

## Example

Before Optimization:
```sql
SELECT * FROM orders o WHERE EXISTS (SELECT 1 FROM order_items oi WHERE oi.order_id = o.id);
```

After Optimization:
```sql
SELECT * FROM orders o WHERE EXISTS (SELECT 1 FROM order_items oi WHERE oi.order_id = o.id LIMIT 1);
```

## History

Our planner used to do this, but in #13750 when we refactored the subquery handling in the planner, we lost this optimisation. It was left as a TODO that wasn't picked up until now.

## Related Issue(s)
Fixes #16149
Optimisation lost in #13750

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
