### PR TITLE
go/vt/callerid: speedup callerid context access

### DIFF
--- a/go/vt/callerid/callerid_test.go
+++ b/go/vt/callerid/callerid_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package callerid_test
+
+import (
+	"context"
+	"testing"
+
+	"vitess.io/vitess/go/vt/callerid"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallerIDContext(t *testing.T) {
+	ef := callerid.NewEffectiveCallerID("principal", "component", "subComponent")
+	im := callerid.NewImmediateCallerID("username")
+	ctx := callerid.NewContext(context.Background(), ef, im)
+
+	assert.Equal(t, ef, callerid.EffectiveCallerIDFromContext(ctx))
+	assert.Equal(t, im, callerid.ImmediateCallerIDFromContext(ctx))
+
+	assert.Nil(t, callerid.EffectiveCallerIDFromContext(context.Background()))
+	assert.Nil(t, callerid.ImmediateCallerIDFromContext(context.Background()))
+}
+
+func BenchmarkCallerIDContext(b *testing.B) {
+	ef := callerid.NewEffectiveCallerID("principal", "component", "subComponent")
+	im := callerid.NewImmediateCallerID("username")
+
+	b.Run("New", func(b *testing.B) {
+		b.ReportAllocs()
+		baseCtx := context.Background()
+		for range b.N {
+			_ = callerid.NewContext(baseCtx, ef, im)
+		}
+	})
+
+	b.Run("EffectiveCallerIDFromContext", func(b *testing.B) {
+		b.ReportAllocs()
+		ctx := callerid.NewContext(context.Background(), ef, im)
+		for range b.N {
+			_ = callerid.EffectiveCallerIDFromContext(ctx)
+		}
+	})
+
+	b.Run("ImmediateCallerIDFromContext", func(b *testing.B) {
+		b.ReportAllocs()
+		ctx := callerid.NewContext(context.Background(), ef, im)
+		for range b.N {
+			_ = callerid.EffectiveCallerIDFromContext(ctx)
+		}
+	})
+}


### PR DESCRIPTION
Relatively minor, but this is called and used relatively frequently, plus a very easy win.

`callerid.NewContext` combines both CallerID and VTGateCallerID into a singular `Context.WithValue`.

This is slightly more performant because each `WithValue` wraps a new layer of `Context`, which also means when doing `Context.Value`, this gets searched recursively through each layer.

Reducing this to 1 "tuple" means 1 less layer of Context wrapping, and these are always both set together through `NewContext`.

As you can see, this ultimately makes `EffectiveCallerIDFromContext` slightly faster due to it being 1 less layer to unwrap.

```
$ benchstat {old,new}.txt
goos: darwin
goarch: arm64
pkg: vitess.io/vitess/go/vt/callerid
                                                │   old.txt   │               new.txt               │
                                                │   sec/op    │   sec/op     vs base                │
CallerIDContext/New-10                            52.92n ± 0%   44.20n ± 3%  -16.46% (p=0.000 n=10)
CallerIDContext/EffectiveCallerIDFromContext-10   7.031n ± 0%   3.435n ± 0%  -51.14% (p=0.000 n=10)
CallerIDContext/ImmediateCallerIDFromContext-10   6.880n ± 2%   3.527n ± 1%  -48.73% (p=0.000 n=10)
geomean                                           13.68n        8.121n       -40.63%

                                                │   old.txt    │               new.txt                │
                                                │     B/op     │    B/op     vs base                  │
CallerIDContext/New-10                            96.00 ± 0%     64.00 ± 0%  -33.33% (p=0.000 n=10)
CallerIDContext/EffectiveCallerIDFromContext-10   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
CallerIDContext/ImmediateCallerIDFromContext-10   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                      ²               -12.64%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                │   old.txt    │               new.txt               │
                                                │  allocs/op   │ allocs/op   vs base                 │
CallerIDContext/New-10                            2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerIDContext/EffectiveCallerIDFromContext-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerIDContext/ImmediateCallerIDFromContext-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                      ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
