### PR TITLE
[release-20.0]  Fix panic in schema tracker in presence of keyspace routing rules (#16383)

### DIFF
--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -229,9 +229,9 @@ func (vm *VSchemaManager) updateTableInfo(vschema *vindexes.VSchema, ks *vindexe
 	// Now that we have ensured that all the tables are created, we can start populating the foreign keys
 	// in the tables.
 	for tblName, tblInfo := range m {
-		rTbl, err := vschema.FindRoutedTable(ksName, tblName, topodatapb.TabletType_PRIMARY)
-		if err != nil {
-			log.Errorf("error finding routed table %s: %v", tblName, err)
+		rTbl := ks.Tables[tblName]
+		if rTbl == nil {
+			log.Errorf("unable to find table %s in %s", tblName, ksName)
 			continue
 		}
 		for _, fkDef := range tblInfo.ForeignKeys {
@@ -240,7 +240,7 @@ func (vm *VSchemaManager) updateTableInfo(vschema *vindexes.VSchema, ks *vindexe
 				continue
 			}
 			parentTbl, err := vschema.FindRoutedTable(ksName, fkDef.ReferenceDefinition.ReferencedTable.Name.String(), topodatapb.TabletType_PRIMARY)
-			if err != nil {
+			if err != nil || parentTbl == nil {
 				log.Errorf("error finding parent table %s: %v", fkDef.ReferenceDefinition.ReferencedTable.Name.String(), err)
 				continue
 			}

--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -336,6 +336,49 @@ func TestVSchemaUpdate(t *testing.T) {
 	}
 }
 
+// TestKeyspaceRoutingRules tests that the vschema manager doens't panic in the presence of keyspace routing rules.
+func TestKeyspaceRoutingRules(t *testing.T) {
+	cols1 := []vindexes.Column{{
+		Name: sqlparser.NewIdentifierCI("id"),
+		Type: querypb.Type_INT64,
+	}}
+	// Create a vschema manager with a fake vschema that returns a table with a column and a primary key.
+	vm := &VSchemaManager{}
+	vm.schema = &fakeSchema{t: map[string]*vindexes.TableInfo{
+		"t1": {
+			Columns: cols1,
+			Indexes: []*sqlparser.IndexDefinition{
+				{
+					Info: &sqlparser.IndexInfo{Type: sqlparser.IndexTypePrimary},
+					Columns: []*sqlparser.IndexColumn{
+						{
+							Column: sqlparser.NewIdentifierCI("id"),
+						},
+					},
+				},
+			},
+		},
+	}}
+	// Define a vschema that has a keyspace routing rule.
+	vs := &vindexes.VSchema{
+		Keyspaces: map[string]*vindexes.KeyspaceSchema{
+			"ks": {
+				Tables:   map[string]*vindexes.Table{},
+				Keyspace: &vindexes.Keyspace{Name: "ks", Sharded: true},
+			},
+			"ks2": {
+				Tables:   map[string]*vindexes.Table{},
+				Keyspace: &vindexes.Keyspace{Name: "ks2", Sharded: true},
+			},
+		},
+		KeyspaceRoutingRules: map[string]string{
+			"ks": "ks2",
+		},
+	}
+	// Ensure that updating the vschema manager from the vschema doesn't cause a panic.
+	vm.updateFromSchema(vs)
+}
+
 func TestRebuildVSchema(t *testing.T) {
 	cols1 := []vindexes.Column{{
 		Name: sqlparser.NewIdentifierCI("id"),


### PR DESCRIPTION
## Description
This is a backport of #16383

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/16382