### PR TITLE
No usage of math/rand

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,13 @@ run:
   timeout: 10m
 
 linters-settings:
+  depguard:
+    rules:
+      use_modern_packages:
+        list-mode: lax
+        deny:
+          - pkg: "math/rand$"
+            desc: Please use math/rand/v2
   errcheck:
     exclude: ./misc/errcheck_excludes.txt
   goimports:
@@ -17,6 +24,7 @@ linters:
   disable-all: true
   enable:
     # Defaults
+    - depguard
     - errcheck
     - govet
     - ineffassign

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path"
@@ -1313,7 +1313,7 @@ func TestReplicaRestoreToPos(t *testing.T, replicaIndex int, restoreToPos replic
 	require.False(t, restoreToPos.IsZero())
 	restoreToPosArg := replication.EncodePosition(restoreToPos)
 	assert.Contains(t, restoreToPosArg, "MySQL56/")
-	if rand.Intn(2) == 0 {
+	if rand.IntN(2) == 0 {
 		// Verify that restore works whether or not the MySQL56/ prefix is present.
 		restoreToPosArg = strings.Replace(restoreToPosArg, "MySQL56/", "", 1)
 		assert.NotContains(t, restoreToPosArg, "MySQL56/")

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -18,11 +18,12 @@ package vreplication
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"os/exec"
@@ -752,7 +753,7 @@ func verifyCopyStateIsOptimized(t *testing.T, tablet *cluster.VttabletProcess) {
 // be used to generate and insert test data.
 func randHex(n int) (string, error) {
 	bytes := make([]byte, n)
-	if _, err := rand.Read(bytes); err != nil {
+	if _, err := crand.Read(bytes); err != nil {
 		return "", err
 	}
 	return hex.EncodeToString(bytes), nil

--- a/go/vt/vtctl/workflow/utils_test.go
+++ b/go/vt/vtctl/workflow/utils_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"sync"
@@ -103,7 +103,7 @@ func testConcurrentKeyspaceRoutingRulesUpdates(t *testing.T, ctx context.Context
 func update(t *testing.T, ts *topo.Server, id int) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	s := fmt.Sprintf("%d_%d", id, rand.Intn(math.MaxInt))
+	s := fmt.Sprintf("%d_%d", id, rand.IntN(math.MaxInt))
 	routes := make(map[string]string)
 	for _, tabletType := range tabletTypeSuffixes {
 		from := fmt.Sprintf("from%s%s", s, tabletType)


### PR DESCRIPTION
This fixes some usages of math/rand and replaces it with math/rand/v2. It also adds a linter check to ensure we don't add new cases anymore.

## Related Issue(s)

Followup to #15513 but also enforces no regressions here. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required