### PR TITLE
VDiff CLI: Fix VDiff `show` bug

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -462,7 +462,6 @@ func getStructFieldNames(s any) []string {
 }
 
 func buildListings(listings []*listing) string {
-	var values []string
 	var lines [][]string
 	var result string
 
@@ -474,6 +473,7 @@ func buildListings(listings []*listing) string {
 	// The header is the first row.
 	lines = append(lines, fields)
 	for _, listing := range listings {
+		var values []string
 		v := reflect.ValueOf(*listing)
 		for _, field := range fields {
 			values = append(values, v.FieldByName(field).String())


### PR DESCRIPTION
## Description

This PR fixes incorrect display of multiple vdiffs for a keyspace/workflow, caused by incorrect initialization of a loop variable.

This was introduced in https://github.com/vitessio/vitess/pull/13976, part of v18, hence backporting upto v18.

See https://github.com/vitessio/vitess/issues/16176 for repro. 
Before this PR:
```
+-----------------------------------------+----------------------+-------------+----------+--------------+
|                                    UUID |             Workflow |    Keyspace |    Shard |        State |
+=========================================+======================+=============+==========+==============+
|    c8de5570-5cfe-4d3e-91f7-0d01b2030525 |    commerce2customer |    customer |        0 |    completed |
+-----------------------------------------+----------------------+-------------+----------+--------------+
|    c8de5570-5cfe-4d3e-91f7-0d01b2030525 |    commerce2customer |    customer |        0 |    completed |
+-----------------------------------------+----------------------+-------------+----------+--------------+
```

After this PR:
```
+-----------------------------------------+----------------------+-------------+----------+--------------+
|                                    UUID |             Workflow |    Keyspace |    Shard |        State |
+=========================================+======================+=============+==========+==============+
|    c8de5570-5cfe-4d3e-91f7-0d01b2030525 |    commerce2customer |    customer |        0 |    completed |
+-----------------------------------------+----------------------+-------------+----------+--------------+
|    598e070b-c217-4a8c-873a-85c4afd0d841 |    commerce2customer |    customer |        0 |    completed |
+-----------------------------------------+----------------------+-------------+----------+--------------+
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16176

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
