### PR TITLE
A couple changes in Online DDL CI

### DIFF
--- a/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
+++ b/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
@@ -339,7 +339,7 @@ func TestSchemaChange(t *testing.T) {
 			})
 			isComplete := false
 			t.Run("optimistic wait for migration completion", func(t *testing.T) {
-				status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, migrationWaitTimeout, schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusComplete)
+				status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, migrationWaitTimeout, schema.OnlineDDLStatusComplete)
 				isComplete = (status == schema.OnlineDDLStatusComplete)
 				fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 			})
@@ -348,7 +348,7 @@ func TestSchemaChange(t *testing.T) {
 					onlineddl.CheckForceMigrationCutOver(t, &vtParams, shards, uuid, true)
 				})
 				t.Run("another optimistic wait for migration completion", func(t *testing.T) {
-					status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, migrationWaitTimeout, schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusComplete)
+					status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, migrationWaitTimeout, schema.OnlineDDLStatusComplete)
 					isComplete = (status == schema.OnlineDDLStatusComplete)
 					fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 				})

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -56,15 +56,20 @@ var (
 	beforeTableName       = `onlineddl_test_before`
 	afterTableName        = `onlineddl_test_after`
 	eventName             = `onlineddl_test`
+
+	testsFilter = ""
 )
 
 const (
-	testDataPath = "testdata"
+	testDataPath     = "testdata"
+	testFilterEnvVar = "ONLINEDDL_SUITE_TEST_FILTER"
 )
 
 func TestMain(m *testing.M) {
 	defer cluster.PanicHandler(nil)
 	flag.Parse()
+
+	testsFilter = os.Getenv(testFilterEnvVar)
 
 	exitcode, err := func() (int, error) {
 		clusterInstance = cluster.NewCluster(cell, hostname)
@@ -183,6 +188,10 @@ func readTestFile(t *testing.T, testName string, fileName string) (content strin
 // testSingle is the main testing function for a single test in the suite.
 // It prepares the grounds, creates the test data, runs a migration, expects results/error, cleans up.
 func testSingle(t *testing.T, testName string, fkOnlineDDLPossible bool) {
+	if !strings.Contains(testName, testsFilter) {
+		t.Skipf("Skipping test %s due to filter: %s=%s", testName, testFilterEnvVar, testsFilter)
+		return
+	}
 	if _, exists := readTestFile(t, testName, "require_rename_table_preserve_foreign_key"); exists {
 		if !fkOnlineDDLPossible {
 			t.Skipf("Skipping test due to require_rename_table_preserve_foreign_key")


### PR DESCRIPTION

## Description

Submitting two changes in Online DDL CI for things I stumbled upon:

1. In "Online DDL flow" CI, used in Upgrade/Downgrade - wasn't waiting properly for migration to complete, escalating the termination logic. The existing logic still works, but ends up force-terminating the migration rather than waiting gracefully.
2. In Online DDL vrepl suite, we now recognize the `$ONLINEDDL_SUITE_TEST_FILTER` environment variable. If set, then we skip any tests not containing the value of `$ONLINEDDL_SUITE_TEST_FILTER`. If unset, then it is the empty string and trivially all test names contain the empty string.
  This is just in a way of making debugging/developing easier.

## Related Issue(s)

None really.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
