### PR TITLE
Schema tracking global routing

### DIFF
--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -331,9 +331,9 @@ func BuildVSchema(source *vschemapb.SrvVSchema, parser *sqlparser.Parser) (vsche
 		created:        time.Now(),
 	}
 	buildKeyspaces(source, vschema, parser)
-	// buildGlobalTables before buildReferences so that buildReferences can
+	// BuildGlobalTables before buildReferences so that buildReferences can
 	// resolve sources which reference global tables.
-	buildGlobalTables(source, vschema)
+	BuildGlobalTables(source, vschema)
 	buildReferences(source, vschema)
 	buildRoutingRule(source, vschema, parser)
 	buildShardRoutingRule(source, vschema)
@@ -437,7 +437,12 @@ func (vschema *VSchema) AddUDF(ksname, udfName string) error {
 	return nil
 }
 
-func buildGlobalTables(source *vschemapb.SrvVSchema, vschema *VSchema) {
+// BuildGlobalTables rebuilds the global tables map that is used for global routing.
+// If a table name is unique across all keyspaces, then Vitess allows the users to use the table
+// without needing to select a database first.
+func BuildGlobalTables(source *vschemapb.SrvVSchema, vschema *VSchema) {
+	// Reinitialize the global Tables map to restart the building process.
+	vschema.globalTables = make(map[string]*Table)
 	for ksname, ks := range source.Keyspaces {
 		ksvschema := vschema.Keyspaces[ksname]
 		// If the keyspace requires explicit routing, don't include any of

--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -196,6 +196,8 @@ func (vm *VSchemaManager) buildAndEnhanceVSchema(v *vschemapb.SrvVSchema) *vinde
 		// We mark the keyspaces that have foreign key management in Vitess and have cyclic foreign keys
 		// to have an error. This makes all queries against them to fail.
 		markErrorIfCyclesInFk(vschema)
+		// We build the global routing table again because schema tracking might have added more tables to the vschema.
+		vindexes.BuildGlobalTables(v, vschema)
 	}
 	return vschema
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR implements the feature requested in #16516.
The fix is pretty straight-forward. Since schema tracking can add tables to the vschema that were previously not there, we should recompute the global tables map that we use for global routing.

This PR also adds an e2e test that verifies the use case described in the issue now works.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #16516

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
