### PR TITLE
Support promotion rule override in `vttablet`

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -260,7 +260,7 @@ Flags:
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
       --pprof-http                                                       enable pprof http endpoints
-      --promotion-rule topodatapb.PromotionRule                          The override Promotion Rule for this tablet. Use 'must_not' with caution as it can lead to issues with reparenting. (default none)
+      --promotion-rule topodatapb.PromotionRule                          Sets the override Promotion Rule for this tablet. Possible values 'none', 'neutral', 'prefer', 'prefer_not' and 'must_not'. Use 'must_not' with caution as it can lead to issues with reparenting. (default none)
       --proto_topo vttest.TopoData                                       vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -260,6 +260,7 @@ Flags:
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
       --pprof-http                                                       enable pprof http endpoints
+      --promotion-rule topodatapb.PromotionRule                          The override Promotion Rule for this tablet. Use 'must_not' with caution as it can lead to issues with reparenting. (default none)
       --proto_topo vttest.TopoData                                       vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -256,6 +256,7 @@ Flags:
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
       --pprof-http                                                       enable pprof http endpoints
+      --promotion-rule topodatapb.PromotionRule                          The override Promotion Rule for this tablet. Use 'must_not' with caution as it can lead to issues with reparenting. (default none)
       --pt-osc-path string                                               override default pt-online-schema-change binary full path (default "/usr/bin/pt-online-schema-change")
       --publish_retry_interval duration                                  how long vttablet waits to retry publishing the tablet record (default 30s)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -256,7 +256,7 @@ Flags:
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
       --pprof-http                                                       enable pprof http endpoints
-      --promotion-rule topodatapb.PromotionRule                          The override Promotion Rule for this tablet. Use 'must_not' with caution as it can lead to issues with reparenting. (default none)
+      --promotion-rule topodatapb.PromotionRule                          Sets the override Promotion Rule for this tablet. Possible values 'none', 'neutral', 'prefer', 'prefer_not' and 'must_not'. Use 'must_not' with caution as it can lead to issues with reparenting. (default none)
       --pt-osc-path string                                               override default pt-online-schema-change binary full path (default "/usr/bin/pt-online-schema-change")
       --publish_retry_interval duration                                  how long vttablet waits to retry publishing the tablet record (default 30s)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)

--- a/go/vt/proto/topodata/topodata.pb.go
+++ b/go/vt/proto/topodata/topodata.pb.go
@@ -186,6 +186,71 @@ func (TabletType) EnumDescriptor() ([]byte, []int) {
 	return file_topodata_proto_rawDescGZIP(), []int{1}
 }
 
+// PromotionRule represents a Durability Policy override for an instance of vttablet.
+type PromotionRule int32
+
+const (
+	// NONE represents an undefined promotion rule.
+	PromotionRule_NONE PromotionRule = 0
+	// MUST represents a must promotion rule.
+	PromotionRule_MUST PromotionRule = 1
+	// NEUTRAL represents a neutral promotion rule.
+	PromotionRule_NEUTRAL PromotionRule = 2
+	// PREFER represents a prefer promotion rule.
+	PromotionRule_PREFER PromotionRule = 3
+	// PREFER_NOT represents a prefer_not promotion rule.
+	PromotionRule_PREFER_NOT PromotionRule = 4
+	// MUST_NOT represents a must_not promotion rule.
+	PromotionRule_MUST_NOT PromotionRule = 5
+)
+
+// Enum value maps for PromotionRule.
+var (
+	PromotionRule_name = map[int32]string{
+		0: "NONE",
+		1: "MUST",
+		2: "NEUTRAL",
+		3: "PREFER",
+		4: "PREFER_NOT",
+		5: "MUST_NOT",
+	}
+	PromotionRule_value = map[string]int32{
+		"NONE":       0,
+		"MUST":       1,
+		"NEUTRAL":    2,
+		"PREFER":     3,
+		"PREFER_NOT": 4,
+		"MUST_NOT":   5,
+	}
+)
+
+func (x PromotionRule) Enum() *PromotionRule {
+	p := new(PromotionRule)
+	*p = x
+	return p
+}
+
+func (x PromotionRule) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PromotionRule) Descriptor() protoreflect.EnumDescriptor {
+	return file_topodata_proto_enumTypes[2].Descriptor()
+}
+
+func (PromotionRule) Type() protoreflect.EnumType {
+	return &file_topodata_proto_enumTypes[2]
+}
+
+func (x PromotionRule) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PromotionRule.Descriptor instead.
+func (PromotionRule) EnumDescriptor() ([]byte, []int) {
+	return file_topodata_proto_rawDescGZIP(), []int{2}
+}
+
 type ShardReplicationError_Type int32
 
 const (
@@ -225,11 +290,11 @@ func (x ShardReplicationError_Type) String() string {
 }
 
 func (ShardReplicationError_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_topodata_proto_enumTypes[2].Descriptor()
+	return file_topodata_proto_enumTypes[3].Descriptor()
 }
 
 func (ShardReplicationError_Type) Type() protoreflect.EnumType {
-	return &file_topodata_proto_enumTypes[2]
+	return &file_topodata_proto_enumTypes[3]
 }
 
 func (x ShardReplicationError_Type) Number() protoreflect.EnumNumber {
@@ -405,6 +470,9 @@ type Tablet struct {
 	PrimaryTermStartTime *vttime.Time `protobuf:"bytes,14,opt,name=primary_term_start_time,json=primaryTermStartTime,proto3" json:"primary_term_start_time,omitempty"`
 	// default_conn_collation is the default connection collation used by this tablet.
 	DefaultConnCollation uint32 `protobuf:"varint,16,opt,name=default_conn_collation,json=defaultConnCollation,proto3" json:"default_conn_collation,omitempty"`
+	// promotion_rule specified the desired Promotion Rule for this tablet. If set,
+	// this overrides the Promotion Rule of the Durability Policy.
+	PromotionRule PromotionRule `protobuf:"varint,17,opt,name=promotion_rule,json=promotionRule,proto3,enum=topodata.PromotionRule" json:"promotion_rule,omitempty"`
 }
 
 func (x *Tablet) Reset() {
@@ -528,6 +596,13 @@ func (x *Tablet) GetDefaultConnCollation() uint32 {
 		return x.DefaultConnCollation
 	}
 	return 0
+}
+
+func (x *Tablet) GetPromotionRule() PromotionRule {
+	if x != nil {
+		return x.PromotionRule
+	}
+	return PromotionRule_NONE
 }
 
 // A Shard contains data about a subset of the data whithin a keyspace.
@@ -1839,7 +1914,7 @@ var file_topodata_proto_rawDesc = []byte{
 	0x54, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x41, 0x6c, 0x69, 0x61, 0x73, 0x12, 0x12, 0x0a, 0x04, 0x63,
 	0x65, 0x6c, 0x6c, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x63, 0x65, 0x6c, 0x6c, 0x12,
 	0x10, 0x0a, 0x03, 0x75, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x03, 0x75, 0x69,
-	0x64, 0x22, 0xba, 0x05, 0x0a, 0x06, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x12, 0x2b, 0x0a, 0x05,
+	0x64, 0x22, 0xfa, 0x05, 0x0a, 0x06, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x12, 0x2b, 0x0a, 0x05,
 	0x61, 0x6c, 0x69, 0x61, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x15, 0x2e, 0x74, 0x6f,
 	0x70, 0x6f, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x41, 0x6c, 0x69,
 	0x61, 0x73, 0x52, 0x05, 0x61, 0x6c, 0x69, 0x61, 0x73, 0x12, 0x1a, 0x0a, 0x08, 0x68, 0x6f, 0x73,
@@ -1874,7 +1949,11 @@ var file_topodata_proto_rawDesc = []byte{
 	0x65, 0x12, 0x34, 0x0a, 0x16, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x5f, 0x63, 0x6f, 0x6e,
 	0x6e, 0x5f, 0x63, 0x6f, 0x6c, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x10, 0x20, 0x01, 0x28,
 	0x0d, 0x52, 0x14, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x43, 0x6f, 0x6e, 0x6e, 0x43, 0x6f,
-	0x6c, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0x3a, 0x0a, 0x0c, 0x50, 0x6f, 0x72, 0x74, 0x4d,
+	0x6c, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x3e, 0x0a, 0x0e, 0x70, 0x72, 0x6f, 0x6d, 0x6f,
+	0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x72, 0x75, 0x6c, 0x65, 0x18, 0x11, 0x20, 0x01, 0x28, 0x0e, 0x32,
+	0x17, 0x2e, 0x74, 0x6f, 0x70, 0x6f, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x50, 0x72, 0x6f, 0x6d, 0x6f,
+	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x75, 0x6c, 0x65, 0x52, 0x0d, 0x70, 0x72, 0x6f, 0x6d, 0x6f, 0x74,
+	0x69, 0x6f, 0x6e, 0x52, 0x75, 0x6c, 0x65, 0x1a, 0x3a, 0x0a, 0x0c, 0x50, 0x6f, 0x72, 0x74, 0x4d,
 	0x61, 0x70, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01,
 	0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c,
 	0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a,
@@ -2100,11 +2179,17 @@ var file_topodata_proto_rawDesc = []byte{
 	0x58, 0x50, 0x45, 0x52, 0x49, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x4c, 0x10, 0x05, 0x12, 0x0a, 0x0a,
 	0x06, 0x42, 0x41, 0x43, 0x4b, 0x55, 0x50, 0x10, 0x06, 0x12, 0x0b, 0x0a, 0x07, 0x52, 0x45, 0x53,
 	0x54, 0x4f, 0x52, 0x45, 0x10, 0x07, 0x12, 0x0b, 0x0a, 0x07, 0x44, 0x52, 0x41, 0x49, 0x4e, 0x45,
-	0x44, 0x10, 0x08, 0x1a, 0x02, 0x10, 0x01, 0x42, 0x38, 0x0a, 0x0f, 0x69, 0x6f, 0x2e, 0x76, 0x69,
-	0x74, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x5a, 0x25, 0x76, 0x69, 0x74, 0x65,
-	0x73, 0x73, 0x2e, 0x69, 0x6f, 0x2f, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2f, 0x67, 0x6f, 0x2f,
-	0x76, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74, 0x6f, 0x70, 0x6f, 0x64, 0x61, 0x74,
-	0x61, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x44, 0x10, 0x08, 0x1a, 0x02, 0x10, 0x01, 0x2a, 0x5a, 0x0a, 0x0d, 0x50, 0x72, 0x6f, 0x6d, 0x6f,
+	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x75, 0x6c, 0x65, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45,
+	0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x4d, 0x55, 0x53, 0x54, 0x10, 0x01, 0x12, 0x0b, 0x0a, 0x07,
+	0x4e, 0x45, 0x55, 0x54, 0x52, 0x41, 0x4c, 0x10, 0x02, 0x12, 0x0a, 0x0a, 0x06, 0x50, 0x52, 0x45,
+	0x46, 0x45, 0x52, 0x10, 0x03, 0x12, 0x0e, 0x0a, 0x0a, 0x50, 0x52, 0x45, 0x46, 0x45, 0x52, 0x5f,
+	0x4e, 0x4f, 0x54, 0x10, 0x04, 0x12, 0x0c, 0x0a, 0x08, 0x4d, 0x55, 0x53, 0x54, 0x5f, 0x4e, 0x4f,
+	0x54, 0x10, 0x05, 0x42, 0x38, 0x0a, 0x0f, 0x69, 0x6f, 0x2e, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73,
+	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x5a, 0x25, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2e, 0x69,
+	0x6f, 0x2f, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2f, 0x67, 0x6f, 0x2f, 0x76, 0x74, 0x2f, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74, 0x6f, 0x70, 0x6f, 0x64, 0x61, 0x74, 0x61, 0x62, 0x06, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2119,82 +2204,84 @@ func file_topodata_proto_rawDescGZIP() []byte {
 	return file_topodata_proto_rawDescData
 }
 
-var file_topodata_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_topodata_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_topodata_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_topodata_proto_goTypes = []any{
 	(KeyspaceType)(0),                     // 0: topodata.KeyspaceType
 	(TabletType)(0),                       // 1: topodata.TabletType
-	(ShardReplicationError_Type)(0),       // 2: topodata.ShardReplicationError.Type
-	(*KeyRange)(nil),                      // 3: topodata.KeyRange
-	(*TabletAlias)(nil),                   // 4: topodata.TabletAlias
-	(*Tablet)(nil),                        // 5: topodata.Tablet
-	(*Shard)(nil),                         // 6: topodata.Shard
-	(*Keyspace)(nil),                      // 7: topodata.Keyspace
-	(*ShardReplication)(nil),              // 8: topodata.ShardReplication
-	(*ShardReplicationError)(nil),         // 9: topodata.ShardReplicationError
-	(*ShardReference)(nil),                // 10: topodata.ShardReference
-	(*ShardTabletControl)(nil),            // 11: topodata.ShardTabletControl
-	(*ThrottledAppRule)(nil),              // 12: topodata.ThrottledAppRule
-	(*ThrottlerConfig)(nil),               // 13: topodata.ThrottlerConfig
-	(*SrvKeyspace)(nil),                   // 14: topodata.SrvKeyspace
-	(*CellInfo)(nil),                      // 15: topodata.CellInfo
-	(*CellsAlias)(nil),                    // 16: topodata.CellsAlias
-	(*TopoConfig)(nil),                    // 17: topodata.TopoConfig
-	(*ExternalVitessCluster)(nil),         // 18: topodata.ExternalVitessCluster
-	(*ExternalClusters)(nil),              // 19: topodata.ExternalClusters
-	nil,                                   // 20: topodata.Tablet.PortMapEntry
-	nil,                                   // 21: topodata.Tablet.TagsEntry
-	(*Shard_SourceShard)(nil),             // 22: topodata.Shard.SourceShard
-	(*Shard_TabletControl)(nil),           // 23: topodata.Shard.TabletControl
-	(*ShardReplication_Node)(nil),         // 24: topodata.ShardReplication.Node
-	nil,                                   // 25: topodata.ThrottlerConfig.ThrottledAppsEntry
-	(*ThrottlerConfig_MetricNames)(nil),   // 26: topodata.ThrottlerConfig.MetricNames
-	nil,                                   // 27: topodata.ThrottlerConfig.AppCheckedMetricsEntry
-	nil,                                   // 28: topodata.ThrottlerConfig.MetricThresholdsEntry
-	(*SrvKeyspace_KeyspacePartition)(nil), // 29: topodata.SrvKeyspace.KeyspacePartition
-	(*vttime.Time)(nil),                   // 30: vttime.Time
+	(PromotionRule)(0),                    // 2: topodata.PromotionRule
+	(ShardReplicationError_Type)(0),       // 3: topodata.ShardReplicationError.Type
+	(*KeyRange)(nil),                      // 4: topodata.KeyRange
+	(*TabletAlias)(nil),                   // 5: topodata.TabletAlias
+	(*Tablet)(nil),                        // 6: topodata.Tablet
+	(*Shard)(nil),                         // 7: topodata.Shard
+	(*Keyspace)(nil),                      // 8: topodata.Keyspace
+	(*ShardReplication)(nil),              // 9: topodata.ShardReplication
+	(*ShardReplicationError)(nil),         // 10: topodata.ShardReplicationError
+	(*ShardReference)(nil),                // 11: topodata.ShardReference
+	(*ShardTabletControl)(nil),            // 12: topodata.ShardTabletControl
+	(*ThrottledAppRule)(nil),              // 13: topodata.ThrottledAppRule
+	(*ThrottlerConfig)(nil),               // 14: topodata.ThrottlerConfig
+	(*SrvKeyspace)(nil),                   // 15: topodata.SrvKeyspace
+	(*CellInfo)(nil),                      // 16: topodata.CellInfo
+	(*CellsAlias)(nil),                    // 17: topodata.CellsAlias
+	(*TopoConfig)(nil),                    // 18: topodata.TopoConfig
+	(*ExternalVitessCluster)(nil),         // 19: topodata.ExternalVitessCluster
+	(*ExternalClusters)(nil),              // 20: topodata.ExternalClusters
+	nil,                                   // 21: topodata.Tablet.PortMapEntry
+	nil,                                   // 22: topodata.Tablet.TagsEntry
+	(*Shard_SourceShard)(nil),             // 23: topodata.Shard.SourceShard
+	(*Shard_TabletControl)(nil),           // 24: topodata.Shard.TabletControl
+	(*ShardReplication_Node)(nil),         // 25: topodata.ShardReplication.Node
+	nil,                                   // 26: topodata.ThrottlerConfig.ThrottledAppsEntry
+	(*ThrottlerConfig_MetricNames)(nil),   // 27: topodata.ThrottlerConfig.MetricNames
+	nil,                                   // 28: topodata.ThrottlerConfig.AppCheckedMetricsEntry
+	nil,                                   // 29: topodata.ThrottlerConfig.MetricThresholdsEntry
+	(*SrvKeyspace_KeyspacePartition)(nil), // 30: topodata.SrvKeyspace.KeyspacePartition
+	(*vttime.Time)(nil),                   // 31: vttime.Time
 }
 var file_topodata_proto_depIdxs = []int32{
-	4,  // 0: topodata.Tablet.alias:type_name -> topodata.TabletAlias
-	20, // 1: topodata.Tablet.port_map:type_name -> topodata.Tablet.PortMapEntry
-	3,  // 2: topodata.Tablet.key_range:type_name -> topodata.KeyRange
+	5,  // 0: topodata.Tablet.alias:type_name -> topodata.TabletAlias
+	21, // 1: topodata.Tablet.port_map:type_name -> topodata.Tablet.PortMapEntry
+	4,  // 2: topodata.Tablet.key_range:type_name -> topodata.KeyRange
 	1,  // 3: topodata.Tablet.type:type_name -> topodata.TabletType
-	21, // 4: topodata.Tablet.tags:type_name -> topodata.Tablet.TagsEntry
-	30, // 5: topodata.Tablet.primary_term_start_time:type_name -> vttime.Time
-	4,  // 6: topodata.Shard.primary_alias:type_name -> topodata.TabletAlias
-	30, // 7: topodata.Shard.primary_term_start_time:type_name -> vttime.Time
-	3,  // 8: topodata.Shard.key_range:type_name -> topodata.KeyRange
-	22, // 9: topodata.Shard.source_shards:type_name -> topodata.Shard.SourceShard
-	23, // 10: topodata.Shard.tablet_controls:type_name -> topodata.Shard.TabletControl
-	0,  // 11: topodata.Keyspace.keyspace_type:type_name -> topodata.KeyspaceType
-	30, // 12: topodata.Keyspace.snapshot_time:type_name -> vttime.Time
-	13, // 13: topodata.Keyspace.throttler_config:type_name -> topodata.ThrottlerConfig
-	24, // 14: topodata.ShardReplication.nodes:type_name -> topodata.ShardReplication.Node
-	2,  // 15: topodata.ShardReplicationError.type:type_name -> topodata.ShardReplicationError.Type
-	4,  // 16: topodata.ShardReplicationError.tablet_alias:type_name -> topodata.TabletAlias
-	3,  // 17: topodata.ShardReference.key_range:type_name -> topodata.KeyRange
-	3,  // 18: topodata.ShardTabletControl.key_range:type_name -> topodata.KeyRange
-	30, // 19: topodata.ThrottledAppRule.expires_at:type_name -> vttime.Time
-	25, // 20: topodata.ThrottlerConfig.throttled_apps:type_name -> topodata.ThrottlerConfig.ThrottledAppsEntry
-	27, // 21: topodata.ThrottlerConfig.app_checked_metrics:type_name -> topodata.ThrottlerConfig.AppCheckedMetricsEntry
-	28, // 22: topodata.ThrottlerConfig.metric_thresholds:type_name -> topodata.ThrottlerConfig.MetricThresholdsEntry
-	29, // 23: topodata.SrvKeyspace.partitions:type_name -> topodata.SrvKeyspace.KeyspacePartition
-	13, // 24: topodata.SrvKeyspace.throttler_config:type_name -> topodata.ThrottlerConfig
-	17, // 25: topodata.ExternalVitessCluster.topo_config:type_name -> topodata.TopoConfig
-	18, // 26: topodata.ExternalClusters.vitess_cluster:type_name -> topodata.ExternalVitessCluster
-	3,  // 27: topodata.Shard.SourceShard.key_range:type_name -> topodata.KeyRange
-	1,  // 28: topodata.Shard.TabletControl.tablet_type:type_name -> topodata.TabletType
-	4,  // 29: topodata.ShardReplication.Node.tablet_alias:type_name -> topodata.TabletAlias
-	12, // 30: topodata.ThrottlerConfig.ThrottledAppsEntry.value:type_name -> topodata.ThrottledAppRule
-	26, // 31: topodata.ThrottlerConfig.AppCheckedMetricsEntry.value:type_name -> topodata.ThrottlerConfig.MetricNames
-	1,  // 32: topodata.SrvKeyspace.KeyspacePartition.served_type:type_name -> topodata.TabletType
-	10, // 33: topodata.SrvKeyspace.KeyspacePartition.shard_references:type_name -> topodata.ShardReference
-	11, // 34: topodata.SrvKeyspace.KeyspacePartition.shard_tablet_controls:type_name -> topodata.ShardTabletControl
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	22, // 4: topodata.Tablet.tags:type_name -> topodata.Tablet.TagsEntry
+	31, // 5: topodata.Tablet.primary_term_start_time:type_name -> vttime.Time
+	2,  // 6: topodata.Tablet.promotion_rule:type_name -> topodata.PromotionRule
+	5,  // 7: topodata.Shard.primary_alias:type_name -> topodata.TabletAlias
+	31, // 8: topodata.Shard.primary_term_start_time:type_name -> vttime.Time
+	4,  // 9: topodata.Shard.key_range:type_name -> topodata.KeyRange
+	23, // 10: topodata.Shard.source_shards:type_name -> topodata.Shard.SourceShard
+	24, // 11: topodata.Shard.tablet_controls:type_name -> topodata.Shard.TabletControl
+	0,  // 12: topodata.Keyspace.keyspace_type:type_name -> topodata.KeyspaceType
+	31, // 13: topodata.Keyspace.snapshot_time:type_name -> vttime.Time
+	14, // 14: topodata.Keyspace.throttler_config:type_name -> topodata.ThrottlerConfig
+	25, // 15: topodata.ShardReplication.nodes:type_name -> topodata.ShardReplication.Node
+	3,  // 16: topodata.ShardReplicationError.type:type_name -> topodata.ShardReplicationError.Type
+	5,  // 17: topodata.ShardReplicationError.tablet_alias:type_name -> topodata.TabletAlias
+	4,  // 18: topodata.ShardReference.key_range:type_name -> topodata.KeyRange
+	4,  // 19: topodata.ShardTabletControl.key_range:type_name -> topodata.KeyRange
+	31, // 20: topodata.ThrottledAppRule.expires_at:type_name -> vttime.Time
+	26, // 21: topodata.ThrottlerConfig.throttled_apps:type_name -> topodata.ThrottlerConfig.ThrottledAppsEntry
+	28, // 22: topodata.ThrottlerConfig.app_checked_metrics:type_name -> topodata.ThrottlerConfig.AppCheckedMetricsEntry
+	29, // 23: topodata.ThrottlerConfig.metric_thresholds:type_name -> topodata.ThrottlerConfig.MetricThresholdsEntry
+	30, // 24: topodata.SrvKeyspace.partitions:type_name -> topodata.SrvKeyspace.KeyspacePartition
+	14, // 25: topodata.SrvKeyspace.throttler_config:type_name -> topodata.ThrottlerConfig
+	18, // 26: topodata.ExternalVitessCluster.topo_config:type_name -> topodata.TopoConfig
+	19, // 27: topodata.ExternalClusters.vitess_cluster:type_name -> topodata.ExternalVitessCluster
+	4,  // 28: topodata.Shard.SourceShard.key_range:type_name -> topodata.KeyRange
+	1,  // 29: topodata.Shard.TabletControl.tablet_type:type_name -> topodata.TabletType
+	5,  // 30: topodata.ShardReplication.Node.tablet_alias:type_name -> topodata.TabletAlias
+	13, // 31: topodata.ThrottlerConfig.ThrottledAppsEntry.value:type_name -> topodata.ThrottledAppRule
+	27, // 32: topodata.ThrottlerConfig.AppCheckedMetricsEntry.value:type_name -> topodata.ThrottlerConfig.MetricNames
+	1,  // 33: topodata.SrvKeyspace.KeyspacePartition.served_type:type_name -> topodata.TabletType
+	11, // 34: topodata.SrvKeyspace.KeyspacePartition.shard_references:type_name -> topodata.ShardReference
+	12, // 35: topodata.SrvKeyspace.KeyspacePartition.shard_tablet_controls:type_name -> topodata.ShardTabletControl
+	36, // [36:36] is the sub-list for method output_type
+	36, // [36:36] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_topodata_proto_init() }
@@ -2473,7 +2560,7 @@ func file_topodata_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_topodata_proto_rawDesc,
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/go/vt/proto/topodata/topodata_vtproto.pb.go
+++ b/go/vt/proto/topodata/topodata_vtproto.pb.go
@@ -83,6 +83,7 @@ func (m *Tablet) CloneVT() *Tablet {
 		MysqlPort:            m.MysqlPort,
 		PrimaryTermStartTime: m.PrimaryTermStartTime.CloneVT(),
 		DefaultConnCollation: m.DefaultConnCollation,
+		PromotionRule:        m.PromotionRule,
 	}
 	if rhs := m.PortMap; rhs != nil {
 		tmpContainer := make(map[string]int32, len(rhs))
@@ -684,6 +685,13 @@ func (m *Tablet) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.PromotionRule != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.PromotionRule))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x88
 	}
 	if m.DefaultConnCollation != 0 {
 		i = encodeVarint(dAtA, i, uint64(m.DefaultConnCollation))
@@ -2058,6 +2066,9 @@ func (m *Tablet) SizeVT() (n int) {
 	if m.DefaultConnCollation != 0 {
 		n += 2 + sov(uint64(m.DefaultConnCollation))
 	}
+	if m.PromotionRule != 0 {
+		n += 2 + sov(uint64(m.PromotionRule))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3322,6 +3333,25 @@ func (m *Tablet) UnmarshalVT(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.DefaultConnCollation |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 17:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PromotionRule", wireType)
+			}
+			m.PromotionRule = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.PromotionRule |= PromotionRule(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/go/vt/topo/topoproto/flag.go
+++ b/go/vt/topo/topoproto/flag.go
@@ -17,6 +17,7 @@ limitations under the License.
 package topoproto
 
 import (
+	"fmt"
 	"strings"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -59,3 +60,25 @@ func (ttf *TabletTypeFlag) Set(v string) error {
 
 // Type is part of the pflag.Value interface.
 func (*TabletTypeFlag) Type() string { return "topodatapb.TabletType" }
+
+// PromotionRuleFlag implements the pflag.Value interface, for parsing a command-line value into a PromotionRule.
+type PromotionRuleFlag topodatapb.PromotionRule
+
+// String is part of the pflag.Value interfaces.
+func (ttf *PromotionRuleFlag) String() string {
+	promotionRule := topodatapb.PromotionRule(*ttf)
+	return strings.ToLower(promotionRule.String())
+}
+
+// Set is part of the pflag.Value interfaces.
+func (ttf *PromotionRuleFlag) Set(v string) error {
+	t, err := ParsePromotionRule(v)
+	if t == topodatapb.PromotionRule_MUST {
+		return fmt.Errorf("promotion rule %v not supported yet", t)
+	}
+	*ttf = PromotionRuleFlag(t)
+	return err
+}
+
+// Type is part of the pflag.Value interface.
+func (*PromotionRuleFlag) Type() string { return "topodatapb.PromotionRule" }

--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -295,3 +295,12 @@ func IsServingType(tabletType topodatapb.TabletType) bool {
 		return false
 	}
 }
+
+// ParsePromotionRule parses the tablet promotion rule.
+func ParsePromotionRule(param string) (topodatapb.PromotionRule, error) {
+	value, ok := topodatapb.PromotionRule_value[strings.ToUpper(param)]
+	if !ok {
+		return topodatapb.PromotionRule_NONE, fmt.Errorf("unknown PromotionRule %v", param)
+	}
+	return topodatapb.PromotionRule(value), nil
+}

--- a/go/vt/topo/topoproto/tablet_test.go
+++ b/go/vt/topo/topoproto/tablet_test.go
@@ -129,3 +129,36 @@ func TestIsTabletsInList(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePromotionRule(t *testing.T) {
+	testcases := []struct {
+		name         string
+		rule         string
+		expectedRule topodatapb.PromotionRule
+		errContains  string
+	}{
+		{
+			name:         "success",
+			rule:         "prefer_not",
+			expectedRule: topodatapb.PromotionRule_PREFER_NOT,
+		},
+		{
+			name:         "invalid",
+			rule:         "this_should_fail",
+			expectedRule: topodatapb.PromotionRule_NONE,
+			errContains:  "unknown PromotionRule",
+		},
+	}
+
+	for _, testcase := range testcases {
+		testcase := testcase
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+			rule, err := ParsePromotionRule(testcase.rule)
+			if testcase.errContains != "" {
+				assert.ErrorContains(t, err, testcase.errContains)
+			}
+			assert.Equal(t, testcase.expectedRule, rule)
+		})
+	}
+}

--- a/go/vt/vtctl/reparentutil/durability.go
+++ b/go/vt/vtctl/reparentutil/durability.go
@@ -108,6 +108,14 @@ func PromotionRule(durability Durabler, tablet *topodatapb.Tablet) promotionrule
 	if tablet == nil || tablet.Alias == nil {
 		return promotionrule.MustNot
 	}
+	// Support per-tablet override.
+	if tablet.PromotionRule != topodatapb.PromotionRule_NONE {
+		promotionRule, err := promotionrule.ParseFromProto(tablet.PromotionRule)
+		if err != nil {
+			log.Errorf("failed to parse tablet promotion rule: %v", err)
+		}
+		return promotionRule
+	}
 	return durability.PromotionRule(tablet)
 }
 

--- a/go/vt/vtctl/reparentutil/durability_test.go
+++ b/go/vt/vtctl/reparentutil/durability_test.go
@@ -331,3 +331,27 @@ func TestDurabilityTest(t *testing.T) {
 		})
 	}
 }
+
+func TestPromotionRule(t *testing.T) {
+	cellName := "zone3"
+	durabler := &durabilityNone{}
+
+	// test --promotion-rule override
+	assert.Equal(t, promotionrule.MustNot, PromotionRule(durabler, &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cellName,
+			Uid:  4,
+		},
+		Type:          topodatapb.TabletType_REPLICA,
+		PromotionRule: topodatapb.PromotionRule_MUST_NOT,
+	}))
+
+	// default
+	assert.Equal(t, promotionrule.Neutral, PromotionRule(durabler, &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cellName,
+			Uid:  5,
+		},
+		Type: topodatapb.TabletType_REPLICA,
+	}))
+}

--- a/go/vt/vtctl/reparentutil/promotionrule/promotion_rule.go
+++ b/go/vt/vtctl/reparentutil/promotionrule/promotion_rule.go
@@ -17,7 +17,10 @@
 package promotionrule
 
 import (
+	"errors"
 	"fmt"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 // CandidatePromotionRule describe the promotion preference/rule for an instance.
@@ -30,6 +33,8 @@ const (
 	PreferNot CandidatePromotionRule = "prefer_not"
 	MustNot   CandidatePromotionRule = "must_not"
 )
+
+var ErrUnsupportedPromotionRule = errors.New("unsupported promotion rule")
 
 var promotionRuleOrderMap = map[CandidatePromotionRule]int{
 	Must:      0,
@@ -63,5 +68,23 @@ func Parse(ruleName string) (CandidatePromotionRule, error) {
 		return CandidatePromotionRule(""), fmt.Errorf("CandidatePromotionRule: %v not supported yet", ruleName)
 	default:
 		return CandidatePromotionRule(""), fmt.Errorf("Invalid CandidatePromotionRule: %v", ruleName)
+	}
+}
+
+// ParseFromProto returns a *CandidatePromotionRule from a topodatapb.PromotionRule.
+func ParseFromProto(promotionRule topodatapb.PromotionRule) (CandidatePromotionRule, error) {
+	switch promotionRule {
+	case topodatapb.PromotionRule_NEUTRAL, topodatapb.PromotionRule_NONE:
+		return Neutral, nil
+	case topodatapb.PromotionRule_MUST:
+		return Must, fmt.Errorf("ParseFromProto: %v not supported yet", promotionRule)
+	case topodatapb.PromotionRule_PREFER:
+		return Prefer, nil
+	case topodatapb.PromotionRule_PREFER_NOT:
+		return PreferNot, nil
+	case topodatapb.PromotionRule_MUST_NOT:
+		return MustNot, nil
+	default:
+		return Neutral, ErrUnsupportedPromotionRule
 	}
 }

--- a/go/vt/vtctl/reparentutil/promotionrule/promotion_rule_test.go
+++ b/go/vt/vtctl/reparentutil/promotionrule/promotion_rule_test.go
@@ -1,0 +1,61 @@
+package promotionrule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestPromotionRuleParseFromProto(t *testing.T) {
+	testcases := []struct {
+		in          topodatapb.PromotionRule
+		out         CandidatePromotionRule
+		errContains string
+	}{
+		{
+			in:  topodatapb.PromotionRule_NONE,
+			out: Neutral,
+		},
+		{
+
+			in:  topodatapb.PromotionRule_NEUTRAL,
+			out: Neutral,
+		},
+		{
+			in:          topodatapb.PromotionRule_MUST,
+			out:         Must,
+			errContains: "ParseFromProto: MUST not supported yet",
+		},
+		{
+			in:  topodatapb.PromotionRule_PREFER,
+			out: Prefer,
+		},
+		{
+			in:  topodatapb.PromotionRule_PREFER_NOT,
+			out: PreferNot,
+		},
+		{
+			in:  topodatapb.PromotionRule_MUST_NOT,
+			out: MustNot,
+		},
+		{
+			in:          999,
+			out:         Neutral,
+			errContains: "unsupported promotion rule",
+		},
+	}
+
+	for _, testcase := range testcases {
+		testcase := testcase
+		t.Run(testcase.in.String(), func(t *testing.T) {
+			t.Parallel()
+			rule, err := ParseFromProto(testcase.in)
+			if testcase.errContains != "" {
+				assert.ErrorContains(t, err, testcase.errContains)
+			}
+			assert.Equal(t, testcase.out, rule)
+		})
+	}
+}

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -106,7 +106,7 @@ func registerInitFlags(fs *pflag.FlagSet) {
 	fs.Var(&initTags, "init_tags", "(init parameter) comma separated list of key:value pairs used to tag the tablet")
 	fs.DurationVar(&initTimeout, "init_timeout", initTimeout, "(init parameter) timeout to use for the init phase.")
 	fs.DurationVar(&mysqlShutdownTimeout, "mysql-shutdown-timeout", mysqlShutdownTimeout, "timeout to use when MySQL is being shut down.")
-	fs.Var((*topoproto.PromotionRuleFlag)(&promotionRule), "promotion-rule", "The override Promotion Rule for this tablet. Use 'must_not' with caution as it can lead to issues with reparenting.")
+	fs.Var((*topoproto.PromotionRuleFlag)(&promotionRule), "promotion-rule", "Sets the override Promotion Rule for this tablet. Possible values 'none', 'neutral', 'prefer', 'prefer_not' and 'must_not'.  Use 'must_not' with caution as it can lead to issues with reparenting.")
 }
 
 var (

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -106,7 +106,7 @@ func registerInitFlags(fs *pflag.FlagSet) {
 	fs.Var(&initTags, "init_tags", "(init parameter) comma separated list of key:value pairs used to tag the tablet")
 	fs.DurationVar(&initTimeout, "init_timeout", initTimeout, "(init parameter) timeout to use for the init phase.")
 	fs.DurationVar(&mysqlShutdownTimeout, "mysql-shutdown-timeout", mysqlShutdownTimeout, "timeout to use when MySQL is being shut down.")
-	fs.Var((*topoproto.PromotionRuleFlag)(&promotionRule), "promotion-rule", "Sets the override Promotion Rule for this tablet. Possible values 'none', 'neutral', 'prefer', 'prefer_not' and 'must_not'.  Use 'must_not' with caution as it can lead to issues with reparenting.")
+	fs.Var((*topoproto.PromotionRuleFlag)(&promotionRule), "promotion-rule", "Sets the override Promotion Rule for this tablet. Possible values 'none', 'neutral', 'prefer', 'prefer_not' and 'must_not'. Use 'must_not' with caution as it can lead to issues with reparenting.")
 }
 
 var (

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -90,6 +90,7 @@ var (
 	initDbNameOverride string
 	skipBuildInfoTags  = "/.*/"
 	initTags           flagutil.StringMapValue
+	promotionRule      topodatapb.PromotionRule
 
 	initTimeout          = 1 * time.Minute
 	mysqlShutdownTimeout = mysqlctl.DefaultShutdownTimeout
@@ -105,6 +106,7 @@ func registerInitFlags(fs *pflag.FlagSet) {
 	fs.Var(&initTags, "init_tags", "(init parameter) comma separated list of key:value pairs used to tag the tablet")
 	fs.DurationVar(&initTimeout, "init_timeout", initTimeout, "(init parameter) timeout to use for the init phase.")
 	fs.DurationVar(&mysqlShutdownTimeout, "mysql-shutdown-timeout", mysqlShutdownTimeout, "timeout to use when MySQL is being shut down.")
+	fs.Var((*topoproto.PromotionRuleFlag)(&promotionRule), "promotion-rule", "The override Promotion Rule for this tablet. Use 'must_not' with caution as it can lead to issues with reparenting.")
 }
 
 var (
@@ -273,6 +275,7 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32, d
 		DbNameOverride:       initDbNameOverride,
 		Tags:                 mergeTags(buildTags, initTags),
 		DefaultConnCollation: uint32(charset),
+		PromotionRule:        promotionRule,
 	}, nil
 }
 

--- a/proto/topodata.proto
+++ b/proto/topodata.proto
@@ -102,6 +102,27 @@ enum TabletType {
   DRAINED = 8;
 }
 
+// PromotionRule represents a Durability Policy override for an instance of vttablet.
+enum PromotionRule {
+  // NONE represents an undefined promotion rule.
+  NONE = 0;
+
+  // MUST represents a must promotion rule.
+  MUST = 1;
+
+  // NEUTRAL represents a neutral promotion rule.
+  NEUTRAL = 2;
+
+  // PREFER represents a prefer promotion rule.
+  PREFER = 3;
+
+  // PREFER_NOT represents a prefer_not promotion rule.
+  PREFER_NOT = 4;
+
+  // MUST_NOT represents a must_not promotion rule.
+  MUST_NOT = 5;
+}
+
 // Tablet represents information about a running instance of vttablet.
 message Tablet {
   // alias is the unique name of the tablet.
@@ -159,6 +180,10 @@ message Tablet {
 
   // default_conn_collation is the default connection collation used by this tablet.
   uint32 default_conn_collation = 16;
+
+  // promotion_rule specified the desired Promotion Rule for this tablet. If set,
+  // this overrides the Promotion Rule of the Durability Policy.
+  PromotionRule promotion_rule = 17;
 
   // OBSOLETE: ip and tablet health information
   // string ip = 3;

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -15726,6 +15726,16 @@ export namespace topodata {
         DRAINED = 8
     }
 
+    /** PromotionRule enum. */
+    enum PromotionRule {
+        NONE = 0,
+        MUST = 1,
+        NEUTRAL = 2,
+        PREFER = 3,
+        PREFER_NOT = 4,
+        MUST_NOT = 5
+    }
+
     /** Properties of a Tablet. */
     interface ITablet {
 
@@ -15767,6 +15777,9 @@ export namespace topodata {
 
         /** Tablet default_conn_collation */
         default_conn_collation?: (number|null);
+
+        /** Tablet promotion_rule */
+        promotion_rule?: (topodata.PromotionRule|null);
     }
 
     /** Represents a Tablet. */
@@ -15816,6 +15829,9 @@ export namespace topodata {
 
         /** Tablet default_conn_collation. */
         public default_conn_collation: number;
+
+        /** Tablet promotion_rule. */
+        public promotion_rule: topodata.PromotionRule;
 
         /**
          * Creates a new Tablet instance using the specified properties.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR implements https://github.com/vitessio/vitess/issues/16377 by adding a `--promotion-rule topodatapb.PromotionRule` flag to `vttablet` _(and indirectly `vtcombo`)_ to express an override to the promotion rule of a single tablet

>       --promotion-rule topodatapb.PromotionRule                          Sets the override Promotion Rule for this tablet. Possible values 'none', 'neutral', 'prefer', 'prefer_not' and 'must_not'. Use 'must_not' with caution as it can lead to issues with reparenting. (default none)

This is an "advanced" feature that comes with some risk if promotion rules like `must_not` are deployed too widely; this risk falls "on the user" and a no-override deployment is recommended _(the Durability Policy calls the shots for tablets consistently)_

In a subsequent release I would like to phase-out [the `promotionrule.CandidatePromotionRule` type](https://github.com/vitessio/vitess/blob/main/go/vt/vtctl/reparentutil/promotionrule/promotion_rule.go#L23-L32) in favour of the new `topodatapb.PromotionRule` type _(added in this PR)_. I believe waiting 1 release will ensure proto-level downgrade/upgrade compatibility

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16377

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
