### PR TITLE
Fix the `v19.0.0` release notes and use the `vitess/lite` image for the MySQL container

### DIFF
--- a/changelog/19.0/19.0.0/release_notes.md
+++ b/changelog/19.0/19.0.0/release_notes.md
@@ -53,6 +53,10 @@ Vitess will however, continue to support importing from MySQL 5.7 into Vitess ev
 
 #### <a id="deprecation-vitess-lite-mysqld"/>Docker Image vitess/lite
 
+> [!CAUTION]  
+> If you are using incremental backups, you must remain on the `vitess/lite` image, as the official MySQL image does not have `mysqlbinlog` installed.
+> See https://github.com/vitessio/vitess/issues/16281 for more information.
+
 The `mysqld` binary is now deprecated in the `vitess/lite` Docker image and will be removed in a future release.
 This means that the MySQL/Percona version specific image tags for the `vitess/lite` image are deprecated.
 

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -15,7 +15,7 @@ spec:
     vtbackup: vitess/lite:latest
     vtorc: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.30
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -11,7 +11,7 @@ spec:
     vtbackup: vitess/lite:latest
     vtorc: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.30
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -11,7 +11,7 @@ spec:
     vtbackup: vitess/lite:latest
     vtorc: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.30
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -11,7 +11,7 @@ spec:
     vtbackup: vitess/lite:latest
     vtorc: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.30
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -52,7 +52,7 @@ spec:
     vtbackup: vitess/lite:latest
     vtorc: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.30
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1


### PR DESCRIPTION
## Description

We overlooked the update to the release notes after fixing https://github.com/vitessio/vitess/issues/15452, and the operator examples are misleading by using the official mysql image for the mysql container instead of the `vitess/lite` image`

We must backport this to `release-19.0` and `release-20.0` where the issue was introduced. For each backport we will need to use the proper `vitess/lite` tag (`v19.0.4` and `v20.0.0` instead of `latest`).

The release notes on the GitHub UI will have to be updated once this is merged.

More information about the whole issue and reproduction can be seen on https://github.com/vitessio/vitess/issues/16281.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/16281

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
