### PR TITLE
[release-20.0] Update post release `v20.0.0`

### DIFF
--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -58,7 +58,7 @@ services:
       - "3306"
 
   vtctld:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15000:$WEB_PORT"
       - "$GRPC_PORT"
@@ -81,7 +81,7 @@ services:
         condition: service_healthy
 
   vtgate:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15099:$WEB_PORT"
       - "$GRPC_PORT"
@@ -111,7 +111,7 @@ services:
         condition: service_healthy
 
   schemaload:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     command:
     - sh
     - -c
@@ -144,12 +144,12 @@ services:
     environment:
       - KEYSPACES=$KEYSPACE
       - GRPC_PORT=15999
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - .:/script
 
   vttablet100:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15100:$WEB_PORT"
       - "$GRPC_PORT"
@@ -181,7 +181,7 @@ services:
       retries: 15
 
   vttablet101:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15101:$WEB_PORT"
       - "$GRPC_PORT"
@@ -213,7 +213,7 @@ services:
       retries: 15
 
   vttablet102:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15102:$WEB_PORT"
       - "$GRPC_PORT"
@@ -245,7 +245,7 @@ services:
       retries: 15
 
   vttablet103:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15103:$WEB_PORT"
       - "$GRPC_PORT"
@@ -277,7 +277,7 @@ services:
       retries: 15
 
   vtorc:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     command: ["sh", "-c", "/script/vtorc-up.sh"]
     depends_on:
       - vtctld
@@ -307,7 +307,7 @@ services:
       retries: 15
 
   vreplication:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - ".:/script"
     environment:

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     - SCHEMA_FILES=lookup_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
     - .:/script
   schemaload_test_keyspace:
@@ -101,7 +101,7 @@ services:
     - SCHEMA_FILES=test_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
     - .:/script
   set_keyspace_durability_policy:
@@ -115,7 +115,7 @@ services:
     environment:
       - KEYSPACES=test_keyspace lookup_keyspace
       - GRPC_PORT=15999
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - .:/script
   vreplication:
@@ -129,7 +129,7 @@ services:
     - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
       --topo_global_root vitess/global
     - EXTERNAL_DB=0
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
     - .:/script
   vtctld:
@@ -143,7 +143,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15000:8080
     - "15999"
@@ -160,7 +160,7 @@ services:
       --normalize_queries=true '
     depends_on:
     - vtctld
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15099:8080
     - "15999"
@@ -182,7 +182,7 @@ services:
     - EXTERNAL_DB=0
     - DB_USER=
     - DB_PASS=
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 13000:8080
     volumes:
@@ -217,7 +217,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15101:8080
     - "15999"
@@ -254,7 +254,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15102:8080
     - "15999"
@@ -291,7 +291,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15201:8080
     - "15999"
@@ -328,7 +328,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15202:8080
     - "15999"
@@ -365,7 +365,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15301:8080
     - "15999"
@@ -402,7 +402,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - 15302:8080
     - "15999"

--- a/examples/compose/vtcompose/docker-compose.test.yml
+++ b/examples/compose/vtcompose/docker-compose.test.yml
@@ -79,7 +79,7 @@ services:
       - SCHEMA_FILES=test_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - .:/script
   schemaload_unsharded_keyspace:
@@ -103,7 +103,7 @@ services:
       - SCHEMA_FILES=unsharded_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - .:/script
   set_keyspace_durability_policy_test_keyspace:
@@ -117,7 +117,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=test_keyspace
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - .:/script
   set_keyspace_durability_policy_unsharded_keyspace:
@@ -130,7 +130,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=unsharded_keyspace
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - .:/script
   vreplication:
@@ -144,7 +144,7 @@ services:
       - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
         --topo_global_root vitess/global
       - EXTERNAL_DB=0
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - .:/script
   vtctld:
@@ -159,7 +159,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 15000:8080
       - "15999"
@@ -176,7 +176,7 @@ services:
       ''grpc-vtgateservice'' --normalize_queries=true '
     depends_on:
       - vtctld
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 15099:8080
       - "15999"
@@ -199,7 +199,7 @@ services:
       - EXTERNAL_DB=0
       - DB_USER=
       - DB_PASS=
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 13000:8080
     volumes:
@@ -234,7 +234,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 15101:8080
       - "15999"
@@ -271,7 +271,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 15102:8080
       - "15999"
@@ -308,7 +308,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 15201:8080
       - "15999"
@@ -345,7 +345,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 15202:8080
       - "15999"
@@ -382,7 +382,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - 15301:8080
       - "15999"

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -525,7 +525,7 @@ func generateExternalPrimary(
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15%[1]d:%[3]d"
       - "%[4]d"
@@ -587,7 +587,7 @@ func generateDefaultTablet(tabAlias int, shard, role, keyspace string, dbInfo ex
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
     - "15%[1]d:%[4]d"
     - "%[5]d"
@@ -625,7 +625,7 @@ func generateVtctld(opts vtOptions) string {
 - op: add
   path: /services/vtctld
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15000:%[1]d"
       - "%[2]d"
@@ -656,7 +656,7 @@ func generateVtgate(opts vtOptions) string {
 - op: add
   path: /services/vtgate
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     ports:
       - "15099:%[1]d"
       - "%[2]d"
@@ -698,7 +698,7 @@ func generateVTOrc(dbInfo externalDbInfo, keyspaceInfoMap map[string]keyspaceInf
 - op: add
   path: /services/vtorc
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - ".:/script"
     environment:
@@ -723,7 +723,7 @@ func generateVreplication(dbInfo externalDbInfo, opts vtOptions) string {
 - op: add
   path: /services/vreplication
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - ".:/script"
     environment:
@@ -751,7 +751,7 @@ func generateSetKeyspaceDurabilityPolicy(
 - op: add
   path: /services/set_keyspace_durability_policy_%[3]s
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - ".:/script"
     environment:
@@ -788,7 +788,7 @@ func generateSchemaload(
 - op: add
   path: /services/schemaload_%[7]s
   value:
-    image: vitess/lite:${VITESS_TAG:-latest}
+    image: vitess/lite:v20.0.0
     volumes:
       - ".:/script"
     environment:

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,12 +8,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtadmin: vitess/vtadmin:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
-    vtorc: vitess/lite:latest
+    vtctld: vitess/lite:v20.0.0
+    vtadmin: vitess/vtadmin:v20.0.0
+    vtgate: vitess/lite:v20.0.0
+    vttablet: vitess/lite:v20.0.0
+    vtbackup: vitess/lite:v20.0.0
+    vtorc: vitess/lite:v20.0.0
     mysqld:
       mysql80Compatible: mysql:8.0.30
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtadmin: vitess/vtadmin:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
-    vtorc: vitess/lite:latest
+    vtctld: vitess/lite:v20.0.0
+    vtadmin: vitess/vtadmin:v20.0.0
+    vtgate: vitess/lite:v20.0.0
+    vttablet: vitess/lite:v20.0.0
+    vtbackup: vitess/lite:v20.0.0
+    vtorc: vitess/lite:v20.0.0
     mysqld:
       mysql80Compatible: mysql:8.0.30
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtadmin: vitess/vtadmin:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
-    vtorc: vitess/lite:latest
+    vtctld: vitess/lite:v20.0.0
+    vtadmin: vitess/vtadmin:v20.0.0
+    vtgate: vitess/lite:v20.0.0
+    vttablet: vitess/lite:v20.0.0
+    vtbackup: vitess/lite:v20.0.0
+    vtorc: vitess/lite:v20.0.0
     mysqld:
       mysql80Compatible: mysql:8.0.30
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtadmin: vitess/vtadmin:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
-    vtorc: vitess/lite:latest
+    vtctld: vitess/lite:v20.0.0
+    vtadmin: vitess/vtadmin:v20.0.0
+    vtgate: vitess/lite:v20.0.0
+    vttablet: vitess/lite:v20.0.0
+    vtbackup: vitess/lite:v20.0.0
+    vtorc: vitess/lite:v20.0.0
     mysqld:
       mysql80Compatible: mysql:8.0.30
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -45,12 +45,12 @@ spec:
             keyspace: "customer"
             shard: "-"
   images:
-    vtctld: vitess/lite:latest
-    vtadmin: vitess/vtadmin:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
-    vtorc: vitess/lite:latest
+    vtctld: vitess/lite:v20.0.0
+    vtadmin: vitess/vtadmin:v20.0.0
+    vtgate: vitess/lite:v20.0.0
+    vttablet: vitess/lite:v20.0.0
+    vtbackup: vitess/lite:v20.0.0
+    vtorc: vitess/lite:v20.0.0
     mysqld:
       mysql80Compatible: mysql:8.0.30
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -6885,7 +6885,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:latest
+          image: planetscale/vitess-operator:v2.13.0
           name: vitess-operator
           resources:
             limits:


### PR DESCRIPTION
## Description

I did not think about this situation while re-working the vitess-releaser tool: since we now have two branches for `release-20.0` but we do all release work on `release-20.0-rc` some stuff were forgotten on the `release-20.0` branch like updating the version of vitess used in our tests and examples.

It is a cherry-pick of https://github.com/vitessio/vitess/pull/16258.

Ideally we should have cherry-picked every Release PRs (for RC-1, RC-2 and GA) to `release-20.0` when they got merged.