### PR TITLE
[release-19.0] Fix vtgate crash in group concat 

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
@@ -135,7 +135,7 @@ func (ab *aggBuilder) handleAggr(ctx *plancontext.PlanningContext, aggr Aggr) er
 	case opcode.AggregateGroupConcat:
 		f := aggr.Func.(*sqlparser.GroupConcatExpr)
 		if f.Distinct || len(f.OrderBy) > 0 || f.Separator != "" {
-			panic("fail here")
+			panic(vterrors.VT12001("cannot evaluate group concat with distinct, order by or a separator"))
 		}
 		// this needs special handling, currently aborting the push of function
 		// and later will try pushing the column instead.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR only backports the vtgate crash fix from https://github.com/vitessio/vitess/pull/16237. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/16238

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
