### PR TITLE
fix: Use authentication_policy to specify default auth plugin for MySQL 8.4

### DIFF
--- a/config/mycnf/mysql84.cnf
+++ b/config/mycnf/mysql84.cnf
@@ -14,7 +14,7 @@ mysqlx = 0
 # 8.4 changes the default auth-plugin to caching_sha2_password and
 # disables mysql_native_password by default.
 mysql_native_password = ON
-default_authentication_plugin = mysql_native_password
+authentication_policy = 'mysql_native_password'
 
 # Semi-sync replication is required for automated unplanned failover
 # (when the primary goes away). Here we just load the plugin so it's


### PR DESCRIPTION
## Description

Fixes #16425

`default_authentication_plugin` was removed starting in MySQL 8.4.0:

> The default_authentication_plugin system variable, deprecated in MySQL 8.0.27, is removed as of
> MySQL 8.4.0. Use authentication_policy instead.
>
> -- https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html

I used the same process for testing the new MySQL 8.4 configuration file as described in the issue #16425.

The binary versions were different:

```
[vitess@78ec5221d252 vitess]$ mysqlctld --version;
mysqlctld version Version: 21.0.0-SNAPSHOT (Git revision cb1ea513ebd55ba3b9d409a235ad42190ea98777 branch 'update-mysql-84-default-cnf') built on Thu Jul 18 03:49:22 UTC 2024 by vitess@78ec5221d252 using go1.22.5 linux/amd64

[vitess@78ec5221d252 vitess]$ mysqld --version
/usr/sbin/mysqld  Ver 8.4.1 for Linux on x86_64 (MySQL Community Server - GPL)

```

When the same process is followed and the script `101_initial_cluster.sh` is run, the script works
and starts the mysqld process. This can be confirmed by looking at the output of `ps` as well as by
connecting directly to MySQL using the socket and the DBA user's name:

```sh
[vitess@78ec5221d252 vitess]$ ps -e
  PID TTY          TIME CMD
	1 pts/0    00:00:00 bash
11660 pts/0    00:00:01 etcd
11694 pts/0    00:00:00 vtctld
11935 pts/1    00:00:00 bash
11944 pts/0    00:00:03 mysqld
11945 pts/0    00:00:03 mysqld
11947 pts/0    00:00:03 mysqld
12086 pts/0    00:00:01 vttablet
12123 pts/0    00:00:01 vttablet
12157 pts/0    00:00:01 vttablet
12189 pts/0    00:00:06 vtorc
12419 pts/0    00:00:00 vtgate
12460 pts/0    00:00:00 vtadmin
13528 pts/1    00:00:00 ps

[vitess@78ec5221d252 vitess]$ mysql -S /vt/vt_0000000100/mysql.sock -u vt_dba
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 29
Server version: 8.4.1 MySQL Community Server - GPL

Copyright (c) 2000, 2024, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> \s
--------------
mysql  Ver 8.4.1 for Linux on x86_64 (MySQL Community Server - GPL)

Connection id:          29
Current database:
Current user:           vt_dba@localhost
SSL:                    Not in use
Current pager:          stdout
Using outfile:          ''
Using delimiter:        ;
Server version:         8.4.1 MySQL Community Server - GPL
Protocol version:       10
Connection:             Localhost via UNIX socket
Server characterset:    utf8mb4
Db     characterset:    utf8mb4
Client characterset:    utf8mb4
Conn.  characterset:    utf8mb4
UNIX socket:            /vt/vt_0000000100/mysql.sock
Binary data as:         Hexadecimal
Uptime:                 2 min 5 sec

Threads: 11  Questions: 2203  Slow queries: 0  Opens: 274  Flush tables: 4  Open tables: 88  Queries per second avg: 17.624
--------------

mysql> ^DBye
```

## Justification for requesting backport to v20

v20 has been released already with the file ([this commit](https://github.com/vitessio/vitess/commit/8f6cfaaa643a08dc111395a75a2d250ee746cfa8#diff-e5c41bef62d4fd127c6858e6c7533f12ad6f1fd07e23792adb19db04981955a8)). `EXTRA_MY_CNF` can not be used to override this default configuration file. This means that users must provide the complete `my.cnf` file using the `--mysqlctl_mycnf_template` argument to `mysqlctld`. (Please correct me if I am wrong. I am using [this](https://github.com/vitessio/vitess/blob/b1620481df197d50110ce37c70e9a7c51b5fd0cc/go/vt/mysqlctl/mysqld.go#L932-L966) part of the code to justify the need for backporting.) 

So, in order to support MySQL 8.4 starting in v20, this should be backported to a future release in the v20 series.

## Related Issue(s)
 
Fixes #16425 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
    - I ran the tests locally and there were many failing tests. But none of the failures were related to mysqld specifically, or this part of the code, I believe. Please let me know if there is a related test, and I will find and fix it.
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required


## Deployment Notes

None.