### PR TITLE
VDiff: Copy non in_keyrange workflow filters to target tablet query

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
@@ -174,10 +174,10 @@ func (td *tableDiffer) buildTablePlan(dbClient binlogplayer.DBClient, dbName str
 		return nil, err
 	}
 
-	// Copy all filters for the source.
+	// Copy all workflow filters for the source query.
 	sourceSelect.Where = sel.Where
 
-	// Copy all non-in_keyrange filters from the source to the target.
+	// Copy all non-in_keyrange workflow filters to the target query.
 	// This is important for things like multi-tenant migrations where
 	// an additional tenant_id filter is applied in the workflow.
 	targetSelect.Where = copyNonKeyRangeExpressions(sel.Where)

--- a/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
@@ -174,8 +174,14 @@ func (td *tableDiffer) buildTablePlan(dbClient binlogplayer.DBClient, dbName str
 		return nil, err
 	}
 
-	// Remove in_keyrange. It's not understood by mysql.
-	sourceSelect.Where = sel.Where // removeKeyrange(sel.Where)
+	// Copy all filters for the source.
+	sourceSelect.Where = sel.Where
+
+	// Copy all non-in_keyrange filters from the source to the target.
+	// This is important for things like multi-tenant migrations where
+	// an additional tenant_id filter is applied in the workflow.
+	targetSelect.Where = copyNonKeyRangeExpressions(sel.Where)
+
 	// The source should also perform the group by.
 	sourceSelect.GroupBy = sel.GroupBy
 	sourceSelect.OrderBy = tp.orderBy

--- a/go/vt/vttablet/tabletmanager/vdiff/utils.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/utils.go
@@ -92,7 +92,7 @@ func stringListContains(lst []string, item string) bool {
 }
 
 // copyNonKeyRangeExpressions copies all expressions from the input WHERE clause
-// to the output WHERE clause except for the in_keyrange() expressions.
+// to the output WHERE clause except for any in_keyrange() expressions.
 func copyNonKeyRangeExpressions(where *sqlparser.Where) *sqlparser.Where {
 	if where == nil {
 		return nil

--- a/go/vt/vttablet/tabletmanager/vdiff/utils.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -88,4 +89,24 @@ func stringListContains(lst []string, item string) bool {
 		}
 	}
 	return contains
+}
+
+// copyNonKeyRangeExpressions copies all expressions from the input WHERE clause
+// to the output WHERE clause except for the in_keyrange() expressions.
+func copyNonKeyRangeExpressions(where *sqlparser.Where) *sqlparser.Where {
+	if where == nil {
+		return nil
+	}
+	exprs := sqlparser.SplitAndExpression(nil, where.Expr)
+	newWhere := &sqlparser.Where{}
+	for _, expr := range exprs {
+		switch expr := expr.(type) {
+		case *sqlparser.FuncExpr:
+			if expr.Name.EqualString("in_keyrange") {
+				continue
+			}
+		}
+		newWhere.Expr = sqlparser.AndExpressions(newWhere.Expr, expr)
+	}
+	return newWhere
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -364,7 +364,6 @@ func TestBuildPlanSuccess(t *testing.T) {
 		},
 	}, {
 		// in_keyrange on RHS of AND.
-		// This is currently not a valid construct, but will be supported in the future.
 		input: &binlogdatapb.Rule{
 			Match:  "t1",
 			Filter: "select * from t1 where c2 = 2 and in_keyrange('-80')",
@@ -374,7 +373,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			dbName:      vdiffDBName,
 			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
 			sourceQuery: "select c1, c2 from t1 where c2 = 2 and in_keyrange('-80') order by c1 asc",
-			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
 			compareCols: []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}, {1, collations.MySQL8().LookupByName(sqltypes.NULL.String()), false, "c2"}},
 			comparePKs:  []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}},
 			pkCols:      []int{0},
@@ -386,7 +385,6 @@ func TestBuildPlanSuccess(t *testing.T) {
 		},
 	}, {
 		// in_keyrange on LHS of AND.
-		// This is currently not a valid construct, but will be supported in the future.
 		input: &binlogdatapb.Rule{
 			Match:  "t1",
 			Filter: "select * from t1 where in_keyrange('-80') and c2 = 2",
@@ -396,7 +394,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			dbName:      vdiffDBName,
 			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
 			sourceQuery: "select c1, c2 from t1 where in_keyrange('-80') and c2 = 2 order by c1 asc",
-			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
 			compareCols: []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}, {1, collations.MySQL8().LookupByName(sqltypes.NULL.String()), false, "c2"}},
 			comparePKs:  []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}},
 			pkCols:      []int{0},
@@ -408,7 +406,6 @@ func TestBuildPlanSuccess(t *testing.T) {
 		},
 	}, {
 		// in_keyrange on cascaded AND expression.
-		// This is currently not a valid construct, but will be supported in the future.
 		input: &binlogdatapb.Rule{
 			Match:  "t1",
 			Filter: "select * from t1 where c2 = 2 and c1 = 1 and in_keyrange('-80')",
@@ -418,7 +415,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			dbName:      vdiffDBName,
 			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
 			sourceQuery: "select c1, c2 from t1 where c2 = 2 and c1 = 1 and in_keyrange('-80') order by c1 asc",
-			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 where c2 = 2 and c1 = 1 order by c1 asc",
 			compareCols: []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}, {1, collations.MySQL8().LookupByName(sqltypes.NULL.String()), false, "c2"}},
 			comparePKs:  []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}},
 			pkCols:      []int{0},
@@ -430,7 +427,6 @@ func TestBuildPlanSuccess(t *testing.T) {
 		},
 	}, {
 		// in_keyrange parenthesized.
-		// This is currently not a valid construct, but will be supported in the future.
 		input: &binlogdatapb.Rule{
 			Match:  "t1",
 			Filter: "select * from t1 where (c2 = 2 and in_keyrange('-80'))",
@@ -440,7 +436,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			dbName:      vdiffDBName,
 			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
 			sourceQuery: "select c1, c2 from t1 where c2 = 2 and in_keyrange('-80') order by c1 asc",
-			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
 			compareCols: []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}, {1, collations.MySQL8().LookupByName(sqltypes.NULL.String()), false, "c2"}},
 			comparePKs:  []compareColInfo{{0, collations.MySQL8().LookupByName(sqltypes.NULL.String()), true, "c1"}},
 			pkCols:      []int{0},


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/issues/15403 we added experimental support for moving tables from a multi-tenant environment (database per tenant, each with the same schema). 

You would do that by specifying a column on the table(s) representing the tenant identifier in the target VSchema and then specifying a tenant identifier value using [`MoveTables create --tenant-id=<val>`](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_movetables/vtctldclient_movetables_create/). You can see an example here: https://github.com/vitessio/vitess/issues/16305#issuecomment-2200745054

There is an optional `--shards <shards>` flag for [`MoveTables create`](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_movetables/vtctldclient_movetables_create/) that would limit the workflow streams created to only the appropriate target shard for the provided tenant identifier value. In order to know what that would be, you would need to [query the vindex function](https://vitess.io/docs/reference/features/vindexes/#query-vindex-functions) to know where they should land. This can be cumbersome in some situations and introduces the potential for human error so should not be required for anything to work properly (and one could argue it's better left to Vitess to figure this out — a future optimization would be for vreplication itself to determine which streams need to be created for the provided tenant identifier). Anyhow, when this `--shards` flag was *also* specified then running VDiff on the workflow worked as expected. When it was *not* specified, however, there would be extra rows reported on the target if you had previously migrated any other tenants.

This PR addresses this issue by ensuring that we copy any WHERE predicates from the workflow filter to the query used on the target tablets for the diff.

I think that we should backport this fix to v20 where the multi-tenant support was added since it's a pretty small change and will eliminate potential issues for those using this new experimental feature (and we want all the usage and input we can get).

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16305

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required