### PR TITLE
Add a note on `QueryCacheHits` and `QueryCacheMisses` in the release notes

### DIFF
--- a/changelog/20.0/20.0.0/release_notes.md
+++ b/changelog/20.0/20.0.0/release_notes.md
@@ -360,8 +360,12 @@ You can now run `VDiff`s on OnlineDDL schema change migrations, which are not ye
 
 VTTablet exposes two new counter stats:
 
- * `QueryCacheHits`: Query engine query cache hits
- * `QueryCacheMisses`: Query engine query cache misses
+ * `QueryCacheHits`: Query engine query plan cache hits
+ * `QueryCacheMisses`: Query engine query plan cache misses
+
+> [!NOTE]
+> `QueryCache` does not refer to a query cache, but to a query plan cache.
+> In v21, these metrics will be deprecated and renamed.
 
 ### <a id="vttablet-query-text-characters-processed"/>VTTablet Query Text Characters Processed
 

--- a/changelog/20.0/20.0.0/summary.md
+++ b/changelog/20.0/20.0.0/summary.md
@@ -359,8 +359,12 @@ You can now run `VDiff`s on OnlineDDL schema change migrations, which are not ye
 
 VTTablet exposes two new counter stats:
 
- * `QueryCacheHits`: Query engine query cache hits
- * `QueryCacheMisses`: Query engine query cache misses
+ * `QueryCacheHits`: Query engine query plan cache hits
+ * `QueryCacheMisses`: Query engine query plan cache misses
+
+> [!NOTE]
+> `QueryCache` does not refer to a query cache, but to a query plan cache.
+> In v21, these metrics will be deprecated and renamed.
 
 ### <a id="vttablet-query-text-characters-processed"/>VTTablet Query Text Characters Processed
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -269,22 +269,22 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	env.Exporter().NewGaugeFunc("StreamBufferSize", "Query engine stream buffer size", qe.streamBufferSize.Load)
 	env.Exporter().NewCounterFunc("TableACLExemptCount", "Query engine table ACL exempt count", qe.tableaclExemptCount.Load)
 
-	env.Exporter().NewGaugeFunc("QueryCacheLength", "Query engine query cache length", func() int64 {
+	env.Exporter().NewGaugeFunc("QueryCacheLength", "Query engine query plan cache length", func() int64 {
 		return int64(qe.plans.Len())
 	})
-	env.Exporter().NewGaugeFunc("QueryCacheSize", "Query engine query cache size", func() int64 {
+	env.Exporter().NewGaugeFunc("QueryCacheSize", "Query engine query plan cache size", func() int64 {
 		return int64(qe.plans.UsedCapacity())
 	})
-	env.Exporter().NewGaugeFunc("QueryCacheCapacity", "Query engine query cache capacity", func() int64 {
+	env.Exporter().NewGaugeFunc("QueryCacheCapacity", "Query engine query plan cache capacity", func() int64 {
 		return int64(qe.plans.MaxCapacity())
 	})
-	env.Exporter().NewCounterFunc("QueryCacheEvictions", "Query engine query cache evictions", func() int64 {
+	env.Exporter().NewCounterFunc("QueryCacheEvictions", "Query engine query plan cache evictions", func() int64 {
 		return qe.plans.Metrics.Evicted()
 	})
-	qe.queryCacheHits = env.Exporter().NewCounterFunc("QueryCacheHits", "Query engine query cache hits", func() int64 {
+	qe.queryCacheHits = env.Exporter().NewCounterFunc("QueryCacheHits", "Query engine query plan cache hits", func() int64 {
 		return qe.plans.Metrics.Hits()
 	})
-	qe.queryCacheMisses = env.Exporter().NewCounterFunc("QueryCacheMisses", "Query engine query cache misses", func() int64 {
+	qe.queryCacheMisses = env.Exporter().NewCounterFunc("QueryCacheMisses", "Query engine query plan cache misses", func() int64 {
 		return qe.plans.Metrics.Misses()
 	})
 


### PR DESCRIPTION
## Description

This PR modifies the v20 release notes to mention that `QueryCacheXX` does not refer to an actual query cache but rather to a query plan cache.

The metrics will be renamed in v21 through https://github.com/vitessio/vitess/pull/16289.

Let's backport this to v20 for the release notes.

## Related Issue(s)

- Follow up of https://github.com/vitessio/vitess/pull/14947
