### PR TITLE
mysqlctl: open backup files with fadvise(2) and FADV_SEQUENTIAL

### DIFF
--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -92,8 +92,7 @@ var (
 // it implements the BackupEngine interface and contains all the logic
 // required to implement a backup/restore by copying files from and to
 // the correct location / storage bucket
-type BuiltinBackupEngine struct {
-}
+type BuiltinBackupEngine struct{}
 
 // builtinBackupManifest represents the backup. It lists all the files, the
 // Position that the backup was taken at, the compression engine used, etc.
@@ -186,7 +185,7 @@ func (fe *FileEntry) fullPath(cnf *Mycnf) (string, error) {
 	return path.Join(fe.ParentPath, root, fe.Name), nil
 }
 
-// open attempts t oopen the file
+// open attempts to open the file
 func (fe *FileEntry) open(cnf *Mycnf, readOnly bool) (*os.File, error) {
 	name, err := fe.fullPath(cnf)
 	if err != nil {
@@ -194,7 +193,7 @@ func (fe *FileEntry) open(cnf *Mycnf, readOnly bool) (*os.File, error) {
 	}
 	var fd *os.File
 	if readOnly {
-		if fd, err = os.Open(name); err != nil {
+		if fd, err = openForSequential(name); err != nil {
 			return nil, vterrors.Wrapf(err, "cannot open source file %v", name)
 		}
 	} else {
@@ -393,7 +392,6 @@ func (be *BuiltinBackupEngine) executeIncrementalBackup(ctx context.Context, par
 // executeFullBackup returns a BackupResult that indicates the usability of the backup,
 // and an overall error.
 func (be *BuiltinBackupEngine) executeFullBackup(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle) (BackupResult, error) {
-
 	if params.IncrementalFromPos != "" {
 		return be.executeIncrementalBackup(ctx, params, bh)
 	}
@@ -968,7 +966,6 @@ func (be *BuiltinBackupEngine) executeRestoreIncrementalBackup(ctx context.Conte
 // we return the position from which replication should start
 // otherwise an error is returned
 func (be *BuiltinBackupEngine) ExecuteRestore(ctx context.Context, params RestoreParams, bh backupstorage.BackupHandle) (*BackupManifest, error) {
-
 	var bm builtinBackupManifest
 	if err := getBackupManifestInto(ctx, bh, &bm); err != nil {
 		return nil, err
@@ -1108,7 +1105,7 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 	// Create the uncompresser if needed.
 	if !bm.SkipCompress {
 		var decompressor io.ReadCloser
-		var deCompressionEngine = bm.CompressionEngine
+		deCompressionEngine := bm.CompressionEngine
 
 		if deCompressionEngine == "" {
 			// for backward compatibility

--- a/go/vt/mysqlctl/builtinbackupengine_linux.go
+++ b/go/vt/mysqlctl/builtinbackupengine_linux.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+li*/
+
+package mysqlctl
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openForSequential opens a file and hints to the kernel that this file
+// is intended to be read sequentially, setting the FADV_SEQUENTIAL flag.
+// See: https://linux.die.net/man/2/fadvise
+func openForSequential(name string) (*os.File, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	// XXX: beyond this path, if we error, we need to close
+	// our File since we're not returning it anymore.
+	fstat, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if err := unix.Fadvise(int(f.Fd()), 0, fstat.Size(), unix.FADV_SEQUENTIAL); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}

--- a/go/vt/mysqlctl/builtinbackupengine_stub.go
+++ b/go/vt/mysqlctl/builtinbackupengine_stub.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+li*/
+
+package mysqlctl
+
+import "os"
+
+func openForSequential(name string) (*os.File, error) {
+	return os.Open(name)
+}


### PR DESCRIPTION
On Linux, the fadvise(2) syscall can be leveraged to hint to the kernel to readahead disk pages since the file is intended to be read sequentially.

This works well with our use of opening this file, then slamming it into `io.Copy`.

In benchmarking, this alone yields around ~50% improvement on the read side without other tunings.

In a naive test, the setup was simply an io.Copy with an os.File for src, and io.Discard for dest:

  no fadvise: 222.41 MB/s
with fadvise: 344.69 MB/s

This is with no other tunings to the kernel.

## Related Issue(s)
#16442 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
