### PR TITLE
Improve the queries upgrade/downgrade CI workflow by using same test code version as binary

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -116,6 +116,22 @@ jobs:
         # install JUnit report formatter
         go install github.com/vitessio/go-junit-report@HEAD
 
+    # Build current commit's binaries
+    - name: Get dependencies for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building the binaries for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        NOVTADMINBUILD=1 make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+        rm -Rf bin/*
+
     # Checkout to the last release of Vitess
     - name: Check out other version's code (${{ steps.output-previous-release-ref.outputs.previous_release_ref }})
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -138,37 +154,19 @@ jobs:
         cp -R bin /tmp/vitess-build-other/
         rm -Rf bin/*
 
-    # Checkout to this build's commit
-    - name: Check out commit's code
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/checkout@v4
-
-    - name: Get dependencies for this commit
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        go mod download
-
-    - name: Building the binaries for this commit
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 10
-      run: |
-        source build.env
-        NOVTADMINBUILD=1 make build
-        mkdir -p /tmp/vitess-build-current/
-        cp -R bin /tmp/vitess-build-current/
-
     # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
     - name: Use last release's VTGate
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
+        cp /tmp/vitess-build-current/* $PWD/bin/
         rm -f $PWD/bin/vtgate
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version
 
-    # Running a test with vtgate at version n-1 and vttablet at version n
-    - name: Run query serving tests (vtgate=N-1, vttablet=N)
+    # Running a test with vtgate at version n-1 and vttablet/vtctld at version n
+    - name: Run query serving tests (vtgate=N-1, vttablet=N, vtctld=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
@@ -177,8 +175,8 @@ jobs:
         source build.env
         eatmydata -- go run test.go -skip-build -keep-data=false -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
 
-    # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
-    - name: Use current version VTGate, and other version VTTablet
+    # Swap the binaries again. This time, vtgate will be at version n, and vttablet/vtctld will be at version n-1
+    - name: Use current version VTGate, and other version VTTablet/VTctld
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
@@ -197,8 +195,8 @@ jobs:
         vtgate --version
         vttablet --version
 
-    # Running a test with vtgate at version n and vttablet at version n-1
-    - name: Run query serving tests (vtgate=N, vttablet=N-1)
+    # Running a test with vtgate at version n and vttablet/vtctld at version n-1
+    - name: Run query serving tests (vtgate=N, vttablet=N-1, vtctld=N-1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -160,7 +160,7 @@ jobs:
       run: |
         source build.env
 
-        cp /tmp/vitess-build-current/* $PWD/bin/
+        cp -r /tmp/vitess-build-current/* $PWD/bin/
         rm -f $PWD/bin/vtgate
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -160,7 +160,7 @@ jobs:
       run: |
         source build.env
 
-        cp -r /tmp/vitess-build-current/* $PWD/bin/
+        cp -r /tmp/vitess-build-current/bin/* $PWD/bin/
         rm -f $PWD/bin/vtgate
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -117,6 +117,22 @@ jobs:
         # install JUnit report formatter
         go install github.com/vitessio/go-junit-report@HEAD
 
+    # Build current commit's binaries
+    - name: Get dependencies for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building the binaries for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        NOVTADMINBUILD=1 make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+        rm -Rf bin/*
+
     # Checkout to the next release of Vitess
     - name: Check out other version's code (${{ steps.output-next-release-ref.outputs.next_release_ref }})
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -139,31 +155,13 @@ jobs:
         cp -R bin /tmp/vitess-build-other/
         rm -Rf bin/*
 
-    # Checkout to this build's commit
-    - name: Check out commit's code
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/checkout@v4
-
-    - name: Get dependencies for this commit
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        go mod download
-
-    - name: Building the binaries for this commit
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 10
-      run: |
-        source build.env
-        NOVTADMINBUILD=1 make build
-        mkdir -p /tmp/vitess-build-current/
-        cp -R bin /tmp/vitess-build-current/
-
     # Swap the binaries in the bin. Use vtgate version n+1 and keep vttablet at version n
     - name: Use next release's VTGate
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
+        cp /tmp/vitess-build-current/* $PWD/bin/
         rm -f $PWD/bin/vtgate
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -161,7 +161,7 @@ jobs:
       run: |
         source build.env
 
-        cp -r /tmp/vitess-build-current/* $PWD/bin/
+        cp -r /tmp/vitess-build-current/bin/* $PWD/bin/
         rm -f $PWD/bin/vtgate
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -161,7 +161,7 @@ jobs:
       run: |
         source build.env
 
-        cp /tmp/vitess-build-current/* $PWD/bin/
+        cp -r /tmp/vitess-build-current/* $PWD/bin/
         rm -f $PWD/bin/vtgate
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version

--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -69,15 +69,10 @@ func TestTabletInitialBackup(t *testing.T) {
 	// Initialize the tablets
 	initTablets(t, false, false)
 
-	vtTabletVersion, err := cluster.GetMajorVersion("vttablet")
-	require.NoError(t, err)
-	// For all version at or above v17.0.0, each replica will start in super_read_only mode. Let's verify that is working correctly.
-	if vtTabletVersion >= 17 {
-		err := primary.VttabletProcess.CreateDB("testDB")
-		require.ErrorContains(t, err, "The MySQL server is running with the --super-read-only option so it cannot execute this statement")
-		err = replica1.VttabletProcess.CreateDB("testDB")
-		require.ErrorContains(t, err, "The MySQL server is running with the --super-read-only option so it cannot execute this statement")
-	}
+	err := primary.VttabletProcess.CreateDB("testDB")
+	require.ErrorContains(t, err, "The MySQL server is running with the --super-read-only option so it cannot execute this statement")
+	err = replica1.VttabletProcess.CreateDB("testDB")
+	require.ErrorContains(t, err, "The MySQL server is running with the --super-read-only option so it cannot execute this statement")
 
 	// Restore the Tablet
 	restore(t, primary, "replica", "NOT_SERVING")
@@ -172,7 +167,7 @@ func firstBackupTest(t *testing.T, tabletType string) {
 	restore(t, replica2, "replica", "SERVING")
 	// Replica2 takes time to serve. Sleeping for 5 sec.
 	time.Sleep(5 * time.Second)
-	//check the new replica has the data
+	// check the new replica has the data
 	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 2)
 
 	removeBackups(t)

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -65,14 +65,9 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 		"--log_dir", vtctld.LogDir,
 		"--port", fmt.Sprintf("%d", vtctld.Port),
 		"--grpc_port", fmt.Sprintf("%d", vtctld.GrpcPort),
+		"--bind-address", "127.0.0.1",
+		"--grpc_bind_address", "127.0.0.1",
 	)
-
-	if v, err := GetMajorVersion("vtctld"); err != nil {
-		return err
-	} else if v >= 18 {
-		vtctld.proc.Args = append(vtctld.proc.Args, "--bind-address", "127.0.0.1")
-		vtctld.proc.Args = append(vtctld.proc.Args, "--grpc_bind_address", "127.0.0.1")
-	}
 
 	if *isCoverage {
 		vtctld.proc.Args = append(vtctld.proc.Args, "--test.coverprofile="+getCoveragePath("vtctld.out"))

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -85,12 +85,8 @@ func (vtgate *VtgateProcess) Setup() (err error) {
 		"--tablet_types_to_wait", vtgate.TabletTypesToWait,
 		"--service_map", vtgate.ServiceMap,
 		"--mysql_auth_server_impl", vtgate.MySQLAuthServerImpl,
-	}
-	if v, err := GetMajorVersion("vtgate"); err != nil {
-		return err
-	} else if v >= 18 {
-		args = append(args, "--bind-address", "127.0.0.1")
-		args = append(args, "--grpc_bind_address", "127.0.0.1")
+		"--bind-address", "127.0.0.1",
+		"--grpc_bind_address", "127.0.0.1",
 	}
 	// If no explicit mysql_server_version has been specified then we autodetect
 	// the MySQL version that will be used for the test and base the vtgate's

--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -126,13 +126,8 @@ func (orc *VTOrcProcess) Setup() (err error) {
 		"--instance-poll-time", "1s",
 		// Faster topo information refresh speeds up the tests. This doesn't add any significant load either
 		"--topo-information-refresh-duration", "3s",
+		"--bind-address", "127.0.0.1",
 	)
-
-	if v, err := GetMajorVersion("vtorc"); err != nil {
-		return err
-	} else if v >= 18 {
-		orc.proc.Args = append(orc.proc.Args, "--bind-address", "127.0.0.1")
-	}
 
 	if *isCoverage {
 		orc.proc.Args = append(orc.proc.Args, "--test.coverprofile="+getCoveragePath("orc.out"))

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -111,13 +111,9 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"--file_backup_storage_root", vttablet.FileBackupStorageRoot,
 		"--service_map", vttablet.ServiceMap,
 		"--db_charset", vttablet.Charset,
+		"--bind-address", "127.0.0.1",
+		"--grpc_bind_address", "127.0.0.1",
 	)
-	if v, err := GetMajorVersion("vttablet"); err != nil {
-		return err
-	} else if v >= 18 {
-		vttablet.proc.Args = append(vttablet.proc.Args, "--bind-address", "127.0.0.1")
-		vttablet.proc.Args = append(vttablet.proc.Args, "--grpc_bind_address", "127.0.0.1")
-	}
 
 	if *isCoverage {
 		vttablet.proc.Args = append(vttablet.proc.Args, "--test.coverprofile="+getCoveragePath("vttablet.out"))

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -205,13 +205,13 @@ func TestReparentFromOutsideWithNoPrimary(t *testing.T) {
 }
 
 func reparentFromOutside(t *testing.T, clusterInstance *cluster.LocalProcessCluster, downPrimary bool) {
-	//This test will start a primary and 3 replicas.
-	//Then:
-	//- one replica will be the new primary
-	//- one replica will be reparented to that new primary
-	//- one replica will be busted and dead in the water and we'll call TabletExternallyReparented.
-	//Args:
-	//downPrimary: kills the old primary first
+	// This test will start a primary and 3 replicas.
+	// Then:
+	// - one replica will be the new primary
+	// - one replica will be reparented to that new primary
+	// - one replica will be busted and dead in the water and we'll call TabletExternallyReparented.
+	// Args:
+	// downPrimary: kills the old primary first
 	ctx := context.Background()
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 
@@ -224,7 +224,7 @@ func reparentFromOutside(t *testing.T, clusterInstance *cluster.LocalProcessClus
 		demoteCommands := []string{"SET GLOBAL read_only = ON", "FLUSH TABLES WITH READ LOCK", "UNLOCK TABLES"}
 		utils.RunSQLs(ctx, t, demoteCommands, tablets[0])
 
-		//Get the position of the old primary and wait for the new one to catch up.
+		// Get the position of the old primary and wait for the new one to catch up.
 		err := utils.WaitForReplicationPosition(t, tablets[0], tablets[1])
 		require.NoError(t, err)
 	}
@@ -460,14 +460,7 @@ func TestFullStatus(t *testing.T) {
 	assert.Contains(t, primaryStatus.PrimaryStatus.String(), "vt-0000000101-bin")
 	assert.Equal(t, primaryStatus.GtidPurged, "MySQL56/")
 	assert.False(t, primaryStatus.ReadOnly)
-	vtTabletVersion, err := cluster.GetMajorVersion("vttablet")
-	require.NoError(t, err)
-	vtcltlVersion, err := cluster.GetMajorVersion("vtctl")
-	require.NoError(t, err)
-	// For all version at or above v17.0.0, each replica will start in super_read_only mode.
-	if vtTabletVersion >= 17 && vtcltlVersion >= 17 {
-		assert.False(t, primaryStatus.SuperReadOnly)
-	}
+	assert.False(t, primaryStatus.SuperReadOnly)
 	assert.True(t, primaryStatus.SemiSyncPrimaryEnabled)
 	assert.True(t, primaryStatus.SemiSyncReplicaEnabled)
 	assert.True(t, primaryStatus.SemiSyncPrimaryStatus)
@@ -521,10 +514,7 @@ func TestFullStatus(t *testing.T) {
 	assert.Contains(t, replicaStatus.PrimaryStatus.String(), "vt-0000000102-bin")
 	assert.Equal(t, replicaStatus.GtidPurged, "MySQL56/")
 	assert.True(t, replicaStatus.ReadOnly)
-	// For all version at or above v17.0.0, each replica will start in super_read_only mode.
-	if vtTabletVersion >= 17 && vtcltlVersion >= 17 {
-		assert.True(t, replicaStatus.SuperReadOnly)
-	}
+	assert.True(t, replicaStatus.SuperReadOnly)
 	assert.False(t, replicaStatus.SemiSyncPrimaryEnabled)
 	assert.True(t, replicaStatus.SemiSyncReplicaEnabled)
 	assert.False(t, replicaStatus.SemiSyncPrimaryStatus)

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -71,7 +71,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 }
 
 func TestAggrWithLimit(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -101,11 +100,9 @@ func TestAggregateTypes(t *testing.T) {
 	mcmp.AssertMatches("select val1 as a, count(*) from aggr_test group by a order by 2, a", `[[VARCHAR("b") INT64(1)] [VARCHAR("d") INT64(1)] [VARCHAR("a") INT64(2)] [VARCHAR("c") INT64(2)] [VARCHAR("e") INT64(2)]]`)
 	mcmp.AssertMatches("select sum(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	mcmp.Run("Average for sharded keyspaces", func(mcmp *utils.MySQLCompare) {
-		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches("select avg(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	})
 	mcmp.Run("Average with group by without selecting the grouped columns", func(mcmp *utils.MySQLCompare) {
-		mcmp.SkipIfBinaryIsBelowVersion(20, "vtgate")
 		mcmp.AssertMatches("select avg(val2) from aggr_test group by val1 order by val1", `[[DECIMAL(1.0000)] [DECIMAL(1.0000)] [DECIMAL(3.5000)] [NULL] [DECIMAL(1.0000)]]`)
 	})
 }
@@ -214,7 +211,6 @@ func TestAggrOnJoin(t *testing.T) {
 		`[[VARCHAR("a")]]`)
 
 	mcmp.Run("Average in join for sharded", func(mcmp *utils.MySQLCompare) {
-		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches(`select avg(a1.val2), avg(a2.val2) from aggr_test a1 join aggr_test a2 on a1.val2 = a2.id join t3 t on a2.val2 = t.id7`,
 			"[[DECIMAL(1.5000) DECIMAL(1.0000)]]")
 
@@ -372,7 +368,6 @@ func TestAggOnTopOfLimit(t *testing.T) {
 			mcmp.AssertMatches("select val1, count(*) from (select id, val1 from aggr_test where val2 < 4 order by val1 limit 2) as x group by val1", `[[NULL INT64(1)] [VARCHAR("a") INT64(1)]]`)
 			mcmp.AssertMatchesNoOrder("select val1, count(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1", `[[NULL INT64(1)] [VARCHAR("a") INT64(2)] [VARCHAR("b") INT64(1)] [VARCHAR("c") INT64(2)]]`)
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches("select avg(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[NULL]]")
 				mcmp.AssertMatchesNoOrder("select val1, avg(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1", `[[NULL DECIMAL(2.0000)] [VARCHAR("a") DECIMAL(3.5000)] [VARCHAR("b") DECIMAL(1.0000)] [VARCHAR("c") DECIMAL(3.5000)]]`)
 			})
@@ -384,7 +379,6 @@ func TestAggOnTopOfLimit(t *testing.T) {
 			mcmp.AssertMatches("select count(val2), sum(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[INT64(0) NULL]]")
 			mcmp.AssertMatches("select val1, count(*), sum(id) from (select id, val1 from aggr_test where val2 < 4 order by val1 limit 2) as x group by val1", `[[NULL INT64(1) DECIMAL(7)] [VARCHAR("a") INT64(1) DECIMAL(2)]]`)
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches("select count(*), sum(val1), avg(val1) from (select id, val1 from aggr_test where val2 < 4 order by val1 desc limit 2) as x", "[[INT64(2) FLOAT64(0) FLOAT64(0)]]")
 				mcmp.AssertMatches("select count(val1), sum(id), avg(id) from (select id, val1 from aggr_test where val2 < 4 order by val1 desc limit 2) as x", "[[INT64(2) DECIMAL(7) DECIMAL(3.5000)]]")
 				mcmp.AssertMatchesNoOrder("select val1, count(val2), sum(val2), avg(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1",
@@ -406,7 +400,6 @@ func TestEmptyTableAggr(t *testing.T) {
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches(" select count(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 				mcmp.AssertMatches(" select avg(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[NULL]]")
 			})
@@ -422,7 +415,6 @@ func TestEmptyTableAggr(t *testing.T) {
 			mcmp.AssertMatches(" select count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 			mcmp.AssertMatches(" select t1.`name`, count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 			mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-				mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 				mcmp.AssertMatches(" select count(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
 				mcmp.AssertMatches(" select avg(t1.value) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[NULL]]")
 				mcmp.AssertMatches(" select t1.`name`, count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
@@ -471,7 +463,6 @@ func TestAggregateLeftJoin(t *testing.T) {
 	mcmp.AssertMatches("SELECT count(*) FROM t2 LEFT JOIN t1 ON t1.t1_id = t2.id WHERE IFNULL(t1.name, 'NOTSET') = 'r'", `[[INT64(1)]]`)
 
 	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches("SELECT avg(t1.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(0.5000)]]`)
 		mcmp.AssertMatches("SELECT avg(t2.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(1.0000)]]`)
 		aggregations := []string{
@@ -528,7 +519,6 @@ func TestScalarAggregate(t *testing.T) {
 	mcmp.Exec("insert into aggr_test(id, val1, val2) values(1,'a',1), (2,'A',1), (3,'b',1), (4,'c',3), (5,'c',4)")
 	mcmp.AssertMatches("select count(distinct val1) from aggr_test", `[[INT64(3)]]`)
 	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.AssertMatches("select avg(val1) from aggr_test", `[[FLOAT64(0)]]`)
 	})
 }
@@ -588,15 +578,11 @@ func TestComplexAggregation(t *testing.T) {
 	mcmp.Exec(`SELECT name+COUNT(t1_id)+1 FROM t1 GROUP BY name`)
 	mcmp.Exec(`SELECT COUNT(*)+shardkey+MIN(t1_id)+1+MAX(t1_id)*SUM(t1_id)+1+name FROM t1 GROUP BY shardkey, name`)
 	mcmp.Run("Average in sharded query", func(mcmp *utils.MySQLCompare) {
-		mcmp.SkipIfBinaryIsBelowVersion(19, "vtgate")
 		mcmp.Exec(`SELECT COUNT(t1_id)+MAX(shardkey)+AVG(t1_id) FROM t1`)
 	})
 }
 
 func TestJoinAggregation(t *testing.T) {
-	// This is new functionality in Vitess 20
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -793,7 +779,6 @@ func TestHavingQueries(t *testing.T) {
 
 // TestJsonAggregation tests that json aggregation works for single sharded queries.
 func TestJsonAggregation(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/derived/cte_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/cte_test.go
@@ -18,12 +18,9 @@ package misc
 
 import (
 	"testing"
-
-	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
 func TestCTEWithOrderByLimit(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -31,7 +28,6 @@ func TestCTEWithOrderByLimit(t *testing.T) {
 }
 
 func TestCTEAggregationOnRHS(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -40,7 +36,6 @@ func TestCTEAggregationOnRHS(t *testing.T) {
 }
 
 func TestCTERemoveInnerOrderBy(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -48,7 +43,6 @@ func TestCTERemoveInnerOrderBy(t *testing.T) {
 }
 
 func TestCTEWithHaving(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -59,7 +53,6 @@ func TestCTEWithHaving(t *testing.T) {
 }
 
 func TestCTEColumns(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -68,7 +61,6 @@ func TestCTEColumns(t *testing.T) {
 }
 
 func TestCTEAggregationsInUnion(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/derived/derived_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/derived_test.go
@@ -92,7 +92,6 @@ func TestDerivedTableColumns(t *testing.T) {
 // We do this by not using the apply join we usually use, and instead use the hash join engine primitive
 // These tests exercise these situations
 func TestDerivedTablesWithLimit(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	// We need full type info before planning this, so we wait for the schema tracker
 	require.NoError(t,
 		utils.WaitForAuthoritative(t, keyspaceName, "user", clusterInstance.VtgateProcess.ReadVSchema))
@@ -116,7 +115,6 @@ func TestDerivedTablesWithLimit(t *testing.T) {
 
 // TestDerivedTableColumnAliasWithJoin tests the derived table having alias column and using it in the join condition
 func TestDerivedTableColumnAliasWithJoin(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -47,8 +47,6 @@ func TestMultiEqual(t *testing.T) {
 
 // TestMultiTableDelete executed multi-table delete queries
 func TestMultiTableDelete(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -78,8 +76,6 @@ func TestMultiTableDelete(t *testing.T) {
 
 // TestDeleteWithLimit executed delete queries with limit
 func TestDeleteWithLimit(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -133,8 +129,6 @@ func TestDeleteWithLimit(t *testing.T) {
 
 // TestUpdateWithLimit executed update queries with limit
 func TestUpdateWithLimit(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -191,8 +185,6 @@ func TestUpdateWithLimit(t *testing.T) {
 
 // TestMultiTableUpdate executed multi-table update queries
 func TestMultiTableUpdate(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -222,8 +214,6 @@ func TestMultiTableUpdate(t *testing.T) {
 
 // TestDeleteWithSubquery executed delete queries with subqueries
 func TestDeleteWithSubquery(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -268,8 +258,6 @@ func TestDeleteWithSubquery(t *testing.T) {
 
 // TestMultiTargetDelete executed multi-target delete queries
 func TestMultiTargetDelete(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -299,8 +287,6 @@ func TestMultiTargetDelete(t *testing.T) {
 
 // TestMultiTargetDeleteMore executed multi-target delete queries with additional cases
 func TestMultiTargetDeleteMore(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -337,8 +323,6 @@ func TestMultiTargetDeleteMore(t *testing.T) {
 
 // TestMultiTargetUpdate executed multi-target update queries
 func TestMultiTargetUpdate(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -368,8 +352,6 @@ func TestMultiTargetUpdate(t *testing.T) {
 
 // TestMultiTargetNonLiteralUpdate executed multi-target update queries with non-literal values.
 func TestMultiTargetNonLiteralUpdate(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -400,8 +382,6 @@ func TestMultiTargetNonLiteralUpdate(t *testing.T) {
 // TestDMLInUnique for update/delete statement using an IN clause with the Vindexes,
 // the query is correctly split according to the corresponding values in the IN list.
 func TestDMLInUnique(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/dml/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/insert_test.go
@@ -21,9 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -56,8 +54,6 @@ func TestSimpleInsertSelect(t *testing.T) {
 
 // TestInsertOnDup test the insert on duplicate key update feature with argument and list argument.
 func TestInsertOnDup(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -92,19 +88,10 @@ func TestFailureInsertSelect(t *testing.T) {
 			// primary key same
 			mcmp.AssertContainsError("insert into s_tbl(id, num) select id, num*20 from s_tbl where id = 1", `AlreadyExists desc = Duplicate entry '1' for key`)
 			// lookup key same (does not fail on MySQL as there is no lookup, and we have not put unique constraint on num column)
-			vtgateVersion, err := cluster.GetMajorVersion("vtgate")
-			require.NoError(t, err)
-			if vtgateVersion >= 19 {
-				utils.AssertContainsError(t, mcmp.VtConn, "insert into s_tbl(id, num) select id*20, num from s_tbl where id = 1", `(errno 1062) (sqlstate 23000)`)
-				// mismatch column count
-				mcmp.AssertContainsError("insert into s_tbl(id, num) select 100,200,300", `column count does not match value count with the row`)
-				mcmp.AssertContainsError("insert into s_tbl(id, num) select 100", `column count does not match value count with the row`)
-			} else {
-				utils.AssertContainsError(t, mcmp.VtConn, "insert into s_tbl(id, num) select id*20, num from s_tbl where id = 1", `lookup.Create: Code: ALREADY_EXISTS`)
-				// mismatch column count
-				mcmp.AssertContainsError("insert into s_tbl(id, num) select 100,200,300", `column count does not match value count at row 1`)
-				mcmp.AssertContainsError("insert into s_tbl(id, num) select 100", `column count does not match value count at row 1`)
-			}
+			utils.AssertContainsError(t, mcmp.VtConn, "insert into s_tbl(id, num) select id*20, num from s_tbl where id = 1", `(errno 1062) (sqlstate 23000)`)
+			// mismatch column count
+			mcmp.AssertContainsError("insert into s_tbl(id, num) select 100,200,300", `column count does not match value count with the row`)
+			mcmp.AssertContainsError("insert into s_tbl(id, num) select 100", `column count does not match value count with the row`)
 		})
 	}
 }
@@ -486,9 +473,6 @@ func TestMixedCases(t *testing.T) {
 
 // TestInsertAlias test the alias feature in insert statement.
 func TestInsertAlias(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vttablet")
-
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -225,8 +225,6 @@ func TestInfrSchemaAndUnionAll(t *testing.T) {
 }
 
 func TestInfoschemaTypes(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
-
 	require.NoError(t,
 		utils.WaitForAuthoritative(t, "ks", "t1", clusterInstance.VtgateProcess.ReadVSchema))
 
@@ -245,9 +243,7 @@ func TestInfoschemaTypes(t *testing.T) {
 }
 
 func TestTypeORMQuery(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	// This test checks that we can run queries similar to the ones that the TypeORM framework uses
-
 	require.NoError(t,
 		utils.WaitForAuthoritative(t, "ks", "t1", clusterInstance.VtgateProcess.ReadVSchema))
 
@@ -294,7 +290,6 @@ WHERE TABLE_SCHEMA = 'ks' AND TABLE_NAME = 't2';
 }
 
 func TestJoinWithSingleShardQueryOnRHS(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	// This test checks that we can run queries like this, where the RHS is a single shard query
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -60,15 +60,8 @@ func TestBitVals(t *testing.T) {
 
 	mcmp.AssertMatches(`select b'1001', 0x9, B'010011011010'`, `[[VARBINARY("\t") VARBINARY("\t") VARBINARY("\x04\xda")]]`)
 	mcmp.AssertMatches(`select b'1001', 0x9, B'010011011010' from t1`, `[[VARBINARY("\t") VARBINARY("\t") VARBINARY("\x04\xda")]]`)
-	vtgateVersion, err := cluster.GetMajorVersion("vtgate")
-	require.NoError(t, err)
-	if vtgateVersion >= 19 {
-		mcmp.AssertMatchesNoCompare(`select 1 + b'1001', 2 + 0x9, 3 + B'010011011010'`, `[[INT64(10) UINT64(11) INT64(1245)]]`, `[[INT64(10) UINT64(11) INT64(1245)]]`)
-		mcmp.AssertMatchesNoCompare(`select 1 + b'1001', 2 + 0x9, 3 + B'010011011010' from t1`, `[[INT64(10) UINT64(11) INT64(1245)]]`, `[[INT64(10) UINT64(11) INT64(1245)]]`)
-	} else {
-		mcmp.AssertMatchesNoCompare(`select 1 + b'1001', 2 + 0x9, 3 + B'010011011010'`, `[[INT64(10) UINT64(11) INT64(1245)]]`, `[[UINT64(10) UINT64(11) UINT64(1245)]]`)
-		mcmp.AssertMatchesNoCompare(`select 1 + b'1001', 2 + 0x9, 3 + B'010011011010' from t1`, `[[INT64(10) UINT64(11) INT64(1245)]]`, `[[UINT64(10) UINT64(11) UINT64(1245)]]`)
-	}
+	mcmp.AssertMatchesNoCompare(`select 1 + b'1001', 2 + 0x9, 3 + B'010011011010'`, `[[INT64(10) UINT64(11) INT64(1245)]]`, `[[INT64(10) UINT64(11) INT64(1245)]]`)
+	mcmp.AssertMatchesNoCompare(`select 1 + b'1001', 2 + 0x9, 3 + B'010011011010' from t1`, `[[INT64(10) UINT64(11) INT64(1245)]]`, `[[INT64(10) UINT64(11) INT64(1245)]]`)
 }
 
 // TestTimeFunctionWithPrecision tests that inserting data with NOW(1) works as intended.
@@ -140,7 +133,6 @@ func TestCast(t *testing.T) {
 
 // TestVindexHints tests that vindex hints work as intended.
 func TestVindexHints(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -323,8 +315,6 @@ func TestAnalyze(t *testing.T) {
 
 // TestTransactionModeVar executes SELECT on `transaction_mode` variable
 func TestTransactionModeVar(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -356,8 +346,6 @@ func TestTransactionModeVar(t *testing.T) {
 
 // TestAliasesInOuterJoinQueries tests that aliases work in queries that have outer join clauses.
 func TestAliasesInOuterJoinQueries(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -377,7 +365,6 @@ func TestAliasesInOuterJoinQueries(t *testing.T) {
 }
 
 func TestAlterTableWithView(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -431,7 +418,6 @@ func TestAlterTableWithView(t *testing.T) {
 
 // TestStraightJoin tests that Vitess respects the ordering of join in a STRAIGHT JOIN query.
 func TestStraightJoin(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -457,7 +443,6 @@ func TestStraightJoin(t *testing.T) {
 }
 
 func TestColumnAliases(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -466,7 +451,6 @@ func TestColumnAliases(t *testing.T) {
 }
 
 func TestHandleNullableColumn(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
 	require.NoError(t,
 		utils.WaitForAuthoritative(t, keyspaceName, "tbl", clusterInstance.VtgateProcess.ReadVSchema))
 	mcmp, closer := start(t)
@@ -480,8 +464,6 @@ func TestHandleNullableColumn(t *testing.T) {
 }
 
 func TestEnumSetVals(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 	require.NoError(t, utils.WaitForAuthoritative(t, keyspaceName, "tbl_enum_set", clusterInstance.VtgateProcess.ReadVSchema))

--- a/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
@@ -86,8 +86,6 @@ func TestOrderBy(t *testing.T) {
 
 func TestOrderByComplex(t *testing.T) {
 	// tests written to try to trick the ORDER BY engine and planner
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/reference/reference_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/reference_test.go
@@ -84,7 +84,6 @@ func TestReferenceRouting(t *testing.T) {
 	)
 
 	t.Run("Complex reference query", func(t *testing.T) {
-		utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 		// Verify a complex query using reference tables with a left join having a derived table with an order by clause works as intended.
 		utils.AssertMatches(
 			t,

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -162,7 +162,6 @@ func TestSubqueryInReference(t *testing.T) {
 
 // TestSubqueryInAggregation validates that subquery work inside aggregation functions.
 func TestSubqueryInAggregation(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -180,7 +179,6 @@ func TestSubqueryInAggregation(t *testing.T) {
 // TestSubqueryInDerivedTable tests that subqueries and derived tables
 // are handled correctly when there are joins inside the derived table
 func TestSubqueryInDerivedTable(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -194,7 +192,6 @@ func TestSubqueries(t *testing.T) {
 	// This method tests many types of subqueries. The queries should move to a vitess-tester test file once we have a way to run them.
 	// The commented out queries are failing because of wrong types being returned.
 	// The tests are commented out until the issue is fixed.
-	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 	queries := []string{
@@ -234,8 +231,6 @@ func TestSubqueries(t *testing.T) {
 }
 
 func TestProperTypesOfPullOutValue(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
-
 	query := "select (select sum(id) from user) from user_extra"
 
 	mcmp, closer := start(t)

--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -100,8 +100,6 @@ func TestQueryTimeoutWithTables(t *testing.T) {
 
 // TestQueryTimeoutWithShardTargeting tests the query timeout with shard targeting.
 func TestQueryTimeoutWithShardTargeting(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
-
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
+++ b/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
@@ -48,7 +48,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 }
 
 func TestTPCHQueries(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 20, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 	err := utils.WaitForColumn(t, clusterInstance.VtgateProcess, keyspaceName, "region", `R_COMMENT`)

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -178,13 +178,7 @@ func TestInitAndUpdate(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	vtgateVersion, err := cluster.GetMajorVersion("vtgate")
-	require.NoError(t, err)
-
-	expected := `[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
-	if vtgateVersion >= 17 {
-		expected = `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
-	}
+	expected := `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		expected,
@@ -192,18 +186,13 @@ func TestInitAndUpdate(t *testing.T) {
 		30*time.Second,
 		"initial table list not complete")
 
-	if vtgateVersion >= 19 {
-		utils.AssertMatches(t, conn,
-			"SHOW VSCHEMA KEYSPACES",
-			`[[VARCHAR("ks") VARCHAR("true") VARCHAR("unmanaged") VARCHAR("")]]`)
-	}
+	utils.AssertMatches(t, conn,
+		"SHOW VSCHEMA KEYSPACES",
+		`[[VARCHAR("ks") VARCHAR("true") VARCHAR("unmanaged") VARCHAR("")]]`)
 
 	// Init
 	_ = utils.Exec(t, conn, "create table test_sc (id bigint primary key)")
-	expected = `[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")]]`
-	if vtgateVersion >= 17 {
-		expected = `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")]]`
-	}
+	expected = `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")]]`
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		expected,
@@ -213,10 +202,7 @@ func TestInitAndUpdate(t *testing.T) {
 
 	// Tables Update via health check.
 	_ = utils.Exec(t, conn, "create table test_sc1 (id bigint primary key)")
-	expected = `[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")] [VARCHAR("test_sc1")]]`
-	if vtgateVersion >= 17 {
-		expected = `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")] [VARCHAR("test_sc1")]]`
-	}
+	expected = `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")] [VARCHAR("test_sc1")]]`
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		expected,
@@ -225,10 +211,7 @@ func TestInitAndUpdate(t *testing.T) {
 		"test_sc1 not in vschema tables")
 
 	_ = utils.Exec(t, conn, "drop table test_sc, test_sc1")
-	expected = `[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
-	if vtgateVersion >= 17 {
-		expected = `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
-	}
+	expected = `[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		expected,
@@ -247,12 +230,7 @@ func TestDMLOnNewTable(t *testing.T) {
 	// create a new table which is not part of the VSchema
 	utils.Exec(t, conn, `create table new_table_tracked(id bigint, name varchar(100), primary key(id)) Engine=InnoDB`)
 
-	vtgateVersion, err := cluster.GetMajorVersion("vtgate")
-	require.NoError(t, err)
-	expected := `[[VARCHAR("dual")] [VARCHAR("new_table_tracked")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
-	if vtgateVersion >= 17 {
-		expected = `[[VARCHAR("new_table_tracked")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
-	}
+	expected := `[[VARCHAR("new_table_tracked")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`
 	// wait for vttablet's schema reload interval to pass
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -182,7 +182,6 @@ func TestNewUnshardedTable(t *testing.T) {
 // creating two tables having the same name differing only in casing, but other operating systems don't.
 // More information at https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html#:~:text=Table%20names%20are%20stored%20in,lowercase%20on%20storage%20and%20lookup.
 func TestCaseSensitiveSchemaTracking(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 19, "vttablet")
 	defer cluster.PanicHandler(t)
 
 	// create a sql connection

--- a/go/test/endtoend/vtgate/vschema/vschema_test.go
+++ b/go/test/endtoend/vtgate/vschema/vschema_test.go
@@ -110,16 +110,7 @@ func TestVSchema(t *testing.T) {
 		`[[INT64(1) VARCHAR("test1")] [INT64(2) VARCHAR("test2")] [INT64(3) VARCHAR("test3")] [INT64(4) VARCHAR("test4")]]`)
 
 	utils.AssertMatches(t, conn, "delete from vt_user", `[]`)
-
-	vtgateVersion, err := cluster.GetMajorVersion("vtgate")
-	require.NoError(t, err)
-
-	// Test empty vschema
-	if vtgateVersion >= 17 {
-		utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[]`)
-	} else {
-		utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[[VARCHAR("dual")]]`)
-	}
+	utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[]`)
 
 	// Use the DDL to create an unsharded vschema and test again
 
@@ -135,11 +126,7 @@ func TestVSchema(t *testing.T) {
 	utils.Exec(t, conn, "commit")
 
 	// Test Showing Tables
-	if vtgateVersion >= 17 {
-		utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[[VARCHAR("main")] [VARCHAR("vt_user")]]`)
-	} else {
-		utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[[VARCHAR("dual")] [VARCHAR("main")] [VARCHAR("vt_user")]]`)
-	}
+	utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[[VARCHAR("main")] [VARCHAR("vt_user")]]`)
 
 	// Test Showing Vindexes
 	utils.AssertMatches(t, conn, "SHOW VSCHEMA VINDEXES", `[]`)


### PR DESCRIPTION
## Description

This PR updates the query serving (queries) upgrade downgrade workflow to use the same version of the code as the binary we are running to execute the tests. That way, there won't be any imcopatibility between test code and binary version.

Moreover, all the "skip if binary version ..." calls were removed.

backporting this enhancement to all branches as it will fix most of our problems with backports

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/16365