### PR TITLE
Fix Join Predicate Cleanup Bug in Route Merging

### DIFF
--- a/go/test/endtoend/vtgate/vitess_tester/join/join.test
+++ b/go/test/endtoend/vtgate/vitess_tester/join/join.test
@@ -1,0 +1,49 @@
+CREATE TABLE `t1`
+(
+    `id`   int unsigned NOT NULL AUTO_INCREMENT,
+    `name` varchar(191) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `t2`
+(
+    `id`    bigint unsigned NOT NULL AUTO_INCREMENT,
+    `t1_id` int unsigned NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `t3`
+(
+    `id`   bigint unsigned NOT NULL AUTO_INCREMENT,
+    `name` varchar(191) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_unicode_ci;
+
+insert into t1 (id, name)
+values (1, 'A'),
+       (2, 'B'),
+       (3, 'C'),
+       (4, 'D');
+
+insert into t2 (id, t1_id)
+values (1, 1),
+       (2, 2),
+       (3, 3);
+
+insert into t3 (id, name)
+values (1, 'A'),
+       (2, 'B'),
+       (3, 'B'),
+       (4, 'B'),
+       (5, 'B');
+
+-- wait_authoritative t1
+-- wait_authoritative t2
+-- wait_authoritative t3
+select 42 from t1 join t2 on t1.id = t2.t1_id join t3 on t1.id = t3.id where t1.name or t2.id or t3.name;

--- a/go/test/endtoend/vtgate/vitess_tester/join/vschema.json
+++ b/go/test/endtoend/vtgate/vitess_tester/join/vschema.json
@@ -1,0 +1,38 @@
+{
+  "keyspaces": {
+    "joinks": {
+      "sharded": true,
+      "vindexes": {
+        "hash": {
+          "type": "hash"
+        }
+      },
+      "tables": {
+        "t1": {
+          "column_vindexes": [
+            {
+              "column": "id",
+              "name": "hash"
+            }
+          ]
+        },
+        "t2": {
+          "column_vindexes": [
+            {
+              "column": "t1_id",
+              "name": "hash"
+            }
+          ]
+        },
+        "t3": {
+          "column_vindexes": [
+            {
+              "column": "id",
+              "name": "hash"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -233,7 +233,9 @@ func (qb *queryBuilder) joinWith(other *queryBuilder, onCondition sqlparser.Expr
 	switch joinType {
 	case sqlparser.NormalJoinType:
 		newFromClause = append(stmt.GetFrom(), otherStmt.GetFrom()...)
-		qb.addPredicate(onCondition)
+		for _, pred := range sqlparser.SplitAndExpression(nil, onCondition) {
+			qb.addPredicate(pred)
+		}
 	default:
 		newFromClause = []sqlparser.TableExpr{buildJoin(stmt, otherStmt, onCondition, joinType)}
 	}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -1825,6 +1825,30 @@
     }
   },
   {
+    "comment": "three table join with join predicate touching all tables",
+    "query": "select 42 from user u join user_extra ue on u.id = ue.user_id join music m on m.user_id = u.id where u.foo or m.foo or ue.foo",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 42 from user u join user_extra ue on u.id = ue.user_id join music m on m.user_id = u.id where u.foo or m.foo or ue.foo",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 42 from `user` as u, user_extra as ue, music as m where 1 != 1",
+        "Query": "select 42 from `user` as u, user_extra as ue, music as m where u.id = ue.user_id and m.user_id = u.id and (u.foo or m.foo or ue.foo)",
+        "Table": "`user`, music, user_extra"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
     "comment": "join of normal table with information_schema",
     "query": "select unsharded.foo from unsharded join information_schema.CHARACTER_SETS",
     "plan": {


### PR DESCRIPTION
## Description
This PR addresses a bug in Vitess where, upon successfully merging three tables into a single Route, the join predicates were sometimes not cleaned up correctly. This issue affects all supported versions of Vitess. Given the minimal nature of the fix, it is recommended to backport this fix to all affected versions.

## Related Issue(s)
Fixes #16387

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
