### PR TITLE
`schemadiff` small internal refactor: formalizing column charset/collation

### DIFF
--- a/go/vt/schemadiff/column.go
+++ b/go/vt/schemadiff/column.go
@@ -122,9 +122,6 @@ func (c *ColumnDefinitionEntity) SetExplicitCharsetCollate() error {
 	if c.columnDefinition.Type.Charset.Name == "" {
 		// Still nothing? Assign the table's charset/collation.
 		c.columnDefinition.Type.Charset.Name = c.tableCharsetCollate.charset
-		if c.columnDefinition.Type.Options.Collate == "" {
-			c.columnDefinition.Type.Options.Collate = c.tableCharsetCollate.collate
-		}
 		if c.columnDefinition.Type.Options.Collate = c.tableCharsetCollate.collate; c.columnDefinition.Type.Options.Collate == "" {
 			collation := c.Env.CollationEnv().DefaultCollationForCharset(c.tableCharsetCollate.charset)
 			if collation == collations.Unknown {

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1731,11 +1731,11 @@ func (c *CreateTableEntity) diffColumns(alterTable *sqlparser.AlterTable,
 		t2ColName := t2Col.Name.Lowered()
 		// we know that column exists in both tables
 		t1Col := t1ColumnsMap[t2ColName]
-		t1ColEntity := NewColumnDefinitionEntity(t1Col.col)
-		t2ColEntity := NewColumnDefinitionEntity(t2Col)
+		t1ColEntity := NewColumnDefinitionEntity(t1Col.col, t1cc)
+		t2ColEntity := NewColumnDefinitionEntity(t2Col, t2cc)
 
 		// check diff between before/after columns:
-		modifyColumnDiff, err := t1ColEntity.ColumnDiff(c.Env, c.Name(), t2ColEntity, t1cc, t2cc, hints)
+		modifyColumnDiff, err := t1ColEntity.ColumnDiff(c.Env, c.Name(), t2ColEntity, hints)
 		if err != nil {
 			return err
 		}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -454,6 +454,15 @@ func NewCreateTableEntity(env *Environment, c *sqlparser.CreateTable) (*CreateTa
 	return entity, nil
 }
 
+func (c *CreateTableEntity) ColumnDefinitionEntities() []*ColumnDefinitionEntity {
+	cc := getTableCharsetCollate(c.Env, &c.CreateTable.TableSpec.Options)
+	entities := make([]*ColumnDefinitionEntity, len(c.CreateTable.TableSpec.Columns))
+	for i := range c.CreateTable.TableSpec.Columns {
+		entities[i] = NewColumnDefinitionEntity(c.Env, c.CreateTable.TableSpec.Columns[i], cc)
+	}
+	return entities
+}
+
 // normalize cleans up the table definition:
 // - setting names to all keys
 // - table option case (upper/lower/special)
@@ -1731,8 +1740,8 @@ func (c *CreateTableEntity) diffColumns(alterTable *sqlparser.AlterTable,
 		t2ColName := t2Col.Name.Lowered()
 		// we know that column exists in both tables
 		t1Col := t1ColumnsMap[t2ColName]
-		t1ColEntity := NewColumnDefinitionEntity(t1Col.col, t1cc)
-		t2ColEntity := NewColumnDefinitionEntity(t2Col, t2cc)
+		t1ColEntity := NewColumnDefinitionEntity(c.Env, t1Col.col, t1cc)
+		t2ColEntity := NewColumnDefinitionEntity(c.Env, t2Col, t2cc)
 
 		// check diff between before/after columns:
 		modifyColumnDiff, err := t1ColEntity.ColumnDiff(c.Env, c.Name(), t2ColEntity, hints)


### PR DESCRIPTION

## Description

This PR does some internal refactoring/cleanup without changing behavior. We give `ColumnDefinitionEntity` some more brainpower, cleanup column diffing (introducing `SetExplicitCharsetCollate` and simplifying `ColumnDiff()`.

## Related Issue(s)

As part of https://github.com/vitessio/vitess/issues/16229

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
