### PR TITLE
Multi-tenant Movetables: add e2e test for vdiff

### DIFF
--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -203,6 +203,7 @@ func TestMultiTenantSimple(t *testing.T) {
 	lastIndex = insertRows(lastIndex, sourceKeyspace)
 	waitForWorkflowState(t, vc, fmt.Sprintf("%s.%s", targetKeyspace, mt.workflowName), binlogdatapb.VReplicationWorkflowState_Running.String())
 
+	vdiff(t, targetKeyspace, workflowName, defaultCellName, false, true, nil)
 	mt.SwitchReads()
 	confirmOnlyReadsSwitched(t)
 
@@ -362,6 +363,7 @@ func TestMultiTenantSharded(t *testing.T) {
 	// Note: we cannot insert into the target keyspace since that is never routed to the source keyspace.
 	lastIndex = insertRows(lastIndex, sourceKeyspace)
 	waitForWorkflowState(t, vc, fmt.Sprintf("%s.%s", targetKeyspace, mt.workflowName), binlogdatapb.VReplicationWorkflowState_Running.String())
+	vdiff(t, targetKeyspace, workflowName, defaultCellName, false, true, nil)
 	mt.SwitchReadsAndWrites()
 	// Note: here we have already switched, and we can insert into the target keyspace, and it should get reverse
 	// replicated to the source keyspace. The source keyspace is routed to the target keyspace at this point.
@@ -558,6 +560,7 @@ func (mtm *multiTenantMigration) switchTraffic(tenantId int64) {
 	mt := mtm.getActiveMoveTables(tenantId)
 	ksWorkflow := fmt.Sprintf("%s.%s", mtm.targetKeyspace, mt.workflowName)
 	waitForWorkflowState(t, vc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String())
+	vdiff(t, mt.targetKeyspace, mt.workflowName, defaultCellName, false, true, nil)
 	mtm.insertSomeData(t, tenantId, sourceKeyspaceName, numAdditionalRowsPerTenant)
 	mt.SwitchReadsAndWrites()
 	mtm.insertSomeData(t, tenantId, sourceKeyspaceName, numAdditionalRowsPerTenant)


### PR DESCRIPTION
## Description

A `vdiff` bug, fixed in https://github.com/vitessio/vitess/pull/16307, meant that you couldn't use `vdiff` for multi-tenant workflows since it included a filter.
This PR runs `vdiff` to confirm that it was failing before the fix and works with the commits from that PR.

```
--- PASS: TestMultiTenantComplex (195.11s)
    --- PASS: TestMultiTenantComplex/insertInitialData (0.11s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf1 (5.26s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf2 (5.28s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf3 (5.26s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf4 (5.25s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf5 (5.28s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf6 (5.29s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf7 (5.28s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf8 (5.27s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf9 (5.28s)
    --- PASS: TestMultiTenantComplex/vtctldclient_vdiff_mt.wf10 (5.26s)
    --- PASS: TestMultiTenantComplex/Verify_all_rows_have_been_migrated (0.00s)
PASS
ok  	vitess.io/vitess/go/test/endtoend/vreplication	196.260s
```

I will rebase after https://github.com/vitessio/vitess/issues/16307 is merged.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16305

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
