### PR TITLE
VReplication workflow package: unit tests for StreamMigrator, Mount et al

### DIFF
--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -256,6 +256,9 @@ type testTMClient struct {
 	readVReplicationWorkflowRequests   map[uint32]*tabletmanagerdatapb.ReadVReplicationWorkflowRequest
 	primaryPositions                   map[uint32]string
 
+	// Stack of ReadVReplicationWorkflowsResponse to return, in order, for each shard
+	readVReplicationWorkflowsResponses map[string][]*tabletmanagerdatapb.ReadVReplicationWorkflowsResponse
+
 	env     *testEnv    // For access to the env config from tmc methods.
 	reverse atomic.Bool // Are we reversing traffic?
 	frozen  atomic.Bool // Are the workflows frozen?
@@ -267,6 +270,7 @@ func newTestTMClient(env *testEnv) *testTMClient {
 		vrQueries:                          make(map[int][]*queryResult),
 		createVReplicationWorkflowRequests: make(map[uint32]*tabletmanagerdatapb.CreateVReplicationWorkflowRequest),
 		readVReplicationWorkflowRequests:   make(map[uint32]*tabletmanagerdatapb.ReadVReplicationWorkflowRequest),
+		readVReplicationWorkflowsResponses: make(map[string][]*tabletmanagerdatapb.ReadVReplicationWorkflowsResponse),
 		primaryPositions:                   make(map[uint32]string),
 		env:                                env,
 	}
@@ -283,6 +287,10 @@ func (tmc *testTMClient) CreateVReplicationWorkflow(ctx context.Context, tablet 
 	}
 	res := sqltypes.MakeTestResult(sqltypes.MakeTestFields("rowsaffected", "int64"), "1")
 	return &tabletmanagerdatapb.CreateVReplicationWorkflowResponse{Result: sqltypes.ResultToProto3(res)}, nil
+}
+
+func (tmc *testTMClient) GetWorkflowKey(keyspace, shard string) string {
+	return fmt.Sprintf("%s/%s", keyspace, shard)
 }
 
 func (tmc *testTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.ReadVReplicationWorkflowRequest) (*tabletmanagerdatapb.ReadVReplicationWorkflowResponse, error) {
@@ -463,6 +471,10 @@ func (tmc *testTMClient) ReadVReplicationWorkflows(ctx context.Context, tablet *
 	tmc.mu.Lock()
 	defer tmc.mu.Unlock()
 
+	workflowKey := tmc.GetWorkflowKey(tablet.Keyspace, tablet.Shard)
+	if resp := tmc.getVReplicationWorkflowsResponse(workflowKey); resp != nil {
+		return resp, nil
+	}
 	workflowType := binlogdatapb.VReplicationWorkflowType_MoveTables
 	if len(req.IncludeWorkflows) > 0 {
 		for _, wf := range req.IncludeWorkflows {
@@ -494,7 +506,7 @@ func (tmc *testTMClient) ReadVReplicationWorkflows(ctx context.Context, tablet *
 									},
 								},
 							},
-							Pos:           "MySQL56/" + position,
+							Pos:           position,
 							TimeUpdated:   protoutil.TimeToProto(time.Now()),
 							TimeHeartbeat: protoutil.TimeToProto(time.Now()),
 						},
@@ -539,6 +551,25 @@ func (tmc *testTMClient) WaitForPosition(ctx context.Context, tablet *topodatapb
 
 func (tmc *testTMClient) VReplicationWaitForPos(ctx context.Context, tablet *topodatapb.Tablet, id int32, pos string) error {
 	return nil
+}
+
+func (tmc *testTMClient) AddVReplicationWorkflowsResponse(key string, resp *tabletmanagerdatapb.ReadVReplicationWorkflowsResponse) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
+	tmc.readVReplicationWorkflowsResponses[key] = append(tmc.readVReplicationWorkflowsResponses[key], resp)
+}
+
+func (tmc *testTMClient) getVReplicationWorkflowsResponse(key string) *tabletmanagerdatapb.ReadVReplicationWorkflowsResponse {
+	if len(tmc.readVReplicationWorkflowsResponses) == 0 {
+		return nil
+	}
+	responses, ok := tmc.readVReplicationWorkflowsResponses[key]
+	if !ok || len(responses) == 0 {
+		return nil
+	}
+	resp := tmc.readVReplicationWorkflowsResponses[key][0]
+	tmc.readVReplicationWorkflowsResponses[key] = tmc.readVReplicationWorkflowsResponses[key][1:]
+	return resp
 }
 
 //

--- a/go/vt/vtctl/workflow/materializer_env_test.go
+++ b/go/vt/vtctl/workflow/materializer_env_test.go
@@ -61,7 +61,7 @@ type testMaterializerEnv struct {
 	venv     *vtenv.Environment
 }
 
-//----------------------------------------------
+// ----------------------------------------------
 // testMaterializerEnv
 
 func newTestMaterializerEnv(t *testing.T, ctx context.Context, ms *vtctldatapb.MaterializeSettings, sourceShards, targetShards []string) *testMaterializerEnv {
@@ -426,7 +426,7 @@ func (tmc *testMaterializerTMClient) ReadVReplicationWorkflows(ctx context.Conte
 						},
 					},
 				},
-				Pos:           "MySQL56/" + position,
+				Pos:           position,
 				TimeUpdated:   protoutil.TimeToProto(time.Now()),
 				TimeHeartbeat: protoutil.TimeToProto(time.Now()),
 			}

--- a/go/vt/vtctl/workflow/mount_test.go
+++ b/go/vt/vtctl/workflow/mount_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/vtenv"
 )
 
+// TestMount tests various Mount-related methods.
 func TestMount(t *testing.T) {
 	const (
 		extCluster = "extcluster"

--- a/go/vt/vtctl/workflow/mount_test.go
+++ b/go/vt/vtctl/workflow/mount_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vtenv"
+)
+
+func TestMount(t *testing.T) {
+	const (
+		extCluster = "extcluster"
+		topoType   = "etcd2"
+		topoServer = "localhost:2379"
+		topoRoot   = "/vitess/global"
+	)
+	ctx := context.Background()
+	ts := memorytopo.NewServer(ctx, "cell")
+	tmc := &fakeTMC{}
+	s := NewServer(vtenv.NewTestEnv(), ts, tmc)
+
+	resp, err := s.MountRegister(ctx, &vtctldatapb.MountRegisterRequest{
+		Name:       extCluster,
+		TopoType:   topoType,
+		TopoServer: topoServer,
+		TopoRoot:   topoRoot,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	respList, err := s.MountList(ctx, &vtctldatapb.MountListRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, respList)
+	require.Equal(t, []string{extCluster}, respList.Names)
+
+	respShow, err := s.MountShow(ctx, &vtctldatapb.MountShowRequest{
+		Name: extCluster,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, respShow)
+	require.Equal(t, extCluster, respShow.Name)
+	require.Equal(t, topoType, respShow.TopoType)
+	require.Equal(t, topoServer, respShow.TopoServer)
+	require.Equal(t, topoRoot, respShow.TopoRoot)
+
+	respUnregister, err := s.MountUnregister(ctx, &vtctldatapb.MountUnregisterRequest{
+		Name: extCluster,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, respUnregister)
+
+	respList, err = s.MountList(ctx, &vtctldatapb.MountListRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, respList)
+	require.Nil(t, respList.Names)
+}

--- a/go/vt/vtctl/workflow/resharder_test.go
+++ b/go/vt/vtctl/workflow/resharder_test.go
@@ -84,7 +84,7 @@ func TestReshardCreate(t *testing.T) {
 							{
 								Id:          1,
 								Tablet:      &topodatapb.TabletAlias{Cell: defaultCellName, Uid: startingTargetTabletUID},
-								SourceShard: "targetks/0", Position: position, Status: "Running", Info: "VStream Lag: 0s",
+								SourceShard: "targetks/0", Position: gtid(position), Status: "Running", Info: "VStream Lag: 0s",
 							},
 						},
 					},
@@ -93,7 +93,7 @@ func TestReshardCreate(t *testing.T) {
 							{
 								Id:          1,
 								Tablet:      &topodatapb.TabletAlias{Cell: defaultCellName, Uid: startingTargetTabletUID + tabletUIDStep},
-								SourceShard: "targetks/0", Position: position, Status: "Running", Info: "VStream Lag: 0s",
+								SourceShard: "targetks/0", Position: gtid(position), Status: "Running", Info: "VStream Lag: 0s",
 							},
 						},
 					},

--- a/go/vt/vtctl/workflow/stream_migrator_test.go
+++ b/go/vt/vtctl/workflow/stream_migrator_test.go
@@ -405,6 +405,22 @@ func (env *streamMigratorEnv) close() {
 	env.tenv.close()
 }
 
+func (env *streamMigratorEnv) addSourceQueries(queries []string) {
+	for _, id := range env.sourceTabletIds {
+		for _, q := range queries {
+			env.tenv.tmc.expectVRQuery(id, q, &sqltypes.Result{})
+		}
+	}
+}
+
+func (env *streamMigratorEnv) addTargetQueries(queries []string) {
+	for _, id := range env.targetTabletIds {
+		for _, q := range queries {
+			env.tenv.tmc.expectVRQuery(id, q, &sqltypes.Result{})
+		}
+	}
+}
+
 func newStreamMigratorEnv(ctx context.Context, t *testing.T, sourceKeyspace, targetKeyspace *testKeyspace) *streamMigratorEnv {
 	tenv := newTestEnv(t, ctx, "cell1", sourceKeyspace, targetKeyspace)
 	env := &streamMigratorEnv{tenv: tenv}
@@ -484,6 +500,50 @@ func addMaterializeWorkflow(t *testing.T, env *streamMigratorEnv, id int32, sour
 	for _, resp := range workflowResponses {
 		env.tenv.tmc.AddVReplicationWorkflowsResponse(workflowKey, resp)
 	}
+	queries := []string{
+		fmt.Sprintf("select distinct vrepl_id from _vt.copy_state where vrepl_id in (%d)", id),
+		fmt.Sprintf("update _vt.vreplication set state='Stopped', message='for cutover' where id in (%d)", id),
+		fmt.Sprintf("delete from _vt.vreplication where db_name='vt_%s' and workflow in ('%s')",
+			env.tenv.sourceKeyspace.KeyspaceName, wfName),
+	}
+	env.addSourceQueries(queries)
+	queries = []string{
+		fmt.Sprintf("delete from _vt.vreplication where db_name='vt_%s' and workflow in ('%s')",
+			env.tenv.sourceKeyspace.KeyspaceName, wfName),
+	}
+	env.addTargetQueries(queries)
+
+}
+
+func addReferenceWorkflow(t *testing.T, env *streamMigratorEnv, id int32, sourceShard string) {
+	var wfs tabletmanagerdata.ReadVReplicationWorkflowsResponse
+	wfName := "wfRef1"
+	wfs.Workflows = append(wfs.Workflows, &tabletmanagerdata.ReadVReplicationWorkflowResponse{
+		Workflow:     wfName,
+		WorkflowType: binlogdatapb.VReplicationWorkflowType_Materialize,
+	})
+	wfs.Workflows[0].Streams = append(wfs.Workflows[0].Streams, &tabletmanagerdata.ReadVReplicationWorkflowResponse_Stream{
+		Id: id,
+		Bls: &binlogdatapb.BinlogSource{
+			Keyspace: env.tenv.sourceKeyspace.KeyspaceName,
+			Shard:    sourceShard,
+			Filter: &binlogdatapb.Filter{
+				Rules: []*binlogdatapb.Rule{
+					{Match: "ref", Filter: "select * from ref"},
+				},
+			},
+		},
+		Pos:   position,
+		State: binlogdatapb.VReplicationWorkflowState_Running,
+	})
+	workflowKey := env.tenv.tmc.GetWorkflowKey(env.tenv.sourceKeyspace.KeyspaceName, sourceShard)
+	workflowResponses := []*tabletmanagerdata.ReadVReplicationWorkflowsResponse{
+		nil,              // this is the response for getting stopped workflows
+		&wfs, &wfs, &wfs, // return the full list for subsequent GetWorkflows calls
+	}
+	for _, resp := range workflowResponses {
+		env.tenv.tmc.AddVReplicationWorkflowsResponse(workflowKey, resp)
+	}
 	for _, id := range env.sourceTabletIds {
 		queries := []string{
 			fmt.Sprintf("select distinct vrepl_id from _vt.copy_state where vrepl_id in (%d)", id),
@@ -496,7 +556,7 @@ func addMaterializeWorkflow(t *testing.T, env *streamMigratorEnv, id int32, sour
 	for _, id := range env.targetTabletIds {
 		queries := []string{
 			fmt.Sprintf("delete from _vt.vreplication where db_name='vt_%s' and workflow in ('%s')",
-				env.tenv.sourceKeyspace.KeyspaceName, wfName),
+				env.tenv.targetKeyspace.KeyspaceName, wfName),
 		}
 		for _, q := range queries {
 			env.tenv.tmc.expectVRQuery(id, q, &sqltypes.Result{})
@@ -534,12 +594,37 @@ func TestBuildStreamMigratorOneMaterialize(t *testing.T) {
 	require.Equal(t, 1, len(workflows))
 	require.NoError(t, sm.MigrateStreams(ctx))
 	require.Len(t, sm.templates, 1)
+	env.addTargetQueries([]string{
+		fmt.Sprintf("update _vt.vreplication set state='Running' where db_name='vt_%s' and workflow in ('%s')",
+			env.tenv.sourceKeyspace.KeyspaceName, "wfMat1"),
+	})
+	require.NoError(t, StreamMigratorFinalize(ctx, env.ts, []string{"wfMat1"}))
 }
 
 func TestBuildStreamMigratorNoStreams(t *testing.T) {
 	ctx := context.Background()
 	env := newStreamMigratorEnv(ctx, t, customerUnshardedKeyspace, customerShardedKeyspace)
 	defer env.close()
+
+	sm, err := BuildStreamMigrator(ctx, env.ts, false, sqlparser.NewTestParser())
+	require.NoError(t, err)
+	require.NotNil(t, sm)
+	require.NotNil(t, sm.streams)
+	require.Equal(t, 0, len(sm.streams))
+
+	workflows, err := sm.StopStreams(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(workflows))
+	require.NoError(t, sm.MigrateStreams(ctx))
+	require.Len(t, sm.templates, 0)
+}
+
+func TestBuildStreamMigratorRefStream(t *testing.T) {
+	ctx := context.Background()
+	env := newStreamMigratorEnv(ctx, t, customerUnshardedKeyspace, customerShardedKeyspace)
+	defer env.close()
+
+	addReferenceWorkflow(t, env, 100, "0")
 
 	sm, err := BuildStreamMigrator(ctx, env.ts, false, sqlparser.NewTestParser())
 	require.NoError(t, err)

--- a/go/vt/vtctl/workflow/stream_migrator_test.go
+++ b/go/vt/vtctl/workflow/stream_migrator_test.go
@@ -544,24 +544,6 @@ func addReferenceWorkflow(t *testing.T, env *streamMigratorEnv, id int32, source
 	for _, resp := range workflowResponses {
 		env.tenv.tmc.AddVReplicationWorkflowsResponse(workflowKey, resp)
 	}
-	for _, id := range env.sourceTabletIds {
-		queries := []string{
-			fmt.Sprintf("select distinct vrepl_id from _vt.copy_state where vrepl_id in (%d)", id),
-			fmt.Sprintf("update _vt.vreplication set state='Stopped', message='for cutover' where id in (%d)", id),
-		}
-		for _, q := range queries {
-			env.tenv.tmc.expectVRQuery(id, q, &sqltypes.Result{})
-		}
-	}
-	for _, id := range env.targetTabletIds {
-		queries := []string{
-			fmt.Sprintf("delete from _vt.vreplication where db_name='vt_%s' and workflow in ('%s')",
-				env.tenv.targetKeyspace.KeyspaceName, wfName),
-		}
-		for _, q := range queries {
-			env.tenv.tmc.expectVRQuery(id, q, &sqltypes.Result{})
-		}
-	}
 }
 
 func TestBuildStreamMigratorOneMaterialize(t *testing.T) {

--- a/go/vt/vtctl/workflow/utils_test.go
+++ b/go/vt/vtctl/workflow/utils_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand/v2"
 	"os"
 	"os/exec"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -91,9 +90,7 @@ func TestCreateDefaultShardRoutingRules(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, rules, len(tc.shards))
 			want := getExpectedRules(tc.sourceKeyspace, tc.targetKeyspace)
-			if !reflect.DeepEqual(want, rules) {
-				require.FailNowf(t, "unexpected rules", "got: %v, want: %v", rules, tc.want)
-			}
+			require.EqualValues(t, want, rules)
 		})
 	}
 }

--- a/go/vt/vtctl/workflow/vreplication_stream_test.go
+++ b/go/vt/vtctl/workflow/vreplication_stream_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestVReplicationStreams(t *testing.T) {
+	var streams VReplicationStreams
+	for i := 1; i <= 3; i++ {
+		streams = append(streams, &VReplicationStream{ID: int32(i), Workflow: fmt.Sprintf("workflow%d", i)})
+	}
+
+	tests := []struct {
+		name           string
+		funcUnderTest  func(VReplicationStreams) interface{}
+		expectedResult interface{}
+	}{
+		{"Test IDs", func(s VReplicationStreams) interface{} { return s.IDs() }, []int32{1, 2, 3}},
+		{"Test Values", func(s VReplicationStreams) interface{} { return s.Values() }, "(1, 2, 3)"},
+		{"Test Workflows", func(s VReplicationStreams) interface{} { return s.Workflows() }, []string{"workflow1", "workflow2", "workflow3"}},
+		{"Test Copy", func(s VReplicationStreams) interface{} { return s.Copy() }, streams.Copy()},
+		{"Test ToSlice", func(s VReplicationStreams) interface{} { return s.ToSlice() }, []*VReplicationStream{streams[0], streams[1], streams[2]}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.funcUnderTest(streams)
+			if !reflect.DeepEqual(result, tt.expectedResult) {
+				t.Errorf("Failed %s: expected %v, got %v", tt.name, tt.expectedResult, result)
+			}
+		})
+	}
+}

--- a/go/vt/vtctl/workflow/vreplication_stream_test.go
+++ b/go/vt/vtctl/workflow/vreplication_stream_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 )
 
+// TestVReplicationStreams tests various methods of VReplicationStreams.
 func TestVReplicationStreams(t *testing.T) {
 	var streams VReplicationStreams
 	for i := 1; i <= 3; i++ {


### PR DESCRIPTION
## Description

As part of the vtctldclient migration, we ported over a lot of existing code and wrote new code in the `go/vt/vtctl/workflow` package. However the unit test frameworks were not. While we have added some unit tests since, the current coverage is still very low.

This is one of multiple PRs that we will create to progressively increase coverage to a more acceptable level.

This PR has tests, among others, for: 
* the `Mount` commands
* `StreamMigrator`
* `ShardRoutingRules`

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16499

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
