### PR TITLE
Small internal cleanups

### DIFF
--- a/go/mysql/collations/env.go
+++ b/go/mysql/collations/env.go
@@ -105,10 +105,6 @@ func NewEnvironment(serverVersion string) *Environment {
 	var version collver = collverMySQL8
 	serverVersion = strings.TrimSpace(strings.ToLower(serverVersion))
 	switch {
-	case strings.HasSuffix(serverVersion, "-ripple"):
-		// the ripple binlog server can mask the actual version of mysqld;
-		// assume we have the highest
-		version = collverMySQL8
 	case strings.Contains(serverVersion, "mariadb"):
 		switch {
 		case strings.Contains(serverVersion, "10.0."):

--- a/go/mysql/collations/env.go
+++ b/go/mysql/collations/env.go
@@ -100,10 +100,9 @@ func fetchCacheEnvironment(version collver) *Environment {
 // The version string must be in the format that is sent by the server as the version packet
 // when opening a new MySQL connection
 func NewEnvironment(serverVersion string) *Environment {
-	// 5.7 is the oldest version we support today, so use that as
-	// the default.
-	// NOTE: this should be changed when we EOL MySQL 5.7 support
-	var version collver = collverMySQL57
+	// 8.0 is the oldest fully supported version, so use that as the default.
+	// All newer MySQL versions including 9 are so far compatible as well.
+	var version collver = collverMySQL8
 	serverVersion = strings.TrimSpace(strings.ToLower(serverVersion))
 	switch {
 	case strings.HasSuffix(serverVersion, "-ripple"):
@@ -125,8 +124,6 @@ func NewEnvironment(serverVersion string) *Environment {
 		version = collverMySQL56
 	case strings.HasPrefix(serverVersion, "5.7."):
 		version = collverMySQL57
-	case strings.HasPrefix(serverVersion, "8."):
-		version = collverMySQL8
 	}
 	return fetchCacheEnvironment(version)
 }

--- a/go/mysql/collations/integration/main_test.go
+++ b/go/mysql/collations/integration/main_test.go
@@ -47,7 +47,7 @@ func mysqlconn(t *testing.T) *mysql.Conn {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(conn.ServerVersion, "8.") {
+	if strings.HasPrefix(conn.ServerVersion, "5.7.") {
 		conn.Close()
 		t.Skipf("collation integration tests are only supported in MySQL 8.0+")
 	}

--- a/go/vt/vtgate/evalengine/api_coerce.go
+++ b/go/vt/vtgate/evalengine/api_coerce.go
@@ -24,7 +24,7 @@ import (
 )
 
 func CoerceTo(value sqltypes.Value, typ Type, sqlmode SQLMode) (sqltypes.Value, error) {
-	cast, err := valueToEvalCast(value, value.Type(), collations.Unknown, typ.values, sqlmode)
+	cast, err := valueToEvalCast(value, value.Type(), typ.collation, typ.values, sqlmode)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}


### PR DESCRIPTION
This cleans up some logic around the default collation and coercion. We now make the MySQL 8 collations the default if there's no version mismatch instead of what we had with MySQL 5.7.

Additionally we fix a small issue that doesn't really matter in practice with an unknown collation, but we know have a full type so we do know it, so let's use it.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required