### PR TITLE
Use default schema reload config values when config file is empty

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -406,8 +406,6 @@ func (cfg *TabletConfig) UnmarshalJSON(data []byte) (err error) {
 		if err != nil {
 			return err
 		}
-	} else {
-		cfg.SchemaReloadInterval = 0
 	}
 
 	if tmp.SchemaChangeReloadTimeout != "" {
@@ -415,8 +413,6 @@ func (cfg *TabletConfig) UnmarshalJSON(data []byte) (err error) {
 		if err != nil {
 			return err
 		}
-	} else {
-		cfg.SchemaChangeReloadTimeout = 0
 	}
 
 	return nil

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -58,6 +58,8 @@ func TestConfigParse(t *testing.T) {
 			MaxInnoDBTrxHistLen: 1000,
 			MaxMySQLReplLagSecs: 400,
 		},
+		SchemaChangeReloadTimeout: 30 * time.Second,
+		SchemaReloadInterval:      30 * time.Minute,
 	}
 
 	gotBytes, err := yaml2.Marshal(&cfg)
@@ -93,6 +95,8 @@ replicationTracker: {}
 rowStreamer:
   maxInnoDBTrxHistLen: 1000
   maxMySQLReplLagSecs: 400
+schemaChangeReloadTimeout: 30s
+schemaReloadIntervalSeconds: 30m0s
 txPool: {}
 `
 	assert.Equal(t, wantBytes, string(gotBytes))


### PR DESCRIPTION
## Description

A behavior change for the for `SchemaReloadInterval` and `SchemaChangeReloadTimeout` configuration options was introduced in: https://github.com/vitessio/vitess/pull/14733

Specifically here, as the value for either one is an empty string after reading the empty config file: https://github.com/vitessio/vitess/pull/14733/files#diff-ee5ffc675b719e69de7147068ab4ecf03f6d5db91a000d212a30f8ce61544691R424-R431

You can see it still on main today here: https://github.com/vitessio/vitess/blob/2e009e3e1d7a84b071926c18ad951f305ebf4cf9/go/vt/vttablet/tabletserver/tabletenv/config.go#L404-L420

This changed the effective defaults for these two configuration options when using config files and not specifying a value for them.

The end result is that we ended up incorrectly overriding the current/default config values when parsing a config file that did NOT specify a value for `SchemaReloadInterval` or `SchemaChangeReloadTimeout`. This PR changes the behavior — to match v18 and older — so that we only override the current/default config if a value for them was specified in the config file.

This fix should be backported to v19, where the behavior change was introduced.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16392

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required