### PR TITLE
fix: reference table join merge

### DIFF
--- a/go/test/endtoend/vtgate/queries/reference/main_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/main_test.go
@@ -18,6 +18,7 @@ package reference
 
 import (
 	"context"
+	_ "embed"
 	"flag"
 	"fmt"
 	"os"
@@ -39,68 +40,16 @@ var (
 	vtParams        mysql.ConnParams
 
 	unshardedKeyspaceName = "uks"
-	unshardedSQLSchema    = `
-		CREATE TABLE IF NOT EXISTS zip(
-			id BIGINT NOT NULL AUTO_INCREMENT,
-			code5 INT(5) NOT NULL,
-			PRIMARY KEY(id)
-		) ENGINE=InnoDB;
+	//go:embed uschema.sql
+	unshardedSQLSchema string
+	//go:embed uvschema.json
+	unshardedVSchema string
 
-		INSERT INTO zip(id, code5)
-		VALUES (1, 47107),
-			   (2, 82845),
-			   (3, 11237);
-
-		CREATE TABLE IF NOT EXISTS zip_detail(
-			id BIGINT NOT NULL AUTO_INCREMENT,
-			zip_id BIGINT NOT NULL,
-			discontinued_at DATE,
-			PRIMARY KEY(id)
-		) ENGINE=InnoDB;
-
-	`
-	unshardedVSchema = `
-		{
-			"sharded":false,
-			"tables": {
-				"zip": {},
-				"zip_detail": {}
-			}
-		}
-	`
 	shardedKeyspaceName = "sks"
-	shardedSQLSchema    = `
-		CREATE TABLE IF NOT EXISTS delivery_failure (
-			id BIGINT NOT NULL,
-			zip_detail_id BIGINT NOT NULL,
-			reason VARCHAR(255),
-			PRIMARY KEY(id)
-		) ENGINE=InnoDB;
-	`
-	shardedVSchema = `
-		{
-			"sharded": true,
-			"vindexes": {
-				"hash": {
-					"type": "hash"
-				}
-			},
-			"tables": {
-				"delivery_failure": {
-					"columnVindexes": [
-						{
-							"column": "id",
-							"name": "hash"
-						}
-					]
-				},
-				"zip_detail": {
-					"type": "reference",
-					"source": "` + unshardedKeyspaceName + `.zip_detail"
-				}
-			}
-		}
-	`
+	//go:embed sschema.sql
+	shardedSQLSchema string
+	//go:embed svschema.json
+	shardedVSchema string
 )
 
 func TestMain(m *testing.M) {

--- a/go/test/endtoend/vtgate/queries/reference/reference_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/reference_test.go
@@ -156,3 +156,18 @@ func TestReferenceRouting(t *testing.T) {
 		`[[INT64(2)]]`,
 	)
 }
+
+// TestMultiReferenceQuery tests that a query with multiple references with unsharded keyspace and sharded keyspace works with join.
+func TestMultiReferenceQuery(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	query :=
+		`select 1
+		 from delivery_failure df1
+         	join delivery_failure df2 on df1.id = df2.id
+         	join uks.zip_detail zd1 on df1.zip_detail_id = zd1.zip_id
+         	join uks.zip_detail zd2 on zd1.zip_id = zd2.zip_id`
+
+	utils.Exec(t, conn, query)
+}

--- a/go/test/endtoend/vtgate/queries/reference/reference_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/reference_test.go
@@ -90,14 +90,14 @@ func TestReferenceRouting(t *testing.T) {
 			t,
 			conn,
 			`SELECT t.id FROM (
-                        SELECT zd.id, zd.zip_id
-                        FROM `+shardedKeyspaceName+`.zip_detail AS zd
-                        WHERE zd.id IN (2)
-                        ORDER BY zd.discontinued_at
-                        LIMIT 1
-                ) AS t
-                LEFT JOIN `+shardedKeyspaceName+`.zip_detail AS t0 ON t.zip_id = t0.zip_id
-                ORDER BY t.id`,
+						SELECT zd.id, zd.zip_id
+						FROM `+shardedKeyspaceName+`.zip_detail AS zd
+						WHERE zd.id IN (2)
+						ORDER BY zd.discontinued_at
+						LIMIT 1
+				) AS t
+				LEFT JOIN `+shardedKeyspaceName+`.zip_detail AS t0 ON t.zip_id = t0.zip_id
+				ORDER BY t.id`,
 			`[[INT64(2)]]`,
 		)
 	})
@@ -166,9 +166,9 @@ func TestMultiReferenceQuery(t *testing.T) {
 	query :=
 		`select 1
 		 from delivery_failure df1
-         	join delivery_failure df2 on df1.id = df2.id
-         	join uks.zip_detail zd1 on df1.zip_detail_id = zd1.zip_id
-         	join uks.zip_detail zd2 on zd1.zip_id = zd2.zip_id`
+		 	join delivery_failure df2 on df1.id = df2.id
+		 	join uks.zip_detail zd1 on df1.zip_detail_id = zd1.zip_id
+		 	join uks.zip_detail zd2 on zd1.zip_id = zd2.zip_id`
 
 	utils.Exec(t, conn, query)
 }

--- a/go/test/endtoend/vtgate/queries/reference/reference_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/reference_test.go
@@ -159,6 +159,7 @@ func TestReferenceRouting(t *testing.T) {
 
 // TestMultiReferenceQuery tests that a query with multiple references with unsharded keyspace and sharded keyspace works with join.
 func TestMultiReferenceQuery(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
 	conn, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/reference/sschema.sql
+++ b/go/test/endtoend/vtgate/queries/reference/sschema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS delivery_failure (
+    id BIGINT NOT NULL,
+    zip_detail_id BIGINT NOT NULL,
+    reason VARCHAR(255),
+    PRIMARY KEY(id)
+) ENGINE=InnoDB;

--- a/go/test/endtoend/vtgate/queries/reference/svschema.json
+++ b/go/test/endtoend/vtgate/queries/reference/svschema.json
@@ -1,0 +1,22 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "hash": {
+      "type": "hash"
+    }
+  },
+  "tables": {
+    "delivery_failure": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ]
+    },
+    "zip_detail": {
+      "type": "reference",
+      "source": "uks.zip_detail"
+    }
+  }
+}

--- a/go/test/endtoend/vtgate/queries/reference/uschema.sql
+++ b/go/test/endtoend/vtgate/queries/reference/uschema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS zip(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    code5 INT(5) NOT NULL,
+    PRIMARY KEY(id)
+) ENGINE=InnoDB;
+
+INSERT INTO zip(id, code5)
+VALUES (1, 47107),
+       (2, 82845),
+       (3, 11237);
+
+CREATE TABLE IF NOT EXISTS zip_detail(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    zip_id BIGINT NOT NULL,
+    discontinued_at DATE,
+    PRIMARY KEY(id)
+) ENGINE=InnoDB;

--- a/go/test/endtoend/vtgate/queries/reference/uvschema.json
+++ b/go/test/endtoend/vtgate/queries/reference/uvschema.json
@@ -1,0 +1,6 @@
+{
+  "tables": {
+    "zip": {},
+    "zip_detail": {}
+  }
+}

--- a/go/vt/vtgate/planbuilder/operators/joins.go
+++ b/go/vt/vtgate/planbuilder/operators/joins.go
@@ -17,7 +17,10 @@ limitations under the License.
 package operators
 
 import (
+	"fmt"
+
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
@@ -86,7 +89,7 @@ func AddPredicate(
 
 		return join
 	}
-	return nil
+	panic(vterrors.VT13001(fmt.Sprintf("pushed wrong predicate to the join: %s", sqlparser.String(expr))))
 }
 
 // we are looking for predicates like `tbl.col = <>` or `<> = tbl.col`,

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -746,5 +746,30 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "two sharded and two unsharded reference table join - all should be merged into one route",
+    "query": "select 1 from user u join user_extra ue on u.id = ue.user_id join main.source_of_ref sr on sr.foo = ue.foo join main.rerouted_ref rr on rr.bar = sr.bar",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from user u join user_extra ue on u.id = ue.user_id join main.source_of_ref sr on sr.foo = ue.foo join main.rerouted_ref rr on rr.bar = sr.bar",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where 1 != 1",
+        "Query": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where rr.bar = sr.bar and u.id = ue.user_id and sr.foo = ue.foo",
+        "Table": "`user`, ref, ref_with_source, user_extra"
+      },
+      "TablesUsed": [
+        "user.ref",
+        "user.ref_with_source",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the join merging logic for two reference tables. The merge should also handle the alternative routes of the reference table during merging.

This needs to be backported to all the supported versions as it causes planner time panic.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/15799

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
