### PR TITLE
Fix Incorrect Optimization with LIMIT and GROUP BY

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -18,7 +18,7 @@ package aggregation
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"sort"
 	"strings"
@@ -71,11 +71,12 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 }
 
 func TestAggrWithLimit(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
 	for i := range 1000 {
-		r := rand.Intn(50)
+		r := rand.IntN(10)
 		mcmp.Exec(fmt.Sprintf("insert into aggr_test(id, val1, val2) values(%d, 'a', %d)", i, r))
 	}
 	mcmp.Exec("select val2, count(*) from aggr_test group by val2 order by count(*), val2 limit 10")

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -18,6 +18,7 @@ package aggregation
 
 import (
 	"fmt"
+	"math/rand"
 	"slices"
 	"sort"
 	"strings"
@@ -67,6 +68,17 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 		mcmp.Close()
 		cluster.PanicHandler(t)
 	}
+}
+
+func TestAggrWithLimit(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	for i := range 1000 {
+		r := rand.Intn(50)
+		mcmp.Exec(fmt.Sprintf("insert into aggr_test(id, val1, val2) values(%d, 'a', %d)", i, r))
+	}
+	mcmp.Exec("select val2, count(*) from aggr_test group by val2 order by count(*), val2 limit 10")
 }
 
 func TestAggregateTypes(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -149,7 +149,7 @@
                     },
                     "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
                     "OrderBy": "(0|3) ASC",
-                    "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc limit :__upper_limit",
+                    "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
                     "Table": "`user`"
                   }
                 ]


### PR DESCRIPTION
## Description
This PR addresses an issue where incorrectly optimized query planning with `LIMIT` led to inaccurate results when `GROUP BY` was used on the vtgate side.

### Details:
* Issue: When planning a query with `LIMIT`, our initial approach tried to reduce the number of rows sent over the wire. However, this optimization caused incorrect results in situations where GROUP BY was applied on the vtgate side. By pushing the `LIMIT` to the MySQL query, vtgate did not receive all the rows necessary for proper grouping and inspection.
* Fix: Adjust the logic to ensure `LIMIT` is not pushed down to MySQL queries in scenarios where vtgate needs to perform `GROUP BY`. This guarantees that all relevant rows are available for accurate grouping and aggregation.

## Related Issue(s)
Fixes #16262

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required