### PR TITLE
VReplication: Properly handle target shards w/o a primary in Reshard

### DIFF
--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -34,6 +34,7 @@ import (
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -141,6 +142,7 @@ func initSrvKeyspace(t *testing.T, topo *topo.Server, keyspace string, sources, 
 	}
 	srvKeyspace.Partitions = append(srvKeyspace.Partitions, getPartition(t, sources))
 	srvKeyspace.Partitions = append(srvKeyspace.Partitions, getPartition(t, targets))
+	log.Errorf("initSrvKeyspace: %v", srvKeyspace)
 	for _, cell := range cells {
 		err := topo.UpdateSrvKeyspace(ctx, cell, keyspace, srvKeyspace)
 		require.NoError(t, err)

--- a/go/vt/vtctl/workflow/resharder.go
+++ b/go/vt/vtctl/workflow/resharder.go
@@ -99,6 +99,9 @@ func (s *Server) buildResharder(ctx context.Context, keyspace, workflow string, 
 		if err != nil {
 			return nil, vterrors.Wrapf(err, "GetShard(%s) failed", shard)
 		}
+		if si.PrimaryAlias == nil {
+			return nil, fmt.Errorf("target shard %v has no primary tablet", shard)
+		}
 		if si.IsPrimaryServing {
 			return nil, fmt.Errorf("target shard %v is in serving state", shard)
 		}

--- a/go/vt/vtctl/workflow/resharder_test.go
+++ b/go/vt/vtctl/workflow/resharder_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+)
+
+const eol = "$"
+
+func TestReshardCreate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	workflowName := "wf1"
+	tableName := "t1"
+	sourceKeyspaceName := "targetks"
+	targetKeyspaceName := "targetks"
+	tabletTypes := []topodatapb.TabletType{
+		topodatapb.TabletType_PRIMARY,
+		topodatapb.TabletType_REPLICA,
+		topodatapb.TabletType_RDONLY,
+	}
+	tabletTypesStr := topoproto.MakeStringTypeCSV(tabletTypes)
+	schema := map[string]*tabletmanagerdatapb.SchemaDefinition{
+		tableName: {
+			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+				{
+					Name:   tableName,
+					Schema: fmt.Sprintf("CREATE TABLE %s (id BIGINT, name VARCHAR(64), PRIMARY KEY (id))", tableName),
+				},
+			},
+		},
+	}
+
+	testcases := []struct {
+		name                           string
+		sourceKeyspace, targetKeyspace *testKeyspace
+		preFunc                        func(env *testEnv)
+		want                           *vtctldatapb.WorkflowStatusResponse
+		wantErr                        bool
+	}{
+		{
+			name: "basic",
+			sourceKeyspace: &testKeyspace{
+				KeyspaceName: sourceKeyspaceName,
+				ShardNames:   []string{"0"},
+			},
+			targetKeyspace: &testKeyspace{
+				KeyspaceName: targetKeyspaceName,
+				ShardNames:   []string{"-80", "80-"},
+			},
+		},
+		{
+			name: "no primary",
+			sourceKeyspace: &testKeyspace{
+				KeyspaceName: sourceKeyspaceName,
+				ShardNames:   []string{"0"},
+			},
+			targetKeyspace: &testKeyspace{
+				KeyspaceName: targetKeyspaceName,
+				ShardNames:   []string{"-80", "80-"},
+			},
+			preFunc: func(env *testEnv) {
+				//err := env.ts.UpdateSrvKeyspace(ctx, cell, keyspace, srvKeyspace)
+				srv, err := env.ts.GetSrvKeyspace(ctx, env.cell, targetKeyspaceName)
+				require.NoError(t, err)
+				t.Logf("srv: %+v", srv)
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotNil(t, tc.sourceKeyspace)
+			require.NotNil(t, tc.targetKeyspace)
+
+			env := newTestEnv(t, ctx, defaultCellName, tc.sourceKeyspace, tc.targetKeyspace)
+			defer env.close()
+			env.tmc.schema = schema
+
+			req := &vtctldatapb.ReshardCreateRequest{
+				Keyspace:     targetKeyspaceName,
+				Workflow:     workflowName,
+				TabletTypes:  tabletTypes,
+				SourceShards: tc.sourceKeyspace.ShardNames,
+				TargetShards: tc.targetKeyspace.ShardNames,
+				Cells:        []string{env.cell},
+			}
+
+			for _, tabletUID := range []int{100, 200, 210} {
+				env.tmc.expectVRQuery(
+					tabletUID,
+					insertPrefix+
+						`\('`+workflowName+`', 'keyspace:"`+targetKeyspaceName+`" shard:"0" filter:{rules:{match:"/.*" filter:"-80"}}', '', [0-9]*, [0-9]*, '`+
+						env.cell+`', '`+tabletTypesStr+`', [0-9]*, 0, 'Stopped', 'vt_`+targetKeyspaceName+`', 4, 0, false, '{}'\)`+eol,
+					&sqltypes.Result{},
+				)
+			}
+			for _, tabletUID := range []int{100, 200, 210} {
+				env.tmc.expectVRQuery(
+					tabletUID,
+					"select distinct table_name from _vt.copy_state cs, _vt.vreplication vr where vr.id = cs.vrepl_id and vr.id = 1",
+					&sqltypes.Result{},
+				)
+				env.tmc.expectVRQuery(
+					tabletUID,
+					"select vrepl_id, table_name, lastpk from _vt.copy_state where vrepl_id in (1) and id in (select max(id) from _vt.copy_state where vrepl_id in (1) group by vrepl_id, table_name)",
+					&sqltypes.Result{},
+				)
+			}
+
+			if tc.preFunc != nil {
+				tc.preFunc(env)
+			}
+
+			res, err := env.ws.ReshardCreate(ctx, req)
+			require.NoError(t, err)
+			t.Logf("ReshardCreate response: %+v", res)
+		})
+	}
+}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1725,7 +1725,7 @@ func (s *Server) ReshardCreate(ctx context.Context, req *vtctldatapb.ReshardCrea
 
 	if err := s.ts.ValidateSrvKeyspace(ctx, keyspace, strings.Join(cells, ",")); err != nil {
 		err2 := vterrors.Wrapf(err, "SrvKeyspace for keyspace %s is corrupt for cell(s) %s", keyspace, cells)
-		log.Errorf("%w", err2)
+		log.Errorf("%v", err2)
 		return nil, err
 	}
 	tabletTypesStr := discovery.BuildTabletTypesString(req.TabletTypes, req.TabletSelectionPreference)

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1755,6 +1755,7 @@ func (s *Server) ReshardCreate(ctx context.Context, req *vtctldatapb.ReshardCrea
 	return s.WorkflowStatus(ctx, &vtctldatapb.WorkflowStatusRequest{
 		Keyspace: req.Keyspace,
 		Workflow: req.Workflow,
+		Shards:   req.TargetShards,
 	})
 }
 


### PR DESCRIPTION
## Description

In the [`vtctldclient Reshard` command](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_reshard/), we were not checking that the target shard had a primary tablet in the shard record before we attempted to access it. This resulted in a client panic when doing a `Reshard` and a target shard did not have a primary tablet. The `Reshard` would have failed anyway, but obviously we should not panic.

The new test case fails on main this way:
```
❯ go test -v -timeout 30s -run ^TestReshardCreate$ vitess.io/vitess/go/vt/vtctl/workflow
=== RUN   TestReshardCreate
=== RUN   TestReshardCreate/basic
W0627 13:20:10.626498   71963 server.go:1753] Streams will not be started since --auto-start is set to false
    resharder_test.go:158: ReshardCreate response: shard_streams:{key:"targetks/-80" value:{streams:{id:1 tablet:{cell:"cell" uid:200} source_shard:"targetks/0" position:"9d10e6ec-07a0-11ee-ae73-8e53f4cf3083:1-97" status:"Running" info:"VStream Lag: 0s"}}} shard_streams:{key:"targetks/0" value:{streams:{id:1 tablet:{cell:"cell" uid:100} source_shard:"targetks/0" position:"9d10e6ec-07a0-11ee-ae73-8e53f4cf3083:1-97" status:"Running" info:"VStream Lag: 0s"}}} shard_streams:{key:"targetks/80-" value:{streams:{id:1 tablet:{cell:"cell" uid:210} source_shard:"targetks/0" position:"9d10e6ec-07a0-11ee-ae73-8e53f4cf3083:1-97" status:"Running" info:"VStream Lag: 0s"}}} traffic_state:"Reads Not Switched. Writes Not Switched"
=== RUN   TestReshardCreate/no_primary
--- FAIL: TestReshardCreate (0.01s)
    --- PASS: TestReshardCreate/basic (0.00s)
    --- FAIL: TestReshardCreate/no_primary (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x1053cb16c]

goroutine 71 [running]:
testing.tRunner.func1.2({0x105fb71a0, 0x106edd380})
        /Users/matt/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.darwin-arm64/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /Users/matt/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.darwin-arm64/src/testing/testing.go:1634 +0x33c
panic({0x105fb71a0?, 0x106edd380?})
        /Users/matt/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.darwin-arm64/src/runtime/panic.go:770 +0x124
vitess.io/vitess/go/vt/topo.(*Server).GetTablet(0x0?, {0x106241c38, 0x140002eb0a0}, 0x0)
        /Users/matt/git/vitess/go/vt/topo/tablet.go:177 +0x3c
vitess.io/vitess/go/vt/vtctl/workflow.(*Server).buildResharder(0x1400082cdb0, {0x106241c38, 0x140002eb0a0}, {0x1058b4995, 0x8}, {0x1058ae754, 0x3}, {0x14000431020, 0x1, 0x1076c0608?}, ...)
```

This is a pretty simple fix, so I think that we should backport this to v18 — when the [`vtctldclient Reshard` command](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_reshard/) command was first added.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16284

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required