### PR TITLE
Make sure end to end test actually tests the fix

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -76,7 +76,7 @@ func TestAggrWithLimit(t *testing.T) {
 	defer closer()
 
 	for i := range 1000 {
-		r := rand.IntN(10)
+		r := rand.IntN(50)
 		mcmp.Exec(fmt.Sprintf("insert into aggr_test(id, val1, val2) values(%d, 'a', %d)", i, r))
 	}
 	mcmp.Exec("select val2, count(*) from aggr_test group by val2 order by count(*), val2 limit 10")


### PR DESCRIPTION
## Description
In a recent PR, #16263 I added an end-to-end test that would not fail without the fixes. This PR changes that test to make sure it fails without the needed code changes.

The original issue was that we are limiting too much data, and the vtgate doesn't see all rows it should receive. To trigger this, we need the LIMIT in the query to be smaller than the number of rows returned by the shards.

## Related Issue(s)
#16263


## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
