### PR TITLE
Remove some unused MySQL 5.6 code

### DIFF
--- a/go/mysql/binlog_event.go
+++ b/go/mysql/binlog_event.go
@@ -158,7 +158,7 @@ type BinlogFormat struct {
 	HeaderSizes []byte
 
 	// ServerVersion is the name of the MySQL server version.
-	// It starts with something like 5.6.33-xxxx.
+	// It starts with something like 8.0.34-xxxx.
 	ServerVersion string
 
 	// FormatVersion is the version number of the binlog file format.

--- a/go/mysql/capabilities/capability.go
+++ b/go/mysql/capabilities/capability.go
@@ -40,7 +40,6 @@ const (
 	InstantAddDropColumnFlavorCapability                                // Adding/dropping column in any position/ordinal.
 	InstantChangeColumnDefaultFlavorCapability                          //
 	InstantExpandEnumCapability                                         //
-	MySQLJSONFlavorCapability                                           // JSON type supported
 	MySQLUpgradeInServerFlavorCapability                                //
 	DynamicRedoLogCapacityFlavorCapability                              // supported in MySQL 8.0.30 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html
 	DisableRedoLogFlavorCapability                                      // supported in MySQL 8.0.21 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-21.html
@@ -89,8 +88,6 @@ func MySQLVersionHasCapability(serverVersion string, capability FlavorCapability
 	}
 	// Capabilities sorted by version.
 	switch capability {
-	case MySQLJSONFlavorCapability:
-		return atLeast(5, 7, 0)
 	case InstantDDLFlavorCapability,
 		InstantExpandEnumCapability,
 		InstantAddLastColumnFlavorCapability,

--- a/go/mysql/capabilities/capability_test.go
+++ b/go/mysql/capabilities/capability_test.go
@@ -145,7 +145,7 @@ func TestMySQLVersionCapableOf(t *testing.T) {
 			isCapable:  false,
 		},
 		{
-			version:    "5.6.7",
+			version:    "5.7.29",
 			capability: InstantDDLFlavorCapability,
 			isCapable:  false,
 		},
@@ -153,16 +153,6 @@ func TestMySQLVersionCapableOf(t *testing.T) {
 			version:    "5.7.29",
 			capability: TransactionalGtidExecutedFlavorCapability,
 			isCapable:  false,
-		},
-		{
-			version:    "5.6.7",
-			capability: MySQLJSONFlavorCapability,
-			isCapable:  false,
-		},
-		{
-			version:    "5.7.29",
-			capability: MySQLJSONFlavorCapability,
-			isCapable:  true,
 		},
 		{
 			version:    "8.0.30",

--- a/go/mysql/flavor_mysqlgr_test.go
+++ b/go/mysql/flavor_mysqlgr_test.go
@@ -84,7 +84,7 @@ func TestMysqlGRSupportCapability(t *testing.T) {
 			isCapable:  false,
 		},
 		{
-			version:    "5.6.7",
+			version:    "5.7.29",
 			capability: capabilities.InstantDDLFlavorCapability,
 			isCapable:  false,
 		},
@@ -92,16 +92,6 @@ func TestMysqlGRSupportCapability(t *testing.T) {
 			version:    "5.7.29",
 			capability: capabilities.TransactionalGtidExecutedFlavorCapability,
 			isCapable:  false,
-		},
-		{
-			version:    "5.6.7",
-			capability: capabilities.MySQLJSONFlavorCapability,
-			isCapable:  false,
-		},
-		{
-			version:    "5.7.29",
-			capability: capabilities.MySQLJSONFlavorCapability,
-			isCapable:  true,
 		},
 		{
 			version:    "8.0.30",

--- a/go/mysql/flavor_test.go
+++ b/go/mysql/flavor_test.go
@@ -54,11 +54,6 @@ func TestServerVersionCapableOf(t *testing.T) {
 			isCapable:  false,
 		},
 		{
-			version:    "5.7.29",
-			capability: capabilities.MySQLJSONFlavorCapability,
-			isCapable:  true,
-		},
-		{
 			version:    "8.0.30",
 			capability: capabilities.DynamicRedoLogCapacityFlavorCapability,
 			isCapable:  true,


### PR DESCRIPTION
## Description

Removes some unused MySQL 5.6 code. Usage of `MySQLJSONFlavorCapability` was already removed some time ago, but the capability was left in. I also noticed some stuff for collations and binlog, but I left that alone (at least for this PR).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
