### PR TITLE
Generalize non-streaming result stats aggregation

### DIFF
--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -153,7 +153,6 @@ func (result *Result) Truncate(l int) *Result {
 
 	out := &Result{
 		InsertID:            result.InsertID,
-		RowsAffected:        result.RowsAffected,
 		Info:                result.Info,
 		SessionStateChanges: result.SessionStateChanges,
 	}
@@ -166,6 +165,7 @@ func (result *Result) Truncate(l int) *Result {
 			out.Rows = append(out.Rows, r[:l])
 		}
 	}
+	out.MergeStats(result)
 	return out
 }
 
@@ -324,17 +324,14 @@ func (result *Result) StripMetadata(incl querypb.ExecuteOptions_IncludedFields) 
 // to another result.Note currently it doesn't handle cases like
 // if two results have different fields.We will enhance this function.
 func (result *Result) AppendResult(src *Result) {
-	if src.RowsAffected == 0 && len(src.Rows) == 0 && len(src.Fields) == 0 {
-		return
-	}
 	if result.Fields == nil {
 		result.Fields = src.Fields
 	}
-	result.RowsAffected += src.RowsAffected
 	if src.InsertID != 0 {
 		result.InsertID = src.InsertID
 	}
 	result.Rows = append(result.Rows, src.Rows...)
+	result.MergeStats(src)
 }
 
 // Stats returns a copy of result with only the stats fields

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -324,6 +324,10 @@ func (result *Result) StripMetadata(incl querypb.ExecuteOptions_IncludedFields) 
 // to another result.Note currently it doesn't handle cases like
 // if two results have different fields.We will enhance this function.
 func (result *Result) AppendResult(src *Result) {
+	if src.RowsAffected == 0 && len(src.Rows) == 0 && len(src.Fields) == 0 {
+		return
+	}
+
 	if result.Fields == nil {
 		result.Fields = src.Fields
 	}

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -324,10 +324,9 @@ func (result *Result) StripMetadata(incl querypb.ExecuteOptions_IncludedFields) 
 // to another result.Note currently it doesn't handle cases like
 // if two results have different fields.We will enhance this function.
 func (result *Result) AppendResult(src *Result) {
-	if src.RowsAffected == 0 && len(src.Rows) == 0 && len(src.Fields) == 0 {
+	if src.StatsEmpty() && len(src.Rows) == 0 && len(src.Fields) == 0 {
 		return
 	}
-
 	if result.Fields == nil {
 		result.Fields = src.Fields
 	}
@@ -343,6 +342,10 @@ func (result *Result) Stats() *Result {
 	return &Result{
 		RowsAffected: result.RowsAffected,
 	}
+}
+
+func (result *Result) StatsEmpty() bool {
+	return result.RowsAffected == 0
 }
 
 // MergeStats updates the receiver's stats by merging in the stats from src.

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -337,6 +337,18 @@ func (result *Result) AppendResult(src *Result) {
 	result.Rows = append(result.Rows, src.Rows...)
 }
 
+// Stats returns a copy of result with only the stats fields
+func (result *Result) Stats() *Result {
+	return &Result{
+		RowsAffected: result.RowsAffected,
+	}
+}
+
+// MergeStats updates the receiver's stats by merging in the stats from src.
+func (result *Result) MergeStats(src *Result) {
+	result.RowsAffected += src.RowsAffected
+}
+
 // Named returns a NamedResult based on this struct
 func (result *Result) Named() *NamedResult {
 	return ToNamedResult(result)

--- a/go/sqltypes/result_test.go
+++ b/go/sqltypes/result_test.go
@@ -348,6 +348,32 @@ func TestAppendResult(t *testing.T) {
 	}
 }
 
+func TestStats(t *testing.T) {
+	result := &Result{
+		RowsAffected: 1,
+		Fields: []*querypb.Field{{
+			Type: Int64,
+		}, {
+			Type: VarChar,
+		}},
+		InsertID: 1,
+		Rows: [][]Value{
+			{TestValue(Int64, "1"), MakeTrusted(VarChar, nil)},
+			{TestValue(Int64, "2"), MakeTrusted(VarChar, nil)},
+		},
+	}
+	want := &Result{
+		RowsAffected: 1,
+	}
+	assert.Equal(t, want, result.Stats())
+}
+
+func TestMergeStats(t *testing.T) {
+	result := &Result{RowsAffected: 1}
+	result.MergeStats(&Result{RowsAffected: 2})
+	assert.Equal(t, uint64(3), result.RowsAffected)
+}
+
 func TestReplaceKeyspace(t *testing.T) {
 	result := &Result{
 		Fields: []*querypb.Field{{

--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -101,19 +101,19 @@ func (c *Concatenate) TryExecute(ctx context.Context, vcursor VCursor, bindVars 
 		return nil, err
 	}
 
-	var rows [][]sqltypes.Value
+	out := &sqltypes.Result{
+		Fields: fields,
+	}
 	err = c.coerceAndVisitResults(res, fieldTypes, func(result *sqltypes.Result) error {
-		rows = append(rows, result.Rows...)
+		out.Rows = append(out.Rows, result.Rows...)
+		out.MergeStats(result)
 		return nil
 	}, evalengine.ParseSQLMode(vcursor.SQLMode()))
 	if err != nil {
 		return nil, err
 	}
 
-	return &sqltypes.Result{
-		Fields: fields,
-		Rows:   rows,
-	}, nil
+	return out, nil
 }
 
 func (c *Concatenate) coerceValuesTo(row sqltypes.Row, fieldTypes []evalengine.Type, sqlmode evalengine.SQLMode) error {

--- a/go/vt/vtgate/engine/distinct.go
+++ b/go/vt/vtgate/engine/distinct.go
@@ -111,6 +111,7 @@ func (d *Distinct) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 		Fields:   input.Fields,
 		InsertID: input.InsertID,
 	}
+	result.MergeStats(input)
 
 	pt := newProbeTable(d.CheckCols, vcursor.Environment().CollationEnv())
 

--- a/go/vt/vtgate/engine/dml_with_input.go
+++ b/go/vt/vtgate/engine/dml_with_input.go
@@ -83,7 +83,7 @@ func (dml *DMLWithInput) TryExecute(ctx context.Context, vcursor VCursor, bindVa
 		if res == nil {
 			res = qr
 		} else {
-			res.RowsAffected += qr.RowsAffected
+			res.MergeStats(qr)
 		}
 	}
 	return res, nil
@@ -146,7 +146,7 @@ func executeNonLiteralUpdate(ctx context.Context, vcursor VCursor, bindVars map[
 		if res == nil {
 			res = qr
 		} else {
-			res.RowsAffected += qr.RowsAffected
+			res.MergeStats(qr)
 		}
 	}
 	return res, nil

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -85,28 +85,25 @@ func (fkc *FkCascade) GetFields(_ context.Context, _ VCursor, _ map[string]*quer
 
 // TryExecute implements the Primitive interface.
 func (fkc *FkCascade) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	stats := &sqltypes.Result{}
-
 	// Execute the Selection primitive to find the rows that are going to modified.
 	// This will be used to find the rows that need modification on the children.
 	selectionRes, err := vcursor.ExecutePrimitive(ctx, fkc.Selection, bindVars, wantfields)
 	if err != nil {
 		return nil, err
 	}
-	stats.MergeStats(selectionRes)
 
 	// If no rows are to be modified, there is nothing to do.
 	if len(selectionRes.Rows) == 0 {
-		return stats, nil
+		return &sqltypes.Result{}, nil
 	}
 
 	for _, child := range fkc.Children {
 		// Having non-empty UpdateExprBvNames is an indication that we have an update query with non-literal expressions in it.
 		// We need to run this query differently because we need to run an update for each row we get back from the SELECT.
 		if len(child.NonLiteralInfo) > 0 {
-			err = fkc.executeNonLiteralExprFkChild(ctx, vcursor, bindVars, wantfields, selectionRes, child, stats)
+			err = fkc.executeNonLiteralExprFkChild(ctx, vcursor, bindVars, wantfields, selectionRes, child)
 		} else {
-			err = fkc.executeLiteralExprFkChild(ctx, vcursor, bindVars, wantfields, selectionRes, child, false, stats)
+			err = fkc.executeLiteralExprFkChild(ctx, vcursor, bindVars, wantfields, selectionRes, child, false)
 		}
 		if err != nil {
 			return nil, err
@@ -114,15 +111,10 @@ func (fkc *FkCascade) TryExecute(ctx context.Context, vcursor VCursor, bindVars 
 	}
 
 	// All the children are modified successfully, we can now execute the Parent Primitive.
-	results, err := vcursor.ExecutePrimitive(ctx, fkc.Parent, bindVars, wantfields)
-	if results != nil {
-		results.MergeStats(stats)
-	}
-
-	return results, err
+	return vcursor.ExecutePrimitive(ctx, fkc.Parent, bindVars, wantfields)
 }
 
-func (fkc *FkCascade) executeLiteralExprFkChild(ctx context.Context, vcursor VCursor, in map[string]*querypb.BindVariable, wantfields bool, selectionRes *sqltypes.Result, child *FkChild, isStreaming bool, stats *sqltypes.Result) error {
+func (fkc *FkCascade) executeLiteralExprFkChild(ctx context.Context, vcursor VCursor, in map[string]*querypb.BindVariable, wantfields bool, selectionRes *sqltypes.Result, child *FkChild, isStreaming bool) error {
 	bindVars := maps.Clone(in)
 	// We create a bindVariable that stores the tuple of columns involved in the fk constraint.
 	bv := &querypb.BindVariable{
@@ -141,22 +133,18 @@ func (fkc *FkCascade) executeLiteralExprFkChild(ctx context.Context, vcursor VCu
 	// be rolled back incase of an error.
 	bindVars[child.BVName] = bv
 	var err error
-	var result *sqltypes.Result
 	if isStreaming {
 		err = vcursor.StreamExecutePrimitive(ctx, child.Exec, bindVars, wantfields, func(result *sqltypes.Result) error { return nil })
 	} else {
-		result, err = vcursor.ExecutePrimitive(ctx, child.Exec, bindVars, wantfields)
+		_, err = vcursor.ExecutePrimitive(ctx, child.Exec, bindVars, wantfields)
 	}
 	if err != nil {
 		return err
 	}
-	if result != nil {
-		stats.MergeStats(result)
-	}
 	return nil
 }
 
-func (fkc *FkCascade) executeNonLiteralExprFkChild(ctx context.Context, vcursor VCursor, in map[string]*querypb.BindVariable, wantfields bool, selectionRes *sqltypes.Result, child *FkChild, stats *sqltypes.Result) error {
+func (fkc *FkCascade) executeNonLiteralExprFkChild(ctx context.Context, vcursor VCursor, in map[string]*querypb.BindVariable, wantfields bool, selectionRes *sqltypes.Result, child *FkChild) error {
 	// For each row in the SELECT we need to run the child primitive.
 	for _, row := range selectionRes.Rows {
 		bindVars := maps.Clone(in)
@@ -199,11 +187,10 @@ func (fkc *FkCascade) executeNonLiteralExprFkChild(ctx context.Context, vcursor 
 		for _, info := range child.NonLiteralInfo {
 			bindVars[info.UpdateExprBvName] = sqltypes.ValueBindVariable(row[info.UpdateExprCol])
 		}
-		result, err := vcursor.ExecutePrimitive(ctx, child.Exec, bindVars, wantfields)
+		_, err := vcursor.ExecutePrimitive(ctx, child.Exec, bindVars, wantfields)
 		if err != nil {
 			return err
 		}
-		stats.MergeStats(result)
 	}
 	return nil
 }

--- a/go/vt/vtgate/engine/fk_cascade_test.go
+++ b/go/vt/vtgate/engine/fk_cascade_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -30,6 +32,7 @@ import (
 // TestDeleteCascade tests that FkCascade executes the child and parent primitives for a delete cascade.
 func TestDeleteCascade(t *testing.T) {
 	fakeRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("cola|colb", "int64|varchar"), "1|a", "2|b")
+	fakeRes.RowsAffected = 1
 
 	inputP := &Route{
 		Query: "select cola, colb from parent where foo = 48",
@@ -63,9 +66,14 @@ func TestDeleteCascade(t *testing.T) {
 	}
 
 	vc := newDMLTestVCursor("0")
-	vc.results = []*sqltypes.Result{fakeRes}
-	_, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
+	vc.results = []*sqltypes.Result{
+		fakeRes,
+		{RowsAffected: 2},
+		{RowsAffected: 3},
+	}
+	results, err := fkc.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
 	require.NoError(t, err)
+	assert.Equal(t, &sqltypes.Result{RowsAffected: 6}, results.Stats())
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
 		`ExecuteMultiShard ks.0: select cola, colb from parent where foo = 48 {} false false`,

--- a/go/vt/vtgate/engine/fk_verify.go
+++ b/go/vt/vtgate/engine/fk_verify.go
@@ -82,7 +82,7 @@ func (f *FkVerify) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	}
 
 	result, err := vcursor.ExecutePrimitive(ctx, f.Exec, bindVars, wantfields)
-	if err == nil {
+	if result != nil {
 		result.MergeStats(stats)
 	}
 	return result, err

--- a/go/vt/vtgate/engine/hash_join.go
+++ b/go/vt/vtgate/engine/hash_join.go
@@ -115,6 +115,8 @@ func (hj *HashJoin) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 	result := &sqltypes.Result{
 		Fields: joinFields(lresult.Fields, rresult.Fields, hj.Cols),
 	}
+	result.MergeStats(lresult)
+	result.MergeStats(rresult)
 
 	for _, currentRHSRow := range rresult.Rows {
 		matches, err := pt.get(currentRHSRow)

--- a/go/vt/vtgate/engine/insert_select.go
+++ b/go/vt/vtgate/engine/insert_select.go
@@ -315,7 +315,7 @@ func (ins *InsertSelect) execInsertSharded(ctx context.Context, vcursor VCursor,
 	}
 
 	result, err := ins.insertIntoShardedTable(ctx, vcursor, bindVars, selectResult)
-	if err == nil {
+	if result != nil {
 		result.MergeStats(selectResult.stats)
 	}
 

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -60,6 +60,7 @@ func (jn *Join) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[st
 		return nil, err
 	}
 	result := &sqltypes.Result{}
+	result.MergeStats(lresult)
 	if len(lresult.Rows) == 0 && wantfields {
 		for k, col := range jn.Vars {
 			joinVars[k] = bindvarForType(lresult.Fields[col])
@@ -86,6 +87,7 @@ func (jn *Join) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[st
 		for _, rrow := range rresult.Rows {
 			result.Rows = append(result.Rows, joinRows(lrow, rrow, jn.Cols))
 		}
+		result.MergeStats(rresult)
 		if jn.Opcode == LeftJoin && len(rresult.Rows) == 0 {
 			result.Rows = append(result.Rows, joinRows(lrow, nil, jn.Cols))
 		}

--- a/go/vt/vtgate/engine/join_test.go
+++ b/go/vt/vtgate/engine/join_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -42,6 +44,7 @@ func TestJoinExecute(t *testing.T) {
 			),
 		},
 	}
+	leftPrim.results[0].RowsAffected = 1
 	rightFields := sqltypes.MakeTestFields(
 		"col4|col5|col6",
 		"int64|varchar|varchar",
@@ -63,6 +66,10 @@ func TestJoinExecute(t *testing.T) {
 			),
 		},
 	}
+	rightPrim.results[0].RowsAffected = 2
+	rightPrim.results[1].RowsAffected = 3
+	rightPrim.results[2].RowsAffected = 4
+
 	bv := map[string]*querypb.BindVariable{
 		"a": sqltypes.Int64BindVariable(10),
 	}
@@ -99,6 +106,7 @@ func TestJoinExecute(t *testing.T) {
 		"3|c|6|f",
 		"3|c|7|g",
 	))
+	assert.Equal(t, uint64(10), r.RowsAffected)
 
 	// Left Join
 	leftPrim.rewind()
@@ -127,6 +135,7 @@ func TestJoinExecute(t *testing.T) {
 		"3|c|6|f",
 		"3|c|7|g",
 	))
+	assert.Equal(t, uint64(10), r.RowsAffected)
 }
 
 func TestJoinExecuteMaxMemoryRows(t *testing.T) {

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -100,6 +100,7 @@ func (sa *ScalarAggregate) TryExecute(ctx context.Context, vcursor VCursor, bind
 		Fields: fields,
 		Rows:   [][]sqltypes.Value{agg.finish()},
 	}
+	out.MergeStats(result)
 	return out.Truncate(sa.TruncateColumnCount), nil
 }
 

--- a/go/vt/vtgate/engine/scalar_aggregation_test.go
+++ b/go/vt/vtgate/engine/scalar_aggregation_test.go
@@ -79,6 +79,7 @@ func TestEmptyRows(outer *testing.T) {
 					// Empty input table
 				)},
 			}
+			fp.results[0].RowsAffected = 1
 
 			oa := &ScalarAggregate{
 				Aggregates: []*AggregateParams{{
@@ -100,6 +101,8 @@ func TestEmptyRows(outer *testing.T) {
 				),
 				test.expectedVal,
 			)
+			// Ensure Result stats are passed through
+			wantResult.RowsAffected = 1
 			utils.MustMatch(t, wantResult, result)
 		})
 	}

--- a/go/vt/vtgate/engine/semi_join.go
+++ b/go/vt/vtgate/engine/semi_join.go
@@ -45,6 +45,7 @@ func (jn *SemiJoin) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 		return nil, err
 	}
 	result := &sqltypes.Result{Fields: lresult.Fields}
+	result.MergeStats(lresult)
 	for _, lrow := range lresult.Rows {
 		for k, col := range jn.Vars {
 			joinVars[k] = sqltypes.ValueBindVariable(lrow[col])
@@ -53,6 +54,7 @@ func (jn *SemiJoin) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 		if err != nil {
 			return nil, err
 		}
+		result.MergeStats(rresult)
 		if len(rresult.Rows) > 0 {
 			result.Rows = append(result.Rows, lrow)
 		}

--- a/go/vt/vtgate/engine/semi_join_test.go
+++ b/go/vt/vtgate/engine/semi_join_test.go
@@ -43,6 +43,7 @@ func TestSemiJoinExecute(t *testing.T) {
 			),
 		},
 	}
+	leftPrim.results[0].RowsAffected = 1
 	rightFields := sqltypes.MakeTestFields(
 		"col4|col5|col6",
 		"int64|varchar|varchar",
@@ -64,6 +65,10 @@ func TestSemiJoinExecute(t *testing.T) {
 			),
 		},
 	}
+	rightPrim.results[0].RowsAffected = 2
+	rightPrim.results[1].RowsAffected = 3
+	rightPrim.results[2].RowsAffected = 4
+
 	bv := map[string]*querypb.BindVariable{
 		"a": sqltypes.Int64BindVariable(10),
 	}
@@ -85,14 +90,16 @@ func TestSemiJoinExecute(t *testing.T) {
 		`Execute a: type:INT64 value:"10" bv: type:VARCHAR value:"b" false`,
 		`Execute a: type:INT64 value:"10" bv: type:VARCHAR value:"c" false`,
 	})
-	utils.MustMatch(t, sqltypes.MakeTestResult(
+	want := sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
 			"col1|col2|col3",
 			"int64|varchar|varchar",
 		),
 		"1|a|aa",
 		"3|c|cc",
-	), r)
+	)
+	want.RowsAffected = 10
+	utils.MustMatch(t, want, r)
 }
 
 func TestSemiJoinStreamExecute(t *testing.T) {

--- a/go/vt/vtgate/engine/sequential.go
+++ b/go/vt/vtgate/engine/sequential.go
@@ -72,7 +72,7 @@ func (s *Sequential) TryExecute(ctx context.Context, vcursor VCursor, bindVars m
 		if err != nil {
 			return nil, err
 		}
-		finalRes.RowsAffected += res.RowsAffected
+		finalRes.MergeStats(res)
 		if finalRes.InsertID == 0 {
 			finalRes.InsertID = res.InsertID
 		}

--- a/go/vt/vtgate/engine/simple_projection.go
+++ b/go/vt/vtgate/engine/simple_projection.go
@@ -107,7 +107,7 @@ func (sc *SimpleProjection) buildResult(inner *sqltypes.Result) *sqltypes.Result
 		}
 		result.Rows = append(result.Rows, row)
 	}
-	result.RowsAffected = inner.RowsAffected
+	result.MergeStats(inner)
 	return result
 }
 

--- a/go/vt/vtgate/engine/simple_projection_test.go
+++ b/go/vt/vtgate/engine/simple_projection_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -42,6 +44,7 @@ func TestSubqueryExecute(t *testing.T) {
 			),
 		},
 	}
+	prim.results[0].RowsAffected = 1
 
 	sq := &SimpleProjection{
 		Cols:     []int{0, 2},
@@ -69,6 +72,7 @@ func TestSubqueryExecute(t *testing.T) {
 		"2|bb",
 		"3|cc",
 	))
+	assert.Equal(t, uint64(1), r.RowsAffected)
 
 	// Error case.
 	sq.Input = &fakePrimitive{

--- a/go/vt/vtgate/engine/uncorrelated_subquery_test.go
+++ b/go/vt/vtgate/engine/uncorrelated_subquery_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -41,6 +43,7 @@ func TestPulloutSubqueryValueGood(t *testing.T) {
 		),
 		"1",
 	)
+	sqResult.RowsAffected = 1
 	sfp := &fakePrimitive{
 		results: []*sqltypes.Result{sqResult},
 	}
@@ -51,6 +54,7 @@ func TestPulloutSubqueryValueGood(t *testing.T) {
 		),
 		"0",
 	)
+	underlyingResult.RowsAffected = 2
 	ufp := &fakePrimitive{
 		results: []*sqltypes.Result{underlyingResult},
 	}
@@ -66,6 +70,7 @@ func TestPulloutSubqueryValueGood(t *testing.T) {
 	sfp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1" false`})
 	ufp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1" sq: type:INT64 value:"1" false`})
 	expectResult(t, result, underlyingResult)
+	assert.Equal(t, uint64(3), result.RowsAffected)
 }
 
 func TestPulloutSubqueryValueNone(t *testing.T) {

--- a/go/vt/vtgate/engine/upsert.go
+++ b/go/vt/vtgate/engine/upsert.go
@@ -83,7 +83,7 @@ func (u *Upsert) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[s
 		if err != nil {
 			return nil, err
 		}
-		result.RowsAffected += qr.RowsAffected
+		result.MergeStats(qr)
 	}
 	return result, nil
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Introduces `Result#MergeStats` and ensures that the non-streaming versions (`#TryExecute`) of all `Primitives` return aggregated stats for any underlying wrapped primitives. `MergeStats` only handles `RowsAffected` at the moment, but extracting this function and making sure it is called on wrapped primitives makes it easier for downstream forks to add additional result-level stats (by updating `MergeStats`), and ensures that they correctly are propagated (and not dropped).

This is an incremental improvement, and does not attempt to implement stats aggregation in `#TryStreamExecute`.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16481
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
