### PR TITLE
VTAdmin: Show throttled status in workflows

### DIFF
--- a/web/vtadmin/src/components/pips/Pip.module.scss
+++ b/web/vtadmin/src/components/pips/Pip.module.scss
@@ -35,4 +35,8 @@
     &.danger {
         background: var(--colorError50);
     }
+
+    &.throttled {
+        background: var(--grey900);
+    }
 }

--- a/web/vtadmin/src/components/pips/Pip.tsx
+++ b/web/vtadmin/src/components/pips/Pip.tsx
@@ -22,7 +22,7 @@ interface Props {
     state?: PipState;
 }
 
-export type PipState = 'primary' | 'success' | 'warning' | 'danger' | null | undefined;
+export type PipState = 'primary' | 'success' | 'warning' | 'danger' | 'throttled' | null | undefined;
 
 export const Pip = ({ className, state }: Props) => {
     return <div className={cx(className, style.pip, state && style[state])} />;

--- a/web/vtadmin/src/components/pips/StreamStatePip.tsx
+++ b/web/vtadmin/src/components/pips/StreamStatePip.tsx
@@ -25,6 +25,7 @@ const STREAM_STATES: { [key: string]: PipState } = {
     Error: 'danger',
     Running: 'success',
     Stopped: null,
+    Throttled: 'throttled',
 };
 
 export const StreamStatePip = ({ state }: Props) => {

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -13,219 +13,199 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { groupBy, orderBy } from "lodash-es";
-import * as React from "react";
-import { Link } from "react-router-dom";
+import { groupBy, orderBy } from 'lodash-es';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
 
-import style from "./Workflows.module.scss";
-import { useWorkflows } from "../../hooks/api";
-import { useDocumentTitle } from "../../hooks/useDocumentTitle";
-import { DataCell } from "../dataTable/DataCell";
-import { DataTable } from "../dataTable/DataTable";
-import { useSyncedURLParam } from "../../hooks/useSyncedURLParam";
-import { filterNouns } from "../../util/filterNouns";
-import { getStreams, getTimeUpdated } from "../../util/workflows";
-import { formatDateTime, formatRelativeTime } from "../../util/time";
-import { StreamStatePip } from "../pips/StreamStatePip";
-import { ContentContainer } from "../layout/ContentContainer";
-import { WorkspaceHeader } from "../layout/WorkspaceHeader";
-import { WorkspaceTitle } from "../layout/WorkspaceTitle";
-import { DataFilter } from "../dataTable/DataFilter";
-import { Tooltip } from "../tooltip/Tooltip";
-import { KeyspaceLink } from "../links/KeyspaceLink";
-import { QueryLoadingPlaceholder } from "../placeholders/QueryLoadingPlaceholder";
-import { UseQueryResult } from "react-query";
+import style from './Workflows.module.scss';
+import { useWorkflows } from '../../hooks/api';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
+import { DataCell } from '../dataTable/DataCell';
+import { DataTable } from '../dataTable/DataTable';
+import { useSyncedURLParam } from '../../hooks/useSyncedURLParam';
+import { filterNouns } from '../../util/filterNouns';
+import { getStreams, getTimeUpdated } from '../../util/workflows';
+import { formatDateTime, formatRelativeTime } from '../../util/time';
+import { StreamStatePip } from '../pips/StreamStatePip';
+import { ContentContainer } from '../layout/ContentContainer';
+import { WorkspaceHeader } from '../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../layout/WorkspaceTitle';
+import { DataFilter } from '../dataTable/DataFilter';
+import { Tooltip } from '../tooltip/Tooltip';
+import { KeyspaceLink } from '../links/KeyspaceLink';
+import { QueryLoadingPlaceholder } from '../placeholders/QueryLoadingPlaceholder';
+import { UseQueryResult } from 'react-query';
 
 export const ThrottleThresholdSeconds = 60;
 
 export const Workflows = () => {
-  useDocumentTitle("Workflows");
-  const workflowsQuery = useWorkflows();
+    useDocumentTitle('Workflows');
+    const workflowsQuery = useWorkflows();
 
-  const { value: filter, updateValue: updateFilter } =
-    useSyncedURLParam("filter");
+    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
 
-  const sortedData = React.useMemo(() => {
-    const mapped = (workflowsQuery.data || []).map((workflow) => ({
-      clusterID: workflow.cluster?.id,
-      clusterName: workflow.cluster?.name,
-      keyspace: workflow.keyspace,
-      name: workflow.workflow?.name,
-      source: workflow.workflow?.source?.keyspace,
-      sourceShards: workflow.workflow?.source?.shards,
-      streams: groupBy(getStreams(workflow), "state"),
-      target: workflow.workflow?.target?.keyspace,
-      targetShards: workflow.workflow?.target?.shards,
-      timeUpdated: getTimeUpdated(workflow),
-      workflowType: workflow.workflow?.workflow_type,
-      workflowSubType: workflow.workflow?.workflow_sub_type,
-    }));
-    const filtered = filterNouns(filter, mapped);
-    return orderBy(filtered, ["name", "clusterName", "source", "target"]);
-  }, [workflowsQuery.data, filter]);
+    const sortedData = React.useMemo(() => {
+        const mapped = (workflowsQuery.data || []).map((workflow) => ({
+            clusterID: workflow.cluster?.id,
+            clusterName: workflow.cluster?.name,
+            keyspace: workflow.keyspace,
+            name: workflow.workflow?.name,
+            source: workflow.workflow?.source?.keyspace,
+            sourceShards: workflow.workflow?.source?.shards,
+            streams: groupBy(getStreams(workflow), 'state'),
+            target: workflow.workflow?.target?.keyspace,
+            targetShards: workflow.workflow?.target?.shards,
+            timeUpdated: getTimeUpdated(workflow),
+            workflowType: workflow.workflow?.workflow_type,
+            workflowSubType: workflow.workflow?.workflow_sub_type,
+        }));
+        const filtered = filterNouns(filter, mapped);
+        return orderBy(filtered, ['name', 'clusterName', 'source', 'target']);
+    }, [workflowsQuery.data, filter]);
 
-  const renderRows = (rows: typeof sortedData) =>
-    rows.map((row, idx) => {
-      const href =
-        row.clusterID && row.keyspace && row.name
-          ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
-          : null;
-      return (
-        <tr key={idx}>
-          <DataCell>
-            <div className="font-bold">
-              {href ? <Link to={href}>{row.name}</Link> : row.name}
-            </div>
-            {row.workflowType && (
-              <div className="text-secondary text-success-200">
-                {row.workflowType}
-                {row.workflowSubType && row.workflowSubType !== "None" && (
-                  <span className="text-sm">
-                    {" (" + row.workflowSubType + ")"}
-                  </span>
-                )}
-              </div>
-            )}
-            <div className="text-sm text-secondary">{row.clusterName}</div>
-          </DataCell>
-          <DataCell>
-            {row.source ? (
-              <>
-                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
-                  {row.source}
-                </KeyspaceLink>
-                <div className={style.shardList}>
-                  {(row.sourceShards || []).join(", ")}
-                </div>
-              </>
-            ) : (
-              <span className="text-secondary">N/A</span>
-            )}
-          </DataCell>
-          <DataCell>
-            {row.target ? (
-              <>
-                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
-                  {row.target}
-                </KeyspaceLink>
-                <div className={style.shardList}>
-                  {(row.targetShards || []).join(", ")}
-                </div>
-              </>
-            ) : (
-              <span className="text-secondary">N/A</span>
-            )}
-          </DataCell>
+    const renderRows = (rows: typeof sortedData) =>
+        rows.map((row, idx) => {
+            const href =
+                row.clusterID && row.keyspace && row.name
+                    ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
+                    : null;
+            return (
+                <tr key={idx}>
+                    <DataCell>
+                        <div className="font-bold">{href ? <Link to={href}>{row.name}</Link> : row.name}</div>
+                        {row.workflowType && (
+                            <div className="text-secondary text-success-200">
+                                {row.workflowType}
+                                {row.workflowSubType && row.workflowSubType !== 'None' && (
+                                    <span className="text-sm">{' (' + row.workflowSubType + ')'}</span>
+                                )}
+                            </div>
+                        )}
+                        <div className="text-sm text-secondary">{row.clusterName}</div>
+                    </DataCell>
+                    <DataCell>
+                        {row.source ? (
+                            <>
+                                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
+                                    {row.source}
+                                </KeyspaceLink>
+                                <div className={style.shardList}>{(row.sourceShards || []).join(', ')}</div>
+                            </>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
+                    <DataCell>
+                        {row.target ? (
+                            <>
+                                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
+                                    {row.target}
+                                </KeyspaceLink>
+                                <div className={style.shardList}>{(row.targetShards || []).join(', ')}</div>
+                            </>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
 
-          <DataCell>
-            <div className={style.streams}>
-              {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-              {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
-                if (streamState in row.streams) {
-                  var numThrottled = 0;
-                  var throttledApp: string | undefined = "";
-                  const streamCount = row.streams[streamState].length;
-                  var streamDescription: string;
-                  switch (streamState) {
-                    case "Error":
-                      streamDescription = "failed";
-                      break;
-                    case "Running":
-                    case "Copying":
-                      const streams = row.streams[streamState];
-                      if (streams !== undefined && streams !== null) {
-                        for (const stream of streams) {
-                          if (
-                            stream?.throttler_status?.time_throttled !== null &&
-                            stream?.throttler_status?.time_throttled !==
-                              undefined &&
-                            // If the stream has been throttled recently, treat it as throttled.
-                            Number(
-                              stream?.throttler_status?.time_throttled?.seconds
-                            ) >
-                              Date.now() / 1000 - ThrottleThresholdSeconds
-                          ) {
-                            numThrottled++;
-                            // In case of multiple streams, show the first throttled app and time.
-                            // The detail page will show each stream separately.
-                            if (numThrottled === 1) {
-                              throttledApp =
-                                stream?.throttler_status?.component_throttled?.toString();
-                            }
-                          }
-                        }
-                      }
-                      streamDescription = streamState.toLocaleLowerCase();
-                      if (numThrottled > 0) {
-                        streamState = "Throttled";
-                      }
-                      break;
-                    default:
-                      streamDescription = streamState.toLocaleLowerCase();
-                  }
-                  const tooltip = [
-                    streamCount,
-                    streamDescription,
-                    streamCount === 1 ? "stream" : "streams",
-                    numThrottled > 0
-                      ? "(" +
-                        numThrottled +
-                        " throttled in " +
-                        throttledApp +
-                        ")"
-                      : "",
-                  ].join(" ");
-                  return (
-                    <Tooltip key={streamState} text={tooltip}>
-                      <span className={style.stream}>
-                        <StreamStatePip state={streamState} /> {streamCount}
-                      </span>
-                    </Tooltip>
-                  );
-                }
-                return (
-                  <span key={streamState} className={style.streamPlaceholder}>
-                    -
-                  </span>
-                );
-              })}
-            </div>
-          </DataCell>
+                    <DataCell>
+                        <div className={style.streams}>
+                            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+                            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
+                                if (streamState in row.streams) {
+                                    var numThrottled = 0;
+                                    var throttledApp: string | undefined = '';
+                                    const streamCount = row.streams[streamState].length;
+                                    var streamDescription: string;
+                                    switch (streamState) {
+                                        case 'Error':
+                                            streamDescription = 'failed';
+                                            break;
+                                        case 'Running':
+                                        case 'Copying':
+                                            const streams = row.streams[streamState];
+                                            if (streams !== undefined && streams !== null) {
+                                                for (const stream of streams) {
+                                                    if (
+                                                        stream?.throttler_status?.time_throttled !== null &&
+                                                        stream?.throttler_status?.time_throttled !== undefined &&
+                                                        // If the stream has been throttled recently, treat it as throttled.
+                                                        Number(stream?.throttler_status?.time_throttled?.seconds) >
+                                                            Date.now() / 1000 - ThrottleThresholdSeconds
+                                                    ) {
+                                                        numThrottled++;
+                                                        // In case of multiple streams, show the first throttled app and time.
+                                                        // The detail page will show each stream separately.
+                                                        if (numThrottled === 1) {
+                                                            throttledApp =
+                                                                stream?.throttler_status?.component_throttled?.toString();
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            streamDescription = streamState.toLocaleLowerCase();
+                                            if (numThrottled > 0) {
+                                                streamState = 'Throttled';
+                                            }
+                                            break;
+                                        default:
+                                            streamDescription = streamState.toLocaleLowerCase();
+                                    }
+                                    const tooltip = [
+                                        streamCount,
+                                        streamDescription,
+                                        streamCount === 1 ? 'stream' : 'streams',
+                                        numThrottled > 0
+                                            ? '(' + numThrottled + ' throttled in ' + throttledApp + ')'
+                                            : '',
+                                    ].join(' ');
+                                    return (
+                                        <Tooltip key={streamState} text={tooltip}>
+                                            <span className={style.stream}>
+                                                <StreamStatePip state={streamState} /> {streamCount}
+                                            </span>
+                                        </Tooltip>
+                                    );
+                                }
+                                return (
+                                    <span key={streamState} className={style.streamPlaceholder}>
+                                        -
+                                    </span>
+                                );
+                            })}
+                        </div>
+                    </DataCell>
 
-          <DataCell>
-            <div className="font-sans whitespace-nowrap">
-              {formatDateTime(row.timeUpdated)}
-            </div>
-            <div className="font-sans text-sm text-secondary">
-              {formatRelativeTime(row.timeUpdated)}
-            </div>
-          </DataCell>
-        </tr>
-      );
-    });
+                    <DataCell>
+                        <div className="font-sans whitespace-nowrap">{formatDateTime(row.timeUpdated)}</div>
+                        <div className="font-sans text-sm text-secondary">{formatRelativeTime(row.timeUpdated)}</div>
+                    </DataCell>
+                </tr>
+            );
+        });
 
-  return (
-    <div>
-      <WorkspaceHeader>
-        <WorkspaceTitle>Workflows</WorkspaceTitle>
-      </WorkspaceHeader>
-      <ContentContainer>
-        <DataFilter
-          autoFocus
-          onChange={(e) => updateFilter(e.target.value)}
-          onClear={() => updateFilter("")}
-          placeholder="Filter workflows"
-          value={filter || ""}
-        />
+    return (
+        <div>
+            <WorkspaceHeader>
+                <WorkspaceTitle>Workflows</WorkspaceTitle>
+            </WorkspaceHeader>
+            <ContentContainer>
+                <DataFilter
+                    autoFocus
+                    onChange={(e) => updateFilter(e.target.value)}
+                    onClear={() => updateFilter('')}
+                    placeholder="Filter workflows"
+                    value={filter || ''}
+                />
 
-        <DataTable
-          columns={["Workflow", "Source", "Target", "Streams", "Last Updated"]}
-          data={sortedData}
-          renderRows={renderRows}
-        />
+                <DataTable
+                    columns={['Workflow', 'Source', 'Target', 'Streams', 'Last Updated']}
+                    data={sortedData}
+                    renderRows={renderRows}
+                />
 
-        <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult} />
-      </ContentContainer>
-    </div>
-  );
+                <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult} />
+            </ContentContainer>
+        </div>
+    );
 };

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -35,7 +35,7 @@ import {Tooltip} from '../tooltip/Tooltip';
 import {KeyspaceLink} from '../links/KeyspaceLink';
 import {QueryLoadingPlaceholder} from '../placeholders/QueryLoadingPlaceholder';
 import {UseQueryResult} from 'react-query';
-import {vttime} from '../../proto/vtadmin';
+import {vtctldata, vttime} from '../../proto/vtadmin';
 
 export const ThrottleThresholdSeconds = 60;
 
@@ -123,9 +123,10 @@ export const Workflows = () => {
                                             streamDescription = 'failed';
                                             break;
                                         case 'Running':
-                                            const running = row.streams['Running'];
-                                            if (running !== undefined && running !== null) {
-                                                for (const stream of running) {
+                                        case 'Copying':
+                                            const streams = row.streams[streamState];
+                                            if (streams !== undefined && streams !== null) {
+                                                for (const stream of streams) {
                                                     if (
                                                         stream?.throttler_status?.time_throttled !== null &&
                                                         stream?.throttler_status?.time_throttled !== undefined &&
@@ -142,11 +143,9 @@ export const Workflows = () => {
                                                 }
                                             }
                                             if (numThrottled > 0) {
-                                                streamDescription = '';
                                                 streamState = 'Throttled';
-                                            } else {
-                                                streamDescription = streamState;
                                             }
+                                            streamDescription = streamState.toLocaleLowerCase();
                                             break;
                                         default:
                                             streamDescription = streamState.toLocaleLowerCase();

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -13,201 +13,220 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {groupBy, orderBy} from 'lodash-es';
-import * as React from 'react';
-import {Link} from 'react-router-dom';
+import { groupBy, orderBy } from "lodash-es";
+import * as React from "react";
+import { Link } from "react-router-dom";
 
-import style from './Workflows.module.scss';
-import {useWorkflows} from '../../hooks/api';
-import {useDocumentTitle} from '../../hooks/useDocumentTitle';
-import {DataCell} from '../dataTable/DataCell';
-import {DataTable} from '../dataTable/DataTable';
-import {useSyncedURLParam} from '../../hooks/useSyncedURLParam';
-import {filterNouns} from '../../util/filterNouns';
-import {getStreams, getTimeUpdated} from '../../util/workflows';
-import {formatDateTime, formatRelativeTime} from '../../util/time';
-import {StreamStatePip} from '../pips/StreamStatePip';
-import {ContentContainer} from '../layout/ContentContainer';
-import {WorkspaceHeader} from '../layout/WorkspaceHeader';
-import {WorkspaceTitle} from '../layout/WorkspaceTitle';
-import {DataFilter} from '../dataTable/DataFilter';
-import {Tooltip} from '../tooltip/Tooltip';
-import {KeyspaceLink} from '../links/KeyspaceLink';
-import {QueryLoadingPlaceholder} from '../placeholders/QueryLoadingPlaceholder';
-import {UseQueryResult} from 'react-query';
-import {vtctldata, vttime} from '../../proto/vtadmin';
+import style from "./Workflows.module.scss";
+import { useWorkflows } from "../../hooks/api";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+import { DataCell } from "../dataTable/DataCell";
+import { DataTable } from "../dataTable/DataTable";
+import { useSyncedURLParam } from "../../hooks/useSyncedURLParam";
+import { filterNouns } from "../../util/filterNouns";
+import { getStreams, getTimeUpdated } from "../../util/workflows";
+import { formatDateTime, formatRelativeTime } from "../../util/time";
+import { StreamStatePip } from "../pips/StreamStatePip";
+import { ContentContainer } from "../layout/ContentContainer";
+import { WorkspaceHeader } from "../layout/WorkspaceHeader";
+import { WorkspaceTitle } from "../layout/WorkspaceTitle";
+import { DataFilter } from "../dataTable/DataFilter";
+import { Tooltip } from "../tooltip/Tooltip";
+import { KeyspaceLink } from "../links/KeyspaceLink";
+import { QueryLoadingPlaceholder } from "../placeholders/QueryLoadingPlaceholder";
+import { UseQueryResult } from "react-query";
+import { vtctldata, vttime } from "../../proto/vtadmin";
 
 export const ThrottleThresholdSeconds = 60;
 
 export const Workflows = () => {
-    useDocumentTitle('Workflows');
-    const workflowsQuery = useWorkflows();
+  useDocumentTitle("Workflows");
+  const workflowsQuery = useWorkflows();
 
-    const {value: filter, updateValue: updateFilter} = useSyncedURLParam('filter');
+  const { value: filter, updateValue: updateFilter } =
+    useSyncedURLParam("filter");
 
-    const sortedData = React.useMemo(() => {
-        const mapped = (workflowsQuery.data || []).map((workflow) => ({
-            clusterID: workflow.cluster?.id,
-            clusterName: workflow.cluster?.name,
-            keyspace: workflow.keyspace,
-            name: workflow.workflow?.name,
-            source: workflow.workflow?.source?.keyspace,
-            sourceShards: workflow.workflow?.source?.shards,
-            streams: groupBy(getStreams(workflow), 'state'),
-            target: workflow.workflow?.target?.keyspace,
-            targetShards: workflow.workflow?.target?.shards,
-            timeUpdated: getTimeUpdated(workflow),
-            workflowType: workflow.workflow?.workflow_type,
-            workflowSubType: workflow.workflow?.workflow_sub_type,
-        }));
-        const filtered = filterNouns(filter, mapped);
-        return orderBy(filtered, ['name', 'clusterName', 'source', 'target']);
-    }, [workflowsQuery.data, filter]);
+  const sortedData = React.useMemo(() => {
+    const mapped = (workflowsQuery.data || []).map((workflow) => ({
+      clusterID: workflow.cluster?.id,
+      clusterName: workflow.cluster?.name,
+      keyspace: workflow.keyspace,
+      name: workflow.workflow?.name,
+      source: workflow.workflow?.source?.keyspace,
+      sourceShards: workflow.workflow?.source?.shards,
+      streams: groupBy(getStreams(workflow), "state"),
+      target: workflow.workflow?.target?.keyspace,
+      targetShards: workflow.workflow?.target?.shards,
+      timeUpdated: getTimeUpdated(workflow),
+      workflowType: workflow.workflow?.workflow_type,
+      workflowSubType: workflow.workflow?.workflow_sub_type,
+    }));
+    const filtered = filterNouns(filter, mapped);
+    return orderBy(filtered, ["name", "clusterName", "source", "target"]);
+  }, [workflowsQuery.data, filter]);
 
-    const renderRows = (rows: typeof sortedData) =>
-        rows.map((row, idx) => {
-            const href =
-                row.clusterID && row.keyspace && row.name
-                    ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
-                    : null;
-            return (
-                <tr key={idx}>
-                    <DataCell>
-                        <div className="font-bold">{href ? <Link to={href}>{row.name}</Link> : row.name}</div>
-                        {row.workflowType && (
-                            <div className="text-secondary text-success-200">
-                                {row.workflowType}
-                                {row.workflowSubType && row.workflowSubType !== 'None' && (
-                                    <span className="text-sm">{' (' + row.workflowSubType + ')'}</span>
-                                )}
-                            </div>
-                        )}
-                        <div className="text-sm text-secondary">{row.clusterName}</div>
-                    </DataCell>
-                    <DataCell>
-                        {row.source ? (
-                            <>
-                                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
-                                    {row.source}
-                                </KeyspaceLink>
-                                <div className={style.shardList}>{(row.sourceShards || []).join(', ')}</div>
-                            </>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
-                    <DataCell>
-                        {row.target ? (
-                            <>
-                                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
-                                    {row.target}
-                                </KeyspaceLink>
-                                <div className={style.shardList}>{(row.targetShards || []).join(', ')}</div>
-                            </>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
+  const renderRows = (rows: typeof sortedData) =>
+    rows.map((row, idx) => {
+      const href =
+        row.clusterID && row.keyspace && row.name
+          ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
+          : null;
+      return (
+        <tr key={idx}>
+          <DataCell>
+            <div className="font-bold">
+              {href ? <Link to={href}>{row.name}</Link> : row.name}
+            </div>
+            {row.workflowType && (
+              <div className="text-secondary text-success-200">
+                {row.workflowType}
+                {row.workflowSubType && row.workflowSubType !== "None" && (
+                  <span className="text-sm">
+                    {" (" + row.workflowSubType + ")"}
+                  </span>
+                )}
+              </div>
+            )}
+            <div className="text-sm text-secondary">{row.clusterName}</div>
+          </DataCell>
+          <DataCell>
+            {row.source ? (
+              <>
+                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
+                  {row.source}
+                </KeyspaceLink>
+                <div className={style.shardList}>
+                  {(row.sourceShards || []).join(", ")}
+                </div>
+              </>
+            ) : (
+              <span className="text-secondary">N/A</span>
+            )}
+          </DataCell>
+          <DataCell>
+            {row.target ? (
+              <>
+                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
+                  {row.target}
+                </KeyspaceLink>
+                <div className={style.shardList}>
+                  {(row.targetShards || []).join(", ")}
+                </div>
+              </>
+            ) : (
+              <span className="text-secondary">N/A</span>
+            )}
+          </DataCell>
 
-                    <DataCell>
-                        <div className={style.streams}>
-                            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-                            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
-                                if (streamState in row.streams) {
-                                    var numThrottled = 0;
-                                    var throttledApp: string | undefined = '';
-                                    const streamCount = row.streams[streamState].length;
-                                    var streamDescription: string;
-                                    switch (streamState) {
-                                        case 'Error':
-                                            streamDescription = 'failed';
-                                            break;
-                                        case 'Running':
-                                        case 'Copying':
-                                            const streams = row.streams[streamState];
-                                            if (streams !== undefined && streams !== null) {
-                                                for (const stream of streams) {
-                                                    if (
-                                                        stream?.throttler_status?.time_throttled !== null &&
-                                                        stream?.throttler_status?.time_throttled !== undefined &&
-                                                        // If the stream has been throttled recently, treat it as throttled.
-                                                        Number(stream?.throttler_status?.time_throttled?.seconds) > (Date.now() / 1000 - ThrottleThresholdSeconds)
-                                                    ) {
-                                                        numThrottled++;
-                                                        // In case of multiple streams, show the first throttled app and time.
-                                                        // The detail page will show each stream separately.
-                                                        if (numThrottled === 1) {
-                                                            throttledApp = stream?.throttler_status?.component_throttled?.toString();
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            streamDescription = streamState.toLocaleLowerCase();
-                                            if (numThrottled > 0) {
-                                                streamState = 'Throttled';
-                                            }
-                                            break;
-                                        default:
-                                            streamDescription = streamState.toLocaleLowerCase();
-                                    }
-                                    const tooltip = [
-                                        streamCount,
-                                        streamDescription,
-                                        streamCount === 1 ? 'stream' : 'streams',
-                                        numThrottled > 0
-                                            ? '(' +
-                                            numThrottled +
-                                            ' throttled in ' +
-                                            throttledApp + ')'
-                                            : '',
-                                    ].join(' ');
-                                    return (
-                                        <Tooltip key={streamState} text={tooltip}>
-                                            <span className={style.stream}>
-                                                <StreamStatePip state={streamState}/> {streamCount}
-                                            </span>
-                                        </Tooltip>
-                                    );
-                                }
-                                return (
-                                    <span key={streamState} className={style.streamPlaceholder}>
-                                        -
-                                    </span>
-                                );
-                            })}
-                        </div>
-                    </DataCell>
+          <DataCell>
+            <div className={style.streams}>
+              {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+              {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
+                if (streamState in row.streams) {
+                  var numThrottled = 0;
+                  var throttledApp: string | undefined = "";
+                  const streamCount = row.streams[streamState].length;
+                  var streamDescription: string;
+                  switch (streamState) {
+                    case "Error":
+                      streamDescription = "failed";
+                      break;
+                    case "Running":
+                    case "Copying":
+                      const streams = row.streams[streamState];
+                      if (streams !== undefined && streams !== null) {
+                        for (const stream of streams) {
+                          if (
+                            stream?.throttler_status?.time_throttled !== null &&
+                            stream?.throttler_status?.time_throttled !==
+                              undefined &&
+                            // If the stream has been throttled recently, treat it as throttled.
+                            Number(
+                              stream?.throttler_status?.time_throttled?.seconds
+                            ) >
+                              Date.now() / 1000 - ThrottleThresholdSeconds
+                          ) {
+                            numThrottled++;
+                            // In case of multiple streams, show the first throttled app and time.
+                            // The detail page will show each stream separately.
+                            if (numThrottled === 1) {
+                              throttledApp =
+                                stream?.throttler_status?.component_throttled?.toString();
+                            }
+                          }
+                        }
+                      }
+                      streamDescription = streamState.toLocaleLowerCase();
+                      if (numThrottled > 0) {
+                        streamState = "Throttled";
+                      }
+                      break;
+                    default:
+                      streamDescription = streamState.toLocaleLowerCase();
+                  }
+                  const tooltip = [
+                    streamCount,
+                    streamDescription,
+                    streamCount === 1 ? "stream" : "streams",
+                    numThrottled > 0
+                      ? "(" +
+                        numThrottled +
+                        " throttled in " +
+                        throttledApp +
+                        ")"
+                      : "",
+                  ].join(" ");
+                  return (
+                    <Tooltip key={streamState} text={tooltip}>
+                      <span className={style.stream}>
+                        <StreamStatePip state={streamState} /> {streamCount}
+                      </span>
+                    </Tooltip>
+                  );
+                }
+                return (
+                  <span key={streamState} className={style.streamPlaceholder}>
+                    -
+                  </span>
+                );
+              })}
+            </div>
+          </DataCell>
 
-                    <DataCell>
-                        <div className="font-sans whitespace-nowrap">{formatDateTime(row.timeUpdated)}</div>
-                        <div className="font-sans text-sm text-secondary">{formatRelativeTime(row.timeUpdated)}</div>
-                    </DataCell>
-                </tr>
-            );
-        });
+          <DataCell>
+            <div className="font-sans whitespace-nowrap">
+              {formatDateTime(row.timeUpdated)}
+            </div>
+            <div className="font-sans text-sm text-secondary">
+              {formatRelativeTime(row.timeUpdated)}
+            </div>
+          </DataCell>
+        </tr>
+      );
+    });
 
-    return (
-        <div>
-            <WorkspaceHeader>
-                <WorkspaceTitle>Workflows</WorkspaceTitle>
-            </WorkspaceHeader>
-            <ContentContainer>
-                <DataFilter
-                    autoFocus
-                    onChange={(e) => updateFilter(e.target.value)}
-                    onClear={() => updateFilter('')}
-                    placeholder="Filter workflows"
-                    value={filter || ''}
-                />
+  return (
+    <div>
+      <WorkspaceHeader>
+        <WorkspaceTitle>Workflows</WorkspaceTitle>
+      </WorkspaceHeader>
+      <ContentContainer>
+        <DataFilter
+          autoFocus
+          onChange={(e) => updateFilter(e.target.value)}
+          onClear={() => updateFilter("")}
+          placeholder="Filter workflows"
+          value={filter || ""}
+        />
 
-                <DataTable
-                    columns={['Workflow', 'Source', 'Target', 'Streams', 'Last Updated']}
-                    data={sortedData}
-                    renderRows={renderRows}
-                />
+        <DataTable
+          columns={["Workflow", "Source", "Target", "Streams", "Last Updated"]}
+          data={sortedData}
+          renderRows={renderRows}
+        />
 
-                <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult}/>
-            </ContentContainer>
-        </div>
-    );
+        <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult} />
+      </ContentContainer>
+    </div>
+  );
 };

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -142,10 +142,10 @@ export const Workflows = () => {
                                                     }
                                                 }
                                             }
+                                            streamDescription = streamState.toLocaleLowerCase();
                                             if (numThrottled > 0) {
                                                 streamState = 'Throttled';
                                             }
-                                            streamDescription = streamState.toLocaleLowerCase();
                                             break;
                                         default:
                                             streamDescription = streamState.toLocaleLowerCase();

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -13,216 +13,199 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { groupBy, orderBy } from "lodash-es";
-import * as React from "react";
-import { Link } from "react-router-dom";
+import { groupBy, orderBy } from 'lodash-es';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
 
-import style from "./Workflows.module.scss";
-import { useWorkflows } from "../../hooks/api";
-import { useDocumentTitle } from "../../hooks/useDocumentTitle";
-import { DataCell } from "../dataTable/DataCell";
-import { DataTable } from "../dataTable/DataTable";
-import { useSyncedURLParam } from "../../hooks/useSyncedURLParam";
-import { filterNouns } from "../../util/filterNouns";
-import { getStreams, getTimeUpdated } from "../../util/workflows";
-import { formatDateTime, formatRelativeTime } from "../../util/time";
-import { StreamStatePip } from "../pips/StreamStatePip";
-import { ContentContainer } from "../layout/ContentContainer";
-import { WorkspaceHeader } from "../layout/WorkspaceHeader";
-import { WorkspaceTitle } from "../layout/WorkspaceTitle";
-import { DataFilter } from "../dataTable/DataFilter";
-import { Tooltip } from "../tooltip/Tooltip";
-import { KeyspaceLink } from "../links/KeyspaceLink";
-import { QueryLoadingPlaceholder } from "../placeholders/QueryLoadingPlaceholder";
-import { UseQueryResult } from "react-query";
-import { vttime } from "../../proto/vtadmin";
+import style from './Workflows.module.scss';
+import { useWorkflows } from '../../hooks/api';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
+import { DataCell } from '../dataTable/DataCell';
+import { DataTable } from '../dataTable/DataTable';
+import { useSyncedURLParam } from '../../hooks/useSyncedURLParam';
+import { filterNouns } from '../../util/filterNouns';
+import { getStreams, getTimeUpdated } from '../../util/workflows';
+import { formatDateTime, formatRelativeTime } from '../../util/time';
+import { StreamStatePip } from '../pips/StreamStatePip';
+import { ContentContainer } from '../layout/ContentContainer';
+import { WorkspaceHeader } from '../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../layout/WorkspaceTitle';
+import { DataFilter } from '../dataTable/DataFilter';
+import { Tooltip } from '../tooltip/Tooltip';
+import { KeyspaceLink } from '../links/KeyspaceLink';
+import { QueryLoadingPlaceholder } from '../placeholders/QueryLoadingPlaceholder';
+import { UseQueryResult } from 'react-query';
+import { vttime } from '../../proto/vtadmin';
 
 export const Workflows = () => {
-  useDocumentTitle("Workflows");
-  const workflowsQuery = useWorkflows();
+    useDocumentTitle('Workflows');
+    const workflowsQuery = useWorkflows();
 
-  const { value: filter, updateValue: updateFilter } =
-    useSyncedURLParam("filter");
+    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
 
-  const sortedData = React.useMemo(() => {
-    const mapped = (workflowsQuery.data || []).map((workflow) => ({
-      clusterID: workflow.cluster?.id,
-      clusterName: workflow.cluster?.name,
-      keyspace: workflow.keyspace,
-      name: workflow.workflow?.name,
-      source: workflow.workflow?.source?.keyspace,
-      sourceShards: workflow.workflow?.source?.shards,
-      streams: groupBy(getStreams(workflow), "state"),
-      target: workflow.workflow?.target?.keyspace,
-      targetShards: workflow.workflow?.target?.shards,
-      timeUpdated: getTimeUpdated(workflow),
-      workflowType: workflow.workflow?.workflow_type,
-      workflowSubType: workflow.workflow?.workflow_sub_type,
-    }));
-    const filtered = filterNouns(filter, mapped);
-    return orderBy(filtered, ["name", "clusterName", "source", "target"]);
-  }, [workflowsQuery.data, filter]);
+    const sortedData = React.useMemo(() => {
+        const mapped = (workflowsQuery.data || []).map((workflow) => ({
+            clusterID: workflow.cluster?.id,
+            clusterName: workflow.cluster?.name,
+            keyspace: workflow.keyspace,
+            name: workflow.workflow?.name,
+            source: workflow.workflow?.source?.keyspace,
+            sourceShards: workflow.workflow?.source?.shards,
+            streams: groupBy(getStreams(workflow), 'state'),
+            target: workflow.workflow?.target?.keyspace,
+            targetShards: workflow.workflow?.target?.shards,
+            timeUpdated: getTimeUpdated(workflow),
+            workflowType: workflow.workflow?.workflow_type,
+            workflowSubType: workflow.workflow?.workflow_sub_type,
+        }));
+        const filtered = filterNouns(filter, mapped);
+        return orderBy(filtered, ['name', 'clusterName', 'source', 'target']);
+    }, [workflowsQuery.data, filter]);
 
-  const renderRows = (rows: typeof sortedData) =>
-    rows.map((row, idx) => {
-      const href =
-        row.clusterID && row.keyspace && row.name
-          ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
-          : null;
-      return (
-        <tr key={idx}>
-          <DataCell>
-            <div className="font-bold">
-              {href ? <Link to={href}>{row.name}</Link> : row.name}
-            </div>
-            {row.workflowType && (
-              <div className="text-secondary text-success-200">
-                {row.workflowType}
-                {row.workflowSubType && row.workflowSubType !== "None" && (
-                  <span className="text-sm">
-                    {" (" + row.workflowSubType + ")"}
-                  </span>
-                )}
-              </div>
-            )}
-            <div className="text-sm text-secondary">{row.clusterName}</div>
-          </DataCell>
-          <DataCell>
-            {row.source ? (
-              <>
-                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
-                  {row.source}
-                </KeyspaceLink>
-                <div className={style.shardList}>
-                  {(row.sourceShards || []).join(", ")}
-                </div>
-              </>
-            ) : (
-              <span className="text-secondary">N/A</span>
-            )}
-          </DataCell>
-          <DataCell>
-            {row.target ? (
-              <>
-                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
-                  {row.target}
-                </KeyspaceLink>
-                <div className={style.shardList}>
-                  {(row.targetShards || []).join(", ")}
-                </div>
-              </>
-            ) : (
-              <span className="text-secondary">N/A</span>
-            )}
-          </DataCell>
+    const renderRows = (rows: typeof sortedData) =>
+        rows.map((row, idx) => {
+            const href =
+                row.clusterID && row.keyspace && row.name
+                    ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
+                    : null;
+            return (
+                <tr key={idx}>
+                    <DataCell>
+                        <div className="font-bold">{href ? <Link to={href}>{row.name}</Link> : row.name}</div>
+                        {row.workflowType && (
+                            <div className="text-secondary text-success-200">
+                                {row.workflowType}
+                                {row.workflowSubType && row.workflowSubType !== 'None' && (
+                                    <span className="text-sm">{' (' + row.workflowSubType + ')'}</span>
+                                )}
+                            </div>
+                        )}
+                        <div className="text-sm text-secondary">{row.clusterName}</div>
+                    </DataCell>
+                    <DataCell>
+                        {row.source ? (
+                            <>
+                                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
+                                    {row.source}
+                                </KeyspaceLink>
+                                <div className={style.shardList}>{(row.sourceShards || []).join(', ')}</div>
+                            </>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
+                    <DataCell>
+                        {row.target ? (
+                            <>
+                                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
+                                    {row.target}
+                                </KeyspaceLink>
+                                <div className={style.shardList}>{(row.targetShards || []).join(', ')}</div>
+                            </>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
 
-          <DataCell>
-            <div className={style.streams}>
-              {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-              {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
-                if (streamState in row.streams) {
-                  var numThrottled = 0;
-                  var throttledApp = "";
-                  var throttledFrom: vttime.ITime | null | undefined;
-                  const streamCount = row.streams[streamState].length;
-                  var streamDescription: string;
-                  switch (streamState) {
-                    case "Error":
-                      streamDescription = "failed";
-                      break;
-                    case "Running":
-                      const running = row.streams["Running"];
-                      if (running !== undefined && running !== null) {
-                        for (const stream of running) {
-                          if (
-                            stream?.throttler_status?.component_throttled !==
-                              null &&
-                            stream?.throttler_status?.component_throttled !==
-                              undefined
-                          ) {
-                            numThrottled++;
-                            throttledApp =
-                              stream?.throttler_status?.component_throttled;
-                            throttledFrom =
-                              stream?.throttler_status?.time_throttled;
-                          }
-                        }
-                      }
-                      if (numThrottled > 0) {
-                        streamDescription = "";
-                        streamState = "Throttled";
-                      } else {
-                        streamDescription = streamState;
-                      }
-                      break;
-                    default:
-                      streamDescription = streamState.toLocaleLowerCase();
-                  }
-                  const tooltip = [
-                    streamCount,
-                    streamDescription,
-                    streamCount === 1 ? "stream" : "streams",
-                    numThrottled > 0
-                      ? "(" +
-                        numThrottled +
-                        " throttled by " +
-                        throttledApp +
-                        " " +
-                        formatRelativeTime(throttledFrom?.seconds) +
-                        ")"
-                      : "",
-                  ].join(" ");
-                  return (
-                    <Tooltip key={streamState} text={tooltip}>
-                      <span className={style.stream}>
-                        <StreamStatePip state={streamState} /> {streamCount}
-                      </span>
-                    </Tooltip>
-                  );
-                }
-                return (
-                  <span key={streamState} className={style.streamPlaceholder}>
-                    -
-                  </span>
-                );
-              })}
-            </div>
-          </DataCell>
+                    <DataCell>
+                        <div className={style.streams}>
+                            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+                            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
+                                if (streamState in row.streams) {
+                                    var numThrottled = 0;
+                                    var throttledApp = '';
+                                    var throttledFrom: vttime.ITime | null | undefined;
+                                    const streamCount = row.streams[streamState].length;
+                                    var streamDescription: string;
+                                    switch (streamState) {
+                                        case 'Error':
+                                            streamDescription = 'failed';
+                                            break;
+                                        case 'Running':
+                                            const running = row.streams['Running'];
+                                            if (running !== undefined && running !== null) {
+                                                for (const stream of running) {
+                                                    if (
+                                                        stream?.throttler_status?.component_throttled !== null &&
+                                                        stream?.throttler_status?.component_throttled !== undefined
+                                                    ) {
+                                                        numThrottled++;
+                                                        throttledApp = stream?.throttler_status?.component_throttled;
+                                                        throttledFrom = stream?.throttler_status?.time_throttled;
+                                                    }
+                                                }
+                                            }
+                                            if (numThrottled > 0) {
+                                                streamDescription = '';
+                                                streamState = 'Throttled';
+                                            } else {
+                                                streamDescription = streamState;
+                                            }
+                                            break;
+                                        default:
+                                            streamDescription = streamState.toLocaleLowerCase();
+                                    }
+                                    const tooltip = [
+                                        streamCount,
+                                        streamDescription,
+                                        streamCount === 1 ? 'stream' : 'streams',
+                                        numThrottled > 0
+                                            ? '(' +
+                                              numThrottled +
+                                              ' throttled by ' +
+                                              throttledApp +
+                                              ' ' +
+                                              formatRelativeTime(throttledFrom?.seconds) +
+                                              ')'
+                                            : '',
+                                    ].join(' ');
+                                    return (
+                                        <Tooltip key={streamState} text={tooltip}>
+                                            <span className={style.stream}>
+                                                <StreamStatePip state={streamState} /> {streamCount}
+                                            </span>
+                                        </Tooltip>
+                                    );
+                                }
+                                return (
+                                    <span key={streamState} className={style.streamPlaceholder}>
+                                        -
+                                    </span>
+                                );
+                            })}
+                        </div>
+                    </DataCell>
 
-          <DataCell>
-            <div className="font-sans whitespace-nowrap">
-              {formatDateTime(row.timeUpdated)}
-            </div>
-            <div className="font-sans text-sm text-secondary">
-              {formatRelativeTime(row.timeUpdated)}
-            </div>
-          </DataCell>
-        </tr>
-      );
-    });
+                    <DataCell>
+                        <div className="font-sans whitespace-nowrap">{formatDateTime(row.timeUpdated)}</div>
+                        <div className="font-sans text-sm text-secondary">{formatRelativeTime(row.timeUpdated)}</div>
+                    </DataCell>
+                </tr>
+            );
+        });
 
-  return (
-    <div>
-      <WorkspaceHeader>
-        <WorkspaceTitle>Workflows</WorkspaceTitle>
-      </WorkspaceHeader>
-      <ContentContainer>
-        <DataFilter
-          autoFocus
-          onChange={(e) => updateFilter(e.target.value)}
-          onClear={() => updateFilter("")}
-          placeholder="Filter workflows"
-          value={filter || ""}
-        />
+    return (
+        <div>
+            <WorkspaceHeader>
+                <WorkspaceTitle>Workflows</WorkspaceTitle>
+            </WorkspaceHeader>
+            <ContentContainer>
+                <DataFilter
+                    autoFocus
+                    onChange={(e) => updateFilter(e.target.value)}
+                    onClear={() => updateFilter('')}
+                    placeholder="Filter workflows"
+                    value={filter || ''}
+                />
 
-        <DataTable
-          columns={["Workflow", "Source", "Target", "Streams", "Last Updated"]}
-          data={sortedData}
-          renderRows={renderRows}
-        />
+                <DataTable
+                    columns={['Workflow', 'Source', 'Target', 'Streams', 'Last Updated']}
+                    data={sortedData}
+                    renderRows={renderRows}
+                />
 
-        <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult} />
-      </ContentContainer>
-    </div>
-  );
+                <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult} />
+            </ContentContainer>
+        </div>
+    );
 };

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -35,7 +35,6 @@ import { Tooltip } from "../tooltip/Tooltip";
 import { KeyspaceLink } from "../links/KeyspaceLink";
 import { QueryLoadingPlaceholder } from "../placeholders/QueryLoadingPlaceholder";
 import { UseQueryResult } from "react-query";
-import { vtctldata, vttime } from "../../proto/vtadmin";
 
 export const ThrottleThresholdSeconds = 60;
 

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -13,189 +13,216 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {groupBy, orderBy} from 'lodash-es';
-import * as React from 'react';
-import {Link} from 'react-router-dom';
+import { groupBy, orderBy } from "lodash-es";
+import * as React from "react";
+import { Link } from "react-router-dom";
 
-import style from './Workflows.module.scss';
-import {useWorkflows} from '../../hooks/api';
-import {useDocumentTitle} from '../../hooks/useDocumentTitle';
-import {DataCell} from '../dataTable/DataCell';
-import {DataTable} from '../dataTable/DataTable';
-import {useSyncedURLParam} from '../../hooks/useSyncedURLParam';
-import {filterNouns} from '../../util/filterNouns';
-import {getStreams, getTimeUpdated} from '../../util/workflows';
-import {formatDateTime, formatRelativeTime} from '../../util/time';
-import {StreamStatePip} from '../pips/StreamStatePip';
-import {ContentContainer} from '../layout/ContentContainer';
-import {WorkspaceHeader} from '../layout/WorkspaceHeader';
-import {WorkspaceTitle} from '../layout/WorkspaceTitle';
-import {DataFilter} from '../dataTable/DataFilter';
-import {Tooltip} from '../tooltip/Tooltip';
-import {KeyspaceLink} from '../links/KeyspaceLink';
-import {QueryLoadingPlaceholder} from '../placeholders/QueryLoadingPlaceholder';
-import {UseQueryResult} from 'react-query';
-import {vttime} from "../../proto/vtadmin";
+import style from "./Workflows.module.scss";
+import { useWorkflows } from "../../hooks/api";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+import { DataCell } from "../dataTable/DataCell";
+import { DataTable } from "../dataTable/DataTable";
+import { useSyncedURLParam } from "../../hooks/useSyncedURLParam";
+import { filterNouns } from "../../util/filterNouns";
+import { getStreams, getTimeUpdated } from "../../util/workflows";
+import { formatDateTime, formatRelativeTime } from "../../util/time";
+import { StreamStatePip } from "../pips/StreamStatePip";
+import { ContentContainer } from "../layout/ContentContainer";
+import { WorkspaceHeader } from "../layout/WorkspaceHeader";
+import { WorkspaceTitle } from "../layout/WorkspaceTitle";
+import { DataFilter } from "../dataTable/DataFilter";
+import { Tooltip } from "../tooltip/Tooltip";
+import { KeyspaceLink } from "../links/KeyspaceLink";
+import { QueryLoadingPlaceholder } from "../placeholders/QueryLoadingPlaceholder";
+import { UseQueryResult } from "react-query";
+import { vttime } from "../../proto/vtadmin";
 
 export const Workflows = () => {
-    useDocumentTitle('Workflows');
-    const workflowsQuery = useWorkflows();
+  useDocumentTitle("Workflows");
+  const workflowsQuery = useWorkflows();
 
-    const {value: filter, updateValue: updateFilter} = useSyncedURLParam('filter');
+  const { value: filter, updateValue: updateFilter } =
+    useSyncedURLParam("filter");
 
-    const sortedData = React.useMemo(() => {
-        const mapped = (workflowsQuery.data || []).map((workflow) => ({
-            clusterID: workflow.cluster?.id,
-            clusterName: workflow.cluster?.name,
-            keyspace: workflow.keyspace,
-            name: workflow.workflow?.name,
-            source: workflow.workflow?.source?.keyspace,
-            sourceShards: workflow.workflow?.source?.shards,
-            streams: groupBy(getStreams(workflow), 'state'),
-            target: workflow.workflow?.target?.keyspace,
-            targetShards: workflow.workflow?.target?.shards,
-            timeUpdated: getTimeUpdated(workflow),
-            workflowType: workflow.workflow?.workflow_type,
-            workflowSubType: workflow.workflow?.workflow_sub_type,
-        }));
-        const filtered = filterNouns(filter, mapped);
-        return orderBy(filtered, ['name', 'clusterName', 'source', 'target']);
-    }, [workflowsQuery.data, filter]);
+  const sortedData = React.useMemo(() => {
+    const mapped = (workflowsQuery.data || []).map((workflow) => ({
+      clusterID: workflow.cluster?.id,
+      clusterName: workflow.cluster?.name,
+      keyspace: workflow.keyspace,
+      name: workflow.workflow?.name,
+      source: workflow.workflow?.source?.keyspace,
+      sourceShards: workflow.workflow?.source?.shards,
+      streams: groupBy(getStreams(workflow), "state"),
+      target: workflow.workflow?.target?.keyspace,
+      targetShards: workflow.workflow?.target?.shards,
+      timeUpdated: getTimeUpdated(workflow),
+      workflowType: workflow.workflow?.workflow_type,
+      workflowSubType: workflow.workflow?.workflow_sub_type,
+    }));
+    const filtered = filterNouns(filter, mapped);
+    return orderBy(filtered, ["name", "clusterName", "source", "target"]);
+  }, [workflowsQuery.data, filter]);
 
-    const renderRows = (rows: typeof sortedData) =>
-        rows.map((row, idx) => {
-            const href =
-                row.clusterID && row.keyspace && row.name
-                    ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
-                    : null;
-            return (
-                <tr key={idx}>
-                    <DataCell>
-                        <div className="font-bold">{href ? <Link to={href}>{row.name}</Link> : row.name}</div>
-                        {row.workflowType && (
-                            <div className="text-secondary text-success-200">
-                                {row.workflowType}
-                                {row.workflowSubType && row.workflowSubType !== 'None' && (
-                                    <span className="text-sm">{' (' + row.workflowSubType + ')'}</span>
-                                )}
-                            </div>
-                        )}
-                        <div className="text-sm text-secondary">{row.clusterName}</div>
-                    </DataCell>
-                    <DataCell>
-                        {row.source ? (
-                            <>
-                                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
-                                    {row.source}
-                                </KeyspaceLink>
-                                <div className={style.shardList}>{(row.sourceShards || []).join(', ')}</div>
-                            </>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
-                    <DataCell>
-                        {row.target ? (
-                            <>
-                                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
-                                    {row.target}
-                                </KeyspaceLink>
-                                <div className={style.shardList}>{(row.targetShards || []).join(', ')}</div>
-                            </>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
+  const renderRows = (rows: typeof sortedData) =>
+    rows.map((row, idx) => {
+      const href =
+        row.clusterID && row.keyspace && row.name
+          ? `/workflow/${row.clusterID}/${row.keyspace}/${row.name}`
+          : null;
+      return (
+        <tr key={idx}>
+          <DataCell>
+            <div className="font-bold">
+              {href ? <Link to={href}>{row.name}</Link> : row.name}
+            </div>
+            {row.workflowType && (
+              <div className="text-secondary text-success-200">
+                {row.workflowType}
+                {row.workflowSubType && row.workflowSubType !== "None" && (
+                  <span className="text-sm">
+                    {" (" + row.workflowSubType + ")"}
+                  </span>
+                )}
+              </div>
+            )}
+            <div className="text-sm text-secondary">{row.clusterName}</div>
+          </DataCell>
+          <DataCell>
+            {row.source ? (
+              <>
+                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
+                  {row.source}
+                </KeyspaceLink>
+                <div className={style.shardList}>
+                  {(row.sourceShards || []).join(", ")}
+                </div>
+              </>
+            ) : (
+              <span className="text-secondary">N/A</span>
+            )}
+          </DataCell>
+          <DataCell>
+            {row.target ? (
+              <>
+                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
+                  {row.target}
+                </KeyspaceLink>
+                <div className={style.shardList}>
+                  {(row.targetShards || []).join(", ")}
+                </div>
+              </>
+            ) : (
+              <span className="text-secondary">N/A</span>
+            )}
+          </DataCell>
 
-                    <DataCell>
-                        <div className={style.streams}>
-                            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-                            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
-                                if (streamState in row.streams) {
-                                    var numThrottled = 0
-                                    var throttledApp = ""
-                                    var throttledFrom: vttime.ITime | null | undefined
-                                    const streamCount = row.streams[streamState].length;
-                                    var streamDescription: string
-                                    switch (streamState) {
-                                        case 'Error':
-                                            streamDescription = 'failed'
-                                            break
-                                        case 'Running':
-                                            const running = row.streams['Running']
-                                            if (running !== undefined && running !== null) {
-                                                for (const stream of running) {
-                                                    if (stream?.throttler_status?.component_throttled !== null && stream?.throttler_status?.component_throttled !== undefined) {
-                                                        numThrottled++
-                                                        throttledApp = stream?.throttler_status?.component_throttled
-                                                        throttledFrom = stream?.throttler_status?.time_throttled
-                                                    }
-                                                }
-                                            }
-                                            if (numThrottled > 0) {
-                                                streamDescription = ''
-                                                streamState = 'Throttled'
-                                            } else {
-                                                streamDescription = streamState
-                                            }
-                                            break;
-                                        default:
-                                            streamDescription = streamState.toLocaleLowerCase();
-                                    }
-                                    const tooltip = [
-                                        streamCount,
-                                        streamDescription,
-                                        streamCount === 1 ? 'stream' : 'streams',
-                                        numThrottled > 0 ? '(' + numThrottled + ' throttled by ' + throttledApp + ' ' + formatRelativeTime(throttledFrom?.seconds) + ')' : ''
-                                    ].join(' ');
-                                    return (
-                                        <Tooltip key={streamState} text={tooltip}>
-                                            <span className={style.stream}>
-                                                <StreamStatePip state={streamState}/> {streamCount}
-                                            </span>
-                                        </Tooltip>
-                                    );
-                                }
-                                return (
-                                    <span key={streamState} className={style.streamPlaceholder}>
-                                        -
-                                    </span>
+          <DataCell>
+            <div className={style.streams}>
+              {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+              {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
+                if (streamState in row.streams) {
+                  var numThrottled = 0;
+                  var throttledApp = "";
+                  var throttledFrom: vttime.ITime | null | undefined;
+                  const streamCount = row.streams[streamState].length;
+                  var streamDescription: string;
+                  switch (streamState) {
+                    case "Error":
+                      streamDescription = "failed";
+                      break;
+                    case "Running":
+                      const running = row.streams["Running"];
+                      if (running !== undefined && running !== null) {
+                        for (const stream of running) {
+                          if (
+                            stream?.throttler_status?.component_throttled !==
+                              null &&
+                            stream?.throttler_status?.component_throttled !==
+                              undefined
+                          ) {
+                            numThrottled++;
+                            throttledApp =
+                              stream?.throttler_status?.component_throttled;
+                            throttledFrom =
+                              stream?.throttler_status?.time_throttled;
+                          }
+                        }
+                      }
+                      if (numThrottled > 0) {
+                        streamDescription = "";
+                        streamState = "Throttled";
+                      } else {
+                        streamDescription = streamState;
+                      }
+                      break;
+                    default:
+                      streamDescription = streamState.toLocaleLowerCase();
+                  }
+                  const tooltip = [
+                    streamCount,
+                    streamDescription,
+                    streamCount === 1 ? "stream" : "streams",
+                    numThrottled > 0
+                      ? "(" +
+                        numThrottled +
+                        " throttled by " +
+                        throttledApp +
+                        " " +
+                        formatRelativeTime(throttledFrom?.seconds) +
+                        ")"
+                      : "",
+                  ].join(" ");
+                  return (
+                    <Tooltip key={streamState} text={tooltip}>
+                      <span className={style.stream}>
+                        <StreamStatePip state={streamState} /> {streamCount}
+                      </span>
+                    </Tooltip>
+                  );
+                }
+                return (
+                  <span key={streamState} className={style.streamPlaceholder}>
+                    -
+                  </span>
+                );
+              })}
+            </div>
+          </DataCell>
 
-                                );
-                            })}
-                        </div>
-                    </DataCell>
+          <DataCell>
+            <div className="font-sans whitespace-nowrap">
+              {formatDateTime(row.timeUpdated)}
+            </div>
+            <div className="font-sans text-sm text-secondary">
+              {formatRelativeTime(row.timeUpdated)}
+            </div>
+          </DataCell>
+        </tr>
+      );
+    });
 
-                    <DataCell>
-                        <div className="font-sans whitespace-nowrap">{formatDateTime(row.timeUpdated)}</div>
-                        <div className="font-sans text-sm text-secondary">{formatRelativeTime(row.timeUpdated)}</div>
-                    </DataCell>
-                </tr>
-            );
-        });
+  return (
+    <div>
+      <WorkspaceHeader>
+        <WorkspaceTitle>Workflows</WorkspaceTitle>
+      </WorkspaceHeader>
+      <ContentContainer>
+        <DataFilter
+          autoFocus
+          onChange={(e) => updateFilter(e.target.value)}
+          onClear={() => updateFilter("")}
+          placeholder="Filter workflows"
+          value={filter || ""}
+        />
 
-    return (
-        <div>
-            <WorkspaceHeader>
-                <WorkspaceTitle>Workflows</WorkspaceTitle>
-            </WorkspaceHeader>
-            <ContentContainer>
-                <DataFilter
-                    autoFocus
-                    onChange={(e) => updateFilter(e.target.value)}
-                    onClear={() => updateFilter('')}
-                    placeholder="Filter workflows"
-                    value={filter || ''}
-                />
+        <DataTable
+          columns={["Workflow", "Source", "Target", "Streams", "Last Updated"]}
+          data={sortedData}
+          renderRows={renderRows}
+        />
 
-                <DataTable
-                    columns={['Workflow', 'Source', 'Target', 'Streams', 'Last Updated']}
-                    data={sortedData}
-                    renderRows={renderRows}
-                />
-
-                <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult}/>
-            </ContentContainer>
-        </div>
-    );
+        <QueryLoadingPlaceholder query={workflowsQuery as UseQueryResult} />
+      </ContentContainer>
+    </div>
+  );
 };

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -116,7 +116,6 @@ export const Workflows = () => {
                                 if (streamState in row.streams) {
                                     var numThrottled = 0;
                                     var throttledApp: string | undefined = '';
-                                    var throttledFrom: vttime.ITime | null | undefined;
                                     const streamCount = row.streams[streamState].length;
                                     var streamDescription: string;
                                     switch (streamState) {
@@ -130,7 +129,7 @@ export const Workflows = () => {
                                                     if (
                                                         stream?.throttler_status?.time_throttled !== null &&
                                                         stream?.throttler_status?.time_throttled !== undefined &&
-                                                        // If the stream has been throttled for more than 5 seconds, show it as throttled.
+                                                        // If the stream has been throttled recently, treat it as throttled.
                                                         Number(stream?.throttler_status?.time_throttled?.seconds) > (Date.now() / 1000 - ThrottleThresholdSeconds)
                                                     ) {
                                                         numThrottled++;
@@ -138,7 +137,6 @@ export const Workflows = () => {
                                                         // The detail page will show each stream separately.
                                                         if (numThrottled === 1) {
                                                             throttledApp = stream?.throttler_status?.component_throttled?.toString();
-                                                            throttledFrom = stream?.throttler_status?.time_throttled;
                                                         }
                                                     }
                                                 }
@@ -161,10 +159,7 @@ export const Workflows = () => {
                                             ? '(' +
                                             numThrottled +
                                             ' throttled in ' +
-                                            throttledApp +
-                                            ' ' +
-                                            formatRelativeTime(throttledFrom?.seconds) +
-                                            ')'
+                                            throttledApp + ')'
                                             : '',
                                     ].join(' ');
                                     return (

--- a/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
@@ -36,7 +36,7 @@
 .headingMetaContainer div {
     width: '100%';
     display: 'flex';
-    justifycontent: 'space-between';
-    paddingtop: '0px';
-    paddingbottom: '0px';
+    justify-content: 'space-between';
+    padding-top: '0px';
+    padding-bottom: '0px';
 }

--- a/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
@@ -32,3 +32,11 @@
         content: none;
     }
 }
+
+.headingMetaContainer div {
+    width: '100%';
+    display: 'flex';
+    justifyContent: 'space-between';
+    paddingTop: '0px';
+    paddingBottom: '0px';
+ }

--- a/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
@@ -14,29 +14,29 @@
  * limitations under the License.
  */
 .headingMeta {
-    display: flex;
+  display: flex;
 }
 
 .headingMeta span {
+  display: inline-block;
+  line-height: 2;
+
+  &::after {
+    color: var(--colorScaffoldingHighlight);
+    content: "/";
     display: inline-block;
-    line-height: 2;
+    margin: 0 1.2rem;
+  }
 
-    &::after {
-        color: var(--colorScaffoldingHighlight);
-        content: '/';
-        display: inline-block;
-        margin: 0 1.2rem;
-    }
-
-    &:last-child::after {
-        content: none;
-    }
+  &:last-child::after {
+    content: none;
+  }
 }
 
 .headingMetaContainer div {
-    width: '100%';
-    display: 'flex';
-    justifyContent: 'space-between';
-    paddingTop: '0px';
-    paddingBottom: '0px';
- }
+  width: "100%";
+  display: "flex";
+  justifycontent: "space-between";
+  paddingtop: "0px";
+  paddingbottom: "0px";
+}

--- a/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.module.scss
@@ -14,29 +14,29 @@
  * limitations under the License.
  */
 .headingMeta {
-  display: flex;
+    display: flex;
 }
 
 .headingMeta span {
-  display: inline-block;
-  line-height: 2;
-
-  &::after {
-    color: var(--colorScaffoldingHighlight);
-    content: "/";
     display: inline-block;
-    margin: 0 1.2rem;
-  }
+    line-height: 2;
 
-  &:last-child::after {
-    content: none;
-  }
+    &::after {
+        color: var(--colorScaffoldingHighlight);
+        content: '/';
+        display: inline-block;
+        margin: 0 1.2rem;
+    }
+
+    &:last-child::after {
+        content: none;
+    }
 }
 
 .headingMetaContainer div {
-  width: "100%";
-  display: "flex";
-  justifycontent: "space-between";
-  paddingtop: "0px";
-  paddingbottom: "0px";
+    width: '100%';
+    display: 'flex';
+    justifycontent: 'space-between';
+    paddingtop: '0px';
+    paddingbottom: '0px';
 }

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
+import {Link, Redirect, Route, Switch, useParams, useRouteMatch} from 'react-router-dom';
 
 import style from './Workflow.module.scss';
 
-import { useWorkflow } from '../../../hooks/api';
-import { NavCrumbs } from '../../layout/NavCrumbs';
-import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
-import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
-import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
-import { KeyspaceLink } from '../../links/KeyspaceLink';
-import { WorkflowStreams } from './WorkflowStreams';
-import { ContentContainer } from '../../layout/ContentContainer';
-import { TabContainer } from '../../tabs/TabContainer';
-import { Tab } from '../../tabs/Tab';
-import { getStreams } from '../../../util/workflows';
-import { Code } from '../../Code';
+import {useWorkflow} from '../../../hooks/api';
+import {NavCrumbs} from '../../layout/NavCrumbs';
+import {WorkspaceHeader} from '../../layout/WorkspaceHeader';
+import {WorkspaceTitle} from '../../layout/WorkspaceTitle';
+import {useDocumentTitle} from '../../../hooks/useDocumentTitle';
+import {KeyspaceLink} from '../../links/KeyspaceLink';
+import {WorkflowStreams} from './WorkflowStreams';
+import {ContentContainer} from '../../layout/ContentContainer';
+import {TabContainer} from '../../tabs/TabContainer';
+import {Tab} from '../../tabs/Tab';
+import {getStreams} from '../../../util/workflows';
+import {Code} from '../../Code';
 
 interface RouteParams {
     clusterID: string;
@@ -37,12 +37,12 @@ interface RouteParams {
 }
 
 export const Workflow = () => {
-    const { clusterID, keyspace, name } = useParams<RouteParams>();
-    const { path, url } = useRouteMatch();
+    const {clusterID, keyspace, name} = useParams<RouteParams>();
+    const {path, url} = useRouteMatch();
 
     useDocumentTitle(`${name} (${keyspace})`);
 
-    const { data } = useWorkflow({ clusterID, keyspace, name });
+    const {data} = useWorkflow({clusterID, keyspace, name});
     const streams = getStreams(data);
 
     return (
@@ -53,35 +53,40 @@ export const Workflow = () => {
                 </NavCrumbs>
 
                 <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
-                <div className={style.headingMeta}>
-                    <span>
-                        Cluster: <code>{clusterID}</code>
-                    </span>
-                    <span>
-                        Target keyspace:{' '}
-                        <KeyspaceLink clusterID={clusterID} name={keyspace}>
-                            <code>{keyspace}</code>
-                        </KeyspaceLink>
-                    </span>
+                <div className={style.headingMetaContainer}>
+                    <div className={style.headingMeta} style={{float: 'left'}}>
+                        <span>
+                            Cluster: <code>{clusterID}</code>
+                        </span>
+                        <span>
+                            Target keyspace:{' '}
+                            <KeyspaceLink clusterID={clusterID} name={keyspace}>
+                                <code>{keyspace}</code>
+                            </KeyspaceLink>
+                        </span>
+                    </div>
+                    <div style={{float: 'right'}}>
+                        <a href={`#workflowStreams`}>Streams</a>
+                    </div>
                 </div>
             </WorkspaceHeader>
 
             <ContentContainer>
                 <TabContainer>
-                    <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
-                    <Tab text="JSON" to={`${url}/json`} />
+                    <Tab text="Streams" to={`${url}/streams`} count={streams.length}/>
+                    <Tab text="JSON" to={`${url}/json`}/>
                 </TabContainer>
 
                 <Switch>
                     <Route path={`${path}/streams`}>
-                        <WorkflowStreams clusterID={clusterID} keyspace={keyspace} name={name} />
+                        <WorkflowStreams clusterID={clusterID} keyspace={keyspace} name={name}/>
                     </Route>
 
                     <Route path={`${path}/json`}>
-                        <Code code={JSON.stringify(data, null, 2)} />
+                        <Code code={JSON.stringify(data, null, 2)}/>
                     </Route>
 
-                    <Redirect exact from={path} to={`${path}/streams`} />
+                    <Redirect exact from={path} to={`${path}/streams`}/>
                 </Switch>
             </ContentContainer>
         </div>

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -13,93 +13,82 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  Link,
-  Redirect,
-  Route,
-  Switch,
-  useParams,
-  useRouteMatch,
-} from "react-router-dom";
+import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
 
-import style from "./Workflow.module.scss";
+import style from './Workflow.module.scss';
 
-import { useWorkflow } from "../../../hooks/api";
-import { NavCrumbs } from "../../layout/NavCrumbs";
-import { WorkspaceHeader } from "../../layout/WorkspaceHeader";
-import { WorkspaceTitle } from "../../layout/WorkspaceTitle";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-import { KeyspaceLink } from "../../links/KeyspaceLink";
-import { WorkflowStreams } from "./WorkflowStreams";
-import { ContentContainer } from "../../layout/ContentContainer";
-import { TabContainer } from "../../tabs/TabContainer";
-import { Tab } from "../../tabs/Tab";
-import { getStreams } from "../../../util/workflows";
-import { Code } from "../../Code";
+import { useWorkflow } from '../../../hooks/api';
+import { NavCrumbs } from '../../layout/NavCrumbs';
+import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
+import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { KeyspaceLink } from '../../links/KeyspaceLink';
+import { WorkflowStreams } from './WorkflowStreams';
+import { ContentContainer } from '../../layout/ContentContainer';
+import { TabContainer } from '../../tabs/TabContainer';
+import { Tab } from '../../tabs/Tab';
+import { getStreams } from '../../../util/workflows';
+import { Code } from '../../Code';
 
 interface RouteParams {
-  clusterID: string;
-  keyspace: string;
-  name: string;
+    clusterID: string;
+    keyspace: string;
+    name: string;
 }
 
 export const Workflow = () => {
-  const { clusterID, keyspace, name } = useParams<RouteParams>();
-  const { path, url } = useRouteMatch();
+    const { clusterID, keyspace, name } = useParams<RouteParams>();
+    const { path, url } = useRouteMatch();
 
-  useDocumentTitle(`${name} (${keyspace})`);
+    useDocumentTitle(`${name} (${keyspace})`);
 
-  const { data } = useWorkflow({ clusterID, keyspace, name });
-  const streams = getStreams(data);
+    const { data } = useWorkflow({ clusterID, keyspace, name });
+    const streams = getStreams(data);
 
-  return (
-    <div>
-      <WorkspaceHeader>
-        <NavCrumbs>
-          <Link to="/workflows">Workflows</Link>
-        </NavCrumbs>
+    return (
+        <div>
+            <WorkspaceHeader>
+                <NavCrumbs>
+                    <Link to="/workflows">Workflows</Link>
+                </NavCrumbs>
 
-        <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
-        <div className={style.headingMetaContainer}>
-          <div className={style.headingMeta} style={{ float: "left" }}>
-            <span>
-              Cluster: <code>{clusterID}</code>
-            </span>
-            <span>
-              Target keyspace:{" "}
-              <KeyspaceLink clusterID={clusterID} name={keyspace}>
-                <code>{keyspace}</code>
-              </KeyspaceLink>
-            </span>
-          </div>
-          <div style={{ float: "right" }}>
-            <a href={`#workflowStreams`}>Scroll To Streams</a>
-          </div>
+                <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
+                <div className={style.headingMetaContainer}>
+                    <div className={style.headingMeta} style={{ float: 'left' }}>
+                        <span>
+                            Cluster: <code>{clusterID}</code>
+                        </span>
+                        <span>
+                            Target keyspace:{' '}
+                            <KeyspaceLink clusterID={clusterID} name={keyspace}>
+                                <code>{keyspace}</code>
+                            </KeyspaceLink>
+                        </span>
+                    </div>
+                    <div style={{ float: 'right' }}>
+                        <a href={`#workflowStreams`}>Scroll To Streams</a>
+                    </div>
+                </div>
+            </WorkspaceHeader>
+
+            <ContentContainer>
+                <TabContainer>
+                    <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
+                    <Tab text="JSON" to={`${url}/json`} />
+                </TabContainer>
+
+                <Switch>
+                    <Route path={`${path}/streams`}>
+                        <WorkflowStreams clusterID={clusterID} keyspace={keyspace} name={name} />
+                    </Route>
+
+                    <Route path={`${path}/json`}>
+                        <Code code={JSON.stringify(data, null, 2)} />
+                    </Route>
+
+                    <Redirect exact from={path} to={`${path}/streams`} />
+                </Switch>
+            </ContentContainer>
         </div>
-      </WorkspaceHeader>
-
-      <ContentContainer>
-        <TabContainer>
-          <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
-          <Tab text="JSON" to={`${url}/json`} />
-        </TabContainer>
-
-        <Switch>
-          <Route path={`${path}/streams`}>
-            <WorkflowStreams
-              clusterID={clusterID}
-              keyspace={keyspace}
-              name={name}
-            />
-          </Route>
-
-          <Route path={`${path}/json`}>
-            <Code code={JSON.stringify(data, null, 2)} />
-          </Route>
-
-          <Redirect exact from={path} to={`${path}/streams`} />
-        </Switch>
-      </ContentContainer>
-    </div>
-  );
+    );
 };

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -13,82 +13,93 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Link, Redirect, Route, Switch, useParams, useRouteMatch} from 'react-router-dom';
+import {
+  Link,
+  Redirect,
+  Route,
+  Switch,
+  useParams,
+  useRouteMatch,
+} from "react-router-dom";
 
-import style from './Workflow.module.scss';
+import style from "./Workflow.module.scss";
 
-import {useWorkflow} from '../../../hooks/api';
-import {NavCrumbs} from '../../layout/NavCrumbs';
-import {WorkspaceHeader} from '../../layout/WorkspaceHeader';
-import {WorkspaceTitle} from '../../layout/WorkspaceTitle';
-import {useDocumentTitle} from '../../../hooks/useDocumentTitle';
-import {KeyspaceLink} from '../../links/KeyspaceLink';
-import {WorkflowStreams} from './WorkflowStreams';
-import {ContentContainer} from '../../layout/ContentContainer';
-import {TabContainer} from '../../tabs/TabContainer';
-import {Tab} from '../../tabs/Tab';
-import {getStreams} from '../../../util/workflows';
-import {Code} from '../../Code';
+import { useWorkflow } from "../../../hooks/api";
+import { NavCrumbs } from "../../layout/NavCrumbs";
+import { WorkspaceHeader } from "../../layout/WorkspaceHeader";
+import { WorkspaceTitle } from "../../layout/WorkspaceTitle";
+import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
+import { KeyspaceLink } from "../../links/KeyspaceLink";
+import { WorkflowStreams } from "./WorkflowStreams";
+import { ContentContainer } from "../../layout/ContentContainer";
+import { TabContainer } from "../../tabs/TabContainer";
+import { Tab } from "../../tabs/Tab";
+import { getStreams } from "../../../util/workflows";
+import { Code } from "../../Code";
 
 interface RouteParams {
-    clusterID: string;
-    keyspace: string;
-    name: string;
+  clusterID: string;
+  keyspace: string;
+  name: string;
 }
 
 export const Workflow = () => {
-    const {clusterID, keyspace, name} = useParams<RouteParams>();
-    const {path, url} = useRouteMatch();
+  const { clusterID, keyspace, name } = useParams<RouteParams>();
+  const { path, url } = useRouteMatch();
 
-    useDocumentTitle(`${name} (${keyspace})`);
+  useDocumentTitle(`${name} (${keyspace})`);
 
-    const {data} = useWorkflow({clusterID, keyspace, name});
-    const streams = getStreams(data);
+  const { data } = useWorkflow({ clusterID, keyspace, name });
+  const streams = getStreams(data);
 
-    return (
-        <div>
-            <WorkspaceHeader>
-                <NavCrumbs>
-                    <Link to="/workflows">Workflows</Link>
-                </NavCrumbs>
+  return (
+    <div>
+      <WorkspaceHeader>
+        <NavCrumbs>
+          <Link to="/workflows">Workflows</Link>
+        </NavCrumbs>
 
-                <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
-                <div className={style.headingMetaContainer}>
-                    <div className={style.headingMeta} style={{float: 'left'}}>
-                        <span>
-                            Cluster: <code>{clusterID}</code>
-                        </span>
-                        <span>
-                            Target keyspace:{' '}
-                            <KeyspaceLink clusterID={clusterID} name={keyspace}>
-                                <code>{keyspace}</code>
-                            </KeyspaceLink>
-                        </span>
-                    </div>
-                    <div style={{float: 'right'}}>
-                        <a href={`#workflowStreams`}>Streams</a>
-                    </div>
-                </div>
-            </WorkspaceHeader>
-
-            <ContentContainer>
-                <TabContainer>
-                    <Tab text="Streams" to={`${url}/streams`} count={streams.length}/>
-                    <Tab text="JSON" to={`${url}/json`}/>
-                </TabContainer>
-
-                <Switch>
-                    <Route path={`${path}/streams`}>
-                        <WorkflowStreams clusterID={clusterID} keyspace={keyspace} name={name}/>
-                    </Route>
-
-                    <Route path={`${path}/json`}>
-                        <Code code={JSON.stringify(data, null, 2)}/>
-                    </Route>
-
-                    <Redirect exact from={path} to={`${path}/streams`}/>
-                </Switch>
-            </ContentContainer>
+        <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
+        <div className={style.headingMetaContainer}>
+          <div className={style.headingMeta} style={{ float: "left" }}>
+            <span>
+              Cluster: <code>{clusterID}</code>
+            </span>
+            <span>
+              Target keyspace:{" "}
+              <KeyspaceLink clusterID={clusterID} name={keyspace}>
+                <code>{keyspace}</code>
+              </KeyspaceLink>
+            </span>
+          </div>
+          <div style={{ float: "right" }}>
+            <a href={`#workflowStreams`}>Streams</a>
+          </div>
         </div>
-    );
+      </WorkspaceHeader>
+
+      <ContentContainer>
+        <TabContainer>
+          <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
+          <Tab text="JSON" to={`${url}/json`} />
+        </TabContainer>
+
+        <Switch>
+          <Route path={`${path}/streams`}>
+            <WorkflowStreams
+              clusterID={clusterID}
+              keyspace={keyspace}
+              name={name}
+            />
+          </Route>
+
+          <Route path={`${path}/json`}>
+            <Code code={JSON.stringify(data, null, 2)} />
+          </Route>
+
+          <Redirect exact from={path} to={`${path}/streams`} />
+        </Switch>
+      </ContentContainer>
+    </div>
+  );
 };

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -13,82 +13,93 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
+import {
+  Link,
+  Redirect,
+  Route,
+  Switch,
+  useParams,
+  useRouteMatch,
+} from "react-router-dom";
 
-import style from './Workflow.module.scss';
+import style from "./Workflow.module.scss";
 
-import { useWorkflow } from '../../../hooks/api';
-import { NavCrumbs } from '../../layout/NavCrumbs';
-import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
-import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
-import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
-import { KeyspaceLink } from '../../links/KeyspaceLink';
-import { WorkflowStreams } from './WorkflowStreams';
-import { ContentContainer } from '../../layout/ContentContainer';
-import { TabContainer } from '../../tabs/TabContainer';
-import { Tab } from '../../tabs/Tab';
-import { getStreams } from '../../../util/workflows';
-import { Code } from '../../Code';
+import { useWorkflow } from "../../../hooks/api";
+import { NavCrumbs } from "../../layout/NavCrumbs";
+import { WorkspaceHeader } from "../../layout/WorkspaceHeader";
+import { WorkspaceTitle } from "../../layout/WorkspaceTitle";
+import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
+import { KeyspaceLink } from "../../links/KeyspaceLink";
+import { WorkflowStreams } from "./WorkflowStreams";
+import { ContentContainer } from "../../layout/ContentContainer";
+import { TabContainer } from "../../tabs/TabContainer";
+import { Tab } from "../../tabs/Tab";
+import { getStreams } from "../../../util/workflows";
+import { Code } from "../../Code";
 
 interface RouteParams {
-    clusterID: string;
-    keyspace: string;
-    name: string;
+  clusterID: string;
+  keyspace: string;
+  name: string;
 }
 
 export const Workflow = () => {
-    const { clusterID, keyspace, name } = useParams<RouteParams>();
-    const { path, url } = useRouteMatch();
+  const { clusterID, keyspace, name } = useParams<RouteParams>();
+  const { path, url } = useRouteMatch();
 
-    useDocumentTitle(`${name} (${keyspace})`);
+  useDocumentTitle(`${name} (${keyspace})`);
 
-    const { data } = useWorkflow({ clusterID, keyspace, name });
-    const streams = getStreams(data);
+  const { data } = useWorkflow({ clusterID, keyspace, name });
+  const streams = getStreams(data);
 
-    return (
-        <div>
-            <WorkspaceHeader>
-                <NavCrumbs>
-                    <Link to="/workflows">Workflows</Link>
-                </NavCrumbs>
+  return (
+    <div>
+      <WorkspaceHeader>
+        <NavCrumbs>
+          <Link to="/workflows">Workflows</Link>
+        </NavCrumbs>
 
-                <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
-                <div className={style.headingMetaContainer}>
-                    <div className={style.headingMeta} style={{ float: 'left' }}>
-                        <span>
-                            Cluster: <code>{clusterID}</code>
-                        </span>
-                        <span>
-                            Target keyspace:{' '}
-                            <KeyspaceLink clusterID={clusterID} name={keyspace}>
-                                <code>{keyspace}</code>
-                            </KeyspaceLink>
-                        </span>
-                    </div>
-                    <div style={{ float: 'right' }}>
-                        <a href={`#workflowStreams`}>Streams</a>
-                    </div>
-                </div>
-            </WorkspaceHeader>
-
-            <ContentContainer>
-                <TabContainer>
-                    <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
-                    <Tab text="JSON" to={`${url}/json`} />
-                </TabContainer>
-
-                <Switch>
-                    <Route path={`${path}/streams`}>
-                        <WorkflowStreams clusterID={clusterID} keyspace={keyspace} name={name} />
-                    </Route>
-
-                    <Route path={`${path}/json`}>
-                        <Code code={JSON.stringify(data, null, 2)} />
-                    </Route>
-
-                    <Redirect exact from={path} to={`${path}/streams`} />
-                </Switch>
-            </ContentContainer>
+        <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
+        <div className={style.headingMetaContainer}>
+          <div className={style.headingMeta} style={{ float: "left" }}>
+            <span>
+              Cluster: <code>{clusterID}</code>
+            </span>
+            <span>
+              Target keyspace:{" "}
+              <KeyspaceLink clusterID={clusterID} name={keyspace}>
+                <code>{keyspace}</code>
+              </KeyspaceLink>
+            </span>
+          </div>
+          <div style={{ float: "right" }}>
+            <a href={`#workflowStreams`}>Streams</a>
+          </div>
         </div>
-    );
+      </WorkspaceHeader>
+
+      <ContentContainer>
+        <TabContainer>
+          <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
+          <Tab text="JSON" to={`${url}/json`} />
+        </TabContainer>
+
+        <Switch>
+          <Route path={`${path}/streams`}>
+            <WorkflowStreams
+              clusterID={clusterID}
+              keyspace={keyspace}
+              name={name}
+            />
+          </Route>
+
+          <Route path={`${path}/json`}>
+            <Code code={JSON.stringify(data, null, 2)} />
+          </Route>
+
+          <Redirect exact from={path} to={`${path}/streams`} />
+        </Switch>
+      </ContentContainer>
+    </div>
+  );
 };

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -13,93 +13,82 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  Link,
-  Redirect,
-  Route,
-  Switch,
-  useParams,
-  useRouteMatch,
-} from "react-router-dom";
+import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
 
-import style from "./Workflow.module.scss";
+import style from './Workflow.module.scss';
 
-import { useWorkflow } from "../../../hooks/api";
-import { NavCrumbs } from "../../layout/NavCrumbs";
-import { WorkspaceHeader } from "../../layout/WorkspaceHeader";
-import { WorkspaceTitle } from "../../layout/WorkspaceTitle";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-import { KeyspaceLink } from "../../links/KeyspaceLink";
-import { WorkflowStreams } from "./WorkflowStreams";
-import { ContentContainer } from "../../layout/ContentContainer";
-import { TabContainer } from "../../tabs/TabContainer";
-import { Tab } from "../../tabs/Tab";
-import { getStreams } from "../../../util/workflows";
-import { Code } from "../../Code";
+import { useWorkflow } from '../../../hooks/api';
+import { NavCrumbs } from '../../layout/NavCrumbs';
+import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
+import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { KeyspaceLink } from '../../links/KeyspaceLink';
+import { WorkflowStreams } from './WorkflowStreams';
+import { ContentContainer } from '../../layout/ContentContainer';
+import { TabContainer } from '../../tabs/TabContainer';
+import { Tab } from '../../tabs/Tab';
+import { getStreams } from '../../../util/workflows';
+import { Code } from '../../Code';
 
 interface RouteParams {
-  clusterID: string;
-  keyspace: string;
-  name: string;
+    clusterID: string;
+    keyspace: string;
+    name: string;
 }
 
 export const Workflow = () => {
-  const { clusterID, keyspace, name } = useParams<RouteParams>();
-  const { path, url } = useRouteMatch();
+    const { clusterID, keyspace, name } = useParams<RouteParams>();
+    const { path, url } = useRouteMatch();
 
-  useDocumentTitle(`${name} (${keyspace})`);
+    useDocumentTitle(`${name} (${keyspace})`);
 
-  const { data } = useWorkflow({ clusterID, keyspace, name });
-  const streams = getStreams(data);
+    const { data } = useWorkflow({ clusterID, keyspace, name });
+    const streams = getStreams(data);
 
-  return (
-    <div>
-      <WorkspaceHeader>
-        <NavCrumbs>
-          <Link to="/workflows">Workflows</Link>
-        </NavCrumbs>
+    return (
+        <div>
+            <WorkspaceHeader>
+                <NavCrumbs>
+                    <Link to="/workflows">Workflows</Link>
+                </NavCrumbs>
 
-        <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
-        <div className={style.headingMetaContainer}>
-          <div className={style.headingMeta} style={{ float: "left" }}>
-            <span>
-              Cluster: <code>{clusterID}</code>
-            </span>
-            <span>
-              Target keyspace:{" "}
-              <KeyspaceLink clusterID={clusterID} name={keyspace}>
-                <code>{keyspace}</code>
-              </KeyspaceLink>
-            </span>
-          </div>
-          <div style={{ float: "right" }}>
-            <a href={`#workflowStreams`}>Streams</a>
-          </div>
+                <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
+                <div className={style.headingMetaContainer}>
+                    <div className={style.headingMeta} style={{ float: 'left' }}>
+                        <span>
+                            Cluster: <code>{clusterID}</code>
+                        </span>
+                        <span>
+                            Target keyspace:{' '}
+                            <KeyspaceLink clusterID={clusterID} name={keyspace}>
+                                <code>{keyspace}</code>
+                            </KeyspaceLink>
+                        </span>
+                    </div>
+                    <div style={{ float: 'right' }}>
+                        <a href={`#workflowStreams`}>Streams</a>
+                    </div>
+                </div>
+            </WorkspaceHeader>
+
+            <ContentContainer>
+                <TabContainer>
+                    <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
+                    <Tab text="JSON" to={`${url}/json`} />
+                </TabContainer>
+
+                <Switch>
+                    <Route path={`${path}/streams`}>
+                        <WorkflowStreams clusterID={clusterID} keyspace={keyspace} name={name} />
+                    </Route>
+
+                    <Route path={`${path}/json`}>
+                        <Code code={JSON.stringify(data, null, 2)} />
+                    </Route>
+
+                    <Redirect exact from={path} to={`${path}/streams`} />
+                </Switch>
+            </ContentContainer>
         </div>
-      </WorkspaceHeader>
-
-      <ContentContainer>
-        <TabContainer>
-          <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
-          <Tab text="JSON" to={`${url}/json`} />
-        </TabContainer>
-
-        <Switch>
-          <Route path={`${path}/streams`}>
-            <WorkflowStreams
-              clusterID={clusterID}
-              keyspace={keyspace}
-              name={name}
-            />
-          </Route>
-
-          <Route path={`${path}/json`}>
-            <Code code={JSON.stringify(data, null, 2)} />
-          </Route>
-
-          <Redirect exact from={path} to={`${path}/streams`} />
-        </Switch>
-      </ContentContainer>
-    </div>
-  );
+    );
 };

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -73,7 +73,7 @@ export const Workflow = () => {
             </span>
           </div>
           <div style={{ float: "right" }}>
-            <a href={`#workflowStreams`}>Streams</a>
+            <a href={`#workflowStreams`}>Scroll To Streams</a>
           </div>
         </div>
       </WorkspaceHeader>

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -14,151 +14,137 @@
  * limitations under the License.
  */
 
-import { groupBy, orderBy } from "lodash-es";
-import React, { useMemo } from "react";
-import { Link } from "react-router-dom";
+import { groupBy, orderBy } from 'lodash-es';
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 
-import { useWorkflow } from "../../../hooks/api";
-import { formatAlias } from "../../../util/tablets";
-import { formatDateTime, formatRelativeTime } from "../../../util/time";
-import {
-  formatStreamKey,
-  getStreams,
-  getStreamSource,
-  getStreamTarget,
-} from "../../../util/workflows";
-import { DataCell } from "../../dataTable/DataCell";
-import { DataTable } from "../../dataTable/DataTable";
-import { TabletLink } from "../../links/TabletLink";
-import { StreamStatePip } from "../../pips/StreamStatePip";
-import { WorkflowStreamsLagChart } from "../../charts/WorkflowStreamsLagChart";
-import { ShardLink } from "../../links/ShardLink";
-import { env } from "../../../util/env";
-import { ThrottleThresholdSeconds } from "../Workflows";
+import { useWorkflow } from '../../../hooks/api';
+import { formatAlias } from '../../../util/tablets';
+import { formatDateTime, formatRelativeTime } from '../../../util/time';
+import { formatStreamKey, getStreams, getStreamSource, getStreamTarget } from '../../../util/workflows';
+import { DataCell } from '../../dataTable/DataCell';
+import { DataTable } from '../../dataTable/DataTable';
+import { TabletLink } from '../../links/TabletLink';
+import { StreamStatePip } from '../../pips/StreamStatePip';
+import { WorkflowStreamsLagChart } from '../../charts/WorkflowStreamsLagChart';
+import { ShardLink } from '../../links/ShardLink';
+import { env } from '../../../util/env';
+import { ThrottleThresholdSeconds } from '../Workflows';
 
 interface Props {
-  clusterID: string;
-  keyspace: string;
-  name: string;
+    clusterID: string;
+    keyspace: string;
+    name: string;
 }
 
-const COLUMNS = ["Stream", "Source", "Target", "Tablet"];
+const COLUMNS = ['Stream', 'Source', 'Target', 'Tablet'];
 
 export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
-  const { data } = useWorkflow({ clusterID, keyspace, name });
+    const { data } = useWorkflow({ clusterID, keyspace, name });
 
-  const streams = useMemo(() => {
-    const rows = getStreams(data).map((stream) => ({
-      key: formatStreamKey(stream),
-      ...stream,
-    }));
+    const streams = useMemo(() => {
+        const rows = getStreams(data).map((stream) => ({
+            key: formatStreamKey(stream),
+            ...stream,
+        }));
 
-    return orderBy(rows, "streamKey");
-  }, [data]);
+        return orderBy(rows, 'streamKey');
+    }, [data]);
 
-  const streamsByState = groupBy(streams, "state");
+    const streamsByState = groupBy(streams, 'state');
 
-  const renderRows = (rows: typeof streams) => {
-    return rows.map((row) => {
-      const href =
-        row.tablet && row.id
-          ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
-          : null;
+    const renderRows = (rows: typeof streams) => {
+        return rows.map((row) => {
+            const href =
+                row.tablet && row.id
+                    ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
+                    : null;
 
-      const source = getStreamSource(row);
-      const target = getStreamTarget(row, keyspace);
-      var isThrottled =
-        Number(row?.throttler_status?.time_throttled?.seconds) >
-        Date.now() / 1000 - ThrottleThresholdSeconds;
-      const rowState = isThrottled ? "Throttled" : row.state;
-      return (
-        <tr key={row.key}>
-          <DataCell>
-            <StreamStatePip state={rowState} />{" "}
-            <Link className="font-bold" to={href}>
-              {row.key}
-            </Link>
-            <div className="text-sm text-secondary">
-              Updated {formatDateTime(row.time_updated?.seconds)}
-            </div>
-            {isThrottled ? (
-              <div className="text-sm text-secondary">
-                <span className="font-bold text-danger">Throttled: </span>
-                in {row.throttler_status?.component_throttled}
-              </div>
-            ) : null}
-          </DataCell>
-          <DataCell>
-            {source ? (
-              <ShardLink
-                clusterID={clusterID}
-                keyspace={row.binlog_source?.keyspace}
-                shard={row.binlog_source?.shard}
-              >
-                {source}
-              </ShardLink>
-            ) : (
-              <span className="text-secondary">N/A</span>
+            const source = getStreamSource(row);
+            const target = getStreamTarget(row, keyspace);
+            var isThrottled =
+                Number(row?.throttler_status?.time_throttled?.seconds) > Date.now() / 1000 - ThrottleThresholdSeconds;
+            const rowState = isThrottled ? 'Throttled' : row.state;
+            return (
+                <tr key={row.key}>
+                    <DataCell>
+                        <StreamStatePip state={rowState} />{' '}
+                        <Link className="font-bold" to={href}>
+                            {row.key}
+                        </Link>
+                        <div className="text-sm text-secondary">
+                            Updated {formatDateTime(row.time_updated?.seconds)}
+                        </div>
+                        {isThrottled ? (
+                            <div className="text-sm text-secondary">
+                                <span className="font-bold text-danger">Throttled: </span>
+                                in {row.throttler_status?.component_throttled}
+                            </div>
+                        ) : null}
+                    </DataCell>
+                    <DataCell>
+                        {source ? (
+                            <ShardLink
+                                clusterID={clusterID}
+                                keyspace={row.binlog_source?.keyspace}
+                                shard={row.binlog_source?.shard}
+                            >
+                                {source}
+                            </ShardLink>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
+                    <DataCell>
+                        {target ? (
+                            <ShardLink clusterID={clusterID} keyspace={keyspace} shard={row.shard}>
+                                {target}
+                            </ShardLink>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
+                    <DataCell>
+                        <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
+                            {formatAlias(row.tablet)}
+                        </TabletLink>
+                    </DataCell>
+                </tr>
+            );
+        });
+    };
+
+    return (
+        <div className="mt-12 mb-16">
+            {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
+                <>
+                    <h3 className="my-8">Stream VReplication Lag</h3>
+                    <WorkflowStreamsLagChart clusterID={clusterID} keyspace={keyspace} workflowName={name} />
+                </>
             )}
-          </DataCell>
-          <DataCell>
-            {target ? (
-              <ShardLink
-                clusterID={clusterID}
-                keyspace={keyspace}
-                shard={row.shard}
-              >
-                {target}
-              </ShardLink>
-            ) : (
-              <span className="text-secondary">N/A</span>
-            )}
-          </DataCell>
-          <DataCell>
-            <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
-              {formatAlias(row.tablet)}
-            </TabletLink>
-          </DataCell>
-        </tr>
-      );
-    });
-  };
 
-  return (
-    <div className="mt-12 mb-16">
-      {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
-        <>
-          <h3 className="my-8">Stream VReplication Lag</h3>
-          <WorkflowStreamsLagChart
-            clusterID={clusterID}
-            keyspace={keyspace}
-            workflowName={name}
-          />
-        </>
-      )}
+            <h3 className="mt-24 mb-8" id="workflowStreams">
+                Streams
+            </h3>
+            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
+                if (!Array.isArray(streamsByState[streamState])) {
+                    return null;
+                }
 
-      <h3 className="mt-24 mb-8" id="workflowStreams">
-        Streams
-      </h3>
-      {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-      {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
-        if (!Array.isArray(streamsByState[streamState])) {
-          return null;
-        }
-
-        return (
-          <div className="my-12" key={streamState}>
-            <DataTable
-              columns={COLUMNS}
-              data={streamsByState[streamState]}
-              // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
-              pageSize={1000}
-              renderRows={renderRows}
-              title={streamState}
-            />
-          </div>
-        );
-      })}
-    </div>
-  );
+                return (
+                    <div className="my-12" key={streamState}>
+                        <DataTable
+                            columns={COLUMNS}
+                            data={streamsByState[streamState]}
+                            // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
+                            pageSize={1000}
+                            renderRows={renderRows}
+                            title={streamState}
+                        />
+                    </div>
+                );
+            })}
+        </div>
+    );
 };

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -14,137 +14,153 @@
  * limitations under the License.
  */
 
-import {groupBy, orderBy} from 'lodash-es';
-import React, {useMemo} from 'react';
-import {Link} from 'react-router-dom';
+import { groupBy, orderBy } from "lodash-es";
+import React, { useMemo } from "react";
+import { Link } from "react-router-dom";
 
-import {useWorkflow} from '../../../hooks/api';
-import {formatAlias} from '../../../util/tablets';
-import {formatDateTime, formatRelativeTime} from '../../../util/time';
-import {formatStreamKey, getStreams, getStreamSource, getStreamTarget} from '../../../util/workflows';
-import {DataCell} from '../../dataTable/DataCell';
-import {DataTable} from '../../dataTable/DataTable';
-import {TabletLink} from '../../links/TabletLink';
-import {StreamStatePip} from '../../pips/StreamStatePip';
-import {WorkflowStreamsLagChart} from '../../charts/WorkflowStreamsLagChart';
-import {ShardLink} from '../../links/ShardLink';
-import {env} from '../../../util/env';
+import { useWorkflow } from "../../../hooks/api";
+import { formatAlias } from "../../../util/tablets";
+import { formatDateTime, formatRelativeTime } from "../../../util/time";
+import {
+  formatStreamKey,
+  getStreams,
+  getStreamSource,
+  getStreamTarget,
+} from "../../../util/workflows";
+import { DataCell } from "../../dataTable/DataCell";
+import { DataTable } from "../../dataTable/DataTable";
+import { TabletLink } from "../../links/TabletLink";
+import { StreamStatePip } from "../../pips/StreamStatePip";
+import { WorkflowStreamsLagChart } from "../../charts/WorkflowStreamsLagChart";
+import { ShardLink } from "../../links/ShardLink";
+import { env } from "../../../util/env";
 
 interface Props {
-    clusterID: string;
-    keyspace: string;
-    name: string;
+  clusterID: string;
+  keyspace: string;
+  name: string;
 }
 
-const COLUMNS = ['Stream', 'Source', 'Target', 'Tablet'];
+const COLUMNS = ["Stream", "Source", "Target", "Tablet"];
 
-export const WorkflowStreams = ({clusterID, keyspace, name}: Props) => {
-    const {data} = useWorkflow({clusterID, keyspace, name});
+export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
+  const { data } = useWorkflow({ clusterID, keyspace, name });
 
-    const streams = useMemo(() => {
-        const rows = getStreams(data).map((stream) => ({
-            key: formatStreamKey(stream),
-            ...stream,
-        }));
+  const streams = useMemo(() => {
+    const rows = getStreams(data).map((stream) => ({
+      key: formatStreamKey(stream),
+      ...stream,
+    }));
 
-        return orderBy(rows, 'streamKey');
-    }, [data]);
+    return orderBy(rows, "streamKey");
+  }, [data]);
 
-    const streamsByState = groupBy(streams, 'state');
+  const streamsByState = groupBy(streams, "state");
 
-    const renderRows = (rows: typeof streams) => {
-        return rows.map((row) => {
-            const href =
-                row.tablet && row.id
-                    ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
-                    : null;
+  const renderRows = (rows: typeof streams) => {
+    return rows.map((row) => {
+      const href =
+        row.tablet && row.id
+          ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
+          : null;
 
-            const source = getStreamSource(row);
-            const target = getStreamTarget(row, keyspace);
-            const rowState = row?.throttler_status?.component_throttled ? 'Throttled' : row.state;
-            return (
-                <tr key={row.key}>
-                    <DataCell>
-                        <StreamStatePip state={rowState}/>{' '}
-                        <Link className="font-bold" to={href}>
-                            {row.key}
-                        </Link>
-                        <div className="text-sm text-secondary">
-                            Updated {formatDateTime(row.time_updated?.seconds)}
-                        </div>
-                        {row?.throttler_status?.component_throttled ? (
-                            <div
-                                className="text-sm text-secondary">
-                                <span className="font-bold text-danger">
-                                    Throttled:
-                                </span>
-                                {row.throttler_status?.component_throttled}
-                                ({formatRelativeTime(row.throttler_status?.time_throttled?.seconds)})
-                            </div>
-                        ) : null
-                        }
-                    </DataCell>
-                    <DataCell>
-                        {source ? (
-                            <ShardLink
-                                clusterID={clusterID}
-                                keyspace={row.binlog_source?.keyspace}
-                                shard={row.binlog_source?.shard}
-                            >
-                                {source}
-                            </ShardLink>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
-                    <DataCell>
-                        {target ? (
-                            <ShardLink clusterID={clusterID} keyspace={keyspace} shard={row.shard}>
-                                {target}
-                            </ShardLink>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
-                    <DataCell>
-                        <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
-                            {formatAlias(row.tablet)}
-                        </TabletLink>
-                    </DataCell>
-                </tr>
-            );
-        });
-    };
-
-    return (
-        <div className="mt-12 mb-16">
-            {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
-                <>
-                    <h3 className="my-8">Stream VReplication Lag</h3>
-                    <WorkflowStreamsLagChart clusterID={clusterID} keyspace={keyspace} workflowName={name}/>
-                </>
+      const source = getStreamSource(row);
+      const target = getStreamTarget(row, keyspace);
+      const rowState = row?.throttler_status?.component_throttled
+        ? "Throttled"
+        : row.state;
+      return (
+        <tr key={row.key}>
+          <DataCell>
+            <StreamStatePip state={rowState} />{" "}
+            <Link className="font-bold" to={href}>
+              {row.key}
+            </Link>
+            <div className="text-sm text-secondary">
+              Updated {formatDateTime(row.time_updated?.seconds)}
+            </div>
+            {row?.throttler_status?.component_throttled ? (
+              <div className="text-sm text-secondary">
+                <span className="font-bold text-danger">Throttled:</span>
+                {row.throttler_status?.component_throttled}(
+                {formatRelativeTime(
+                  row.throttler_status?.time_throttled?.seconds
+                )}
+                )
+              </div>
+            ) : null}
+          </DataCell>
+          <DataCell>
+            {source ? (
+              <ShardLink
+                clusterID={clusterID}
+                keyspace={row.binlog_source?.keyspace}
+                shard={row.binlog_source?.shard}
+              >
+                {source}
+              </ShardLink>
+            ) : (
+              <span className="text-secondary">N/A</span>
             )}
+          </DataCell>
+          <DataCell>
+            {target ? (
+              <ShardLink
+                clusterID={clusterID}
+                keyspace={keyspace}
+                shard={row.shard}
+              >
+                {target}
+              </ShardLink>
+            ) : (
+              <span className="text-secondary">N/A</span>
+            )}
+          </DataCell>
+          <DataCell>
+            <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
+              {formatAlias(row.tablet)}
+            </TabletLink>
+          </DataCell>
+        </tr>
+      );
+    });
+  };
 
-            <h3 className="mt-24 mb-8" id="workflowStreams">Streams</h3>
-            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
-                if (!Array.isArray(streamsByState[streamState])) {
-                    return null;
-                }
+  return (
+    <div className="mt-12 mb-16">
+      {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
+        <>
+          <h3 className="my-8">Stream VReplication Lag</h3>
+          <WorkflowStreamsLagChart
+            clusterID={clusterID}
+            keyspace={keyspace}
+            workflowName={name}
+          />
+        </>
+      )}
 
-                return (
-                    <div className="my-12" key={streamState}>
-                        <DataTable
-                            columns={COLUMNS}
-                            data={streamsByState[streamState]}
-                            // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
-                            pageSize={1000}
-                            renderRows={renderRows}
-                            title={streamState}
-                        />
-                    </div>
-                );
-            })}
-        </div>
-    );
+      <h3 className="mt-24 mb-8" id="workflowStreams">
+        Streams
+      </h3>
+      {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+      {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
+        if (!Array.isArray(streamsByState[streamState])) {
+          return null;
+        }
+
+        return (
+          <div className="my-12" key={streamState}>
+            <DataTable
+              columns={COLUMNS}
+              data={streamsByState[streamState]}
+              // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
+              pageSize={1000}
+              renderRows={renderRows}
+              title={streamState}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
 };

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -83,12 +83,8 @@ export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
             </div>
             {isThrottled ? (
               <div className="text-sm text-secondary">
-                <span className="font-bold text-danger">Throttled:</span>
-                {row.throttler_status?.component_throttled}(
-                {formatRelativeTime(
-                  row.throttler_status?.time_throttled?.seconds
-                )}
-                )
+                <span className="font-bold text-danger">Throttled: </span>
+                in {row.throttler_status?.component_throttled}
               </div>
             ) : null}
           </DataCell>

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -14,153 +14,135 @@
  * limitations under the License.
  */
 
-import { groupBy, orderBy } from "lodash-es";
-import React, { useMemo } from "react";
-import { Link } from "react-router-dom";
+import { groupBy, orderBy } from 'lodash-es';
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 
-import { useWorkflow } from "../../../hooks/api";
-import { formatAlias } from "../../../util/tablets";
-import { formatDateTime, formatRelativeTime } from "../../../util/time";
-import {
-  formatStreamKey,
-  getStreams,
-  getStreamSource,
-  getStreamTarget,
-} from "../../../util/workflows";
-import { DataCell } from "../../dataTable/DataCell";
-import { DataTable } from "../../dataTable/DataTable";
-import { TabletLink } from "../../links/TabletLink";
-import { StreamStatePip } from "../../pips/StreamStatePip";
-import { WorkflowStreamsLagChart } from "../../charts/WorkflowStreamsLagChart";
-import { ShardLink } from "../../links/ShardLink";
-import { env } from "../../../util/env";
+import { useWorkflow } from '../../../hooks/api';
+import { formatAlias } from '../../../util/tablets';
+import { formatDateTime, formatRelativeTime } from '../../../util/time';
+import { formatStreamKey, getStreams, getStreamSource, getStreamTarget } from '../../../util/workflows';
+import { DataCell } from '../../dataTable/DataCell';
+import { DataTable } from '../../dataTable/DataTable';
+import { TabletLink } from '../../links/TabletLink';
+import { StreamStatePip } from '../../pips/StreamStatePip';
+import { WorkflowStreamsLagChart } from '../../charts/WorkflowStreamsLagChart';
+import { ShardLink } from '../../links/ShardLink';
+import { env } from '../../../util/env';
 
 interface Props {
-  clusterID: string;
-  keyspace: string;
-  name: string;
+    clusterID: string;
+    keyspace: string;
+    name: string;
 }
 
-const COLUMNS = ["Stream", "Source", "Target", "Tablet"];
+const COLUMNS = ['Stream', 'Source', 'Target', 'Tablet'];
 
 export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
-  const { data } = useWorkflow({ clusterID, keyspace, name });
+    const { data } = useWorkflow({ clusterID, keyspace, name });
 
-  const streams = useMemo(() => {
-    const rows = getStreams(data).map((stream) => ({
-      key: formatStreamKey(stream),
-      ...stream,
-    }));
+    const streams = useMemo(() => {
+        const rows = getStreams(data).map((stream) => ({
+            key: formatStreamKey(stream),
+            ...stream,
+        }));
 
-    return orderBy(rows, "streamKey");
-  }, [data]);
+        return orderBy(rows, 'streamKey');
+    }, [data]);
 
-  const streamsByState = groupBy(streams, "state");
+    const streamsByState = groupBy(streams, 'state');
 
-  const renderRows = (rows: typeof streams) => {
-    return rows.map((row) => {
-      const href =
-        row.tablet && row.id
-          ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
-          : null;
+    const renderRows = (rows: typeof streams) => {
+        return rows.map((row) => {
+            const href =
+                row.tablet && row.id
+                    ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
+                    : null;
 
-      const source = getStreamSource(row);
-      const target = getStreamTarget(row, keyspace);
-      const rowState = row?.throttler_status?.component_throttled
-        ? "Throttled"
-        : row.state;
-      return (
-        <tr key={row.key}>
-          <DataCell>
-            <StreamStatePip state={rowState} />{" "}
-            <Link className="font-bold" to={href}>
-              {row.key}
-            </Link>
-            <div className="text-sm text-secondary">
-              Updated {formatDateTime(row.time_updated?.seconds)}
-            </div>
-            {row?.throttler_status?.component_throttled ? (
-              <div className="text-sm text-secondary">
-                <span className="font-bold text-danger">Throttled:</span>
-                {row.throttler_status?.component_throttled}(
-                {formatRelativeTime(
-                  row.throttler_status?.time_throttled?.seconds
-                )}
-                )
-              </div>
-            ) : null}
-          </DataCell>
-          <DataCell>
-            {source ? (
-              <ShardLink
-                clusterID={clusterID}
-                keyspace={row.binlog_source?.keyspace}
-                shard={row.binlog_source?.shard}
-              >
-                {source}
-              </ShardLink>
-            ) : (
-              <span className="text-secondary">N/A</span>
+            const source = getStreamSource(row);
+            const target = getStreamTarget(row, keyspace);
+            const rowState = row?.throttler_status?.component_throttled ? 'Throttled' : row.state;
+            return (
+                <tr key={row.key}>
+                    <DataCell>
+                        <StreamStatePip state={rowState} />{' '}
+                        <Link className="font-bold" to={href}>
+                            {row.key}
+                        </Link>
+                        <div className="text-sm text-secondary">
+                            Updated {formatDateTime(row.time_updated?.seconds)}
+                        </div>
+                        {row?.throttler_status?.component_throttled ? (
+                            <div className="text-sm text-secondary">
+                                <span className="font-bold text-danger">Throttled:</span>
+                                {row.throttler_status?.component_throttled}(
+                                {formatRelativeTime(row.throttler_status?.time_throttled?.seconds)})
+                            </div>
+                        ) : null}
+                    </DataCell>
+                    <DataCell>
+                        {source ? (
+                            <ShardLink
+                                clusterID={clusterID}
+                                keyspace={row.binlog_source?.keyspace}
+                                shard={row.binlog_source?.shard}
+                            >
+                                {source}
+                            </ShardLink>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
+                    <DataCell>
+                        {target ? (
+                            <ShardLink clusterID={clusterID} keyspace={keyspace} shard={row.shard}>
+                                {target}
+                            </ShardLink>
+                        ) : (
+                            <span className="text-secondary">N/A</span>
+                        )}
+                    </DataCell>
+                    <DataCell>
+                        <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
+                            {formatAlias(row.tablet)}
+                        </TabletLink>
+                    </DataCell>
+                </tr>
+            );
+        });
+    };
+
+    return (
+        <div className="mt-12 mb-16">
+            {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
+                <>
+                    <h3 className="my-8">Stream VReplication Lag</h3>
+                    <WorkflowStreamsLagChart clusterID={clusterID} keyspace={keyspace} workflowName={name} />
+                </>
             )}
-          </DataCell>
-          <DataCell>
-            {target ? (
-              <ShardLink
-                clusterID={clusterID}
-                keyspace={keyspace}
-                shard={row.shard}
-              >
-                {target}
-              </ShardLink>
-            ) : (
-              <span className="text-secondary">N/A</span>
-            )}
-          </DataCell>
-          <DataCell>
-            <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
-              {formatAlias(row.tablet)}
-            </TabletLink>
-          </DataCell>
-        </tr>
-      );
-    });
-  };
 
-  return (
-    <div className="mt-12 mb-16">
-      {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
-        <>
-          <h3 className="my-8">Stream VReplication Lag</h3>
-          <WorkflowStreamsLagChart
-            clusterID={clusterID}
-            keyspace={keyspace}
-            workflowName={name}
-          />
-        </>
-      )}
+            <h3 className="mt-24 mb-8" id="workflowStreams">
+                Streams
+            </h3>
+            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
+                if (!Array.isArray(streamsByState[streamState])) {
+                    return null;
+                }
 
-      <h3 className="mt-24 mb-8" id="workflowStreams">
-        Streams
-      </h3>
-      {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-      {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
-        if (!Array.isArray(streamsByState[streamState])) {
-          return null;
-        }
-
-        return (
-          <div className="my-12" key={streamState}>
-            <DataTable
-              columns={COLUMNS}
-              data={streamsByState[streamState]}
-              // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
-              pageSize={1000}
-              renderRows={renderRows}
-              title={streamState}
-            />
-          </div>
-        );
-      })}
-    </div>
-  );
+                return (
+                    <div className="my-12" key={streamState}>
+                        <DataTable
+                            columns={COLUMNS}
+                            data={streamsByState[streamState]}
+                            // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
+                            pageSize={1000}
+                            renderRows={renderRows}
+                            title={streamState}
+                        />
+                    </div>
+                );
+            })}
+        </div>
+    );
 };

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -14,137 +14,155 @@
  * limitations under the License.
  */
 
-import {groupBy, orderBy} from 'lodash-es';
-import React, {useMemo} from 'react';
-import {Link} from 'react-router-dom';
+import { groupBy, orderBy } from "lodash-es";
+import React, { useMemo } from "react";
+import { Link } from "react-router-dom";
 
-import {useWorkflow} from '../../../hooks/api';
-import {formatAlias} from '../../../util/tablets';
-import {formatDateTime, formatRelativeTime} from '../../../util/time';
-import {formatStreamKey, getStreams, getStreamSource, getStreamTarget} from '../../../util/workflows';
-import {DataCell} from '../../dataTable/DataCell';
-import {DataTable} from '../../dataTable/DataTable';
-import {TabletLink} from '../../links/TabletLink';
-import {StreamStatePip} from '../../pips/StreamStatePip';
-import {WorkflowStreamsLagChart} from '../../charts/WorkflowStreamsLagChart';
-import {ShardLink} from '../../links/ShardLink';
-import {env} from '../../../util/env';
-import {ThrottleThresholdSeconds} from "../Workflows";
+import { useWorkflow } from "../../../hooks/api";
+import { formatAlias } from "../../../util/tablets";
+import { formatDateTime, formatRelativeTime } from "../../../util/time";
+import {
+  formatStreamKey,
+  getStreams,
+  getStreamSource,
+  getStreamTarget,
+} from "../../../util/workflows";
+import { DataCell } from "../../dataTable/DataCell";
+import { DataTable } from "../../dataTable/DataTable";
+import { TabletLink } from "../../links/TabletLink";
+import { StreamStatePip } from "../../pips/StreamStatePip";
+import { WorkflowStreamsLagChart } from "../../charts/WorkflowStreamsLagChart";
+import { ShardLink } from "../../links/ShardLink";
+import { env } from "../../../util/env";
+import { ThrottleThresholdSeconds } from "../Workflows";
 
 interface Props {
-    clusterID: string;
-    keyspace: string;
-    name: string;
+  clusterID: string;
+  keyspace: string;
+  name: string;
 }
 
-const COLUMNS = ['Stream', 'Source', 'Target', 'Tablet'];
+const COLUMNS = ["Stream", "Source", "Target", "Tablet"];
 
-export const WorkflowStreams = ({clusterID, keyspace, name}: Props) => {
-    const {data} = useWorkflow({clusterID, keyspace, name});
+export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
+  const { data } = useWorkflow({ clusterID, keyspace, name });
 
-    const streams = useMemo(() => {
-        const rows = getStreams(data).map((stream) => ({
-            key: formatStreamKey(stream),
-            ...stream,
-        }));
+  const streams = useMemo(() => {
+    const rows = getStreams(data).map((stream) => ({
+      key: formatStreamKey(stream),
+      ...stream,
+    }));
 
-        return orderBy(rows, 'streamKey');
-    }, [data]);
+    return orderBy(rows, "streamKey");
+  }, [data]);
 
-    const streamsByState = groupBy(streams, 'state');
+  const streamsByState = groupBy(streams, "state");
 
-    const renderRows = (rows: typeof streams) => {
-        return rows.map((row) => {
-            const href =
-                row.tablet && row.id
-                    ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
-                    : null;
+  const renderRows = (rows: typeof streams) => {
+    return rows.map((row) => {
+      const href =
+        row.tablet && row.id
+          ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
+          : null;
 
-            const source = getStreamSource(row);
-            const target = getStreamTarget(row, keyspace);
-            var isThrottled = Number(row?.throttler_status?.time_throttled?.seconds) > (Date.now() / 1000 - ThrottleThresholdSeconds)
-            const rowState = isThrottled ? 'Throttled' : row.state;
-            return (
-                <tr key={row.key}>
-                    <DataCell>
-                        <StreamStatePip state={rowState}/>{' '}
-                        <Link className="font-bold" to={href}>
-                            {row.key}
-                        </Link>
-                        <div className="text-sm text-secondary">
-                            Updated {formatDateTime(row.time_updated?.seconds)}
-                        </div>
-                        {isThrottled ? (
-                            <div className="text-sm text-secondary">
-                                <span className="font-bold text-danger">Throttled:</span>
-                                {row.throttler_status?.component_throttled}(
-                                {formatRelativeTime(row.throttler_status?.time_throttled?.seconds)})
-                            </div>
-                        ) : null}
-                    </DataCell>
-                    <DataCell>
-                        {source ? (
-                            <ShardLink
-                                clusterID={clusterID}
-                                keyspace={row.binlog_source?.keyspace}
-                                shard={row.binlog_source?.shard}
-                            >
-                                {source}
-                            </ShardLink>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
-                    <DataCell>
-                        {target ? (
-                            <ShardLink clusterID={clusterID} keyspace={keyspace} shard={row.shard}>
-                                {target}
-                            </ShardLink>
-                        ) : (
-                            <span className="text-secondary">N/A</span>
-                        )}
-                    </DataCell>
-                    <DataCell>
-                        <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
-                            {formatAlias(row.tablet)}
-                        </TabletLink>
-                    </DataCell>
-                </tr>
-            );
-        });
-    };
-
-    return (
-        <div className="mt-12 mb-16">
-            {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
-                <>
-                    <h3 className="my-8">Stream VReplication Lag</h3>
-                    <WorkflowStreamsLagChart clusterID={clusterID} keyspace={keyspace} workflowName={name}/>
-                </>
+      const source = getStreamSource(row);
+      const target = getStreamTarget(row, keyspace);
+      var isThrottled =
+        Number(row?.throttler_status?.time_throttled?.seconds) >
+        Date.now() / 1000 - ThrottleThresholdSeconds;
+      const rowState = isThrottled ? "Throttled" : row.state;
+      return (
+        <tr key={row.key}>
+          <DataCell>
+            <StreamStatePip state={rowState} />{" "}
+            <Link className="font-bold" to={href}>
+              {row.key}
+            </Link>
+            <div className="text-sm text-secondary">
+              Updated {formatDateTime(row.time_updated?.seconds)}
+            </div>
+            {isThrottled ? (
+              <div className="text-sm text-secondary">
+                <span className="font-bold text-danger">Throttled:</span>
+                {row.throttler_status?.component_throttled}(
+                {formatRelativeTime(
+                  row.throttler_status?.time_throttled?.seconds
+                )}
+                )
+              </div>
+            ) : null}
+          </DataCell>
+          <DataCell>
+            {source ? (
+              <ShardLink
+                clusterID={clusterID}
+                keyspace={row.binlog_source?.keyspace}
+                shard={row.binlog_source?.shard}
+              >
+                {source}
+              </ShardLink>
+            ) : (
+              <span className="text-secondary">N/A</span>
             )}
+          </DataCell>
+          <DataCell>
+            {target ? (
+              <ShardLink
+                clusterID={clusterID}
+                keyspace={keyspace}
+                shard={row.shard}
+              >
+                {target}
+              </ShardLink>
+            ) : (
+              <span className="text-secondary">N/A</span>
+            )}
+          </DataCell>
+          <DataCell>
+            <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
+              {formatAlias(row.tablet)}
+            </TabletLink>
+          </DataCell>
+        </tr>
+      );
+    });
+  };
 
-            <h3 className="mt-24 mb-8" id="workflowStreams">
-                Streams
-            </h3>
-            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
-                if (!Array.isArray(streamsByState[streamState])) {
-                    return null;
-                }
+  return (
+    <div className="mt-12 mb-16">
+      {env().VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
+        <>
+          <h3 className="my-8">Stream VReplication Lag</h3>
+          <WorkflowStreamsLagChart
+            clusterID={clusterID}
+            keyspace={keyspace}
+            workflowName={name}
+          />
+        </>
+      )}
 
-                return (
-                    <div className="my-12" key={streamState}>
-                        <DataTable
-                            columns={COLUMNS}
-                            data={streamsByState[streamState]}
-                            // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
-                            pageSize={1000}
-                            renderRows={renderRows}
-                            title={streamState}
-                        />
-                    </div>
-                );
-            })}
-        </div>
-    );
+      <h3 className="mt-24 mb-8" id="workflowStreams">
+        Streams
+      </h3>
+      {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
+      {["Error", "Copying", "Running", "Stopped"].map((streamState) => {
+        if (!Array.isArray(streamsByState[streamState])) {
+          return null;
+        }
+
+        return (
+          <div className="my-12" key={streamState}>
+            <DataTable
+              columns={COLUMNS}
+              data={streamsByState[streamState]}
+              // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
+              pageSize={1000}
+              renderRows={renderRows}
+              title={streamState}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
 };

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -61,11 +61,11 @@ export const WorkflowStreams = ({clusterID, keyspace, name}: Props) => {
 
             const source = getStreamSource(row);
             const target = getStreamTarget(row, keyspace);
-
+            const rowState = row?.throttler_status?.component_throttled ? 'Throttled' : row.state;
             return (
                 <tr key={row.key}>
                     <DataCell>
-                        <StreamStatePip state={row?.throttler_status?.component_throttled ? 'Throttled' : row.state}/>{' '}
+                        <StreamStatePip state={rowState}/>{' '}
                         <Link className="font-bold" to={href}>
                             {row.key}
                         </Link>


### PR DESCRIPTION
## Description

When a VReplication workflow is throttled, the app that caused the throttling and the time of the last throttle are recorded in the `_vt.vreplication` table. Currently those attributes are only shown in the json output tab of the workflow screen and are not easy to find. 

The throttler app and time are not reset once throttling has ended. So we only show a stream as throttled if it is within (currently) a minute. The throttler is updating this row on each check (every 250ms - 1s).

This PR changes the status color for a throttled running workflow to black and adds the throttler details (app name and time since throttled) to the summary workflow tooltip and to the streams details section.

It also adds a new internal link in the header to scroll down to the Streams section for convenience and visibility.

<details>
<summary> Workflow summary page </summary>
<img src=https://github.com/vitessio/vitess/assets/57520317/3fd9b3dc-7c00-4e00-897b-7b83c5c9b463/>
</details>

<details>
<summary> Workflow Streams Section </summary>
<img src=https://github.com/vitessio/vitess/assets/57520317/742d3bab-38c2-488f-8fb6-d4213362125c/>
</details>


## Related Issue(s)

https://github.com/vitessio/vitess/issues/11690

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
