### PR TITLE
VReplication: Properly ignore errors from trying to drop tables that don't exist

### DIFF
--- a/go/test/endtoend/vreplication/materialize_test.go
+++ b/go/test/endtoend/vreplication/materialize_test.go
@@ -108,7 +108,6 @@ const smMaterializeSchemaSource = `
 
 const smMaterializeVSchemaSource = `
 {
-  "sharded": true,
   "tables": {
       "mat": {
           "column_vindexes": [
@@ -196,6 +195,8 @@ func testMaterialize(t *testing.T, useVtctldClient bool) {
 	ks2Primary := vc.getPrimaryTablet(t, targetKs, shard)
 	_, err = ks2Primary.QueryTablet(customFunc, targetKs, true)
 	require.NoError(t, err)
+
+	testMaterializeWithNonExistentTable(t)
 
 	materialize(t, smMaterializeSpec2, useVtctldClient)
 	catchup(t, ks2Primary, "wf1", "Materialize")

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -1185,9 +1185,7 @@ func materialize(t *testing.T, spec string, useVtctldClient bool) {
 
 func testMaterializeWithNonExistentTable(t *testing.T) {
 	t.Run("vtctldclient materialize with nonexistent table", func(t *testing.T) {
-		tableSettings := `[
-		{"target_table": "table_that_doesnt_exist", "create_ddl": "create table mat_val_counts (mat_val varbinary(10), cnt int unsigned, primary key (mat_val))", "source_expression": "select val, count(*) as cnt from mat group by val"},
-		]`
+		tableSettings := `[{"target_table": "table_that_doesnt_exist", "create_ddl": "create table mat_val_counts (mat_val varbinary(10), cnt int unsigned, primary key (mat_val))", "source_expression": "select val, count(*) as cnt from mat group by val"}]`
 		output, err := vc.VtctldClient.ExecuteCommandWithOutput("materialize", "--workflow=tablenogood", "--target-keyspace=source",
 			"create", "--source-keyspace=source", "--table-settings", tableSettings)
 		require.NoError(t, err, "Materialize create failed, err: %v, output: %s", err, output)

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -1183,6 +1183,18 @@ func materialize(t *testing.T, spec string, useVtctldClient bool) {
 	}
 }
 
+func testMaterializeWithNonExistentTable(t *testing.T) {
+	t.Run("vtctldclient materialize with nonexistent table", func(t *testing.T) {
+		tableSettings := `[{"target_table": "table_that_doesnt_exist", "create_ddl": "create table mat_val_counts (mat_val varbinary(10), cnt int unsigned, primary key (mat_val))", "source_expression": "select val, count(*) as cnt from mat group by val"}]`
+		output, err := vc.VtctldClient.ExecuteCommandWithOutput("materialize", "--workflow=tablenogood", "--target-keyspace=source",
+			"create", "--source-keyspace=source", "--table-settings", tableSettings)
+		require.NoError(t, err, "Materialize create failed, err: %v, output: %s", err, output)
+		waitForWorkflowState(t, vc, "source.tablenogood", binlogdatapb.VReplicationWorkflowState_Stopped.String())
+		output, err = vc.VtctldClient.ExecuteCommandWithOutput("materialize", "--workflow=tablenogood", "--target-keyspace=source", "cancel")
+		require.NoError(t, err, "Materialize cancel failed, err: %v, output: %s", err, output)
+	})
+}
+
 func materializeProduct(t *testing.T, useVtctldClient bool) {
 	t.Run("materializeProduct", func(t *testing.T) {
 		// Materializing from "product" keyspace to "customer" keyspace.

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -1185,7 +1185,9 @@ func materialize(t *testing.T, spec string, useVtctldClient bool) {
 
 func testMaterializeWithNonExistentTable(t *testing.T) {
 	t.Run("vtctldclient materialize with nonexistent table", func(t *testing.T) {
-		tableSettings := `[{"target_table": "table_that_doesnt_exist", "create_ddl": "create table mat_val_counts (mat_val varbinary(10), cnt int unsigned, primary key (mat_val))", "source_expression": "select val, count(*) as cnt from mat group by val"}]`
+		tableSettings := `[
+		{"target_table": "table_that_doesnt_exist", "create_ddl": "create table mat_val_counts (mat_val varbinary(10), cnt int unsigned, primary key (mat_val))", "source_expression": "select val, count(*) as cnt from mat group by val"},
+		]`
 		output, err := vc.VtctldClient.ExecuteCommandWithOutput("materialize", "--workflow=tablenogood", "--target-keyspace=source",
 			"create", "--source-keyspace=source", "--table-settings", tableSettings)
 		require.NoError(t, err, "Materialize create failed, err: %v, output: %s", err, output)

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -66,6 +66,7 @@ type testKeyspace struct {
 type queryResult struct {
 	query  string
 	result *querypb.QueryResult
+	err    error
 }
 
 func TestMain(m *testing.M) {
@@ -389,7 +390,7 @@ func (tmc *testTMClient) VReplicationExec(ctx context.Context, tablet *topodatap
 		return nil, fmt.Errorf("tablet %v:\nunexpected query\n%s\nwant:\n%s", tablet, query, qrs[0].query)
 	}
 	tmc.vrQueries[int(tablet.Alias.Uid)] = qrs[1:]
-	return qrs[0].result, nil
+	return qrs[0].result, qrs[0].err
 }
 
 func (tmc *testTMClient) ExecuteFetchAsDba(ctx context.Context, tablet *topodatapb.Tablet, usePool bool, req *tabletmanagerdatapb.ExecuteFetchAsDbaRequest) (*querypb.QueryResult, error) {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2549,8 +2549,8 @@ func (s *Server) optimizeCopyStateTable(tablet *topodatapb.Tablet) {
 			MaxRows: uint64(100), // always produces 1+rows with notes and status
 		}); err != nil {
 			// The error is a gRPC status.Error, so we need to convert it to an sqlerror.SQLError.
-			err := sqlerror.NewSQLErrorFromError(err)
-			if mysqlErr, ok := err.(*sqlerror.SQLError); ok && (mysqlErr.Num == sqlerror.ERNoSuchTable || mysqlErr.Num == sqlerror.ERBadTable) {
+			if mysqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError); ok &&
+				(mysqlErr.Num == sqlerror.ERNoSuchTable || mysqlErr.Num == sqlerror.ERBadTable) {
 				return
 			}
 			log.Warningf("Failed to optimize the copy_state table on %q: %v", tablet.Alias.String(), err)

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -314,7 +314,7 @@ func TestWorkflowDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "basic with existing denied table entries",
+			name: "basic with missing denied table entries",
 			sourceKeyspace: &testKeyspace{
 				KeyspaceName: sourceKeyspaceName,
 				ShardNames:   []string{"0"},
@@ -331,6 +331,8 @@ func TestWorkflowDelete(t *testing.T) {
 				defer targetUnlock(&err)
 				for _, shard := range env.targetKeyspace.ShardNames {
 					_, err := env.ts.UpdateShardFields(lockCtx, targetKeyspaceName, shard, func(si *topo.ShardInfo) error {
+						// So t1_2 and t1_3 do not exist in the denied table list when we go
+						// to remove t1, t1_2, and t1_3.
 						err := si.UpdateDeniedTables(lockCtx, topodatapb.TabletType_PRIMARY, nil, false, []string{table1Name, "t2", "t3"})
 						return err
 					})

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -213,15 +213,34 @@ func TestWorkflowDelete(t *testing.T) {
 	defer cancel()
 
 	workflowName := "wf1"
-	tableName := "t1"
+	table1Name := "t1"
+	table2Name := "t1_2"
+	table3Name := "t1_3"
+	tableTemplate := "CREATE TABLE %s (id BIGINT, name VARCHAR(64), PRIMARY KEY (id))"
 	sourceKeyspaceName := "sourceks"
 	targetKeyspaceName := "targetks"
 	schema := map[string]*tabletmanagerdatapb.SchemaDefinition{
-		"t1": {
+		table1Name: {
 			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
 				{
-					Name:   tableName,
-					Schema: fmt.Sprintf("CREATE TABLE %s (id BIGINT, name VARCHAR(64), PRIMARY KEY (id))", tableName),
+					Name:   table1Name,
+					Schema: fmt.Sprintf(tableTemplate, table1Name),
+				},
+			},
+		},
+		table2Name: {
+			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+				{
+					Name:   table2Name,
+					Schema: fmt.Sprintf(tableTemplate, table2Name),
+				},
+			},
+		},
+		table3Name: {
+			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+				{
+					Name:   table3Name,
+					Schema: fmt.Sprintf(tableTemplate, table3Name),
 				},
 			},
 		},
@@ -261,7 +280,21 @@ func TestWorkflowDelete(t *testing.T) {
 			},
 			expectedTargetQueries: []*queryResult{
 				{
-					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, tableName),
+					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, table1Name),
+					result: &querypb.QueryResult{},
+				},
+				{
+					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, table2Name),
+					result: &querypb.QueryResult{},
+					// We don't care that the cell and tablet info is off in the error message, only that
+					// it contains the expected SQL error we'd encounter when attempting to drop a table
+					// that doesn't exist. That will then cause this error to be non-fatal and the workflow
+					// delete work will continue.
+					err: fmt.Errorf("rpc error: code = Unknown desc = TabletManager.ExecuteFetchAsDba on cell-01: rpc error: code = Unknown desc = Unknown table 'vt_%s.%s' (errno 1051) (sqlstate 42S02) during query: drop table `vt_%s`.`%s`",
+						targetKeyspaceName, table2Name, targetKeyspaceName, table2Name),
+				},
+				{
+					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, table3Name),
 					result: &querypb.QueryResult{},
 				},
 			},
@@ -298,7 +331,7 @@ func TestWorkflowDelete(t *testing.T) {
 				defer targetUnlock(&err)
 				for _, shard := range env.targetKeyspace.ShardNames {
 					_, err := env.ts.UpdateShardFields(lockCtx, targetKeyspaceName, shard, func(si *topo.ShardInfo) error {
-						err := si.UpdateDeniedTables(lockCtx, topodatapb.TabletType_PRIMARY, nil, false, []string{tableName, "t2", "t3"})
+						err := si.UpdateDeniedTables(lockCtx, topodatapb.TabletType_PRIMARY, nil, false, []string{table1Name, "t2", "t3"})
 						return err
 					})
 					require.NoError(t, err)
@@ -317,7 +350,15 @@ func TestWorkflowDelete(t *testing.T) {
 			},
 			expectedTargetQueries: []*queryResult{
 				{
-					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, tableName),
+					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, table1Name),
+					result: &querypb.QueryResult{},
+				},
+				{
+					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, table2Name),
+					result: &querypb.QueryResult{},
+				},
+				{
+					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", targetKeyspaceName, table3Name),
 					result: &querypb.QueryResult{},
 				},
 			},

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -258,7 +258,7 @@ func TestWorkflowDelete(t *testing.T) {
 		postFunc                       func(t *testing.T, env *testEnv)
 	}{
 		{
-			name: "basic",
+			name: "missing table",
 			sourceKeyspace: &testKeyspace{
 				KeyspaceName: sourceKeyspaceName,
 				ShardNames:   []string{"0"},
@@ -314,7 +314,7 @@ func TestWorkflowDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "basic with missing denied table entries",
+			name: "missing denied table entries",
 			sourceKeyspace: &testKeyspace{
 				KeyspaceName: sourceKeyspaceName,
 				ShardNames:   []string{"0"},

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -549,8 +549,8 @@ func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType T
 			})
 			if err != nil {
 				// The error is a gRPC status.Error, so we need to convert it to an sqlerror.SQLError.
-				err := sqlerror.NewSQLErrorFromError(err)
-				if mysqlErr, ok := err.(*sqlerror.SQLError); ok && (mysqlErr.Num == sqlerror.ERNoSuchTable || mysqlErr.Num == sqlerror.ERBadTable) {
+				if mysqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError); ok &&
+					(mysqlErr.Num == sqlerror.ERNoSuchTable || mysqlErr.Num == sqlerror.ERBadTable) {
 					ts.Logger().Warningf("%s: Table %s did not exist when attempting to remove it", topoproto.TabletAliasString(source.GetPrimary().GetAlias()), tableName)
 					return nil
 				}
@@ -1182,8 +1182,8 @@ func (ts *trafficSwitcher) removeTargetTables(ctx context.Context) error {
 			log.Infof("Removed target table with result: %+v", res)
 			if err != nil {
 				// The error is a gRPC status.Error, so we need to convert it to an sqlerror.SQLError.
-				err := sqlerror.NewSQLErrorFromError(err)
-				if mysqlErr, ok := err.(*sqlerror.SQLError); ok && (mysqlErr.Num == sqlerror.ERNoSuchTable || mysqlErr.Num == sqlerror.ERBadTable) {
+				if mysqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError); ok &&
+					(mysqlErr.Num == sqlerror.ERNoSuchTable || mysqlErr.Num == sqlerror.ERBadTable) {
 					// The table was already gone, so we can ignore the error.
 					ts.Logger().Warningf("%s: Table %s did not exist when attempting to remove it", topoproto.TabletAliasString(target.GetPrimary().GetAlias()), tableName)
 					return nil

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -954,8 +954,8 @@ func getTabletTypeSuffix(tabletType topodatapb.TabletType) string {
 // when e.g. processing a gRPC error which will be a status.Error that needs to be
 // converted to an sqlerror.SQLError before we can examine the error code.
 func IsTableDidNotExistError(err error) bool {
-	if mysqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError); ok {
-		return mysqlErr.Num == sqlerror.ERNoSuchTable || mysqlErr.Num == sqlerror.ERBadTable
+	if sqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError); ok {
+		return sqlErr.Num == sqlerror.ERNoSuchTable || sqlErr.Num == sqlerror.ERBadTable
 	}
 	return false
 }

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -28,13 +28,9 @@ import (
 	"strings"
 	"sync"
 
-	"vitess.io/vitess/go/mysql/sqlerror"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
 	"google.golang.org/protobuf/encoding/prototext"
 
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sets"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/concurrency"
@@ -47,9 +43,11 @@ import (
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"


### PR DESCRIPTION
## Description

This is a follow-up to: https://github.com/vitessio/vitess/pull/15977 We should backport the fix to v20, where that work was first added.

There were two problems:
1.   The concrete error type returned from the ExecuteFetch RPC call was a gRPC `status.Error` and NOT the `sqlerror.SQLError` type returned from the database failure so we needed to first convert it
2. The error code returned when the table did not exist was actually [`Error number: 1051; Symbol: [ER_BAD_TABLE_ERROR]`](https://dev.mysql.com/doc/mysql-errors/en/server-error-reference.html#error_er_bad_table_error)

This was missed due to inadequate testing. I've added an endtoend test here — along with updating the unit test (and framework) to test this behavior — which fails on main as expected:
```
❯ go test -v -timeout 10m -run ^TestMaterialize$ vitess.io/vitess/go/test/endtoend/vreplication
VTDATAROOT is /opt/vtdataroot/vreple2e_513606
=== RUN   TestMaterialize
=== RUN   TestMaterialize/Materialize
E0730 13:37:41.449283   10971 vtorc_process.go:103] configuration - {
	"Debug": true,
	"ListenAddress": ":0",
	"MySQLTopologyUser": "orc_client_user",
	"MySQLTopologyPassword": "orc_client_user_password",
	"MySQLReplicaUser": "vt_repl",
	"MySQLReplicaPassword": "",
	"RecoveryPeriodBlockSeconds": 1
}
=== RUN   TestMaterialize/Materialize/vtctldclient_materialize_with_nonexistent_table
    vreplication_test.go:1194:
        	Error Trace:	/Users/matt/git/vitess/go/test/endtoend/vreplication/vreplication_test.go:1194
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestMaterialize/Materialize/vtctldclient_materialize_with_nonexistent_table
        	Messages:   	Materialize cancel failed, err: exit status 1, output: E0730 13:37:57.945022   12107 main.go:56] rpc error: code = Unknown desc = TabletManager.ExecuteFetchAsDba on zone1-0000000300: rpc error: code = Unknown desc = Unknown table 'vt_source.table_that_doesnt_exist' (errno 1051) (sqlstate 42S02) during query: drop table `vt_source`.`table_that_doesnt_exist`
```

The updated unit test demonstrating that we are properly handling the case where 1 of N tables doesn't exist:
```
❯ go test -count 1 -v -race -timeout 30s -run ^TestWorkflowDelete$ vitess.io/vitess/go/vt/vtctl/workflow
# vitess.io/vitess/go/vt/vtctl/workflow.test
=== RUN   TestWorkflowDelete
=== RUN   TestWorkflowDelete/missing_table
W0801 09:59:41.614732   13583 traffic_switcher.go:1183] cell-0000000210: Table `t1_2` did not exist when attempting to remove it
W0801 09:59:41.614759   13583 traffic_switcher.go:1183] cell-0000000200: Table `t1_2` did not exist when attempting to remove it
W0801 09:59:41.615560   13583 shard.go:404] Trying to remove TabletControl.DeniedTables for missing type PRIMARY in shard sourceks/0
W0801 09:59:41.615904   13583 shard.go:404] Trying to remove TabletControl.DeniedTables for missing type PRIMARY in shard targetks/80-
W0801 09:59:41.615951   13583 shard.go:404] Trying to remove TabletControl.DeniedTables for missing type PRIMARY in shard targetks/-80
=== RUN   TestWorkflowDelete/missing_denied_table_entries
W0801 09:59:41.619304   13583 shard.go:404] Trying to remove TabletControl.DeniedTables for missing type PRIMARY in shard sourceks/0
W0801 09:59:41.619547   13583 shard.go:454] one or more tables did not exist in the denylist:t1_2,t1_3
W0801 09:59:41.619553   13583 shard.go:454] one or more tables did not exist in the denylist:t1_2,t1_3
--- PASS: TestWorkflowDelete (0.01s)
    --- PASS: TestWorkflowDelete/missing_table (0.01s)
    --- PASS: TestWorkflowDelete/missing_denied_table_entries (0.00s)
PASS
ok  	vitess.io/vitess/go/vt/vtctl/workflow	2.141s
```

And which fails, as expected, on main:
```
❯ go test -count 1 -v -race -timeout 30s -run ^TestWorkflowDelete$ vitess.io/vitess/go/vt/vtctl/workflow
# vitess.io/vitess/go/vt/vtctl/workflow.test
ld: warning: '/private/var/folders/wv/yn5161kd4r5gx_p046xvsr0w0000gn/T/go-link-409845145/000014.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
=== RUN   TestWorkflowDelete
=== RUN   TestWorkflowDelete/missing_table
E0801 10:05:55.179911   17216 traffic_switcher.go:1187] cell-0000000210: Error removing table `t1_2`: rpc error: code = Unknown desc = TabletManager.ExecuteFetchAsDba on cell-01: rpc error: code = Unknown desc = Unknown table 'vt_targetks.t1_2' (errno 1051) (sqlstate 42S02) during query: drop table `vt_targetks`.`t1_2`
E0801 10:05:55.181247   17216 traffic_switcher.go:1187] cell-0000000200: Error removing table `t1_2`: rpc error: code = Unknown desc = TabletManager.ExecuteFetchAsDba on cell-01: rpc error: code = Unknown desc = Unknown table 'vt_targetks.t1_2' (errno 1051) (sqlstate 42S02) during query: drop table `vt_targetks`.`t1_2`
    server_test.go:418:
        	Error Trace:	/Users/matt/git/vitess/go/vt/vtctl/workflow/server_test.go:418
        	Error:      	unexpected error value
        	Test:       	TestWorkflowDelete/missing_table
        	Messages:   	Server.WorkflowDelete() error = Code: UNKNOWN
        	            	rpc error: code = Unknown desc = TabletManager.ExecuteFetchAsDba on cell-01: rpc error: code = Unknown desc = Unknown table 'vt_targetks.t1_2' (errno 1051) (sqlstate 42S02) during query: drop table `vt_targetks`.`t1_2`
        	            	rpc error: code = Unknown desc = TabletManager.ExecuteFetchAsDba on cell-01: rpc error: code = Unknown desc = Unknown table 'vt_targetks.t1_2' (errno 1051) (sqlstate 42S02) during query: drop table `vt_targetks`.`t1_2`
        	            	, wantErr false
=== RUN   TestWorkflowDelete/missing_denied_table_entries
W0801 10:05:55.184561   17216 shard.go:404] Trying to remove TabletControl.DeniedTables for missing type PRIMARY in shard sourceks/0
W0801 10:05:55.184880   17216 shard.go:454] one or more tables did not exist in the denylist:t1_2,t1_3
W0801 10:05:55.184886   17216 shard.go:454] one or more tables did not exist in the denylist:t1_2,t1_3
--- FAIL: TestWorkflowDelete (0.01s)
    --- FAIL: TestWorkflowDelete/missing_table (0.01s)
    --- PASS: TestWorkflowDelete/missing_denied_table_entries (0.00s)
FAIL
FAIL	vitess.io/vitess/go/vt/vtctl/workflow	1.191s
FAIL
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16470

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required