### PR TITLE
fix issue with aggregation inside of derived tables

### DIFF
--- a/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
+++ b/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
@@ -56,5 +56,9 @@ select COUNT(*)
 from (select 1 as one
       FROM `t3`
       WHERE `t3`.`name` = 'B'
-      ORDER BY id DESC LIMIT 25
-      OFFSET 0) subquery_for_count;
+      ORDER BY id DESC
+      LIMIT 25 OFFSET 0) subquery_for_count;
+
+select u.id, u.t1_id, t.num_segments
+from (select id, count(*) as num_segments from t1 group by 1 order by 2 desc limit 20) t
+         join t2 u on u.id = t.id;

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -466,6 +466,14 @@ func buildAggregation(op *Aggregator, qb *queryBuilder) {
 	if op.WithRollup {
 		qb.setWithRollup()
 	}
+
+	if op.DT != nil {
+		sel := qb.asSelectStatement()
+		qb.stmt = nil
+		qb.addTableExpr(op.DT.Alias, op.DT.Alias, TableID(op), &sqlparser.DerivedTable{
+			Select: sel,
+		}, nil, op.DT.Columns)
+	}
 }
 
 func buildOrdering(op *Ordering, qb *queryBuilder) {

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -108,7 +108,7 @@ func expandSelectHorizon(ctx *plancontext.PlanningContext, horizon *Horizon, sel
 	}
 
 	if len(qp.OrderExprs) > 0 {
-		op = expandOrderBy(ctx, op, qp)
+		op = expandOrderBy(ctx, op, qp, horizon.Alias)
 		extracted = append(extracted, "Ordering")
 	}
 
@@ -124,7 +124,7 @@ func expandSelectHorizon(ctx *plancontext.PlanningContext, horizon *Horizon, sel
 	return op, Rewrote(fmt.Sprintf("expand SELECT horizon into (%s)", strings.Join(extracted, ", ")))
 }
 
-func expandOrderBy(ctx *plancontext.PlanningContext, op Operator, qp *QueryProjection) Operator {
+func expandOrderBy(ctx *plancontext.PlanningContext, op Operator, qp *QueryProjection, derived string) Operator {
 	var newOrder []OrderBy
 	sqc := &SubQueryBuilder{}
 	proj, ok := op.(*Projection)
@@ -134,6 +134,9 @@ func expandOrderBy(ctx *plancontext.PlanningContext, op Operator, qp *QueryProje
 		newExpr, subqs := sqc.pullOutValueSubqueries(ctx, expr.SimplifiedExpr, TableID(op), false)
 		if newExpr == nil {
 			// If no subqueries are found, retain the original order expression
+			if derived != "" {
+				exposeOrderingColumn(ctx, qp, expr, derived)
+			}
 			newOrder = append(newOrder, expr)
 			continue
 		}
@@ -164,6 +167,22 @@ func expandOrderBy(ctx *plancontext.PlanningContext, op Operator, qp *QueryProje
 	return &Ordering{
 		Source: op,
 		Order:  newOrder,
+	}
+}
+
+// exposeOrderingColumn will expose the ordering column to the outer query
+func exposeOrderingColumn(ctx *plancontext.PlanningContext, qp *QueryProjection, expr OrderBy, derived string) {
+	for _, se := range qp.SelectExprs {
+		aliasedExpr, err := se.GetAliasedExpr()
+		if err == nil {
+			// if we get an error, we'll just use the whatever was in the AST
+			if ctx.SemTable.EqualsExprWithDeps(aliasedExpr.Expr, expr.SimplifiedExpr) {
+				newExpr := sqlparser.NewColNameWithQualifier(aliasedExpr.ColumnName(), sqlparser.NewTableName(derived))
+				ctx.SemTable.CopySemanticInfo(expr.SimplifiedExpr, newExpr)
+				expr.SimplifiedExpr = newExpr
+				continue
+			}
+		}
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -180,6 +180,7 @@ func exposeOrderingColumn(ctx *plancontext.PlanningContext, qp *QueryProjection,
 				newExpr := sqlparser.NewColNameWithQualifier(aliasedExpr.ColumnName(), sqlparser.NewTableName(derived))
 				ctx.SemTable.CopySemanticInfo(orderBy.SimplifiedExpr, newExpr)
 				orderBy.SimplifiedExpr = newExpr
+				orderBy.Inner = &sqlparser.Order{Expr: newExpr, Direction: orderBy.Inner.Direction}
 				break
 			}
 		}

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -174,15 +174,15 @@ func expandOrderBy(ctx *plancontext.PlanningContext, op Operator, qp *QueryProje
 func exposeOrderingColumn(ctx *plancontext.PlanningContext, qp *QueryProjection, orderBy OrderBy, derived string) OrderBy {
 	for _, se := range qp.SelectExprs {
 		aliasedExpr, err := se.GetAliasedExpr()
-		if err == nil {
-			// if we get an error, we'll just use the whatever was in the AST
-			if ctx.SemTable.EqualsExprWithDeps(aliasedExpr.Expr, orderBy.SimplifiedExpr) {
-				newExpr := sqlparser.NewColNameWithQualifier(aliasedExpr.ColumnName(), sqlparser.NewTableName(derived))
-				ctx.SemTable.CopySemanticInfo(orderBy.SimplifiedExpr, newExpr)
-				orderBy.SimplifiedExpr = newExpr
-				orderBy.Inner = &sqlparser.Order{Expr: newExpr, Direction: orderBy.Inner.Direction}
-				break
-			}
+		if err != nil {
+			panic(vterrors.VT13001("unexpected expression in select"))
+		}
+		if ctx.SemTable.EqualsExprWithDeps(aliasedExpr.Expr, orderBy.SimplifiedExpr) {
+			newExpr := sqlparser.NewColNameWithQualifier(aliasedExpr.ColumnName(), sqlparser.NewTableName(derived))
+			ctx.SemTable.CopySemanticInfo(orderBy.SimplifiedExpr, newExpr)
+			orderBy.SimplifiedExpr = newExpr
+			orderBy.Inner = &sqlparser.Order{Expr: newExpr, Direction: orderBy.Inner.Direction}
+			break
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -664,8 +664,9 @@ func (qp *QueryProjection) useGroupingOverDistinct(ctx *plancontext.PlanningCont
 	return true
 }
 
-// addColumn adds a column to the QueryProjection if it is not already present
-func (qp *QueryProjection) addColumn(ctx *plancontext.PlanningContext, expr sqlparser.Expr) {
+// addColumn adds a column to the QueryProjection if it is not already present.
+// It will use a column name that is available on the outside of the derived table
+func (qp *QueryProjection) addDerivedColumn(ctx *plancontext.PlanningContext, expr sqlparser.Expr) {
 	for _, selectExpr := range qp.SelectExprs {
 		getExpr, err := selectExpr.GetExpr()
 		if err != nil {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -788,7 +788,7 @@
                 },
                 "FieldQuery": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` where 1 != 1 group by id) as t where 1 != 1",
                 "OrderBy": "0 DESC",
-                "Query": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` group by id) as t order by count(*) desc limit 20",
+                "Query": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` group by id) as t order by t.num_segments desc limit 20",
                 "Table": "`user`"
               }
             ]
@@ -3702,7 +3702,7 @@
                     },
                     "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
                     "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by `user`.val1 asc limit 2",
+                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
                     "Table": "`user`"
                   }
                 ]
@@ -7225,7 +7225,7 @@
                     },
                     "FieldQuery": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where 1 != 1) as subquery_for_count where 1 != 1",
                     "OrderBy": "(1|3) DESC",
-                    "Query": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where `user`.is_not_deleted = true) as subquery_for_count order by id desc limit 25",
+                    "Query": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where `user`.is_not_deleted = true) as subquery_for_count order by subquery_for_count.id desc limit 25",
                     "Table": "`user`"
                   }
                 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -761,6 +761,58 @@
     }
   },
   {
+    "comment": "Aggregation with derived table",
+    "query": "select u.id, u.name, t.num_segments from (select id, count(*) as num_segments from user group by 1 order by 2 desc limit 20) t join unsharded u on u.id = t.id",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select u.id, u.name, t.num_segments from (select id, count(*) as num_segments from user group by 1 order by 2 desc limit 20) t join unsharded u on u.id = t.id",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0,R:1,L:0",
+        "JoinVars": {
+          "t_id": 1
+        },
+        "TableName": "`user`_unsharded",
+        "Inputs": [
+          {
+            "OperatorType": "Limit",
+            "Count": "20",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` where 1 != 1 group by id) as t where 1 != 1",
+                "OrderBy": "0 DESC",
+                "Query": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` group by id) as t order by count(*) desc limit 20",
+                "Table": "`user`"
+              }
+            ]
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select u.id, u.`name` from unsharded as u where 1 != 1",
+            "Query": "select u.id, u.`name` from unsharded as u where u.id = :t_id",
+            "Table": "unsharded"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "scatter aggregate multiple group by (numbers)",
     "query": "select a, b, count(*) from user group by 2, 1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -352,7 +352,7 @@
                     },
                     "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
                     "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by `user`.val1 asc limit 2",
+                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
                     "Table": "`user`"
                   }
                 ]


### PR DESCRIPTION
## Description
For queries doing aggregation inside derived tables, the planner sometimes struggled with which columns are available.

This PR makes sure to handle these queries well.

## Related Issue(s)
Fixes #16367


## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
