### PR TITLE
Flaky test fix `TestCanGetKeyspaces`

### DIFF
--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -238,9 +238,6 @@ func TestCanGetKeyspaces(t *testing.T) {
 	conf := config
 	defer resetConfig(conf)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	clusterInstance, err := startCluster()
 	require.NoError(t, err)
 	defer clusterInstance.TearDown()
@@ -251,15 +248,14 @@ func TestCanGetKeyspaces(t *testing.T) {
 		}
 	}()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	assertGetKeyspaces(ctx, t, clusterInstance)
 }
 
 func TestExternalTopoServerConsul(t *testing.T) {
 	conf := config
 	defer resetConfig(conf)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	// Start a single consul in the background.
 	cmd, serverAddr := startConsul(t)
@@ -279,6 +275,8 @@ func TestExternalTopoServerConsul(t *testing.T) {
 	require.NoError(t, err)
 	defer cluster.TearDown()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	assertGetKeyspaces(ctx, t, cluster)
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR further fixes more flakiness in `TestCanGetKeyspaces`. It was noticed in the CI - 
```
I0618 04:44:44.442798   13689 main.go:332] Local cluster started.
main_test.go:467:
Error Trace:	/opt/actions-runner/_work/vitess/vitess/go/cmd/vttestserver/cli/main_test.go:467
/opt/actions-runner/_work/vitess/vitess/go/cmd/vttestserver/cli/main_test.go:254
Error:      	Received unexpected error:
rpc error: code = DeadlineExceeded desc = context deadline exceeded
Test:       	TestCanGetKeyspaces
```

The problem was that we created a context with timeout in the start before the cluster was setup. The cluster setup can take more than 10 seconds, especially in the CI. So, we should be creating the context after the cluster setup is complete.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
