### PR TITLE
Online DDL: remove legacy (and ancient) 'REVERT <uuid>' syntax

### DIFF
--- a/go/vt/schema/online_ddl_test.go
+++ b/go/vt/schema/online_ddl_test.go
@@ -157,10 +157,14 @@ func TestGetRevertUUID(t *testing.T) {
 	}{
 		{
 			statement: "revert 4e5dcf80_354b_11eb_82cd_f875a4d24e90",
-			uuid:      "4e5dcf80_354b_11eb_82cd_f875a4d24e90",
+			isError:   true,
 		},
 		{
 			statement: "REVERT   4e5dcf80_354b_11eb_82cd_f875a4d24e90",
+			isError:   true,
+		},
+		{
+			statement: "revert vitess_migration '4e5dcf80_354b_11eb_82cd_f875a4d24e90'",
 			uuid:      "4e5dcf80_354b_11eb_82cd_f875a4d24e90",
 		},
 		{
@@ -185,6 +189,9 @@ func TestGetRevertUUID(t *testing.T) {
 	for _, ts := range tt {
 		t.Run(ts.statement, func(t *testing.T) {
 			onlineDDL, err := NewOnlineDDL("test_ks", "t", ts.statement, NewDDLStrategySetting(DDLStrategyOnline, ""), migrationContext, "", parser)
+			if err != nil && ts.isError {
+				return
+			}
 			assert.NoError(t, err)
 			require.NotNil(t, onlineDDL)
 			uuid, err := onlineDDL.GetRevertUUID(parser)

--- a/go/vt/schema/parser.go
+++ b/go/vt/schema/parser.go
@@ -17,7 +17,6 @@ limitations under the License.
 package schema
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -50,7 +49,6 @@ var (
 		// ALTER TABLE tbl something
 		regexp.MustCompile(alterTableBasicPattern + `([\S]+)\s+(.*$)`),
 	}
-	revertStatementRegexp = regexp.MustCompile(`(?i)^revert\s+([\S]*)$`)
 
 	enumValuesRegexp = regexp.MustCompile("(?i)^enum[(](.*)[)]$")
 	setValuesRegexp  = regexp.MustCompile("(?i)^set[(](.*)[)]$")
@@ -77,19 +75,6 @@ func ParseAlterTableOptions(alterStatement string) (explicitSchema, explicitTabl
 		}
 	}
 	return explicitSchema, explicitTable, alterOptions
-}
-
-// legacyParseRevertUUID expects a query like "revert 4e5dcf80_354b_11eb_82cd_f875a4d24e90" and returns the UUID value.
-func legacyParseRevertUUID(sql string) (uuid string, err error) {
-	submatch := revertStatementRegexp.FindStringSubmatch(sql)
-	if len(submatch) == 0 {
-		return "", fmt.Errorf("Not a Revert DDL: '%s'", sql)
-	}
-	uuid = submatch[1]
-	if !IsOnlineDDLUUID(uuid) {
-		return "", fmt.Errorf("Not an online DDL UUID: '%s'", uuid)
-	}
-	return uuid, nil
 }
 
 // ParseEnumValues parses the comma delimited part of an enum column definition

--- a/go/vt/schema/parser_test.go
+++ b/go/vt/schema/parser_test.go
@@ -48,23 +48,6 @@ func TestParseAlterTableOptions(t *testing.T) {
 	}
 }
 
-func TestLegacyParseRevertUUID(t *testing.T) {
-
-	{
-		uuid, err := legacyParseRevertUUID("revert 4e5dcf80_354b_11eb_82cd_f875a4d24e90")
-		assert.NoError(t, err)
-		assert.Equal(t, "4e5dcf80_354b_11eb_82cd_f875a4d24e90", uuid)
-	}
-	{
-		_, err := legacyParseRevertUUID("revert 4e5dcf80_354b_11eb_82cd_f875a4")
-		assert.Error(t, err)
-	}
-	{
-		_, err := legacyParseRevertUUID("revert vitess_migration '4e5dcf80_354b_11eb_82cd_f875a4d24e90'")
-		assert.Error(t, err)
-	}
-}
-
 func TestParseEnumValues(t *testing.T) {
 	{
 		inputs := []string{

--- a/go/vt/vtgate/engine/revert_migration.go
+++ b/go/vt/vtgate/engine/revert_migration.go
@@ -80,14 +80,12 @@ func (v *RevertMigration) TryExecute(ctx context.Context, vcursor VCursor, bindV
 		Rows: [][]sqltypes.Value{},
 	}
 
-	sql := fmt.Sprintf("revert %s", v.Stmt.UUID)
-
 	ddlStrategySetting, err := schema.ParseDDLStrategy(vcursor.Session().GetDDLStrategy())
 	if err != nil {
 		return nil, err
 	}
 	ddlStrategySetting.Strategy = schema.DDLStrategyOnline // and we keep the options as they were
-	onlineDDL, err := schema.NewOnlineDDL(v.GetKeyspaceName(), "", sql, ddlStrategySetting, fmt.Sprintf("vtgate:%s", vcursor.Session().GetSessionUUID()), "", vcursor.Environment().Parser())
+	onlineDDL, err := schema.NewOnlineDDL(v.GetKeyspaceName(), "", v.Query, ddlStrategySetting, fmt.Sprintf("vtgate:%s", vcursor.Session().GetSessionUUID()), "", vcursor.Environment().Parser())
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION

## Description

This is a long overdue cleanup PR, removing support for a long since unused `revert` syntax.

To revert a migration, we use this syntax: `revert vitess_migration '<uuid'>`.

When revert was first introduced, we used this syntax: `revert <uuid>`. This syntax is not being used in over 3 years now since the [new syntax was introduced](https://github.com/vitessio/vitess/pull/7656).

This PR cleans up support of the old syntax.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/7656
- https://github.com/vitessio/vitess/pull/7478
- https://github.com/vitessio/vitess/issues/6926

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
