### PR TITLE
Deprecate `UpdateThrottlerConfig`'s `--check-as-check-self` and `--check-as-check-shard` flags

### DIFF
--- a/go/cmd/vtctldclient/command/throttler.go
+++ b/go/cmd/vtctldclient/command/throttler.go
@@ -37,7 +37,7 @@ import (
 var (
 	// UpdateThrottlerConfig makes a UpdateThrottlerConfig gRPC call to a vtctld.
 	UpdateThrottlerConfig = &cobra.Command{
-		Use:                   "UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] [--custom-query=<query>] [--check-as-check-self|--check-as-check-shard] [--throttle-app|unthrottle-app=<name>] [--throttle-app-ratio=<float, range [0..1]>] [--throttle-app-duration=<duration>] <keyspace>",
+		Use:                   "UpdateThrottlerConfig [--enable|--disable] [--metric-name=<name>] [--threshold=<float64>] [--custom-query=<query>] [--throttle-app|unthrottle-app=<name>] [--throttle-app-ratio=<float, range [0..1]>] [--throttle-app-duration=<duration>] [--throttle-app-exempt=<bool>] [--app-name=<name> --app-metrics=<metrics>] <keyspace>",
 		Short:                 "Update the tablet throttler configuration for all tablets in the given keyspace (across all cells)",
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),

--- a/go/cmd/vtctldclient/command/throttler.go
+++ b/go/cmd/vtctldclient/command/throttler.go
@@ -171,6 +171,8 @@ func init() {
 	UpdateThrottlerConfig.Flags().StringVar(&updateThrottlerConfigOptions.CustomQuery, "custom-query", "", "custom throttler check query")
 	UpdateThrottlerConfig.Flags().BoolVar(&updateThrottlerConfigOptions.CheckAsCheckSelf, "check-as-check-self", false, "/throttler/check requests behave as is /throttler/check-self was called")
 	UpdateThrottlerConfig.Flags().BoolVar(&updateThrottlerConfigOptions.CheckAsCheckShard, "check-as-check-shard", false, "use standard behavior for /throttler/check requests")
+	UpdateThrottlerConfig.Flags().MarkDeprecated("check-as-check-self", "specify metric with scope in --app-metrics to apply to all checks, or use --scope in CheckThrottler for a specific check")
+	UpdateThrottlerConfig.Flags().MarkDeprecated("check-as-check-shard", "specify metric with scope in --app-metrics to apply to all checks, or use --scope in CheckThrottler for a specific check")
 
 	UpdateThrottlerConfig.Flags().StringVar(&unthrottledAppRule.Name, "unthrottle-app", "", "an app name to unthrottle")
 	UpdateThrottlerConfig.Flags().StringVar(&throttledAppRule.Name, "throttle-app", "", "an app name to throttle")
@@ -178,7 +180,7 @@ func init() {
 	UpdateThrottlerConfig.Flags().DurationVar(&throttledAppDuration, "throttle-app-duration", throttle.DefaultAppThrottleDuration, "duration after which throttled app rule expires (app specififed in --throttled-app)")
 	UpdateThrottlerConfig.Flags().BoolVar(&throttledAppRule.Exempt, "throttle-app-exempt", throttledAppRule.Exempt, "exempt this app from being at all throttled. WARNING: use with extreme care, as this is likely to push metrics beyond the throttler's threshold, and starve other apps")
 	UpdateThrottlerConfig.Flags().StringVar(&updateThrottlerConfigOptions.AppName, "app-name", "", "app name for which to assign metrics (requires --app-metrics)")
-	UpdateThrottlerConfig.Flags().StringSliceVar(&updateThrottlerConfigOptions.AppCheckedMetrics, "app-metrics", nil, "metrics to be used when checking the throttler for the app (requires --app-name). Empty to restore to default metrics")
+	UpdateThrottlerConfig.Flags().StringSliceVar(&updateThrottlerConfigOptions.AppCheckedMetrics, "app-metrics", nil, "metrics to be used when checking the throttler for the app (requires --app-name). Empty to restore to default metrics. Example: --app-metrics=lag,custom,shard/loadavg")
 	UpdateThrottlerConfig.MarkFlagsMutuallyExclusive("unthrottle-app", "throttle-app")
 	UpdateThrottlerConfig.MarkFlagsRequiredTogether("app-name", "app-metrics")
 


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->


## Description

For `v21`, this PR adds a deprecation message when the flags `--check-as-check-self` or `--check-as-check-shard` are specified. The flags are still allowed, but the new [Throttler multi metric](https://github.com/vitessio/vitess/pull/15988) approach provides a different (and better) mechanism, where you may specify the desired scope per metric. 

For example:
```sh
$ vtctldclient UpdateThrottlerConfig --app-name=all --app-metrics=loadavg,shard/lag,shard/threads_running commerce
$ vtctldclient UpdateThrottlerConfig --app-name=vstreamer --app-metrics=self/lag commerce
```
Both exist at the same time. Both are visible in `GetKeyspace`:
```sh
$ vtctldclient GetKeyspace commerce | jq .keyspace.throttler_config
```
```json
{
  "enabled": true,
  "threshold": 10.0,
  "custom_query": "",
  "check_as_check_self": false,
  "throttled_apps": {},
  "app_checked_metrics": {
    "all": {
      "names": [
        "loadavg",
        "shard/lag",
        "shard/threads_running"
      ]
    },
    "vstreamer": {
      "names": [
        "self/lag"
      ]
    }
  },
  "metric_thresholds": {}
}
```

The flags will be removed in `v22` or later.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15624#issuecomment-2205944012

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
