### PR TITLE
Add release notes for the new connection drain (+ use dashes instead of underscore)

### DIFF
--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -8,7 +8,7 @@
     - [Deletion of deprecated metrics](#metric-deletion)
     - [VTTablet Flags](#vttablet-flags)
   - **[Traffic Mirroring](#traffic-mirroring)**
-  - **[New Connection Drain](#new-connection-drain)**
+  - **[New VTGate Shutdown Behavior](#new-vtgate-shutdown-behavior)**
 
 ## <a id="major-changes"/>Major Changes
 
@@ -51,12 +51,13 @@ $ vtctldclient --server :15999 MoveTables --target-keyspace customer --workflow 
 
 Mirror rules can be inspected with `GetMirrorRules`.
 
-### <a id="new-connection-drain"/>New Connection Drain
+### <a id="new-vtgate-shutdown-behavior"/>New VTGate Shutdown Behavior
 
-We are adding a new way to terminate VTGate in v21 by using a connection drain timeout rather than an activity drain timeout.
-The goal of this new drain is to disallow new connections when VTGate is shutting down, but keep allowing idle/actives
-connections to execute queries until they disconnect or until the `--onterm_timeout` is reached.
+We added a new option to affect the VTGate shutdown process in v21 by using a connection drain timeout rather than the older activity drain timeout.
+The goal of this new behavior, connection draining option, is to disallow new connections when VTGate is shutting down,
+but continue allowing existing connections to finish their work until they manually disconnect or until the `--onterm_timeout` timeout is reached,
+without getting a `Server shutdown in progress` error.
 
-This new connection drain can be enabled by setting the `--mysql-server-drain-onterm` VTGate flag to `true`.
+This new behavior can be enabled by specifying the new `--mysql-server-drain-onterm` flag to VTGate.
 
 See more information about this change by [reading its RFC](https://github.com/vitessio/vitess/issues/15971).

--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -7,8 +7,8 @@
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
     - [Deletion of deprecated metrics](#metric-deletion)
     - [VTTablet Flags](#vttablet-flags)
-  - **[Breaking changes](#breaking-changes)**
   - **[Traffic Mirroring](#traffic-mirroring)**
+  - **[New Connection Drain](#new-connection-drain)**
 
 ## <a id="major-changes"/>Major Changes
 
@@ -50,3 +50,13 @@ $ vtctldclient --server :15999 MoveTables --target-keyspace customer --workflow 
 ```
 
 Mirror rules can be inspected with `GetMirrorRules`.
+
+### <a id="new-connection-drain"/>New Connection Drain
+
+We are adding a new way to terminate VTGate in v21 by using a connection drain timeout rather than an activity drain timeout.
+The goal of this new drain is to disallow new connections when VTGate is shutting down, but keep allowing idle/actives
+connections to execute queries until they disconnect or until the `--onterm_timeout` is reached.
+
+This new connection drain can be enabled by setting the `--mysql_server_drain_onterm` VTGate flag to `true`.
+
+See more information about this change by [reading its RFC](https://github.com/vitessio/vitess/issues/15971).

--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -57,6 +57,6 @@ We are adding a new way to terminate VTGate in v21 by using a connection drain t
 The goal of this new drain is to disallow new connections when VTGate is shutting down, but keep allowing idle/actives
 connections to execute queries until they disconnect or until the `--onterm_timeout` is reached.
 
-This new connection drain can be enabled by setting the `--mysql_server_drain_onterm` VTGate flag to `true`.
+This new connection drain can be enabled by setting the `--mysql-server-drain-onterm` VTGate flag to `true`.
 
 See more information about this change by [reading its RFC](https://github.com/vitessio/vitess/issues/15971).

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -223,6 +223,7 @@ Flags:
       --mycnf_slow_log_path string                                       mysql slow query log path
       --mycnf_socket_file string                                         mysql socket file
       --mycnf_tmp_dir string                                             mysql tmp directory
+      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for connected clients to drain
       --mysql-server-keepalive-period duration                           TCP period between keep-alives
       --mysql-server-pool-conn-read-buffers                              If set, the server will pool incoming connection read buffers
       --mysql-shutdown-timeout duration                                  timeout to use when MySQL is being shut down. (default 5m0s)
@@ -231,7 +232,6 @@ Flags:
       --mysql_default_workload string                                    Default session workload (OLTP, OLAP, DBA) (default "OLTP")
       --mysql_port int                                                   mysql port (default 3306)
       --mysql_server_bind_address string                                 Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.
-      --mysql_server_drain_onterm                                        If set, the server waits for --onterm_timeout for connected clients to drain
       --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_port int                                            If set, also listen for MySQL binary protocol connections on this port. (default -1)
       --mysql_server_query_timeout duration                              mysql query timeout

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -223,7 +223,7 @@ Flags:
       --mycnf_slow_log_path string                                       mysql slow query log path
       --mycnf_socket_file string                                         mysql socket file
       --mycnf_tmp_dir string                                             mysql tmp directory
-      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for connected clients to drain
+      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for already connected clients to complete their in flight work
       --mysql-server-keepalive-period duration                           TCP period between keep-alives
       --mysql-server-pool-conn-read-buffers                              If set, the server will pool incoming connection read buffers
       --mysql-shutdown-timeout duration                                  timeout to use when MySQL is being shut down. (default 5m0s)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -119,7 +119,7 @@ Flags:
       --max_payload_size int                                             The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
       --message_stream_grace_period duration                             the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent. (default 30s)
       --min_number_serving_vttablets int                                 The minimum number of vttablets for each replicating tablet_type (e.g. replica, rdonly) that will be continue to be used even with replication lag above discovery_low_replication_lag, but still below discovery_high_replication_lag_minimum_serving. (default 2)
-      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for connected clients to drain
+      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for already connected clients to complete their in flight work
       --mysql-server-keepalive-period duration                           TCP period between keep-alives
       --mysql-server-pool-conn-read-buffers                              If set, the server will pool incoming connection read buffers
       --mysql_allow_clear_text_without_tls                               If set, the server will allow the use of a clear text password over non-SSL connections.

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -119,6 +119,7 @@ Flags:
       --max_payload_size int                                             The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
       --message_stream_grace_period duration                             the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent. (default 30s)
       --min_number_serving_vttablets int                                 The minimum number of vttablets for each replicating tablet_type (e.g. replica, rdonly) that will be continue to be used even with replication lag above discovery_low_replication_lag, but still below discovery_high_replication_lag_minimum_serving. (default 2)
+      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for connected clients to drain
       --mysql-server-keepalive-period duration                           TCP period between keep-alives
       --mysql-server-pool-conn-read-buffers                              If set, the server will pool incoming connection read buffers
       --mysql_allow_clear_text_without_tls                               If set, the server will allow the use of a clear text password over non-SSL connections.
@@ -141,7 +142,6 @@ Flags:
       --mysql_ldap_auth_config_string string                             JSON representation of LDAP server config.
       --mysql_ldap_auth_method string                                    client-side authentication method to use. Supported values: mysql_clear_password, dialog. (default "mysql_clear_password")
       --mysql_server_bind_address string                                 Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.
-      --mysql_server_drain_onterm                                        If set, the server waits for --onterm_timeout for connected clients to drain
       --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_port int                                            If set, also listen for MySQL binary protocol connections on this port. (default -1)
       --mysql_server_query_timeout duration                              mysql query timeout

--- a/go/test/endtoend/vtgate/connectiondrain/main_test.go
+++ b/go/test/endtoend/vtgate/connectiondrain/main_test.go
@@ -61,7 +61,7 @@ func setupCluster(t *testing.T) (*cluster.LocalProcessCluster, mysql.ConnParams)
 	require.NoError(t, err)
 
 	// Start vtgate
-	clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--mysql_server_drain_onterm", "--onterm_timeout", "30s")
+	clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--mysql-server-drain-onterm", "--onterm_timeout", "30s")
 	err = clusterInstance.StartVtgate()
 	require.NoError(t, err)
 

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -103,7 +103,7 @@ func registerPluginFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&mysqlKeepAlivePeriod, "mysql-server-keepalive-period", mysqlKeepAlivePeriod, "TCP period between keep-alives")
 	fs.DurationVar(&mysqlServerFlushDelay, "mysql_server_flush_delay", mysqlServerFlushDelay, "Delay after which buffered response will be flushed to the client.")
 	fs.StringVar(&mysqlDefaultWorkloadName, "mysql_default_workload", mysqlDefaultWorkloadName, "Default session workload (OLTP, OLAP, DBA)")
-	fs.BoolVar(&mysqlDrainOnTerm, "mysql-server-drain-onterm", mysqlDrainOnTerm, "If set, the server waits for --onterm_timeout for connected clients to drain")
+	fs.BoolVar(&mysqlDrainOnTerm, "mysql-server-drain-onterm", mysqlDrainOnTerm, "If set, the server waits for --onterm_timeout for already connected clients to complete their in flight work")
 }
 
 // vtgateHandler implements the Listener interface.

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -103,7 +103,7 @@ func registerPluginFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&mysqlKeepAlivePeriod, "mysql-server-keepalive-period", mysqlKeepAlivePeriod, "TCP period between keep-alives")
 	fs.DurationVar(&mysqlServerFlushDelay, "mysql_server_flush_delay", mysqlServerFlushDelay, "Delay after which buffered response will be flushed to the client.")
 	fs.StringVar(&mysqlDefaultWorkloadName, "mysql_default_workload", mysqlDefaultWorkloadName, "Default session workload (OLTP, OLAP, DBA)")
-	fs.BoolVar(&mysqlDrainOnTerm, "mysql_server_drain_onterm", mysqlDrainOnTerm, "If set, the server waits for --onterm_timeout for connected clients to drain")
+	fs.BoolVar(&mysqlDrainOnTerm, "mysql-server-drain-onterm", mysqlDrainOnTerm, "If set, the server waits for --onterm_timeout for connected clients to drain")
 }
 
 // vtgateHandler implements the Listener interface.


### PR DESCRIPTION
## Description

This PR adds the release notes for the changes implemented by https://github.com/vitessio/vitess/pull/16298.

It also changes the flag to use dashes instead of underscores.

## Related Issue(s)

- Related to https://github.com/vitessio/vitess/issues/15971
