### PR TITLE
Add new mysql connection drain

### DIFF
--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -141,6 +141,7 @@ Flags:
       --mysql_ldap_auth_config_string string                             JSON representation of LDAP server config.
       --mysql_ldap_auth_method string                                    client-side authentication method to use. Supported values: mysql_clear_password, dialog. (default "mysql_clear_password")
       --mysql_server_bind_address string                                 Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.
+      --mysql_server_drain_onterm                                        If set, the server waits for --onterm_timeout for connected clients to drain
       --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_port int                                            If set, also listen for MySQL binary protocol connections on this port. (default -1)
       --mysql_server_query_timeout duration                              mysql query timeout

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -237,6 +237,19 @@ func (vtgate *VtgateProcess) WaitForStatusOfTabletInShard(name string, endPoints
 	return fmt.Errorf("wait for %s failed", name)
 }
 
+// IsShutdown checks if the vtgate process is shutdown
+func (vtgate *VtgateProcess) IsShutdown() bool {
+	return vtgate.proc.ProcessState.Exited()
+}
+
+// Terminate sends a SIGTERM to vtgate
+func (vtgate *VtgateProcess) Terminate() error {
+	if vtgate.proc == nil {
+		return nil
+	}
+	return vtgate.proc.Process.Signal(syscall.SIGTERM)
+}
+
 // TearDown shuts down the running vtgate service
 func (vtgate *VtgateProcess) TearDown() error {
 	if vtgate.proc == nil || vtgate.exit == nil {

--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -59,7 +59,6 @@ func Run(bindAddress string, port int) {
 	signal.Notify(ExitChan, syscall.SIGTERM, syscall.SIGINT)
 	// Wait for signal
 	<-ExitChan
-	l.Close()
 
 	startTime := time.Now()
 	log.Infof("Entering lameduck mode for at least %v", timeouts.LameduckPeriod)
@@ -71,6 +70,7 @@ func Run(bindAddress string, port int) {
 		log.Infof("Sleeping an extra %v after OnTermSync to finish lameduck period", remain)
 		time.Sleep(remain)
 	}
+	l.Close()
 
 	log.Info("Shutting down gracefully")
 	fireOnCloseHooks(timeouts.OnCloseTimeout)

--- a/go/vt/vtgate/endtoend/connectiondrain/schema.sql
+++ b/go/vt/vtgate/endtoend/connectiondrain/schema.sql
@@ -1,0 +1,5 @@
+create table t1(
+                   id1 bigint,
+                   id2 bigint,
+                   primary key(id1)
+) Engine=InnoDB;

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -75,6 +75,7 @@ var (
 
 	mysqlDefaultWorkloadName = "OLTP"
 	mysqlDefaultWorkload     int32
+	mysqlDrainOnTerm         bool
 
 	mysqlServerFlushDelay = 100 * time.Millisecond
 )
@@ -102,6 +103,7 @@ func registerPluginFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&mysqlKeepAlivePeriod, "mysql-server-keepalive-period", mysqlKeepAlivePeriod, "TCP period between keep-alives")
 	fs.DurationVar(&mysqlServerFlushDelay, "mysql_server_flush_delay", mysqlServerFlushDelay, "Delay after which buffered response will be flushed to the client.")
 	fs.StringVar(&mysqlDefaultWorkloadName, "mysql_default_workload", mysqlDefaultWorkloadName, "Default session workload (OLTP, OLAP, DBA)")
+	fs.BoolVar(&mysqlDrainOnTerm, "mysql_server_drain_onterm", mysqlDrainOnTerm, "If set, the server waits for --onterm_timeout for connected clients to drain")
 }
 
 // vtgateHandler implements the Listener interface.
@@ -621,18 +623,28 @@ func newMysqlUnixSocket(address string, authServer mysql.AuthServer, handler mys
 }
 
 func (srv *mysqlServer) shutdownMysqlProtocolAndDrain() {
-	if srv.tcpListener != nil {
-		srv.tcpListener.Shutdown()
-		srv.tcpListener = nil
-	}
-	if srv.unixListener != nil {
-		srv.unixListener.Shutdown()
-		srv.unixListener = nil
-	}
 	if srv.sigChan != nil {
 		signal.Stop(srv.sigChan)
 	}
 
+	if mysqlDrainOnTerm {
+		stopListener(srv.unixListener, false)
+		stopListener(srv.tcpListener, false)
+		// We wait for connected clients to drain by themselves or to run into the onterm timeout
+		log.Infof("Starting drain loop, waiting for all clients to disconnect")
+		reported := time.Now()
+		for srv.vtgateHandle.numConnections() > 0 {
+			if time.Since(reported) > 2*time.Second {
+				log.Infof("Still waiting for client connections to drain (%d connected)...", srv.vtgateHandle.numConnections())
+				reported = time.Now()
+			}
+			time.Sleep(1000 * time.Millisecond)
+		}
+		return
+	}
+
+	stopListener(srv.unixListener, true)
+	stopListener(srv.tcpListener, true)
 	if busy := srv.vtgateHandle.busyConnections.Load(); busy > 0 {
 		log.Infof("Waiting for all client connections to be idle (%d active)...", busy)
 		start := time.Now()
@@ -646,6 +658,18 @@ func (srv *mysqlServer) shutdownMysqlProtocolAndDrain() {
 			time.Sleep(1 * time.Millisecond)
 			busy = srv.vtgateHandle.busyConnections.Load()
 		}
+	}
+}
+
+// stopListener Close or Shutdown a mysql listener depending on the shutdown argument.
+func stopListener(listener *mysql.Listener, shutdown bool) {
+	if listener == nil {
+		return
+	}
+	if shutdown {
+		listener.Shutdown()
+	} else {
+		listener.Close()
 	}
 }
 


### PR DESCRIPTION
## Description

This PR implements the https://github.com/vitessio/vitess/issues/15971 RFC by adding a new mysql connection drain, which comes as an alternative to the already existing activity drain timeout.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15971

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
