### PR TITLE
vindex function: error when keyspace not selected

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -342,7 +342,7 @@ func (t *noopVCursor) ExceedsMaxMemoryRows(numRows int) bool {
 }
 
 func (t *noopVCursor) GetKeyspace() string {
-	return ""
+	return "test_ks"
 }
 
 func (t *noopVCursor) RecordWarning(warning *querypb.QueryWarning) {

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -153,6 +153,9 @@ func (vf *VindexFunc) mapVindex(ctx context.Context, vcursor VCursor, bindVars m
 		case key.DestinationKeyspaceID:
 			if len(d) > 0 {
 				if vcursor != nil {
+					if vcursor.GetKeyspace() == "" {
+						return nil, vterrors.VT09005()
+					}
 					resolvedShards, _, err := vcursor.ResolveDestinations(ctx, vcursor.GetKeyspace(), nil, []key.Destination{d})
 					if err != nil {
 						return nil, err

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -427,6 +427,19 @@ func TestSetSystemVariablesWithReservedConnection(t *testing.T) {
 	sbc1.Queries = nil
 }
 
+func TestSelectVindexFunc(t *testing.T) {
+	executor, _, _, _, _ := createExecutorEnv(t)
+
+	query := "select * from hash_index where id = 1"
+	session := NewAutocommitSession(&vtgatepb.Session{})
+	_, err := executor.Execute(context.Background(), nil, "TestSelectVindexFunc", session, query, nil)
+	require.ErrorContains(t, err, "VT09005: no database selected")
+
+	session.TargetString = KsTestSharded
+	_, err = executor.Execute(context.Background(), nil, "TestSelectVindexFunc", session, query, nil)
+	require.NoError(t, err)
+}
+
 func TestCreateTableValidTimestamp(t *testing.T) {
 	executor, sbc1, _, _, _ := createExecutorEnv(t)
 	executor.normalize = true


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR sends error message back with `no database selected` when a vindex function query is executed without a default database.

Example:
```
mysql> select * from hash where id = 4;
ERROR 1046 (3D000): no database selected: use keyspace<:shard><@type> or keyspace<[range]><@type> (<> are optional)
mysql> use customer;
Database changed
mysql> select * from hash where id = 4;
+------------+--------------------------+--------------------------+----------------------+------------------------------------+--------------+
| id         | keyspace_id              | range_start              | range_end            | hex_keyspace_id                    | shard        |
+------------+--------------------------+--------------------------+----------------------+------------------------------------+--------------+
| 0x34       | 0xD2FD8867D50D2DFE       | 0x                       | 0x                   | 0x64326664383836376435306432646665 | 0x2D         |
+------------+--------------------------+--------------------------+----------------------+------------------------------------+--------------+
1 row in set (0.00 sec)

```

Earlier the error was
`ERROR 1105 (HY000): keyspace  fetch error: node doesn't exist: /vitess/zone1/keyspaces/SrvKeyspace`

## Related Issue(s)
- resolves https://github.com/vitessio/vitess/issues/16519

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
