### PR TITLE
Release docs: Add vreplication related entries to the v20 summary

### DIFF
--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -28,6 +28,9 @@
     - [Delete with Multi Target Support](#delete-multi-target)
     - [User Defined Functions Support](#udf-support)
     - [Insert Row Alias Support](#insert-row-alias-support)
+  - **[VReplication](#vreplication)**
+    - [Multi-tenant Migrations](#multi-tenant)
+    - [VDiff Support For OnlineDDL Migrations](#vdiff-online-ddl)
   - **[Query Timeout](#query-timeout)**
   - **[Flag changes](#flag-changes)**
     - [`pprof-http` default change](#pprof-http-default)
@@ -334,6 +337,19 @@ The new flag `--querylog-sample-rate float` adds support for sampling queries ba
 #### <a id="tablet-filter-tags-flag"/>New `--tablet-filter-tags` flag
 
 The new flag `--tablet-filter-tags StringMap` adds support to VTGate for filtering tablets by tablet tag key/values, specified as comma-separated list of key:values. The tags of a tablet are defined by the VTTablet flag `--init_tags`, which is also defined as a comma-separated list of key:values.
+
+### <a id="vreplication"/>VReplication
+
+#### <a id="multi-tenant"/> Multi-tenant migrations
+
+Support for multi-tenant imports has been added to `MoveTables`. If you have a multi-tenant architecture where each
+tenant has their own database, you can import the tenants using multiple `MoveTables` workfows, one per tenant.
+Each import is initiated with the new `--tenant-id` flag. The column name (and data type) need to be specified in
+the VSchema of the target keyspace.
+
+#### <a id="vdiff-online-ddl"/> VDiff support for OnlineDDL migrations
+
+You can now run `VDiff`s on an OnlineDDL schema change migration in progress.
 
 ## <a id="minor-changes"/>Minor Changes
 

--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -349,7 +349,7 @@ the VSchema of the target keyspace.
 
 #### <a id="vdiff-online-ddl"/> VDiff support for OnlineDDL migrations
 
-You can now run `VDiff`s on an OnlineDDL schema change migration in progress.
+You can now run `VDiff`s on OnlineDDL schema change migrations, which are not yet cut over.
 
 ## <a id="minor-changes"/>Minor Changes
 

--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -29,7 +29,7 @@
     - [User Defined Functions Support](#udf-support)
     - [Insert Row Alias Support](#insert-row-alias-support)
   - **[VReplication](#vreplication)**
-    - [Multi-tenant Migrations](#multi-tenant)
+    - [Multi-tenant Imports](#multi-tenant)
     - [VDiff Support For OnlineDDL Migrations](#vdiff-online-ddl)
   - **[Query Timeout](#query-timeout)**
   - **[Flag changes](#flag-changes)**
@@ -340,7 +340,7 @@ The new flag `--tablet-filter-tags StringMap` adds support to VTGate for filteri
 
 ### <a id="vreplication"/>VReplication
 
-#### <a id="multi-tenant"/> Multi-tenant migrations
+#### <a id="multi-tenant"/> Multi-tenant Imports
 
 Support for multi-tenant imports has been added to `MoveTables`. If you have a multi-tenant architecture where each
 tenant has their own database, you can import the tenants using multiple `MoveTables` workfows, one per tenant.


### PR DESCRIPTION

## Description

Adds VReplication section and entries to v20 summary doc.


## Related Issue(s)

# Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
