### PR TITLE
Complex Expression handling for uncorrelated IN and NOT IN subqueries

### DIFF
--- a/go/test/endtoend/vtgate/vitess_tester/subquery/subquery.test
+++ b/go/test/endtoend/vtgate/vitess_tester/subquery/subquery.test
@@ -27,8 +27,16 @@ INSERT INTO t2 (id3, id4) VALUES
 SELECT count(*) FROM t1 WHERE id1 = 0 AND id1 IN (SELECT id4 FROM t2);
 # Aggregation query with a complex expression that has an IN subquery.
 SELECT count(*) FROM t1 WHERE id1 = 2 OR id1 IN (SELECT id4 FROM t2);
+# Aggregation query with multiple expressions one of which is an IN subquery that returns empty results.
+SELECT count(*) FROM t1 WHERE id1 = 0 AND id1 IN (SELECT id4 FROM t2 where id4 = 3);
+# Aggregation query with a complex expression that has an IN subquery that returns empty results.
+SELECT count(*) FROM t1 WHERE id1 = 2 OR id1 IN (SELECT id4 FROM t2 where id4 = 3);
 
 # Aggregation query with multiple expressions one of which is an NOT IN subquery.
 SELECT count(*) FROM t1 WHERE id1 = 2 AND id1 NOT IN (SELECT id4 FROM t2);
 # Aggregation query with a complex expression that has an NOT IN subquery.
 SELECT count(*) FROM t1 WHERE id1 = 0 OR id1 NOT IN (SELECT id4 FROM t2);
+# Aggregation query with multiple expressions one of which is an NOT IN subquery that returns empty results.
+SELECT count(*) FROM t1 WHERE id1 = 2 AND id1 NOT IN (SELECT id4 FROM t2 where id4 = 3);
+# Aggregation query with a complex expression that has an NOT IN subquery that returns empty results.
+SELECT count(*) FROM t1 WHERE id1 = 0 OR id1 NOT IN (SELECT id4 FROM t2 where id4 = 3);

--- a/go/test/endtoend/vtgate/vitess_tester/subquery/subquery.test
+++ b/go/test/endtoend/vtgate/vitess_tester/subquery/subquery.test
@@ -1,0 +1,34 @@
+create table t1
+(
+    id1 bigint,
+    id2 bigint,
+    primary key (id1)
+) Engine = InnoDB;
+
+create table t2
+(
+    id3 bigint,
+    id4 bigint,
+    primary key (id3)
+) Engine = InnoDB;
+
+INSERT INTO t1 (id1, id2) VALUES
+(0, 0),
+(1, 1),
+(2, 2),
+(3, 3),
+(4, 4);
+
+INSERT INTO t2 (id3, id4) VALUES
+(0, 0),
+(1, 1);
+
+# Aggregation query with multiple expressions one of which is an IN subquery.
+SELECT count(*) FROM t1 WHERE id1 = 0 AND id1 IN (SELECT id4 FROM t2);
+# Aggregation query with a complex expression that has an IN subquery.
+SELECT count(*) FROM t1 WHERE id1 = 2 OR id1 IN (SELECT id4 FROM t2);
+
+# Aggregation query with multiple expressions one of which is an NOT IN subquery.
+SELECT count(*) FROM t1 WHERE id1 = 2 AND id1 NOT IN (SELECT id4 FROM t2);
+# Aggregation query with a complex expression that has an NOT IN subquery.
+SELECT count(*) FROM t1 WHERE id1 = 0 OR id1 NOT IN (SELECT id4 FROM t2);

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -208,7 +208,7 @@ func (sq *SubQuery) GetMergePredicates() []sqlparser.Expr {
 }
 
 func (sq *SubQuery) settle(ctx *plancontext.PlanningContext, outer Operator) Operator {
-	if !sq.TopLevel {
+	if !sq.TopLevel && sq.correlated {
 		panic(subqueryNotAtTopErr)
 	}
 	if sq.correlated && sq.FilterType != opcode.PulloutExists {
@@ -253,6 +253,20 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 	}
 	post := func(cursor *sqlparser.CopyOnWriteCursor) {
 		node := cursor.Node()
+		// For IN and NOT IN type filters, we have to add a Expression that checks if we got any rows back or not
+		// for correctness. That expression should be ANDed with the expression that has the IN/NOT IN comparison.
+		if compExpr, isCompExpr := node.(*sqlparser.ComparisonExpr); sq.FilterType.NeedsListArg() && isCompExpr {
+			if listArg, isListArg := compExpr.Right.(sqlparser.ListArg); isListArg && listArg.String() == sq.ArgName {
+				if sq.FilterType == opcode.PulloutIn {
+					cursor.Replace(sqlparser.AndExpressions(sqlparser.NewArgument(hasValuesArg()), compExpr))
+				} else {
+					cursor.Replace(&sqlparser.OrExpr{
+						Left:  sqlparser.NewNotExpr(sqlparser.NewArgument(hasValuesArg())),
+						Right: compExpr,
+					})
+				}
+			}
+		}
 		if _, ok := node.(*sqlparser.Subquery); !ok {
 			return
 		}
@@ -277,13 +291,18 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 		sq.FilterType = opcode.PulloutExists // it's the same pullout as EXISTS, just with a NOT in front of the predicate
 		predicates = append(predicates, sqlparser.NewNotExpr(sqlparser.NewArgument(hasValuesArg())))
 	case opcode.PulloutIn:
-		predicates = append(predicates, sqlparser.NewArgument(hasValuesArg()), rhsPred)
+		// Because we replace the comparison expression with an AND expression, it might be the top level construct there.
+		// In this case, it is better to send the two sides of the AND expression separately in the predicates because it can
+		// lead to better routing. This however might not always be true for example we can have the rhsPred to be something like
+		// `user.id = 2 OR (:__sq_has_values AND user.id IN ::sql1)`
+		if andExpr, isAndExpr := rhsPred.(*sqlparser.AndExpr); isAndExpr {
+			predicates = append(predicates, andExpr.Left, andExpr.Right)
+		} else {
+			predicates = append(predicates, rhsPred)
+		}
 		sq.SubqueryValueName = sq.ArgName
 	case opcode.PulloutNotIn:
-		predicates = append(predicates, &sqlparser.OrExpr{
-			Left:  sqlparser.NewNotExpr(sqlparser.NewArgument(hasValuesArg())),
-			Right: rhsPred,
-		})
+		predicates = append(predicates, rhsPred)
 		sq.SubqueryValueName = sq.ArgName
 	case opcode.PulloutValue:
 		predicates = append(predicates, rhsPred)

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -208,6 +208,8 @@ func (sq *SubQuery) GetMergePredicates() []sqlparser.Expr {
 }
 
 func (sq *SubQuery) settle(ctx *plancontext.PlanningContext, outer Operator) Operator {
+	// We can allow uncorrelated queries even when subquery isn't the top level construct,
+	// like if its underneath an Aggregator, because they will be pulled out and run separately.
 	if !sq.TopLevel && sq.correlated {
 		panic(subqueryNotAtTopErr)
 	}

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1884,6 +1884,112 @@
     }
   },
   {
+    "comment": "Complex expression in a subquery used in IN clause of an aggregate query",
+    "query": "select count(*) from user where user.id = 2 or user.id in (select id from unsharded_a where colb = 2)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(*) from user where user.id = 2 or user.id in (select id from unsharded_a where colb = 2)",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum_count_star(0) AS count(*)",
+        "Inputs": [
+          {
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutIn",
+            "PulloutVars": [
+              "__sq_has_values",
+              "__sq1"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select id from unsharded_a where 1 != 1",
+                "Query": "select id from unsharded_a where colb = 2",
+                "Table": "unsharded_a"
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select count(*) from `user` where 1 != 1",
+                "Query": "select count(*) from `user` where `user`.id = 2 or :__sq_has_values and `user`.id in ::__sq1",
+                "Table": "`user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded_a",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Complex expression in a subquery used in NOT IN clause of an aggregate query",
+    "query": "select count(*) from user where user.id = 2 or user.id not in (select id from unsharded_a where colb = 2)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(*) from user where user.id = 2 or user.id not in (select id from unsharded_a where colb = 2)",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum_count_star(0) AS count(*)",
+        "Inputs": [
+          {
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutNotIn",
+            "PulloutVars": [
+              "__sq_has_values",
+              "__sq1"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select id from unsharded_a where 1 != 1",
+                "Query": "select id from unsharded_a where colb = 2",
+                "Table": "unsharded_a"
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select count(*) from `user` where 1 != 1",
+                "Query": "select count(*) from `user` where `user`.id = 2 or (not :__sq_has_values or `user`.id not in ::__sq1)",
+                "Table": "`user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded_a",
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "testing SingleRow Projection with arithmetics",
     "query": "select 42+2",
     "plan": {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
As described in https://github.com/vitessio/vitess/issues/16433, Vitess did not support complex expressions even in uncorrelated queries.
This PR adds this support. One change that we had to make was with how we add `:__sq_has_values` expression on IN and NOT IN subqueries. Previously we would add the clause after we replaced the subquery with a list argument. That worked well for cases wherein we didn't have a complex expression but doesn't work well otherwise. 

For example, for a query like `select count(*) from user where user.id = 2 or user.id in (select id from unsharded_a where colb = 2)`, after we pullout the subquery, we want the final query to look like 
```sql
select count(*) from `user` where `user`.id = 2 or (:__sq_has_values and `user`.id in ::__sq1)
```
and not like 
```sql
select count(*) from `user` where :__sq_has_values and (`user`.id = 2 or `user`.id in ::__sq1)
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #16433 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
