### PR TITLE
CI: increase timeout for  Online DDL foreign key stress tests

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -142,7 +142,7 @@ var (
 	replicaFK       *cluster.Vttablet
 	vtParams        mysql.ConnParams
 
-	onlineDDLStrategy     = "vitess --unsafe-allow-foreign-keys --cut-over-threshold=15s"
+	onlineDDLStrategy     = "vitess --unsafe-allow-foreign-keys --cut-over-threshold=30s --force-cut-over-after=15s"
 	hostname              = "localhost"
 	keyspaceName          = "ks"
 	cell                  = "zone1"
@@ -332,7 +332,7 @@ func TestMain(m *testing.M) {
 			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
-			"--migration_check_interval", "5s",
+			"--migration_check_interval", "3s",
 			"--watch_replication_stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{}


### PR DESCRIPTION
## Description

This PR increases the migration cut-over lock timeout in foreign key stress tests, to reduce flakiness caused by timeouts.

It also reduces migration check interval giving the Online DDL scheduler more opportunity to force cut-over the migration.

## Related Issue(s)

No issue. Reducing CI flakiness.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
