### PR TITLE
feat: remove ORDER BY from inside derived table

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -1743,6 +1743,47 @@
     }
   },
   {
+    "comment": "Unneeded ORDER BY inside derived table removed",
+    "query": "select * from (select id from user order by foo) dt1, (select id from user order by baz) dt2",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select * from (select id from user order by foo) dt1, (select id from user order by baz) dt2",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0,R:0",
+        "TableName": "`user`_`user`",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select dt1.id from (select id from `user` where 1 != 1) as dt1 where 1 != 1",
+            "Query": "select dt1.id from (select id from `user`) as dt1",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select dt2.id from (select id from `user` where 1 != 1) as dt2 where 1 != 1",
+            "Query": "select dt2.id from (select id from `user`) as dt2",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "join of information_schema with normal table",
     "query": "select unsharded.foo from information_schema.CHARACTER_SETS join unsharded",
     "plan": {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -62,6 +62,20 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 		return r.handleAliasedTable(node)
 	case *sqlparser.Delete:
 		return handleDelete(node)
+	case *sqlparser.DerivedTable:
+		return r.handleDerivedTable(node)
+	}
+	return nil
+}
+
+func (r *earlyRewriter) handleDerivedTable(dt *sqlparser.DerivedTable) error {
+	sel, ok := dt.Select.(*sqlparser.Select)
+	if !ok {
+		return nil
+	}
+	if len(sel.OrderBy) > 0 && sel.Limit == nil {
+		// inside derived tables, we can safely remove ORDER BY clauses if there is no LIMIT clause
+		sel.OrderBy = nil
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Small refactoring - an `ORDER BY` inside a derive table means nothing if it's not also accompanied with a `LIMIT`. The only way to guarantee sort order on the output is to add an `ORDER BY` to the outer `SELECT`.

This PR adds code that removes these clauses early during semantic analysis, so that later planner phases are not confused by them.

## Related Issue(s)

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
