### PR TITLE
Online DDL shadow table: rename referenced table name in self referencing FK

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -996,7 +996,6 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream, sh
 	}
 
 	renameQuery := sqlparser.BuildParsedQuery(sqlSwapTables, onlineDDL.Table, sentryTableName, vreplTable, onlineDDL.Table, sentryTableName, vreplTable)
-
 	waitForRenameProcess := func() error {
 		// This function waits until it finds the RENAME TABLE... query running in MySQL's PROCESSLIST, or until timeout
 		// The function assumes that one of the renamed tables is locked, thus causing the RENAME to block. If nothing
@@ -1404,6 +1403,25 @@ func (e *Executor) duplicateCreateTable(ctx context.Context, onlineDDL *schema.O
 	}
 	newCreateTable = sqlparser.Clone(originalCreateTable)
 	newCreateTable.SetTable(newCreateTable.GetTable().Qualifier.CompliantName(), newTableName)
+
+	// If this table has a self-referencing foreign key constraint, ensure the referenced table gets renamed:
+	renameSelfFK := func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		switch node := node.(type) {
+		case *sqlparser.ConstraintDefinition:
+			fk, ok := node.Details.(*sqlparser.ForeignKeyDefinition)
+			if !ok {
+				return true, nil
+			}
+			if referencedTableName := fk.ReferenceDefinition.ReferencedTable.Name.String(); referencedTableName == originalCreateTable.Table.Name.String() {
+				// This is a self-referencing foreign key
+				// We need to rename the referenced table as well
+				fk.ReferenceDefinition.ReferencedTable.Name = sqlparser.NewIdentifierCS(newTableName)
+			}
+		}
+		return true, nil
+	}
+	_ = sqlparser.Walk(renameSelfFK, newCreateTable)
+
 	// manipulate CreateTable statement: take care of constraints names which have to be
 	// unique across the schema
 	constraintMap, err = e.validateAndEditCreateTableStatement(onlineDDL, newCreateTable)

--- a/go/vt/vttablet/onlineddl/executor_test.go
+++ b/go/vt/vttablet/onlineddl/executor_test.go
@@ -370,6 +370,24 @@ func TestDuplicateCreateTable(t *testing.T) {
 			expectSQL:     "create table mytable (\n\tid int primary key,\n\ti int,\n\tconstraint f_bjj16562shq086ozik3zf6kjg foreign key (i) references parent (id) on delete cascade\n)",
 			expectMapSize: 1,
 		},
+		{
+			sql:           "create table self (id int primary key, i int, constraint f foreign key (i) references self (id))",
+			newName:       "mytable",
+			expectSQL:     "create table mytable (\n\tid int primary key,\n\ti int,\n\tconstraint f_8aymb58nzb78l5jhq600veg6y foreign key (i) references mytable (id)\n)",
+			expectMapSize: 1,
+		},
+		{
+			sql:     "create table self (id int primary key, i1 int, i2 int, constraint f1 foreign key (i1) references self (id), constraint f1 foreign key (i2) references parent (id))",
+			newName: "mytable",
+			expectSQL: `create table mytable (
+	id int primary key,
+	i1 int,
+	i2 int,
+	constraint f1_1rlsg9yls1t91i35zq5gyeoq7 foreign key (i1) references mytable (id),
+	constraint f1_59t4lvb1ncti6fxy27drad4jp foreign key (i2) references parent (id)
+)`,
+			expectMapSize: 1,
+		},
 	}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/16204.

In a `vitess` migration, we programmatically create a shadow table that is a duplicate of the original table, but with a another name. We take care of renaming any constraints as those must be unique across the schema and otherwise copy any foreign key definitions as-is.

However, in the case of a self-referencing foreign key, we must rename the referenced table name to match the shadow table. To illustrate, if we duplicate table `t` as `_vt_vrp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`, then this statement:

```sql
create table t (id int primary key, i int, constraint f foreign key (i) references t (id))
```

Will now turn into:
```sql
create table _vt_vrp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_ (id int primary key, i int, constraint f foreign key (i) references _vt_vrp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_ (id))
```



## Related Issue(s)

https://github.com/vitessio/vitess/issues/16204

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
