### PR TITLE
Fix panic in schema tracker in presence of keyspace routing rules

### DIFF
--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -336,6 +336,49 @@ func TestVSchemaUpdate(t *testing.T) {
 	}
 }
 
+// TestKeyspaceRoutingRules tests that the vschema manager doens't panic in the presence of keyspace routing rules.
+func TestKeyspaceRoutingRules(t *testing.T) {
+	cols1 := []vindexes.Column{{
+		Name: sqlparser.NewIdentifierCI("id"),
+		Type: querypb.Type_INT64,
+	}}
+	// Create a vschema manager with a fake vschema that returns a table with a column and a primary key.
+	vm := &VSchemaManager{}
+	vm.schema = &fakeSchema{t: map[string]*vindexes.TableInfo{
+		"t1": {
+			Columns: cols1,
+			Indexes: []*sqlparser.IndexDefinition{
+				{
+					Info: &sqlparser.IndexInfo{Type: sqlparser.IndexTypePrimary},
+					Columns: []*sqlparser.IndexColumn{
+						{
+							Column: sqlparser.NewIdentifierCI("id"),
+						},
+					},
+				},
+			},
+		},
+	}}
+	// Define a vschema that has a keyspace routing rule.
+	vs := &vindexes.VSchema{
+		Keyspaces: map[string]*vindexes.KeyspaceSchema{
+			"ks": {
+				Tables:   map[string]*vindexes.Table{},
+				Keyspace: &vindexes.Keyspace{Name: "ks", Sharded: true},
+			},
+			"ks2": {
+				Tables:   map[string]*vindexes.Table{},
+				Keyspace: &vindexes.Keyspace{Name: "ks2", Sharded: true},
+			},
+		},
+		KeyspaceRoutingRules: map[string]string{
+			"ks": "ks2",
+		},
+	}
+	// Ensure that updating the vschema manager from the vschema doesn't cause a panic.
+	vm.updateFromSchema(vs)
+}
+
 func TestRebuildVSchema(t *testing.T) {
 	cols1 := []vindexes.Column{{
 		Name: sqlparser.NewIdentifierCI("id"),


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the panic found in https://github.com/vitessio/vitess/issues/16382.

This PR reproduced the panic as a unit test and then it fixes it. The problem is that we are using `FindRoutedTable` function to find the table which can fail to find the table if keyspace routing rules are present.

The fix is to not go through the `FindRoutedTable` function at all. In the `updateTableInfo` function, we already go over all the tables and add them to the keyspace map if the table doesn't exist when we populate the columns in `setColumns`. 
We should use this table map directly.

The use of `FindRoutedTable` would be justified if we were supporting cross-keyspace foreign keys. Since we don't support them, all the foreign key references are guaranteed to be to tables that exist in the tables of the same keyspace. So it is safe to find both the table and the table it is foreign key related to in the table map that we populate right before this loop.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #16382

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
