### PR TITLE
CI flaky test: Fix flakiness in vreplication_migrate_vdiff2_convert_tz

### DIFF
--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -306,10 +306,17 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, tks *Keyspace, 
 	checkVDiffCountStat(t, statsTablet, tc.vdiffCount)
 
 	// These are done here so that we have a valid workflow to test the commands against.
-	if tc.stop {
-		testStop(t, ksWorkflow, allCellNames)
-		tc.vdiffCount++ // We did either vtctlclient OR vtctldclient vdiff create
-	}
+
+	// FIXME: this test is temporarily disabled because it's flaky. The issue is that the vdiff reaches the completed
+	// state before the stop command is issued, so the expectation is not matched. So that the rest of the tests
+	// can be run in CI immediately, commenting this out until we find a proper solution.
+	/*
+		if tc.stop {
+			testStop(t, ksWorkflow, allCellNames)
+			tc.vdiffCount++ // We did either vtctlclient OR vtctldclient vdiff create
+		}
+	*/
+
 	if tc.testCLICreateWait {
 		testCLICreateWait(t, ksWorkflow, allCellNames)
 		tc.vdiffCount++ // We did either vtctlclient OR vtctldclient vdiff create

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -307,15 +307,10 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, tks *Keyspace, 
 
 	// These are done here so that we have a valid workflow to test the commands against.
 
-	// FIXME: this test is temporarily disabled because it's flaky. The issue is that the vdiff reaches the completed
-	// state before the stop command is issued, so the expectation is not matched. So that the rest of the tests
-	// can be run in CI immediately, commenting this out until we find a proper solution.
-	/*
-		if tc.stop {
-			testStop(t, ksWorkflow, allCellNames)
-			tc.vdiffCount++ // We did either vtctlclient OR vtctldclient vdiff create
-		}
-	*/
+	if tc.stop {
+		testStop(t, ksWorkflow, allCellNames)
+		tc.vdiffCount++ // We did either vtctlclient OR vtctldclient vdiff create
+	}
 
 	if tc.testCLICreateWait {
 		testCLICreateWait(t, ksWorkflow, allCellNames)
@@ -526,14 +521,16 @@ func testResume(t *testing.T, tc *testCase, cells string) {
 
 func testStop(t *testing.T, ksWorkflow, cells string) {
 	t.Run("Stop", func(t *testing.T) {
-		// create a new VDiff and immediately stop it
+		// Create a new VDiff and immediately stop it.
 		uuid, _ := performVDiff2Action(t, false, ksWorkflow, cells, "create", "", false)
 		_, _ = performVDiff2Action(t, false, ksWorkflow, cells, "stop", uuid, false)
-		// confirm the VDiff is in the expected stopped state
+		// Confirm the VDiff is in the expected state.
 		_, output := performVDiff2Action(t, false, ksWorkflow, cells, "show", uuid, false)
 		jsonOutput := getVDiffInfo(output)
-		require.Equal(t, "stopped", jsonOutput.State)
-		// confirm that the context cancelled error was also cleared
+		// It may have been able to complete before we could stop it (there's virtually no data
+		// to diff). There's no way to avoid this potential race so don't consider that a failure.
+		require.True(t, (jsonOutput.State == "stopped" || jsonOutput.State == "completed"), "expected vdiff state to be stopped or completed but it was %s", jsonOutput.State)
+		// Confirm that the context cancelled error was also cleared.
 		require.False(t, strings.Contains(output, `"Errors":`))
 	})
 }

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -26,8 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	vdiff2 "vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 )
@@ -329,16 +331,7 @@ type vdiffInfo struct {
 
 func getVDiffInfo(json string) *vdiffInfo {
 	var info vdiffInfo
-	info.Workflow = gjson.Get(json, "Workflow").String()
-	info.Keyspace = gjson.Get(json, "Keyspace").String()
-	info.State = gjson.Get(json, "State").String()
-	info.Shards = gjson.Get(json, "Shards").String()
-	info.RowsCompared = gjson.Get(json, "RowsCompared").Int()
-	info.StartedAt = gjson.Get(json, "StartedAt").String()
-	info.CompletedAt = gjson.Get(json, "CompletedAt").String()
-	info.HasMismatch = gjson.Get(json, "HasMismatch").Bool()
-	info.Progress.Percentage = gjson.Get(json, "Progress.Percentage").Float()
-	info.Progress.ETA = gjson.Get(json, "Progress.ETA").String()
+	_ = json2.Unmarshal([]byte(json), &info)
 	return &info
 }
 

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -29,9 +29,9 @@ import (
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
+	vdiff2 "vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-	vdiff2 "vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 )
 
 const (


### PR DESCRIPTION
## Description

Fixes two flaky tests:

1. Address the`VDiff stop` test which also regularly fails locally. The problem here is that we are trying to stop a vdiff which completes before it can be stopped. `vtctldclient` is generally much faster and we have virtually no data to diff so there's not really any way to avoid this race. So we consider `stopped` and `completed` to be valid/acceptable.

2. Fixes `TestVtctldMigrate` e2e test.
After https://github.com/vitessio/vitess/pull/15977 the target also has denied tables and hence we need to query the tablets directly rather than check via vtgate.

## Related Issue(s)


## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
