### PR TITLE
VStream API: validate that last PK has fields defined

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -88,7 +88,7 @@ type uvstreamer struct {
 
 	config *uvstreamerConfig
 
-	vs *vstreamer //last vstreamer created in uvstreamer
+	vs *vstreamer // last vstreamer created in uvstreamer
 }
 
 type uvstreamerConfig struct {
@@ -138,6 +138,10 @@ func (uvs *uvstreamer) buildTablePlan() error {
 	uvs.plans = make(map[string]*tablePlan)
 	tableLastPKs := make(map[string]*binlogdatapb.TableLastPK)
 	for _, tablePK := range uvs.inTablePKs {
+		if tablePK != nil && tablePK.Lastpk != nil && len(tablePK.Lastpk.Fields) == 0 {
+			log.Errorf("lastpk for table %s has no fields defined", tablePK.TableName)
+			return fmt.Errorf("lastpk for table %s has no fields defined", tablePK.TableName)
+		}
 		tableLastPKs[tablePK.TableName] = tablePK
 	}
 	tables := uvs.se.GetSchema()
@@ -313,7 +317,7 @@ func (uvs *uvstreamer) send2(evs []*binlogdatapb.VEvent) error {
 	}
 	behind := time.Now().UnixNano() - uvs.lastTimestampNs
 	uvs.setReplicationLagSeconds(behind / 1e9)
-	//log.Infof("sbm set to %d", uvs.ReplicationLagSeconds)
+	// log.Infof("sbm set to %d", uvs.ReplicationLagSeconds)
 	var evs2 []*binlogdatapb.VEvent
 	if len(uvs.plans) > 0 {
 		evs2 = uvs.filterEvents(evs)

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -139,7 +139,6 @@ func (uvs *uvstreamer) buildTablePlan() error {
 	tableLastPKs := make(map[string]*binlogdatapb.TableLastPK)
 	for _, tablePK := range uvs.inTablePKs {
 		if tablePK != nil && tablePK.Lastpk != nil && len(tablePK.Lastpk.Fields) == 0 {
-			log.Errorf("lastpk for table %s has no fields defined", tablePK.TableName)
 			return fmt.Errorf("lastpk for table %s has no fields defined", tablePK.TableName)
 		}
 		tableLastPKs[tablePK.TableName] = tablePK
@@ -317,7 +316,6 @@ func (uvs *uvstreamer) send2(evs []*binlogdatapb.VEvent) error {
 	}
 	behind := time.Now().UnixNano() - uvs.lastTimestampNs
 	uvs.setReplicationLagSeconds(behind / 1e9)
-	// log.Infof("sbm set to %d", uvs.ReplicationLagSeconds)
 	var evs2 []*binlogdatapb.VEvent
 	if len(uvs.plans) > 0 {
 		evs2 = uvs.filterEvents(evs)

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -398,8 +398,8 @@ func TestMissingTables(t *testing.T) {
 	runCases(t, filter, testcases, startPos, nil)
 }
 
-// TestVStreamTableNoPKsWithoutFields confirms that, if a lastpk is passed with no fields defined, it errors out.
-func TestVStreamTableNoPKsWithoutFields(t *testing.T) {
+// TestVStreamMissingFieldsInLastPK tests that we error out if the lastpk for a table is missing the fields spec.
+func TestVStreamMissingFieldsInLastPK(t *testing.T) {
 	ts := &TestSpec{
 		t: t,
 		ddls: []string{


### PR DESCRIPTION
## Description

The `vstream API` currently doesn't validate that the `Fields` for a specified `TableLastPK` are defined. This results in a panics:

```
2024-07-16 18:28:49.897	runtime/panic.go:113 (0x436d5e)
2024-07-16 18:28:49.897	vitess.io/vitess/go/sqltypes/result.go:288 (0xcc1fda)
2024-07-16 18:28:49.897	vitess.io/vitess/go/sqltypes/proto3.go:92 (0xcc1e96)
2024-07-16 18:28:49.897	vitess.io/vitess/go/sqltypes/proto3.go:123 (0xcc2210)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/copy.go:183 (0x15269b2)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/copy.go:211 (0x1526b97)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/copy.go:60 (0x152558c)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/copy.go:39 (0x1525327)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go:418 (0x15390b5)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/engine.go:236 (0x152969c)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/tabletserver/tabletserver.go:1138 (0x15fc07a)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/vttablet/grpcqueryservice/server.go:336 (0x17f6a47)
2024-07-16 18:28:49.897	vitess.io/vitess/go/vt/proto/queryservice/queryservice_grpc.pb.go:1170 (0x17e9ad2)
2024-07-16 18:28:49.897	google.golang.org/grpc@v1.59.0/server.go:1637 (0xa2a2e3)
2024-07-16 18:28:49.897	google.golang.org/grpc@v1.59.0/server.go:1741 (0xa2bd6f)
2024-07-16 18:28:49.897	google.golang.org/grpc@v1.59.0/server.go:986 (0xa2452b)
2024-07-16 18:28:49.897	runtime/asm_amd64.s:1598 (0x470b60)
```

This happens because the downstream code converts  a `query.QueryResult` to a `sqltypes.Result` for which it requires Field type information to be specified.

Since this can crash `vttablets` we should backport it to all supported versions.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16479

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
