### PR TITLE
go/mysql: use clear builtin for zerofill

### DIFF
--- a/go/mysql/encoding.go
+++ b/go/mysql/encoding.go
@@ -132,15 +132,8 @@ func writeLenEncString(data []byte, pos int, value string) int {
 }
 
 func writeZeroes(data []byte, pos int, len int) int {
-	// XXX: This implementation is optimized to leverage
-	// the go compiler's memclr pattern, see: https://github.com/golang/go/issues/5373
 	end := pos + len
-	data = data[pos:end]
-
-	for i := range data {
-		data[i] = 0
-	}
-
+	clear(data[pos:end])
 	return end
 }
 


### PR DESCRIPTION
This is implemented as the same performance optimization, but is a more clear intention.

Iteration from https://github.com/vitessio/vitess/pull/16341

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
