### PR TITLE
VReplication Workflow: set state correctly when restarting workflow streams in the copy phase

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -59,6 +59,8 @@ const (
 	// Update field values for multiple workflows. The final format specifier is
 	// used to optionally add any additional predicates to the query.
 	sqlUpdateVReplicationWorkflows = "update /*vt+ ALLOW_UNSAFE_VREPLICATION_WRITE */ %s.vreplication set%s where db_name = '%s'%s"
+	// Check if workflow is still copying.
+	sqlGetVReplicationCopyStatus = "select distinct vrepl_id from %s.copy_state where vrepl_id = %a"
 )
 
 var (
@@ -379,6 +381,25 @@ func (tm *TabletManager) ReadVReplicationWorkflow(ctx context.Context, req *tabl
 	return resp, nil
 }
 
+func isStreamCopying(tm *TabletManager, id int64) (bool, error) {
+	bindVars := map[string]*querypb.BindVariable{
+		"id": sqltypes.Int64BindVariable(id),
+	}
+	parsed := sqlparser.BuildParsedQuery(sqlGetVReplicationCopyStatus, sidecar.GetIdentifier(), ":id")
+	stmt, err := parsed.GenerateQuery(bindVars, nil)
+	if err != nil {
+		return false, err
+	}
+	res, err := tm.VREngine.Exec(stmt)
+	if err != nil {
+		return false, err
+	}
+	if res != nil && len(res.Rows) > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
 // UpdateVReplicationWorkflow updates the sidecar databases's vreplication
 // record(s) for this tablet's vreplication workflow stream(s). If there
 // are no streams for the given workflow on the tablet then a nil result
@@ -456,6 +477,17 @@ func (tm *TabletManager) UpdateVReplicationWorkflow(ctx context.Context, req *ta
 		}
 		if !textutil.ValueIsSimulatedNull(req.State) {
 			state = binlogdatapb.VReplicationWorkflowState_name[int32(req.State)]
+		}
+		if state == binlogdatapb.VReplicationWorkflowState_Running.String() {
+			// `Workflow Start` sets the new state to Running. However, if stream is still copying tables, we should set
+			// the state as Copying.
+			isCopying, err := isStreamCopying(tm, id)
+			if err != nil {
+				return nil, err
+			}
+			if isCopying {
+				state = binlogdatapb.VReplicationWorkflowState_Copying.String()
+			}
 		}
 		bindVars = map[string]*querypb.BindVariable{
 			"st": sqltypes.StringBindVariable(state),


### PR DESCRIPTION
## Description

This PR fixes a bug where a workflow which has been stopped during the copy phase has its published state (observable at `debug/vars` set incorrectly to Running when it is restarted.  We now check for tables still pending copy and update the stream state to `Copying` or `Running` based on whether we are still in the copy phase.

### Backports

This issue has been around for about 15 months, so backporting to all supported versions.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15337

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
