### PR TITLE
Use release branches instead of git tags for upgrade/downgrade

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set output with latest release branch
+    - name: Set output with next release branch
       id: output-next-release-ref
       run: |
         next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set output with latest release branch
+    - name: Set output with next release branch
       id: output-next-release-ref
       run: |
         next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set output with latest release branch
+    - name: Set output with next release branch
       id: output-next-release-ref
       run: |
         next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set output with latest release branch
+    - name: Set output with next release branch
       id: output-next-release-ref
       run: |
         next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set output with latest release branch
+    - name: Set output with next release branch
       id: output-next-release-ref
       run: |
         next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set output with latest release branch
+    - name: Set output with next release branch
       id: output-next-release-ref
       run: |
         next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})

--- a/tools/get_next_release.sh
+++ b/tools/get_next_release.sh
@@ -15,8 +15,7 @@
 # limitations under the License.
 
 # github.base_ref $1
-
-target_release=""
+# github.ref $2
 
 base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
 if [ "$base_release_branch" == "" ]; then
@@ -25,16 +24,14 @@ fi
 if [ "$base_release_branch" != "" ]; then
   latest_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
-  target_major_release=$((major_release+1))
-  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
-  target_release="v$target_release_number"
-  if [ -z "$target_release_number" ]
-  then
-    target_release="release-$target_major_release.0"
-  fi
+
+  # If these two are equal it means we are standing on the highest release branch possible, the next release is 'main'
   if [ "$major_release" == "$latest_major_release" ]; then
-    target_release="main"
+    echo "main"
+    exit 0
   fi
+
+  target_major_release="release-$((major_release+1)).0"
 fi
 
-echo "$target_release"
+echo "$target_major_release"

--- a/tools/get_previous_release.sh
+++ b/tools/get_previous_release.sh
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is used to build and copy the Angular 2 based vtctld UI
-# into the release folder (app) for checkin. Prior to running this script,
-# bootstrap.sh and bootstrap_web.sh should already have been run.
-
 # github.base_ref $1
 # github.ref $2
 

--- a/tools/get_previous_release.sh
+++ b/tools/get_previous_release.sh
@@ -30,4 +30,4 @@ else
   target_major_release=$major_release
 fi
 
-echo "release-$target_major_release.O"
+echo "release-$target_major_release.0"

--- a/tools/get_previous_release.sh
+++ b/tools/get_previous_release.sh
@@ -19,26 +19,19 @@
 # bootstrap.sh and bootstrap_web.sh should already have been run.
 
 # github.base_ref $1
-
-target_release=""
+# github.ref $2
 
 base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
 if [ "$base_release_branch" == "" ]; then
   base_release_branch=$(echo "$2" | grep -E 'release-[0-9]*.0$')
 fi
+
 if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
   target_major_release=$((major_release-1))
-  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
-  target_release="v$target_release_number"
 else
-  target_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
-  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
-  target_release="v$target_release_number"
-  if [ -z "$target_release_number" ]
-  then
-    target_release="release-$target_major_release.0"
-  fi
+  major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
+  target_major_release=$major_release
 fi
 
-echo "$target_release"
+echo "release-$target_major_release.O"


### PR DESCRIPTION
## Description

This PR changes what git ref we use during the upgrade/downgrade tests. Instead of using the next/previous git tags, we will use release branches. This will ensure that a change made on `main` is compatible with the next release we will make out of `release-20.0`. Prior to that, we were just checking that a branch was compatible with the next/previous release, which does not cover new code that was merged on the release branch.

Let's backport this to all supported release branches as we want all branches to follow this new methodology.

### Tests
```sh
# upgrade on main, no upgrade = empty line output
$ ./tools/get_next_release.sh main refs/pull/00000/merge 


# upgrade on release-20.0
$ ./tools/get_next_release.sh release-20.0 refs/pull/00000/merge
main

# upgrade on release-19.0
$ ./tools/get_next_release.sh release-19.0 refs/pull/00000/merge
release-20.0

# upgrade on release-18.0
$ ./tools/get_next_release.sh release-18.0 refs/pull/00000/merge
release-19.0

# downgrade on main
./tools/get_previous_release.sh  refs/heads/main
release-20.0

# downgrade on release-20.0
$ ./tools/get_previous_release.sh release-20.0 refs/pull/00000/merge
release-19.0

# downgrade on release-19.0
$ ./tools/get_previous_release.sh release-19.0 refs/pull/00000/merge
release-18.0

# downgrade on release-18.0
$ ./tools/get_previous_release.sh release-18.0 refs/pull/00000/merge
release-17.0
```

## Related Issue(s)

- Part of https://github.com/vitessio/vitess/issues/16365