### PR TITLE
 [cleanup] Protos: Use UnmarshalPB() when unmarshalling a proto object

### DIFF
--- a/go/cmd/vtctldclient/command/vschemas.go
+++ b/go/cmd/vtctldclient/command/vschemas.go
@@ -102,7 +102,7 @@ func commandApplyVSchema(cmd *cobra.Command, args []string) error {
 		}
 
 		var vs vschemapb.Keyspace
-		err = json2.Unmarshal(schema, &vs)
+		err = json2.UnmarshalPB(schema, &vs)
 		if err != nil {
 			return err
 		}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -837,7 +837,7 @@ func checkTabletType(t *testing.T, alias string, tabletType topodata.TabletType)
 		output, err := localCluster.VtctldClientProcess.ExecuteCommandWithOutput("GetTablet", alias)
 		require.NoError(t, err)
 		var tabletPB topodata.Tablet
-		err = json2.Unmarshal([]byte(output), &tabletPB)
+		err = json2.UnmarshalPB([]byte(output), &tabletPB)
 		require.NoError(t, err)
 		if tabletType == tabletPB.Type {
 			return
@@ -1058,7 +1058,7 @@ func terminateBackup(t *testing.T, alias string) {
 		text := scanner.Text()
 		if strings.Contains(text, stopBackupMsg) {
 			tmpProcess.Process.Signal(syscall.SIGTERM)
-			found = true //nolint
+			found = true // nolint
 			return
 		}
 	}

--- a/go/test/endtoend/cluster/vtctldclient_process.go
+++ b/go/test/endtoend/cluster/vtctldclient_process.go
@@ -173,7 +173,7 @@ func (vtctldclient *VtctldClientProcess) GetShardReplication(keyspace string, sh
 	}
 
 	var resp vtctldatapb.GetShardReplicationResponse
-	err = json2.Unmarshal([]byte(out), &resp)
+	err = json2.UnmarshalPB([]byte(out), &resp)
 	return resp.ShardReplicationByCell, err
 }
 
@@ -252,7 +252,7 @@ func (vtctldclient *VtctldClientProcess) GetKeyspace(keyspace string) (*vtctldat
 	}
 
 	var ks vtctldatapb.Keyspace
-	err = json2.Unmarshal([]byte(data), &ks)
+	err = json2.UnmarshalPB([]byte(data), &ks)
 	if err != nil {
 		return nil, vterrors.Wrapf(err, "failed to parse keyspace output: %s", data)
 	}
@@ -267,7 +267,7 @@ func (vtctldclient *VtctldClientProcess) GetShard(keyspace string, shard string)
 	}
 
 	var si vtctldatapb.Shard
-	err = json2.Unmarshal([]byte(data), &si)
+	err = json2.UnmarshalPB([]byte(data), &si)
 	if err != nil {
 		return nil, vterrors.Wrapf(err, "failed to parse shard output: %s", data)
 	}
@@ -282,7 +282,7 @@ func (vtctldclient *VtctldClientProcess) GetTablet(alias string) (*topodatapb.Ta
 	}
 
 	var tablet topodatapb.Tablet
-	err = json2.Unmarshal([]byte(data), &tablet)
+	err = json2.UnmarshalPB([]byte(data), &tablet)
 	if err != nil {
 		return nil, vterrors.Wrapf(err, "failed to parse tablet output: %s", data)
 	}

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -130,7 +130,7 @@ func TestPITRRecovery(t *testing.T) {
 	initializeCluster(t)
 	defer clusterInstance.Teardown()
 
-	//start the binlog server and point it to primary
+	// start the binlog server and point it to primary
 	bs := startBinlogServer(t, primary)
 	defer bs.stop()
 
@@ -167,11 +167,11 @@ func TestPITRRecovery(t *testing.T) {
 	// starting resharding process
 	performResharding(t)
 
-	//start the binlog server and point it to shard0Primary
+	// start the binlog server and point it to shard0Primary
 	bs0 := startBinlogServer(t, shard0Primary)
 	defer bs0.stop()
 
-	//start the binlog server and point it to shard1Primary
+	// start the binlog server and point it to shard1Primary
 	bs1 := startBinlogServer(t, shard1Primary)
 	defer bs1.stop()
 
@@ -585,7 +585,7 @@ func waitForNoWorkflowLag(t *testing.T, vc *cluster.LocalProcessCluster, ks stri
 		require.NoError(t, err)
 
 		var resp vtctldatapb.GetWorkflowsResponse
-		err = json2.Unmarshal([]byte(output), &resp)
+		err = json2.UnmarshalPB([]byte(output), &resp)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(resp.Workflows), 1, "responce should have at least one workflow")
 		lag = resp.Workflows[0].MaxVReplicationTransactionLag

--- a/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
+++ b/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
@@ -46,7 +46,7 @@ func waitForLowLag(t *testing.T, clusterInstance *cluster.LocalProcessCluster, k
 		require.NoError(t, err)
 
 		var resp vtctldatapb.GetWorkflowsResponse
-		err = json2.Unmarshal([]byte(output), &resp)
+		err = json2.UnmarshalPB([]byte(output), &resp)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(resp.Workflows), 1, "responce should have at least one workflow")
 		lagSeconds := resp.Workflows[0].MaxVReplicationTransactionLag

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -197,7 +197,7 @@ func runHookAndAssert(t *testing.T, params []string, expectedStatus int64, expec
 		require.Nil(t, err)
 
 		var resp vtctldatapb.ExecuteHookResponse
-		err = json2.Unmarshal([]byte(hr), &resp)
+		err = json2.UnmarshalPB([]byte(hr), &resp)
 		require.Nil(t, err)
 
 		assert.Equal(t, expectedStatus, resp.HookResult.ExitStatus)

--- a/go/vt/tableacl/tableacl.go
+++ b/go/vt/tableacl/tableacl.go
@@ -113,7 +113,7 @@ func (tacl *tableACL) init(configFile string, aclCB func()) error {
 	config := &tableaclpb.Config{}
 	if err := config.UnmarshalVT(data); err != nil {
 		// try to parse tableacl as json file
-		if jsonErr := json2.Unmarshal(data, config); jsonErr != nil {
+		if jsonErr := json2.UnmarshalPB(data, config); jsonErr != nil {
 			log.Infof("unable to parse tableACL config file as a protobuf or json file.  protobuf err: %v  json err: %v", err, jsonErr)
 			return fmt.Errorf("unable to unmarshal Table ACL data: %s", data)
 		}

--- a/go/vt/vtctl/endtoend/get_schema_test.go
+++ b/go/vt/vtctl/endtoend/get_schema_test.go
@@ -173,7 +173,7 @@ func TestGetSchema(t *testing.T) {
 	val := events[0].Value
 
 	actual := &tabletmanagerdatapb.SchemaDefinition{}
-	err = json2.Unmarshal([]byte(val), actual)
+	err = json2.UnmarshalPB([]byte(val), actual)
 	require.NoError(t, err)
 
 	utils.MustMatch(t, sd, actual)
@@ -214,7 +214,7 @@ func TestGetSchema(t *testing.T) {
 	val = events[0].Value
 
 	actual = &tabletmanagerdatapb.SchemaDefinition{}
-	err = json2.Unmarshal([]byte(val), actual)
+	err = json2.UnmarshalPB([]byte(val), actual)
 	require.NoError(t, err)
 
 	utils.MustMatch(t, sd, actual)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2507,7 +2507,7 @@ func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFl
 	}
 	keyspace := subFlags.Arg(0)
 	specs := &vschemapb.Keyspace{}
-	if err := json2.Unmarshal([]byte(subFlags.Arg(1)), specs); err != nil {
+	if err := json2.UnmarshalPB([]byte(subFlags.Arg(1)), specs); err != nil {
 		return err
 	}
 	return wr.CreateLookupVindex(ctx, keyspace, specs, *cells, *tabletTypes, *continueAfterCopyWithOwner)
@@ -2533,7 +2533,7 @@ func commandMaterialize(ctx context.Context, wr *wrangler.Wrangler, subFlags *pf
 		return fmt.Errorf("a single argument is required: <json_spec>")
 	}
 	ms := &vtctldatapb.MaterializeSettings{}
-	if err := json2.Unmarshal([]byte(subFlags.Arg(0)), ms); err != nil {
+	if err := json2.UnmarshalPB([]byte(subFlags.Arg(0)), ms); err != nil {
 		return err
 	}
 	ms.Cell = *cells
@@ -3402,7 +3402,7 @@ func commandApplyVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *p
 		}
 
 		vs = &vschemapb.Keyspace{}
-		err := json2.Unmarshal(schema, vs)
+		err := json2.UnmarshalPB(schema, vs)
 		if err != nil {
 			return err
 		}
@@ -3490,7 +3490,7 @@ func commandApplyRoutingRules(ctx context.Context, wr *wrangler.Wrangler, subFla
 	}
 
 	rr := &vschemapb.RoutingRules{}
-	if err := json2.Unmarshal(rulesBytes, rr); err != nil {
+	if err := json2.UnmarshalPB(rulesBytes, rr); err != nil {
 		return err
 	}
 

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -390,7 +390,7 @@ func (ts *trafficSwitcher) addParticipatingTablesToKeyspace(ctx context.Context,
 	if strings.HasPrefix(tableSpecs, "{") { // user defined the vschema snippet, typically for a sharded target
 		wrap := fmt.Sprintf(`{"tables": %s}`, tableSpecs)
 		ks := &vschemapb.Keyspace{}
-		if err := json2.Unmarshal([]byte(wrap), ks); err != nil {
+		if err := json2.UnmarshalPB([]byte(wrap), ks); err != nil {
 			return err
 		}
 		for table, vtab := range ks.Tables {

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -101,7 +101,7 @@ func (vte *VTExplain) buildTopology(ctx context.Context, ts *topo.Server, opts *
 	// handle string->enum conversion correctly.
 	var srvVSchema vschemapb.SrvVSchema
 	wrappedStr := fmt.Sprintf(`{"keyspaces": %s}`, vschemaStr)
-	err := json2.Unmarshal([]byte(wrappedStr), &srvVSchema)
+	err := json2.UnmarshalPB([]byte(wrappedStr), &srvVSchema)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtgate/planbuilder/fuzz.go
+++ b/go/vt/vtgate/planbuilder/fuzz.go
@@ -37,7 +37,7 @@ func onceInit() {
 // loadSchemaForFuzzing is a helper to load *vindexes.VSchema
 // for fuzzing.
 func loadSchemaForFuzzing(f *fuzz.ConsumeFuzzer) (*vindexes.VSchema, error) {
-	//formal, err := vindexes.LoadFormal(filename)
+	// formal, err := vindexes.LoadFormal(filename)
 	formal, err := loadFormalForFuzzing(f)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func loadFormalForFuzzing(f *fuzz.ConsumeFuzzer) (*vschemapb.SrvVSchema, error) 
 	if err != nil {
 		return nil, err
 	}
-	err = json2.Unmarshal(data, formal)
+	err = json2.UnmarshalPB(data, formal)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -81,7 +81,7 @@ func getSandboxSrvVSchema() *vschemapb.SrvVSchema {
 	defer sandboxMu.Unlock()
 	for keyspace, sandbox := range ksToSandbox {
 		var vs vschemapb.Keyspace
-		if err := json2.Unmarshal([]byte(sandbox.VSchema), &vs); err != nil {
+		if err := json2.UnmarshalPB([]byte(sandbox.VSchema), &vs); err != nil {
 			panic(err)
 		}
 		result.Keyspaces[keyspace] = &vs

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1349,7 +1349,7 @@ func LoadFormal(filename string) (*vschemapb.SrvVSchema, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = json2.Unmarshal(data, formal)
+	err = json2.UnmarshalPB(data, formal)
 	if err != nil {
 		return nil, err
 	}
@@ -1367,7 +1367,7 @@ func LoadFormalKeyspace(filename string) (*vschemapb.Keyspace, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = json2.Unmarshal(data, formal)
+	err = json2.UnmarshalPB(data, formal)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -2735,7 +2735,7 @@ func TestVSchemaPBJSON(t *testing.T) {
 	}
 `
 	var got vschemapb.Keyspace
-	if err := json2.Unmarshal([]byte(in), &got); err != nil {
+	if err := json2.UnmarshalPB([]byte(in), &got); err != nil {
 		t.Error(err)
 	}
 	want := vschemapb.Keyspace{

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
@@ -77,7 +77,7 @@ func init() {
   }
 }`
 	var kspb vschemapb.Keyspace
-	if err := json2.Unmarshal([]byte(input), &kspb); err != nil {
+	if err := json2.UnmarshalPB([]byte(input), &kspb); err != nil {
 		panic(fmt.Errorf("Unmarshal failed: %v", err))
 	}
 	srvVSchema := &vschemapb.SrvVSchema{

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -202,7 +202,7 @@ func (te *Env) Close() {
 func (te *Env) SetVSchema(vs string) error {
 	ctx := context.Background()
 	var kspb vschemapb.Keyspace
-	if err := json2.Unmarshal([]byte(vs), &kspb); err != nil {
+	if err := json2.UnmarshalPB([]byte(vs), &kspb); err != nil {
 		return err
 	}
 	if err := te.TopoServ.SaveVSchema(ctx, te.KeyspaceName, &kspb); err != nil {

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -162,7 +162,7 @@ func (wr *Wrangler) MoveTables(ctx context.Context, workflow, sourceKeyspace, ta
 		}
 		wrap := fmt.Sprintf(`{"tables": %s}`, tableSpecs)
 		ks := &vschemapb.Keyspace{}
-		if err := json2.Unmarshal([]byte(wrap), ks); err != nil {
+		if err := json2.UnmarshalPB([]byte(wrap), ks); err != nil {
 			return err
 		}
 		for table, vtab := range ks.Tables {

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1743,7 +1743,7 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 	wg.Wait()
 
 	if !ts.keepRoutingRules {
-		//check if table is routable
+		// check if table is routable
 		if ts.MigrationType() == binlogdatapb.MigrationType_TABLES {
 			rules, err := topotools.GetRoutingRules(ctx, ts.TopoServer())
 			if err != nil {
@@ -1981,7 +1981,7 @@ func (ts *trafficSwitcher) addParticipatingTablesToKeyspace(ctx context.Context,
 	if strings.HasPrefix(tableSpecs, "{") { // user defined the vschema snippet, typically for a sharded target
 		wrap := fmt.Sprintf(`{"tables": %s}`, tableSpecs)
 		ks := &vschemapb.Keyspace{}
-		if err := json2.Unmarshal([]byte(wrap), ks); err != nil {
+		if err := json2.UnmarshalPB([]byte(wrap), ks); err != nil {
 			return err
 		}
 		for table, vtab := range ks.Tables {


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/pull/16096 we added `UnmarshalPB` for adding type safety while deserializing proto objects. That PR only updated the routing rules related code.

In this PR we update move uses of `Unmarshal` over, which deserialize protos.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16095
https://github.com/vitessio/vitess/pull/16096

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
