### PR TITLE
Handle dual queries with LIMIT on the vtgate

### DIFF
--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -242,9 +242,25 @@ func createSelectOperator(ctx *plancontext.PlanningContext, selStmt sqlparser.Se
 }
 
 func isOnlyDual(sel *sqlparser.Select) bool {
-	if sel.Where != nil || sel.GroupBy != nil || sel.Having != nil || sel.Limit != nil || sel.OrderBy != nil {
+	if sel.Where != nil || sel.GroupBy != nil || sel.Having != nil || sel.OrderBy != nil {
 		// we can only deal with queries without any other subclauses - just SELECT and FROM, nothing else is allowed
 		return false
+	}
+
+	if sel.Limit != nil {
+		if sel.Limit.Offset != nil {
+			return false
+		}
+		limit := sel.Limit.Rowcount
+		switch limit := limit.(type) {
+		case nil:
+			return true
+		case *sqlparser.Literal:
+			if limit.Val == "0" {
+				// A limit with any value other than zero can still return a row
+				return false
+			}
+		}
 	}
 
 	if len(sel.From) > 1 {

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -254,12 +254,13 @@ func isOnlyDual(sel *sqlparser.Select) bool {
 		limit := sel.Limit.Rowcount
 		switch limit := limit.(type) {
 		case nil:
-			return true
 		case *sqlparser.Literal:
 			if limit.Val == "0" {
 				// A limit with any value other than zero can still return a row
 				return false
 			}
+		default:
+			return false
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2718,6 +2718,28 @@
     }
   },
   {
+    "comment": "Dual query should be handled on the vtgate even with a LIMIT",
+    "query": "select last_insert_id() limit 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select last_insert_id() limit 1",
+      "Instructions": {
+        "OperatorType": "Projection",
+        "Expressions": [
+          ":__lastInsertId as last_insert_id()"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "SingleRow"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.dual"
+      ]
+    }
+  },
+  {
     "comment": "PullOut subquery with an aggregation that should be typed in the final output",
     "query": "select (select sum(col) from user) from user_extra",
     "plan": {


### PR DESCRIPTION
## Description
Dual queries can most of the time be handled on the vtgate side, without having to send anything down to MySQL.

This PR extends this functionality to include `dual` queries with `LIMIT` in them.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
