### PR TITLE
VReplication: Auto renew lease on Keyspace Lock

### DIFF
--- a/go/vt/topo/etcd2topo/lock.go
+++ b/go/vt/topo/etcd2topo/lock.go
@@ -22,7 +22,6 @@ import (
 	"path"
 
 	"github.com/spf13/pflag"
-
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 

--- a/go/vt/vtctl/workflow/resharder.go
+++ b/go/vt/vtctl/workflow/resharder.go
@@ -99,6 +99,9 @@ func (s *Server) buildResharder(ctx context.Context, keyspace, workflow string, 
 		if err != nil {
 			return nil, vterrors.Wrapf(err, "GetShard(%s) failed", shard)
 		}
+		if si.PrimaryAlias == nil {
+			return nil, fmt.Errorf("target shard %v has no primary tablet", shard)
+		}
 		if si.IsPrimaryServing {
 			return nil, fmt.Errorf("target shard %v is in serving state", shard)
 		}

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -126,8 +126,8 @@ func (r *switcher) cancelMigration(ctx context.Context, sm *StreamMigrator) {
 	r.ts.cancelMigration(ctx, sm)
 }
 
-func (r *switcher) lockKeyspace(ctx context.Context, keyspace, action string) (context.Context, func(*error), error) {
-	return r.s.ts.LockKeyspace(ctx, keyspace, action)
+func (r *switcher) lockKeyspace(ctx context.Context, keyspace, action string, doneCh <-chan struct{}, errCh chan<- error) (context.Context, func(*error), error) {
+	return r.s.ts.LockKeyspaceWithLeaseRenewal(ctx, keyspace, action, doneCh, errCh)
 }
 
 func (r *switcher) freezeTargetVReplication(ctx context.Context) error {

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -126,8 +126,8 @@ func (r *switcher) cancelMigration(ctx context.Context, sm *StreamMigrator) {
 	r.ts.cancelMigration(ctx, sm)
 }
 
-func (r *switcher) lockKeyspace(ctx context.Context, keyspace, action string, doneCh <-chan struct{}, errCh chan<- error) (context.Context, func(*error), error) {
-	return r.s.ts.LockKeyspaceWithLeaseRenewal(ctx, keyspace, action, doneCh, errCh)
+func (r *switcher) lockKeyspace(ctx context.Context, keyspace, action string) (context.Context, func(*error), <-chan error, error) {
+	return r.s.ts.LockKeyspaceWithLeaseRenewal(ctx, keyspace, action)
 }
 
 func (r *switcher) freezeTargetVReplication(ctx context.Context) error {

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -293,11 +293,11 @@ func (dr *switcherDryRun) cancelMigration(ctx context.Context, sm *StreamMigrato
 	dr.drLog.Log("Cancel migration as requested")
 }
 
-func (dr *switcherDryRun) lockKeyspace(ctx context.Context, keyspace, _ string, _ <-chan struct{}, _ chan<- error) (context.Context, func(*error), error) {
+func (dr *switcherDryRun) lockKeyspace(ctx context.Context, keyspace, _ string) (context.Context, func(*error), <-chan error, error) {
 	dr.drLog.Logf("Lock keyspace %s", keyspace)
 	return ctx, func(e *error) {
 		dr.drLog.Logf("Unlock keyspace %s", keyspace)
-	}, nil
+	}, nil, nil
 }
 
 func (dr *switcherDryRun) removeSourceTables(ctx context.Context, removalType TableRemovalType) error {

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -293,7 +293,7 @@ func (dr *switcherDryRun) cancelMigration(ctx context.Context, sm *StreamMigrato
 	dr.drLog.Log("Cancel migration as requested")
 }
 
-func (dr *switcherDryRun) lockKeyspace(ctx context.Context, keyspace, _ string) (context.Context, func(*error), error) {
+func (dr *switcherDryRun) lockKeyspace(ctx context.Context, keyspace, _ string, _ <-chan struct{}, _ chan<- error) (context.Context, func(*error), error) {
 	dr.drLog.Logf("Lock keyspace %s", keyspace)
 	return ctx, func(e *error) {
 		dr.drLog.Logf("Unlock keyspace %s", keyspace)

--- a/go/vt/vtctl/workflow/switcher_interface.go
+++ b/go/vt/vtctl/workflow/switcher_interface.go
@@ -24,7 +24,7 @@ import (
 )
 
 type iswitcher interface {
-	lockKeyspace(ctx context.Context, keyspace, action string, doneCh <-chan struct{}, errCh chan<- error) (context.Context, func(*error), error)
+	lockKeyspace(ctx context.Context, keyspace, action string) (context.Context, func(*error), <-chan error, error)
 	cancelMigration(ctx context.Context, sm *StreamMigrator)
 	stopStreams(ctx context.Context, sm *StreamMigrator) ([]string, error)
 	stopSourceWrites(ctx context.Context) error

--- a/go/vt/vtctl/workflow/switcher_interface.go
+++ b/go/vt/vtctl/workflow/switcher_interface.go
@@ -24,7 +24,7 @@ import (
 )
 
 type iswitcher interface {
-	lockKeyspace(ctx context.Context, keyspace, action string) (context.Context, func(*error), error)
+	lockKeyspace(ctx context.Context, keyspace, action string, doneCh <-chan struct{}, errCh chan<- error) (context.Context, func(*error), error)
 	cancelMigration(ctx context.Context, sm *StreamMigrator)
 	stopStreams(ctx context.Context, sm *StreamMigrator) ([]string, error)
 	stopSourceWrites(ctx context.Context) error

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -28,10 +28,6 @@ import (
 	"strings"
 	"sync"
 
-	querypb "vitess.io/vitess/go/vt/proto/query"
-
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/sets"
@@ -46,9 +42,11 @@ import (
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"


### PR DESCRIPTION
## Description

VReplication uses `Keyspace` topo server locks in order to prevent concurrent changes that could cause breakages. It does that in these primary locations:
  1. When performing a traffic switch (`SwitchTraffic` and `ReverseTraffic`) in various workflows like `MoveTables` and `Reshard`
  2. When cleaning up resources related to a workflow when canceling/deleting/completing it 
  3. When initializing a VDiff

This is done in order to prevent concurrent changes to shared resources such as the `_vt.vreplication` record on target shards.

At some point, I think we should add a distributed `workflow` lock in the topo to coordinate on related issues. We may want those both at a keyspace level and at a shard level — depending on the level of concurrency control we require for the given operation. This lock can then also be held for as long as needed as it would not impact other Vitess operations (the Keyspace Lock is used for things e.g. like updating the throttler config, durability policy, or schema for a keyspace). This will be a major project, however, and for the time being we can instead make a relatively minor change to how the `Keyspace` locks are managed in the noted cases within VReplication. In this PR the change is that we automatically renew the Keyspace Lock while holding it, up to a maximum time (hard coded at 10 mins now but will probably add a flag for this ~ `--max-keyspace-lock-ttl=<duration>` which defaults to 10m).

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/11811

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required