### PR TITLE
Online DDL internal cleanup: using formal statements as opposed to textual SQL

### DIFF
--- a/go/vt/vttablet/onlineddl/analysis.go
+++ b/go/vt/vttablet/onlineddl/analysis.go
@@ -68,23 +68,6 @@ func (p *SpecialAlterPlan) String() string {
 	return string(b)
 }
 
-// getCreateTableStatement gets a formal AlterTable representation of the given table
-func (e *Executor) getCreateTableStatement(ctx context.Context, tableName string) (*sqlparser.CreateTable, error) {
-	showCreateTable, err := e.showCreateTable(ctx, tableName)
-	if err != nil {
-		return nil, vterrors.Wrapf(err, "in Executor.getCreateTableStatement()")
-	}
-	stmt, err := e.env.Environment().Parser().ParseStrictDDL(showCreateTable)
-	if err != nil {
-		return nil, err
-	}
-	createTable, ok := stmt.(*sqlparser.CreateTable)
-	if !ok {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "expected CREATE TABLE. Got %v", sqlparser.CanonicalString(stmt))
-	}
-	return createTable, nil
-}
-
 // analyzeInstantDDL takes declarative CreateTable and AlterTable, as well as a server version, and checks whether it is possible to run the ALTER
 // using ALGORITHM=INSTANT for that version.
 func analyzeInstantDDL(alterTable *sqlparser.AlterTable, createTable *sqlparser.CreateTable, capableOf capabilities.CapableOf) (*SpecialAlterPlan, error) {

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1518,7 +1518,7 @@ func (e *Executor) initVreplicationOriginalMigration(ctx context.Context, online
 		return v, err
 	}
 
-	v = NewVRepl(e.env.Environment(), onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, originalCreateTable, vreplCreateTable, onlineDDL.SQL, onlineDDL.StrategySetting().IsAnalyzeTableFlag())
+	v = NewVRepl(e.env.Environment(), onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, originalCreateTable, vreplCreateTable, alterTable, onlineDDL.StrategySetting().IsAnalyzeTableFlag())
 	return v, nil
 }
 
@@ -1572,7 +1572,7 @@ func (e *Executor) initVreplicationRevertMigration(ctx context.Context, onlineDD
 	if err := e.updateArtifacts(ctx, onlineDDL.UUID, vreplTableName); err != nil {
 		return v, err
 	}
-	v = NewVRepl(e.env.Environment(), onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, nil, nil, "", false)
+	v = NewVRepl(e.env.Environment(), onlineDDL.UUID, e.keyspace, e.shard, e.dbName, onlineDDL.Table, vreplTableName, nil, nil, nil, false)
 	v.pos = revertStream.pos
 	return v, nil
 }

--- a/go/vt/vttablet/onlineddl/executor_test.go
+++ b/go/vt/vttablet/onlineddl/executor_test.go
@@ -391,9 +391,13 @@ func TestDuplicateCreateTable(t *testing.T) {
 	}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {
-			originalCreateTable, newCreateTable, constraintMap, err := e.duplicateCreateTable(ctx, onlineDDL, tcase.sql, tcase.newName)
+			stmt, err := e.env.Environment().Parser().ParseStrictDDL(tcase.sql)
+			require.NoError(t, err)
+			originalCreateTable, ok := stmt.(*sqlparser.CreateTable)
+			require.True(t, ok)
+			require.NotNil(t, originalCreateTable)
+			newCreateTable, constraintMap, err := e.duplicateCreateTable(ctx, onlineDDL, originalCreateTable, tcase.newName)
 			assert.NoError(t, err)
-			assert.NotNil(t, originalCreateTable)
 			assert.NotNil(t, newCreateTable)
 			assert.NotNil(t, constraintMap)
 

--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -108,8 +108,8 @@ type VRepl struct {
 	alterQuery  string
 	tableRows   int64
 
-	originalShowCreateTable string
-	vreplShowCreateTable    string
+	originalCreateTable *sqlparser.CreateTable
+	vreplCreateTable    *sqlparser.CreateTable
 
 	analyzeTable bool
 
@@ -150,27 +150,27 @@ func NewVRepl(
 	dbName string,
 	sourceTable string,
 	targetTable string,
-	originalShowCreateTable string,
-	vreplShowCreateTable string,
+	originalCreateTable *sqlparser.CreateTable,
+	vreplCreateTable *sqlparser.CreateTable,
 	alterQuery string,
 	analyzeTable bool,
 ) *VRepl {
 	return &VRepl{
-		env:                     env,
-		workflow:                workflow,
-		keyspace:                keyspace,
-		shard:                   shard,
-		dbName:                  dbName,
-		sourceTable:             sourceTable,
-		targetTable:             targetTable,
-		originalShowCreateTable: originalShowCreateTable,
-		vreplShowCreateTable:    vreplShowCreateTable,
-		alterQuery:              alterQuery,
-		analyzeTable:            analyzeTable,
-		parser:                  vrepl.NewAlterTableParser(),
-		enumToTextMap:           map[string]string{},
-		intToEnumMap:            map[string]bool{},
-		convertCharset:          map[string](*binlogdatapb.CharsetConversion){},
+		env:                 env,
+		workflow:            workflow,
+		keyspace:            keyspace,
+		shard:               shard,
+		dbName:              dbName,
+		sourceTable:         sourceTable,
+		targetTable:         targetTable,
+		originalCreateTable: originalCreateTable,
+		vreplCreateTable:    vreplCreateTable,
+		alterQuery:          alterQuery,
+		analyzeTable:        analyzeTable,
+		parser:              vrepl.NewAlterTableParser(),
+		enumToTextMap:       map[string]string{},
+		intToEnumMap:        map[string]bool{},
+		convertCharset:      map[string](*binlogdatapb.CharsetConversion){},
 	}
 }
 
@@ -461,7 +461,7 @@ func (v *VRepl) analyzeTables(ctx context.Context, conn *dbconnpool.DBConnection
 	}
 	v.addedUniqueKeys = vrepl.AddedUniqueKeys(sourceUniqueKeys, targetUniqueKeys, v.parser.ColumnRenameMap())
 	v.removedUniqueKeys = vrepl.RemovedUniqueKeys(sourceUniqueKeys, targetUniqueKeys, v.parser.ColumnRenameMap())
-	v.removedForeignKeyNames, err = vrepl.RemovedForeignKeyNames(v.env, v.originalShowCreateTable, v.vreplShowCreateTable)
+	v.removedForeignKeyNames, err = vrepl.RemovedForeignKeyNames(v.env, v.originalCreateTable, v.vreplCreateTable)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/onlineddl/vrepl/foreign_key.go
+++ b/go/vt/vttablet/onlineddl/vrepl/foreign_key.go
@@ -29,17 +29,17 @@ import (
 // RemovedForeignKeyNames returns the names of removed foreign keys, ignoring mere name changes
 func RemovedForeignKeyNames(
 	venv *vtenv.Environment,
-	originalCreateTable string,
-	vreplCreateTable string,
+	originalCreateTable *sqlparser.CreateTable,
+	vreplCreateTable *sqlparser.CreateTable,
 ) (names []string, err error) {
-	if originalCreateTable == "" || vreplCreateTable == "" {
+	if originalCreateTable == nil || vreplCreateTable == nil {
 		return nil, nil
 	}
 	env := schemadiff.NewEnv(venv, venv.CollationEnv().DefaultConnectionCharset())
 	diffHints := schemadiff.DiffHints{
 		ConstraintNamesStrategy: schemadiff.ConstraintNamesIgnoreAll,
 	}
-	diff, err := schemadiff.DiffCreateTablesQueries(env, originalCreateTable, vreplCreateTable, &diffHints)
+	diff, err := schemadiff.DiffTables(env, originalCreateTable, vreplCreateTable, &diffHints)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/onlineddl/vrepl/parser.go
+++ b/go/vt/vttablet/onlineddl/vrepl/parser.go
@@ -23,9 +23,7 @@ package vrepl
 import (
 	"strings"
 
-	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
-	"vitess.io/vitess/go/vt/vterrors"
 )
 
 // AlterTableParser is a parser tool for ALTER TABLE statements
@@ -48,13 +46,13 @@ func NewAlterTableParser() *AlterTableParser {
 // NewParserFromAlterStatement creates a new parser with a ALTER TABLE statement
 func NewParserFromAlterStatement(alterTable *sqlparser.AlterTable) *AlterTableParser {
 	parser := NewAlterTableParser()
-	parser.analyzeAlter(alterTable)
+	parser.AnalyzeAlter(alterTable)
 	return parser
 }
 
-// analyzeAlter looks for specific changes in the AlterTable statement, that are relevant
+// AnalyzeAlter looks for specific changes in the AlterTable statement, that are relevant
 // to OnlineDDL/VReplication
-func (p *AlterTableParser) analyzeAlter(alterTable *sqlparser.AlterTable) {
+func (p *AlterTableParser) AnalyzeAlter(alterTable *sqlparser.AlterTable) {
 	for _, opt := range alterTable.AlterOptions {
 		switch opt := opt.(type) {
 		case *sqlparser.RenameTableName:
@@ -75,20 +73,6 @@ func (p *AlterTableParser) analyzeAlter(alterTable *sqlparser.AlterTable) {
 			}
 		}
 	}
-}
-
-// ParseAlterStatement is the main function of th eparser, and parses an ALTER TABLE statement
-func (p *AlterTableParser) ParseAlterStatement(alterQuery string, parser *sqlparser.Parser) (err error) {
-	stmt, err := parser.ParseStrictDDL(alterQuery)
-	if err != nil {
-		return err
-	}
-	alterTable, ok := stmt.(*sqlparser.AlterTable)
-	if !ok {
-		return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "expected AlterTable statement, got %v", sqlparser.CanonicalString(stmt))
-	}
-	p.analyzeAlter(alterTable)
-	return nil
 }
 
 // GetNonTrivialRenames gets a list of renamed column


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Some internal refactoring, using more format `sqlparser.Statement` ot `sqlparser.CreateTable` etc. rather than raw SQL text.

## Related Issue(s)

Initial work for https://github.com/vitessio/vitess/issues/16229

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
