### PR TITLE
[release-19.0] Fix panic in schema tracker in presence of keyspace routing rules (#16383)

### DIFF
--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -212,9 +212,9 @@ func (vm *VSchemaManager) updateFromSchema(vschema *vindexes.VSchema) {
 		// Now that we have ensured that all the tables are created, we can start populating the foreign keys
 		// in the tables.
 		for tblName, tblInfo := range m {
-			rTbl, err := vschema.FindRoutedTable(ksName, tblName, topodatapb.TabletType_PRIMARY)
-			if err != nil {
-				log.Errorf("error finding routed table %s: %v", tblName, err)
+			rTbl := ks.Tables[tblName]
+			if rTbl == nil {
+				log.Errorf("unable to find table %s in %s", tblName, ksName)
 				continue
 			}
 			for _, fkDef := range tblInfo.ForeignKeys {
@@ -223,7 +223,7 @@ func (vm *VSchemaManager) updateFromSchema(vschema *vindexes.VSchema) {
 					continue
 				}
 				parentTbl, err := vschema.FindRoutedTable(ksName, fkDef.ReferenceDefinition.ReferencedTable.Name.String(), topodatapb.TabletType_PRIMARY)
-				if err != nil {
+				if err != nil || parentTbl == nil {
 					log.Errorf("error finding parent table %s: %v", fkDef.ReferenceDefinition.ReferencedTable.Name.String(), err)
 					continue
 				}


### PR DESCRIPTION
## Description
This is a backport of #16383

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/16382