### PR TITLE
VReplication: disable use of `session_track_gtids`

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -88,14 +88,7 @@ func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query s
 			query, err)
 	}
 
-	_, err = conn.ExecuteFetch("set session session_track_gtids = START_GTID", 1, false)
-	if err != nil {
-		// session_track_gtids = START_GTID unsupported or cannot execute. Resort to LOCK-based snapshot
-		gtid, err = conn.startSnapshot(ctx, table)
-	} else {
-		// session_track_gtids = START_GTID supported. Get a transaction with consistent GTID without LOCKing tables.
-		gtid, err = conn.startSnapshotWithConsistentGTID(ctx)
-	}
+	gtid, err = conn.startSnapshot(ctx, table)
 	if err != nil {
 		return "", rotatedLog, err
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
@@ -95,14 +95,7 @@ func (ts *tableStreamer) Stream() error {
 	defer conn.Close()
 	ts.snapshotConn = conn
 
-	_, err = conn.ExecuteFetch("set session session_track_gtids = START_GTID", 1, false)
-	if err != nil {
-		// session_track_gtids = START_GTID unsupported or cannot execute. Resort to LOCK-based snapshot
-		ts.gtid, err = conn.startSnapshotAllTables(ts.ctx)
-	} else {
-		// session_track_gtids = START_GTID supported. Get a transaction with consistent GTID without LOCKing tables.
-		ts.gtid, err = conn.startSnapshotWithConsistentGTID(ts.ctx)
-	}
+	ts.gtid, err = conn.startSnapshotAllTables(ts.ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

## Description

An alternative approach to https://github.com/vitessio/vitess/pull/16421, addressing https://github.com/vitessio/vitess/issues/16420.
It's really a completely different take: this PR disables the use of tracked session GTIDs, essentially undoing some of the work in #11061. VReplication table streamer and row streamer will only ever use the tried-and-true `flush tables with read lock` to capture a transactionally consistent GTID.

There are multiple reasons here. First, the discrepancy of behavior we have right now between different flavors of MySQL, and across different CI jobs. This makes debugging and reproducibility more difficult to handle, and we've struggled with this for a while.
Next, and what actually kicks this work, is we're seeing a bug, and incorrect value for the tracked GTID, under certain workloads and with specific table structures. We began investigation into this. Out of precaution, we prefer to disable it at this time.

## Related Issue(s)

#16420 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
