### PR TITLE
fix: sequence table next value acl permission to writer role 

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/permission.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/permission.go
@@ -36,7 +36,13 @@ func BuildPermissions(stmt sqlparser.Statement) []Permission {
 	var permissions []Permission
 	// All Statement types myst be covered here.
 	switch node := stmt.(type) {
-	case *sqlparser.Union, *sqlparser.Select:
+	case *sqlparser.Select:
+		role := tableacl.READER
+		if _, ok := node.SelectExprs[0].(*sqlparser.Nextval); ok {
+			role = tableacl.WRITER
+		}
+		permissions = buildSubqueryPermissions(node, role, permissions)
+	case *sqlparser.Union:
 		permissions = buildSubqueryPermissions(node, tableacl.READER, permissions)
 	case *sqlparser.Insert:
 		permissions = buildTableExprPermissions(node.Table, tableacl.WRITER, permissions)

--- a/go/vt/vttablet/tabletserver/planbuilder/permission_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/permission_test.go
@@ -174,6 +174,12 @@ func TestBuildPermissions(t *testing.T) {
 		}, {
 			TableName: "t1", // derived table in update or delete needs reader permission as they cannot be modified.
 		}},
+	}, {
+		input: "select next 10 values from seq",
+		output: []Permission{{
+			TableName: "seq",
+			Role:      tableacl.WRITER,
+		}},
 	}}
 
 	for _, tcase := range tcases {

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -140,7 +140,7 @@
   "Permissions": [
     {
       "TableName": "seq",
-      "Role": 0
+      "Role": 1
     }
   ],
   "NextCount": "1"
@@ -154,7 +154,7 @@
   "Permissions": [
     {
       "TableName": "seq",
-      "Role": 0
+      "Role": 1
     }
   ],
   "NextCount": "10"
@@ -169,7 +169,7 @@
   "Permissions": [
     {
       "TableName": "seq",
-      "Role": 0
+      "Role": 1
     }
   ],
   "NextCount": ":a"
@@ -183,7 +183,7 @@
   "Permissions": [
     {
       "TableName": "seq",
-      "Role": 0
+      "Role": 1
     }
   ],
   "NextCount": "12345667852342342342323423423"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

For Select and Union queries, Vitess only checks for read permission on vttablet.
This PR changes to check on write permission for the Next Value of sequence table calls.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/16510

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
