### PR TITLE
Remove unnecessary node install step in local/region examples workflow

### DIFF
--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -59,12 +59,6 @@ jobs:
       with:
         go-version: 1.22.4
 
-    - uses: actions/setup-node@v4
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
-      with:
-        # node-version should match package.json
-        node-version: '20.12.2'
-
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       run: |

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -59,12 +59,6 @@ jobs:
       with:
         go-version: 1.22.4
 
-    - uses: actions/setup-node@v4
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
-      with:
-        # node-version should match package.json
-        node-version: '20.12.2'
-
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       run: |


### PR DESCRIPTION
## Description

The local and region examples already install the node version needed by vtadmin in their scripts. Plus the node install step was not working since the `NVM_DIR` variable was not set, resulting in the script to anyway download node.
