### PR TITLE
fix: show tables to use any keyspace on system schema

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -95,10 +95,13 @@ func TestShowTables(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()
 
-	query := "show tables;"
-	qr := utils.Exec(t, conn, query)
-
+	qr := utils.Exec(t, conn, "show tables")
 	assert.Equal(t, "Tables_in_ks", qr.Fields[0].Name)
+
+	// no error on executing `show tables` on system schema
+	utils.Exec(t, conn, `use mysql`)
+	utils.Exec(t, conn, "show tables")
+	utils.Exec(t, conn, "show tables from information_schema")
 }
 
 func TestCastConvert(t *testing.T) {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1105,6 +1105,15 @@ func TestExecutorShowTargeted(t *testing.T) {
 	}
 }
 
+func TestExecutorShowFromSystemSchema(t *testing.T) {
+	executor, _, _, _, ctx := createExecutorEnv(t)
+
+	session := NewSafeSession(&vtgatepb.Session{TargetString: "mysql"})
+
+	_, err := executor.Execute(ctx, nil, "TestExecutorShowFromSystemSchema", session, "show tables", nil)
+	require.NoError(t, err)
+}
+
 func TestExecutorUse(t *testing.T) {
 	executor, _, _, _, ctx := createExecutorEnv(t)
 

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -819,7 +819,7 @@ func commentedShardQueries(shardQueries []*querypb.BoundQuery, marginComments sq
 
 // TargetDestination implements the ContextVSchema interface
 func (vc *vcursorImpl) TargetDestination(qualifier string) (key.Destination, *vindexes.Keyspace, topodatapb.TabletType, error) {
-	keyspaceName := vc.keyspace
+	keyspaceName := vc.getActualKeyspace()
 	if vc.destination == nil && qualifier != "" {
 		keyspaceName = qualifier
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the `show tables` on system schemas like `mysql`, `information_schema`, etc.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/16518

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
