### PR TITLE
go/mysql: improve GTID encoding for OK packet

### DIFF
--- a/go/mysql/encoding.go
+++ b/go/mysql/encoding.go
@@ -332,6 +332,53 @@ func readLenEncStringAsBytesCopy(data []byte, pos int) ([]byte, int, bool) {
 	return result, pos + s, true
 }
 
+// > encGtidData("xxx")
+//
+//	[07 03 05 00 03 78 78 78]
+//	 |  |  |  |  |  |------|
+//	 |  |  |  |  |  ^-------- "xxx"
+//	 |  |  |  |  ^------------ length of rest of bytes, 3
+//	 |  |  |  ^--------------- fixed 0x00
+//	 |  |  ^------------------ length of rest of bytes, 5
+//	 |  ^--------------------- fixed 0x03 (SESSION_TRACK_GTIDS)
+//	 ^------------------------ length of rest of bytes, 7
+//
+// This is ultimately lenencoded strings of length encoded strings, or:
+// > lenenc(0x03 + lenenc(0x00 + lenenc(data)))
+func encGtidData(data string) []byte {
+	const SessionTrackGtids = 0x03
+
+	// calculate total size up front to do 1 allocation
+	// encoded layout is:
+	// lenenc(0x03 + lenenc(0x00 + lenenc(data)))
+	dataSize := uint64(len(data))
+	dataLenEncSize := uint64(lenEncIntSize(dataSize))
+
+	wrapSize := uint64(dataSize + dataLenEncSize + 1)
+	wrapLenEncSize := uint64(lenEncIntSize(wrapSize))
+
+	totalSize := uint64(wrapSize + wrapLenEncSize + 1)
+	totalLenEncSize := uint64(lenEncIntSize(totalSize))
+
+	gtidData := make([]byte, int(totalSize+totalLenEncSize))
+
+	pos := 0
+	pos = writeLenEncInt(gtidData, pos, totalSize)
+
+	gtidData[pos] = SessionTrackGtids
+	pos++
+
+	pos = writeLenEncInt(gtidData, pos, wrapSize)
+
+	gtidData[pos] = 0x00
+	pos++
+
+	pos = writeLenEncInt(gtidData, pos, dataSize)
+	writeEOFString(gtidData, pos, data)
+
+	return gtidData
+}
+
 type coder struct {
 	data []byte
 	pos  int
@@ -395,5 +442,9 @@ func (d *coder) writeLenEncString(value string) {
 }
 
 func (d *coder) writeEOFString(value string) {
+	d.pos += copy(d.data[d.pos:], value)
+}
+
+func (d *coder) writeEOFBytes(value []byte) {
 	d.pos += copy(d.data[d.pos:], value)
 }


### PR DESCRIPTION
This isn't a super common path, but if we are tracking GTIDs, this will happen for every single query.

This enhancement effectively calculates the full size of the GTID data to be encoded up front to do a single allocation rather than naively appending to a slice.

I also added documentation and extracted the GTID encoding to it's own function with unit tests.

I also cleaned up how it's utilized to avoid some unnecessary byte -> string allocations within the packet writer.

```
$ benchstat {old,new}.txt
goos: darwin
goarch: arm64
pkg: vitess.io/vitess/go/mysql
               │   old.txt    │               new.txt               │
               │    sec/op    │   sec/op     vs base                │
EncGtidData-10   104.65n ± 1%   15.55n ± 0%  -85.14% (p=0.000 n=10)

               │   old.txt   │              new.txt               │
               │    B/op     │    B/op     vs base                │
EncGtidData-10   56.000 ± 0%   8.000 ± 0%  -85.71% (p=0.000 n=10)

               │  old.txt   │              new.txt               │
               │ allocs/op  │ allocs/op   vs base                │
EncGtidData-10   7.000 ± 0%   1.000 ± 0%  -85.71% (p=0.000 n=10)
```

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
