### PR TITLE
Modify distributed transaction commit flow

### DIFF
--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -34,8 +34,9 @@ func (e ErrorCode) ToString() string {
 // See above reference for more information on each code.
 const (
 	// Vitess specific errors, (100-999)
-	ERNotReplica      = ErrorCode(100)
-	ERNonAtomicCommit = ErrorCode(301)
+	ERNotReplica       = ErrorCode(100)
+	ERNonAtomicCommit  = ErrorCode(301)
+	ERInAtomicRecovery = ErrorCode(302)
 
 	// unknown
 	ERUnknownError = ErrorCode(1105)

--- a/go/test/endtoend/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/transaction/twopc/twopc_test.go
@@ -583,7 +583,7 @@ func TestDTResolveAfterMMCommit(t *testing.T) {
 	require.ErrorContains(t, err, "Fail After MM commit")
 
 	testWarningAndTransactionStatus(t, conn,
-		"distributed transaction ID failed during metadata manager commit; transaction will be committed/roll based on the state on recovery",
+		"distributed transaction ID failed during metadata manager commit; transaction will be committed/rollbacked based on the state on recovery",
 		false, "COMMIT", "ks:40-80,ks:-40")
 
 	// Below check ensures that the transaction is resolved by the resolver on receiving unresolved transaction signal from MM.

--- a/go/test/endtoend/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/transaction/twopc/twopc_test.go
@@ -31,11 +31,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/callerid"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
 
 // TestDTCommit tests distributed transaction commit for insert, update and delete operations
@@ -580,6 +582,10 @@ func TestDTResolveAfterMMCommit(t *testing.T) {
 	_, err = conn.Execute(newCtx, "commit", nil)
 	require.ErrorContains(t, err, "Fail After MM commit")
 
+	testWarningAndTransactionStatus(t, conn,
+		"distributed transaction ID failed during metadata manager commit; transaction will be committed/roll based on the state on recovery",
+		false, "COMMIT", "ks:40-80,ks:-40")
+
 	// Below check ensures that the transaction is resolved by the resolver on receiving unresolved transaction signal from MM.
 	tableMap := make(map[string][]*querypb.Field)
 	dtMap := make(map[string]string)
@@ -656,6 +662,10 @@ func TestDTResolveAfterRMPrepare(t *testing.T) {
 	_, err = conn.Execute(newCtx, "commit", nil)
 	require.ErrorContains(t, err, "Fail After RM prepared")
 
+	testWarningAndTransactionStatus(t, conn,
+		"distributed transaction ID failed during transaction prepare phase; prepare transaction rollback attempted; conclude on recovery",
+		true /* transaction concluded */, "", "")
+
 	// Below check ensures that the transaction is resolved by the resolver on receiving unresolved transaction signal from MM.
 	tableMap := make(map[string][]*querypb.Field)
 	dtMap := make(map[string]string)
@@ -713,6 +723,10 @@ func TestDTResolveDuringRMPrepare(t *testing.T) {
 	newCtx := callerid.NewContext(qCtx, callerid.NewEffectiveCallerID("RMPrepare_-40_FailNow", "", ""), nil)
 	_, err = conn.Execute(newCtx, "commit", nil)
 	require.ErrorContains(t, err, "Fail During RM prepare")
+
+	testWarningAndTransactionStatus(t, conn,
+		"distributed transaction ID failed during transaction prepare phase; prepare transaction rollback attempted; conclude on recovery",
+		true, "", "")
 
 	// Below check ensures that the transaction is resolved by the resolver on receiving unresolved transaction signal from MM.
 	tableMap := make(map[string][]*querypb.Field)
@@ -775,6 +789,10 @@ func TestDTResolveDuringRMCommit(t *testing.T) {
 	newCtx := callerid.NewContext(qCtx, callerid.NewEffectiveCallerID("RMCommit_-40_FailNow", "", ""), nil)
 	_, err = conn.Execute(newCtx, "commit", nil)
 	require.ErrorContains(t, err, "Fail During RM commit")
+
+	testWarningAndTransactionStatus(t, conn,
+		"distributed transaction ID failed during resource manager commit; transaction will be committed on recovery",
+		false, "COMMIT", "ks:40-80,ks:-40")
 
 	// Below check ensures that the transaction is resolved by the resolver on receiving unresolved transaction signal from MM.
 	tableMap := make(map[string][]*querypb.Field)
@@ -851,18 +869,9 @@ func TestDTResolveAfterTransactionRecord(t *testing.T) {
 	_, err = conn.Execute(newCtx, "commit", nil)
 	require.ErrorContains(t, err, "Fail After TR created")
 
-	t.Run("ReadTransactionState", func(t *testing.T) {
-		errStr := err.Error()
-		indx := strings.Index(errStr, "Fail")
-		require.Greater(t, indx, 0)
-		dtid := errStr[0 : indx-2]
-		res, err := conn.Execute(context.Background(), fmt.Sprintf(`show transaction status for '%v'`, dtid), nil)
-		require.NoError(t, err)
-		resStr := fmt.Sprintf("%v", res.Rows)
-		require.Contains(t, resStr, `[[VARCHAR("ks:80-`)
-		require.Contains(t, resStr, `VARCHAR("PREPARE") DATETIME("`)
-		require.Contains(t, resStr, `+0000 UTC") VARCHAR("ks:40-80")]]`)
-	})
+	testWarningAndTransactionStatus(t, conn,
+		"distributed transaction ID failed during transaction record creation; rollback attempted; conclude on recovery",
+		false, "PREPARE", "ks:40-80")
 
 	// Below check ensures that the transaction is resolved by the resolver on receiving unresolved transaction signal from MM.
 	tableMap := make(map[string][]*querypb.Field)
@@ -883,36 +892,66 @@ func TestDTResolveAfterTransactionRecord(t *testing.T) {
 		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
 }
 
-// TestDTWarningAfterMMCommit tests that failure after MM commit returns a warning.
-func TestDTWarningAfterMMCommit(t *testing.T) {
-	defer cleanup(t)
+type warn struct {
+	level string
+	code  uint16
+	msg   string
+}
 
-	vtgateConn, err := cluster.DialVTGate(context.Background(), t.Name(), vtgateGrpcAddress, "dt_user", "")
-	require.NoError(t, err)
-	defer vtgateConn.Close()
+func toWarn(row sqltypes.Row) warn {
+	code, _ := row[1].ToUint16()
+	return warn{
+		level: row[0].ToString(),
+		code:  code,
+		msg:   row[2].ToString(),
+	}
+}
 
-	conn := vtgateConn.Session("", nil)
-	qCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	// Insert into multiple shards
-	_, err = conn.Execute(qCtx, "begin", nil)
+type txStatus struct {
+	dtid         string
+	state        string
+	rTime        string
+	participants string
+}
+
+func toTxStatus(row sqltypes.Row) txStatus {
+	return txStatus{
+		dtid:         row[0].ToString(),
+		state:        row[1].ToString(),
+		rTime:        row[2].ToString(),
+		participants: row[3].ToString(),
+	}
+}
+
+func testWarningAndTransactionStatus(t *testing.T, conn *vtgateconn.VTGateSession, warnMsg string,
+	txConcluded bool, txState string, txParticipants string) {
+	t.Helper()
+
+	qr, err := conn.Execute(context.Background(), "show warnings", nil)
 	require.NoError(t, err)
-	_, err = conn.Execute(qCtx, "insert into twopc_user(id, name) values(7,'foo')", nil)
-	require.NoError(t, err)
-	_, err = conn.Execute(qCtx, "insert into twopc_user(id, name) values(8,'bar')", nil)
-	require.NoError(t, err)
-	_, err = conn.Execute(qCtx, "insert into twopc_user(id, name) values(9,'baz')", nil)
-	require.NoError(t, err)
-	_, err = conn.Execute(qCtx, "insert into twopc_user(id, name) values(10,'apa')", nil)
+	require.Len(t, qr.Rows, 1)
+
+	// validate warning output
+	w := toWarn(qr.Rows[0])
+	assert.Equal(t, "Warning", w.level)
+	assert.EqualValues(t, 302, w.code)
+	assert.Contains(t, w.msg, warnMsg)
+
+	// extract transaction ID
+	indx := strings.Index(w.msg, " ")
+	require.Greater(t, indx, 0)
+	dtid := w.msg[:indx]
+
+	qr, err = conn.Execute(context.Background(), fmt.Sprintf(`show transaction status for '%v'`, dtid), nil)
 	require.NoError(t, err)
 
-	// The caller ID is used to simulate the failure at the desired point.
-	newCtx := callerid.NewContext(qCtx, callerid.NewEffectiveCallerID("MMCommitted_FailNow", "", ""), nil)
-	_, err = conn.Execute(newCtx, "commit", nil)
-	require.ErrorContains(t, err, "Fail After MM commit")
-
-	qr, err := conn.Execute(qCtx, "show warnings", nil)
-	require.NoError(t, err)
-	require.Contains(t, fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("Warning") UINT16(302) VARCHAR("ks:80-:`)
-	require.Contains(t, fmt.Sprintf("%v", qr.Rows), `distributed transaction ID failed during metadata manager commit`)
+	// validate transaction status
+	if txConcluded {
+		require.Empty(t, qr.Rows)
+	} else {
+		tx := toTxStatus(qr.Rows[0])
+		assert.Equal(t, dtid, tx.dtid)
+		assert.Equal(t, txState, tx.state)
+		assert.Equal(t, txParticipants, tx.participants)
+	}
 }

--- a/go/vt/vtgate/debug_2pc.go
+++ b/go/vt/vtgate/debug_2pc.go
@@ -18,4 +18,52 @@ limitations under the License.
 
 package vtgate
 
+import (
+	"context"
+
+	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/log"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
 const DebugTwoPc = true
+
+// checkTestFailure is used to simulate failures in 2PC flow for testing when DebugTwoPc is true.
+func checkTestFailure(ctx context.Context, expectCaller string, target *querypb.Target) error {
+	callerID := callerid.EffectiveCallerIDFromContext(ctx)
+	if callerID == nil || callerID.GetPrincipal() != expectCaller {
+		return nil
+	}
+	switch callerID.Principal {
+	case "TRCreated_FailNow":
+		log.Errorf("Fail After TR created")
+		// no commit decision is made. Transaction should be a rolled back.
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Fail After TR created")
+	case "RMPrepare_-40_FailNow":
+		if target.Shard != "-40" {
+			return nil
+		}
+		log.Errorf("Fail During RM prepare")
+		// no commit decision is made. Transaction should be a rolled back.
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Fail During RM prepare")
+	case "RMPrepared_FailNow":
+		log.Errorf("Fail After RM prepared")
+		// no commit decision is made. Transaction should be a rolled back.
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Fail After RM prepared")
+	case "MMCommitted_FailNow":
+		log.Errorf("Fail After MM commit")
+		//  commit decision is made. Transaction should be committed.
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Fail After MM commit")
+	case "RMCommit_-40_FailNow":
+		if target.Shard != "-40" {
+			return nil
+		}
+		log.Errorf("Fail During RM commit")
+		// commit decision is made. Transaction should be a committed.
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Fail During RM commit")
+	default:
+		return nil
+	}
+}

--- a/go/vt/vtgate/engine/transaction_status.go
+++ b/go/vt/vtgate/engine/transaction_status.go
@@ -84,7 +84,7 @@ func (t *TransactionStatus) TryExecute(ctx context.Context, vcursor VCursor, bin
 	if wantfields {
 		res.Fields = t.getFields()
 	}
-	if transactionState != nil {
+	if transactionState != nil && transactionState.Dtid != "" {
 		var participantString []string
 		for _, participant := range transactionState.Participants {
 			participantString = append(participantString, fmt.Sprintf("%s:%s", participant.Keyspace, participant.Shard))

--- a/go/vt/vtgate/production.go
+++ b/go/vt/vtgate/production.go
@@ -18,6 +18,12 @@ limitations under the License.
 
 package vtgate
 
+import (
+	"context"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
 // This file defines debug constants that are always false.
 // This file is used for building production code.
 // We use go build directives to include a file that defines the constant to true
@@ -26,3 +32,7 @@ package vtgate
 // production performance.
 
 const DebugTwoPc = false
+
+func checkTestFailure(_ context.Context, _ string, _ *querypb.Target) error {
+	return nil
+}

--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -302,7 +302,7 @@ func createWarningMessage(dtid string, txPhase commitPhase) string {
 	case COMMIT2PC_PREPARE:
 		warningMsg += " transaction prepare phase; prepare transaction rollback attempted; conclude on recovery"
 	case COMMIT2PC_STARTCOMMIT:
-		warningMsg += " metadata manager commit; transaction will be committed/roll based on the state on recovery"
+		warningMsg += " metadata manager commit; transaction will be committed/rollbacked based on the state on recovery"
 	case COMMIT2PC_PREPARECOMMIT:
 		warningMsg += " resource manager commit; transaction will be committed on recovery"
 	case COMMIT2PC_CONCLUDE:

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -1090,9 +1090,7 @@ func TestTxConnCommit2PCConcludeTransactionFail(t *testing.T) {
 	sbc0.MustFailConcludeTransaction = 1
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
 	err := sc.txConn.Commit(ctx, session)
-	want := "error: err"
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), want, "Commit")
+	require.NoError(t, err) // ConcludeTransaction is best-effort as it does not impact the outcome.
 	assert.EqualValues(t, 1, sbc0.CreateTransactionCount.Load(), "sbc0.CreateTransactionCount")
 	assert.EqualValues(t, 1, sbc1.PrepareCount.Load(), "sbc1.PrepareCount")
 	assert.EqualValues(t, 1, sbc0.StartCommitCount.Load(), "sbc0.StartCommitCount")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR updates the commit flow as per the new design doc on atomic distributed transactions.
- Any failure before a commit decision rollback the transaction.
- Any failure before conclude, records a warning and return an error.
- The user can track the transaction state by issuing `show warnings` and then extracting transaction ID. Later can issue `show transaction status for '<id>'` to know the current state of it.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #16245 

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
