### PR TITLE
Protect the `.Conn` property of `tabletHealthCheck` from being read/modified concurrently.

### DIFF
--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -265,10 +265,10 @@ func TestReplicaTransactions(t *testing.T) {
 	_ = replicaTablet.VttabletProcess.TearDown()
 	// Healthcheck interval on tablet is set to 1s, so sleep for 2s
 	time.Sleep(2 * time.Second)
-	utils.AssertContainsError(t, readConn, fetchAllCustomers, "is either down or nonexistent")
+	utils.AssertContainsError(t, readConn, fetchAllCustomers, "connect: connection refused")
 
 	// bring up the tablet again
-	// trying to use the same session/transaction should fail as the vtgate has
+	// trying to use the same session/transaction should fail as the vttablet has
 	// been restarted and the session lost
 	replicaTablet.VttabletProcess.ServingStatus = "SERVING"
 	err = replicaTablet.VttabletProcess.Setup()

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -840,7 +840,7 @@ func (hc *HealthCheckImpl) TabletConnection(ctx context.Context, alias *topodata
 	hc.mu.Lock()
 	thc := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(alias))]
 	hc.mu.Unlock()
-	if thc == nil || thc.Conn == nil {
+	if thc == nil {
 		// TODO: test that throws this error
 		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "tablet: %v is either down or nonexistent", alias)
 	}

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -356,6 +356,9 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 }
 
 func (thc *tabletHealthCheck) closeConnection(ctx context.Context, err error) {
+	thc.connMu.Lock()
+	defer thc.connMu.Unlock()
+
 	log.Warningf("tablet %v healthcheck stream error: %v", thc.Tablet, err)
 	thc.setServingState(false, err.Error())
 	thc.LastError = err
@@ -366,6 +369,9 @@ func (thc *tabletHealthCheck) closeConnection(ctx context.Context, err error) {
 // finalizeConn closes the health checking connection.
 // To be called only on exit from checkConn().
 func (thc *tabletHealthCheck) finalizeConn() {
+	thc.connMu.Lock()
+	defer thc.connMu.Unlock()
+
 	thc.setServingState(false, "finalizeConn closing connection")
 	// Note: checkConn() exits only when thc.ctx.Done() is closed. Thus it's
 	// safe to simply get Err() value here and assign to LastError.


### PR DESCRIPTION
## Description

During multiple external primary failovers + `TabletExternallyReparented` calls across different keyspaces we've run into situations where different `vtgate` processes would end up being "stuck" and unable to serve queries that are supposed to be routed to the newly elected primary.

Those queries all fail with a `vttablet: Connection Closed` error, which can only happen if `gRPCQueryClient.cc` is set to `nil`. The only place in the code base where `gRPCQueryClient.cc` is modified is in `gRPCQueryClient.Close`, which in turn is only ever called from `tabletHealthCheck.closeConnection` or `tabletHealthCheck.finalizeConn`.

This leads me to believe that there are situations where we can end up with a `tabletHealthCheck` on which `Conn` is non-`nil` but `gRPCQueryClient.cc` is `nil`. This would explain the `vttablet: Connection Closed` errors we're seeing, while at the same time not seeing the grpc connection being re-established.

I noticed that the modification of `tabletHealthCheck.Conn` in both `tabletHealthCheck.closeConnection` and `tabletHealthCheck.finalizeConn` is not protected by a mutex like it is in `tabletHealthCheck.Connection`. I'm not sure this really explains the issue we're seeing, but it seems like a good idea to protect the `.Conn` property of `tabletHealthCheck` from being read/modified concurrently.

I added a test case that simulates how I believe this code is used in `vtgate` - by having `tabletHealthCheck.checkConn` run in one goroutine while calling `tabletHealthCheck.Connection` from another goroutine while the connection sporadically receives errors (so as to trigger `tabletHealthCheck.closeConnection` to be called).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
