### PR TITLE
Online DDL: do not update last_throttled_timestamp with zero value

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3870,8 +3870,10 @@ func (e *Executor) reviewRunningMigrations(ctx context.Context) (countRunnning i
 				_ = e.updateRowsCopied(ctx, uuid, s.rowsCopied)
 				_ = e.updateMigrationProgressByRowsCopied(ctx, uuid, s.rowsCopied)
 				_ = e.updateMigrationETASecondsByProgress(ctx, uuid)
-				_ = e.updateMigrationLastThrottled(ctx, uuid, time.Unix(s.timeThrottled, 0), s.componentThrottled)
-
+				if s.timeThrottled != 0 {
+					// Avoid creating a 0000-00-00 00:00:00 timestamp
+					_ = e.updateMigrationLastThrottled(ctx, uuid, time.Unix(s.timeThrottled, 0), s.componentThrottled)
+				}
 				if onlineDDL.StrategySetting().IsInOrderCompletion() {
 					// We will fail an in-order migration if there's _prior_ migrations within the same migration-context
 					// which have failed.


### PR DESCRIPTION

## Description

`_vt.schema_migrations.last_throttled_timestamp` indicates the last time a vreplication migration was throttled, value copied from `_vt.vreplication.time_throttled`. However, it is possible for the value to be zero if `timeThrottled` is uninitialized. In this PR we avoid updating `last_throttled_timestamp` to the zero value. 

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/16394

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
