### PR TITLE
simplify merging logic

### DIFF
--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -57,6 +57,7 @@ jobs:
           end_to_end:
             - 'go/**/*.go'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/test/endtoend/vtgate/vitess_tester/**'
             - 'go/test/endtoend/onlineddl/vrepl_suite/**'
             - 'test.go'
             - 'Makefile'

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -58,7 +58,6 @@ jobs:
             - 'go/**/*.go'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/test/endtoend/vtgate/vitess_tester/**'
-            - 'go/test/endtoend/onlineddl/vrepl_suite/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/go/test/endtoend/vtgate/vitess_tester/two_sharded_keyspaces/queries.test
+++ b/go/test/endtoend/vtgate/vitess_tester/two_sharded_keyspaces/queries.test
@@ -24,3 +24,6 @@ insert into corder.corder(order_id, customer_id, sku, price) values(4, 4, 'SKU-1
 insert into corder.corder(order_id, customer_id, sku, price) values(5, 5, 'SKU-1002', 30);
 
 select co.order_id, co.customer_id, co.price from corder.corder co left join customer.customer cu on co.customer_id=cu.customer_id where cu.customer_id=1;
+
+# This query was accidentally disallowed by https://github.com/vitessio/vitess/pull/16520
+select 1 from customer.customer where id in (select customer_id from corder.corder where price > 50);

--- a/go/test/endtoend/vtgate/vitess_tester/two_sharded_keyspaces/queries.test
+++ b/go/test/endtoend/vtgate/vitess_tester/two_sharded_keyspaces/queries.test
@@ -1,29 +1,39 @@
 use customer;
-create table if not exists customer(
-                                       customer_id bigint not null,
-                                       email varbinary(128),
-                                       primary key(customer_id)
-) ENGINE=InnoDB;
-insert into customer.customer(customer_id, email) values(1, '[alice@domain.com](mailto:alice@domain.com)');
-insert into customer.customer(customer_id, email) values(2, '[bob@domain.com](mailto:bob@domain.com)');
-insert into customer.customer(customer_id, email) values(3, '[charlie@domain.com](mailto:charlie@domain.com)');
-insert into customer.customer(customer_id, email) values(4, '[dan@domain.com](mailto:dan@domain.com)');
-insert into customer.customer(customer_id, email) values(5, '[eve@domain.com](mailto:eve@domain.com)');
-use corder;
-create table if not exists corder(
-                                     order_id bigint not null,
-                                     customer_id bigint,
-                                     sku varbinary(128),
-                                     price bigint,
-                                     primary key(order_id)
-) ENGINE=InnoDB;
-insert into corder.corder(order_id, customer_id, sku, price) values(1, 1, 'SKU-1001', 100);
-insert into corder.corder(order_id, customer_id, sku, price) values(2, 2, 'SKU-1002', 30);
-insert into corder.corder(order_id, customer_id, sku, price) values(3, 3, 'SKU-1002', 30);
-insert into corder.corder(order_id, customer_id, sku, price) values(4, 4, 'SKU-1002', 30);
-insert into corder.corder(order_id, customer_id, sku, price) values(5, 5, 'SKU-1002', 30);
+create table if not exists customer
+(
+    customer_id bigint not null,
+    email       varbinary(128),
+    primary key (customer_id)
+) ENGINE = InnoDB;
 
-select co.order_id, co.customer_id, co.price from corder.corder co left join customer.customer cu on co.customer_id=cu.customer_id where cu.customer_id=1;
+insert into customer.customer(customer_id, email)
+values (1, '[alice@domain.com](mailto:alice@domain.com)'),
+       (2, '[bob@domain.com](mailto:bob@domain.com)'),
+       (3, '[charlie@domain.com](mailto:charlie@domain.com)'),
+       (4, '[dan@domain.com](mailto:dan@domain.com)'),
+       (5, '[eve@domain.com](mailto:eve@domain.com)');
+use corder;
+create table if not exists corder
+(
+    order_id    bigint not null,
+    customer_id bigint,
+    sku         varbinary(128),
+    price       bigint,
+    primary key (order_id)
+) ENGINE = InnoDB;
+insert into corder.corder(order_id, customer_id, sku, price)
+values (1, 1, 'SKU-1001', 100),
+       (2, 2, 'SKU-1002', 30),
+       (3, 3, 'SKU-1002', 30),
+       (4, 4, 'SKU-1002', 30),
+       (5, 5, 'SKU-1002', 30);
+
+select co.order_id, co.customer_id, co.price
+from corder.corder co
+         left join customer.customer cu on co.customer_id = cu.customer_id
+where cu.customer_id = 1;
 
 # This query was accidentally disallowed by https://github.com/vitessio/vitess/pull/16520
-select 1 from customer.customer where id in (select customer_id from corder.corder where price > 50);
+select 1
+from customer.customer
+where customer_id in (select customer_id from corder.corder where price > 50);

--- a/go/vt/vtgate/planbuilder/operators/join_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/join_merging.go
@@ -76,7 +76,7 @@ func mergeJoinInputs(ctx *plancontext.PlanningContext, lhs, rhs Operator, joinPr
 
 	// sharded routing is complex, so we handle it in a separate method
 	case a == sharded && b == sharded:
-		return tryMergeShardedRouting(ctx, lhsRoute, rhsRoute, m, joinPredicates, false /*isSubquery*/)
+		return tryMergeShardedRouting(ctx, lhsRoute, rhsRoute, m, joinPredicates)
 
 	default:
 		return nil

--- a/go/vt/vtgate/planbuilder/operators/sharded_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/sharded_routing.go
@@ -23,7 +23,6 @@ import (
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"
-	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
@@ -639,9 +638,10 @@ func tryMergeShardedRouting(
 	routeA, routeB *Route,
 	m merger,
 	joinPredicates []sqlparser.Expr,
-	isSubquery bool,
 ) *Route {
-	sameKeyspace := routeA.Routing.Keyspace() == routeB.Routing.Keyspace()
+	if routeA.Routing.Keyspace() != routeB.Routing.Keyspace() {
+		return nil
+	}
 	tblA := routeA.Routing.(*ShardedRouting)
 	tblB := routeB.Routing.(*ShardedRouting)
 
@@ -667,13 +667,6 @@ func tryMergeShardedRouting(
 			// If we are doing two Scatters, we have to make sure that the
 			// joins are on the correct vindex to allow them to be merged
 			// no join predicates - no vindex
-			return nil
-		}
-
-		if !sameKeyspace {
-			if isSubquery {
-				panic(vterrors.VT12001("cross-shard correlated subquery"))
-			}
 			return nil
 		}
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -758,7 +758,7 @@ func mergeSubqueryInputs(ctx *plancontext.PlanningContext, in, out Operator, joi
 
 	// sharded routing is complex, so we handle it in a separate method
 	case inner == sharded && outer == sharded:
-		return tryMergeShardedRouting(ctx, inRoute, outRoute, m, joinPredicates, true /*isSubquery*/)
+		return tryMergeShardedRouting(ctx, inRoute, outRoute, m, joinPredicates)
 
 	default:
 		return nil

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -296,8 +296,8 @@
   },
   {
     "comment": "Cross keyspace query with subquery",
-    "query": "select 1 from user where id in (select id from t1)",
-    "plan": "VT12001: unsupported: cross-shard correlated subquery"
+    "query": "select 1 from user where id = (select id from t1 where user.foo = t1.bar)",
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
     "comment": "multi-shard union",

--- a/test/templates/cluster_vitess_tester.tpl
+++ b/test/templates/cluster_vitess_tester.tpl
@@ -55,6 +55,7 @@ jobs:
           end_to_end:
             - 'go/**/*.go'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/test/endtoend/vtgate/vitess_tester/**'
             - 'go/test/endtoend/onlineddl/vrepl_suite/**'
             - 'test.go'
             - 'Makefile'

--- a/test/templates/cluster_vitess_tester.tpl
+++ b/test/templates/cluster_vitess_tester.tpl
@@ -56,7 +56,6 @@ jobs:
             - 'go/**/*.go'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/test/endtoend/vtgate/vitess_tester/**'
-            - 'go/test/endtoend/onlineddl/vrepl_suite/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'


### PR DESCRIPTION
## Description
This PR introduces a refined solution to the issue where vtgate stopped accepting cross-keyspace queries. In the original fix, we incorrectly rejected subqueries that weren't merged and failed to properly handle non-correlated subqueries from different keyspaces. This updated approach corrects the handling of these subqueries by planning them differently, ensuring that cross-keyspace functionality is restored in a more accurate and efficient manner.

## Related Issues
This PR supersedes the previous fix and addresses the same underlying problem introduced in #12197 and initially addressed in #16515.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
