### PR TITLE
Add `vtctldclient` container image

### DIFF
--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -85,7 +85,7 @@ jobs:
       fail-fast: true
       matrix:
         debian: [ bullseye, bookworm ]
-        component: [ vtadmin, vtorc, vtgate, vttablet, mysqlctld, mysqlctl, vtctl, vtctlclient, vtctld, logrotate, logtail, vtbackup, vtexplain ]
+        component: [ vtadmin, vtorc, vtgate, vttablet, mysqlctld, mysqlctl, vtctl, vtctlclient, vtctld, vtctldclient, logrotate, logtail, vtbackup, vtexplain ]
 
     steps:
       - name: Check out code

--- a/docker/binaries/vtctldclient/Dockerfile
+++ b/docker/binaries/vtctldclient/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2019 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=stable-slim
+
+FROM vitess/lite:${VT_BASE_VER} AS lite
+
+FROM debian:${DEBIAN_VER}
+
+RUN apt-get update && \
+   apt-get upgrade -qq && \
+   apt-get install jq curl -qq --no-install-recommends && \
+   apt-get autoremove && \
+   apt-get clean && \
+   rm -rf /var/lib/apt/lists/*
+
+COPY --from=lite /vt/bin/vtctldclient /usr/bin/
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess
+
+CMD ["/usr/bin/vtctldclient"]

--- a/docker/binaries/vtctldclient/Dockerfile
+++ b/docker/binaries/vtctldclient/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 The Vitess Authors.
+# Copyright 2024 The Vitess Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

Introduces the `vtctldclient` image.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

`vtctldclient` is a typed replacement of `vtctlclient` which has been deprecated since Vitess v18. A `vtctlclient` image has continued to be published however and a `vtctldclient` image is absent from the projects published images. This introduces `vtctldclient` to resolve this and so that `vtctlclient` can be removed at a later point.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #16288

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
    - Note: this adds a new image which likely needs a Docker Hub readme. It's unclear to me how to author that.

## Deployment Notes

This change should not impact the broader vitess code and is isolated to the container image and the docker build processes (adds a new image). A description of the image will need to be added (the [`vtctlclient`](https://hub.docker.com/r/vitess/vtctlclient) description is minimal but could be reused for this)
