### PR TITLE
Fix flaky tests that use vtcombo

### DIFF
--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -60,7 +60,7 @@ func TestRunsVschemaMigrations(t *testing.T) {
 	cluster, err := startCluster()
 	defer cluster.TearDown()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table", vindex: "my_vdx", vindexType: "hash", column: "id"})
 	assertColumnVindex(t, cluster, columnVindex{keyspace: "app_customer", table: "customers", vindex: "hash", vindexType: "hash", column: "id"})
 
@@ -77,7 +77,7 @@ func TestPersistentMode(t *testing.T) {
 	dir := t.TempDir()
 
 	cluster, err := startPersistentCluster(dir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Add a new "ad-hoc" vindex via vtgate once the cluster is up, to later make sure it is persisted across teardowns
 	err = addColumnVindex(cluster, "test_keyspace", "alter vschema on persistence_test add vindex my_vdx(id)")
@@ -116,7 +116,7 @@ func TestPersistentMode(t *testing.T) {
 		cluster.PersistentMode = false // Cleanup the tmpdir as we're done
 		cluster.TearDown()
 	}()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// rerun our sanity checks to make sure vschema is persisted correctly
 	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table", vindex: "my_vdx", vindexType: "hash", column: "id"})
@@ -137,7 +137,7 @@ func TestForeignKeysAndDDLModes(t *testing.T) {
 	defer resetConfig(conf)
 
 	cluster, err := startCluster("--foreign_key_mode=allow", "--enable_online_ddl=true", "--enable_direct_ddl=true")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer cluster.TearDown()
 
 	err = execOnCluster(cluster, "test_keyspace", func(conn *mysql.Conn) error {
@@ -163,7 +163,7 @@ func TestForeignKeysAndDDLModes(t *testing.T) {
 
 	cluster.TearDown()
 	cluster, err = startCluster("--foreign_key_mode=disallow", "--enable_online_ddl=false", "--enable_direct_ddl=false")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer cluster.TearDown()
 
 	err = execOnCluster(cluster, "test_keyspace", func(conn *mysql.Conn) error {
@@ -191,7 +191,7 @@ func TestNoScatter(t *testing.T) {
 	defer resetConfig(conf)
 
 	cluster, err := startCluster("--no_scatter")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer cluster.TearDown()
 
 	_ = execOnCluster(cluster, "app_customer", func(conn *mysql.Conn) error {
@@ -208,7 +208,7 @@ func TestCreateDbaTCPUser(t *testing.T) {
 	defer resetConfig(conf)
 
 	clusterInstance, err := startCluster("--initialize-with-vt-dba-tcp=true")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer clusterInstance.TearDown()
 
 	defer func() {
@@ -242,7 +242,7 @@ func TestCanGetKeyspaces(t *testing.T) {
 	defer cancel()
 
 	clusterInstance, err := startCluster()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer clusterInstance.TearDown()
 
 	defer func() {
@@ -276,7 +276,7 @@ func TestExternalTopoServerConsul(t *testing.T) {
 
 	cluster, err := startCluster("--external_topo_implementation=consul",
 		fmt.Sprintf("--external_topo_global_server_address=%s", serverAddr), "--external_topo_global_root=consul_test/global")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer cluster.TearDown()
 
 	assertGetKeyspaces(ctx, t, cluster)
@@ -312,7 +312,7 @@ func TestMtlsAuth(t *testing.T) {
 		fmt.Sprintf("--vtctld_grpc_cert=%s", clientCert),
 		fmt.Sprintf("--vtctld_grpc_ca=%s", caCert),
 		fmt.Sprintf("--grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() {
 		cluster.PersistentMode = false // Cleanup the tmpdir as we're done
 		cluster.TearDown()
@@ -356,7 +356,7 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 		fmt.Sprintf("--grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
 	defer cluster.TearDown()
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "code = Unauthenticated desc = client certificate not authorized")
 }
 

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -19,8 +19,10 @@ package vttest
 import (
 	"fmt"
 	"math/rand/v2"
+	"net"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"vitess.io/vitess/go/vt/proto/vttest"
@@ -231,9 +233,19 @@ func tmpdir(dataroot string) (dir string, err error) {
 	return
 }
 
+// randomPort gets a random port that is available for a TCP connection.
+// After we generate a random port, we try to establish a tcp connection on it.
+// If it fails, then we try a different port.
 func randomPort() int {
-	v := rand.Int32N(20000)
-	return int(v + 10000)
+	for {
+		port := int(rand.Int32N(20000) + 10000)
+		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err != nil {
+			continue
+		}
+		ln.Close()
+		return port
+	}
 }
 
 // NewLocalTestEnv returns an instance of the default test environment used

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -234,16 +234,23 @@ func tmpdir(dataroot string) (dir string, err error) {
 }
 
 // randomPort gets a random port that is available for a TCP connection.
-// After we generate a random port, we try to establish a tcp connection on it.
-// If it fails, then we try a different port.
+// After we generate a random port, we try to establish tcp connections on it and the next 5 values.
+// If any of them fail, then we try a different port.
 func randomPort() int {
 	for {
 		port := int(rand.Int32N(20000) + 10000)
-		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
-		if err != nil {
+		portInUse := false
+		for i := 0; i < 6; i++ {
+			ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port+i)))
+			if err != nil {
+				portInUse = true
+				break
+			}
+			ln.Close()
+		}
+		if portInUse {
 			continue
 		}
-		ln.Close()
 		return port
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Some tests like `TestCanGetKeyspaces` have been flaky. They occasionally end up panicking - 
```
2024-06-13T08:34:17.3101964Z --- FAIL: TestCanGetKeyspaces (12.89s)
2024-06-13T08:34:17.3102209Z panic: runtime error: invalid memory address or nil pointer dereference [recovered]
2024-06-13T08:34:17.3102594Z 	panic: runtime error: invalid memory address or nil pointer dereference
2024-06-13T08:34:17.3102810Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x16d5060]
2024-06-13T08:34:17.3102825Z 
2024-06-13T08:34:17.3102924Z goroutine 957 [running]:
2024-06-13T08:34:17.3103056Z testing.tRunner.func1.2({0x1859800, 0x2d13550})
2024-06-13T08:34:17.3103371Z 	/opt/actions-runner/_work/_tool/go/1.22.4/x64/src/testing/testing.go:1631 +0x24a
2024-06-13T08:34:17.3103465Z testing.tRunner.func1()
2024-06-13T08:34:17.3103758Z 	/opt/actions-runner/_work/_tool/go/1.22.4/x64/src/testing/testing.go:1634 +0x377
2024-06-13T08:34:17.3103850Z panic({0x1859800?, 0x2d13550?})
2024-06-13T08:34:17.3104134Z 	/opt/actions-runner/_work/_tool/go/1.22.4/x64/src/runtime/panic.go:770 +0x132
2024-06-13T08:34:17.3104363Z vitess.io/vitess/go/cmd/vttestserver/cli.consumeEventStream({0x0, 0x0})
2024-06-13T08:34:17.3104756Z 	/opt/actions-runner/_work/vitess-private/vitess-private/go/cmd/vttestserver/cli/main_test.go:483 +0x80
2024-06-13T08:34:17.3105193Z vitess.io/vitess/go/cmd/vttestserver/cli.assertGetKeyspaces({_, _}, _, {{0xc000b87260, 0x0, {0x1af1cb9, 0xb}, {0x0, 0x0}, {0x0, ...}, ...}, ...})
2024-06-13T08:34:17.3105625Z 	/opt/actions-runner/_work/vitess-private/vitess-private/go/cmd/vttestserver/cli/main_test.go:469 +0x277
2024-06-13T08:34:17.3105861Z vitess.io/vitess/go/cmd/vttestserver/cli.TestCanGetKeyspaces(0xc00038a4e0)
2024-06-13T08:34:17.3106244Z 	/opt/actions-runner/_work/vitess-private/vitess-private/go/cmd/vttestserver/cli/main_test.go:254 +0x2b2
2024-06-13T08:34:17.3106386Z testing.tRunner(0xc00038a4e0, 0x1e42150)
2024-06-13T08:34:17.3106667Z 	/opt/actions-runner/_work/_tool/go/1.22.4/x64/src/testing/testing.go:1689 +0xfb
2024-06-13T08:34:17.3106791Z created by testing.(*T).Run in goroutine 1
2024-06-13T08:34:17.3107074Z 	/opt/actions-runner/_work/_tool/go/1.22.4/x64/src/testing/testing.go:1742 +0x390
2024-06-13T08:34:17.3107225Z FAIL	vitess.io/vitess/go/cmd/vttestserver/cli	61.087s
```

The problem was 2 fold. The first being, that when we setup a new cluster we only assert that we don't have an error, we don't require it. This causes the test to continue to run even when the cluster setup fails. We eventually end up using the cluster, which is nil (cause of the failure), and this panics the test.

So, the first thing we do is change all `assert.Error` calls to `require.Error` calls that setup a cluster using vtcombo.

Once we do this, we see the actual underlying error that fails these tests - 
```
2024-06-14T06:09:31.9570978Z F0614 06:09:10.732810   38226 grpc_server.go:300] Cannot listen on port 29482 for gRPC: listen tcp :29482: bind: address already in use
2024-06-14T06:09:31.9571157Z     main_test.go:245: 
2024-06-14T06:09:31.9572114Z         	Error Trace:	/opt/actions-runner/_work//vitess/go/cmd/vttestserver/cli/main_test.go:245
2024-06-14T06:09:31.9572444Z         	Error:      	Received unexpected error:
2024-06-14T06:09:31.9573045Z         	            	process 'vtcombo' exited prematurely (err: exit status 1)
2024-06-14T06:09:31.9573324Z         	Test:       	TestCanGetKeyspaces
2024-06-14T06:09:31.9573554Z --- FAIL: TestCanGetKeyspaces (10.64s)
```

The problem is that we are choosing a random port for starting a cluster, and that port might already be in use by some other process. This PR fixes this issue by changing the logic of finding a random port to also verify that the port in question is also available for a tcp connection. If not, we retry and try a different random port.

I have verified that this fix indeed works, by 1 running the test multiple times, and 2 by ensuring that we correctly move away from ports that are already in use - 
```
E0614 15:48:12.382166   84785 environment.go:243] Can't listen on port 100: listen tcp 127.0.0.1:100: bind: permission denied, trying next port
I0614 15:48:12.383906   84785 environment.go:248] Port 29622 is available, reserving..
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
