### PR TITLE
builtinbackup: log during restore as restore, not as backup

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1032,7 +1032,7 @@ func verifySemiSyncStatus(t *testing.T, vttablet *cluster.Vttablet, expectedStat
 }
 
 func terminateBackup(t *testing.T, alias string) {
-	stopBackupMsg := "Done taking Backup"
+	stopBackupMsg := "Completed backing up"
 	if useXtrabackup {
 		stopBackupMsg = "Starting backup with"
 		useXtrabackup = false

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -776,7 +776,7 @@ func (bp *backupPipe) ReportProgress(period time.Duration, logger logutil.Logger
 	for {
 		select {
 		case <-bp.done:
-			logger.Infof("completed %s %q", messageStr, bp.filename)
+			logger.Infof("Completed %s %q", messageStr, bp.filename)
 			return
 		case <-tick.C:
 			written := float64(atomic.LoadInt64(&bp.nn))
@@ -817,7 +817,7 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	}
 
 	br := newBackupReader(fe.Name, fi.Size(), timedSource)
-	go br.ReportProgress(builtinBackupProgress, params.Logger /*restore*/, false)
+	go br.ReportProgress(builtinBackupProgress, params.Logger, false /*restore*/)
 
 	// Open the destination file for writing, and a buffer.
 	params.Logger.Infof("Backing up file: %v", fe.Name)
@@ -1082,7 +1082,7 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 	}()
 
 	br := newBackupReader(name, 0, timedSource)
-	go br.ReportProgress(builtinBackupProgress, params.Logger /*restore*/, true)
+	go br.ReportProgress(builtinBackupProgress, params.Logger, true /*restore*/)
 	var reader io.Reader = br
 
 	// Open the destination file for writing.


### PR DESCRIPTION
## Description
Parameterize the `ReportProgress` function which is being used by both backup and restore so that we log properly.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #16482
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
