### PR TITLE
Remove unused parameters in reparent code and add CheckLockShard calls

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -202,7 +202,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 
 	// check that we still have the shard lock. If we don't then we can terminate at this point
 	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
-		return vterrors.Wrapf(err, "lost topology lock, aborting: %v", err)
+		return vterrors.Wrap(err, lostTopologyLockMsg)
 	}
 
 	// find the valid candidates for becoming the primary
@@ -255,8 +255,8 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	erp.logger.Infof("intermediate source is ideal candidate- %v", isIdeal)
 
 	// Check (again) we still have the topology lock.
-	if err = topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
-		return vterrors.Wrapf(err, "lost topology lock, aborting: %v", err)
+	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
+		return vterrors.Wrap(err, lostTopologyLockMsg)
 	}
 
 	// initialize the newPrimary with the intermediate source, override this value if it is not the ideal candidate
@@ -286,6 +286,10 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 				return err
 			}
 			newPrimary = betterCandidate
+		}
+
+		if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
+			return vterrors.Wrap(err, lostTopologyLockMsg)
 		}
 	}
 

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -157,8 +157,6 @@ func (pr *PlannedReparenter) getLockAction(opts PlannedReparentOptions) string {
 func (pr *PlannedReparenter) preflightChecks(
 	ctx context.Context,
 	ev *events.Reparent,
-	keyspace string,
-	shard string,
 	tabletMap map[string]*topo.TabletInfo,
 	opts *PlannedReparentOptions, // we take a pointer here to set NewPrimaryAlias
 ) (isNoop bool, err error) {
@@ -220,7 +218,6 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 	shard string,
 	currentPrimary *topo.TabletInfo,
 	primaryElect *topodatapb.Tablet,
-	tabletMap map[string]*topo.TabletInfo,
 	opts PlannedReparentOptions,
 ) error {
 	primaryElectAliasStr := topoproto.TabletAliasString(primaryElect.Alias)
@@ -260,7 +257,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 
 	// Verify we still have the topology lock before doing the demotion.
 	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
-		return vterrors.Wrap(err, "lost topology lock; aborting")
+		return vterrors.Wrap(err, lostTopologyLockMsg)
 	}
 
 	// Next up, demote the current primary and get its replication position.
@@ -375,7 +372,6 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 	shard string,
 	primaryElect *topodatapb.Tablet,
 	tabletMap map[string]*topo.TabletInfo,
-	opts PlannedReparentOptions,
 ) error {
 	primaryElectAliasStr := topoproto.TabletAliasString(primaryElect.Alias)
 
@@ -490,7 +486,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 
 	// Check that we still have the topology lock.
 	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
-		return vterrors.Wrap(err, "lost topology lock; aborting")
+		return vterrors.Wrap(err, lostTopologyLockMsg)
 	}
 	return nil
 }
@@ -533,10 +529,15 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	}
 
 	// Check invariants that PlannedReparentShard depends on.
-	if isNoop, err := pr.preflightChecks(ctx, ev, keyspace, shard, tabletMap, &opts); err != nil {
+	if isNoop, err := pr.preflightChecks(ctx, ev, tabletMap, &opts); err != nil {
 		return err
 	} else if isNoop {
 		return nil
+	}
+
+	// Before we run any RPCs that change the cluster configuration, we should ensure we still hold the topology lock.
+	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
+		return vterrors.Wrap(err, lostTopologyLockMsg)
 	}
 
 	currentPrimary := FindCurrentPrimary(tabletMap, pr.logger)
@@ -594,7 +595,7 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	case currentPrimary == nil && ev.ShardInfo.PrimaryTermStartTime != nil:
 		// Case (2): no clear current primary. Try to find a safe promotion
 		// candidate, and promote to it.
-		err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap, opts)
+		err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap)
 		// We need to call `PromoteReplica` when we reparent the tablets.
 		promoteReplicaRequired = true
 	case topoproto.TabletAliasEqual(currentPrimary.Alias, opts.NewPrimaryAlias):
@@ -604,7 +605,7 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	default:
 		// Case (4): desired primary and current primary differ. Do a graceful
 		// demotion-then-promotion.
-		err = pr.performGracefulPromotion(ctx, ev, keyspace, shard, currentPrimary, ev.NewPrimary, tabletMap, opts)
+		err = pr.performGracefulPromotion(ctx, ev, keyspace, shard, currentPrimary, ev.NewPrimary, opts)
 		// We need to call `PromoteReplica` when we reparent the tablets.
 		promoteReplicaRequired = true
 	}
@@ -614,7 +615,7 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	}
 
 	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
-		return vterrors.Wrap(err, "lost topology lock, aborting")
+		return vterrors.Wrap(err, lostTopologyLockMsg)
 	}
 
 	if err := pr.reparentTablets(ctx, ev, reparentJournalPos, promoteReplicaRequired, tabletMap, opts); err != nil {

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -1081,7 +1081,7 @@ func TestPlannedReparenter_preflightChecks(t *testing.T) {
 				require.NoError(t, err)
 				tt.opts.durability = durability
 			}
-			isNoop, err := pr.preflightChecks(ctx, tt.ev, tt.keyspace, tt.shard, tt.tabletMap, tt.opts)
+			isNoop, err := pr.preflightChecks(ctx, tt.ev, tt.tabletMap, tt.opts)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				assert.Equal(t, tt.expectedIsNoop, isNoop, "preflightChecks returned wrong isNoop signal")
@@ -1109,7 +1109,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 		shard          string
 		currentPrimary *topo.TabletInfo
 		primaryElect   *topodatapb.Tablet
-		tabletMap      map[string]*topo.TabletInfo
 		opts           PlannedReparentOptions
 
 		expectedEvent *events.Reparent
@@ -1171,7 +1170,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: false,
 		},
@@ -1204,7 +1202,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 		},
@@ -1240,7 +1237,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 		},
@@ -1279,7 +1275,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts: PlannedReparentOptions{
 				WaitReplicasTimeout: time.Millisecond * 10,
 			},
@@ -1318,7 +1313,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 		},
@@ -1362,7 +1356,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 		},
@@ -1418,7 +1411,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 		},
@@ -1477,7 +1469,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts: PlannedReparentOptions{
 				WaitReplicasTimeout: time.Millisecond * 10,
 			},
@@ -1535,7 +1526,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 		},
@@ -1594,7 +1584,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 			extraAssertions: func(t *testing.T, err error) {
@@ -1656,7 +1645,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			tabletMap: map[string]*topo.TabletInfo{},
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 			extraAssertions: func(t *testing.T, err error) {
@@ -1713,7 +1701,6 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 				tt.shard,
 				tt.currentPrimary,
 				tt.primaryElect,
-				tt.tabletMap,
 				tt.opts,
 			)
 
@@ -2395,9 +2382,7 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 				ctx = _ctx
 			}
 
-			durability, err := GetDurabilityPolicy("none")
-			require.NoError(t, err)
-			err = pr.performPotentialPromotion(ctx, tt.keyspace, tt.shard, tt.primaryElect, tt.tabletMap, PlannedReparentOptions{durability: durability})
+			err := pr.performPotentialPromotion(ctx, tt.keyspace, tt.shard, tt.primaryElect, tt.tabletMap)
 			if tt.shouldErr {
 				assert.Error(t, err)
 

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -49,6 +49,10 @@ var (
 	successResult          = "success"
 )
 
+const (
+	lostTopologyLockMsg = "lost topology lock, aborting"
+)
+
 // ElectNewPrimary finds a tablet that should become a primary after reparent.
 // The criteria for the new primary-elect are (preferably) to be in the same
 // cell as the current primary, and to be different from avoidPrimaryAlias. The


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR makes the 2 following changes - 
1. Removes unused parameters from a lot of function calls.
2. Adds `CheckShardLocked` calls to PRS and ERS code after a RPC has run to ensure we don't end up running any RPC without holding the shard lock.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
