### PR TITLE
Fix the install dependencies script in Docker

### DIFF
--- a/docker/utils/install_dependencies.sh
+++ b/docker/utils/install_dependencies.sh
@@ -66,7 +66,6 @@ BASE_PACKAGES=(
     zstd
 )
 
-percona-release enable-only tools
 apt-get update
 apt-get install -y --no-install-recommends "${BASE_PACKAGES[@]}"
 


### PR DESCRIPTION
## Description

After merging https://github.com/vitessio/vitess/pull/16329 we realized the docker build were failing due to an unknown command, this fixes it.