### PR TITLE
Fix flakiness in `vtexplain` unit test case.

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -207,9 +207,9 @@ SELECT id FROM orders WHERE id IN (1, "1", 1)
 2 ks_sharded/40-80: select id from orders where id in (1, '1', 1) limit 10001
 
 ----------------------------------------------------------------------
-(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 2)
+(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 3)
 
-2 ks_sharded/-40: select dt.c0 as id, dt.c1 as `name`, weight_string(dt.c0), weight_string(dt.c1) from (select distinct `user`.id, `user`.`name` from `user` where `user`.id = 2) as dt(c0, c1) limit 10001
-2 ks_sharded/-40: select dt.c0 as id, dt.c1 as `name`, weight_string(dt.c0), weight_string(dt.c1) from (select distinct `user`.id, `user`.`name` from `user` where `user`.id = 1) as dt(c0, c1) limit 10001
+1 ks_sharded/-40: select dt.c0 as id, dt.c1 as `name`, weight_string(dt.c0), weight_string(dt.c1) from (select distinct `user`.id, `user`.`name` from `user` where `user`.id = 1) as dt(c0, c1) limit 10001
+1 ks_sharded/40-80: select dt.c0 as id, dt.c1 as `name`, weight_string(dt.c0), weight_string(dt.c1) from (select distinct `user`.id, `user`.`name` from `user` where `user`.id = 3) as dt(c0, c1) limit 10001
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/selectsharded-queries.sql
+++ b/go/vt/vtexplain/testdata/selectsharded-queries.sql
@@ -40,4 +40,4 @@ SELECT user.id, user.name, name_info.info FROM user INNER JOIN music ON (user.id
 
 SELECT id FROM orders WHERE id IN (1, "1", 1);
 
-(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 2);
+(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 3);


### PR DESCRIPTION
## Description

The test case I added for https://github.com/vitessio/vitess/pull/16129 is flaky, unfortunately. 😞 

The reason for that seems to be that both parts of the `UNION` get sent to the same shard, and the order in which they are sent is not deterministic. This causes the test to fail sometimes, because the order of the results is different.

It's very unfortunate that I noticed that after backporting the change to various release branches, as this flakiness fix now will need to be backported too.

I verified that this test is no longer flaky by running:

```
go test -count 10 -race vitess.io/vitess/go/vt/vtexplain
```

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
