### PR TITLE
Throttler flaky test: explicitly disabling throttler so as to ensure it does not re-enable

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -771,6 +771,16 @@ func TestApplyThrottlerConfigAppCheckedMetrics(t *testing.T) {
 				assert.Len(t, checkResult.Metrics, 1)
 			})
 		})
+
+		t.Run("Disable", func(t *testing.T) {
+			throttlerConfig := &topodatapb.ThrottlerConfig{
+				Enabled:           false,
+				MetricThresholds:  map[string]float64{},
+				AppCheckedMetrics: map[string]*topodatapb.ThrottlerConfig_MetricNames{},
+			}
+			throttler.applyThrottlerConfig(ctx, throttlerConfig)
+			sleepTillThresholdApplies()
+		})
 	})
 }
 


### PR DESCRIPTION
## Description

A quick followup to https://github.com/vitessio/vitess/pull/15988
Though tested for literally _months_ in CI and locally, we now see a flaky test caused by https://github.com/vitessio/vitess/pull/15988. The reason for the failure is that the test configures the throttler to be enabled, while at the same time attempts to disable it.

The fix is to explicitly configure the throttler to be disabled at the end of the test.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15624

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
