### PR TITLE
MoveTables: do not set session foreign_key_checks, if target has it turned off globally

### DIFF
--- a/go/test/endtoend/vreplication/fk_config_test.go
+++ b/go/test/endtoend/vreplication/fk_config_test.go
@@ -22,7 +22,6 @@ var (
 	initialFKSchema = `
 create table parent(id int, name varchar(128), primary key(id)) engine=innodb;
 create table child(id int, parent_id int, name varchar(128), primary key(id), foreign key(parent_id) references parent(id) on delete cascade) engine=innodb;
-create view vparent as select * from parent;
 create table t1(id int, name varchar(128), primary key(id)) engine=innodb;
 create table t2(id int, t1id int, name varchar(128), primary key(id), foreign key(t1id) references t1(id) on delete cascade) engine=innodb;
 create table t11 (id int primary key, i int);
@@ -39,6 +38,7 @@ insert into t11 values(1, null);
 insert into t12 values(1, 1);
 update t11 set i = 1 where id = 1;
 `
+	createParentView = `create view vparent as select * from parent;`
 
 	initialFKSourceVSchema = `
 {

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -359,9 +359,9 @@ func dropTargetConstraints(t *testing.T, targetKeyspace string) {
 }
 
 // TestFKWorkflowConstraintsOnlyOnSource runs a MoveTables workflow with atomic copy. It deletes some constraints on the
-// target and sets the global foreign_key_checks=0 on the source. It then inserts data into the target which will violate
-// the original foreign key constraints. The workflow should complete successfully, since the global foreign_key_checks
-// is set to 0 on the source and it should behave the same as on the target where the constraints are dropped.
+// target and sets the global foreign_key_checks=0 on the source. After SwitchTraffic, it  inserts data into the target
+// which would otherwise violate foreign key constraints on the source. The insert should not fail in the reverse
+// workflow on the source, since the global foreign_key_checks are off on the source.
 func TestFKWorkflowConstraintsOnlyOnSource(t *testing.T) {
 	config, deferFunc := initTestFKWorkflow(t)
 	defer deferFunc()

--- a/go/vt/binlog/binlogplayer/mock_dbclient.go
+++ b/go/vt/binlog/binlogplayer/mock_dbclient.go
@@ -191,7 +191,7 @@ func (dc *MockDBClient) ExecuteFetch(query string, maxrows int) (qr *sqltypes.Re
 	if dc.Tag != "" {
 		msg = fmt.Sprintf("[%s] %s", dc.Tag, msg)
 	}
-	dc.t.Logf(msg, query)
+	dc.t.Logf(msg, LimitString(query, 256))
 
 	for q, result := range dc.invariants {
 		if strings.Contains(strings.ToLower(query), strings.ToLower(q)) {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -236,7 +236,7 @@ func execConnStatements(t *testing.T, conn *dbconnpool.DBConnection, queries []s
 	}
 }
 
-//--------------------------------------
+// --------------------------------------
 // Topos and tablets
 
 func addTablet(id int) *topodatapb.Tablet {
@@ -348,7 +348,7 @@ func (ftc *fakeTabletConn) VStreamRows(ctx context.Context, request *binlogdatap
 	})
 }
 
-//--------------------------------------
+// --------------------------------------
 // Binlog Client to TabletManager
 
 // fakeBinlogClient satisfies binlogplayer.Client.
@@ -425,7 +425,7 @@ func expectFBCRequest(t *testing.T, tablet *topodatapb.Tablet, pos string, table
 	}
 }
 
-//--------------------------------------
+// --------------------------------------
 // DBCLient wrapper
 
 func realDBClientFactory() binlogplayer.DBClient {
@@ -486,7 +486,7 @@ func (dbc *realDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Resu
 		globalDBQueries <- query
 	} else if testSetForeignKeyQueries && strings.Contains(query, "set foreign_key_checks") {
 		globalDBQueries <- query
-	} else if testForeignKeyQueries && strings.Contains(query, "foreign_key_checks") { //allow select/set for foreign_key_checks
+	} else if testForeignKeyQueries && strings.Contains(query, "foreign_key_checks") { // allow select/set for foreign_key_checks
 		globalDBQueries <- query
 	}
 	return qr, err
@@ -581,6 +581,7 @@ func shouldIgnoreQuery(query string) bool {
 		// This is only executed if the table has no defined Primary Key, which we don't know in the lower level
 		// code.
 		"SELECT index_cols.COLUMN_NAME AS column_name, index_cols.INDEX_NAME as index_name FROM information_schema.STATISTICS",
+		"select @@global.foreign_key_checks",
 	}
 	if sidecardb.MatchesInitQuery(query) {
 		return true

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -290,7 +290,7 @@ func testPlayerCopyVarcharPKCaseInsensitive(t *testing.T) {
 		// Back to copy mode.
 		// Inserts can happen out of order.
 		// Updates must happen in order.
-		//upd1 := expect.
+		// upd1 := expect.
 		upd1 := expect.Then(qh.Eventually(
 			"insert into dst(idc,val) values ('B',3)",
 			`/insert into _vt.copy_state \(lastpk, vrepl_id, table_name\) values \('fields:{name:"idc" type:VARCHAR charset:33 flags:20483} rows:{lengths:1 values:"B"}'.*`,


### PR DESCRIPTION
## Description

When we implemented `atomic copy` when we started supporting foreign keys, we also started using the `RowEvent` `flags` attribute to set the session's `foreign_key_checks variable` depending on the value in the binlog event. 

However in certain situations (for example: #16296) this could cause reverse workflows to fail and cannot be recovered. This PR adds logic 
so that `vplayer` will no longer set `foreign_key_checks` at the session level if it is turned off in the `global` scope.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16296

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
