### PR TITLE
Support `SHOW VITESS_MIGRATIONS` from inside a transaction

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -572,6 +572,11 @@ func testScheduler(t *testing.T) {
 			}
 		})
 	})
+	t.Run("show vitess_migrations in transaction", func(t *testing.T) {
+		// The function validates there is no error
+		rs := onlineddl.VtgateExecQueryInTransaction(t, &vtParams, "show vitess_migrations", "")
+		assert.NotEmpty(t, rs.Rows)
+	})
 
 	forceCutoverCapable, err := capableOf(capabilities.PerformanceSchemaDataLocksTableCapability) // 8.0
 	require.NoError(t, err)

--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -66,6 +66,29 @@ func VtgateExecQuery(t *testing.T, vtParams *mysql.ConnParams, query string, exp
 	return qr
 }
 
+// VtgateExecQueryInTransaction runs a query on VTGate using given query params, inside a transaction
+func VtgateExecQueryInTransaction(t *testing.T, vtParams *mysql.ConnParams, query string, expectError string) *sqltypes.Result {
+	t.Helper()
+
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	_, err = conn.ExecuteFetch("begin", -1, true)
+	require.NoError(t, err)
+	qr, err := conn.ExecuteFetch(query, -1, true)
+	if expectError == "" {
+		require.NoError(t, err)
+	} else {
+		require.Error(t, err, "error should not be nil")
+		assert.Contains(t, err.Error(), expectError, "Unexpected error")
+	}
+	_, err = conn.ExecuteFetch("commit", -1, true)
+	require.NoError(t, err)
+	return qr
+}
+
 // VtgateExecDDL executes a DDL query with given strategy
 func VtgateExecDDL(t *testing.T, vtParams *mysql.ConnParams, ddlStrategy string, query string, expectError string) *sqltypes.Result {
 	t.Helper()

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -876,6 +876,10 @@ func TestExecutorShow(t *testing.T) {
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
+	query = "show vitess_migrations"
+	_, err = executor.Execute(ctx, nil, "TestExecute", session, query, nil)
+	require.NoError(t, err)
+
 	query = "show vschema vindexes"
 	qr, err = executor.Execute(ctx, nil, "TestExecute", session, query, nil)
 	require.NoError(t, err)

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -876,10 +876,6 @@ func TestExecutorShow(t *testing.T) {
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
-	query = "show vitess_migrations"
-	_, err = executor.Execute(ctx, nil, "TestExecute", session, query, nil)
-	require.NoError(t, err)
-
 	query = "show vschema vindexes"
 	qr, err = executor.Execute(ctx, nil, "TestExecute", session, query, nil)
 	require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -203,7 +203,7 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 	case p.PlanRevertMigration:
 		return qre.execRevertMigration()
 	case p.PlanShowMigrations:
-		return qre.execShowMigrations()
+		return qre.execShowMigrations(nil)
 	case p.PlanShowMigrationLogs:
 		return qre.execShowMigrationLogs()
 	case p.PlanShowThrottledApps:
@@ -308,6 +308,8 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 		return qre.execLoad(conn)
 	case p.PlanCallProc:
 		return qre.execProc(conn)
+	case p.PlanShowMigrations:
+		return qre.execShowMigrations(conn)
 	}
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] %s unexpected plan type", qre.plan.PlanID.String())
 }
@@ -958,7 +960,7 @@ func (qre *QueryExecutor) execRevertMigration() (*sqltypes.Result, error) {
 	return qre.tsv.onlineDDLExecutor.SubmitMigration(qre.ctx, qre.plan.FullStmt)
 }
 
-func (qre *QueryExecutor) execShowMigrations() (*sqltypes.Result, error) {
+func (qre *QueryExecutor) execShowMigrations(conn *StatefulConnection) (*sqltypes.Result, error) {
 	if showStmt, ok := qre.plan.FullStmt.(*sqlparser.Show); ok {
 		return qre.tsv.onlineDDLExecutor.ShowMigrations(qre.ctx, showStmt)
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

See story in https://github.com/vitessio/vitess/issues/16242

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/16242

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
