### PR TITLE
[release-18.0] Release of `v18.0.6`

### DIFF
--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - name: Fail if Code Freeze is enabled
       run: |
-        exit 1
+        exit 0

--- a/changelog/18.0/18.0.6/changelog.md
+++ b/changelog/18.0/18.0.6/changelog.md
@@ -1,0 +1,55 @@
+# Changelog of Vitess v18.0.6
+
+### Bug fixes 
+#### Docker
+ * [release-18.0] Fix the install dependencies script in Docker (#16340) [#16345](https://github.com/vitessio/vitess/pull/16345) 
+#### Query Serving
+ * [release-18.0] fix: handle info_schema routing (#15899) [#15905](https://github.com/vitessio/vitess/pull/15905)
+ * [release-18.0] fix: remove keyspace when merging subqueries (#16019) [#16026](https://github.com/vitessio/vitess/pull/16026)
+ * [release-18.0] Fix Incorrect Optimization with LIMIT and GROUP BY (#16263) [#16266](https://github.com/vitessio/vitess/pull/16266)
+ * [release-18.0] planner: Handle ORDER BY inside derived tables (#16353) [#16358](https://github.com/vitessio/vitess/pull/16358)
+ * [release-18.0] Fix Join Predicate Cleanup Bug in Route Merging (#16386) [#16388](https://github.com/vitessio/vitess/pull/16388) 
+#### VReplication
+ * [release-18.0] vtctldclient: Apply (Shard | Keyspace| Table) Routing Rules commands don't work (#16096) [#16123](https://github.com/vitessio/vitess/pull/16123)
+ * [release-18.0] VDiff CLI: Fix VDiff `show` bug (#16177) [#16197](https://github.com/vitessio/vitess/pull/16197)
+ * [release-18.0] VReplication Workflow: set state correctly when restarting workflow streams in the copy phase (#16217) [#16221](https://github.com/vitessio/vitess/pull/16221)
+ * [release-18.0] VReplication: Properly handle target shards w/o a primary in Reshard (#16283) [#16290](https://github.com/vitessio/vitess/pull/16290) 
+#### VTTablet
+ * [18.x] Fix `schemacopy` collation issues [#15859](https://github.com/vitessio/vitess/pull/15859) 
+#### VTorc
+ * [release-18.0] Add timeout to all the contexts used for RPC calls in vtorc (#15991) [#16104](https://github.com/vitessio/vitess/pull/16104) 
+#### vtexplain
+ * [release-18.0] Fix `vtexplain` not handling `UNION` queries with `weight_string` results correctly. (#16129) [#16156](https://github.com/vitessio/vitess/pull/16156)
+### CI/Build 
+#### Build/CI
+ * [release-18.0] Add DCO workflow (#16052) [#16055](https://github.com/vitessio/vitess/pull/16055)
+ * [release-18.0] Remove DCO workaround (#16087) [#16090](https://github.com/vitessio/vitess/pull/16090)
+ * [release-18.0] CI: Fix for xtrabackup install failures (#16329) [#16331](https://github.com/vitessio/vitess/pull/16331) 
+#### General
+ * [release-18.0] Upgrade the Golang version to `go1.21.11` [#16063](https://github.com/vitessio/vitess/pull/16063)
+ * [release-18.0] Upgrade the Golang version to `go1.21.12` [#16320](https://github.com/vitessio/vitess/pull/16320)
+### Dependencies 
+#### VTAdmin
+ * [release-18.0] Update braces package (#16115) [#16117](https://github.com/vitessio/vitess/pull/16117)
+### Internal Cleanup 
+#### Examples
+ * [release-18.0] Update env.sh so that is does not error when running on Mac (#15835) [#15914](https://github.com/vitessio/vitess/pull/15914)
+### Performance 
+#### VTTablet
+ * [release-18.0] Do not load table stats when booting `vttablet`. (#15715) [#16099](https://github.com/vitessio/vitess/pull/16099)
+### Regression 
+#### Query Serving
+ * [release-18.0] fix: insert on duplicate update to add list argument in the bind variables map (#15961) [#15966](https://github.com/vitessio/vitess/pull/15966)
+### Release 
+#### General
+ * [release-18.0] Bump to `v18.0.6-SNAPSHOT` after the `v18.0.5` release [#15888](https://github.com/vitessio/vitess/pull/15888)
+ * [release-18.0] Code Freeze for `v18.0.6` [#16444](https://github.com/vitessio/vitess/pull/16444)
+### Testing 
+#### Query Serving
+ * [release-18.0] test: Cleaner plan tests output (#15922) [#15923](https://github.com/vitessio/vitess/pull/15923)
+ * [release-18] Vitess tester workflow (#16127) [#16419](https://github.com/vitessio/vitess/pull/16419) 
+#### VTCombo
+ * [release-18.0] Fix flaky tests that use vtcombo (#16178) [#16211](https://github.com/vitessio/vitess/pull/16211) 
+#### vtexplain
+ * [release-18.0] Fix flakiness in `vtexplain` unit test case. (#16159) [#16166](https://github.com/vitessio/vitess/pull/16166)
+

--- a/changelog/18.0/18.0.6/release_notes.md
+++ b/changelog/18.0/18.0.6/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v18.0.6
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/18.0/18.0.6/changelog.md).
+
+The release includes 28 merged Pull Requests.
+
+Thanks to all our contributors: @GuptaManan100, @app/vitess-bot, @arthurschreiber, @shlomi-noach, @vitess-bot
+

--- a/changelog/18.0/README.md
+++ b/changelog/18.0/README.md
@@ -1,4 +1,8 @@
 ## v18.0
+* **[18.0.6](18.0.6)**
+	* [Changelog](18.0.6/changelog.md)
+	* [Release Notes](18.0.6/release_notes.md)
+
 * **[18.0.5](18.0.5)**
 	* [Changelog](18.0.5/changelog.md)
 	* [Release Notes](18.0.5/release_notes.md)

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -58,7 +58,7 @@ services:
       - "3306"
 
   vtctld:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15000:$WEB_PORT"
       - "$GRPC_PORT"
@@ -81,7 +81,7 @@ services:
         condition: service_healthy
 
   vtgate:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15099:$WEB_PORT"
       - "$GRPC_PORT"
@@ -111,7 +111,7 @@ services:
         condition: service_healthy
 
   schemaload:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     command:
     - sh
     - -c
@@ -144,12 +144,12 @@ services:
     environment:
       - KEYSPACES=$KEYSPACE
       - GRPC_PORT=15999
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - .:/script
 
   vttablet100:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15100:$WEB_PORT"
       - "$GRPC_PORT"
@@ -181,7 +181,7 @@ services:
       retries: 15
 
   vttablet101:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15101:$WEB_PORT"
       - "$GRPC_PORT"
@@ -213,7 +213,7 @@ services:
       retries: 15
 
   vttablet102:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15102:$WEB_PORT"
       - "$GRPC_PORT"
@@ -245,7 +245,7 @@ services:
       retries: 15
 
   vttablet103:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15103:$WEB_PORT"
       - "$GRPC_PORT"
@@ -277,7 +277,7 @@ services:
       retries: 15
 
   vtorc:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     command: ["sh", "-c", "/script/vtorc-up.sh"]
     depends_on:
       - vtctld
@@ -307,7 +307,7 @@ services:
       retries: 15
 
   vreplication:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - ".:/script"
     environment:

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     - SCHEMA_FILES=lookup_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
     - .:/script
   schemaload_test_keyspace:
@@ -101,7 +101,7 @@ services:
     - SCHEMA_FILES=test_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
     - .:/script
   set_keyspace_durability_policy:
@@ -115,7 +115,7 @@ services:
     environment:
       - KEYSPACES=test_keyspace lookup_keyspace
       - GRPC_PORT=15999
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - .:/script
   vreplication:
@@ -129,7 +129,7 @@ services:
     - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
       --topo_global_root vitess/global
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
     - .:/script
   vtctld:
@@ -143,7 +143,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15000:8080
     - "15999"
@@ -160,7 +160,7 @@ services:
       --normalize_queries=true '
     depends_on:
     - vtctld
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15099:8080
     - "15999"
@@ -182,7 +182,7 @@ services:
     - EXTERNAL_DB=0
     - DB_USER=
     - DB_PASS=
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 13000:8080
     volumes:
@@ -217,7 +217,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15101:8080
     - "15999"
@@ -254,7 +254,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15102:8080
     - "15999"
@@ -291,7 +291,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15201:8080
     - "15999"
@@ -328,7 +328,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15202:8080
     - "15999"
@@ -365,7 +365,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15301:8080
     - "15999"
@@ -402,7 +402,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - 15302:8080
     - "15999"

--- a/examples/compose/vtcompose/docker-compose.test.yml
+++ b/examples/compose/vtcompose/docker-compose.test.yml
@@ -79,7 +79,7 @@ services:
       - SCHEMA_FILES=test_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - .:/script
   schemaload_unsharded_keyspace:
@@ -103,7 +103,7 @@ services:
       - SCHEMA_FILES=unsharded_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - .:/script
   set_keyspace_durability_policy_test_keyspace:
@@ -117,7 +117,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=test_keyspace
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - .:/script
   set_keyspace_durability_policy_unsharded_keyspace:
@@ -130,7 +130,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=unsharded_keyspace
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - .:/script
   vreplication:
@@ -144,7 +144,7 @@ services:
       - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
         --topo_global_root vitess/global
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - .:/script
   vtctld:
@@ -159,7 +159,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 15000:8080
       - "15999"
@@ -176,7 +176,7 @@ services:
       ''grpc-vtgateservice'' --normalize_queries=true '
     depends_on:
       - vtctld
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 15099:8080
       - "15999"
@@ -199,7 +199,7 @@ services:
       - EXTERNAL_DB=0
       - DB_USER=
       - DB_PASS=
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 13000:8080
     volumes:
@@ -234,7 +234,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 15101:8080
       - "15999"
@@ -271,7 +271,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 15102:8080
       - "15999"
@@ -308,7 +308,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 15201:8080
       - "15999"
@@ -345,7 +345,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 15202:8080
       - "15999"
@@ -382,7 +382,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - 15301:8080
       - "15999"

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -533,7 +533,7 @@ func generateDefaultShard(tabAlias int, shard string, keyspaceData keyspaceInfo,
 - op: add
   path: /services/init_shard_primary%[2]d
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     command: ["sh", "-c", "/vt/bin/vtctldclient %[5]s InitShardPrimary --force %[4]s/%[3]s %[6]s-%[2]d "]
     %[1]s
 `, dependsOn, aliases[0], shard, keyspaceData.keyspace, opts.topologyFlags, opts.cell)
@@ -565,7 +565,7 @@ func generateExternalPrimary(
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15%[1]d:%[3]d"
       - "%[4]d"
@@ -627,7 +627,7 @@ func generateDefaultTablet(tabAlias int, shard, role, keyspace string, dbInfo ex
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
     - "15%[1]d:%[4]d"
     - "%[5]d"
@@ -665,7 +665,7 @@ func generateVtctld(opts vtOptions) string {
 - op: add
   path: /services/vtctld
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15000:%[1]d"
       - "%[2]d"
@@ -696,7 +696,7 @@ func generateVtgate(opts vtOptions) string {
 - op: add
   path: /services/vtgate
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     ports:
       - "15099:%[1]d"
       - "%[2]d"
@@ -738,7 +738,7 @@ func generateVTOrc(dbInfo externalDbInfo, keyspaceInfoMap map[string]keyspaceInf
 - op: add
   path: /services/vtorc
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - ".:/script"
     environment:
@@ -763,7 +763,7 @@ func generateVreplication(dbInfo externalDbInfo, opts vtOptions) string {
 - op: add
   path: /services/vreplication
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - ".:/script"
     environment:
@@ -791,7 +791,7 @@ func generateSetKeyspaceDurabilityPolicy(
 - op: add
   path: /services/set_keyspace_durability_policy_%[3]s
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - ".:/script"
     environment:
@@ -828,7 +828,7 @@ func generateSchemaload(
 - op: add
   path: /services/schemaload_%[7]s
   value:
-    image: vitess/lite:v18.0.5
+    image: vitess/lite:v18.0.6
     volumes:
       - ".:/script"
     environment:

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,14 +8,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.6
+    vtadmin: vitess/vtadmin:v18.0.6
+    vtgate: vitess/lite:v18.0.6
+    vttablet: vitess/lite:v18.0.6
+    vtbackup: vitess/lite:v18.0.6
+    vtorc: vitess/lite:v18.0.6
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.6
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.6
+    vtadmin: vitess/vtadmin:v18.0.6
+    vtgate: vitess/lite:v18.0.6
+    vttablet: vitess/lite:v18.0.6
+    vtbackup: vitess/lite:v18.0.6
+    vtorc: vitess/lite:v18.0.6
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.6
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.6
+    vtadmin: vitess/vtadmin:v18.0.6
+    vtgate: vitess/lite:v18.0.6
+    vttablet: vitess/lite:v18.0.6
+    vtbackup: vitess/lite:v18.0.6
+    vtorc: vitess/lite:v18.0.6
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.6
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.5
-    vtadmin: vitess/vtadmin:v18.0.5
-    vtgate: vitess/lite:v18.0.5
-    vttablet: vitess/lite:v18.0.5
-    vtbackup: vitess/lite:v18.0.5
-    vtorc: vitess/lite:v18.0.5
+    vtctld: vitess/lite:v18.0.6
+    vtadmin: vitess/vtadmin:v18.0.6
+    vtgate: vitess/lite:v18.0.6
+    vttablet: vitess/lite:v18.0.6
+    vtbackup: vitess/lite:v18.0.6
+    vtorc: vitess/lite:v18.0.6
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.5
+      mysql80Compatible: vitess/lite:v18.0.6
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/go/vt/servenv/version.go
+++ b/go/vt/servenv/version.go
@@ -19,4 +19,4 @@ package servenv
 // DO NOT EDIT
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
-const versionName = "18.0.6-SNAPSHOT"
+const versionName = "18.0.6"

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.6-SNAPSHOT</version>
+    <version>18.0.6</version>
   </parent>
   <artifactId>vitess-client</artifactId>
 

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.6-SNAPSHOT</version>
+    <version>18.0.6</version>
   </parent>
   <artifactId>vitess-example</artifactId>
 

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.6-SNAPSHOT</version>
+    <version>18.0.6</version>
   </parent>
   <artifactId>vitess-grpc-client</artifactId>
 

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.6-SNAPSHOT</version>
+    <version>18.0.6</version>
   </parent>
   <artifactId>vitess-jdbc</artifactId>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.vitess</groupId>
   <artifactId>vitess-parent</artifactId>
-  <version>18.0.6-SNAPSHOT</version>
+  <version>18.0.6</version>
   <packaging>pom</packaging>
 
   <name>Vitess Java Client libraries [Parent]</name>


### PR DESCRIPTION
Includes the release notes and release commit for the `v18.0.6` release. Once this PR is merged, we will be able to tag `v18.0.6` on the merge commit.