### PR TITLE
VReplication: handle escaped identifiers in vschema when initializing sequence tables

### DIFF
--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -147,7 +147,7 @@ create table nopk (name varchar(128), age int unsigned);
       ],
       "auto_increment": {
         "column": "cid",
-        "sequence": "customer_seq"
+         "sequence": "` + "`customer_seq`" + `"
       }
     },
     "customer_name": {

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -147,7 +147,7 @@ create table nopk (name varchar(128), age int unsigned);
       ],
       "auto_increment": {
         "column": "cid",
-         "sequence": "` + "`customer_seq`" + `"
+        "sequence": "` + "`customer_seq`" + `"
       }
     },
     "customer_name": {
@@ -295,7 +295,7 @@ create table nopk (name varchar(128), age int unsigned);
 	      ],
 	      "auto_increment": {
 	        "column": "cid",
-	        "sequence": "customer_seq"
+	        "sequence": "` + "`customer_seq`" + `"
 	      }
 	},
     "orders": {
@@ -345,7 +345,7 @@ create table nopk (name varchar(128), age int unsigned);
 	      ],
 	      "auto_increment": {
 	        "column": "cid",
-	        "sequence": "customer_seq"
+	        "sequence": "` + "`customer_seq`" + `"
 	      }
 	},
     "orders": {

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -88,7 +88,7 @@ create table nopk (name varchar(128), age int unsigned);
     "orders": {},
     "loadtest": {},
     "customer": {},
-    "customer_seq": {
+    "` + "`customer_seq`" + `": {
       "type": "sequence"
     },
     "customer2": {},

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -88,7 +88,7 @@ create table nopk (name varchar(128), age int unsigned);
     "orders": {},
     "loadtest": {},
     "customer": {},
-    "` + "`customer_seq`" + `": {
+    "customer_seq": {
       "type": "sequence"
     },
     "customer2": {},
@@ -295,7 +295,7 @@ create table nopk (name varchar(128), age int unsigned);
 	      ],
 	      "auto_increment": {
 	        "column": "cid",
-	        "sequence": "` + "`customer_seq`" + `"
+	        "sequence": "` + "`product`.`customer_seq`" + `"
 	      }
 	},
     "orders": {

--- a/go/test/endtoend/vreplication/fk_ext_test.go
+++ b/go/test/endtoend/vreplication/fk_ext_test.go
@@ -248,7 +248,7 @@ func doReshard(t *testing.T, keyspace, workflowName, sourceShards, targetShards 
 		sourceShards:   sourceShards,
 		targetShards:   targetShards,
 		skipSchemaCopy: true,
-	}, workflowFlavorVtctl)
+	}, workflowFlavorVtctld)
 	rs.Create()
 	waitForWorkflowState(t, vc, fmt.Sprintf("%s.%s", keyspace, workflowName), binlogdatapb.VReplicationWorkflowState_Running.String())
 	for _, targetTab := range targetTabs {
@@ -355,7 +355,7 @@ func doMoveTables(t *testing.T, sourceKeyspace, targetKeyspace, workflowName, ta
 		},
 		sourceKeyspace: sourceKeyspace,
 		atomicCopy:     atomicCopy,
-	}, workflowFlavorRandom)
+	}, workflowFlavorVtctld)
 	mt.Create()
 
 	waitForWorkflowState(t, vc, fmt.Sprintf("%s.%s", targetKeyspace, workflowName), binlogdatapb.VReplicationWorkflowState_Running.String())

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -34,7 +34,7 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
-const testWorkflowFlavor = workflowFlavorRandom
+const testWorkflowFlavor = workflowFlavorVtctld
 
 // TestFKWorkflow runs a MoveTables workflow with atomic copy for a db with foreign key constraints.
 // It inserts initial data, then simulates load. We insert both child rows with foreign keys and those without,

--- a/go/test/endtoend/vreplication/partial_movetables_test.go
+++ b/go/test/endtoend/vreplication/partial_movetables_test.go
@@ -53,7 +53,7 @@ func testCancel(t *testing.T) {
 		sourceKeyspace: sourceKeyspace,
 		tables:         table,
 		sourceShards:   shard,
-	}, workflowFlavorRandom)
+	}, workflowFlavorVtctld)
 	mt.Create()
 
 	checkDenyList := func(keyspace string, expected bool) {
@@ -390,9 +390,5 @@ func testPartialMoveTablesBasic(t *testing.T, flavor workflowFlavor) {
 // We test with both the vtctlclient and vtctldclient flavors.
 func TestPartialMoveTablesBasic(t *testing.T) {
 	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
-	for _, flavor := range workflowFlavors {
-		t.Run(workflowFlavorNames[flavor], func(t *testing.T) {
-			testPartialMoveTablesBasic(t, flavor)
-		})
-	}
+	testPartialMoveTablesBasic(t, workflowFlavorVtctld)
 }

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -176,6 +176,7 @@ func TestVDiff2(t *testing.T) {
 	// We ONLY add primary tablets in this test.
 	tks, err := vc.AddKeyspace(t, []*Cell{zone3, zone1, zone2}, targetKs, strings.Join(targetShards, ","), customerVSchema, customerSchema, 0, 0, 200, targetKsOpts)
 	require.NoError(t, err)
+	verifyClusterHealth(t, vc)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1387,6 +1387,7 @@ func (ts *trafficSwitcher) getTargetSequenceMetadata(ctx context.Context) (map[s
 		}
 		var err error
 		for tableName, tableDef := range kvs.Tables {
+			// The table name can be escaped in the vschema definition.
 			if tableName, err = sqlescape.UnescapeID(tableName); err != nil {
 				return err
 			}
@@ -1433,6 +1434,7 @@ func (ts *trafficSwitcher) getTargetSequenceMetadata(ctx context.Context) (map[s
 	searchGroup, gctx := errgroup.WithContext(ctx)
 	searchCompleted := make(chan struct{})
 	for _, keyspace := range keyspaces {
+		// The keyspace name can be escaped in the vschema definition.
 		keyspace, err := sqlescape.UnescapeID(keyspace)
 		if err != nil {
 			return nil, err

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1692,10 +1692,11 @@ func (ts *trafficSwitcher) initializeTargetSequences(ctx context.Context, sequen
 		// ResetSequences interfaces with the schema engine and the actual
 		// table identifiers DO NOT contain the backticks. So we have to
 		// ensure that the table name is unescaped.
-		if backingTable, err = sqlescape.UnescapeID(backingTable); err != nil {
-			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid table name %s: %v", backingTable, err)
+		escapedBackingTable, err := sqlescape.UnescapeID(backingTable)
+		if err != nil {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid sequence backing table name %s: %v", backingTable, err)
 		}
-		ierr = ts.TabletManagerClient().ResetSequences(ictx, ti.Tablet, []string{backingTable})
+		ierr = ts.TabletManagerClient().ResetSequences(ictx, ti.Tablet, []string{escapedBackingTable})
 		if ierr != nil {
 			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to reset the sequence cache for backing table %s on shard %s/%s using tablet %s: %v",
 				sequenceMetadata.backingTableName, sequenceShard.Keyspace(), sequenceShard.ShardName(), sequenceShard.PrimaryAlias, ierr)

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -142,8 +142,6 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 					},
 				},
 			},
-			// key: ```my-seq1```, value: &{```my-seq1``` ```source-ks``` vt_`source-ks` t1 vt_targetks 0x14000758640}
-			// column_vindexes:{column:"`my-col`" name:"xxhash"} auto_increment:{column:"`my-col`" sequence:"`source-ks`.`my-seq1`"}
 			want: map[string]*sequenceMetadata{
 				"my-seq1": {
 					backingTableName:     "my-seq1",
@@ -204,7 +202,6 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 				sources:        sources,
 				targets:        targets,
 			}
-			//t.Logf("DEBUG: ts: %+v", ts)
 			got, err := ts.getTargetSequenceMetadata(ctx)
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package workflow
 
 import (
+	"context"
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
@@ -54,5 +61,157 @@ func TestReverseWorkflowName(t *testing.T) {
 	for _, test := range tests {
 		got := ReverseWorkflowName(test.in)
 		assert.Equal(t, test.out, got)
+	}
+}
+
+func TestGetTargetSequenceMetadata(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cell := "cell1"
+	workflow := "wf1"
+	table := "t1"
+	sourceKeyspace := &testKeyspace{
+		KeyspaceName: "source-ks",
+		ShardNames:   []string{"0"},
+	}
+	targetKeyspace := &testKeyspace{
+		KeyspaceName: "targetks",
+		ShardNames:   []string{"-80", "80-"},
+	}
+	vindexes := map[string]*vschema.Vindex{
+		"xxhash": {
+			Type: "xxhash",
+		},
+		"unicode_loose_xxhash": {
+			Type: "unicode_loose_xxhash",
+		},
+	}
+	env := newTestEnv(t, ctx, cell, sourceKeyspace, targetKeyspace)
+	defer env.close()
+	/*
+		env.tmc.schema = map[string]*tabletmanagerdatapb.SchemaDefinition{
+			"t1": {
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					{
+						Name: "t1",
+						Columns: []string{
+							"my-col",
+						},
+					},
+				},
+			},
+		}
+	*/
+
+	type testCase struct {
+		name          string
+		sourceVSchema *vschema.Keyspace
+		targetVSchema *vschema.Keyspace
+		want          map[string]*sequenceMetadata
+		err           string
+	}
+	tests := []testCase{
+		{
+			name: "no sequences",
+			want: nil,
+		},
+		{
+			name: "sequences with backticks all over",
+			sourceVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					"`my-seq1`": {
+						Type: "sequence",
+					},
+				},
+			},
+			targetVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					table: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:   "xxhash",
+								Column: "`my-col`",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "`my-col`",
+							Sequence: fmt.Sprintf("`%s`.`my-seq1`", sourceKeyspace.KeyspaceName),
+						},
+					},
+				},
+			},
+			// key: ```my-seq1```, value: &{```my-seq1``` ```source-ks``` vt_`source-ks` t1 vt_targetks 0x14000758640}
+			// column_vindexes:{column:"`my-col`" name:"xxhash"} auto_increment:{column:"`my-col`" sequence:"`source-ks`.`my-seq1`"}
+			want: map[string]*sequenceMetadata{
+				"my-seq1": {
+					backingTableName:     "my-seq1",
+					backingTableKeyspace: "source-ks",
+					backingTableDBName:   "vt_source-ks",
+					usingTableName:       table,
+					usingTableDBName:     "vt_targetks",
+					usingTableDefinition: &vschema.Table{
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Column: "`my-col`",
+								Name:   "xxhash",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "`my-col`",
+							Sequence: fmt.Sprintf("`%s`.`my-seq1`", sourceKeyspace.KeyspaceName),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := env.ts.SaveVSchema(ctx, sourceKeyspace.KeyspaceName, tc.sourceVSchema)
+			require.NoError(t, err)
+			err = env.ts.SaveVSchema(ctx, targetKeyspace.KeyspaceName, tc.targetVSchema)
+			require.NoError(t, err)
+			err = env.ts.RebuildSrvVSchema(ctx, nil)
+			require.NoError(t, err)
+			sources := make(map[string]*MigrationSource, len(sourceKeyspace.ShardNames))
+			targets := make(map[string]*MigrationTarget, len(targetKeyspace.ShardNames))
+			for i, shard := range sourceKeyspace.ShardNames {
+				tablet := env.tablets[sourceKeyspace.KeyspaceName][startingSourceTabletUID+(i*tabletUIDStep)]
+				sources[shard] = &MigrationSource{
+					primary: &topo.TabletInfo{
+						Tablet: tablet,
+					},
+				}
+			}
+			for i, shard := range targetKeyspace.ShardNames {
+				tablet := env.tablets[targetKeyspace.KeyspaceName][startingTargetTabletUID+(i*tabletUIDStep)]
+				targets[shard] = &MigrationTarget{
+					primary: &topo.TabletInfo{
+						Tablet: tablet,
+					},
+				}
+			}
+			ts := &trafficSwitcher{
+				id:             1,
+				ws:             env.ws,
+				workflow:       workflow,
+				tables:         []string{table},
+				sourceKeyspace: sourceKeyspace.KeyspaceName,
+				targetKeyspace: targetKeyspace.KeyspaceName,
+				sources:        sources,
+				targets:        targets,
+			}
+			//t.Logf("DEBUG: ts: %+v", ts)
+			got, err := ts.getTargetSequenceMetadata(ctx)
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.True(t, reflect.DeepEqual(tc.want, got), "want: %v, got: %v", tc.want, got)
+		})
 	}
 }

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -197,6 +197,122 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "invalid table name",
+			sourceVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					"`my-`seq1`": {
+						Type: "sequence",
+					},
+				},
+			},
+			targetVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					table: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:   "xxhash",
+								Column: "`my-col`",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "`my-col`",
+							Sequence: "`my-seq1`",
+						},
+					},
+				},
+			},
+			err: "invalid table name `my-`seq1` in keyspace source-ks: UnescapeID err: unexpected single backtick at position 3 in 'my-`seq1'",
+		},
+		{
+			name: "invalid keyspace name",
+			sourceVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					"`my-seq1`": {
+						Type: "sequence",
+					},
+				},
+			},
+			targetVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					table: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:   "xxhash",
+								Column: "`my-col`",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "`my-col`",
+							Sequence: "`ks`1`.`my-seq1`",
+						},
+					},
+				},
+			},
+			err: "invalid keyspace in qualified sequence table name `ks`1`.`my-seq1` defined in sequence table column_vindexes:{column:\"`my-col`\" name:\"xxhash\"} auto_increment:{column:\"`my-col`\" sequence:\"`ks`1`.`my-seq1`\"}: UnescapeID err: unexpected single backtick at position 2 in 'ks`1'",
+		},
+		{
+			name: "invalid auto-inc column name",
+			sourceVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					"`my-seq1`": {
+						Type: "sequence",
+					},
+				},
+			},
+			targetVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					table: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:   "xxhash",
+								Column: "`my-col`",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "`my`-col`",
+							Sequence: "`my-seq1`",
+						},
+					},
+				},
+			},
+			err: "invalid auto-increment column name `my`-col` defined in sequence table column_vindexes:{column:\"my-col\" name:\"xxhash\"} auto_increment:{column:\"`my`-col`\" sequence:\"my-seq1\"}: UnescapeID err: unexpected single backtick at position 2 in 'my`-col'",
+		},
+		{
+			name: "invalid sequence name",
+			sourceVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					"`my-seq1`": {
+						Type: "sequence",
+					},
+				},
+			},
+			targetVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					table: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:   "xxhash",
+								Column: "`my-col`",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "`my-col`",
+							Sequence: "`my-`seq1`",
+						},
+					},
+				},
+			},
+			err: "invalid sequence table name `my-`seq1` defined in sequence table column_vindexes:{column:\"`my-col`\" name:\"xxhash\"} auto_increment:{column:\"`my-col`\" sequence:\"`my-`seq1`\"}: UnescapeID err: unexpected single backtick at position 3 in 'my-`seq1'",
+		},
 	}
 
 	for _, tc := range tests {

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -919,7 +919,7 @@ func (se *Engine) ResetSequences(tables []string) error {
 	for _, tableName := range tables {
 		if table, ok := se.tables[tableName]; ok {
 			if table.SequenceInfo != nil {
-				log.Infof("Resetting sequence info for table %v: %s", tableName, table.SequenceInfo)
+				log.Infof("Resetting sequence info for table %s: %+v", tableName, table.SequenceInfo)
 				table.SequenceInfo.Reset()
 			}
 		} else {

--- a/tools/unit_test_race.sh
+++ b/tools/unit_test_race.sh
@@ -54,7 +54,7 @@ for pkg in $flaky_tests; do
   max_attempts=3
   attempt=1
   # Set a timeout because some tests may deadlock when they flake.
-  until go test -timeout 2m $VT_GO_PARALLEL $pkg -v -race -count=1; do
+  until go test -timeout 5m $VT_GO_PARALLEL $pkg -v -race -count=1; do
     echo "FAILED (try $attempt/$max_attempts) in $pkg (return code $?). See above for errors."
     if [ $((++attempt)) -gt $max_attempts ]; then
       echo "ERROR: Flaky Go unit tests in package $pkg failed too often (after $max_attempts retries). Please reduce the flakiness."


### PR DESCRIPTION
## Description

This work ensures that VReplication — when initializing sequence tables during a traffic switch — handles any escaped identifiers (by unescaping them) that may be in the vschema while continuing to ensure that they are escaped when using them in SQL queries.

This PR also moves more of the VReplication endtoend tests to `vtctldclient` as we  now escape the backing sequence table `customer_seq` references in the test vschemas and the `vtctlclient` (wrangler) implementation remains unchanged as it's long deprecated and should be removed entirely in v21 or v22.

I think that this is worth back porting to the latest GA release (v20), for RC2 if we can.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16160

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required