### PR TITLE
refactor: remove TableName from Primitive

### DIFF
--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -70,15 +70,6 @@ func (c *Concatenate) GetKeyspaceName() string {
 	return res
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (c *Concatenate) GetTableName() string {
-	res := c.Sources[0].GetTableName()
-	for i := 1; i < len(c.Sources); i++ {
-		res = formatTwoOptionsNicely(res, c.Sources[i].GetTableName())
-	}
-	return res
-}
-
 func formatTwoOptionsNicely(a, b string) string {
 	if a == b {
 		return a

--- a/go/vt/vtgate/engine/dbddl.go
+++ b/go/vt/vtgate/engine/dbddl.go
@@ -89,11 +89,6 @@ func (c *DBDDL) GetKeyspaceName() string {
 	return c.name
 }
 
-// GetTableName implements the Primitive interface
-func (c *DBDDL) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements the Primitive interface
 func (c *DBDDL) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	name := vcursor.GetDBDDLPluginName()
@@ -125,9 +120,9 @@ func (c *DBDDL) createDatabase(ctx context.Context, vcursor VCursor, plugin DBDD
 			break
 		}
 		select {
-		case <-ctx.Done(): //context cancelled
+		case <-ctx.Done(): // context cancelled
 			return nil, vterrors.Errorf(vtrpc.Code_DEADLINE_EXCEEDED, "could not validate create database: destination not resolved")
-		case <-time.After(500 * time.Millisecond): //timeout
+		case <-time.After(500 * time.Millisecond): // timeout
 		}
 	}
 	var queries []*querypb.BoundQuery
@@ -146,9 +141,9 @@ func (c *DBDDL) createDatabase(ctx context.Context, vcursor VCursor, plugin DBDD
 			if err != nil {
 				noErr = false
 				select {
-				case <-ctx.Done(): //context cancelled
+				case <-ctx.Done(): // context cancelled
 					return nil, vterrors.Errorf(vtrpc.Code_DEADLINE_EXCEEDED, "could not validate create database: tablets not healthy")
-				case <-time.After(500 * time.Millisecond): //timeout
+				case <-time.After(500 * time.Millisecond): // timeout
 				}
 				break
 			}
@@ -167,9 +162,9 @@ func (c *DBDDL) dropDatabase(ctx context.Context, vcursor VCursor, plugin DBDDLP
 	}
 	for vcursor.KeyspaceAvailable(c.name) {
 		select {
-		case <-ctx.Done(): //context cancelled
+		case <-ctx.Done(): // context cancelled
 			return nil, vterrors.Errorf(vtrpc.Code_DEADLINE_EXCEEDED, "could not validate drop database: keyspace still available in vschema")
-		case <-time.After(500 * time.Millisecond): //timeout
+		case <-time.After(500 * time.Millisecond): // timeout
 		}
 	}
 

--- a/go/vt/vtgate/engine/ddl.go
+++ b/go/vt/vtgate/engine/ddl.go
@@ -72,11 +72,6 @@ func (ddl *DDL) GetKeyspaceName() string {
 	return ddl.Keyspace.Name
 }
 
-// GetTableName implements the Primitive interface
-func (ddl *DDL) GetTableName() string {
-	return ddl.DDL.GetTable().Name.String()
-}
-
 // IsOnlineSchemaDDL returns true if the query is an online schema change DDL
 func (ddl *DDL) isOnlineSchemaDDL() bool {
 	switch ddl.DDL.GetAction() {

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -126,7 +126,6 @@ func (del *Delete) deleteVindexEntries(ctx context.Context, vcursor VCursor, bin
 func (del *Delete) description() PrimitiveDescription {
 	other := map[string]any{
 		"Query":                del.Query,
-		"Table":                del.GetTableName(),
 		"OwnedVindexQuery":     del.OwnedVindexQuery,
 		"MultiShardAutocommit": del.MultiShardAutocommit,
 		"QueryTimeout":         del.QueryTimeout,

--- a/go/vt/vtgate/engine/distinct.go
+++ b/go/vt/vtgate/engine/distinct.go
@@ -166,11 +166,6 @@ func (d *Distinct) GetKeyspaceName() string {
 	return d.Source.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (d *Distinct) GetTableName() string {
-	return d.Source.GetTableName()
-}
-
 // GetFields implements the Primitive interface
 func (d *Distinct) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return d.Source.GetFields(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/dml.go
+++ b/go/vt/vtgate/engine/dml.go
@@ -19,8 +19,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
@@ -105,20 +103,6 @@ func (dml *DML) RouteType() string {
 // GetKeyspaceName specifies the Keyspace that this primitive routes to.
 func (dml *DML) GetKeyspaceName() string {
 	return dml.Keyspace.Name
-}
-
-// GetTableName specifies the table that this primitive routes to.
-func (dml *DML) GetTableName() string {
-	sort.Strings(dml.TableNames)
-	var tableNames []string
-	var previousTbl string
-	for _, name := range dml.TableNames {
-		if name != previousTbl {
-			tableNames = append(tableNames, name)
-			previousTbl = name
-		}
-	}
-	return strings.Join(tableNames, ", ")
 }
 
 func allowOnlyPrimary(rss ...*srvtopo.ResolvedShard) error {

--- a/go/vt/vtgate/engine/dml_with_input.go
+++ b/go/vt/vtgate/engine/dml_with_input.go
@@ -50,10 +50,6 @@ func (dml *DMLWithInput) GetKeyspaceName() string {
 	return dml.Input.GetKeyspaceName()
 }
 
-func (dml *DMLWithInput) GetTableName() string {
-	return dml.Input.GetTableName()
-}
-
 func (dml *DMLWithInput) Inputs() ([]Primitive, []map[string]any) {
 	return append([]Primitive{dml.Input}, dml.DMLs...), nil
 }

--- a/go/vt/vtgate/engine/exec_prepared_statement.go
+++ b/go/vt/vtgate/engine/exec_prepared_statement.go
@@ -45,10 +45,6 @@ func (e *ExecStmt) GetKeyspaceName() string {
 	return e.Input.GetKeyspaceName()
 }
 
-func (e *ExecStmt) GetTableName() string {
-	return e.Input.GetTableName()
-}
-
 func (e *ExecStmt) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.VT12001("prepare command on execute statement")
 }

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -65,10 +65,6 @@ func (f *fakePrimitive) GetKeyspaceName() string {
 	return "fakeKs"
 }
 
-func (f *fakePrimitive) GetTableName() string {
-	return "fakeTable"
-}
-
 func (f *fakePrimitive) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	f.log = append(f.log, fmt.Sprintf("Execute %v %v", printBindVars(bindVars), wantfields))
 	if f.results == nil {

--- a/go/vt/vtgate/engine/filter.go
+++ b/go/vt/vtgate/engine/filter.go
@@ -49,11 +49,6 @@ func (f *Filter) GetKeyspaceName() string {
 	return f.Input.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (f *Filter) GetTableName() string {
-	return f.Input.GetTableName()
-}
-
 // TryExecute satisfies the Primitive interface.
 func (f *Filter) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	result, err := vcursor.ExecutePrimitive(ctx, f.Input, bindVars, wantfields)

--- a/go/vt/vtgate/engine/fk_cascade.go
+++ b/go/vt/vtgate/engine/fk_cascade.go
@@ -73,11 +73,6 @@ func (fkc *FkCascade) GetKeyspaceName() string {
 	return fkc.Parent.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface.
-func (fkc *FkCascade) GetTableName() string {
-	return fkc.Parent.GetTableName()
-}
-
 // GetFields implements the Primitive interface.
 func (fkc *FkCascade) GetFields(_ context.Context, _ VCursor, _ map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] GetFields should not be called")

--- a/go/vt/vtgate/engine/fk_verify.go
+++ b/go/vt/vtgate/engine/fk_verify.go
@@ -57,11 +57,6 @@ func (f *FkVerify) GetKeyspaceName() string {
 	return f.Exec.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (f *FkVerify) GetTableName() string {
-	return f.Exec.GetTableName()
-}
-
 // GetFields implements the Primitive interface
 func (f *FkVerify) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] GetFields should not be called")

--- a/go/vt/vtgate/engine/hash_join.go
+++ b/go/vt/vtgate/engine/hash_join.go
@@ -214,11 +214,6 @@ func (hj *HashJoin) GetKeyspaceName() string {
 	return hj.Left.GetKeyspaceName() + "_" + hj.Right.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (hj *HashJoin) GetTableName() string {
-	return hj.Left.GetTableName() + "_" + hj.Right.GetTableName()
-}
-
 // GetFields implements the Primitive interface
 func (hj *HashJoin) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	joinVars := make(map[string]*querypb.BindVariable)
@@ -248,7 +243,6 @@ func (hj *HashJoin) Inputs() ([]Primitive, []map[string]any) {
 // description implements the Primitive interface
 func (hj *HashJoin) description() PrimitiveDescription {
 	other := map[string]any{
-		"TableName":         hj.GetTableName(),
 		"JoinColumnIndexes": strings.Trim(strings.Join(strings.Fields(fmt.Sprint(hj.Cols)), ","), "[]"),
 		"Predicate":         sqlparser.String(hj.ASTPred),
 		"ComparisonType":    hj.ComparisonType.String(),

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -350,7 +350,6 @@ func (ins *Insert) buildVindexRowsValues(ctx context.Context, vcursor VCursor, b
 func (ins *Insert) description() PrimitiveDescription {
 	other := ins.commonDesc()
 	other["Query"] = ins.Query
-	other["TableName"] = ins.GetTableName()
 
 	if len(ins.VindexValues) > 0 {
 		valuesOffsets := map[string]string{}

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -137,11 +137,6 @@ func (ic *InsertCommon) GetKeyspaceName() string {
 	return ic.Keyspace.Name
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (ic *InsertCommon) GetTableName() string {
-	return ic.TableName
-}
-
 // GetFields fetches the field info.
 func (ic *InsertCommon) GetFields(context.Context, VCursor, map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.VT13001("unexpected fields call for insert query")

--- a/go/vt/vtgate/engine/insert_select.go
+++ b/go/vt/vtgate/engine/insert_select.go
@@ -319,7 +319,6 @@ func (ins *InsertSelect) execInsertSharded(ctx context.Context, vcursor VCursor,
 
 func (ins *InsertSelect) description() PrimitiveDescription {
 	other := ins.commonDesc()
-	other["TableName"] = ins.GetTableName()
 
 	if len(ins.VindexValueOffset) > 0 {
 		valuesOffsets := map[string]string{}

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -279,11 +279,6 @@ func (jn *Join) GetKeyspaceName() string {
 	return jn.Left.GetKeyspaceName() + "_" + jn.Right.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (jn *Join) GetTableName() string {
-	return jn.Left.GetTableName() + "_" + jn.Right.GetTableName()
-}
-
 // NeedsTransaction implements the Primitive interface
 func (jn *Join) NeedsTransaction() bool {
 	return jn.Right.NeedsTransaction() || jn.Left.NeedsTransaction()
@@ -302,7 +297,6 @@ func combineVars(bv1, bv2 map[string]*querypb.BindVariable) map[string]*querypb.
 
 func (jn *Join) description() PrimitiveDescription {
 	other := map[string]any{
-		"TableName":         jn.GetTableName(),
 		"JoinColumnIndexes": jn.joinColsDescription(),
 	}
 	if len(jn.Vars) > 0 {

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -52,11 +52,6 @@ func (l *Limit) GetKeyspaceName() string {
 	return l.Input.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (l *Limit) GetTableName() string {
-	return l.Input.GetTableName()
-}
-
 // TryExecute satisfies the Primitive interface.
 func (l *Limit) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	count, offset, err := l.getCountAndOffset(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/lock.go
+++ b/go/vt/vtgate/engine/lock.go
@@ -67,11 +67,6 @@ func (l *Lock) GetKeyspaceName() string {
 	return l.Keyspace.Name
 }
 
-// GetTableName is part of the Primitive interface
-func (l *Lock) GetTableName() string {
-	return "dual"
-}
-
 // TryExecute is part of the Primitive interface
 func (l *Lock) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	return l.execLock(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/memory_sort.go
+++ b/go/vt/vtgate/engine/memory_sort.go
@@ -54,11 +54,6 @@ func (ms *MemorySort) GetKeyspaceName() string {
 	return ms.Input.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (ms *MemorySort) GetTableName() string {
-	return ms.Input.GetTableName()
-}
-
 // TryExecute satisfies the Primitive interface.
 func (ms *MemorySort) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	count, err := ms.fetchCount(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/merge_sort.go
+++ b/go/vt/vtgate/engine/merge_sort.go
@@ -62,9 +62,6 @@ func (ms *MergeSort) RouteType() string { return "MergeSort" }
 // GetKeyspaceName satisfies Primitive.
 func (ms *MergeSort) GetKeyspaceName() string { return "" }
 
-// GetTableName satisfies Primitive.
-func (ms *MergeSort) GetTableName() string { return "" }
-
 // TryExecute is not supported.
 func (ms *MergeSort) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] Execute is not reachable")

--- a/go/vt/vtgate/engine/mstream.go
+++ b/go/vt/vtgate/engine/mstream.go
@@ -53,11 +53,6 @@ func (m *MStream) GetKeyspaceName() string {
 	return m.Keyspace.Name
 }
 
-// GetTableName implements the Primitive interface
-func (m *MStream) GetTableName() string {
-	return m.TableName
-}
-
 // TryExecute implements the Primitive interface
 func (m *MStream) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	return nil, vterrors.VT13001("TryExecute is not supported for MStream")

--- a/go/vt/vtgate/engine/online_ddl.go
+++ b/go/vt/vtgate/engine/online_ddl.go
@@ -65,11 +65,6 @@ func (v *OnlineDDL) GetKeyspaceName() string {
 	return v.Keyspace.Name
 }
 
-// GetTableName implements the Primitive interface
-func (v *OnlineDDL) GetTableName() string {
-	return v.DDL.GetTable().Name.String()
-}
-
 // TryExecute implements the Primitive interface
 func (v *OnlineDDL) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (result *sqltypes.Result, err error) {
 	result = &sqltypes.Result{

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -89,11 +89,6 @@ func (oa *OrderedAggregate) GetKeyspaceName() string {
 	return oa.Input.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (oa *OrderedAggregate) GetTableName() string {
-	return oa.Input.GetTableName()
-}
-
 // TryExecute is a Primitive function.
 func (oa *OrderedAggregate) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, _ bool) (*sqltypes.Result, error) {
 	qr, err := oa.execute(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/plan.go
+++ b/go/vt/vtgate/engine/plan.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -109,4 +110,8 @@ func (p *Plan) MarshalJSON() ([]byte, error) {
 	}
 
 	return b.Bytes(), nil
+}
+
+func (p *Plan) GetTableName() string {
+	return strings.Join(p.TablesUsed, ",")
 }

--- a/go/vt/vtgate/engine/plan_description_test.go
+++ b/go/vt/vtgate/engine/plan_description_test.go
@@ -40,7 +40,6 @@ func TestCreateRoutePlanDescription(t *testing.T) {
 		TargetDestination: key.DestinationAllShards{},
 		Other: map[string]any{
 			"Query":      route.Query,
-			"Table":      route.GetTableName(),
 			"FieldQuery": route.FieldQuery,
 			"Vindex":     route.Vindex.String(),
 		},
@@ -98,7 +97,6 @@ func getDescriptionFor(route *Route) PrimitiveDescription {
 		TargetDestination: key.DestinationAllShards{},
 		Other: map[string]any{
 			"Query":      route.Query,
-			"Table":      route.GetTableName(),
 			"FieldQuery": route.FieldQuery,
 			"Vindex":     route.Vindex.String(),
 		},

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -232,7 +232,6 @@ type (
 	Primitive interface {
 		RouteType() string
 		GetKeyspaceName() string
-		GetTableName() string
 		GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
 		NeedsTransaction() bool
 

--- a/go/vt/vtgate/engine/projection.go
+++ b/go/vt/vtgate/engine/projection.go
@@ -49,11 +49,6 @@ func (p *Projection) GetKeyspaceName() string {
 	return p.Input.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (p *Projection) GetTableName() string {
-	return p.Input.GetTableName()
-}
-
 // TryExecute implements the Primitive interface
 func (p *Projection) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	result, err := vcursor.ExecutePrimitive(ctx, p.Input, bindVars, wantfields)

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -57,11 +57,6 @@ func (r *RenameFields) GetKeyspaceName() string {
 	return r.Input.GetKeyspaceName()
 }
 
-// GetTableName implements the primitive interface
-func (r *RenameFields) GetTableName() string {
-	return r.Input.GetTableName()
-}
-
 // TryExecute implements the Primitive interface
 func (r *RenameFields) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	qr, err := vcursor.ExecutePrimitive(ctx, r.Input, bindVars, wantfields)

--- a/go/vt/vtgate/engine/replace_variables.go
+++ b/go/vt/vtgate/engine/replace_variables.go
@@ -46,11 +46,6 @@ func (r *ReplaceVariables) GetKeyspaceName() string {
 	return r.Input.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (r *ReplaceVariables) GetTableName() string {
-	return r.Input.GetTableName()
-}
-
 // TryExecute implements the Primitive interface
 func (r *ReplaceVariables) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	qr, err := vcursor.ExecutePrimitive(ctx, r.Input, bindVars, wantfields)

--- a/go/vt/vtgate/engine/revert_migration.go
+++ b/go/vt/vtgate/engine/revert_migration.go
@@ -63,11 +63,6 @@ func (v *RevertMigration) GetKeyspaceName() string {
 	return v.Keyspace.Name
 }
 
-// GetTableName implements the Primitive interface
-func (v *RevertMigration) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements the Primitive interface
 func (v *RevertMigration) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (result *sqltypes.Result, err error) {
 	result = &sqltypes.Result{

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -123,11 +123,6 @@ func (route *Route) GetKeyspaceName() string {
 	return route.Keyspace.Name
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (route *Route) GetTableName() string {
-	return route.TableName
-}
-
 // TryExecute performs a non-streaming exec.
 func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	ctx, cancelFunc := addQueryTimeout(ctx, vcursor, route.QueryTimeout)
@@ -393,7 +388,6 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 func (route *Route) description() PrimitiveDescription {
 	other := map[string]any{
 		"Query":      route.Query,
-		"Table":      route.GetTableName(),
 		"FieldQuery": route.FieldQuery,
 	}
 	if route.Vindex != nil {

--- a/go/vt/vtgate/engine/rows.go
+++ b/go/vt/vtgate/engine/rows.go
@@ -49,11 +49,6 @@ func (r *Rows) GetKeyspaceName() string {
 	return ""
 }
 
-// GetTableName implements the Primitive interface
-func (r *Rows) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements the Primitive interface
 func (r *Rows) TryExecute(context.Context, VCursor, map[string]*querypb.BindVariable, bool) (*sqltypes.Result, error) {
 	return &sqltypes.Result{

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -52,11 +52,6 @@ func (sa *ScalarAggregate) GetKeyspaceName() string {
 
 }
 
-// GetTableName implements the Primitive interface
-func (sa *ScalarAggregate) GetTableName() string {
-	return sa.Input.GetTableName()
-}
-
 // GetFields implements the Primitive interface
 func (sa *ScalarAggregate) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	qr, err := sa.Input.GetFields(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/semi_join.go
+++ b/go/vt/vtgate/engine/semi_join.go
@@ -113,20 +113,13 @@ func (jn *SemiJoin) GetKeyspaceName() string {
 	return jn.Left.GetKeyspaceName() + "_" + jn.Right.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (jn *SemiJoin) GetTableName() string {
-	return jn.Left.GetTableName() + "_" + jn.Right.GetTableName()
-}
-
 // NeedsTransaction implements the Primitive interface
 func (jn *SemiJoin) NeedsTransaction() bool {
 	return jn.Right.NeedsTransaction() || jn.Left.NeedsTransaction()
 }
 
 func (jn *SemiJoin) description() PrimitiveDescription {
-	other := map[string]any{
-		"TableName": jn.GetTableName(),
-	}
+	other := map[string]any{}
 	if len(jn.Vars) > 0 {
 		other["JoinVars"] = orderedStringIntMap(jn.Vars)
 	}

--- a/go/vt/vtgate/engine/send.go
+++ b/go/vt/vtgate/engine/send.go
@@ -84,11 +84,6 @@ func (s *Send) GetKeyspaceName() string {
 	return s.Keyspace.Name
 }
 
-// GetTableName implements Primitive interface
-func (s *Send) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements Primitive interface
 func (s *Send) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	ctx, cancelFunc := addQueryTimeout(ctx, vcursor, s.QueryTimeout)
@@ -189,7 +184,6 @@ func (s *Send) GetFields(ctx context.Context, vcursor VCursor, bindVars map[stri
 func (s *Send) description() PrimitiveDescription {
 	other := map[string]any{
 		"Query":                    s.Query,
-		"Table":                    s.GetTableName(),
 		"IsDML":                    s.IsDML,
 		"SingleShardOnly":          s.SingleShardOnly,
 		"ShardNameNeeded":          s.ShardNameNeeded,

--- a/go/vt/vtgate/engine/sequential.go
+++ b/go/vt/vtgate/engine/sequential.go
@@ -55,15 +55,6 @@ func (s *Sequential) GetKeyspaceName() string {
 	return res
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (s *Sequential) GetTableName() string {
-	res := s.Sources[0].GetTableName()
-	for i := 1; i < len(s.Sources); i++ {
-		res = formatTwoOptionsNicely(res, s.Sources[i].GetTableName())
-	}
-	return res
-}
-
 // TryExecute performs a non-streaming exec.
 func (s *Sequential) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantFields bool) (*sqltypes.Result, error) {
 	finalRes := &sqltypes.Result{}

--- a/go/vt/vtgate/engine/session_primitive.go
+++ b/go/vt/vtgate/engine/session_primitive.go
@@ -54,11 +54,6 @@ func (s *SessionPrimitive) GetKeyspaceName() string {
 	return ""
 }
 
-// GetTableName implements the Primitive interface
-func (s *SessionPrimitive) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements the Primitive interface
 func (s *SessionPrimitive) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	return s.action(vcursor.Session())

--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -113,11 +113,6 @@ func (s *Set) GetKeyspaceName() string {
 	return ""
 }
 
-// GetTableName implements the Primitive interface method.
-func (s *Set) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements the Primitive interface method.
 func (s *Set) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	input, err := vcursor.ExecutePrimitive(ctx, s.Input, bindVars, false)

--- a/go/vt/vtgate/engine/show_exec.go
+++ b/go/vt/vtgate/engine/show_exec.go
@@ -43,10 +43,6 @@ func (s *ShowExec) GetKeyspaceName() string {
 	return ""
 }
 
-func (s *ShowExec) GetTableName() string {
-	return ""
-}
-
 func (s *ShowExec) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*query.BindVariable) (*sqltypes.Result, error) {
 	qr, err := s.TryExecute(ctx, vcursor, bindVars, true)
 	if err != nil {

--- a/go/vt/vtgate/engine/simple_projection.go
+++ b/go/vt/vtgate/engine/simple_projection.go
@@ -56,11 +56,6 @@ func (sc *SimpleProjection) GetKeyspaceName() string {
 	return sc.Input.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (sc *SimpleProjection) GetTableName() string {
-	return sc.Input.GetTableName()
-}
-
 // TryExecute performs a non-streaming exec.
 func (sc *SimpleProjection) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	inner, err := vcursor.ExecutePrimitive(ctx, sc.Input, bindVars, wantfields)

--- a/go/vt/vtgate/engine/singlerow.go
+++ b/go/vt/vtgate/engine/singlerow.go
@@ -41,11 +41,6 @@ func (s *SingleRow) GetKeyspaceName() string {
 	return ""
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (s *SingleRow) GetTableName() string {
-	return ""
-}
-
 // TryExecute performs a non-streaming exec.
 func (s *SingleRow) TryExecute(context.Context, VCursor, map[string]*querypb.BindVariable, bool) (*sqltypes.Result, error) {
 	result := sqltypes.Result{

--- a/go/vt/vtgate/engine/sql_calc_found_rows.go
+++ b/go/vt/vtgate/engine/sql_calc_found_rows.go
@@ -43,11 +43,6 @@ func (s *SQLCalcFoundRows) GetKeyspaceName() string {
 	return s.LimitPrimitive.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (s *SQLCalcFoundRows) GetTableName() string {
-	return s.LimitPrimitive.GetTableName()
-}
-
 // TryExecute implements the Primitive interface
 func (s *SQLCalcFoundRows) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	limitQr, err := vcursor.ExecutePrimitive(ctx, s.LimitPrimitive, bindVars, wantfields)

--- a/go/vt/vtgate/engine/throttle_app.go
+++ b/go/vt/vtgate/engine/throttle_app.go
@@ -60,11 +60,6 @@ func (v *ThrottleApp) GetKeyspaceName() string {
 	return v.Keyspace.Name
 }
 
-// GetTableName implements the Primitive interface
-func (v *ThrottleApp) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements the Primitive interface
 func (v *ThrottleApp) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (result *sqltypes.Result, err error) {
 	if err := vcursor.ThrottleApp(ctx, v.ThrottledAppRule); err != nil {

--- a/go/vt/vtgate/engine/transaction_status.go
+++ b/go/vt/vtgate/engine/transaction_status.go
@@ -44,10 +44,6 @@ func (t *TransactionStatus) GetKeyspaceName() string {
 	return ""
 }
 
-func (t *TransactionStatus) GetTableName() string {
-	return ""
-}
-
 func (t *TransactionStatus) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return &sqltypes.Result{
 		Fields: t.getFields(),

--- a/go/vt/vtgate/engine/uncorrelated_subquery.go
+++ b/go/vt/vtgate/engine/uncorrelated_subquery.go
@@ -60,11 +60,6 @@ func (ps *UncorrelatedSubquery) GetKeyspaceName() string {
 	return ps.Outer.GetKeyspaceName()
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (ps *UncorrelatedSubquery) GetTableName() string {
-	return ps.Outer.GetTableName()
-}
-
 // TryExecute satisfies the Primitive interface.
 func (ps *UncorrelatedSubquery) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	combinedVars, err := ps.execSubquery(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/unlock.go
+++ b/go/vt/vtgate/engine/unlock.go
@@ -42,10 +42,6 @@ func (u *Unlock) GetKeyspaceName() string {
 	return ""
 }
 
-func (u *Unlock) GetTableName() string {
-	return ""
-}
-
 func (u *Unlock) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.VT13001("GetFields should not be called for unlock tables")
 }

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -200,7 +200,6 @@ func (upd *Update) updateVindexEntries(ctx context.Context, vcursor VCursor, bin
 func (upd *Update) description() PrimitiveDescription {
 	other := map[string]any{
 		"Query":                upd.Query,
-		"Table":                upd.GetTableName(),
 		"OwnedVindexQuery":     upd.OwnedVindexQuery,
 		"MultiShardAutocommit": upd.MultiShardAutocommit,
 		"QueryTimeout":         upd.QueryTimeout,

--- a/go/vt/vtgate/engine/update_target.go
+++ b/go/vt/vtgate/engine/update_target.go
@@ -54,11 +54,6 @@ func (updTarget *UpdateTarget) GetKeyspaceName() string {
 	return updTarget.Target
 }
 
-// GetTableName implements the Primitive interface
-func (updTarget *UpdateTarget) GetTableName() string {
-	return ""
-}
-
 // TryExecute implements the Primitive interface
 func (updTarget *UpdateTarget) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*query.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	err := vcursor.Session().SetTarget(updTarget.Target)

--- a/go/vt/vtgate/engine/upsert.go
+++ b/go/vt/vtgate/engine/upsert.go
@@ -62,14 +62,6 @@ func (u *Upsert) GetKeyspaceName() string {
 	return ""
 }
 
-// GetTableName implements Primitive interface type.
-func (u *Upsert) GetTableName() string {
-	if len(u.Upserts) > 0 {
-		return u.Upserts[0].Insert.GetTableName()
-	}
-	return ""
-}
-
 // GetFields implements Primitive interface type.
 func (u *Upsert) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.VT13001("unexpected to receive GetFields call for insert on duplicate key update query")

--- a/go/vt/vtgate/engine/vexplain.go
+++ b/go/vt/vtgate/engine/vexplain.go
@@ -56,11 +56,6 @@ func (v *VExplain) GetKeyspaceName() string {
 	return v.Input.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (v *VExplain) GetTableName() string {
-	return v.Input.GetTableName()
-}
-
 // GetFields implements the Primitive interface
 func (v *VExplain) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return v.Input.GetFields(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -84,11 +84,6 @@ func (vf *VindexFunc) GetKeyspaceName() string {
 	return ""
 }
 
-// GetTableName specifies the table that this primitive routes to.
-func (vf *VindexFunc) GetTableName() string {
-	return ""
-}
-
 // TryExecute performs a non-streaming exec.
 func (vf *VindexFunc) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	return vf.mapVindex(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/vindex_lookup.go
+++ b/go/vt/vtgate/engine/vindex_lookup.go
@@ -65,11 +65,6 @@ func (vr *VindexLookup) GetKeyspaceName() string {
 	return vr.SendTo.GetKeyspaceName()
 }
 
-// GetTableName implements the Primitive interface
-func (vr *VindexLookup) GetTableName() string {
-	return vr.SendTo.GetTableName()
-}
-
 // GetFields implements the Primitive interface
 func (vr *VindexLookup) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return vr.SendTo.GetFields(ctx, vcursor, bindVars)

--- a/go/vt/vtgate/engine/vschema_ddl.go
+++ b/go/vt/vtgate/engine/vschema_ddl.go
@@ -57,11 +57,6 @@ func (v *AlterVSchema) GetKeyspaceName() string {
 	return v.Keyspace.Name
 }
 
-// GetTableName implements the Primitive interface
-func (v *AlterVSchema) GetTableName() string {
-	return v.AlterVschemaDDL.Table.Name.String()
-}
-
 // TryExecute implements the Primitive interface
 func (v *AlterVSchema) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*query.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	err := vcursor.ExecuteVSchema(ctx, v.Keyspace.Name, v.AlterVschemaDDL)

--- a/go/vt/vtgate/engine/vstream.go
+++ b/go/vt/vtgate/engine/vstream.go
@@ -55,11 +55,6 @@ func (v *VStream) GetKeyspaceName() string {
 	return v.Keyspace.Name
 }
 
-// GetTableName implements the Primitive interface
-func (v *VStream) GetTableName() string {
-	return v.TableName
-}
-
 // TryExecute implements the Primitive interface
 func (v *VStream) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	return nil, vterrors.VT13001("TryExecute is not supported for VStream")

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -23,7 +23,6 @@
                 "JoinVars": {
                   "user_foo": 1
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -33,8 +32,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                    "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                    "Table": "`user`"
+                    "Query": "select count(*), `user`.foo from `user` group by `user`.foo"
                   },
                   {
                     "OperatorType": "Route",
@@ -44,8 +42,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra where user_extra.bar = :user_foo group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra where user_extra.bar = :user_foo group by .0"
                   }
                 ]
               }
@@ -83,7 +80,6 @@
                 "JoinVars": {
                   "user_foo": 1
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -93,8 +89,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select sum(`user`.col), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                    "Query": "select sum(`user`.col), `user`.foo from `user` group by `user`.foo",
-                    "Table": "`user`"
+                    "Query": "select sum(`user`.col), `user`.foo from `user` group by `user`.foo"
                   },
                   {
                     "OperatorType": "Route",
@@ -104,8 +99,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra where user_extra.bar = :user_foo group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra where user_extra.bar = :user_foo group by .0"
                   }
                 ]
               }
@@ -143,7 +137,6 @@
                 "JoinVars": {
                   "user_foo": 1
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -153,8 +146,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(`user`.col), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                    "Query": "select count(`user`.col), `user`.foo from `user` group by `user`.foo",
-                    "Table": "`user`"
+                    "Query": "select count(`user`.col), `user`.foo from `user` group by `user`.foo"
                   },
                   {
                     "OperatorType": "Route",
@@ -164,8 +156,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra where user_extra.bar = :user_foo group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra where user_extra.bar = :user_foo group by .0"
                   }
                 ]
               }
@@ -197,7 +188,6 @@
             "JoinVars": {
               "user_foo": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -207,8 +197,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select max(`user`.col), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                "Query": "select max(`user`.col), `user`.foo from `user` group by `user`.foo",
-                "Table": "`user`"
+                "Query": "select max(`user`.col), `user`.foo from `user` group by `user`.foo"
               },
               {
                 "OperatorType": "Route",
@@ -218,8 +207,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1 group by .0",
-                "Query": "select 1 from user_extra where user_extra.bar = :user_foo group by .0",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra where user_extra.bar = :user_foo group by .0"
               }
             ]
           }
@@ -249,7 +237,6 @@
             "JoinVars": {
               "user_foo": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -259,8 +246,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                "Query": "select `user`.foo from `user` group by `user`.foo",
-                "Table": "`user`"
+                "Query": "select `user`.foo from `user` group by `user`.foo"
               },
               {
                 "OperatorType": "Route",
@@ -270,8 +256,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select min(user_extra.col) from user_extra where 1 != 1 group by .0",
-                "Query": "select min(user_extra.col) from user_extra where user_extra.bar = :user_foo group by .0",
-                "Table": "user_extra"
+                "Query": "select min(user_extra.col) from user_extra where user_extra.bar = :user_foo group by .0"
               }
             ]
           }
@@ -297,8 +282,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id, count(*) as c from `user` where 1 != 1 group by id",
-        "Query": "select id, count(*) as c from `user` group by id having max(col) > 10",
-        "Table": "`user`"
+        "Query": "select id, count(*) as c from `user` group by id having max(col) > 10"
       },
       "TablesUsed": [
         "user.user"
@@ -324,8 +308,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-            "Query": "select count(*) as a from `user`",
-            "Table": "`user`"
+            "Query": "select count(*) as a from `user`"
           }
         ]
       },
@@ -353,8 +336,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-            "Query": "select id, count(*) from `user`",
-            "Table": "`user`"
+            "Query": "select id, count(*) from `user`"
           }
         ]
       },
@@ -383,8 +365,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select distinct col from `user`",
-            "Table": "`user`"
+            "Query": "select distinct col from `user`"
           }
         ]
       },
@@ -413,8 +394,7 @@
             },
             "FieldQuery": "select col from `user` where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col from `user` group by col order by col asc",
-            "Table": "`user`"
+            "Query": "select col from `user` group by col order by col asc"
           }
         ]
       },
@@ -437,8 +417,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id, count(distinct col) from `user` where 1 != 1 group by id",
-        "Query": "select id, count(distinct col) from `user` group by id",
-        "Table": "`user`"
+        "Query": "select id, count(distinct col) from `user` group by id"
       },
       "TablesUsed": [
         "user.user"
@@ -466,8 +445,7 @@
             },
             "FieldQuery": "select col, count(distinct id), sum(distinct id) from `user` where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col, count(distinct id), sum(distinct id) from `user` group by col order by col asc",
-            "Table": "`user`"
+            "Query": "select col, count(distinct id), sum(distinct id) from `user` group by col order by col asc"
           }
         ]
       },
@@ -498,8 +476,7 @@
             },
             "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, col2, weight_string(col1), weight_string(col2)",
             "OrderBy": "(0|2) ASC, (1|3) ASC",
-            "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc",
-            "Table": "`user`"
+            "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc"
           }
         ]
       },
@@ -529,8 +506,7 @@
             },
             "FieldQuery": "select col2, weight_string(col2) from `user` where 1 != 1 group by col2, weight_string(col2)",
             "OrderBy": "(0|1) ASC",
-            "Query": "select col2, weight_string(col2) from `user` group by col2, weight_string(col2) order by col2 asc",
-            "Table": "`user`"
+            "Query": "select col2, weight_string(col2) from `user` group by col2, weight_string(col2) order by col2 asc"
           }
         ]
       },
@@ -553,8 +529,7 @@
           "Sharded": false
         },
         "FieldQuery": "select a, b, count(*) from unsharded where 1 != 1 group by a, b with rollup",
-        "Query": "select a, b, count(*) from unsharded group by a, b with rollup",
-        "Table": "unsharded"
+        "Query": "select a, b, count(*) from unsharded group by a, b with rollup"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -575,8 +550,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id, user_id, count(*) from music where 1 != 1 group by id, user_id with rollup",
-        "Query": "select id, user_id, count(*) from music group by id, user_id with rollup",
-        "Table": "music"
+        "Query": "select id, user_id, count(*) from music group by id, user_id with rollup"
       },
       "TablesUsed": [
         "user.music"
@@ -605,8 +579,7 @@
             },
             "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, col2, weight_string(col1), weight_string(col2)",
             "OrderBy": "(0|2) ASC, (1|3) ASC",
-            "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc",
-            "Table": "`user`"
+            "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc"
           }
         ]
       },
@@ -637,8 +610,7 @@
             },
             "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, col2, weight_string(col1), weight_string(col2)",
             "OrderBy": "(0|2) ASC, (1|3) ASC",
-            "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc",
-            "Table": "`user`"
+            "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc"
           }
         ]
       },
@@ -669,8 +641,7 @@
             },
             "FieldQuery": "select col1, min(col2) as `min(distinct col2)`, weight_string(col1), weight_string(min(col2)) from `user` where 1 != 1 group by col1, weight_string(col1)",
             "OrderBy": "(0|2) ASC",
-            "Query": "select col1, min(col2) as `min(distinct col2)`, weight_string(col1), weight_string(min(col2)) from `user` group by col1, weight_string(col1) order by col1 asc",
-            "Table": "`user`"
+            "Query": "select col1, min(col2) as `min(distinct col2)`, weight_string(col1), weight_string(min(col2)) from `user` group by col1, weight_string(col1) order by col1 asc"
           }
         ]
       },
@@ -706,8 +677,7 @@
                 },
                 "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, col2, weight_string(col1), weight_string(col2)",
                 "OrderBy": "(0|2) ASC, (1|3) ASC",
-                "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc",
-                "Table": "`user`"
+                "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc"
               }
             ]
           }
@@ -750,8 +720,7 @@
             },
             "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, b, weight_string(a), weight_string(b)",
             "OrderBy": "(0|3) ASC, (1|4) ASC",
-            "Query": "select a, b, count(*), weight_string(a), weight_string(b) from `user` group by a, b, weight_string(a), weight_string(b) order by a asc, b asc",
-            "Table": "`user`"
+            "Query": "select a, b, count(*), weight_string(a), weight_string(b) from `user` group by a, b, weight_string(a), weight_string(b) order by a asc, b asc"
           }
         ]
       },
@@ -773,7 +742,6 @@
         "JoinVars": {
           "t_id": 1
         },
-        "TableName": "`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Limit",
@@ -788,8 +756,7 @@
                 },
                 "FieldQuery": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` where 1 != 1 group by id) as t where 1 != 1",
                 "OrderBy": "0 DESC",
-                "Query": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` group by id) as t order by t.num_segments desc limit 20",
-                "Table": "`user`"
+                "Query": "select t.num_segments, t.id from (select id, count(*) as num_segments from `user` group by id) as t order by t.num_segments desc limit 20"
               }
             ]
           },
@@ -801,8 +768,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u.id, u.`name` from unsharded as u where 1 != 1",
-            "Query": "select u.id, u.`name` from unsharded as u where u.id = :t_id",
-            "Table": "unsharded"
+            "Query": "select u.id, u.`name` from unsharded as u where u.id = :t_id"
           }
         ]
       },
@@ -834,8 +800,7 @@
             },
             "FieldQuery": "select a, b, count(*), weight_string(b), weight_string(a) from `user` where 1 != 1 group by b, a, weight_string(b), weight_string(a)",
             "OrderBy": "(1|3) ASC, (0|4) ASC",
-            "Query": "select a, b, count(*), weight_string(b), weight_string(a) from `user` group by b, a, weight_string(b), weight_string(a) order by b asc, a asc",
-            "Table": "`user`"
+            "Query": "select a, b, count(*), weight_string(b), weight_string(a) from `user` group by b, a, weight_string(b), weight_string(a) order by b asc, a asc"
           }
         ]
       },
@@ -866,8 +831,7 @@
             },
             "FieldQuery": "select a, b, count(*), weight_string(b), weight_string(a) from `user` where 1 != 1 group by b, a, weight_string(b), weight_string(a)",
             "OrderBy": "(1|3) ASC, (0|4) ASC",
-            "Query": "select a, b, count(*), weight_string(b), weight_string(a) from `user` group by b, a, weight_string(b), weight_string(a) order by b asc, a asc",
-            "Table": "`user`"
+            "Query": "select a, b, count(*), weight_string(b), weight_string(a) from `user` group by b, a, weight_string(b), weight_string(a) order by b asc, a asc"
           }
         ]
       },
@@ -896,7 +860,6 @@
             "JoinVars": {
               "user_id": 0
             },
-            "TableName": "`user`, user_extra_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -907,8 +870,7 @@
                 },
                 "FieldQuery": "select `user`.id, weight_string(`user`.id) from `user`, user_extra where 1 != 1",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select `user`.id, weight_string(`user`.id) from `user`, user_extra where `user`.id = user_extra.user_id order by `user`.id asc",
-                "Table": "`user`, user_extra"
+                "Query": "select `user`.id, weight_string(`user`.id) from `user`, user_extra where `user`.id = user_extra.user_id order by `user`.id asc"
               },
               {
                 "OperatorType": "Route",
@@ -919,7 +881,6 @@
                 },
                 "FieldQuery": "select music.`name` from music where 1 != 1",
                 "Query": "select music.`name` from music where music.id = :user_id",
-                "Table": "music",
                 "Values": [
                   ":user_id"
                 ],
@@ -956,8 +917,7 @@
             },
             "FieldQuery": "select col from `user` where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col from `user` group by col order by col asc",
-            "Table": "`user`"
+            "Query": "select col from `user` group by col order by col asc"
           }
         ]
       },
@@ -990,8 +950,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(*) from `user` where 1 != 1",
-            "Query": "select count(*) from `user`",
-            "Table": "`user`"
+            "Query": "select count(*) from `user`"
           }
         ]
       },
@@ -1022,8 +981,7 @@
             },
             "FieldQuery": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` where 1 != 1 group by a, b, c, weight_string(a), weight_string(b), weight_string(c)",
             "OrderBy": "(0|5) ASC, (1|6) ASC, (2|7) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, b, c, weight_string(a), weight_string(b), weight_string(c) order by a asc, b asc, c asc",
-            "Table": "`user`"
+            "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, b, c, weight_string(a), weight_string(b), weight_string(c) order by a asc, b asc, c asc"
           }
         ]
       },
@@ -1054,8 +1012,7 @@
             },
             "FieldQuery": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` where 1 != 1 group by a, b, c, weight_string(a), weight_string(b), weight_string(c)",
             "OrderBy": "(0|5) ASC, (1|6) ASC, (2|7) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, b, c, weight_string(a), weight_string(b), weight_string(c) order by `user`.a asc, `user`.b asc, `user`.c asc",
-            "Table": "`user`"
+            "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, b, c, weight_string(a), weight_string(b), weight_string(c) order by `user`.a asc, `user`.b asc, `user`.c asc"
           }
         ]
       },
@@ -1086,8 +1043,7 @@
             },
             "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by a, b, c, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
             "OrderBy": "(3|5) ASC, (1|6) ASC, (0|7) ASC, (2|8) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by a, b, c, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc",
-            "Table": "`user`"
+            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by a, b, c, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc"
           }
         ]
       },
@@ -1118,8 +1074,7 @@
             },
             "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by c, b, a, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
             "OrderBy": "(3|5) ASC, (1|6) ASC, (0|7) ASC, (2|8) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by c, b, a, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc",
-            "Table": "`user`"
+            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by c, b, a, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc"
           }
         ]
       },
@@ -1150,8 +1105,7 @@
             },
             "FieldQuery": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` where 1 != 1 group by c, b, a, weight_string(a), weight_string(c), weight_string(b)",
             "OrderBy": "(0|4) DESC, (2|5) DESC, (1|6) ASC",
-            "Query": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` group by c, b, a, weight_string(a), weight_string(c), weight_string(b) order by a desc, c desc, `user`.b asc",
-            "Table": "`user`"
+            "Query": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` group by c, b, a, weight_string(a), weight_string(c), weight_string(b) order by a desc, c desc, `user`.b asc"
           }
         ]
       },
@@ -1190,8 +1144,7 @@
                 },
                 "FieldQuery": "select col, count(*) from `user` where 1 != 1 group by col",
                 "OrderBy": "0 ASC",
-                "Query": "select col, count(*) from `user` group by col order by col asc",
-                "Table": "`user`"
+                "Query": "select col, count(*) from `user` group by col order by col asc"
               }
             ]
           }
@@ -1216,8 +1169,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id, count(*) from unsharded as route2 where 1 != 1 group by id",
-        "Query": "select id, count(*) from unsharded as route2 group by id",
-        "Table": "unsharded"
+        "Query": "select id, count(*) from unsharded as route2 group by id"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1238,8 +1190,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from ref where 1 != 1",
-        "Query": "select col from ref order by ref.col asc",
-        "Table": "ref"
+        "Query": "select col from ref order by ref.col asc"
       },
       "TablesUsed": [
         "user.ref"
@@ -1265,8 +1216,7 @@
               "Sharded": true
             },
             "FieldQuery": "select a, count(*) from `user` where 1 != 1",
-            "Query": "select a, count(*) from `user`",
-            "Table": "`user`"
+            "Query": "select a, count(*) from `user`"
           }
         ]
       },
@@ -1297,8 +1247,7 @@
             },
             "FieldQuery": "select a, count(*), weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
             "OrderBy": "(0|2) ASC",
-            "Query": "select a, count(*), weight_string(a) from `user` group by a, weight_string(a) order by a asc",
-            "Table": "`user`"
+            "Query": "select a, count(*), weight_string(a) from `user` group by a, weight_string(a) order by a asc"
           }
         ]
       },
@@ -1329,8 +1278,7 @@
             },
             "FieldQuery": "select id, 1.1 from `user` where 1 != 1 group by 1.1",
             "OrderBy": "1 ASC",
-            "Query": "select id, 1.1 from `user` group by 1.1 order by 1.1 asc",
-            "Table": "`user`"
+            "Query": "select id, 1.1 from `user` group by 1.1 order by 1.1 asc"
           }
         ]
       },
@@ -1363,8 +1311,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where 1 != 1) as a where 1 != 1",
-            "Query": "select count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a",
-            "Table": "`user`, user_extra"
+            "Query": "select count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a"
           }
         ]
       },
@@ -1388,8 +1335,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from (select `user`.col, user_extra.extra from `user`, user_extra where 1 != 1) as a where 1 != 1",
-        "Query": "select col from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a",
-        "Table": "`user`, user_extra"
+        "Query": "select col from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a"
       },
       "TablesUsed": [
         "user.user",
@@ -1418,8 +1364,7 @@
             },
             "FieldQuery": "select col, count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where 1 != 1) as a where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col, count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a group by col order by col asc",
-            "Table": "`user`, user_extra"
+            "Query": "select col, count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a group by col order by col asc"
           }
         ]
       },
@@ -1451,8 +1396,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1",
-            "Query": "select distinct col1, col2, weight_string(col1), weight_string(col2) from `user`",
-            "Table": "`user`"
+            "Query": "select distinct col1, col2, weight_string(col1), weight_string(col2) from `user`"
           }
         ]
       },
@@ -1480,8 +1424,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(*) from `user` where 1 != 1",
-            "Query": "select count(*) from `user`",
-            "Table": "`user`"
+            "Query": "select count(*) from `user`"
           }
         ]
       },
@@ -1506,7 +1449,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1517,8 +1459,7 @@
                 },
                 "FieldQuery": "select `user`.a, weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select `user`.a, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc",
-                "Table": "`user`"
+                "Query": "select `user`.a, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc"
               },
               {
                 "OperatorType": "Route",
@@ -1528,8 +1469,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1 group by .0",
-                "Query": "select 1 from user_extra group by .0",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra group by .0"
               }
             ]
           }
@@ -1563,8 +1503,7 @@
             },
             "FieldQuery": "select col1, col2, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, col2, weight_string(col1), weight_string(col2)",
             "OrderBy": "(0|3) ASC, (1|4) ASC",
-            "Query": "select col1, col2, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc",
-            "Table": "`user`"
+            "Query": "select col1, col2, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2, weight_string(col1), weight_string(col2) order by col1 asc, col2 asc"
           }
         ]
       },
@@ -1599,8 +1538,7 @@
                 },
                 "FieldQuery": "select col, count(*) as k from `user` where 1 != 1 group by col",
                 "OrderBy": "0 ASC",
-                "Query": "select col, count(*) as k from `user` group by col order by col asc",
-                "Table": "`user`"
+                "Query": "select col, count(*) as k from `user` group by col order by col asc"
               }
             ]
           }
@@ -1632,8 +1570,7 @@
             },
             "FieldQuery": "select col, count(*) as k from `user` where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col, count(*) as k from `user` group by col order by col asc",
-            "Table": "`user`"
+            "Query": "select col, count(*) as k from `user` group by col order by col asc"
           }
         ]
       },
@@ -1656,8 +1593,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.id, count(*) as c from `user`, user_extra where 1 != 1 group by `user`.id",
-        "Query": "select `user`.id, count(*) as c from `user`, user_extra where `user`.id = user_extra.user_id group by `user`.id having max(`user`.col) > 10",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.id, count(*) as c from `user`, user_extra where `user`.id = user_extra.user_id group by `user`.id having max(`user`.col) > 10"
       },
       "TablesUsed": [
         "user.user",
@@ -1684,8 +1620,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(*) from `user` where 1 != 1",
-            "Query": "select count(*) from `user` where exists (select 1 from user_extra where user_id = `user`.id group by user_id having max(col) > 10)",
-            "Table": "`user`"
+            "Query": "select count(*) from `user` where exists (select 1 from user_extra where user_id = `user`.id group by user_id having max(col) > 10)"
           }
         ]
       },
@@ -1709,8 +1644,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1 group by id",
-        "Query": "select id from `user` group by id having count(id) = 10",
-        "Table": "`user`"
+        "Query": "select id from `user` group by id having count(id) = 10"
       },
       "TablesUsed": [
         "user.user"
@@ -1738,8 +1672,7 @@
             },
             "FieldQuery": "select lower(col1) as v, count(*) from authoritative where 1 != 1 group by lower(col1)",
             "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-            "Query": "select lower(col1) as v, count(*) from authoritative group by lower(col1) order by lower(col1) asc",
-            "Table": "authoritative"
+            "Query": "select lower(col1) as v, count(*) from authoritative group by lower(col1) order by lower(col1) asc"
           }
         ]
       },
@@ -1769,8 +1702,7 @@
             },
             "FieldQuery": "select char_length(col1) as a, count(*) from authoritative where 1 != 1 group by char_length(col1)",
             "OrderBy": "0 ASC",
-            "Query": "select char_length(col1) as a, count(*) from authoritative group by char_length(col1) order by char_length(authoritative.col1) asc",
-            "Table": "authoritative"
+            "Query": "select char_length(col1) as a, count(*) from authoritative group by char_length(col1) order by char_length(authoritative.col1) asc"
           }
         ]
       },
@@ -1799,8 +1731,7 @@
             "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
             "OrderBy": "(0|1) ASC",
             "Query": "select id, weight_string(id) from `user` order by id asc limit 2",
-            "ResultColumns": 1,
-            "Table": "`user`"
+            "ResultColumns": 1
           }
         ]
       },
@@ -1820,7 +1751,6 @@
         "JoinVars": {
           "user_id": 1
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "InputName": "Outer",
@@ -1833,8 +1763,7 @@
             "FieldQuery": "select col, id, weight_string(id) from `user` where 1 != 1",
             "OrderBy": "(1|2) ASC",
             "Query": "select col, id, weight_string(id) from `user` order by `user`.id asc",
-            "ResultColumns": 2,
-            "Table": "`user`"
+            "ResultColumns": 2
           },
           {
             "InputName": "SubQuery",
@@ -1846,7 +1775,6 @@
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
             "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id limit 1",
-            "Table": "user_extra",
             "Values": [
               "3"
             ],
@@ -1883,8 +1811,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -1918,8 +1845,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -1953,8 +1879,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -1988,8 +1913,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -2023,8 +1947,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -2058,8 +1981,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -2093,8 +2015,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -2128,8 +2049,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -2166,8 +2086,7 @@
                 },
                 "FieldQuery": "select col1, count(*) as a, weight_string(col1) from `user` where 1 != 1 group by col1, weight_string(col1)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select col1, count(*) as a, weight_string(col1) from `user` group by col1, weight_string(col1) order by col1 asc",
-                "Table": "`user`"
+                "Query": "select col1, count(*) as a, weight_string(col1) from `user` group by col1, weight_string(col1) order by col1 asc"
               }
             ]
           }
@@ -2204,8 +2123,7 @@
                 },
                 "FieldQuery": "select count(*) as a, col2, weight_string(col2) from `user` where 1 != 1 group by col2, weight_string(col2)",
                 "OrderBy": "(1|2) ASC",
-                "Query": "select count(*) as a, col2, weight_string(col2) from `user` group by col2, weight_string(col2) order by col2 asc",
-                "Table": "`user`"
+                "Query": "select count(*) as a, col2, weight_string(col2) from `user` group by col2, weight_string(col2) order by col2 asc"
               }
             ]
           }
@@ -2231,7 +2149,6 @@
         },
         "FieldQuery": "select col1, udf_aggr(col2) as r from `user` where 1 != 1 group by col1",
         "Query": "select col1, udf_aggr(col2) as r from `user` where id = 1 group by col1 having udf_aggr(`user`.col2) >= 0.3",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -2256,8 +2173,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id, udf_aggr(col2) as r from `user` where 1 != 1 group by id",
-        "Query": "select id, udf_aggr(col2) as r from `user` group by id",
-        "Table": "`user`"
+        "Query": "select id, udf_aggr(col2) as r from `user` group by id"
       },
       "TablesUsed": [
         "user.user"
@@ -2285,8 +2201,7 @@
             },
             "FieldQuery": "select col, textcol1 from `user` where 1 != 1 group by col, textcol1",
             "OrderBy": "0 ASC, 1 ASC COLLATE latin1_swedish_ci",
-            "Query": "select col, textcol1 from `user` group by col, textcol1 order by col asc, textcol1 asc",
-            "Table": "`user`"
+            "Query": "select col, textcol1 from `user` group by col, textcol1 order by col asc, textcol1 asc"
           }
         ]
       },
@@ -2332,7 +2247,6 @@
                     },
                     "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
                     "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                    "Table": "name_user_vdx",
                     "Values": [
                       "::name"
                     ],
@@ -2346,8 +2260,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1, count(id) from `user` where 1 != 1",
-                    "Query": "select 1, count(id) from `user` where `name` = 'a'",
-                    "Table": "`user`"
+                    "Query": "select 1, count(id) from `user` where `name` = 'a'"
                   }
                 ]
               }
@@ -2381,7 +2294,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2391,8 +2303,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from `user` where 1 != 1",
-                    "Query": "select count(*) from `user`",
-                    "Table": "`user`"
+                    "Query": "select count(*) from `user`"
                   },
                   {
                     "OperatorType": "Route",
@@ -2402,8 +2313,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra group by .0"
                   }
                 ]
               }
@@ -2441,8 +2351,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1, count(id) from `user` where 1 != 1",
-                "Query": "select 1, count(id) from `user`",
-                "Table": "`user`"
+                "Query": "select 1, count(id) from `user`"
               }
             ]
           }
@@ -2478,7 +2387,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0,L:1,L:2",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2489,8 +2397,7 @@
                     },
                     "FieldQuery": "select count(*), `user`.a, weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
                     "OrderBy": "(1|2) ASC",
-                    "Query": "select count(*), `user`.a, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc",
-                    "Table": "`user`"
+                    "Query": "select count(*), `user`.a, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -2500,8 +2407,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra group by .0"
                   }
                 ]
               }
@@ -2540,7 +2446,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "R:0,L:0,L:1,L:2",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2551,8 +2456,7 @@
                     },
                     "FieldQuery": "select count(*), `user`.a, weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
                     "OrderBy": "(1|2) ASC",
-                    "Query": "select count(*), `user`.a, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc",
-                    "Table": "`user`"
+                    "Query": "select count(*), `user`.a, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -2562,8 +2466,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(user_extra.a) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(user_extra.a) from user_extra group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(user_extra.a) from user_extra group by .0"
                   }
                 ]
               }
@@ -2611,7 +2514,6 @@
                     "JoinVars": {
                       "u_foo": 2
                     },
-                    "TableName": "`user`_user_extra_unsharded",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -2621,8 +2523,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(u.textcol1), count(*), u.foo from `user` as u where 1 != 1 group by u.foo",
-                        "Query": "select count(u.textcol1), count(*), u.foo from `user` as u group by u.foo",
-                        "Table": "`user`"
+                        "Query": "select count(u.textcol1), count(*), u.foo from `user` as u group by u.foo"
                       },
                       {
                         "OperatorType": "Projection",
@@ -2640,7 +2541,6 @@
                             "JoinVars": {
                               "ue_bar": 2
                             },
-                            "TableName": "user_extra_unsharded",
                             "Inputs": [
                               {
                                 "OperatorType": "Route",
@@ -2650,8 +2550,7 @@
                                   "Sharded": true
                                 },
                                 "FieldQuery": "select count(*), count(ue.foo), ue.bar from user_extra as ue where 1 != 1 group by ue.bar",
-                                "Query": "select count(*), count(ue.foo), ue.bar from user_extra as ue where ue.bar = :u_foo group by ue.bar",
-                                "Table": "user_extra"
+                                "Query": "select count(*), count(ue.foo), ue.bar from user_extra as ue where ue.bar = :u_foo group by ue.bar"
                               },
                               {
                                 "OperatorType": "Route",
@@ -2661,8 +2560,7 @@
                                   "Sharded": false
                                 },
                                 "FieldQuery": "select count(*), us.bar, weight_string(us.bar) from unsharded as us where 1 != 1 group by us.bar, weight_string(us.bar)",
-                                "Query": "select count(*), us.bar, weight_string(us.bar) from unsharded as us where us.baz = :ue_bar group by us.bar, weight_string(us.bar)",
-                                "Table": "unsharded"
+                                "Query": "select count(*), us.bar, weight_string(us.bar) from unsharded as us where us.baz = :ue_bar group by us.bar, weight_string(us.bar)"
                               }
                             ]
                           }
@@ -2705,8 +2603,7 @@
             },
             "FieldQuery": "select col1, min(id) as `min(distinct id)`, col3, weight_string(col1), weight_string(min(id)), weight_string(col3) from `user` where 1 != 1 group by col1, col3, weight_string(col1), weight_string(col3)",
             "OrderBy": "(0|3) ASC, (2|5) ASC",
-            "Query": "select col1, min(id) as `min(distinct id)`, col3, weight_string(col1), weight_string(min(id)), weight_string(col3) from `user` group by col1, col3, weight_string(col1), weight_string(col3) order by col1 asc, col3 asc",
-            "Table": "`user`"
+            "Query": "select col1, min(id) as `min(distinct id)`, col3, weight_string(col1), weight_string(min(id)), weight_string(col3) from `user` group by col1, col3, weight_string(col1), weight_string(col3) order by col1 asc, col3 asc"
           }
         ]
       },
@@ -2732,7 +2629,6 @@
             "JoinVars": {
               "user_apa": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "InputName": "Outer",
@@ -2743,8 +2639,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*), `user`.apa from `user` where 1 != 1 group by `user`.apa",
-                "Query": "select count(*), `user`.apa from `user` group by `user`.apa",
-                "Table": "`user`"
+                "Query": "select count(*), `user`.apa from `user` group by `user`.apa"
               },
               {
                 "InputName": "SubQuery",
@@ -2759,8 +2654,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra where user_extra.bar = :user_apa limit 1",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra where user_extra.bar = :user_apa limit 1"
                   }
                 ]
               }
@@ -2796,8 +2690,7 @@
             },
             "FieldQuery": "select val2, val1, count(*), weight_string(val2), weight_string(val1) from `user` where 1 != 1 group by val2, val1, weight_string(val2), weight_string(val1)",
             "OrderBy": "(0|3) ASC, (1|4) ASC",
-            "Query": "select val2, val1, count(*), weight_string(val2), weight_string(val1) from `user` group by val2, val1, weight_string(val2), weight_string(val1) order by val2 asc, val1 asc",
-            "Table": "`user`"
+            "Query": "select val2, val1, count(*), weight_string(val2), weight_string(val1) from `user` group by val2, val1, weight_string(val2), weight_string(val1) order by val2 asc, val1 asc"
           }
         ]
       },
@@ -2828,8 +2721,7 @@
             },
             "FieldQuery": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from `user` where 1 != 1 group by ascii(col2), weight_string(ascii(col2))",
             "OrderBy": "(0|2) ASC",
-            "Query": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from `user` group by ascii(col2), weight_string(ascii(col2)) order by ascii(col2) asc",
-            "Table": "`user`"
+            "Query": "select ascii(col2) as a, count(*), weight_string(ascii(col2)) from `user` group by ascii(col2), weight_string(ascii(col2)) order by ascii(col2) asc"
           }
         ]
       },
@@ -2860,8 +2752,7 @@
             },
             "FieldQuery": "select tcol1, tcol2, tcol2, weight_string(tcol1), weight_string(tcol2) from `user` where 1 != 1 group by tcol1, tcol2, weight_string(tcol1), weight_string(tcol2)",
             "OrderBy": "(0|3) ASC, (1|4) ASC",
-            "Query": "select tcol1, tcol2, tcol2, weight_string(tcol1), weight_string(tcol2) from `user` group by tcol1, tcol2, weight_string(tcol1), weight_string(tcol2) order by tcol1 asc, tcol2 asc",
-            "Table": "`user`"
+            "Query": "select tcol1, tcol2, tcol2, weight_string(tcol1), weight_string(tcol2) from `user` group by tcol1, tcol2, weight_string(tcol1), weight_string(tcol2) order by tcol1 asc, tcol2 asc"
           }
         ]
       },
@@ -2892,8 +2783,7 @@
             },
             "FieldQuery": "select tcol2, tcol1, count(*), tcol2, weight_string(tcol1), weight_string(tcol2) from `user` where 1 != 1 group by tcol1, tcol2, weight_string(tcol1), weight_string(tcol2)",
             "OrderBy": "(1|4) ASC, (0|5) ASC",
-            "Query": "select tcol2, tcol1, count(*), tcol2, weight_string(tcol1), weight_string(tcol2) from `user` group by tcol1, tcol2, weight_string(tcol1), weight_string(tcol2) order by tcol1 asc, tcol2 asc",
-            "Table": "`user`"
+            "Query": "select tcol2, tcol1, count(*), tcol2, weight_string(tcol1), weight_string(tcol2) from `user` group by tcol1, tcol2, weight_string(tcol1), weight_string(tcol2) order by tcol1 asc, tcol2 asc"
           }
         ]
       },
@@ -2922,7 +2812,6 @@
             "JoinVars": {
               "u2_val2": 3
             },
-            "TableName": "`user`_`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Join",
@@ -2931,7 +2820,6 @@
                 "JoinVars": {
                   "u_val2": 1
                 },
-                "TableName": "`user`_`user`",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2942,8 +2830,7 @@
                     },
                     "FieldQuery": "select u.textcol1, u.val2, weight_string(u.val2) from `user` as u where 1 != 1",
                     "OrderBy": "0 ASC COLLATE latin1_swedish_ci, (1|2) ASC",
-                    "Query": "select u.textcol1, u.val2, weight_string(u.val2) from `user` as u order by u.textcol1 asc, u.val2 asc",
-                    "Table": "`user`"
+                    "Query": "select u.textcol1, u.val2, weight_string(u.val2) from `user` as u order by u.textcol1 asc, u.val2 asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -2954,7 +2841,6 @@
                     },
                     "FieldQuery": "select u2.val2 from `user` as u2 where 1 != 1",
                     "Query": "select u2.val2 from `user` as u2 where u2.id = :u_val2",
-                    "Table": "`user`",
                     "Values": [
                       ":u_val2"
                     ],
@@ -2971,7 +2857,6 @@
                 },
                 "FieldQuery": "select 1 from music as m where 1 != 1",
                 "Query": "select 1 from music as m where m.id = :u2_val2",
-                "Table": "music",
                 "Values": [
                   ":u2_val2"
                 ],
@@ -3001,8 +2886,7 @@
           "Sharded": true
         },
         "FieldQuery": "select group_concat(user_id order by `name` asc), id from `user` where 1 != 1 group by id",
-        "Query": "select group_concat(user_id order by `name` asc), id from `user` group by id",
-        "Table": "`user`"
+        "Query": "select group_concat(user_id order by `name` asc), id from `user` group by id"
       },
       "TablesUsed": [
         "user.user"
@@ -3023,8 +2907,7 @@
           "Sharded": false
         },
         "FieldQuery": "select count(distinct user_id, `name`) from unsharded where 1 != 1",
-        "Query": "select count(distinct user_id, `name`) from unsharded",
-        "Table": "unsharded"
+        "Query": "select count(distinct user_id, `name`) from unsharded"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -3052,7 +2935,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -3062,8 +2944,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select sum(col) from (select `user`.col as col, 32 from `user` where 1 != 1) as t where 1 != 1",
-                    "Query": "select sum(col) from (select `user`.col as col, 32 from `user`) as t",
-                    "Table": "`user`"
+                    "Query": "select sum(col) from (select `user`.col as col, 32 from `user`) as t"
                   },
                   {
                     "OperatorType": "Route",
@@ -3073,8 +2954,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra group by .0"
                   }
                 ]
               }
@@ -3114,8 +2994,7 @@
                 },
                 "FieldQuery": "select foo, count(*), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, count(*), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, count(*), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -3152,8 +3031,7 @@
                 },
                 "FieldQuery": "select foo, sum(foo), sum(bar), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select foo, sum(foo), sum(bar), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, sum(foo), sum(bar), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -3190,8 +3068,7 @@
                 },
                 "FieldQuery": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -3229,8 +3106,7 @@
                 },
                 "FieldQuery": "select foo, count(*), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, count(*), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, count(*), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -3279,7 +3155,6 @@
                         "JoinVars": {
                           "ue_id": 1
                         },
-                        "TableName": "user_extra_`user`",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -3289,8 +3164,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*), ue.id from user_extra as ue where 1 != 1 group by ue.id",
-                            "Query": "select count(*), ue.id from user_extra as ue group by ue.id",
-                            "Table": "user_extra"
+                            "Query": "select count(*), ue.id from user_extra as ue group by ue.id"
                           },
                           {
                             "OperatorType": "Route",
@@ -3301,7 +3175,6 @@
                             },
                             "FieldQuery": "select count(u.`name`), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
                             "Query": "select count(u.`name`), u.id, weight_string(u.id) from `user` as u where u.id = :ue_id group by u.id, weight_string(u.id)",
-                            "Table": "`user`",
                             "Values": [
                               ":ue_id"
                             ],
@@ -3337,8 +3210,7 @@
           "Sharded": true
         },
         "FieldQuery": "select u.id from `user` as u, user_extra as ue where 1 != 1 group by u.id",
-        "Query": "select u.id from `user` as u, user_extra as ue where ue.user_id = u.id group by u.id having count(u.`name`) = 3",
-        "Table": "`user`, user_extra"
+        "Query": "select u.id from `user` as u, user_extra as ue where ue.user_id = u.id group by u.id having count(u.`name`) = 3"
       },
       "TablesUsed": [
         "user.user",
@@ -3384,7 +3256,6 @@
                         "JoinVars": {
                           "ue_id": 1
                         },
-                        "TableName": "user_extra_`user`",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -3394,8 +3265,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*), ue.id from user_extra as ue where 1 != 1 group by ue.id",
-                            "Query": "select count(*), ue.id from user_extra as ue group by ue.id",
-                            "Table": "user_extra"
+                            "Query": "select count(*), ue.id from user_extra as ue group by ue.id"
                           },
                           {
                             "OperatorType": "Route",
@@ -3406,7 +3276,6 @@
                             },
                             "FieldQuery": "select count(*), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
                             "Query": "select count(*), u.id, weight_string(u.id) from `user` as u where u.id = :ue_id group by u.id, weight_string(u.id)",
-                            "Table": "`user`",
                             "Values": [
                               ":ue_id"
                             ],
@@ -3448,7 +3317,6 @@
             "JoinVars": {
               "user_col": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3459,8 +3327,7 @@
                 },
                 "FieldQuery": "select `user`.col, `user`.id, weight_string(`user`.id) from `user` where 1 != 1 group by `user`.id, `user`.col, weight_string(`user`.id)",
                 "OrderBy": "(1|2) ASC",
-                "Query": "select `user`.col, `user`.id, weight_string(`user`.id) from `user` group by `user`.id, `user`.col, weight_string(`user`.id) order by `user`.id asc",
-                "Table": "`user`"
+                "Query": "select `user`.col, `user`.id, weight_string(`user`.id) from `user` group by `user`.id, `user`.col, weight_string(`user`.id) order by `user`.id asc"
               },
               {
                 "OperatorType": "Route",
@@ -3470,8 +3337,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1 group by .0",
-                "Query": "select 1 from user_extra where user_extra.col = :user_col /* INT16 */ group by .0",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra where user_extra.col = :user_col /* INT16 */ group by .0"
               }
             ]
           }
@@ -3507,8 +3373,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-            "Query": "select id, count(*) from `user`",
-            "Table": "`user`"
+            "Query": "select id, count(*) from `user`"
           }
         ]
       },
@@ -3533,7 +3398,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3544,8 +3408,7 @@
                 },
                 "FieldQuery": "select `user`.id, weight_string(`user`.id) from `user` where 1 != 1 group by `user`.id, weight_string(`user`.id)",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select `user`.id, weight_string(`user`.id) from `user` group by `user`.id, weight_string(`user`.id) order by `user`.id asc",
-                "Table": "`user`"
+                "Query": "select `user`.id, weight_string(`user`.id) from `user` group by `user`.id, weight_string(`user`.id) order by `user`.id asc"
               },
               {
                 "OperatorType": "Route",
@@ -3555,8 +3418,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1 group by .0",
-                "Query": "select 1 from user_extra group by .0",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra group by .0"
               }
             ]
           }
@@ -3595,8 +3457,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select x.phone, x.id, x.city from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.phone, x.id, x.city from (select phone, id, city from `user` where id > 12) as x limit 10",
-                    "Table": "`user`"
+                    "Query": "select x.phone, x.id, x.city from (select phone, id, city from `user` where id > 12) as x limit 10"
                   }
                 ]
               }
@@ -3636,8 +3497,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where id > 12) as x limit 10",
-                    "Table": "`user`"
+                    "Query": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where id > 12) as x limit 10"
                   }
                 ]
               }
@@ -3672,7 +3532,6 @@
                 "JoinVars": {
                   "user_id": 0
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Limit",
@@ -3686,8 +3545,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select x.`user.id` from (select `user`.id as `user.id` from `user` where 1 != 1) as x where 1 != 1",
-                        "Query": "select x.`user.id` from (select `user`.id as `user.id` from `user`) as x limit 10",
-                        "Table": "`user`"
+                        "Query": "select x.`user.id` from (select `user`.id as `user.id` from `user`) as x limit 10"
                       }
                     ]
                   },
@@ -3703,8 +3561,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select x.col from (select user_extra.col as col from user_extra where 1 != 1) as x where 1 != 1",
-                        "Query": "select x.col from (select user_extra.col as col from user_extra where user_extra.id = :user_id) as x limit 10",
-                        "Table": "user_extra"
+                        "Query": "select x.col from (select user_extra.col as col from user_extra where user_extra.id = :user_id) as x limit 10"
                       }
                     ]
                   }
@@ -3750,8 +3607,7 @@
                     },
                     "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
                     "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
-                    "Table": "`user`"
+                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2"
                   }
                 ]
               }
@@ -3788,8 +3644,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-                "Query": "select id, count(*) from `user`",
-                "Table": "`user`"
+                "Query": "select id, count(*) from `user`"
               }
             ]
           }
@@ -3827,8 +3682,7 @@
                 },
                 "FieldQuery": "select `user`.intcol, count(`user`.intcol) from `user` where 1 != 1 group by `user`.intcol",
                 "OrderBy": "0 ASC",
-                "Query": "select `user`.intcol, count(`user`.intcol) from `user` group by `user`.intcol order by `user`.intcol asc",
-                "Table": "`user`"
+                "Query": "select `user`.intcol, count(`user`.intcol) from `user` group by `user`.intcol order by `user`.intcol asc"
               }
             ]
           }
@@ -3873,7 +3727,6 @@
                     "JoinVars": {
                       "m_order": 1
                     },
-                    "TableName": "user_extra_`user`",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -3883,8 +3736,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(m.predef1), m.`order` from user_extra as m where 1 != 1 group by m.`order`",
-                        "Query": "select count(m.predef1), m.`order` from user_extra as m group by m.`order`",
-                        "Table": "user_extra"
+                        "Query": "select count(m.predef1), m.`order` from user_extra as m group by m.`order`"
                       },
                       {
                         "OperatorType": "Route",
@@ -3895,7 +3747,6 @@
                         },
                         "FieldQuery": "select u.`name`, count(*), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
                         "Query": "select u.`name`, count(*), u.id, weight_string(u.id) from `user` as u where u.id = :m_order group by u.id, weight_string(u.id)",
-                        "Table": "`user`",
                         "Values": [
                           ":m_order"
                         ],
@@ -3939,7 +3790,6 @@
                 "JoinVars": {
                   "u_col": 1
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -3949,8 +3799,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(u.id), u.col from `user` as u where 1 != 1 group by u.col",
-                    "Query": "select count(u.id), u.col from `user` as u group by u.col",
-                    "Table": "`user`"
+                    "Query": "select count(u.id), u.col from `user` as u group by u.col"
                   },
                   {
                     "OperatorType": "Route",
@@ -3960,8 +3809,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra as ue where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra as ue where ue.col = :u_col /* INT16 */ group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra as ue where ue.col = :u_col /* INT16 */ group by .0"
                   }
                 ]
               }
@@ -3999,7 +3847,6 @@
                 "JoinVars": {
                   "u_col": 1
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4009,8 +3856,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), u.col from `user` as u where 1 != 1 group by u.col",
-                    "Query": "select count(*), u.col from `user` as u group by u.col",
-                    "Table": "`user`"
+                    "Query": "select count(*), u.col from `user` as u group by u.col"
                   },
                   {
                     "OperatorType": "Route",
@@ -4020,8 +3866,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(ue.id) from user_extra as ue where 1 != 1 group by .0",
-                    "Query": "select count(ue.id) from user_extra as ue where ue.col = :u_col /* INT16 */ group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(ue.id) from user_extra as ue where ue.col = :u_col /* INT16 */ group by .0"
                   }
                 ]
               }
@@ -4062,8 +3907,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select sum(a) as a, sum(b) as b from `user` where 1 != 1",
-                "Query": "select sum(a) as a, sum(b) as b from `user`",
-                "Table": "`user`"
+                "Query": "select sum(a) as a, sum(b) as b from `user`"
               }
             ]
           }
@@ -4088,8 +3932,7 @@
           "Sharded": true
         },
         "FieldQuery": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where 1 != 1 group by user_id, flowId) as t1 where 1 != 1",
-        "Query": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where localDate > :v1 group by user_id, flowId) as t1 where `count` >= :v2",
-        "Table": "user_extra"
+        "Query": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where localDate > :v1 group by user_id, flowId) as t1 where `count` >= :v2"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -4123,8 +3966,7 @@
                 },
                 "FieldQuery": "select foo, max(baz) as bazo, weight_string(foo), weight_string(max(baz)) from (select foo, baz from `user` where 1 != 1) as f where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, max(baz) as bazo, weight_string(foo), weight_string(max(baz)) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, max(baz) as bazo, weight_string(foo), weight_string(max(baz)) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -4162,8 +4004,7 @@
                 },
                 "FieldQuery": "select foo, count(baz) as bazo, weight_string(foo) from (select foo, baz from `user` where 1 != 1) as f where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, count(baz) as bazo, weight_string(foo) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, count(baz) as bazo, weight_string(foo) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -4201,8 +4042,7 @@
                 },
                 "FieldQuery": "select col, count(*), col + 1 from `user` where 1 != 1 group by col",
                 "OrderBy": "0 ASC",
-                "Query": "select col, count(*), col + 1 from `user` group by col order by col asc",
-                "Table": "`user`"
+                "Query": "select col, count(*), col + 1 from `user` group by col order by col asc"
               }
             ]
           }
@@ -4229,8 +4069,7 @@
         "FieldQuery": "select id, id + 1, weight_string(id + 1) from `user` where 1 != 1 group by id",
         "OrderBy": "(1|2) ASC",
         "Query": "select id, id + 1, weight_string(id + 1) from `user` group by id order by id + 1 asc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -4259,8 +4098,7 @@
             },
             "FieldQuery": "select a, a + 1, weight_string(a + 1) from `user` where 1 != 1 group by a + 1, weight_string(a + 1)",
             "OrderBy": "(1|2) ASC",
-            "Query": "select a, a + 1, weight_string(a + 1) from `user` group by a + 1, weight_string(a + 1) order by a + 1 asc",
-            "Table": "`user`"
+            "Query": "select a, a + 1, weight_string(a + 1) from `user` group by a + 1, weight_string(a + 1) order by a + 1 asc"
           }
         ]
       },
@@ -4293,7 +4131,6 @@
                 "JoinVars": {
                   "user_foo": 1
                 },
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4303,8 +4140,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                    "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                    "Table": "`user`"
+                    "Query": "select count(*), `user`.foo from `user` group by `user`.foo"
                   },
                   {
                     "OperatorType": "Route",
@@ -4314,8 +4150,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from music where 1 != 1 group by .0",
-                    "Query": "select count(*) from music where music.bar = :user_foo group by .0",
-                    "Table": "music"
+                    "Query": "select count(*) from music where music.bar = :user_foo group by .0"
                   }
                 ]
               }
@@ -4353,7 +4188,6 @@
                 "JoinVars": {
                   "user_foo": 1
                 },
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4363,8 +4197,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                    "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                    "Table": "`user`"
+                    "Query": "select count(*), `user`.foo from `user` group by `user`.foo"
                   },
                   {
                     "OperatorType": "Route",
@@ -4374,8 +4207,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from music where 1 != 1 group by .0",
-                    "Query": "select count(*) from music where music.bar = :user_foo group by .0",
-                    "Table": "music"
+                    "Query": "select count(*) from music where music.bar = :user_foo group by .0"
                   }
                 ]
               }
@@ -4416,7 +4248,6 @@
                 "JoinVars": {
                   "user_foo": 2
                 },
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4427,8 +4258,7 @@
                     },
                     "FieldQuery": "select count(*), `user`.col, `user`.foo from `user` where 1 != 1 group by `user`.col, `user`.foo",
                     "OrderBy": "1 ASC",
-                    "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo order by `user`.col asc",
-                    "Table": "`user`"
+                    "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo order by `user`.col asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -4438,8 +4268,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from music where 1 != 1 group by .0",
-                    "Query": "select count(*) from music where music.bar = :user_foo group by .0",
-                    "Table": "music"
+                    "Query": "select count(*) from music where music.bar = :user_foo group by .0"
                   }
                 ]
               }
@@ -4486,7 +4315,6 @@
                     "JoinVars": {
                       "user_foo": 1
                     },
-                    "TableName": "`user`_music",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -4496,8 +4324,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                        "Table": "`user`"
+                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo"
                       },
                       {
                         "OperatorType": "Route",
@@ -4507,8 +4334,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), music.col, weight_string(music.col) from music where 1 != 1 group by music.col, weight_string(music.col)",
-                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)",
-                        "Table": "music"
+                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)"
                       }
                     ]
                   }
@@ -4551,7 +4377,6 @@
                 "JoinVars": {
                   "user_foo": 2
                 },
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4562,8 +4387,7 @@
                     },
                     "FieldQuery": "select count(*), `user`.col, `user`.foo from `user` where 1 != 1 group by `user`.col, `user`.foo",
                     "OrderBy": "1 ASC",
-                    "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo order by `user`.col asc",
-                    "Table": "`user`"
+                    "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo order by `user`.col asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -4573,8 +4397,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from music where 1 != 1 group by .0",
-                    "Query": "select count(*) from music where music.bar = :user_foo group by .0",
-                    "Table": "music"
+                    "Query": "select count(*) from music where music.bar = :user_foo group by .0"
                   }
                 ]
               }
@@ -4621,7 +4444,6 @@
                     "JoinVars": {
                       "user_foo": 1
                     },
-                    "TableName": "`user`_music",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -4631,8 +4453,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                        "Table": "`user`"
+                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo"
                       },
                       {
                         "OperatorType": "Route",
@@ -4642,8 +4463,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), music.col, weight_string(music.col) from music where 1 != 1 group by music.col, weight_string(music.col)",
-                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)",
-                        "Table": "music"
+                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)"
                       }
                     ]
                   }
@@ -4683,7 +4503,6 @@
                 "JoinVars": {
                   "user_extra_baz": 1
                 },
-                "TableName": "user_extra_`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4693,8 +4512,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), user_extra.baz from user_extra where 1 != 1 group by user_extra.baz",
-                    "Query": "select count(*), user_extra.baz from user_extra group by user_extra.baz",
-                    "Table": "user_extra"
+                    "Query": "select count(*), user_extra.baz from user_extra group by user_extra.baz"
                   },
                   {
                     "OperatorType": "Projection",
@@ -4709,7 +4527,6 @@
                         "JoinVars": {
                           "user_foo": 1
                         },
-                        "TableName": "`user`_music",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -4719,8 +4536,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                            "Query": "select count(*), `user`.foo from `user` where `user`.foo = :user_extra_baz group by `user`.foo",
-                            "Table": "`user`"
+                            "Query": "select count(*), `user`.foo from `user` where `user`.foo = :user_extra_baz group by `user`.foo"
                           },
                           {
                             "OperatorType": "Route",
@@ -4730,8 +4546,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*) from music where 1 != 1 group by .0",
-                            "Query": "select count(*) from music where music.bar = :user_foo group by .0",
-                            "Table": "music"
+                            "Query": "select count(*) from music where music.bar = :user_foo group by .0"
                           }
                         ]
                       }
@@ -4774,7 +4589,6 @@
                 "JoinVars": {
                   "user_foo": 1
                 },
-                "TableName": "`user`_music_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
@@ -4790,7 +4604,6 @@
                         "JoinVars": {
                           "user_foo": 1
                         },
-                        "TableName": "`user`_music",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -4800,8 +4613,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                            "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                            "Table": "`user`"
+                            "Query": "select count(*), `user`.foo from `user` group by `user`.foo"
                           },
                           {
                             "OperatorType": "Route",
@@ -4811,8 +4623,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*) from music where 1 != 1 group by .0",
-                            "Query": "select count(*) from music where music.bar = :user_foo group by .0",
-                            "Table": "music"
+                            "Query": "select count(*) from music where music.bar = :user_foo group by .0"
                           }
                         ]
                       }
@@ -4826,8 +4637,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra where user_extra.baz = :user_foo group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra where user_extra.baz = :user_foo group by .0"
                   }
                 ]
               }
@@ -4866,7 +4676,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0,L:1,L:2",
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4877,8 +4686,7 @@
                     },
                     "FieldQuery": "select count(*), u.col, u.intcol from `user` as u where 1 != 1 group by u.col, u.intcol",
                     "OrderBy": "2 ASC, 1 ASC",
-                    "Query": "select count(*), u.col, u.intcol from `user` as u group by u.col, u.intcol order by u.intcol asc, u.col asc",
-                    "Table": "`user`"
+                    "Query": "select count(*), u.col, u.intcol from `user` as u group by u.col, u.intcol order by u.intcol asc, u.col asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -4888,8 +4696,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from music where 1 != 1 group by .0",
-                    "Query": "select count(*) from music group by .0",
-                    "Table": "music"
+                    "Query": "select count(*) from music group by .0"
                   }
                 ]
               }
@@ -4917,8 +4724,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col, val, id from `user` where 1 != 1 group by col, val, id",
-        "Query": "select col, val, id from `user` group by col, val, id",
-        "Table": "`user`"
+        "Query": "select col, val, id from `user` group by col, val, id"
       },
       "TablesUsed": [
         "user.user"
@@ -4947,8 +4753,7 @@
               "Sharded": true
             },
             "FieldQuery": "select a, b as a, weight_string(a), weight_string(b) from `user` where 1 != 1",
-            "Query": "select distinct a, b as a, weight_string(a), weight_string(b) from `user`",
-            "Table": "`user`"
+            "Query": "select distinct a, b as a, weight_string(a), weight_string(b) from `user`"
           }
         ]
       },
@@ -4978,8 +4783,7 @@
               "Sharded": true
             },
             "FieldQuery": "select a + 1, weight_string(a + 1) from `user` where 1 != 1",
-            "Query": "select distinct a + 1, weight_string(a + 1) from `user`",
-            "Table": "`user`"
+            "Query": "select distinct a + 1, weight_string(a + 1) from `user`"
           }
         ]
       },
@@ -5016,8 +4820,7 @@
                 },
                 "FieldQuery": "select count(*), col from `user` where 1 != 1 group by col",
                 "OrderBy": "1 ASC",
-                "Query": "select count(*), col from `user` group by col order by col asc",
-                "Table": "`user`"
+                "Query": "select count(*), col from `user` group by col order by col asc"
               }
             ]
           }
@@ -5049,8 +4852,7 @@
             },
             "FieldQuery": "select min(textcol1), max(textcol2), textcol1, textcol1, weight_string(max(textcol2)) from `user` where 1 != 1 group by textcol1",
             "OrderBy": "2 ASC COLLATE latin1_swedish_ci",
-            "Query": "select min(textcol1), max(textcol2), textcol1, textcol1, weight_string(max(textcol2)) from `user` group by textcol1 order by textcol1 asc",
-            "Table": "`user`"
+            "Query": "select min(textcol1), max(textcol2), textcol1, textcol1, weight_string(max(textcol2)) from `user` group by textcol1 order by textcol1 asc"
           }
         ]
       },
@@ -5081,8 +4883,7 @@
             },
             "FieldQuery": "select col, min(textcol1), max(textcol2), textcol1, textcol1, weight_string(max(textcol2)) from `user` where 1 != 1 group by col, textcol1",
             "OrderBy": "0 ASC, 3 ASC COLLATE latin1_swedish_ci",
-            "Query": "select col, min(textcol1), max(textcol2), textcol1, textcol1, weight_string(max(textcol2)) from `user` group by col, textcol1 order by col asc, textcol1 asc",
-            "Table": "`user`"
+            "Query": "select col, min(textcol1), max(textcol2), textcol1, textcol1, weight_string(max(textcol2)) from `user` group by col, textcol1 order by col asc, textcol1 asc"
           }
         ]
       },
@@ -5112,8 +4913,7 @@
             },
             "FieldQuery": "select col, col, count(*) from `user` where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col, col, count(*) from `user` group by col order by col asc",
-            "Table": "`user`"
+            "Query": "select col, col, count(*) from `user` group by col order by col asc"
           }
         ]
       },
@@ -5145,7 +4945,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0,R:1",
-                "TableName": "user_extra_`user`_`user`",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -5155,8 +4954,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra as ue where 1 != 1",
-                    "Query": "select count(*) from user_extra as ue",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra as ue"
                   },
                   {
                     "OperatorType": "Projection",
@@ -5169,7 +4967,6 @@
                         "OperatorType": "Join",
                         "Variant": "Join",
                         "JoinColumnIndexes": "L:0,R:0,L:1",
-                        "TableName": "`user`_`user`",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -5179,8 +4976,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*), count(u.col) from `user` as u where 1 != 1 group by .0",
-                            "Query": "select count(*), count(u.col) from `user` as u group by .0",
-                            "Table": "`user`"
+                            "Query": "select count(*), count(u.col) from `user` as u group by .0"
                           },
                           {
                             "OperatorType": "Route",
@@ -5190,8 +4986,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*) from `user` as u2 where 1 != 1 group by .0",
-                            "Query": "select count(*) from `user` as u2 group by .0",
-                            "Table": "`user`"
+                            "Query": "select count(*) from `user` as u2 group by .0"
                           }
                         ]
                       }
@@ -5229,7 +5024,6 @@
             "JoinVars": {
               "user_col": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5240,8 +5034,7 @@
                 },
                 "FieldQuery": "select `user`.col, `user`.bar, weight_string(`user`.bar) from `user` where 1 != 1 group by `user`.col, `user`.bar, weight_string(`user`.bar)",
                 "OrderBy": "0 ASC, (1|2) ASC",
-                "Query": "select `user`.col, `user`.bar, weight_string(`user`.bar) from `user` group by `user`.col, `user`.bar, weight_string(`user`.bar) order by `user`.col asc, `user`.bar asc",
-                "Table": "`user`"
+                "Query": "select `user`.col, `user`.bar, weight_string(`user`.bar) from `user` group by `user`.col, `user`.bar, weight_string(`user`.bar) order by `user`.col asc, `user`.bar asc"
               },
               {
                 "OperatorType": "Route",
@@ -5251,8 +5044,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select min(user_extra.foo), max(user_extra.bar), weight_string(user_extra.foo), weight_string(user_extra.bar) from user_extra where 1 != 1 group by .0, weight_string(user_extra.foo), weight_string(user_extra.bar)",
-                "Query": "select min(user_extra.foo), max(user_extra.bar), weight_string(user_extra.foo), weight_string(user_extra.bar) from user_extra where user_extra.bar = :user_col /* INT16 */ group by .0, weight_string(user_extra.foo), weight_string(user_extra.bar)",
-                "Table": "user_extra"
+                "Query": "select min(user_extra.foo), max(user_extra.bar), weight_string(user_extra.foo), weight_string(user_extra.bar) from user_extra where user_extra.bar = :user_col /* INT16 */ group by .0, weight_string(user_extra.foo), weight_string(user_extra.bar)"
               }
             ]
           }
@@ -5283,7 +5075,6 @@
             "JoinVars": {
               "u_foo": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5293,8 +5084,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.foo from `user` as u where 1 != 1",
-                "Query": "select u.foo from `user` as u",
-                "Table": "`user`"
+                "Query": "select u.foo from `user` as u"
               },
               {
                 "OperatorType": "Route",
@@ -5304,8 +5094,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select :u_foo * ue.bar, weight_string(:u_foo * ue.bar) from user_extra as ue where 1 != 1",
-                "Query": "select :u_foo * ue.bar, weight_string(:u_foo * ue.bar) from user_extra as ue",
-                "Table": "user_extra"
+                "Query": "select :u_foo * ue.bar, weight_string(:u_foo * ue.bar) from user_extra as ue"
               }
             ]
           }
@@ -5335,7 +5124,6 @@
             "JoinVars": {
               "user_foo": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5345,8 +5133,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.foo from `user` where 1 != 1",
-                "Query": "select `user`.foo from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.foo from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -5356,8 +5143,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select :user_foo + user_extra.bar from user_extra where 1 != 1",
-                "Query": "select :user_foo + user_extra.bar from user_extra",
-                "Table": "user_extra"
+                "Query": "select :user_foo + user_extra.bar from user_extra"
               }
             ]
           }
@@ -5402,7 +5188,6 @@
                     "JoinVars": {
                       "user_id": 1
                     },
-                    "TableName": "`user`_user_extra",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -5412,8 +5197,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), `user`.id from `user` where 1 != 1 group by `user`.id",
-                        "Query": "select count(*), `user`.id from `user` group by `user`.id",
-                        "Table": "`user`"
+                        "Query": "select count(*), `user`.id from `user` group by `user`.id"
                       },
                       {
                         "OperatorType": "Route",
@@ -5423,8 +5207,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra where 1 != 1 group by :user_id + user_extra.id, weight_string(:user_id + user_extra.id)",
-                        "Query": "select count(*), :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra group by :user_id + user_extra.id, weight_string(:user_id + user_extra.id)",
-                        "Table": "user_extra"
+                        "Query": "select count(*), :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra group by :user_id + user_extra.id, weight_string(:user_id + user_extra.id)"
                       }
                     ]
                   }
@@ -5465,8 +5248,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1, count(*) from `user` where 1 != 1",
-                "Query": "select 1, count(*) from `user`",
-                "Table": "`user`"
+                "Query": "select 1, count(*) from `user`"
               }
             ]
           }
@@ -5508,7 +5290,6 @@
                     "JoinVars": {
                       "user_col": 2
                     },
-                    "TableName": "`user`_user_extra",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -5518,8 +5299,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select sum(`user`.foo), count(*), `user`.col from `user` where 1 != 1 group by `user`.col",
-                        "Query": "select sum(`user`.foo), count(*), `user`.col from `user` group by `user`.col",
-                        "Table": "`user`"
+                        "Query": "select sum(`user`.foo), count(*), `user`.col from `user` group by `user`.col"
                       },
                       {
                         "OperatorType": "Route",
@@ -5529,8 +5309,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), sum(user_extra.bar) from user_extra where 1 != 1 group by .0",
-                        "Query": "select count(*), sum(user_extra.bar) from user_extra where user_extra.col = :user_col /* INT16 */ group by .0",
-                        "Table": "user_extra"
+                        "Query": "select count(*), sum(user_extra.bar) from user_extra where user_extra.col = :user_col /* INT16 */ group by .0"
                       }
                     ]
                   }
@@ -5561,7 +5340,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5571,8 +5349,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.a from `user` where 1 != 1",
-                "Query": "select `user`.a from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.a from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -5582,8 +5359,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra"
               }
             ]
           }
@@ -5621,7 +5397,6 @@
                 "JoinVars": {
                   "u_bar": 2
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -5631,8 +5406,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), any_value(u.`name`), u.bar from `user` as u where 1 != 1 group by u.bar",
-                    "Query": "select count(*), any_value(u.`name`), u.bar from `user` as u group by u.bar",
-                    "Table": "`user`"
+                    "Query": "select count(*), any_value(u.`name`), u.bar from `user` as u group by u.bar"
                   },
                   {
                     "OperatorType": "Route",
@@ -5642,8 +5416,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), any_value(ue.title) from user_extra as ue where 1 != 1 group by .0",
-                    "Query": "select count(*), any_value(ue.title) from user_extra as ue where ue.foo = :u_bar group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*), any_value(ue.title) from user_extra as ue where ue.foo = :u_bar group by .0"
                   }
                 ]
               }
@@ -5675,7 +5448,6 @@
             "JoinVars": {
               "d_id": 1
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -5701,8 +5473,7 @@
                             },
                             "FieldQuery": "select id, count(*) as a, weight_string(id) from `user` where 1 != 1",
                             "OrderBy": "1 ASC, (0|2) ASC",
-                            "Query": "select id, count(*) as a, weight_string(id) from `user` order by count(*) asc, id asc",
-                            "Table": "`user`"
+                            "Query": "select id, count(*) as a, weight_string(id) from `user` order by count(*) asc, id asc"
                           }
                         ]
                       }
@@ -5719,7 +5490,6 @@
                 },
                 "FieldQuery": "select 1 from music where 1 != 1 group by .0",
                 "Query": "select 1 from music where music.user_id = :d_id group by .0",
-                "Table": "music",
                 "Values": [
                   ":d_id"
                 ],
@@ -5760,7 +5530,6 @@
                 "JoinVars": {
                   "music_foo": 0
                 },
-                "TableName": "music_`user`",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -5770,8 +5539,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select music.foo from music where 1 != 1",
-                    "Query": "select music.foo from music",
-                    "Table": "music"
+                    "Query": "select music.foo from music"
                   },
                   {
                     "OperatorType": "Route",
@@ -5782,7 +5550,6 @@
                     },
                     "FieldQuery": "select `user`.id, `user`.bar, weight_string(`user`.bar) from `user` where 1 != 1",
                     "Query": "select `user`.id, `user`.bar, weight_string(`user`.bar) from `user` where `user`.id = :music_foo",
-                    "Table": "`user`",
                     "Values": [
                       ":music_foo"
                     ],
@@ -5821,8 +5588,7 @@
             },
             "FieldQuery": "select intcol, group_concat(foo) from `user` where 1 != 1 group by intcol",
             "OrderBy": "0 ASC",
-            "Query": "select intcol, group_concat(foo) from `user` group by intcol order by intcol asc",
-            "Table": "`user`"
+            "Query": "select intcol, group_concat(foo) from `user` group by intcol order by intcol asc"
           }
         ]
       },
@@ -5857,7 +5623,6 @@
                 "JoinVars": {
                   "u_col": 5
                 },
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -5868,8 +5633,7 @@
                     },
                     "FieldQuery": "select u.foo, u.bar, u.baz, weight_string(u.foo), weight_string(u.baz), u.col from `user` as u where 1 != 1",
                     "OrderBy": "(0|3) ASC",
-                    "Query": "select u.foo, u.bar, u.baz, weight_string(u.foo), weight_string(u.baz), u.col from `user` as u order by u.foo asc",
-                    "Table": "`user`"
+                    "Query": "select u.foo, u.bar, u.baz, weight_string(u.foo), weight_string(u.baz), u.col from `user` as u order by u.foo asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -5879,8 +5643,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from music as m where 1 != 1",
-                    "Query": "select 1 from music as m where m.col = :u_col /* INT16 */",
-                    "Table": "music"
+                    "Query": "select 1 from music as m where m.col = :u_col /* INT16 */"
                   }
                 ]
               }
@@ -5911,7 +5674,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,R:0,R:1,L:1",
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5922,8 +5684,7 @@
                 },
                 "FieldQuery": "select u.col1, weight_string(u.col1) from `user` as u where 1 != 1 group by u.col1, weight_string(u.col1)",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select u.col1, weight_string(u.col1) from `user` as u group by u.col1, weight_string(u.col1) order by u.col1 asc",
-                "Table": "`user`"
+                "Query": "select u.col1, weight_string(u.col1) from `user` as u group by u.col1, weight_string(u.col1) order by u.col1 asc"
               },
               {
                 "OperatorType": "Route",
@@ -5933,8 +5694,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(distinct m.user_id), sum(distinct m.user_id) from music as m where 1 != 1 group by .0",
-                "Query": "select count(distinct m.user_id), sum(distinct m.user_id) from music as m group by .0",
-                "Table": "music"
+                "Query": "select count(distinct m.user_id), sum(distinct m.user_id) from music as m group by .0"
               }
             ]
           }
@@ -5968,8 +5728,7 @@
             },
             "FieldQuery": "select foo, min(bar) as `min(distinct bar)`, baz, baz, max(toto) as `max(distinct toto)`, weight_string(foo), weight_string(min(bar)), weight_string(baz), weight_string(max(toto)) from `user` where 1 != 1 group by foo, baz, weight_string(foo), weight_string(baz)",
             "OrderBy": "(0|5) ASC, (2|7) ASC",
-            "Query": "select foo, min(bar) as `min(distinct bar)`, baz, baz, max(toto) as `max(distinct toto)`, weight_string(foo), weight_string(min(bar)), weight_string(baz), weight_string(max(toto)) from `user` group by foo, baz, weight_string(foo), weight_string(baz) order by foo asc, baz asc",
-            "Table": "`user`"
+            "Query": "select foo, min(bar) as `min(distinct bar)`, baz, baz, max(toto) as `max(distinct toto)`, weight_string(foo), weight_string(min(bar)), weight_string(baz), weight_string(max(toto)) from `user` group by foo, baz, weight_string(foo), weight_string(baz) order by foo asc, baz asc"
           }
         ]
       },
@@ -6000,8 +5759,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select col from `user` where 1 != 1",
-                "Query": "select col from `user`",
-                "Table": "`user`"
+                "Query": "select col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -6011,8 +5769,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select col from unsharded where 1 != 1",
-                "Query": "select col from unsharded",
-                "Table": "unsharded"
+                "Query": "select col from unsharded"
               }
             ]
           }
@@ -6051,8 +5808,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select x.id, x.val2 from (select id, val2 from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.id, x.val2 from (select id, val2 from `user` where val2 is null) as x limit 2",
-                    "Table": "`user`"
+                    "Query": "select x.id, x.val2 from (select id, val2 from `user` where val2 is null) as x limit 2"
                   }
                 ]
               }
@@ -6086,7 +5842,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0",
-                "TableName": "`user`_`user`",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -6096,8 +5851,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from `user` where 1 != 1",
-                    "Query": "select count(*) from `user`",
-                    "Table": "`user`"
+                    "Query": "select count(*) from `user`"
                   },
                   {
                     "OperatorType": "Aggregate",
@@ -6125,8 +5879,7 @@
                                   "Sharded": true
                                 },
                                 "FieldQuery": "select count(*), .0, 1 from `user` where 1 != 1 group by .0",
-                                "Query": "select count(*), .0, 1 from `user` group by .0",
-                                "Table": "`user`"
+                                "Query": "select count(*), .0, 1 from `user` group by .0"
                               }
                             ]
                           }
@@ -6172,8 +5925,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) from user_extra where 1 != 1",
-                "Query": "select count(*) from user_extra",
-                "Table": "user_extra"
+                "Query": "select count(*) from user_extra"
               }
             ]
           },
@@ -6199,8 +5951,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from `user` where 1 != 1",
-                    "Query": "select count(*) from `user`",
-                    "Table": "`user`"
+                    "Query": "select count(*) from `user`"
                   }
                 ]
               },
@@ -6213,8 +5964,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select :__sq1 /* INT64 */ + :__sq2 /* INT64 */ as `(select count(*) from ``user``) + (select count(*) from user_extra)` from dual where 1 != 1",
-                "Query": "select :__sq1 /* INT64 */ + :__sq2 /* INT64 */ as `(select count(*) from ``user``) + (select count(*) from user_extra)` from dual",
-                "Table": "dual"
+                "Query": "select :__sq1 /* INT64 */ + :__sq2 /* INT64 */ as `(select count(*) from ``user``) + (select count(*) from user_extra)` from dual"
               }
             ]
           }
@@ -6252,8 +6002,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select sum(id), count(id) from `user` where 1 != 1",
-                "Query": "select sum(id), count(id) from `user`",
-                "Table": "`user`"
+                "Query": "select sum(id), count(id) from `user`"
               }
             ]
           }
@@ -6300,8 +6049,7 @@
                     },
                     "FieldQuery": "select bar, sum(id), count(foo), count(id), weight_string(bar) from `user` where 1 != 1 group by bar, weight_string(bar)",
                     "OrderBy": "(0|4) ASC",
-                    "Query": "select bar, sum(id), count(foo), count(id), weight_string(bar) from `user` group by bar, weight_string(bar) order by bar asc",
-                    "Table": "`user`"
+                    "Query": "select bar, sum(id), count(foo), count(id), weight_string(bar) from `user` group by bar, weight_string(bar) order by bar asc"
                   }
                 ]
               }
@@ -6350,8 +6098,7 @@
                     },
                     "FieldQuery": "select bar, sum(id), count(foo), count(id), weight_string(bar) from `user` where 1 != 1 group by bar, weight_string(bar)",
                     "OrderBy": "(0|4) ASC",
-                    "Query": "select bar, sum(id), count(foo), count(id), weight_string(bar) from `user` group by bar, weight_string(bar) order by bar asc",
-                    "Table": "`user`"
+                    "Query": "select bar, sum(id), count(foo), count(id), weight_string(bar) from `user` group by bar, weight_string(bar) order by bar asc"
                   }
                 ]
               }
@@ -6390,8 +6137,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select sum(foo), sum(bar), count(foo), count(bar) from `user` where 1 != 1",
-                "Query": "select sum(foo), sum(bar), count(foo), count(bar) from `user`",
-                "Table": "`user`"
+                "Query": "select sum(foo), sum(bar), count(foo), count(bar) from `user`"
               }
             ]
           }
@@ -6428,8 +6174,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select sum(foo), count(foo), count(foo) from `user` where 1 != 1",
-                "Query": "select sum(foo), count(foo), count(foo) from `user`",
-                "Table": "`user`"
+                "Query": "select sum(foo), count(foo), count(foo) from `user`"
               }
             ]
           }
@@ -6453,7 +6198,6 @@
         "JoinVars": {
           "tables_table_name": 0
         },
-        "TableName": "`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -6464,7 +6208,6 @@
             },
             "FieldQuery": "select `tables`.table_name from (select table_name from `user` where 1 != 1 group by table_name) as `tables` where 1 != 1",
             "Query": "select `tables`.table_name from (select table_name from `user` where id = 143 group by table_name) as `tables`",
-            "Table": "`user`",
             "Values": [
               "143"
             ],
@@ -6478,8 +6221,7 @@
               "Sharded": true
             },
             "FieldQuery": "select c.column_name from `user` as c where 1 != 1",
-            "Query": "select c.column_name from `user` as c where c.table_name = :tables_table_name",
-            "Table": "`user`"
+            "Query": "select c.column_name from `user` as c where c.table_name = :tables_table_name"
           }
         ]
       },
@@ -6512,7 +6254,6 @@
                 "JoinVars": {
                   "foobars_min_id": 0
                 },
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Aggregate",
@@ -6534,8 +6275,7 @@
                             },
                             "FieldQuery": "select min(bb.id) as min_id, max(bb.id) as max_id, weight_string(min(bb.id)), weight_string(max(bb.id)) from `user` as bb where 1 != 1",
                             "OrderBy": "0 ASC COLLATE utf8mb4_0900_ai_ci",
-                            "Query": "select min(bb.id) as min_id, max(bb.id) as max_id, weight_string(min(bb.id)), weight_string(max(bb.id)) from `user` as bb order by min(bb.id) asc",
-                            "Table": "`user`"
+                            "Query": "select min(bb.id) as min_id, max(bb.id) as max_id, weight_string(min(bb.id)), weight_string(max(bb.id)) from `user` as bb order by min(bb.id) asc"
                           }
                         ]
                       }
@@ -6549,8 +6289,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select b.col, weight_string(b.col) from music as b where 1 != 1 group by b.col, weight_string(b.col)",
-                    "Query": "select b.col, weight_string(b.col) from music as b where b.id > :foobars_min_id group by b.col, weight_string(b.col)",
-                    "Table": "music"
+                    "Query": "select b.col, weight_string(b.col) from music as b where b.id > :foobars_min_id group by b.col, weight_string(b.col)"
                   }
                 ]
               }
@@ -6596,7 +6335,6 @@
                     "OperatorType": "Join",
                     "Variant": "Join",
                     "JoinColumnIndexes": "L:0,R:0,L:1,R:1,L:2,R:2",
-                    "TableName": "`user`_music",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -6606,8 +6344,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), cast(`user`.foo as datetime) as f1, weight_string(cast(`user`.foo as datetime)) from `user` where 1 != 1 group by cast(`user`.foo as datetime), weight_string(cast(`user`.foo as datetime))",
-                        "Query": "select count(*), cast(`user`.foo as datetime) as f1, weight_string(cast(`user`.foo as datetime)) from `user` group by cast(`user`.foo as datetime), weight_string(cast(`user`.foo as datetime))",
-                        "Table": "`user`"
+                        "Query": "select count(*), cast(`user`.foo as datetime) as f1, weight_string(cast(`user`.foo as datetime)) from `user` group by cast(`user`.foo as datetime), weight_string(cast(`user`.foo as datetime))"
                       },
                       {
                         "OperatorType": "Route",
@@ -6617,8 +6354,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), cast(music.foo as datetime) as f2, weight_string(cast(music.foo as datetime)) from music where 1 != 1 group by cast(music.foo as datetime), weight_string(cast(music.foo as datetime))",
-                        "Query": "select count(*), cast(music.foo as datetime) as f2, weight_string(cast(music.foo as datetime)) from music group by cast(music.foo as datetime), weight_string(cast(music.foo as datetime))",
-                        "Table": "music"
+                        "Query": "select count(*), cast(music.foo as datetime) as f2, weight_string(cast(music.foo as datetime)) from music group by cast(music.foo as datetime), weight_string(cast(music.foo as datetime))"
                       }
                     ]
                   }
@@ -6669,7 +6405,6 @@
                     "ComparisonType": "INT16",
                     "JoinColumnIndexes": "-1,1,-2,2,-3,3",
                     "Predicate": "`user`.col = ue.col",
-                    "TableName": "`user`_user_extra",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -6679,8 +6414,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), `user`.col, `user`.foo from `user` where 1 != 1 group by `user`.col, `user`.foo",
-                        "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo",
-                        "Table": "`user`"
+                        "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo"
                       },
                       {
                         "OperatorType": "Aggregate",
@@ -6710,8 +6444,7 @@
                                           "Sharded": true
                                         },
                                         "FieldQuery": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra where 1 != 1) as ue where 1 != 1",
-                                        "Query": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra) as ue limit 10",
-                                        "Table": "user_extra"
+                                        "Query": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra) as ue limit 10"
                                       }
                                     ]
                                   }
@@ -6750,7 +6483,6 @@
         },
         "FieldQuery": "select max((select min(col) from `user` where 1 != 1)) from dual where 1 != 1",
         "Query": "select max((select min(col) from `user` where id = 1)) from dual",
-        "Table": "dual",
         "Values": [
           "1"
         ],
@@ -6790,8 +6522,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select min(col) from unsharded where 1 != 1",
-                "Query": "select min(col) from unsharded",
-                "Table": "unsharded"
+                "Query": "select min(col) from unsharded"
               },
               {
                 "InputName": "Outer",
@@ -6803,7 +6534,6 @@
                 },
                 "FieldQuery": "select max(:__sq1), weight_string(:__sq1) from `user` where 1 != 1 group by weight_string(:__sq1)",
                 "Query": "select max(:__sq1), weight_string(:__sq1) from `user` where id = 1 group by weight_string(:__sq1)",
-                "Table": "`user`",
                 "Values": [
                   "1"
                 ],
@@ -6848,7 +6578,6 @@
                 },
                 "FieldQuery": "select min(col) from `user` where 1 != 1",
                 "Query": "select min(col) from `user` where id = 1",
-                "Table": "`user`",
                 "Values": [
                   "1"
                 ],
@@ -6864,7 +6593,6 @@
                 },
                 "FieldQuery": "select max(:__sq1 /* INT16 */), weight_string(:__sq1 /* INT16 */) from `user` where 1 != 1 group by weight_string(:__sq1 /* INT16 */)",
                 "Query": "select max(:__sq1 /* INT16 */), weight_string(:__sq1 /* INT16 */) from `user` where id = 2 group by weight_string(:__sq1 /* INT16 */)",
-                "Table": "`user`",
                 "Values": [
                   "2"
                 ],
@@ -6894,7 +6622,6 @@
         },
         "FieldQuery": "select max((select group_concat(col1, col2) from `user` where 1 != 1)) from dual where 1 != 1",
         "Query": "select max((select group_concat(col1, col2) from `user` where id = 1)) from dual",
-        "Table": "dual",
         "Values": [
           "1"
         ],
@@ -6921,7 +6648,6 @@
         },
         "FieldQuery": "select max((select group_concat(col1, col2) from `user` where 1 != 1)) from `user` where 1 != 1",
         "Query": "select max((select group_concat(col1, col2) from `user` where id = 1)) from `user` where id = 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -6961,7 +6687,6 @@
                 },
                 "FieldQuery": "select group_concat(col1, col2) from `user` where 1 != 1",
                 "Query": "select group_concat(col1, col2) from `user` where id = 1",
-                "Table": "`user`",
                 "Values": [
                   "1"
                 ],
@@ -6976,8 +6701,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select max(:__sq1), weight_string(:__sq1) from `user` where 1 != 1 group by weight_string(:__sq1)",
-                "Query": "select max(:__sq1), weight_string(:__sq1) from `user` group by weight_string(:__sq1)",
-                "Table": "`user`"
+                "Query": "select max(:__sq1), weight_string(:__sq1) from `user` group by weight_string(:__sq1)"
               }
             ]
           }
@@ -7008,8 +6732,7 @@
               "Sharded": true
             },
             "FieldQuery": "select max((select max(col2) from `user` as u1 where 1 != 1)), weight_string(max((select max(col2) from `user` as u1 where 1 != 1))) from `user` as u2 where 1 != 1",
-            "Query": "select max((select max(col2) from `user` as u1 where u1.id = u2.id)), weight_string(max((select max(col2) from `user` as u1 where u1.id = u2.id))) from `user` as u2",
-            "Table": "`user`"
+            "Query": "select max((select max(col2) from `user` as u1 where u1.id = u2.id)), weight_string(max((select max(col2) from `user` as u1 where u1.id = u2.id))) from `user` as u2"
           }
         ]
       },
@@ -7037,8 +6760,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(a, b) from `user` where 1 != 1",
-            "Query": "select count(a, b) from `user`",
-            "Table": "`user`"
+            "Query": "select count(a, b) from `user`"
           }
         ]
       },
@@ -7066,8 +6788,7 @@
               "Sharded": true
             },
             "FieldQuery": "select group_concat(col1, col2) from `user` where 1 != 1",
-            "Query": "select group_concat(col1, col2) from `user`",
-            "Table": "`user`"
+            "Query": "select group_concat(col1, col2) from `user`"
           }
         ]
       },
@@ -7095,8 +6816,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(distinct `name`, id) from `user` where 1 != 1",
-            "Query": "select count(distinct `name`, id) from `user`",
-            "Table": "`user`"
+            "Query": "select count(distinct `name`, id) from `user`"
           }
         ]
       },
@@ -7121,8 +6841,7 @@
         "FieldQuery": "select id, from_unixtime(min(col)) as col, min(col) from `user` where 1 != 1 group by id",
         "OrderBy": "2 ASC COLLATE utf8mb4_0900_ai_ci",
         "Query": "select id, from_unixtime(min(col)) as col, min(col) from `user` group by id order by min(col) asc",
-        "ResultColumns": 2,
-        "Table": "`user`"
+        "ResultColumns": 2
       },
       "TablesUsed": [
         "user.user"
@@ -7152,8 +6871,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select sum(x) as col from `user` where 1 != 1",
-                "Query": "select sum(x) as col from `user` where x > 0",
-                "Table": "`user`"
+                "Query": "select sum(x) as col from `user` where x > 0"
               }
             ]
           }
@@ -7188,8 +6906,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1 group by id",
-        "Query": "select id from `user` group by id having udf_aggr(foo) > 1",
-        "Table": "`user`"
+        "Query": "select id from `user` group by id having udf_aggr(foo) > 1"
       },
       "TablesUsed": [
         "user.user"
@@ -7210,8 +6927,7 @@
           "Sharded": false
         },
         "FieldQuery": "select bar, udf_aggr(foo) from unsharded where 1 != 1 group by bar",
-        "Query": "select bar, udf_aggr(foo) from unsharded group by bar",
-        "Table": "unsharded"
+        "Query": "select bar, udf_aggr(foo) from unsharded group by bar"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -7233,7 +6949,6 @@
         },
         "FieldQuery": "select bar, udf_aggr(foo) from `user` where 1 != 1 group by bar",
         "Query": "select bar, udf_aggr(foo) from `user` where id = 17 group by bar",
-        "Table": "`user`",
         "Values": [
           "17"
         ],
@@ -7273,8 +6988,7 @@
                     },
                     "FieldQuery": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where 1 != 1) as subquery_for_count where 1 != 1",
                     "OrderBy": "(1|3) DESC",
-                    "Query": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where `user`.is_not_deleted = true) as subquery_for_count order by subquery_for_count.id desc limit 25",
-                    "Table": "`user`"
+                    "Query": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where `user`.is_not_deleted = true) as subquery_for_count order by subquery_for_count.id desc limit 25"
                   }
                 ]
               }
@@ -7320,7 +7034,6 @@
                     "JoinVars": {
                       "user_team_id": 1
                     },
-                    "TableName": "`user`_user_extra",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -7330,8 +7043,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select sum(`user`.type), `user`.team_id from `user` where 1 != 1 group by `user`.team_id",
-                        "Query": "select sum(`user`.type), `user`.team_id from `user` group by `user`.team_id",
-                        "Table": "`user`"
+                        "Query": "select sum(`user`.type), `user`.team_id from `user` group by `user`.team_id"
                       },
                       {
                         "OperatorType": "Route",
@@ -7341,8 +7053,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), user_extra.id, weight_string(user_extra.id) from user_extra where 1 != 1 group by user_extra.id, weight_string(user_extra.id)",
-                        "Query": "select count(*), user_extra.id, weight_string(user_extra.id) from user_extra where user_extra.id = :user_team_id group by user_extra.id, weight_string(user_extra.id)",
-                        "Table": "user_extra"
+                        "Query": "select count(*), user_extra.id, weight_string(user_extra.id) from user_extra where user_extra.id = :user_team_id group by user_extra.id, weight_string(user_extra.id)"
                       }
                     ]
                   }

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -18,8 +18,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-            "Query": "select count(*) as a from `user`",
-            "Table": "`user`"
+            "Query": "select count(*) as a from `user`"
           }
         ]
       },
@@ -47,8 +46,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where 1 != 1) as a where 1 != 1",
-            "Query": "select count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a",
-            "Table": "`user`, user_extra"
+            "Query": "select count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a"
           }
         ]
       },
@@ -72,8 +70,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from (select `user`.col, user_extra.extra from `user`, user_extra where 1 != 1) as a where 1 != 1",
-        "Query": "select col from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a",
-        "Table": "`user`, user_extra"
+        "Query": "select col from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a"
       },
       "TablesUsed": [
         "user.user",
@@ -102,8 +99,7 @@
             },
             "FieldQuery": "select col, count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where 1 != 1) as a where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col, count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a group by col order by col asc",
-            "Table": "`user`, user_extra"
+            "Query": "select col, count(*) from (select `user`.col, user_extra.extra from `user`, user_extra where `user`.id = user_extra.user_id) as a group by col order by col asc"
           }
         ]
       },
@@ -134,7 +130,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -144,8 +139,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select sum(col) from (select `user`.col as col, 32 from `user` where 1 != 1) as t where 1 != 1",
-                    "Query": "select sum(col) from (select `user`.col as col, 32 from `user`) as t",
-                    "Table": "`user`"
+                    "Query": "select sum(col) from (select `user`.col as col, 32 from `user`) as t"
                   },
                   {
                     "OperatorType": "Route",
@@ -155,8 +149,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
-                    "Query": "select count(*) from user_extra group by .0",
-                    "Table": "user_extra"
+                    "Query": "select count(*) from user_extra group by .0"
                   }
                 ]
               }
@@ -197,8 +190,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select x.phone, x.id, x.city from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.phone, x.id, x.city from (select phone, id, city from `user` where id > 12) as x limit 10",
-                    "Table": "`user`"
+                    "Query": "select x.phone, x.id, x.city from (select phone, id, city from `user` where id > 12) as x limit 10"
                   }
                 ]
               }
@@ -238,8 +230,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where id > 12) as x limit 10",
-                    "Table": "`user`"
+                    "Query": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where id > 12) as x limit 10"
                   }
                 ]
               }
@@ -274,7 +265,6 @@
                 "JoinVars": {
                   "user_id": 0
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Limit",
@@ -288,8 +278,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select x.`user.id` from (select `user`.id as `user.id` from `user` where 1 != 1) as x where 1 != 1",
-                        "Query": "select x.`user.id` from (select `user`.id as `user.id` from `user`) as x limit 10",
-                        "Table": "`user`"
+                        "Query": "select x.`user.id` from (select `user`.id as `user.id` from `user`) as x limit 10"
                       }
                     ]
                   },
@@ -305,8 +294,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select x.col from (select user_extra.col as col from user_extra where 1 != 1) as x where 1 != 1",
-                        "Query": "select x.col from (select user_extra.col as col from user_extra where user_extra.id = :user_id) as x limit 10",
-                        "Table": "user_extra"
+                        "Query": "select x.col from (select user_extra.col as col from user_extra where user_extra.id = :user_id) as x limit 10"
                       }
                     ]
                   }
@@ -352,8 +340,7 @@
                     },
                     "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
                     "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
-                    "Table": "`user`"
+                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2"
                   }
                 ]
               }
@@ -390,8 +377,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-                "Query": "select id, count(*) from `user`",
-                "Table": "`user`"
+                "Query": "select id, count(*) from `user`"
               }
             ]
           }
@@ -429,8 +415,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select sum(a) as a, sum(b) as b from `user` where 1 != 1",
-                "Query": "select sum(a) as a, sum(b) as b from `user`",
-                "Table": "`user`"
+                "Query": "select sum(a) as a, sum(b) as b from `user`"
               }
             ]
           }
@@ -455,8 +440,7 @@
           "Sharded": true
         },
         "FieldQuery": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where 1 != 1 group by user_id, flowId) as t1 where 1 != 1",
-        "Query": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where localDate > :v1 group by user_id, flowId) as t1 where `count` >= :v2",
-        "Table": "user_extra"
+        "Query": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where localDate > :v1 group by user_id, flowId) as t1 where `count` >= :v2"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -490,8 +474,7 @@
                 },
                 "FieldQuery": "select foo, max(baz) as bazo, weight_string(foo), weight_string(max(baz)) from (select foo, baz from `user` where 1 != 1) as f where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, max(baz) as bazo, weight_string(foo), weight_string(max(baz)) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, max(baz) as bazo, weight_string(foo), weight_string(max(baz)) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -529,8 +512,7 @@
                 },
                 "FieldQuery": "select foo, count(baz) as bazo, weight_string(foo) from (select foo, baz from `user` where 1 != 1) as f where 1 != 1 group by foo, weight_string(foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, count(baz) as bazo, weight_string(foo) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc",
-                "Table": "`user`"
+                "Query": "select foo, count(baz) as bazo, weight_string(foo) from (select foo, baz from `user`) as f group by foo, weight_string(foo) order by foo asc"
               }
             ]
           }
@@ -559,7 +541,6 @@
             "JoinVars": {
               "d_id": 1
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -585,8 +566,7 @@
                             },
                             "FieldQuery": "select id, count(*) as a, weight_string(id) from `user` where 1 != 1",
                             "OrderBy": "1 ASC, (0|2) ASC",
-                            "Query": "select id, count(*) as a, weight_string(id) from `user` order by count(*) asc, id asc",
-                            "Table": "`user`"
+                            "Query": "select id, count(*) as a, weight_string(id) from `user` order by count(*) asc, id asc"
                           }
                         ]
                       }
@@ -603,7 +583,6 @@
                 },
                 "FieldQuery": "select 1 from music where 1 != 1 group by .0",
                 "Query": "select 1 from music where music.user_id = :d_id group by .0",
-                "Table": "music",
                 "Values": [
                   ":d_id"
                 ],
@@ -641,8 +620,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select col from `user` where 1 != 1",
-                "Query": "select col from `user`",
-                "Table": "`user`"
+                "Query": "select col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -652,8 +630,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select col from unsharded where 1 != 1",
-                "Query": "select col from unsharded",
-                "Table": "unsharded"
+                "Query": "select col from unsharded"
               }
             ]
           }
@@ -692,8 +669,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select x.id, x.val2 from (select id, val2 from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.id, x.val2 from (select id, val2 from `user` where val2 is null) as x limit 2",
-                    "Table": "`user`"
+                    "Query": "select x.id, x.val2 from (select id, val2 from `user` where val2 is null) as x limit 2"
                   }
                 ]
               }
@@ -734,8 +710,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*), 1 from `user` where 1 != 1",
-                    "Query": "select count(*), 1 from `user`",
-                    "Table": "`user`"
+                    "Query": "select count(*), 1 from `user`"
                   }
                 ]
               }
@@ -763,7 +738,6 @@
         },
         "FieldQuery": "select id from (select id, col from `user` where 1 != 1) as t where 1 != 1",
         "Query": "select id from (select id, col from `user` where id = 5) as t",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -789,7 +763,6 @@
         },
         "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t, user_extra where 1 != 1",
         "Query": "select t.id from (select id from `user` where id = 5) as t, user_extra where t.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -816,7 +789,6 @@
         },
         "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t, user_extra where 1 != 1",
         "Query": "select t.id from (select `user`.id from `user` where `user`.id = 5) as t, user_extra where t.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -843,7 +815,6 @@
         },
         "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t, user_extra where 1 != 1",
         "Query": "select t.id from (select id from `user` where id = 5) as t, user_extra where t.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -868,7 +839,6 @@
         "JoinVars": {
           "t_id": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -879,7 +849,6 @@
             },
             "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t where 1 != 1",
             "Query": "select t.id from (select id from `user` where id = 5) as t",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -893,8 +862,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra where user_extra.col = :t_id",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra where user_extra.col = :t_id"
           }
         ]
       },
@@ -919,7 +887,6 @@
         },
         "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
         "Query": "select id from (select id, col from `user` as route1 where id = 5) as t",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -945,7 +912,6 @@
         },
         "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
         "Query": "select id from (select id, col from `user` as route1 where id = 5) as t",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -975,8 +941,7 @@
           "Sharded": true
         },
         "FieldQuery": "select t.id from (select id, textcol1 as baz from `user` as route1 where 1 != 1) as t, (select id, textcol1 + textcol1 as baz from `user` where 1 != 1) as s where 1 != 1",
-        "Query": "select t.id from (select id, textcol1 as baz from `user` as route1 where textcol1 = '3') as t, (select id, textcol1 + textcol1 as baz from `user` where textcol1 + textcol1 = '3') as s where t.id = s.id",
-        "Table": "`user`"
+        "Query": "select t.id from (select id, textcol1 as baz from `user` as route1 where textcol1 = '3') as t, (select id, textcol1 + textcol1 as baz from `user` where textcol1 + textcol1 = '3') as s where t.id = s.id"
       },
       "TablesUsed": [
         "user.user"
@@ -997,8 +962,7 @@
           "Sharded": true
         },
         "FieldQuery": "select bar from (select foo + 4 as bar from (select colA + colB as foo from `user` where 1 != 1) as u where 1 != 1) as t where 1 != 1",
-        "Query": "select bar from (select foo + 4 as bar from (select colA + colB as foo from `user` where colA + colB + 4 = 5) as u) as t",
-        "Table": "`user`"
+        "Query": "select bar from (select foo + 4 as bar from (select colA + colB as foo from `user` where colA + colB + 4 = 5) as u) as t"
       },
       "TablesUsed": [
         "user.user"
@@ -1020,7 +984,6 @@
         },
         "FieldQuery": "select u.col, e.col from (select col from `user` where 1 != 1) as u, (select col from user_extra where 1 != 1) as e where 1 != 1",
         "Query": "select u.col, e.col from (select col from `user` where id = 5) as u, (select col from user_extra where user_id = 5) as e",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1046,13 +1009,11 @@
           "t_col1": 0,
           "t_id": 1
         },
-        "TableName": "`user`_user_extra_unsharded",
         "Inputs": [
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:1,L:0",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1062,8 +1023,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
-                "Table": "`user`"
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t"
               },
               {
                 "OperatorType": "Route",
@@ -1073,8 +1033,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra"
               }
             ]
           },
@@ -1086,8 +1045,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded where 1 != 1",
-            "Query": "select 1 from unsharded where unsharded.id = :t_id and unsharded.col1 = :t_col1",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded where unsharded.id = :t_id and unsharded.col1 = :t_col1"
           }
         ]
       },
@@ -1111,7 +1069,6 @@
         "JoinVars": {
           "user_col": 2
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1121,8 +1078,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t",
-            "Table": "`user`"
+            "Query": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t"
           },
           {
             "OperatorType": "Route",
@@ -1132,8 +1088,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra where user_extra.col = :user_col /* INT16 */",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra where user_extra.col = :user_col /* INT16 */"
           }
         ]
       },
@@ -1153,7 +1108,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "unsharded_a_`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1163,14 +1117,12 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded_a as ua where 1 != 1",
-            "Query": "select 1 from unsharded_a as ua",
-            "Table": "unsharded_a"
+            "Query": "select 1 from unsharded_a as ua"
           },
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1180,8 +1132,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
-                "Table": "`user`"
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t"
               },
               {
                 "OperatorType": "Route",
@@ -1191,8 +1142,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra"
               }
             ]
           }
@@ -1218,7 +1168,6 @@
         "JoinVars": {
           "ua_id": 0
         },
-        "TableName": "unsharded_a_`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1228,14 +1177,12 @@
               "Sharded": false
             },
             "FieldQuery": "select ua.id from unsharded_a as ua where 1 != 1",
-            "Query": "select ua.id from unsharded_a as ua",
-            "Table": "unsharded_a"
+            "Query": "select ua.id from unsharded_a as ua"
           },
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1246,7 +1193,6 @@
                 },
                 "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
                 "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id) as t",
-                "Table": "`user`",
                 "Values": [
                   ":ua_id"
                 ],
@@ -1260,8 +1206,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra"
               }
             ]
           }
@@ -1284,7 +1229,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1294,8 +1238,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id from (select `user`.id from `user`) as t",
-            "Table": "`user`"
+            "Query": "select t.id from (select `user`.id from `user`) as t"
           },
           {
             "OperatorType": "Route",
@@ -1305,8 +1248,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -1341,8 +1283,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -1367,8 +1308,7 @@
           "Sharded": false
         },
         "FieldQuery": "with u as (select * from unsharded where 1 != 1) select u.* from u where 1 != 1",
-        "Query": "with u as (select * from unsharded) select u.* from u",
-        "Table": "unsharded"
+        "Query": "with u as (select * from unsharded) select u.* from u"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1385,7 +1325,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1396,7 +1335,6 @@
             },
             "FieldQuery": "select t.id, t.col from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
             "Query": "select t.id, t.col from (select `user`.id, `user`.col from `user` where `user`.id = 5) as t",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -1410,8 +1348,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -1431,7 +1368,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1441,8 +1377,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id + 1 from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select id + 1 from (select `user`.id, `user`.col from `user`) as t",
-            "Table": "`user`"
+            "Query": "select id + 1 from (select `user`.id, `user`.col from `user`) as t"
           },
           {
             "OperatorType": "Route",
@@ -1452,8 +1387,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -1490,7 +1424,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -1504,8 +1437,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.a from (select id as b, `name` from `user` where 1 != 1) as u(a, n) where 1 != 1",
-            "Query": "select u.a from (select id as b, `name` from `user` where `name` = 1) as u(a, n)",
-            "Table": "`user`"
+            "Query": "select u.a from (select id as b, `name` from `user` where `name` = 1) as u(a, n)"
           }
         ]
       },
@@ -1541,7 +1473,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -1555,8 +1486,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.a from (select id as b, `name` from `user` where 1 != 1) as u(a, n) where 1 != 1",
-            "Query": "select u.a from (select id as b, `name` from `user` where b = 1 and `name` = 1) as u(a, n)",
-            "Table": "`user`"
+            "Query": "select u.a from (select id as b, `name` from `user` where b = 1 and `name` = 1) as u(a, n)"
           }
         ]
       },
@@ -1575,7 +1505,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1585,8 +1514,7 @@
               "Sharded": true
             },
             "FieldQuery": "select i + 1 from (select `user`.id from `user` where 1 != 1) as t(i) where 1 != 1",
-            "Query": "select i + 1 from (select `user`.id from `user`) as t(i)",
-            "Table": "`user`"
+            "Query": "select i + 1 from (select `user`.id from `user`) as t(i)"
           },
           {
             "OperatorType": "Route",
@@ -1596,8 +1524,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -1620,13 +1547,11 @@
         "JoinVars": {
           "t_col1": 1
         },
-        "TableName": "`user`_unsharded_unsharded",
         "Inputs": [
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_unsharded",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1636,8 +1561,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 0, t.col1 from (select `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select 0, t.col1 from (select `user`.col1 from `user`) as t",
-                "Table": "`user`"
+                "Query": "select 0, t.col1 from (select `user`.col1 from `user`) as t"
               },
               {
                 "OperatorType": "Route",
@@ -1647,8 +1571,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded where 1 != 1",
-                "Query": "select 1 from unsharded",
-                "Table": "unsharded"
+                "Query": "select 1 from unsharded"
               }
             ]
           },
@@ -1660,8 +1583,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded where 1 != 1",
-            "Query": "select 1 from unsharded where unsharded.a = :t_col1 and unsharded.col1 = :t_col1",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded where unsharded.a = :t_col1 and unsharded.col1 = :t_col1"
           }
         ]
       },
@@ -1685,8 +1607,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id2 from (select id from `user` where 1 != 1) as x(id2) where 1 != 1",
-        "Query": "select id2 from (select id from `user`) as x(id2)",
-        "Table": "`user`"
+        "Query": "select id2 from (select id from `user`) as x(id2)"
       },
       "TablesUsed": [
         "user.user"
@@ -1707,8 +1628,7 @@
           "Sharded": false
         },
         "FieldQuery": "with u as (select col from unsharded join unsharded_b where 1 != 1) select col from u join unsharded_a as ua where 1 != 1",
-        "Query": "with u as (select col from unsharded join unsharded_b) select col from u join unsharded_a as ua limit 1",
-        "Table": "unsharded, unsharded_a, unsharded_b"
+        "Query": "with u as (select col from unsharded join unsharded_b) select col from u join unsharded_a as ua limit 1"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -1731,13 +1651,11 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
-            "TableName": "`user`_user_extra_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -1747,8 +1665,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select u.col from (select `user`.col from `user` where 1 != 1) as u where 1 != 1",
-                    "Query": "select u.col from (select `user`.col from `user`) as u",
-                    "Table": "`user`"
+                    "Query": "select u.col from (select `user`.col from `user`) as u"
                   },
                   {
                     "OperatorType": "Route",
@@ -1758,8 +1675,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra"
                   }
                 ]
               },
@@ -1775,8 +1691,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
-                    "Query": "select 1 from user_extra as ue limit 1",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra as ue limit 1"
                   }
                 ]
               }
@@ -1804,8 +1719,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from (select * from `user` where 1 != 1) as x where 1 != 1",
-        "Query": "select * from (select * from `user`) as x",
-        "Table": "`user`"
+        "Query": "select * from (select * from `user`) as x"
       },
       "TablesUsed": [
         "user.user"
@@ -1834,8 +1748,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.c0 as id, dt.c1 as foo, weight_string(dt.c0), weight_string(dt.c1) from (select id, foo from (select id, foo from `user` where 1 != 1) as x where 1 != 1 union select id, foo from (select id, foo from `user` where 1 != 1) as x where 1 != 1) as dt(c0, c1) where 1 != 1",
-            "Query": "select dt.c0 as id, dt.c1 as foo, weight_string(dt.c0), weight_string(dt.c1) from (select id, foo from (select id, foo from `user`) as x union select id, foo from (select id, foo from `user`) as x) as dt(c0, c1)",
-            "Table": "`user`"
+            "Query": "select dt.c0 as id, dt.c1 as foo, weight_string(dt.c0), weight_string(dt.c1) from (select id, foo from (select id, foo from `user`) as x union select id, foo from (select id, foo from `user`) as x) as dt(c0, c1)"
           }
         ]
       },
@@ -1858,8 +1771,7 @@
           "Sharded": false
         },
         "FieldQuery": "with recursive cte(n) as (select 1 from dual where 1 != 1 union all select n + 1 from cte where 1 != 1) select cte.n from unsharded join cte on unsharded.id = cte.n where 1 != 1",
-        "Query": "with recursive cte(n) as (select 1 from dual union all select n + 1 from cte where n < 5) select cte.n from unsharded join cte on unsharded.id = cte.n",
-        "Table": "dual, unsharded"
+        "Query": "with recursive cte(n) as (select 1 from dual union all select n + 1 from cte where n < 5) select cte.n from unsharded join cte on unsharded.id = cte.n"
       },
       "TablesUsed": [
         "main.dual",
@@ -1881,8 +1793,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 'count_a' as tab, num from count_a where 1 != 1 union select 'count_b' as tab, num from count_b where 1 != 1",
-        "Query": "with count_a as (select count(id) as num from unsharded_a) , count_b as (select count(id) as num from unsharded_b) select 'count_a' as tab, num from count_a union select 'count_b' as tab, num from count_b",
-        "Table": "unsharded_a, unsharded_b"
+        "Query": "with count_a as (select count(id) as num from unsharded_a) , count_b as (select count(id) as num from unsharded_b) select 'count_a' as tab, num from count_a union select 'count_b' as tab, num from count_b"
       },
       "TablesUsed": [
         "main.unsharded_a",
@@ -1926,8 +1837,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(user_id) as num from user_metadata where 1 != 1",
-                        "Query": "select count(user_id) as num from user_metadata",
-                        "Table": "user_metadata"
+                        "Query": "select count(user_id) as num from user_metadata"
                       }
                     ]
                   }
@@ -1953,8 +1863,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(user_id) as num from user_extra where 1 != 1",
-                        "Query": "select count(user_id) as num from user_extra",
-                        "Table": "user_extra"
+                        "Query": "select count(user_id) as num from user_extra"
                       }
                     ]
                   }
@@ -2030,8 +1939,7 @@
                                                   "Sharded": true
                                                 },
                                                 "FieldQuery": "select t.id, 1, 1000 from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-                                                "Query": "select t.id, 1, 1000 from (select `user`.id from `user` where `user`.textcol1 = 'open' and `user`.intcol = 1) as t limit :__upper_limit",
-                                                "Table": "`user`"
+                                                "Query": "select t.id, 1, 1000 from (select `user`.id from `user` where `user`.textcol1 = 'open' and `user`.intcol = 1) as t limit :__upper_limit"
                                               }
                                             ]
                                           }
@@ -2066,8 +1974,7 @@
                                                   "Sharded": true
                                                 },
                                                 "FieldQuery": "select t.id, 1, 1000 from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-                                                "Query": "select t.id, 1, 1000 from (select `user`.id from `user` where `user`.textcol1 = 'closed' and `user`.intcol = 1) as t limit :__upper_limit",
-                                                "Table": "`user`"
+                                                "Query": "select t.id, 1, 1000 from (select `user`.id from `user` where `user`.textcol1 = 'closed' and `user`.intcol = 1) as t limit :__upper_limit"
                                               }
                                             ]
                                           }

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -23,8 +23,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update m1 set val = 1",
-        "Table": "m1"
+        "Query": "update m1 set val = 1"
       },
       "TablesUsed": [
         "main.m1"
@@ -45,8 +44,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded set val = 1",
-        "Table": "unsharded"
+        "Query": "update unsharded set val = 1"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -67,8 +65,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded set col = (select col from unsharded limit 1)",
-        "Table": "unsharded"
+        "Query": "update unsharded set col = (select col from unsharded limit 1)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -89,8 +86,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded set col = (select id from unsharded union select id from unsharded)",
-        "Table": "unsharded"
+        "Query": "update unsharded set col = (select id from unsharded union select id from unsharded)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -111,8 +107,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded set col = (select id from unsharded as a join unsharded as b on a.id = b.id)",
-        "Table": "unsharded"
+        "Query": "update unsharded set col = (select id from unsharded as a join unsharded as b on a.id = b.id)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -133,8 +128,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id set col1 = 'asdf' where keepers.id is null and foo.col is not null and foo.col < 1000",
-        "Table": "unsharded"
+        "Query": "update unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id set col1 = 'asdf' where keepers.id is null and foo.col is not null and foo.col < 1000"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -156,7 +150,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` as route1 set a = 1 where id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -181,8 +174,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded_a set a = (select a from unsharded as route2)",
-        "Table": "unsharded, unsharded_a"
+        "Query": "update unsharded_a set a = (select a from unsharded as route2)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -204,8 +196,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from unsharded",
-        "Table": "unsharded"
+        "Query": "delete from unsharded"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -226,8 +217,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from seq",
-        "Table": "seq"
+        "Query": "delete from seq"
       },
       "TablesUsed": [
         "main.seq"
@@ -248,8 +238,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from unsharded_ref",
-        "Table": "unsharded_ref"
+        "Query": "delete from unsharded_ref"
       },
       "TablesUsed": [
         "main.unsharded_ref"
@@ -271,7 +260,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set val = 1 where id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -297,7 +285,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` as user_alias set val = 1 where user_alias.id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -323,7 +310,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set val = 1 where id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -349,7 +335,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set val = 1 where `name` = 'foo' and id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -381,7 +366,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io' from user_metadata where user_id = 1 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1",
-        "Table": "user_metadata",
         "Values": [
           "1"
         ],
@@ -419,7 +403,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io', address = '155 5th street' from user_metadata where user_id = 1 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1",
-        "Table": "user_metadata",
         "Values": [
           "1"
         ],
@@ -451,7 +434,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io' from user_metadata where user_id = 1 order by user_id asc limit 10 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1 order by user_id asc limit 10",
-        "Table": "user_metadata",
         "Values": [
           "1"
         ],
@@ -483,7 +465,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select user_id, music_id = 1 from music_extra where user_id = 1 for update",
         "Query": "update music_extra set music_id = 1 where user_id = 1",
-        "Table": "music_extra",
         "Values": [
           "1"
         ],
@@ -509,7 +490,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set val = 1 where id = id2 and id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -535,7 +515,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set val = 1 where id = 18446744073709551616 and id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -564,7 +543,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id = 1 for update",
         "Query": "delete from `user` where id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -589,8 +567,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete a from unsharded_a as a, unsharded_b as b where a.id = b.id and b.val = 1",
-        "Table": "unsharded_a, unsharded_b"
+        "Query": "delete a from unsharded_a as a, unsharded_b as b where a.id = b.id and b.val = 1"
       },
       "TablesUsed": [
         "main.unsharded_a",
@@ -612,8 +589,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete a from unsharded_a as a join unsharded_b as b on a.id = b.id where b.val = 1",
-        "Table": "unsharded_a, unsharded_b"
+        "Query": "delete a from unsharded_a as a join unsharded_b as b on a.id = b.id where b.val = 1"
       },
       "TablesUsed": [
         "main.unsharded_a",
@@ -635,8 +611,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete foo from unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col < 1000",
-        "Table": "unsharded"
+        "Query": "delete foo from unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col < 1000"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -661,7 +636,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as route1 where id = 1 for update",
         "Query": "delete from `user` as route1 where id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -686,8 +660,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from unsharded_a where a = (select a from unsharded as route2)",
-        "Table": "unsharded, unsharded_a"
+        "Query": "delete from unsharded_a where a = (select a from unsharded as route2)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -710,7 +683,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update music set val = 1 where id = 1",
-        "Table": "music",
         "Values": [
           "1"
         ],
@@ -735,8 +707,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded_a as a join unsharded_b as b on a.id = b.id set a.val = 'foo' where b.val = 1",
-        "Table": "unsharded_a, unsharded_b"
+        "Query": "update unsharded_a as a join unsharded_b as b on a.id = b.id set a.val = 'foo' where b.val = 1"
       },
       "TablesUsed": [
         "main.unsharded_a",
@@ -758,8 +729,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded_a as a, unsharded_b as b set a.val = 'foo' where a.id = b.id and b.val = 1",
-        "Table": "unsharded_a, unsharded_b"
+        "Query": "update unsharded_a as a, unsharded_b as b set a.val = 'foo' where a.id = b.id and b.val = 1"
       },
       "TablesUsed": [
         "main.unsharded_a",
@@ -785,7 +755,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select user_id, id from music where id = 1 for update",
         "Query": "delete from music where id = 1",
-        "Table": "music",
         "Values": [
           "1"
         ],
@@ -811,7 +780,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete from music_extra where user_id = 1",
-        "Table": "music_extra",
         "Values": [
           "1"
         ],
@@ -836,8 +804,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded values ()",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded values ()"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -858,8 +825,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded values (1, 2)",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded values (1, 2)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -880,8 +846,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded values (1, 2) on duplicate key update x = 3",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded values (1, 2) on duplicate key update x = 3"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -903,8 +868,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
-        "Query": "insert into unsharded_authoritative(col1, col2) values (:__seq0, 1)",
-        "TableName": "unsharded_authoritative"
+        "Query": "insert into unsharded_authoritative(col1, col2) values (:__seq0, 1)"
       },
       "TablesUsed": [
         "main.unsharded_authoritative"
@@ -927,7 +891,6 @@
         "TargetTabletType": "PRIMARY",
         "InsertIgnore": true,
         "Query": "insert into music(user_id, id) values (:_user_id_0, :_id_0) on duplicate key update user_id = values(user_id)",
-        "TableName": "music",
         "VindexValues": {
           "music_user_map": "2",
           "user_index": "1"
@@ -954,7 +917,6 @@
         "TargetTabletType": "PRIMARY",
         "InsertIgnore": true,
         "Query": "insert into music(user_id, id) values (:_user_id_0, :_id_0), (:_user_id_1, :_id_1) on duplicate key update user_id = values(user_id)",
-        "TableName": "music",
         "VindexValues": {
           "music_user_map": "2, 4",
           "user_index": "1, 3"
@@ -979,8 +941,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded select id from unsharded_auto",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded select id from unsharded_auto"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -1002,8 +963,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded select id from unsharded join unsharded_auto",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded select id from unsharded join unsharded_auto"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -1026,8 +986,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(18446744073709551616)",
-        "Query": "insert into unsharded_auto(id, val) values (:__seq0, 'aa')",
-        "TableName": "unsharded_auto"
+        "Query": "insert into unsharded_auto(id, val) values (:__seq0, 'aa')"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1049,8 +1008,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
-        "Query": "insert into unsharded_auto(id, val) values (:__seq0, 'aa')",
-        "TableName": "unsharded_auto"
+        "Query": "insert into unsharded_auto(id, val) values (:__seq0, 'aa')"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1072,8 +1030,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
-        "Query": "insert into unsharded_auto(val, id) values ('aa', :__seq0)",
-        "TableName": "unsharded_auto"
+        "Query": "insert into unsharded_auto(val, id) values ('aa', :__seq0)"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1095,8 +1052,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
-        "Query": "insert into unsharded_auto(val, id) values (false, :__seq0)",
-        "TableName": "unsharded_auto"
+        "Query": "insert into unsharded_auto(val, id) values (false, :__seq0)"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1118,8 +1074,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1, null)",
-        "Query": "insert into unsharded_auto(id, val) values (:__seq0, 'aa'), (:__seq1, 'bb')",
-        "TableName": "unsharded_auto"
+        "Query": "insert into unsharded_auto(id, val) values (:__seq0, 'aa'), (:__seq1, 'bb')"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1140,8 +1095,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded values (1, 1)",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded values (1, 1)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1164,7 +1118,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
         "Query": "insert into `user`(id, val, `Name`, Costly) values (:_Id_0, 1, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1192,7 +1145,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
         "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1224,7 +1176,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into authoritative(user_id, col1, col2) values (:_user_id_0, 2, 3)",
-        "TableName": "authoritative",
         "VindexValues": {
           "user_index": "1"
         }
@@ -1250,7 +1201,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
         "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1278,7 +1228,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
         "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1307,7 +1256,6 @@
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
         "InsertIgnore": true,
         "Query": "insert ignore into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1336,7 +1284,6 @@
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
         "InsertIgnore": true,
         "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0) on duplicate key update col = 2",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1364,7 +1311,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(:aa)",
         "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1392,7 +1338,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
         "Query": "insert into `user`(nonid, id, `Name`, Costly) values (2, :_Id_0, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1420,7 +1365,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
         "Query": "insert into `user`(id, nonid, `Name`, Costly) values (:_Id_0, 2, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1448,7 +1392,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
         "Query": "insert into `user`(nonid, id, `Name`, Costly) values (true, :_Id_0, :_Name_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
@@ -1476,7 +1419,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
         "Query": "insert into `user`(nonid, `name`, id, Costly) values (2, :_Name_0, :_Id_0, :_Costly_0)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "'foo'",
@@ -1504,7 +1446,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
         "Query": "insert into user_extra(nonid, extra_id, user_id) values (2, :__seq0, :_user_id_0)",
-        "TableName": "user_extra",
         "VindexValues": {
           "user_index": "null"
         }
@@ -1529,7 +1470,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into `weird``name`(`a``b*c`, `b*c`) values (:_a_b_c_0, 2)",
-        "TableName": "weird`name",
         "VindexValues": {
           "user_index": "1"
         }
@@ -1553,8 +1493,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded select 1 from dual union select 1 from dual",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded select 1 from dual union select 1 from dual"
       },
       "TablesUsed": [
         "main.dual",
@@ -1578,7 +1517,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(18446744073709551616)",
         "Query": "insert into user_extra(nonid, extra_id, user_id) values (2, :__seq0, :_user_id_0)",
-        "TableName": "user_extra",
         "VindexValues": {
           "user_index": "null"
         }
@@ -1603,7 +1541,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into music_extra(music_id, user_id) values (:_music_id_0, :_user_id_0)",
-        "TableName": "music_extra",
         "VindexValues": {
           "music_user_map": "1",
           "user_index": "18446744073709551616"
@@ -1640,7 +1577,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1, 2)",
         "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0), (:_Id_1, :_Name_1, :_Costly_1)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null, null",
           "name_user_map": "null, null",
@@ -1669,7 +1605,6 @@
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1, 2)",
         "Query": "insert /*vt+ QUERY_TIMEOUT_MS=1 */ into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0), (:_Id_1, :_Name_1, :_Costly_1)",
         "QueryTimeout": 1,
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null, null",
           "name_user_map": "null, null",
@@ -1698,7 +1633,6 @@
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1, 2)",
         "MultiShardAutocommit": true,
         "Query": "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0), (:_Id_1, :_Name_1, :_Costly_1)",
-        "TableName": "user",
         "VindexValues": {
           "costly_map": "null, null",
           "name_user_map": "null, null",
@@ -1729,8 +1663,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "replace into unsharded values (1, 2)",
-        "TableName": "unsharded"
+        "Query": "replace into unsharded values (1, 2)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1751,8 +1684,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "replace into unsharded select id from unsharded_auto",
-        "TableName": "unsharded"
+        "Query": "replace into unsharded select id from unsharded_auto"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -1775,8 +1707,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(18446744073709551616)",
-        "Query": "replace into unsharded_auto(id, val) values (:__seq0, 'aa')",
-        "TableName": "unsharded_auto"
+        "Query": "replace into unsharded_auto(id, val) values (:__seq0, 'aa')"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1798,8 +1729,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
-        "Query": "replace into unsharded_auto(id, val) values (:__seq0, 'aa')",
-        "TableName": "unsharded_auto"
+        "Query": "replace into unsharded_auto(id, val) values (:__seq0, 'aa')"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1821,8 +1751,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
-        "Query": "replace into unsharded_auto(val, id) values ('aa', :__seq0)",
-        "TableName": "unsharded_auto"
+        "Query": "replace into unsharded_auto(val, id) values ('aa', :__seq0)"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1844,8 +1773,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1, null)",
-        "Query": "replace into unsharded_auto(id, val) values (:__seq0, 'aa'), (:__seq1, 'bb')",
-        "TableName": "unsharded_auto"
+        "Query": "replace into unsharded_auto(id, val) values (:__seq0, 'aa'), (:__seq1, 'bb')"
       },
       "TablesUsed": [
         "main.unsharded_auto"
@@ -1872,7 +1800,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into multicolvin(column_a, column_b, column_c, kid) values (:_column_a_0, :_column_b_0, :_column_c_0, :_kid_0)",
-        "TableName": "multicolvin",
         "VindexValues": {
           "cola_map": "1",
           "colb_colc_map": "2, 3",
@@ -1899,7 +1826,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into overlap_vindex(kid, column_a, column_b) values (:_kid_0, :_column_a_0, 3)",
-        "TableName": "overlap_vindex",
         "VindexValues": {
           "cola_kid_map": "2, 1",
           "kid_index": "1"
@@ -1925,7 +1851,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into multicolvin(column_a, column_b, column_c, kid) values (:_column_a_0, :_column_b_0, :_column_c_0, :_kid_0), (:_column_a_1, :_column_b_1, :_column_c_1, :_kid_1)",
-        "TableName": "multicolvin",
         "VindexValues": {
           "cola_map": "1, 5",
           "colb_colc_map": "2, 6, 3, 7",
@@ -1955,7 +1880,6 @@
         "KsidVindex": "kid_index",
         "OwnedVindexQuery": "select kid, column_a, column_b, column_c from multicolvin where kid = 1 for update",
         "Query": "delete from multicolvin where kid = 1",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -1987,7 +1911,6 @@
         "KsidVindex": "kid_index",
         "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_b = 1 and column_c = 2 from multicolvin where kid = 1 for update",
         "Query": "update multicolvin set column_b = 1, column_c = 2 where kid = 1",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -2020,7 +1943,6 @@
         "KsidVindex": "kid_index",
         "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_a = 0, column_b = 1 and column_c = 2 from multicolvin where kid = 1 for update",
         "Query": "update multicolvin set column_a = 0, column_b = 1, column_c = 2 where kid = 1",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -2045,8 +1967,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1",
-        "Table": "user_extra"
+        "Query": "update user_extra set val = 1"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2067,8 +1988,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1",
-        "Table": "user_extra"
+        "Query": "update user_extra set val = 1"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2090,8 +2010,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "MultiShardAutocommit": true,
-        "Query": "update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ user_extra set val = 1",
-        "Table": "user_extra"
+        "Query": "update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ user_extra set val = 1"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2113,8 +2032,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update /*vt+ QUERY_TIMEOUT_MS=1 */ user_extra set val = 1",
-        "QueryTimeout": 1,
-        "Table": "user_extra"
+        "QueryTimeout": 1
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2135,8 +2053,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1 where id between 1 and 2",
-        "Table": "user_extra"
+        "Query": "update user_extra set val = 1 where id between 1 and 2"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2158,7 +2075,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update user_extra set val = 1 where user_id in ::__vals",
-        "Table": "user_extra",
         "Values": [
           "(1, 2)"
         ],
@@ -2183,8 +2099,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1 where `name` = 'foo'",
-        "Table": "user_extra"
+        "Query": "update user_extra set val = 1 where `name` = 'foo'"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2205,8 +2120,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1 where id in (1, 2)",
-        "Table": "user_extra"
+        "Query": "update user_extra set val = 1 where id in (1, 2)"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2227,8 +2141,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1 where `name` = 'foo' or id = 1",
-        "Table": "user_extra"
+        "Query": "update user_extra set val = 1 where `name` = 'foo' or id = 1"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2249,8 +2162,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from user_extra",
-        "Table": "user_extra"
+        "Query": "delete from user_extra"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2271,8 +2183,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from user_extra",
-        "Table": "user_extra"
+        "Query": "delete from user_extra"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2293,8 +2204,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from user_extra where user_id between 1 and 2",
-        "Table": "user_extra"
+        "Query": "delete from user_extra where user_id between 1 and 2"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2315,8 +2225,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from user_extra where `name` = 'jose'",
-        "Table": "user_extra"
+        "Query": "delete from user_extra where `name` = 'jose'"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2338,8 +2247,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "MultiShardAutocommit": true,
-        "Query": "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where `name` = 'jose'",
-        "Table": "user_extra"
+        "Query": "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where `name` = 'jose'"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2361,8 +2269,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete /*vt+ QUERY_TIMEOUT_MS=1 */ from user_extra where `name` = 'jose'",
-        "QueryTimeout": 1,
-        "Table": "user_extra"
+        "QueryTimeout": 1
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2384,7 +2291,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete from user_extra where user_id in ::__vals",
-        "Table": "user_extra",
         "Values": [
           "(1, 2)"
         ],
@@ -2409,8 +2315,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)",
-        "Table": "unsharded, unsharded_a, unsharded_b"
+        "Query": "update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -2433,8 +2338,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from unsharded where col = (select id from unsharded_a where id = unsharded.col)",
-        "Table": "unsharded, unsharded_a"
+        "Query": "delete from unsharded where col = (select id from unsharded_a where id = unsharded.col)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -2463,7 +2367,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id = 1 for update",
         "Query": "update `user` set `name` = null where id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -2488,8 +2391,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded values (:__lastInsertId, 2)",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded values (:__lastInsertId, 2)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2517,7 +2419,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id in (1, 2, 3) for update",
         "Query": "update `user` set `name` = null where id in ::__vals",
-        "Table": "user",
         "Values": [
           "(1, 2, 3)"
         ],
@@ -2548,8 +2449,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` for update",
-        "Query": "update `user` set `name` = null",
-        "Table": "user"
+        "Query": "update `user` set `name` = null"
       },
       "TablesUsed": [
         "user.user"
@@ -2576,8 +2476,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id + 1 = 2 for update",
-        "Query": "update `user` set `name` = null where id + 1 = 2",
-        "Table": "user"
+        "Query": "update `user` set `name` = null where id + 1 = 2"
       },
       "TablesUsed": [
         "user.user"
@@ -2602,7 +2501,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id in (1, 2, 3) for update",
         "Query": "delete from `user` where id in ::__vals",
-        "Table": "user",
         "Values": [
           "(1, 2, 3)"
         ],
@@ -2630,8 +2528,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id + 1 = 2 for update",
-        "Query": "delete from `user` where id + 1 = 2",
-        "Table": "user"
+        "Query": "delete from `user` where id + 1 = 2"
       },
       "TablesUsed": [
         "user.user"
@@ -2655,8 +2552,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
-        "Query": "delete from `user`",
-        "Table": "user"
+        "Query": "delete from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -2681,7 +2577,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select user_id, id from music where id = 1 for update",
         "Query": "delete from music where id = 1",
-        "Table": "music",
         "Values": [
           "1"
         ],
@@ -2706,8 +2601,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update `user` set val = 1",
-        "Table": "user"
+        "Query": "update `user` set val = 1"
       },
       "TablesUsed": [
         "user.user"
@@ -2731,8 +2625,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
-        "Query": "delete from `user`",
-        "Table": "user"
+        "Query": "delete from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -2760,7 +2653,6 @@
         "KsidVindex": "kid_index",
         "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_c = 2 from multicolvin where kid = 1 for update",
         "Query": "update multicolvin set column_c = 2 where kid = 1",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -2792,7 +2684,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = _binary 'abc' from `user` where id = 1 for update",
         "Query": "update `user` set `name` = _binary 'abc' where id = 1",
-        "Table": "user",
         "Values": [
           "1"
         ],
@@ -2821,7 +2712,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `name` = _binary 'abc' for update",
         "Query": "delete from `user` where `name` = _binary 'abc'",
-        "Table": "user",
         "Values": [
           "'abc'"
         ],
@@ -2849,8 +2739,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
-        "Query": "delete from `user`",
-        "Table": "user"
+        "Query": "delete from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -2877,8 +2766,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = 'myname' from `user` for update",
-        "Query": "update `user` set `name` = 'myname'",
-        "Table": "user"
+        "Query": "update `user` set `name` = 'myname'"
       },
       "TablesUsed": [
         "user.user"
@@ -2899,8 +2787,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update user_extra set val = 1",
-        "Table": "user_extra"
+        "Query": "update user_extra set val = 1"
       },
       "TablesUsed": [
         "user.user_extra"
@@ -2924,8 +2811,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id * `user`.col = `user`.foo for update",
-        "Query": "delete from `user` where `user`.id * `user`.col = `user`.foo",
-        "Table": "user"
+        "Query": "delete from `user` where `user`.id * `user`.col = `user`.foo"
       },
       "TablesUsed": [
         "user.user"
@@ -2961,8 +2847,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into user_privacy_consents(user_id, accepted_at) select user_id, accepted_at from (select 1 as user_id, 1629194864 as accepted_at from dual) as tmp where not exists (select 1 from user_privacy_consents where user_id = 1)",
-        "TableName": "user_privacy_consents"
+        "Query": "insert into user_privacy_consents(user_id, accepted_at) select user_id, accepted_at from (select 1 as user_id, 1629194864 as accepted_at from dual) as tmp where not exists (select 1 from user_privacy_consents where user_id = 1)"
       },
       "TablesUsed": [
         "main.dual",
@@ -2987,8 +2872,7 @@
         "KsidLength": 1,
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 20 for update",
-        "Query": "delete from t1 where c2 = 20",
-        "Table": "t1"
+        "Query": "delete from t1 where c2 = 20"
       },
       "TablesUsed": [
         "zlookup_unique.t1"
@@ -3015,8 +2899,7 @@
         "KsidLength": 1,
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 20 for update",
-        "Query": "update t1 set c2 = 1 where c2 = 20",
-        "Table": "t1"
+        "Query": "update t1 set c2 = 1 where c2 = 20"
       },
       "TablesUsed": [
         "zlookup_unique.t1"
@@ -3041,7 +2924,6 @@
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 10 and c3 = 20 for update",
         "Query": "delete from t1 where c2 = 10 and c3 = 20",
-        "Table": "t1",
         "Values": [
           "20"
         ],
@@ -3073,7 +2955,6 @@
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 10 and c3 = 20 for update",
         "Query": "update t1 set c2 = 1 where c2 = 10 and c3 = 20",
-        "Table": "t1",
         "Values": [
           "20"
         ],
@@ -3102,7 +2983,6 @@
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 10 and c3 in (20, 21) for update",
         "Query": "delete from t1 where c2 = 10 and c3 in ::__vals",
-        "Table": "t1",
         "Values": [
           "(20, 21)"
         ],
@@ -3134,7 +3014,6 @@
         "KsidVindex": "xxhash",
         "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 10 and c3 in (20, 21) for update",
         "Query": "update t1 set c2 = 1 where c2 = 10 and c3 in ::__vals",
-        "Table": "t1",
         "Values": [
           "(20, 21)"
         ],
@@ -3165,8 +3044,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly, u.`name` = 'john' from `user` as u where u.col > 20 for update",
-        "Query": "update `user` as u set u.`name` = 'john' where u.col > 20",
-        "Table": "user"
+        "Query": "update `user` as u set u.`name` = 'john' where u.col > 20"
       },
       "TablesUsed": [
         "user.user"
@@ -3190,8 +3068,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as u where u.col > 20 for update",
-        "Query": "delete from `user` as u where u.col > 20",
-        "Table": "user"
+        "Query": "delete from `user` as u where u.col > 20"
       },
       "TablesUsed": [
         "user.user"
@@ -3213,7 +3090,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update multicol_tbl set x = 1 where cola = 1 and colb = 2",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "2"
@@ -3240,7 +3116,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update multicol_tbl set x = 1 where colb = 2 and cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "2"
@@ -3267,7 +3142,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update multicol_tbl set x = 1 where colb in ::__vals1 and cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "(1, 2)"
@@ -3294,7 +3168,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update multicol_tbl set x = 1 where colb in ::__vals1 and cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(3, 4)",
           "(1, 2)"
@@ -3324,7 +3197,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola = 1 and colb = 2 for update",
         "Query": "delete from multicol_tbl where cola = 1 and colb = 2",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "2"
@@ -3354,7 +3226,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb = 2 and cola = 1 for update",
         "Query": "delete from multicol_tbl where colb = 2 and cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "2"
@@ -3384,7 +3255,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb in (1, 2) and cola = 1 for update",
         "Query": "delete from multicol_tbl where colb in ::__vals1 and cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "(1, 2)"
@@ -3414,7 +3284,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb in (1, 2) and cola in (3, 4) for update",
         "Query": "delete from multicol_tbl where colb in ::__vals1 and cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(3, 4)",
           "(1, 2)"
@@ -3447,7 +3316,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name`, colc = 1 from multicol_tbl where cola = 1 and colb = 2 for update",
         "Query": "update multicol_tbl set colc = 1 where cola = 1 and colb = 2",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "2"
@@ -3474,7 +3342,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update multicol_tbl set x = 42 where `name` = 'foo'",
-        "Table": "multicol_tbl",
         "Values": [
           "'foo'"
         ],
@@ -3500,7 +3367,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update multicol_tbl set x = 42 where cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1"
         ],
@@ -3532,7 +3398,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name`, `name` = 'bar' from multicol_tbl where cola = 1 for update",
         "Query": "update multicol_tbl set `name` = 'bar' where cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1"
         ],
@@ -3564,7 +3429,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name`, `name` = 'bar' from multicol_tbl where cola in (1, 2) for update",
         "Query": "update multicol_tbl set `name` = 'bar' where cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(1, 2)"
         ],
@@ -3590,7 +3454,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update multicol_tbl set x = 1 where `name` = 'foo' and cola = 2",
-        "Table": "multicol_tbl",
         "Values": [
           "'foo'"
         ],
@@ -3619,7 +3482,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' for update",
         "Query": "delete from multicol_tbl where `name` = 'foo'",
-        "Table": "multicol_tbl",
         "Values": [
           "'foo'"
         ],
@@ -3648,7 +3510,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola = 1 for update",
         "Query": "delete from multicol_tbl where cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1"
         ],
@@ -3677,7 +3538,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola in (1, 2) for update",
         "Query": "delete from multicol_tbl where cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(1, 2)"
         ],
@@ -3706,7 +3566,6 @@
         "KsidVindex": "multicolIdx",
         "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' and cola = 2 for update",
         "Query": "delete from multicol_tbl where `name` = 'foo' and cola = 2",
-        "Table": "multicol_tbl",
         "Values": [
           "'foo'"
         ],
@@ -3731,7 +3590,6 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "TableName": "music",
         "VindexOffsetFromSelect": {
           "music_user_map": "[0]",
           "user_index": "[1]"
@@ -3745,8 +3603,7 @@
               "Sharded": true
             },
             "FieldQuery": "select * from `user` where 1 != 1",
-            "Query": "select * from `user` lock in share mode",
-            "Table": "`user`"
+            "Query": "select * from `user` lock in share mode"
           }
         ]
       },
@@ -3786,7 +3643,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(1)",
-        "TableName": "user_extra",
         "VindexOffsetFromSelect": {
           "user_index": "[0]"
         },
@@ -3799,8 +3655,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` lock in share mode",
-            "Table": "`user`"
+            "Query": "select id from `user` lock in share mode"
           }
         ]
       },
@@ -3825,7 +3680,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(2)",
-        "TableName": "user_extra",
         "VindexOffsetFromSelect": {
           "user_index": "[1]"
         },
@@ -3838,8 +3692,7 @@
               "Sharded": true
             },
             "FieldQuery": "select null, id from `user` where 1 != 1",
-            "Query": "select null, id from `user` lock in share mode",
-            "Table": "`user`"
+            "Query": "select null, id from `user` lock in share mode"
           }
         ]
       },
@@ -3864,7 +3717,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(0)",
-        "TableName": "user",
         "VindexOffsetFromSelect": {
           "costly_map": "[-1]",
           "name_user_map": "[-1]",
@@ -3879,8 +3731,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from dual where 1 != 1",
-            "Query": "select 1 from dual lock in share mode",
-            "Table": "dual"
+            "Query": "select 1 from dual lock in share mode"
           }
         ]
       },
@@ -3905,7 +3756,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(1)",
-        "TableName": "user",
         "VindexOffsetFromSelect": {
           "costly_map": "[-1]",
           "name_user_map": "[-1]",
@@ -3920,8 +3770,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from dual where 1 != 1",
-            "Query": "select 1 from dual lock in share mode",
-            "Table": "dual"
+            "Query": "select 1 from dual lock in share mode"
           }
         ]
       },
@@ -3951,7 +3800,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(2)",
-        "TableName": "user_extra",
         "VindexOffsetFromSelect": {
           "user_index": "[0]"
         },
@@ -3964,8 +3812,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col1, col2 from `user` where 1 != 1",
-            "Query": "select col1, col2 from `user` lock in share mode",
-            "Table": "`user`"
+            "Query": "select col1, col2 from `user` lock in share mode"
           }
         ]
       },
@@ -3989,8 +3836,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into unsharded(col) select col from unsharded_auto",
-        "TableName": "unsharded"
+        "Query": "insert into unsharded(col) select col from unsharded_auto"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -4013,7 +3859,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(2)",
-        "TableName": "user_extra",
         "VindexOffsetFromSelect": {
           "user_index": "[0]"
         },
@@ -4026,8 +3871,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col1, col2 from t1 where 1 != 1",
-            "Query": "select col1, col2 from t1 lock in share mode",
-            "Table": "t1"
+            "Query": "select col1, col2 from t1 lock in share mode"
           }
         ]
       },
@@ -4052,7 +3896,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(2)",
-        "TableName": "user_extra",
         "VindexOffsetFromSelect": {
           "user_index": "[0]"
         },
@@ -4065,8 +3908,7 @@
               "Sharded": false
             },
             "FieldQuery": "select col1, col2 from unsharded_tab where 1 != 1",
-            "Query": "select col1, col2 from unsharded_tab lock in share mode",
-            "Table": "unsharded_tab"
+            "Query": "select col1, col2 from unsharded_tab lock in share mode"
           }
         ]
       },
@@ -4090,7 +3932,6 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "TableName": "unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4100,8 +3941,7 @@
               "Sharded": false
             },
             "FieldQuery": "select col from unsharded_tab where 1 != 1",
-            "Query": "select col from unsharded_tab lock in share mode",
-            "Table": "unsharded_tab"
+            "Query": "select col from unsharded_tab lock in share mode"
           }
         ]
       },
@@ -4125,7 +3965,6 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "TableName": "unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4135,8 +3974,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from t1 where 1 != 1",
-            "Query": "select col from t1 lock in share mode",
-            "Table": "t1"
+            "Query": "select col from t1 lock in share mode"
           }
         ]
       },
@@ -4168,8 +4006,7 @@
               "Sharded": false
             },
             "FieldQuery": "select id from unsharded where 1 != 1",
-            "Query": "select id from unsharded lock in share mode",
-            "Table": "unsharded"
+            "Query": "select id from unsharded lock in share mode"
           },
           {
             "InputName": "Outer",
@@ -4180,8 +4017,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update `user` set col = :__sq1",
-            "Table": "user"
+            "Query": "update `user` set col = :__sq1"
           }
         ]
       },
@@ -4213,8 +4049,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` lock in share mode",
-            "Table": "`user`"
+            "Query": "select id from `user` lock in share mode"
           },
           {
             "InputName": "Outer",
@@ -4225,8 +4060,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update unsharded set col = :__sq1",
-            "Table": "unsharded"
+            "Query": "update unsharded set col = :__sq1"
           }
         ]
       },
@@ -4257,7 +4091,6 @@
             "JoinVars": {
               "unsharded_id": 0
             },
-            "TableName": "unsharded_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -4267,8 +4100,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-                "Query": "select unsharded.id from unsharded lock in share mode",
-                "Table": "unsharded"
+                "Query": "select unsharded.id from unsharded lock in share mode"
               },
               {
                 "OperatorType": "Route",
@@ -4279,7 +4111,6 @@
                 },
                 "FieldQuery": "select id from `user` where 1 != 1",
                 "Query": "select id from `user` where `user`.id = :unsharded_id lock in share mode",
-                "Table": "`user`",
                 "Values": [
                   ":unsharded_id"
                 ],
@@ -4296,8 +4127,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update unsharded set col = :__sq1",
-            "Table": "unsharded"
+            "Query": "update unsharded set col = :__sq1"
           }
         ]
       },
@@ -4322,7 +4152,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set col = (select count(*) from user_extra where user_extra.user_id = 5) where id = 5",
-        "Table": "user",
         "Values": [
           "5"
         ],
@@ -4349,7 +4178,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set col = (select count(*) from user_extra where user_extra.user_id = `user`.id) where id = 5",
-        "Table": "user",
         "Values": [
           "5"
         ],
@@ -4375,8 +4203,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update `user` set col = (select count(*) from user_extra where user_extra.user_id = `user`.id) where id > 5",
-        "Table": "user"
+        "Query": "update `user` set col = (select count(*) from user_extra where user_extra.user_id = `user`.id) where id > 5"
       },
       "TablesUsed": [
         "user.user",
@@ -4399,7 +4226,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into authoritative(user_id) values (:_user_id_0)",
-        "TableName": "authoritative",
         "VindexValues": {
           "user_index": "null"
         }
@@ -4435,8 +4261,7 @@
             "KsidLength": 1,
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
-            "Query": "delete from `user`",
-            "Table": "user"
+            "Query": "delete from `user`"
           }
         ]
       },
@@ -4466,8 +4291,7 @@
             "KsidLength": 1,
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
-            "Query": "delete from `user`",
-            "Table": "user"
+            "Query": "delete from `user`"
           }
         ]
       },
@@ -4490,8 +4314,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete foo from unsharded as foo join (select id from unsharded as a join unsharded_b as b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col < 1000",
-        "Table": "unsharded, unsharded_b"
+        "Query": "delete foo from unsharded as foo join (select id from unsharded as a join unsharded_b as b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col < 1000"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -4514,7 +4337,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update `user` set col = 1 where (`name`, col) in (('aa', 'bb'), ('cc', 'dd'))",
-        "Table": "user",
         "Values": [
           "('aa', 'cc')"
         ],
@@ -4543,7 +4365,6 @@
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where (`name`, col) in (('aa', 'bb'), ('cc', 'dd')) for update",
         "Query": "delete from `user` where (`name`, col) in (('aa', 'bb'), ('cc', 'dd'))",
-        "Table": "user",
         "Values": [
           "('aa', 'cc')"
         ],
@@ -4568,8 +4389,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into ref(col) values (1)",
-        "TableName": "ref"
+        "Query": "insert into ref(col) values (1)"
       },
       "TablesUsed": [
         "user.ref"
@@ -4590,8 +4410,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update m1 set foo = last_insert_id(foo + 1) where id = 12345",
-        "Table": "m1"
+        "Query": "update m1 set foo = last_insert_id(foo + 1) where id = 12345"
       },
       "TablesUsed": [
         "main.m1"
@@ -4613,8 +4432,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update /*vt+ QUERY_TIMEOUT_MS=1 */ unsharded set val = 1",
-        "QueryTimeout": 1,
-        "Table": "unsharded"
+        "QueryTimeout": 1
       },
       "TablesUsed": [
         "main.unsharded"
@@ -4636,8 +4454,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*vt+ QUERY_TIMEOUT_MS=1 */ into unsharded values ()",
-        "QueryTimeout": 1,
-        "TableName": "unsharded"
+        "QueryTimeout": 1
       },
       "TablesUsed": [
         "main.unsharded"
@@ -4659,7 +4476,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "InputAsNonStreaming": true,
-        "TableName": "music",
         "VindexOffsetFromSelect": {
           "music_user_map": "[0]",
           "user_index": "[1]"
@@ -4674,7 +4490,6 @@
             },
             "FieldQuery": "select id, user_id from music where 1 != 1",
             "Query": "select id, user_id from music where user_id = 1 lock in share mode",
-            "Table": "music",
             "Values": [
               "1"
             ],
@@ -4703,7 +4518,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null, null, null)",
         "Query": "insert into mixed_tbl(shard_key, lkp_key) values (:_shard_key_0, :_lkp_key_0), (:_shard_key_1, :_lkp_key_1), (:_shard_key_2, :_lkp_key_2)",
-        "TableName": "mixed_tbl",
         "VindexValues": {
           "lkp_shard_map": ":__seq0, :__seq1, :__seq2",
           "shard_index": "1, 4, 9"
@@ -4730,7 +4544,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1, null, 27)",
         "Query": "insert into mixed_tbl(shard_key, lkp_key) values (:_shard_key_0, :_lkp_key_0), (:_shard_key_1, :_lkp_key_1), (:_shard_key_2, :_lkp_key_2)",
-        "TableName": "mixed_tbl",
         "VindexValues": {
           "lkp_shard_map": ":__seq0, :__seq1, :__seq2",
           "shard_index": "1, 4, 9"
@@ -4756,7 +4569,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(1)",
-        "TableName": "mixed_tbl",
         "VindexOffsetFromSelect": {
           "lkp_shard_map": "[1]",
           "shard_index": "[0]"
@@ -4771,7 +4583,6 @@
             },
             "FieldQuery": "select foo from `user` where 1 != 1",
             "Query": "select foo from `user` where id = 1 lock in share mode",
-            "Table": "`user`",
             "Values": [
               "1"
             ],
@@ -4800,7 +4611,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(1)",
-        "TableName": "mixed_tbl",
         "VindexOffsetFromSelect": {
           "lkp_shard_map": "[1]",
           "shard_index": "[0]"
@@ -4815,7 +4625,6 @@
             },
             "FieldQuery": "select foo, bar from `user` where 1 != 1",
             "Query": "select foo, bar from `user` where id = 1 lock in share mode",
-            "Table": "`user`",
             "Values": [
               "1"
             ],
@@ -4850,7 +4659,6 @@
         "TargetTabletType": "PRIMARY",
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Offset(0)",
         "InputAsNonStreaming": true,
-        "TableName": "user",
         "VindexOffsetFromSelect": {
           "costly_map": "[-1]",
           "name_user_map": "[-1]",
@@ -4865,8 +4673,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` lock in share mode",
-            "Table": "`user`"
+            "Query": "select id from `user` lock in share mode"
           }
         ]
       },
@@ -4916,7 +4723,6 @@
         "TargetTabletType": "PRIMARY",
         "InsertIgnore": true,
         "Query": "insert into music(id, user_id, col) values (:_id_0, :_user_id_0, 3) on duplicate key update music.col = 5",
-        "TableName": "music",
         "VindexValues": {
           "music_user_map": "1",
           "user_index": "2"
@@ -4941,8 +4747,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from source_of_ref where col = 1",
-        "Table": "source_of_ref"
+        "Query": "delete from source_of_ref where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -4963,8 +4768,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from ref",
-        "Table": "ref"
+        "Query": "delete from ref"
       },
       "TablesUsed": [
         "user.ref"
@@ -4988,8 +4792,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select Id, `Name`, Costly from `user` limit 20 for update",
-        "Query": "delete from `user` limit 20",
-        "Table": "user"
+        "Query": "delete from `user` limit 20"
       },
       "TablesUsed": [
         "user.user"
@@ -5013,8 +4816,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u, ref_with_source as r where u.col = r.col for update",
-        "Query": "delete u from `user` as u, ref_with_source as r where u.col = r.col",
-        "Table": "user"
+        "Query": "delete u from `user` as u, ref_with_source as r where u.col = r.col"
       },
       "TablesUsed": [
         "user.ref_with_source",
@@ -5039,8 +4841,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u, music as m where u.id = m.user_id for update",
-        "Query": "delete u from `user` as u, music as m where u.id = m.user_id",
-        "Table": "user"
+        "Query": "delete u from `user` as u, music as m where u.id = m.user_id"
       },
       "TablesUsed": [
         "user.music",
@@ -5068,7 +4869,6 @@
             "JoinVars": {
               "user_extra_id": 0
             },
-            "TableName": "user_extra_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5078,8 +4878,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-                "Query": "select user_extra.id from user_extra",
-                "Table": "user_extra"
+                "Query": "select user_extra.id from user_extra"
               },
               {
                 "OperatorType": "Route",
@@ -5090,7 +4889,6 @@
                 },
                 "FieldQuery": "select `user`.id from `user` where 1 != 1",
                 "Query": "select `user`.id from `user` where `user`.`name` = 'foo' and `user`.id = :user_extra_id",
-                "Table": "`user`",
                 "Values": [
                   ":user_extra_id"
                 ],
@@ -5110,7 +4908,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select `user`.Id, `user`.`Name`, `user`.Costly from `user` where `user`.id in ::dml_vals for update",
             "Query": "delete from `user` where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5144,7 +4941,6 @@
             "JoinVars": {
               "u_col": 1
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5154,8 +4950,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
-                "Query": "select u.id, u.col from `user` as u",
-                "Table": "`user`"
+                "Query": "select u.id, u.col from `user` as u"
               },
               {
                 "OperatorType": "Route",
@@ -5165,8 +4960,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from music as m where 1 != 1",
-                "Query": "select 1 from music as m where m.col = :u_col /* INT16 */",
-                "Table": "music"
+                "Query": "select 1 from music as m where m.col = :u_col /* INT16 */"
               }
             ]
           },
@@ -5182,7 +4976,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dml_vals for update",
             "Query": "delete from `user` as u where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5216,7 +5009,6 @@
             "JoinVars": {
               "m_col": 0
             },
-            "TableName": "music_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5226,8 +5018,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select m.col from music as m where 1 != 1",
-                "Query": "select m.col from music as m where m.foo = 42",
-                "Table": "music"
+                "Query": "select m.col from music as m where m.foo = 42"
               },
               {
                 "OperatorType": "Route",
@@ -5237,8 +5028,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id from `user` as u where 1 != 1",
-                "Query": "select u.id from `user` as u where u.col = :m_col",
-                "Table": "`user`"
+                "Query": "select u.id from `user` as u where u.col = :m_col"
               }
             ]
           },
@@ -5254,7 +5044,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dml_vals for update",
             "Query": "delete from `user` as u where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5285,8 +5074,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u, music as m where m.foo = 42 and u.id = m.user_id for update",
-        "Query": "delete u from `user` as u, music as m where m.foo = 42 and u.id = m.user_id",
-        "Table": "user"
+        "Query": "delete u from `user` as u, music as m where m.foo = 42 and u.id = m.user_id"
       },
       "TablesUsed": [
         "user.music",
@@ -5314,7 +5102,6 @@
             "JoinVars": {
               "u_col": 1
             },
-            "TableName": "`user`_music, user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5324,8 +5111,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
-                "Query": "select u.id, u.col from `user` as u where u.col = 30",
-                "Table": "`user`"
+                "Query": "select u.id, u.col from `user` as u where u.col = 30"
               },
               {
                 "OperatorType": "Route",
@@ -5335,8 +5121,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from music as m, user_extra as ue where 1 != 1",
-                "Query": "select 1 from music as m, user_extra as ue where m.bar = 40 and m.col = :u_col /* INT16 */ and ue.foo = 20 and m.user_id = ue.user_id",
-                "Table": "music, user_extra"
+                "Query": "select 1 from music as m, user_extra as ue where m.bar = 40 and m.col = :u_col /* INT16 */ and ue.foo = 20 and m.user_id = ue.user_id"
               }
             ]
           },
@@ -5352,7 +5137,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select u.Id, u.`Name`, u.Costly from `user` as u where u.id in ::dml_vals for update",
             "Query": "delete from `user` as u where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5387,7 +5171,6 @@
             "JoinVars": {
               "u_col": 0
             },
-            "TableName": "`user`_music, user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5397,8 +5180,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.col from `user` as u where 1 != 1",
-                "Query": "select u.col from `user` as u where u.col = 30",
-                "Table": "`user`"
+                "Query": "select u.col from `user` as u where u.col = 30"
               },
               {
                 "OperatorType": "Route",
@@ -5408,8 +5190,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select m.id from music as m, user_extra as ue where 1 != 1",
-                "Query": "select m.id from music as m, user_extra as ue where m.bar = 40 and m.col = :u_col /* INT16 */ and ue.foo = 20 and m.user_id = ue.user_id",
-                "Table": "music, user_extra"
+                "Query": "select m.id from music as m, user_extra as ue where m.bar = 40 and m.col = :u_col /* INT16 */ and ue.foo = 20 and m.user_id = ue.user_id"
               }
             ]
           },
@@ -5425,7 +5206,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select m.user_id, m.id from music as m where m.id in ::dml_vals for update",
             "Query": "delete from music as m where m.id in ::dml_vals",
-            "Table": "music",
             "Values": [
               "::dml_vals"
             ],
@@ -5465,8 +5245,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id from `user` where 1 != 1",
-                "Query": "select `user`.id from `user` limit :__upper_limit",
-                "Table": "`user`"
+                "Query": "select `user`.id from `user` limit :__upper_limit"
               }
             ]
           },
@@ -5482,7 +5261,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id in ::dml_vals for update",
             "Query": "delete from `user` where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5521,8 +5299,7 @@
                 },
                 "FieldQuery": "select `user`.id, `name`, weight_string(`name`), col from `user` where 1 != 1",
                 "OrderBy": "(1|2) ASC, 3 ASC",
-                "Query": "select `user`.id, `name`, weight_string(`name`), col from `user` order by `name` asc, col asc limit :__upper_limit",
-                "Table": "`user`"
+                "Query": "select `user`.id, `name`, weight_string(`name`), col from `user` order by `name` asc, col asc limit :__upper_limit"
               }
             ]
           },
@@ -5538,7 +5315,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id in ::dml_vals for update",
             "Query": "delete from `user` where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5576,8 +5352,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id from `user` where 1 != 1",
-                "Query": "select `user`.id from `user` where `name` = 'foo' or id = 1 limit :__upper_limit lock in share mode",
-                "Table": "`user`"
+                "Query": "select `user`.id from `user` where `name` = 'foo' or id = 1 limit :__upper_limit lock in share mode"
               }
             ]
           },
@@ -5590,7 +5365,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "update `user` set val = 1 where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5628,8 +5402,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id from `user` where 1 != 1",
-                "Query": "select `user`.id from `user` where id > 10 limit :__upper_limit lock in share mode",
-                "Table": "`user`"
+                "Query": "select `user`.id from `user` where id > 10 limit :__upper_limit lock in share mode"
               }
             ]
           },
@@ -5648,7 +5421,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = 'abc' from `user` where `user`.id in ::dml_vals for update",
             "Query": "update `user` set `name` = 'abc' where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5681,7 +5453,6 @@
             "JoinVars": {
               "ue_id": 0
             },
-            "TableName": "user_extra_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5691,8 +5462,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.id from user_extra as ue where 1 != 1",
-                "Query": "select ue.id from user_extra as ue lock in share mode",
-                "Table": "user_extra"
+                "Query": "select ue.id from user_extra as ue lock in share mode"
               },
               {
                 "OperatorType": "Route",
@@ -5703,7 +5473,6 @@
                 },
                 "FieldQuery": "select u.id from `user` as u where 1 != 1",
                 "Query": "select u.id from `user` as u where u.id = :ue_id lock in share mode",
-                "Table": "`user`",
                 "Values": [
                   ":ue_id"
                 ],
@@ -5726,7 +5495,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly, u.`name` = 'foo' from `user` as u where u.id in ::dml_vals for update",
             "Query": "update `user` as u set u.`name` = 'foo' where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5760,7 +5528,6 @@
             "JoinVars": {
               "user_extra_id": 0
             },
-            "TableName": "user_extra_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5770,8 +5537,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-                "Query": "select user_extra.id from user_extra lock in share mode",
-                "Table": "user_extra"
+                "Query": "select user_extra.id from user_extra lock in share mode"
               },
               {
                 "OperatorType": "Route",
@@ -5782,7 +5548,6 @@
                 },
                 "FieldQuery": "select `user`.id from `user` where 1 != 1",
                 "Query": "select `user`.id from `user` where `user`.id = :user_extra_id lock in share mode",
-                "Table": "`user`",
                 "Values": [
                   ":user_extra_id"
                 ],
@@ -5805,7 +5570,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly, `user`.`name` = 'foo' from `user` where `user`.id in ::dml_vals for update",
             "Query": "update `user` set `user`.`name` = 'foo' where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5842,7 +5606,6 @@
             "JoinVars": {
               "ue_id": 1
             },
-            "TableName": "user_extra_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5852,8 +5615,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.col, ue.id from user_extra as ue where 1 != 1",
-                "Query": "select ue.col, ue.id from user_extra as ue for update",
-                "Table": "user_extra"
+                "Query": "select ue.col, ue.id from user_extra as ue for update"
               },
               {
                 "OperatorType": "Route",
@@ -5864,7 +5626,6 @@
                 },
                 "FieldQuery": "select u.id from `user` as u where 1 != 1",
                 "Query": "select u.id from `user` as u where u.id = :ue_id for update",
-                "Table": "`user`",
                 "Values": [
                   ":ue_id"
                 ],
@@ -5881,7 +5642,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "update `user` as u set u.col = :ue_col /* INT16 */ where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5918,7 +5678,6 @@
             "JoinVars": {
               "ue_id": 2
             },
-            "TableName": "user_extra_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5928,8 +5687,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.foo, ue.bar, ue.id from user_extra as ue where 1 != 1",
-                "Query": "select ue.foo, ue.bar, ue.id from user_extra as ue for update",
-                "Table": "user_extra"
+                "Query": "select ue.foo, ue.bar, ue.id from user_extra as ue for update"
               },
               {
                 "OperatorType": "Route",
@@ -5940,7 +5698,6 @@
                 },
                 "FieldQuery": "select u.id from `user` as u where 1 != 1",
                 "Query": "select u.id from `user` as u where u.id = :ue_id for update",
-                "Table": "`user`",
                 "Values": [
                   ":ue_id"
                 ],
@@ -5957,7 +5714,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "update `user` as u set u.col = :ue_foo + :ue_bar + u.baz where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -5996,7 +5752,6 @@
             "JoinVars": {
               "user_id": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -6007,7 +5762,6 @@
                 },
                 "FieldQuery": "select `user`.id, `user`.baz from `user` where 1 != 1",
                 "Query": "select `user`.id, `user`.baz from `user` where `user`.id = 1 for update",
-                "Table": "`user`",
                 "Values": [
                   "1"
                 ],
@@ -6021,8 +5775,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.id, ue.user_id from user_extra as ue where 1 != 1",
-                "Query": "select ue.id, ue.user_id from user_extra as ue where ue.id = :user_id for update",
-                "Table": "user_extra"
+                "Query": "select ue.id, ue.user_id from user_extra as ue where ue.id = :user_id for update"
               }
             ]
           },
@@ -6041,7 +5794,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly, `user`.`name` = :ue_id + 'foo' from `user` where `user`.id in ::dml_vals for update",
             "Query": "update `user` set `user`.`name` = :ue_id + 'foo' where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -6056,7 +5808,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "update user_extra as ue set ue.bar = :user_baz where (ue.id, ue.user_id) in ::dml_vals",
-            "Table": "user_extra",
             "Values": [
               "dml_vals:1"
             ],
@@ -6097,8 +5848,7 @@
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "OwnedVindexQuery": "select user_id, id from music as bar for update",
-        "Query": "delete from music as bar",
-        "Table": "music"
+        "Query": "delete from music as bar"
       },
       "TablesUsed": [
         "user.music"
@@ -6119,8 +5869,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update music as bar set col = 23",
-        "Table": "music"
+        "Query": "update music as bar set col = 23"
       },
       "TablesUsed": [
         "user.music"
@@ -6142,7 +5891,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into music(id, user_id) values (:_id_0, :_user_id_0)",
-        "TableName": "music",
         "VindexValues": {
           "music_user_map": "2",
           "user_index": "null"
@@ -6176,7 +5924,6 @@
             },
             "FieldQuery": "select id from music where 1 != 1",
             "Query": "select id from music where user_id = 1",
-            "Table": "music",
             "Values": [
               "1"
             ],
@@ -6195,7 +5942,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id = :__sq1 for update",
             "Query": "delete from `user` where id = :__sq1",
-            "Table": "user",
             "Values": [
               ":__sq1"
             ],
@@ -6231,8 +5977,7 @@
               "Sharded": false
             },
             "FieldQuery": "select id from unsharded where 1 != 1",
-            "Query": "select id from unsharded",
-            "Table": "unsharded"
+            "Query": "select id from unsharded"
           },
           {
             "InputName": "Outer",
@@ -6246,8 +5991,7 @@
             "KsidLength": 1,
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where col = :__sq1 for update",
-            "Query": "delete from `user` where col = :__sq1",
-            "Table": "user"
+            "Query": "delete from `user` where col = :__sq1"
           }
         ]
       },
@@ -6279,8 +6023,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user`",
-            "Table": "`user`"
+            "Query": "select id from `user`"
           },
           {
             "InputName": "Outer",
@@ -6291,8 +6034,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete from unsharded where col = :__sq1",
-            "Table": "unsharded"
+            "Query": "delete from unsharded where col = :__sq1"
           }
         ]
       },
@@ -6332,8 +6074,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id from `user` where 1 != 1",
-                "Query": "select id from `user`",
-                "Table": "`user`"
+                "Query": "select id from `user`"
               },
               {
                 "InputName": "Outer",
@@ -6344,8 +6085,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select id from unsharded where 1 != 1",
-                "Query": "select id from unsharded where id = :__sq2",
-                "Table": "unsharded"
+                "Query": "select id from unsharded where id = :__sq2"
               }
             ]
           },
@@ -6358,8 +6098,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete from unsharded where col = :__sq1",
-            "Table": "unsharded"
+            "Query": "delete from unsharded where col = :__sq1"
           }
         ]
       },
@@ -6390,7 +6129,6 @@
             "JoinVars": {
               "unsharded_id": 0
             },
-            "TableName": "unsharded_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -6400,8 +6138,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-                "Query": "select unsharded.id from unsharded",
-                "Table": "unsharded"
+                "Query": "select unsharded.id from unsharded"
               },
               {
                 "OperatorType": "Route",
@@ -6412,7 +6149,6 @@
                 },
                 "FieldQuery": "select id from `user` where 1 != 1",
                 "Query": "select id from `user` where `user`.id = :unsharded_id",
-                "Table": "`user`",
                 "Values": [
                   ":unsharded_id"
                 ],
@@ -6429,8 +6165,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete from unsharded where col = :__sq1",
-            "Table": "unsharded"
+            "Query": "delete from unsharded where col = :__sq1"
           }
         ]
       },
@@ -6462,7 +6197,6 @@
               "u_col": 1,
               "u_foo": 2
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -6472,8 +6206,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col, u.foo from `user` as u where 1 != 1",
-                "Query": "select u.id, u.col, u.foo from `user` as u where u.baz = 12 for update",
-                "Table": "`user`"
+                "Query": "select u.id, u.col, u.foo from `user` as u where u.baz = 12 for update"
               },
               {
                 "OperatorType": "Route",
@@ -6483,8 +6216,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select m.id from music as m where 1 != 1",
-                "Query": "select m.id from music as m where m.baz = 21 and m.bar = :u_foo and m.col = :u_col /* INT16 */ for update",
-                "Table": "music"
+                "Query": "select m.id from music as m where m.baz = 21 and m.bar = :u_foo and m.col = :u_col /* INT16 */ for update"
               }
             ]
           },
@@ -6500,7 +6232,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as u where u.id in ::dml_vals for update",
             "Query": "delete from `user` as u where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -6518,7 +6249,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select user_id, id from music as m where m.id in ::dml_vals for update",
             "Query": "delete from music as m where m.id in ::dml_vals",
-            "Table": "music",
             "Values": [
               "::dml_vals"
             ],
@@ -6553,7 +6283,6 @@
             "JoinVars": {
               "music_id": 0
             },
-            "TableName": "music_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -6563,8 +6292,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select music.id from music where 1 != 1",
-                "Query": "select music.id from music for update",
-                "Table": "music"
+                "Query": "select music.id from music for update"
               },
               {
                 "OperatorType": "Route",
@@ -6575,7 +6303,6 @@
                 },
                 "FieldQuery": "select `user`.id from `user` where 1 != 1",
                 "Query": "select `user`.id from `user` where `user`.id = :music_id for update",
-                "Table": "`user`",
                 "Values": [
                   ":music_id"
                 ],
@@ -6595,7 +6322,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select user_id, id from music where music.id in ::dml_vals for update",
             "Query": "delete from music where music.id in ::dml_vals",
-            "Table": "music",
             "Values": [
               "::dml_vals"
             ],
@@ -6613,7 +6339,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id in ::dml_vals for update",
             "Query": "delete from `user` where `user`.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -6649,8 +6374,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.id, m.id from `user` as u, music as m where 1 != 1",
-            "Query": "select u.id, m.id from `user` as u, music as m where u.id = m.user_id for update",
-            "Table": "`user`, music"
+            "Query": "select u.id, m.id from `user` as u, music as m where u.id = m.user_id for update"
           },
           {
             "OperatorType": "Delete",
@@ -6664,7 +6388,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as u where u.id in ::dml_vals for update",
             "Query": "delete from `user` as u where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -6682,7 +6405,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select user_id, id from music as m where m.id in ::dml_vals for update",
             "Query": "delete from music as m where m.id in ::dml_vals",
-            "Table": "music",
             "Values": [
               "::dml_vals"
             ],
@@ -6717,7 +6439,6 @@
             "JoinVars": {
               "u_col": 1
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -6727,8 +6448,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
-                "Query": "select u.id, u.col from `user` as u for update",
-                "Table": "`user`"
+                "Query": "select u.id, u.col from `user` as u for update"
               },
               {
                 "OperatorType": "Route",
@@ -6738,8 +6458,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select m.id from music as m where 1 != 1",
-                "Query": "select m.id from music as m where m.col = :u_col /* INT16 */ for update",
-                "Table": "music"
+                "Query": "select m.id from music as m where m.col = :u_col /* INT16 */ for update"
               }
             ]
           },
@@ -6755,7 +6474,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as u where u.id in ::dml_vals for update",
             "Query": "delete from `user` as u where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -6773,7 +6491,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select user_id, id from music as m where m.id in ::dml_vals for update",
             "Query": "delete from music as m where m.id in ::dml_vals",
-            "Table": "music",
             "Values": [
               "::dml_vals"
             ],
@@ -6809,8 +6526,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.id, ue.id, ue.user_id from `user` as u, user_extra as ue where 1 != 1",
-            "Query": "select u.id, ue.id, ue.user_id from `user` as u, user_extra as ue where u.id = ue.user_id for update",
-            "Table": "`user`, user_extra"
+            "Query": "select u.id, ue.id, ue.user_id from `user` as u, user_extra as ue where u.id = ue.user_id for update"
           },
           {
             "OperatorType": "Delete",
@@ -6824,7 +6540,6 @@
             "KsidVindex": "user_index",
             "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as u where u.id in ::dml_vals for update",
             "Query": "delete from `user` as u where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -6839,7 +6554,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete from user_extra as ue where (ue.id, ue.user_id) in ::dml_vals",
-            "Table": "user_extra",
             "Values": [
               "dml_vals:1"
             ],
@@ -6875,8 +6589,7 @@
               "Sharded": true
             },
             "FieldQuery": "select ev.oid, ev.ename, o.oid, o.region_id from `order` as o, order_event as ev where 1 != 1",
-            "Query": "select ev.oid, ev.ename, o.oid, o.region_id from `order` as o, order_event as ev where ev.ename = 'a' and o.oid = ev.oid for update",
-            "Table": "`order`, order_event"
+            "Query": "select ev.oid, ev.ename, o.oid, o.region_id from `order` as o, order_event as ev where ev.ename = 'a' and o.oid = ev.oid for update"
           },
           {
             "OperatorType": "Delete",
@@ -6887,7 +6600,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete from order_event as ev where (ev.oid, ev.ename) in ::dml_vals",
-            "Table": "order_event",
             "Values": [
               "dml_vals:0"
             ],
@@ -6905,7 +6617,6 @@
             "KsidVindex": "xxhash",
             "OwnedVindexQuery": "select region_id, oid from `order` as o where (o.oid, o.region_id) in ::dml_vals for update",
             "Query": "delete from `order` as o where (o.oid, o.region_id) in ::dml_vals",
-            "Table": "order",
             "Values": [
               "dml_vals:1"
             ],
@@ -6940,7 +6651,6 @@
             "JoinVars": {
               "u_col": 1
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -6950,8 +6660,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
-                "Query": "select u.id, u.col from `user` as u for update",
-                "Table": "`user`"
+                "Query": "select u.id, u.col from `user` as u for update"
               },
               {
                 "OperatorType": "Route",
@@ -6961,8 +6670,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select m.id from music as m where 1 != 1",
-                "Query": "select m.id from music as m where m.col = :u_col /* INT16 */ for update",
-                "Table": "music"
+                "Query": "select m.id from music as m where m.col = :u_col /* INT16 */ for update"
               }
             ]
           },
@@ -6975,7 +6683,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "update ignore `user` as u set u.foo = 21 where u.id in ::dml_vals",
-            "Table": "user",
             "Values": [
               "::dml_vals"
             ],
@@ -6990,7 +6697,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "update ignore music as m set m.bar = 'abc' where m.id in ::dml_vals",
-            "Table": "music",
             "Values": [
               "::dml_vals"
             ],
@@ -7020,7 +6726,6 @@
         "TargetTabletType": "PRIMARY",
         "InsertIgnore": true,
         "Query": "insert into authoritative(user_id, col1, col2) values (:_user_id_0, '2', 3), (:_user_id_1, '5', 6) as new on duplicate key update col2 = new.user_id + new.col1",
-        "TableName": "authoritative",
         "VindexValues": {
           "user_index": "1, 4"
         }
@@ -7046,7 +6751,6 @@
         "TargetTabletType": "PRIMARY",
         "InsertIgnore": true,
         "Query": "insert into authoritative(user_id, col1, col2) values (:_user_id_0, '2', 3), (:_user_id_1, '5', 6) as new (a, b, c) on duplicate key update col1 = a + c",
-        "TableName": "authoritative",
         "VindexValues": {
           "user_index": "1, 4"
         }
@@ -7072,7 +6776,6 @@
         "TargetTabletType": "PRIMARY",
         "InsertIgnore": true,
         "Query": "insert into authoritative(user_id, col1, col2) values (:_user_id_0, '2', 3), (:_user_id_1, '5', 6) as new on duplicate key update col2 = new.user_id + new.col1",
-        "TableName": "authoritative",
         "VindexValues": {
           "user_index": "1, 4"
         }
@@ -7098,7 +6801,6 @@
         "TargetTabletType": "PRIMARY",
         "InsertIgnore": true,
         "Query": "insert into authoritative(user_id, col1, col2) values (:_user_id_0, '2', 3), (:_user_id_1, '5', 6) as new (a, b, c) on duplicate key update col1 = a + c",
-        "TableName": "authoritative",
         "VindexValues": {
           "user_index": "1, 4"
         }

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -13,8 +13,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user`",
-        "Table": "`user`"
+        "Query": "select id from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -35,8 +34,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where someColumn = null",
-        "Table": "`user`"
+        "Query": "select id from `user` where someColumn = null"
       },
       "TablesUsed": [
         "user.user"
@@ -57,8 +55,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where someColumn <=> null",
-        "Table": "`user`"
+        "Query": "select id from `user` where someColumn <=> null"
       },
       "TablesUsed": [
         "user.user"
@@ -80,7 +77,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.id = 5",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -106,7 +102,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.id = 5 + 5",
-        "Table": "`user`",
         "Values": [
           "10"
         ],
@@ -132,7 +127,6 @@
         },
         "FieldQuery": "select id from music where 1 != 1",
         "Query": "select id from music where id = 5 and user_id = 4",
-        "Table": "music",
         "Values": [
           "4"
         ],
@@ -170,7 +164,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -184,8 +177,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where costly = 'aa' and `name` = 'bb'",
-            "Table": "`user`"
+            "Query": "select id from `user` where costly = 'aa' and `name` = 'bb'"
           }
         ]
       },
@@ -221,7 +213,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -235,8 +226,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where costly in ('aa', 'bb') and `name` in ::__vals",
-            "Table": "`user`"
+            "Query": "select id from `user` where costly in ('aa', 'bb') and `name` in ::__vals"
           }
         ]
       },
@@ -272,7 +262,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -286,8 +275,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (`name`, col) in (('aa', 'bb'), ('cc', 'dd'))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (`name`, col) in (('aa', 'bb'), ('cc', 'dd'))"
           }
         ]
       },
@@ -323,7 +311,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -337,8 +324,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (col, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (col, `name`) in (('aa', 'bb'), ('cc', 'dd'))"
           }
         ]
       },
@@ -374,7 +360,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -388,8 +373,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))"
           }
         ]
       },
@@ -425,7 +409,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -439,8 +422,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (`name`, costly) in (('aa', 'bb'), ('cc', 'dd'))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (`name`, costly) in (('aa', 'bb'), ('cc', 'dd'))"
           }
         ]
       },
@@ -476,7 +458,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -490,8 +471,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (col, costly) in (('aa', 'bb')) and (col, `name`) in (('cc', 'dd'))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (col, costly) in (('aa', 'bb')) and (col, `name`) in (('cc', 'dd'))"
           }
         ]
       },
@@ -515,7 +495,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where (col, `name`) in (('aa', 'bb')) and id = 5",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -553,7 +532,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -567,8 +545,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))"
           }
         ]
       },
@@ -604,7 +581,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -618,8 +594,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where ((col1, `name`), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))",
-            "Table": "`user`"
+            "Query": "select id from `user` where ((col1, `name`), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))"
           }
         ]
       },
@@ -655,7 +630,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -669,8 +643,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (`name`, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (`name`, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))"
           }
         ]
       },
@@ -693,8 +666,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where ((col1, `name`), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))",
-        "Table": "`user`"
+        "Query": "select id from `user` where ((col1, `name`), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))"
       },
       "TablesUsed": [
         "user.user"
@@ -715,8 +687,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where (col1, `name`) in (select * from music where music.user_id = `user`.id)",
-        "Table": "`user`"
+        "Query": "select id from `user` where (col1, `name`) in (select * from music where music.user_id = `user`.id)"
       },
       "TablesUsed": [
         "user.music",
@@ -751,7 +722,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -765,8 +735,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (col1, `name`) in (('aa', 1 + 1))",
-            "Table": "`user`"
+            "Query": "select id from `user` where (col1, `name`) in (('aa', 1 + 1))"
           }
         ]
       },
@@ -789,8 +758,7 @@
           "Sharded": true
         },
         "FieldQuery": "select Id from `user` where 1 != 1",
-        "Query": "select Id from `user` where 1 in ('aa', 'bb')",
-        "Table": "`user`"
+        "Query": "select Id from `user` where 1 in ('aa', 'bb')"
       },
       "TablesUsed": [
         "user.user"
@@ -811,8 +779,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where `name` in (col, 'bb')",
-        "Table": "`user`"
+        "Query": "select id from `user` where `name` in (col, 'bb')"
       },
       "TablesUsed": [
         "user.user"
@@ -846,7 +813,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -860,8 +826,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where `name` = :a",
-            "Table": "`user`"
+            "Query": "select id from `user` where `name` = :a"
           }
         ]
       },
@@ -884,8 +849,7 @@
           "Sharded": true
         },
         "FieldQuery": "select u.id from `user` as u where 1 != 1",
-        "Query": "select u.id from `user` as u where not exists (select 1 from user_extra as ue where u.id = ue.user_id)",
-        "Table": "`user`"
+        "Query": "select u.id from `user` as u where not exists (select 1 from user_extra as ue where u.id = ue.user_id)"
       },
       "TablesUsed": [
         "user.user",
@@ -920,7 +884,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -934,8 +897,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where `name` = 18446744073709551615",
-            "Table": "`user`"
+            "Query": "select id from `user` where `name` = 18446744073709551615"
           }
         ]
       },
@@ -971,7 +933,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -985,8 +946,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where `name` in ::__vals",
-            "Table": "`user`"
+            "Query": "select id from `user` where `name` in ::__vals"
           }
         ]
       },
@@ -1010,7 +970,6 @@
         },
         "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
         "Query": "select user_extra.id from `user`, user_extra where `user`.id = 5 and `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1037,7 +996,6 @@
         },
         "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
         "Query": "select user_extra.id from `user`, user_extra where user_extra.user_id = 5 and `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1064,7 +1022,6 @@
         },
         "FieldQuery": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where 1 != 1",
         "Query": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where `user`.id = 5",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1091,7 +1048,6 @@
         },
         "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
         "Query": "select user_extra.id from `user`, user_extra where user_extra.user_id = 5 and `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1116,7 +1072,6 @@
         "JoinVars": {
           "user_col": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1127,7 +1082,6 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select `user`.col from `user` where `user`.id = 5",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -1141,8 +1095,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-            "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */",
-            "Table": "user_extra"
+            "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */"
           }
         ]
       },
@@ -1167,7 +1120,6 @@
         },
         "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
         "Query": "select user_extra.id from `user`, user_extra where `user`.id = 5 and user_extra.user_id = 5 and `user`.col = user_extra.col",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1192,7 +1144,6 @@
         "JoinVars": {
           "user_col": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1202,8 +1153,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -1214,7 +1164,6 @@
             },
             "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
             "Query": "select user_extra.id from user_extra where user_extra.user_id = :user_col /* INT16 */ and user_extra.col = :user_col /* INT16 */",
-            "Table": "user_extra",
             "Values": [
               ":user_col"
             ],
@@ -1241,7 +1190,6 @@
         "JoinVars": {
           "user_col": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1251,8 +1199,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user` where 1 = 1",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user` where 1 = 1"
           },
           {
             "OperatorType": "Route",
@@ -1262,8 +1209,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-            "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */ and 1 = 1",
-            "Table": "user_extra"
+            "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */ and 1 = 1"
           }
         ]
       },
@@ -1288,7 +1234,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.col = 5 and `user`.id in ::__vals",
-        "Table": "`user`",
         "Values": [
           "(1, 2)"
         ],
@@ -1314,7 +1259,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.col = case `user`.col when 'foo' then true else false end and `user`.id in ::__vals",
-        "Table": "`user`",
         "Values": [
           "(1, 2)"
         ],
@@ -1352,7 +1296,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -1366,8 +1309,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id or col as val from `user` where 1 != 1",
-            "Query": "select id or col as val from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa'",
-            "Table": "`user`"
+            "Query": "select id or col as val from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa'"
           }
         ]
       },
@@ -1403,7 +1345,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -1417,8 +1358,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where `user`.col = false and `user`.id in (1, 2) and `user`.`name` = 'aa'",
-            "Table": "`user`"
+            "Query": "select id from `user` where `user`.col = false and `user`.id in (1, 2) and `user`.`name` = 'aa'"
           }
         ]
       },
@@ -1442,7 +1382,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa' and `user`.id = 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1468,7 +1407,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.id = 1 and `user`.`name` = 'aa' and `user`.id in (1, 2) and `user`.col = 5",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1494,7 +1432,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where (`user`.id = 1 or `user`.`name` = 'aa') and `user`.id in ::__vals",
-        "Table": "`user`",
         "Values": [
           "(1, 2)"
         ],
@@ -1518,7 +1455,6 @@
         "JoinVars": {
           "unsharded_id": 0
         },
-        "TableName": "unsharded_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1528,8 +1464,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.id from unsharded",
-            "Table": "unsharded"
+            "Query": "select unsharded.id from unsharded"
           },
           {
             "OperatorType": "Route",
@@ -1540,7 +1475,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where `user`.id = :unsharded_id",
-            "Table": "`user`",
             "Values": [
               ":unsharded_id"
             ],
@@ -1569,7 +1503,6 @@
         },
         "FieldQuery": "select col from `user` as route1 where 1 != 1",
         "Query": "select col from `user` as route1 where id = 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1593,7 +1526,6 @@
         "JoinVars": {
           "user_extra_col": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1603,8 +1535,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.col from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.col from user_extra"
           },
           {
             "OperatorType": "Route",
@@ -1615,7 +1546,6 @@
             },
             "FieldQuery": "select u.m from `user` as u where 1 != 1",
             "Query": "select u.m from `user` as u where u.id in ::__vals and u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col /* INT16 */)",
-            "Table": "`user`",
             "Values": [
               "(:user_extra_col, 1)"
             ],
@@ -1642,7 +1572,6 @@
         "JoinVars": {
           "user_extra_col": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1652,8 +1581,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.col from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.col from user_extra"
           },
           {
             "OperatorType": "Route",
@@ -1664,7 +1592,6 @@
             },
             "FieldQuery": "select u.m from `user` as u where 1 != 1",
             "Query": "select u.m from `user` as u where u.id in ::__vals and u.id in (select m2 from `user` where `user`.id = u.id)",
-            "Table": "`user`",
             "Values": [
               "(:user_extra_col, 1)"
             ],
@@ -1688,7 +1615,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1698,8 +1624,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           },
           {
             "OperatorType": "Route",
@@ -1710,7 +1635,6 @@
             },
             "FieldQuery": "select u.m from `user` as u where 1 != 1",
             "Query": "select u.m from `user` as u where u.id = 5 and u.id in (select m2 from `user` where `user`.id = 5)",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -1737,7 +1661,6 @@
         "JoinVars": {
           "user_extra_col": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1747,8 +1670,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.col from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.col from user_extra"
           },
           {
             "OperatorType": "Route",
@@ -1759,7 +1681,6 @@
             },
             "FieldQuery": "select u.m from `user` as u where 1 != 1",
             "Query": "select u.m from `user` as u where u.id in ::__vals and u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col /* INT16 */ and `user`.id in (select m3 from user_extra where user_extra.user_id = `user`.id))",
-            "Table": "`user`",
             "Values": [
               "(:user_extra_col, 1)"
             ],
@@ -1787,8 +1708,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where `user`.col in (select user_extra.col from user_extra where user_extra.user_id = `user`.id)",
-        "Table": "`user`"
+        "Query": "select id from `user` where `user`.col in (select user_extra.col from user_extra where user_extra.user_id = `user`.id)"
       },
       "TablesUsed": [
         "user.user",
@@ -1811,7 +1731,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5 and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 5)",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1838,7 +1757,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 'aa' and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 'aa')",
-        "Table": "`user`",
         "Values": [
           "'aa'"
         ],
@@ -1865,7 +1783,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = :a and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = :a)",
-        "Table": "`user`",
         "Values": [
           ":a"
         ],
@@ -1896,8 +1813,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id2 from `user` as uu where 1 != 1",
-        "Query": "select id2 from `user` as uu where id in (select id from `user` where id = uu.id and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))",
-        "Table": "`user`"
+        "Query": "select id2 from `user` as uu where id in (select id from `user` where id = uu.id and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))"
       },
       "TablesUsed": [
         "user.user",
@@ -1928,8 +1844,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -1941,7 +1856,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where :__sq_has_values and id in ::__vals",
-            "Table": "`user`",
             "Values": [
               "::__sq1"
             ],
@@ -1977,8 +1891,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -1989,8 +1902,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where not :__sq_has_values or id not in ::__sq1",
-            "Table": "`user`"
+            "Query": "select id from `user` where not :__sq_has_values or id not in ::__sq1"
           }
         ]
       },
@@ -2025,8 +1937,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from `user` where 1 != 1",
-                "Query": "select 1 from `user` limit 1",
-                "Table": "`user`"
+                "Query": "select 1 from `user` limit 1"
               }
             ]
           },
@@ -2039,8 +1950,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where :__sq_has_values",
-            "Table": "`user`"
+            "Query": "select id from `user` where :__sq_has_values"
           }
         ]
       },
@@ -2071,8 +1981,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -2084,7 +1993,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where id = :__sq1",
-            "Table": "`user`",
             "Values": [
               ":__sq1"
             ],
@@ -2128,8 +2036,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id3 from `user` where 1 != 1",
-                "Query": "select id3 from `user`",
-                "Table": "`user`"
+                "Query": "select id3 from `user`"
               },
               {
                 "InputName": "Outer",
@@ -2140,8 +2047,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id2 from `user` where 1 != 1",
-                "Query": "select id2 from `user` where :__sq_has_values and id2 in ::__sq2",
-                "Table": "`user`"
+                "Query": "select id2 from `user` where :__sq_has_values and id2 in ::__sq2"
               }
             ]
           },
@@ -2155,7 +2061,6 @@
             },
             "FieldQuery": "select id1 from `user` where 1 != 1",
             "Query": "select id1 from `user` where id = :__sq1",
-            "Table": "`user`",
             "Values": [
               ":__sq1"
             ],
@@ -2182,8 +2087,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` where id = (select id from `user` as route1 where route1.id = `user`.id)",
-        "Table": "`user`"
+        "Query": "select col from `user` where id = (select id from `user` as route1 where route1.id = `user`.id)"
       },
       "TablesUsed": [
         "user.user"
@@ -2212,8 +2116,7 @@
               "Sharded": false
             },
             "FieldQuery": "select id from unsharded as route2 where 1 != 1",
-            "Query": "select id from unsharded as route2",
-            "Table": "unsharded"
+            "Query": "select id from unsharded as route2"
           },
           {
             "InputName": "Outer",
@@ -2225,7 +2128,6 @@
             },
             "FieldQuery": "select col from `user` where 1 != 1",
             "Query": "select col from `user` where id = :__sq1",
-            "Table": "`user`",
             "Values": [
               ":__sq1"
             ],
@@ -2254,7 +2156,6 @@
         },
         "FieldQuery": "select user_extra.Id from `user`, user_extra where 1 != 1",
         "Query": "select user_extra.Id from `user`, user_extra where `user`.Id = 5 and `user`.iD = user_extra.User_Id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -2280,8 +2181,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where database()",
-        "Table": "`user`"
+        "Query": "select id from `user` where database()"
       },
       "TablesUsed": [
         "user.user"
@@ -2302,8 +2202,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from music where 1 != 1",
-        "Query": "select id from music where id = null",
-        "Table": "music"
+        "Query": "select id from music where id = null"
       },
       "TablesUsed": [
         "user.music"
@@ -2324,8 +2223,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from music where 1 != 1",
-        "Query": "select id from music where id is null",
-        "Table": "music"
+        "Query": "select id from music where id is null"
       },
       "TablesUsed": [
         "user.music"
@@ -2346,8 +2244,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from music where 1 != 1",
-        "Query": "select id from music where id is not null",
-        "Table": "music"
+        "Query": "select id from music where id is not null"
       },
       "TablesUsed": [
         "user.music"
@@ -2368,8 +2265,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from music where 1 != 1",
-        "Query": "select id from music where user_id = 4 and id = null",
-        "Table": "music"
+        "Query": "select id from music where user_id = 4 and id = null"
       },
       "TablesUsed": [
         "user.music"
@@ -2390,8 +2286,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from music where 1 != 1",
-        "Query": "select id from music where user_id = 4 and id in (null)",
-        "Table": "music"
+        "Query": "select id from music where user_id = 4 and id in (null)"
       },
       "TablesUsed": [
         "user.music"
@@ -2413,7 +2308,6 @@
         },
         "FieldQuery": "select id from music where 1 != 1",
         "Query": "select id from music where user_id = 4 and id in (null, 1, 2)",
-        "Table": "music",
         "Values": [
           "4"
         ],
@@ -2438,8 +2332,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from music where 1 != 1",
-        "Query": "select id from music where user_id = 4 and id not in (null, 1, 2)",
-        "Table": "music"
+        "Query": "select id from music where user_id = 4 and id not in (null, 1, 2)"
       },
       "TablesUsed": [
         "user.music"
@@ -2460,8 +2353,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from music where 1 != 1",
-        "Query": "select id from music where id not in (null, 1, 2) and user_id = 4",
-        "Table": "music"
+        "Query": "select id from music where id not in (null, 1, 2) and user_id = 4"
       },
       "TablesUsed": [
         "user.music"
@@ -2492,7 +2384,6 @@
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
             "Query": "select user_extra.col from user_extra where user_extra.user_id = 411",
-            "Table": "user_extra",
             "Values": [
               "411"
             ],
@@ -2517,7 +2408,6 @@
                 },
                 "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
                 "Query": "select user_extra.col from user_extra where user_extra.user_id = 42",
-                "Table": "user_extra",
                 "Values": [
                   "42"
                 ],
@@ -2533,7 +2423,6 @@
                 },
                 "FieldQuery": "select id from `user` where 1 != 1",
                 "Query": "select id from `user` where (not :__sq_has_values or id not in ::__sq1) and :__sq_has_values1 and id in ::__vals",
-                "Table": "`user`",
                 "Values": [
                   "::__sq2"
                 ],
@@ -2564,7 +2453,6 @@
         },
         "FieldQuery": "select c2 from cfc_vindex_col where 1 != 1",
         "Query": "select c2 from cfc_vindex_col where c1 like 'A%'",
-        "Table": "cfc_vindex_col",
         "Values": [
           "'A%'"
         ],
@@ -2590,7 +2478,6 @@
         },
         "FieldQuery": "select col from samecolvin where 1 != 1",
         "Query": "select col from samecolvin where col = :col",
-        "Table": "samecolvin",
         "Values": [
           ":col"
         ],
@@ -2615,8 +2502,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where `user`.id > 5",
-        "Table": "`user`"
+        "Query": "select id from `user` where `user`.id > 5"
       },
       "TablesUsed": [
         "user.user"
@@ -2637,8 +2523,7 @@
           "Sharded": false
         },
         "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-        "Query": "select unsharded.id from unsharded where unsharded.`name` in (select `name` from unsharded_a)",
-        "Table": "unsharded, unsharded_a"
+        "Query": "select unsharded.id from unsharded where unsharded.`name` in (select `name` from unsharded_a)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -2669,8 +2554,7 @@
               "Sharded": false
             },
             "FieldQuery": "select col from unsharded where 1 != 1",
-            "Query": "select col from unsharded where col = id",
-            "Table": "unsharded"
+            "Query": "select col from unsharded where col = id"
           },
           {
             "InputName": "Outer",
@@ -2682,7 +2566,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where :__sq_has_values and id in ::__vals",
-            "Table": "`user`",
             "Values": [
               "::__sq1"
             ],
@@ -2710,8 +2593,7 @@
           "Sharded": true
         },
         "FieldQuery": "select u.id from `user` as u where 1 != 1",
-        "Query": "select u.id from `user` as u where u.col in (select ue.user_id from user_extra as ue where ue.user_id = u.id)",
-        "Table": "`user`"
+        "Query": "select u.id from `user` as u where u.col in (select ue.user_id from user_extra as ue where ue.user_id = u.id)"
       },
       "TablesUsed": [
         "user.user",
@@ -2733,8 +2615,7 @@
           "Sharded": false
         },
         "FieldQuery": "select t.table_schema from information_schema.`tables` as t where 1 != 1",
-        "Query": "select t.table_schema from information_schema.`tables` as t where t.table_schema in (select c.column_name from information_schema.`columns` as c)",
-        "Table": "information_schema.`tables`"
+        "Query": "select t.table_schema from information_schema.`tables` as t where t.table_schema in (select c.column_name from information_schema.`columns` as c)"
       }
     }
   },
@@ -2752,8 +2633,7 @@
           "Sharded": true
         },
         "FieldQuery": "select ref.col from ref where 1 != 1",
-        "Query": "select ref.col from ref where ref.col in (select ref.col from ref)",
-        "Table": "ref"
+        "Query": "select ref.col from ref where ref.col in (select ref.col from ref)"
       },
       "TablesUsed": [
         "user.ref"
@@ -2775,7 +2655,6 @@
         },
         "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
         "Query": "select u1.col from `user` as u1 where u1.id = 5 and u1.`name` in (select u2.`name` from `user` as u2 where u2.id = 5)",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -2801,7 +2680,6 @@
         },
         "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
         "Query": "select u1.col from `user` as u1 where u1.id = 5 and exists (select 1 from `user` as u2 where u2.id = 5)",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -2827,7 +2705,6 @@
         },
         "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
         "Query": "select u1.col from `user` as u1 where u1.id = 5 and not exists (select 1 from `user` as u2 where u2.id = 5)",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -2861,7 +2738,6 @@
             },
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
             "Query": "select 1 from `user` as u2 where u2.id = 5 limit 1",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -2876,8 +2752,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
-            "Query": "select u1.col from `user` as u1 where not :__sq_has_values",
-            "Table": "`user`"
+            "Query": "select u1.col from `user` as u1 where not :__sq_has_values"
           }
         ]
       },
@@ -2910,7 +2785,6 @@
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
             "Query": "select user_extra.col from user_extra where user_extra.user_id = 4",
-            "Table": "user_extra",
             "Values": [
               "4"
             ],
@@ -2926,7 +2800,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where id = 5 and id not in (select user_extra.col from user_extra where user_extra.user_id = 5) and :__sq_has_values and id in ::__sq2",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -2964,7 +2837,6 @@
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
             "Query": "select user_extra.col from user_extra where user_extra.user_id = 4",
-            "Table": "user_extra",
             "Values": [
               "4"
             ],
@@ -2980,7 +2852,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where id = 5 and id in (select user_extra.col from user_extra where user_extra.user_id = 5) and (not :__sq_has_values or id not in ::__sq1)",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -3008,8 +2879,7 @@
           "Sharded": true
         },
         "FieldQuery": "select u.id from `user` as u where 1 != 1",
-        "Query": "select u.id from `user` as u where u.col in (select ue.user_id from user_extra as ue where ue.user_id = u.id) and u.col2 in (select ue.user_id from user_extra as ue where ue.user_id = u.id)",
-        "Table": "`user`"
+        "Query": "select u.id from `user` as u where u.col in (select ue.user_id from user_extra as ue where ue.user_id = u.id) and u.col2 in (select ue.user_id from user_extra as ue where ue.user_id = u.id)"
       },
       "TablesUsed": [
         "user.user",
@@ -3032,7 +2902,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.id = `user`.col and `user`.col = 5",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -3057,8 +2926,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user`, user_extra where 1 != 1",
-        "Query": "select id from `user`, user_extra where user_extra.col = user_extra.user_id and `user`.id = user_extra.col",
-        "Table": "`user`, user_extra"
+        "Query": "select id from `user`, user_extra where user_extra.col = user_extra.user_id and `user`.id = user_extra.col"
       },
       "TablesUsed": [
         "user.user",
@@ -3079,7 +2947,6 @@
         "JoinVars": {
           "user_extra_col": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3089,8 +2956,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.col from user_extra where user_extra.col = user_extra.user_id or user_extra.col2 = user_extra.`name`",
-            "Table": "user_extra"
+            "Query": "select user_extra.col from user_extra where user_extra.col = user_extra.user_id or user_extra.col2 = user_extra.`name`"
           },
           {
             "OperatorType": "Route",
@@ -3101,7 +2967,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where `user`.id = :user_extra_col /* INT16 */",
-            "Table": "`user`",
             "Values": [
               ":user_extra_col"
             ],
@@ -3129,8 +2994,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` where id = (select id from `user` as a where a.id = `user`.id)",
-        "Table": "`user`"
+        "Query": "select col from `user` where id = (select id from `user` as a where a.id = `user`.id)"
       },
       "TablesUsed": [
         "user.user"
@@ -3150,7 +3014,6 @@
         "JoinVars": {
           "user_col": 1
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3160,8 +3023,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.id, `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.id, `user`.col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -3171,8 +3033,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra where user_extra.foobar = 5 and user_extra.col = :user_col /* INT16 */",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra where user_extra.foobar = 5 and user_extra.col = :user_col /* INT16 */"
           }
         ]
       },
@@ -3205,7 +3066,6 @@
             "JoinVars": {
               "user_col": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3215,8 +3075,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.id, `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.id, `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -3226,8 +3085,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-                "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */",
-                "Table": "user_extra"
+                "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */"
               }
             ]
           }
@@ -3270,8 +3128,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id from music where 1 != 1",
-                "Query": "select id from music where col2 = 'a'",
-                "Table": "music"
+                "Query": "select id from music where col2 = 'a'"
               },
               {
                 "InputName": "Outer",
@@ -3282,8 +3139,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id, `user`.col, weight_string(`user`.id) from `user` where 1 != 1",
-                "Query": "select `user`.id, `user`.col, weight_string(`user`.id) from `user` where :__sq_has_values and `user`.col in ::__sq1",
-                "Table": "`user`"
+                "Query": "select `user`.id, `user`.col, weight_string(`user`.id) from `user` where :__sq_has_values and `user`.col in ::__sq1"
               }
             ]
           }
@@ -3310,7 +3166,6 @@
         },
         "FieldQuery": "select * from multicolvin where 1 != 1",
         "Query": "select * from multicolvin where column_b = 1",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -3336,7 +3191,6 @@
         },
         "FieldQuery": "select * from multicolvin where 1 != 1",
         "Query": "select * from multicolvin where column_b = 1 and column_c = 2",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -3362,7 +3216,6 @@
         },
         "FieldQuery": "select * from multicolvin where 1 != 1",
         "Query": "select * from multicolvin where column_b = 1 and column_c = 2 and column_a = 3",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -3388,7 +3241,6 @@
         },
         "FieldQuery": "select * from multicolvin where 1 != 1",
         "Query": "select * from multicolvin where column_a = 3 and column_b = 1",
-        "Table": "multicolvin",
         "Values": [
           "1"
         ],
@@ -3414,7 +3266,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where cola = 1 and colb = 2",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "2"
@@ -3441,7 +3292,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where colb = 2 and cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "2"
@@ -3468,7 +3318,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where cola in ::__vals0 and colb in ::__vals1",
-        "Table": "multicol_tbl",
         "Values": [
           "(1, 2)",
           "(3, 4)"
@@ -3495,7 +3344,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where colb in ::__vals1 and cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(1, 2)",
           "(3, 4)"
@@ -3522,7 +3370,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where colb = 1 and cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(3, 4)",
           "1"
@@ -3549,7 +3396,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 34 and `name` = 'apa'",
-        "Table": "`user`",
         "Values": [
           "34"
         ],
@@ -3575,7 +3421,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in (5, 6) and colb = 7",
-        "Table": "multicol_tbl",
         "Values": [
           "4",
           "7"
@@ -3602,7 +3447,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where colb = 4 and colb in ::__vals1 and cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(5, 6)",
           "(1, 10)"
@@ -3629,7 +3473,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where colb in (1, 10) and colb = 4 and cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "(5, 6)",
           "4"
@@ -3656,7 +3499,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where colb in (1, 2) and cola in (3, 4) and cola = 5 and colb = 6",
-        "Table": "multicol_tbl",
         "Values": [
           "5",
           "6"
@@ -3683,7 +3525,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where (cola, colb) in ((1, 2), (3, 4))",
-        "Table": "multicol_tbl",
         "Values": [
           "(1, 3)",
           "(2, 4)"
@@ -3710,7 +3551,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where cola = 1",
-        "Table": "multicol_tbl",
         "Values": [
           "1"
         ],
@@ -3736,7 +3576,6 @@
         },
         "FieldQuery": "select * from multicol_tbl where 1 != 1",
         "Query": "select * from multicol_tbl where cola = 1 and colb in ::__vals1",
-        "Table": "multicol_tbl",
         "Values": [
           "1",
           "(2, 3)"
@@ -3762,8 +3601,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 0 from unsharded_a left join unsharded_b on unsharded_a.col = unsharded_b.col where 1 != 1",
-        "Query": "select 0 from unsharded_a left join unsharded_b on unsharded_a.col = unsharded_b.col where coalesce(unsharded_b.col, 4) = 5",
-        "Table": "unsharded_a, unsharded_b"
+        "Query": "select 0 from unsharded_a left join unsharded_b on unsharded_a.col = unsharded_b.col where coalesce(unsharded_b.col, 4) = 5"
       },
       "TablesUsed": [
         "main.unsharded_a",
@@ -3785,8 +3623,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
-        "Query": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where `user`.id is null",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where `user`.id is null"
       },
       "TablesUsed": [
         "user.user",
@@ -3809,7 +3646,6 @@
         },
         "FieldQuery": "select music.id from music left join `user` on music.user_id = `user`.id where 1 != 1",
         "Query": "select music.id from music left join `user` on music.user_id = `user`.id where music.user_id = 10 and `user`.id <=> null",
-        "Table": "`user`, music",
         "Values": [
           "10"
         ],
@@ -3836,7 +3672,6 @@
         },
         "FieldQuery": "select music.id from music left join `user` on music.user_id = `user`.id where 1 != 1",
         "Query": "select music.id from music left join `user` on music.user_id = `user`.id where music.user_id = 5 and (`user`.`name` = 'Trent Reznor' or music.genre = 'pop')",
-        "Table": "`user`, music",
         "Values": [
           "5"
         ],
@@ -3863,7 +3698,6 @@
         },
         "FieldQuery": "select music.id from music left join `user` on music.user_id = `user`.id where 1 != 1",
         "Query": "select music.id from music left join `user` on music.user_id = `user`.id where music.user_id = 5 and (`user`.`name` = 'Trent Reznor' or music.genre = 'pop')",
-        "Table": "`user`, music",
         "Values": [
           "5"
         ],
@@ -3890,7 +3724,6 @@
         },
         "FieldQuery": "select music.id from music, `user` where 1 != 1",
         "Query": "select music.id from music, `user` where music.user_id = 5 and music.user_id = `user`.id and music.componist = `user`.`name`",
-        "Table": "`user`, music",
         "Values": [
           "5"
         ],
@@ -3917,7 +3750,6 @@
         },
         "FieldQuery": "select music.id from music, `user` where 1 != 1",
         "Query": "select music.id from music, `user` where music.user_id = 5 and `user`.id is not null and `user`.id = music.user_id",
-        "Table": "`user`, music",
         "Values": [
           "5"
         ],
@@ -3944,7 +3776,6 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "Query": "select col from `user` where id in ::__vals",
-        "Table": "`user`",
         "Values": [
           "(1, 2)"
         ],
@@ -3970,7 +3801,6 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "Query": "select col from `user` where id in ::__vals",
-        "Table": "`user`",
         "Values": [
           "(1, 2, 3)"
         ],
@@ -3996,7 +3826,6 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "Query": "select col from `user` where id in ::__vals",
-        "Table": "`user`",
         "Values": [
           "(1, 2, 3, 4)"
         ],
@@ -4022,7 +3851,6 @@
         },
         "FieldQuery": "select id from music where 1 != 1",
         "Query": "select id from music where id is null and user_id in ::__vals",
-        "Table": "music",
         "Values": [
           "(1, 2)"
         ],
@@ -4047,8 +3875,7 @@
           "Sharded": true
         },
         "FieldQuery": "select a + 2 as a from `user` where 1 != 1",
-        "Query": "select a + 2 as a from `user` where `user`.a + 2 = 42",
-        "Table": "`user`"
+        "Query": "select a + 2 as a from `user` where `user`.a + 2 = 42"
       },
       "TablesUsed": [
         "user.user"
@@ -4071,8 +3898,7 @@
         "FieldQuery": "select a + 2 as a, weight_string(a + 2) from `user` where 1 != 1",
         "OrderBy": "(0|1) ASC",
         "Query": "select a + 2 as a, weight_string(a + 2) from `user` order by `user`.a + 2 asc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -4093,8 +3919,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col + 2 as a from `user` where 1 != 1",
-        "Query": "select `user`.col + 2 as a from `user` where `user`.col + 2 = 42",
-        "Table": "`user`"
+        "Query": "select `user`.col + 2 as a from `user` where `user`.col + 2 = 42"
       },
       "TablesUsed": [
         "user.user"
@@ -4115,8 +3940,7 @@
           "Sharded": false
         },
         "FieldQuery": "select col + 2 as a from unsharded where 1 != 1",
-        "Query": "select col + 2 as a from unsharded having a = 42",
-        "Table": "unsharded"
+        "Query": "select col + 2 as a from unsharded having a = 42"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -4138,7 +3962,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5 and (`name` = 'apa' or foo = 'bar')",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -4164,7 +3987,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id in ::__vals and (id = 5 or `name` = 'bar') and (`name` = 'foo' or id = 12) and `name` in ('foo', 'bar')",
-        "Table": "`user`",
         "Values": [
           "(5, 12)"
         ],
@@ -4206,7 +4028,6 @@
                     "JoinVars": {
                       "a_textcol1": 1
                     },
-                    "TableName": "`user`_`user`",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -4217,8 +4038,7 @@
                         },
                         "FieldQuery": "select sum(a.id), a.textcol1 from `user` as a where 1 != 1 group by a.textcol1",
                         "OrderBy": "1 ASC COLLATE latin1_swedish_ci",
-                        "Query": "select sum(a.id), a.textcol1 from `user` as a group by a.textcol1 order by a.textcol1 asc",
-                        "Table": "`user`"
+                        "Query": "select sum(a.id), a.textcol1 from `user` as a group by a.textcol1 order by a.textcol1 asc"
                       },
                       {
                         "OperatorType": "Route",
@@ -4228,8 +4048,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*) from `user` as b where 1 != 1 group by .0",
-                        "Query": "select count(*) from `user` as b where b.textcol2 = :a_textcol1 /* VARCHAR */ group by .0",
-                        "Table": "`user`"
+                        "Query": "select count(*) from `user` as b where b.textcol2 = :a_textcol1 /* VARCHAR */ group by .0"
                       }
                     ]
                   }
@@ -4258,8 +4077,7 @@
           "Sharded": true
         },
         "FieldQuery": "select textcol1 from `user` where 1 != 1",
-        "Query": "select textcol1 from `user` where foo = 42",
-        "Table": "`user`"
+        "Query": "select textcol1 from `user` where foo = 42"
       },
       "TablesUsed": [
         "user.user"
@@ -4276,7 +4094,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "unsharded_`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4286,15 +4103,13 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded where 1 != 1",
-            "Query": "select 1 from unsharded",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded"
           },
           {
             "OperatorType": "SemiJoin",
             "JoinVars": {
               "u1_bar": 0
             },
-            "TableName": "`user`_unsharded",
             "Inputs": [
               {
                 "InputName": "Outer",
@@ -4305,8 +4120,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u1.bar from `user` as u1 where 1 != 1",
-                "Query": "select u1.bar from `user` as u1",
-                "Table": "`user`"
+                "Query": "select u1.bar from `user` as u1"
               },
               {
                 "InputName": "SubQuery",
@@ -4317,8 +4131,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded as u2 where 1 != 1",
-                "Query": "select 1 from unsharded as u2 where u2.baz = :u1_bar limit 1",
-                "Table": "unsharded"
+                "Query": "select 1 from unsharded as u2 where u2.baz = :u1_bar limit 1"
               }
             ]
           }
@@ -4360,7 +4173,6 @@
                     "JoinVars": {
                       "user_id": 1
                     },
-                    "TableName": "`user`_user_extra",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -4370,8 +4182,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), `user`.id from `user` where 1 != 1 group by `user`.id",
-                        "Query": "select count(*), `user`.id from `user` group by `user`.id",
-                        "Table": "`user`"
+                        "Query": "select count(*), `user`.id from `user` group by `user`.id"
                       },
                       {
                         "OperatorType": "Route",
@@ -4381,8 +4192,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select count(*), user_extra.collections_status from user_extra where 1 != 1 group by user_extra.collections_status",
-                        "Query": "select count(*), user_extra.collections_status from user_extra where user_extra.bar = :user_id group by user_extra.collections_status",
-                        "Table": "user_extra"
+                        "Query": "select count(*), user_extra.collections_status from user_extra where user_extra.bar = :user_id group by user_extra.collections_status"
                       }
                     ]
                   }
@@ -4418,8 +4228,7 @@
             "FieldQuery": "select 1, ts, weight_string(ts) from `user` where 1 != 1",
             "OrderBy": "(1|2) ASC",
             "Query": "select 1, ts, weight_string(ts) from `user` where shard_key = 1 and is_removed = 1 and cmd in ('A', 'B', 'C') and (not user_id = 1 or not user_id is not null or not ts >= 1 or not ts <= 2) and (not user_id = 1 or not user_id is not null or not ts >= 12 or not ts <= 13) and (not user_id = 1 or not user_id is not null or not ts >= 14 or not ts <= 15) and (not user_id = 1 or not user_id is not null or not ts >= 16 or not ts <= 17) and (not user_id = 1 or not user_id is not null or not ts >= 18 or not ts <= 19) and (not user_id = 1 or not user_id is not null or not ts >= 110 or not ts <= 111) and (not user_id = 1 or not user_id is not null or not ts >= 112 or not ts <= 113) and (not user_id = 1 or not user_id is not null or not ts >= 114 or not ts <= 115) and (not user_id = 1 or not user_id is not null or not ts >= 116 or not ts <= 117) and (not user_id = 1 or not user_id is not null or not ts >= 118 or not ts <= 119) and (not user_id = 1 or not user_id is not null or not ts >= 120 or not ts <= 121) and (not user_id = 1 or not user_id is not null or not ts >= 122 or not ts <= 123) and (not user_id = 1 or not user_id is not null or not ts >= 124 or not ts <= 125) and (not user_id = 1 or not user_id is not null or not ts >= 126 or not ts <= 127) and (not user_id = 1 or not user_id is not null or not ts >= 128 or not ts <= 129) and (not user_id = 1 or not user_id is not null or not ts >= 130 or not ts <= 131) and (not user_id = 1 or not user_id is not null or not ts >= 132 or not ts <= 133) and (not user_id = 1 or not user_id is not null or not ts >= 134 or not ts <= 135) and (not user_id = 1 or not user_id is not null or not ts >= 136 or not ts <= 137) and (not user_id = 1 or not user_id is not null or not ts >= 138 or not ts <= 139) and (not user_id = 1 or not user_id is not null or not ts >= 140 or not ts <= 141) and (not user_id = 1 or not user_id is not null or not ts >= 142 or not ts <= 143) and (not user_id = 1 or not user_id is not null or not ts >= 144 or not ts <= 145) and (not user_id = 1 or not user_id is not null or not ts >= 146 or not ts <= 147) and (not user_id = 1 or not user_id is not null or not ts >= 148 or not ts <= 149) and (not user_id = 1 or not user_id is not null or not ts >= 150 or not ts <= 151) and (not user_id = 1 or not user_id is not null or not ts >= 152 or not ts <= 153) and (not user_id = 1 or not user_id is not null or not ts >= 154 or not ts <= 155) and (not user_id = 1 or not user_id is not null or not ts >= 156 or not ts <= 157) and (not user_id = 1 or not user_id is not null or not ts >= 158 or not ts <= 159) and (not user_id = 1 or not user_id is not null or not ts >= 160 or not ts <= 161) and (not user_id = 1 or not user_id is not null or not ts >= 162 or not ts <= 163) and (not user_id = 1 or not user_id is not null or not ts >= 164 or not ts <= 165) and (not user_id = 1 or not user_id is not null or not ts >= 166 or not ts <= 167) and (not user_id = 1 or not user_id is not null or not ts >= 168 or not ts <= 169) and (not user_id = 1 or not user_id is not null or not ts >= 170 or not ts <= 171) and (not user_id = 1 or not user_id is not null or not ts >= 172 or not ts <= 173) and (not user_id = 1 or not user_id is not null or not ts >= 174 or not ts <= 175) and (not user_id = 1 or not user_id is not null or not ts >= 176 or not ts <= 177) and (not user_id = 1 or not user_id is not null or not ts >= 178 or not ts <= 179) and (not user_id = 1 or not user_id is not null or not ts >= 180 or not ts <= 181) and (not user_id = 1 or not user_id is not null or not ts >= 182 or not ts <= 183) and (not user_id = 1 or not user_id is not null or not ts >= 184 or not ts <= 185) and (not user_id = 1 or not user_id is not null or not ts >= 186 or not ts <= 187) and (not user_id = 1 or not user_id is not null or not ts >= 188 or not ts <= 189) and (not user_id = 1 or not user_id is not null or not ts >= 190 or not ts <= 191) and (not user_id = 1 or not user_id is not null or not ts >= 192 or not ts <= 193) and (not user_id = 1 or not user_id is not null or not ts >= 194 or not ts <= 195) and (not user_id = 1 or not user_id is not null or not ts >= 196 or not ts <= 197) and (not user_id = 1 or not user_id is not null or not ts >= 198 or not ts <= 199) and (not user_id = 1 or not user_id is not null or not ts >= 1100 or not ts <= 1101) and (not user_id = 1 or not user_id is not null or not ts >= 1102 or not ts <= 1103) and (not user_id = 1 or not user_id is not null or not ts >= 1104 or not ts <= 1105) and (not user_id = 1 or not user_id is not null or not ts >= 1106 or not ts <= 1107) and (not user_id = 1 or not user_id is not null or not ts >= 1108 or not ts <= 1109) and (not user_id = 1 or not user_id is not null or not ts >= 1110 or not ts <= 1111) and (not user_id = 1 or not user_id is not null or not ts >= 1112 or not ts <= 1113) and (not user_id = 1 or not user_id is not null or not ts >= 1114 or not ts <= 1115) and (not user_id = 1 or not user_id is not null or not ts >= 1116 or not ts <= 1117) and (not user_id = 1 or not user_id is not null or not ts >= 1118 or not ts <= 1119) and (not user_id = 1 or not user_id is not null or not ts >= 1120 or not ts <= 1121) and (not user_id = 1 or not user_id is not null or not ts >= 1122 or not ts <= 1123) and (not user_id = 1 or not user_id is not null or not ts >= 1124 or not ts <= 1125) and (not user_id = 1 or not user_id is not null or not ts >= 1126 or not ts <= 1127) and (not user_id = 1 or not user_id is not null or not ts >= 1128 or not ts <= 1129) and (not user_id = 1 or not user_id is not null or not ts >= 1130 or not ts <= 1131) and (not user_id = 1 or not user_id is not null or not ts >= 1132 or not ts <= 1133) and (not user_id = 1 or not user_id is not null or not ts >= 1134 or not ts <= 1135) and (not user_id = 1 or not user_id is not null or not ts >= 1136 or not ts <= 1137) and (not user_id = 1 or not user_id is not null or not ts >= 1138 or not ts <= 1139) and (not user_id = 1 or not user_id is not null or not ts >= 1140 or not ts <= 1141) and (not user_id = 1 or not user_id is not null or not ts >= 1142 or not ts <= 1143) and (not user_id = 1 or not user_id is not null or not ts >= 1144 or not ts <= 1145) and (not user_id = 1 or not user_id is not null or not ts >= 1146 or not ts <= 1147) and (not user_id = 1 or not user_id is not null or not ts >= 1148 or not ts <= 1149) and (not user_id = 1 or not user_id is not null or not ts >= 1150 or not ts <= 1151) and (not user_id = 1 or not user_id is not null or not ts >= 1152 or not ts <= 1153) and (not user_id = 1 or not user_id is not null or not ts >= 1154 or not ts <= 1155) and (not user_id = 1 or not user_id is not null or not ts >= 1156 or not ts <= 1157) and (not user_id = 1 or not user_id is not null or not ts >= 1158 or not ts <= 1159) and (not user_id = 1 or not user_id is not null or not ts >= 1160 or not ts <= 1161) and (not user_id = 1 or not user_id is not null or not ts >= 1162 or not ts <= 1163) and (not user_id = 1 or not user_id is not null or not ts >= 1164 or not ts <= 1165) and (not user_id = 1 or not user_id is not null or not ts >= 1166 or not ts <= 1167) and (not user_id = 1 or not user_id is not null or not ts >= 1168 or not ts <= 1169) and (not user_id = 1 or not user_id is not null or not ts >= 1170 or not ts <= 1171) and (not user_id = 1 or not user_id is not null or not ts >= 1172 or not ts <= 1173) and (not user_id = 1 or not user_id is not null or not ts >= 1174 or not ts <= 1175) and (not user_id = 1 or not user_id is not null or not ts >= 1176 or not ts <= 1177) and (not user_id = 1 or not user_id is not null or not ts >= 1178 or not ts <= 1179) and (not user_id = 1 or not user_id is not null or not ts >= 1180 or not ts <= 1181) and (not user_id = 1 or not user_id is not null or not ts >= 1182 or not ts <= 1183) and (not user_id = 1 or not user_id is not null or not ts >= 1184 or not ts <= 1185) and (not user_id = 1 or not user_id is not null or not ts >= 1186 or not ts <= 1187) and (not user_id = 1 or not user_id is not null or not ts >= 1188 or not ts <= 1189) and (not user_id = 1 or not user_id is not null or not ts >= 1190 or not ts <= 1191) and (not user_id = 1 or not user_id is not null or not ts >= 1192 or not ts <= 1193) and (not user_id = 1 or not user_id is not null or not ts >= 1194 or not ts <= 1195) and (not user_id = 1 or not user_id is not null or not ts >= 1196 or not ts <= 1197) and (not user_id = 1 or not user_id is not null or not ts >= 1198 or not ts <= 1199) and (not user_id = 1 or not user_id is not null or not ts >= 1200 or not ts <= 1201) and (not user_id = 1 or not user_id is not null or not ts >= 1202 or not ts <= 1203) and (not user_id = 1 or not user_id is not null or not ts >= 1204 or not ts <= 1205) and (not user_id = 1 or not user_id is not null or not ts >= 1206 or not ts <= 1207) and (not user_id = 1 or not user_id is not null or not ts >= 1208 or not ts <= 1209) and (not user_id = 1 or not user_id is not null or not ts >= 1210 or not ts <= 1211) and (not user_id = 1 or not user_id is not null or not ts >= 1212 or not ts <= 1213) and (not user_id = 1 or not user_id is not null or not ts >= 1214 or not ts <= 1215) and (not user_id = 1 or not user_id is not null or not ts >= 1216 or not ts <= 1217) and (not user_id = 1 or not user_id is not null or not ts >= 1218 or not ts <= 1219) and (not user_id = 1 or not user_id is not null or not ts >= 1220 or not ts <= 1221) and (not user_id = 1 or not user_id is not null or not ts >= 1222 or not ts <= 1223) and (not user_id = 1 or not user_id is not null or not ts >= 1224 or not ts <= 1225) and (not user_id = 1 or not user_id is not null or not ts >= 1226 or not ts <= 1227) and (not user_id = 1 or not user_id is not null or not ts >= 1228 or not ts <= 1229) and (not user_id = 1 or not user_id is not null or not ts >= 1230 or not ts <= 1231) and (not user_id = 1 or not user_id is not null or not ts >= 1232 or not ts <= 1233) and (not user_id = 1 or not user_id is not null or not ts >= 1234 or not ts <= 1235) and (not user_id = 1 or not user_id is not null or not ts >= 1236 or not ts <= 1237) and (not user_id = 1 or not user_id is not null or not ts >= 1238 or not ts <= 1239) and (not user_id = 1 or not user_id is not null or not ts >= 1240 or not ts <= 1241) and (not user_id = 1 or not user_id is not null or not ts >= 1242 or not ts <= 1243) and (not user_id = 1 or not user_id is not null or not ts >= 1244 or not ts <= 1245) and (not user_id = 1 or not user_id is not null or not ts >= 1246 or not ts <= 1247) and (not user_id = 1 or not user_id is not null or not ts >= 1248 or not ts <= 1249) and (not user_id = 1 or not user_id is not null or not ts >= 1250 or not ts <= 1251) and (not user_id = 1 or not user_id is not null or not ts >= 1252 or not ts <= 1253) and (not user_id = 1 or not user_id is not null or not ts >= 1254 or not ts <= 1255) and (not user_id = 1 or not user_id is not null or not ts >= 1256 or not ts <= 1257) and (not user_id = 1 or not user_id is not null or not ts >= 1258 or not ts <= 1259) and (not user_id = 1 or not user_id is not null or not ts >= 1260 or not ts <= 1261) and (not user_id = 1 or not user_id is not null or not ts >= 1262 or not ts <= 1263) and (not user_id = 1 or not user_id is not null or not ts >= 1264 or not ts <= 1265) and (not user_id = 1 or not user_id is not null or not ts >= 1266 or not ts <= 1267) and (not user_id = 1 or not user_id is not null or not ts >= 1268 or not ts <= 1269) and (not user_id = 1 or not user_id is not null or not ts >= 1270 or not ts <= 1271) and (not user_id = 1 or not user_id is not null or not ts >= 1272 or not ts <= 1273) and (not user_id = 1 or not user_id is not null or not ts >= 1274 or not ts <= 1275) and (not user_id = 1 or not user_id is not null or not ts >= 1276 or not ts <= 1277) and (not user_id = 1 or not user_id is not null or not ts >= 1278 or not ts <= 1279) and (not user_id = 1 or not user_id is not null or not ts >= 1280 or not ts <= 1281) and (not user_id = 1 or not user_id is not null or not ts >= 1282 or not ts <= 1283) and (not user_id = 1 or not user_id is not null or not ts >= 1284 or not ts <= 1285) and (not user_id = 1 or not user_id is not null or not ts >= 1286 or not ts <= 1287) and (not user_id = 1 or not user_id is not null or not ts >= 1288 or not ts <= 1289) and (not user_id = 1 or not user_id is not null or not ts >= 1290 or not ts <= 1291) and (not user_id = 1 or not user_id is not null or not ts >= 1292 or not ts <= 1293) and (not user_id = 1 or not user_id is not null or not ts >= 1294 or not ts <= 1295) and (not user_id = 1 or not user_id is not null or not ts >= 1296 or not ts <= 1297) and (not user_id = 1 or not user_id is not null or not ts >= 1298 or not ts <= 1299) and (not user_id = 1 or not user_id is not null or not ts >= 1300 or not ts <= 1301) and (not user_id = 1 or not user_id is not null or not ts >= 1302 or not ts <= 1303) and (not user_id = 1 or not user_id is not null or not ts >= 1304 or not ts <= 1305) and (not user_id = 1 or not user_id is not null or not ts >= 1306 or not ts <= 1307) and (not user_id = 1 or not user_id is not null or not ts >= 1308 or not ts <= 1309) and (not user_id = 1 or not user_id is not null or not ts >= 1310 or not ts <= 1311) and (not user_id = 1 or not user_id is not null or not ts >= 1312 or not ts <= 1313) and (not user_id = 1 or not user_id is not null or not ts >= 1314 or not ts <= 1315) and (not user_id = 1 or not user_id is not null or not ts >= 1316 or not ts <= 1317) and (not user_id = 1 or not user_id is not null or not ts >= 1318 or not ts <= 1319) and (not user_id = 1 or not user_id is not null or not ts >= 1320 or not ts <= 1321) and (not user_id = 1 or not user_id is not null or not ts >= 1322 or not ts <= 1323) and (not user_id = 1 or not user_id is not null or not ts >= 1324 or not ts <= 1325) and (not user_id = 1 or not user_id is not null or not ts >= 1326 or not ts <= 1327) and (not user_id = 1 or not user_id is not null or not ts >= 1328 or not ts <= 1329) and (not user_id = 1 or not user_id is not null or not ts >= 1330 or not ts <= 1331) and (not user_id = 1 or not user_id is not null or not ts >= 1332 or not ts <= 1333) and (not user_id = 1 or not user_id is not null or not ts >= 1334 or not ts <= 1335) and (not user_id = 1 or not user_id is not null or not ts >= 1336 or not ts <= 1337) and (not user_id = 1 or not user_id is not null or not ts >= 1338 or not ts <= 1339) and (not user_id = 1 or not user_id is not null or not ts >= 1340 or not ts <= 1341) and (not user_id = 1 or not user_id is not null or not ts >= 1342 or not ts <= 1343) and (not user_id = 1 or not user_id is not null or not ts >= 1344 or not ts <= 1345) and (not user_id = 1 or not user_id is not null or not ts >= 1346 or not ts <= 1347) and (not user_id = 1 or not user_id is not null or not ts >= 1348 or not ts <= 1349) and (not user_id = 1 or not user_id is not null or not ts >= 1350 or not ts <= 1351) and (not user_id = 1 or not user_id is not null or not ts >= 1352 or not ts <= 1353) and (not user_id = 1 or not user_id is not null or not ts >= 1354 or not ts <= 1355) and (not user_id = 1 or not user_id is not null or not ts >= 1356 or not ts <= 1357) and (not user_id = 1 or not user_id is not null or not ts >= 1358 or not ts <= 1359) and (not user_id = 1 or not user_id is not null or not ts >= 1360 or not ts <= 1361) and (not user_id = 1 or not user_id is not null or not ts >= 1362 or not ts <= 1363) and (not user_id = 1 or not user_id is not null or not ts >= 1364 or not ts <= 1365) and (not user_id = 1 or not user_id is not null or not ts >= 1366 or not ts <= 1367) and (not user_id = 1 or not user_id is not null or not ts >= 1368 or not ts <= 1369) and (not user_id = 1 or not user_id is not null or not ts >= 1370 or not ts <= 1371) and (not user_id = 1 or not user_id is not null or not ts >= 1372 or not ts <= 1373) and (not user_id = 1 or not user_id is not null or not ts >= 1374 or not ts <= 1375) and (not user_id = 1 or not user_id is not null or not ts >= 1376 or not ts <= 1377) and (not user_id = 1 or not user_id is not null or not ts >= 1378 or not ts <= 1379) and (not user_id = 1 or not user_id is not null or not ts >= 1380 or not ts <= 1381) and (not user_id = 1 or not user_id is not null or not ts >= 1382 or not ts <= 1383) and (not user_id = 1 or not user_id is not null or not ts >= 1384 or not ts <= 1385) and (not user_id = 1 or not user_id is not null or not ts >= 1386 or not ts <= 1387) and (not user_id = 1 or not user_id is not null or not ts >= 1388 or not ts <= 1389) and (not user_id = 1 or not user_id is not null or not ts >= 1390 or not ts <= 1391) and (not user_id = 1 or not user_id is not null or not ts >= 1392 or not ts <= 1393) and (not user_id = 1 or not user_id is not null or not ts >= 1394 or not ts <= 1395) and (not user_id = 1 or not user_id is not null or not ts >= 1396 or not ts <= 1397) and (not user_id = 1 or not user_id is not null or not ts >= 1398 or not ts <= 1399) and (not user_id = 1 or not user_id is not null or not ts >= 1400 or not ts <= 1401) and (not user_id = 1 or not user_id is not null or not ts >= 1402 or not ts <= 1403) and (not user_id = 1 or not user_id is not null or not ts >= 1404 or not ts <= 1405) and (not user_id = 1 or not user_id is not null or not ts >= 1406 or not ts <= 1407) and (not user_id = 1 or not user_id is not null or not ts >= 1408 or not ts <= 1409) and (not user_id = 1 or not user_id is not null or not ts >= 1410 or not ts <= 1411) and (not user_id = 1 or not user_id is not null or not ts >= 1412 or not ts <= 1413) and (not user_id = 1 or not user_id is not null or not ts >= 1414 or not ts <= 1415) and (not user_id = 1 or not user_id is not null or not ts >= 1416 or not ts <= 1417) and (not user_id = 1 or not user_id is not null or not ts >= 1418 or not ts <= 1419) and (not user_id = 1 or not user_id is not null or not ts >= 1420 or not ts <= 1421) and (not user_id = 1 or not user_id is not null or not ts >= 1422 or not ts <= 1423) and (not user_id = 1 or not user_id is not null or not ts >= 1424 or not ts <= 1425) and (not user_id = 1 or not user_id is not null or not ts >= 1426 or not ts <= 1427) and (not user_id = 1 or not user_id is not null or not ts >= 1428 or not ts <= 1429) and (not user_id = 1 or not user_id is not null or not ts >= 1430 or not ts <= 1431) and (not user_id = 1 or not user_id is not null or not ts >= 1432 or not ts <= 1433) and (not user_id = 1 or not user_id is not null or not ts >= 1434 or not ts <= 1435) and (not user_id = 1 or not user_id is not null or not ts >= 1436 or not ts <= 1437) and (not user_id = 1 or not user_id is not null or not ts >= 1438 or not ts <= 1439) and (not user_id = 1 or not user_id is not null or not ts >= 1440 or not ts <= 1441) and (not user_id = 1 or not user_id is not null or not ts >= 1442 or not ts <= 1443) and (not user_id = 1 or not user_id is not null or not ts >= 1444 or not ts <= 1445) and (not user_id = 1 or not user_id is not null or not ts >= 1446 or not ts <= 1447) and (not user_id = 1 or not user_id is not null or not ts >= 1448 or not ts <= 1449) and (not user_id = 1 or not user_id is not null or not ts >= 1450 or not ts <= 1451) and (not user_id = 1 or not user_id is not null or not ts >= 1452 or not ts <= 1453) and (not user_id = 1 or not user_id is not null or not ts >= 1454 or not ts <= 1455) and (not user_id = 1 or not user_id is not null or not ts >= 1456 or not ts <= 1457) and (not user_id = 1 or not user_id is not null or not ts >= 1458 or not ts <= 1459) and (not user_id = 1 or not user_id is not null or not ts >= 1460 or not ts <= 1461) and (not user_id = 1 or not user_id is not null or not ts >= 1462 or not ts <= 1463) and (not user_id = 1 or not user_id is not null or not ts >= 1464 or not ts <= 1465) and (not user_id = 1 or not user_id is not null or not ts >= 1466 or not ts <= 1467) and (not user_id = 1 or not user_id is not null or not ts >= 1468 or not ts <= 1469) and (not user_id = 1 or not user_id is not null or not ts >= 1470 or not ts <= 1471) and (not user_id = 1 or not user_id is not null or not ts >= 1472 or not ts <= 1473) and (not user_id = 1 or not user_id is not null or not ts >= 1474 or not ts <= 1475) and (not user_id = 1 or not user_id is not null or not ts >= 1476 or not ts <= 1477) and (not user_id = 1 or not user_id is not null or not ts >= 1478 or not ts <= 1479) and (not user_id = 1 or not user_id is not null or not ts >= 1480 or not ts <= 1481) and (not user_id = 1 or not user_id is not null or not ts >= 1482 or not ts <= 1483) and (not user_id = 1 or not user_id is not null or not ts >= 1484 or not ts <= 1485) and (not user_id = 1 or not user_id is not null or not ts >= 1486 or not ts <= 1487) and (not user_id = 1 or not user_id is not null or not ts >= 1488 or not ts <= 1489) and (not user_id = 1 or not user_id is not null or not ts >= 1490 or not ts <= 1491) and (not user_id = 1 or not user_id is not null or not ts >= 1492 or not ts <= 1493) and (not user_id = 1 or not user_id is not null or not ts >= 1494 or not ts <= 1495) and (not user_id = 1 or not user_id is not null or not ts >= 1496 or not ts <= 1497) and (not user_id = 1 or not user_id is not null or not ts >= 1498 or not ts <= 1499) and (not user_id = 1 or not user_id is not null or not ts >= 1500 or not ts <= 1501) and (not user_id = 1 or not user_id is not null or not ts >= 1502 or not ts <= 1503) and (not user_id = 1 or not user_id is not null or not ts >= 1504 or not ts <= 1505) and (not user_id = 1 or not user_id is not null or not ts >= 1506 or not ts <= 1507) and (not user_id = 1 or not user_id is not null or not ts >= 1508 or not ts <= 1509) and (not user_id = 1 or not user_id is not null or not ts >= 1510 or not ts <= 1511) and (not user_id = 1 or not user_id is not null or not ts >= 1512 or not ts <= 1513) and (not user_id = 1 or not user_id is not null or not ts >= 1514 or not ts <= 1515) and (not user_id = 1 or not user_id is not null or not ts >= 1516 or not ts <= 1517) and (not user_id = 1 or not user_id is not null or not ts >= 1518 or not ts <= 1519) and (not user_id = 1 or not user_id is not null or not ts >= 1520 or not ts <= 1521) and (not user_id = 1 or not user_id is not null or not ts >= 1522 or not ts <= 1523) and (not user_id = 1 or not user_id is not null or not ts >= 1524 or not ts <= 1525) and (not user_id = 1 or not user_id is not null or not ts >= 1526 or not ts <= 1527) and (not user_id = 1 or not user_id is not null or not ts >= 1528 or not ts <= 1529) and (not user_id = 1 or not user_id is not null or not ts >= 1530 or not ts <= 1531) and (not user_id = 1 or not user_id is not null or not ts >= 1532 or not ts <= 1533) and (not user_id = 1 or not user_id is not null or not ts >= 1534 or not ts <= 1535) and (not user_id = 1 or not user_id is not null or not ts >= 1536 or not ts <= 1537) and (not user_id = 1 or not user_id is not null or not ts >= 1538 or not ts <= 1539) and (not user_id = 1 or not user_id is not null or not ts >= 1540 or not ts <= 1541) and (not user_id = 1 or not user_id is not null or not ts >= 1542 or not ts <= 1543) and (not user_id = 1 or not user_id is not null or not ts >= 1544 or not ts <= 1545) and (not user_id = 1 or not user_id is not null or not ts >= 1546 or not ts <= 1547) and (not user_id = 1 or not user_id is not null or not ts >= 1548 or not ts <= 1549) and (not user_id = 1 or not user_id is not null or not ts >= 1550 or not ts <= 1551) and (not user_id = 1 or not user_id is not null or not ts >= 1552 or not ts <= 1553) and (not user_id = 1 or not user_id is not null or not ts >= 1554 or not ts <= 1555) and (not user_id = 1 or not user_id is not null or not ts >= 1556 or not ts <= 1557) and (not user_id = 1 or not user_id is not null or not ts >= 1558 or not ts <= 1559) and (not user_id = 1 or not user_id is not null or not ts >= 1560 or not ts <= 1561) and (not user_id = 1 or not user_id is not null or not ts >= 1562 or not ts <= 1563) and (not user_id = 1 or not user_id is not null or not ts >= 1564 or not ts <= 1565) and (not user_id = 1 or not user_id is not null or not ts >= 1566 or not ts <= 1567) and (not user_id = 1 or not user_id is not null or not ts >= 1568 or not ts <= 1569) and (not user_id = 1 or not user_id is not null or not ts >= 1570 or not ts <= 1571) and (not user_id = 1 or not user_id is not null or not ts >= 1572 or not ts <= 1573) and (not user_id = 1 or not user_id is not null or not ts >= 1574 or not ts <= 1575) and (not user_id = 1 or not user_id is not null or not ts >= 1576 or not ts <= 1577) and (not user_id = 1 or not user_id is not null or not ts >= 1578 or not ts <= 1579) and (not user_id = 1 or not user_id is not null or not ts >= 1580 or not ts <= 1581) and (not user_id = 1 or not user_id is not null or not ts >= 1582 or not ts <= 1583) and (not user_id = 1 or not user_id is not null or not ts >= 1584 or not ts <= 1585) and (not user_id = 1 or not user_id is not null or not ts >= 1586 or not ts <= 1587) and (not user_id = 1 or not user_id is not null or not ts >= 1588 or not ts <= 1589) and (not user_id = 1 or not user_id is not null or not ts >= 1590 or not ts <= 1591) and (not user_id = 1 or not user_id is not null or not ts >= 1592 or not ts <= 1593) and (not user_id = 1 or not user_id is not null or not ts >= 1594 or not ts <= 1595) and (not user_id = 1 or not user_id is not null or not ts >= 1596 or not ts <= 1597) and (not user_id = 1 or not user_id is not null or not ts >= 1598 or not ts <= 1599) and (not user_id = 1 or not user_id is not null or not ts >= 1600 or not ts <= 1601) and (not user_id = 1 or not user_id is not null or not ts >= 1602 or not ts <= 1603) and (not user_id = 1 or not user_id is not null or not ts >= 1604 or not ts <= 1605) and (not user_id = 1 or not user_id is not null or not ts >= 1606 or not ts <= 1607) and (not user_id = 1 or not user_id is not null or not ts >= 1608 or not ts <= 1609) and (not user_id = 1 or not user_id is not null or not ts >= 1610 or not ts <= 1611) and (not user_id = 1 or not user_id is not null or not ts >= 1612 or not ts <= 1613) and (not user_id = 1 or not user_id is not null or not ts >= 1614 or not ts <= 1615) and (not user_id = 1 or not user_id is not null or not ts >= 1616 or not ts <= 1617) and (not user_id = 1 or not user_id is not null or not ts >= 1618 or not ts <= 1619) and (not user_id = 1 or not user_id is not null or not ts >= 1620 or not ts <= 1621) and (not user_id = 1 or not user_id is not null or not ts >= 1622 or not ts <= 1623) and (not user_id = 1 or not user_id is not null or not ts >= 1624 or not ts <= 1625) and (not user_id = 1 or not user_id is not null or not ts >= 1626 or not ts <= 1627) and (not user_id = 1 or not user_id is not null or not ts >= 1628 or not ts <= 1629) and (not user_id = 1 or not user_id is not null or not ts >= 1630 or not ts <= 1631) and (not user_id = 1 or not user_id is not null or not ts >= 1632 or not ts <= 1633) and (not user_id = 1 or not user_id is not null or not ts >= 1634 or not ts <= 1635) and (not user_id = 1 or not user_id is not null or not ts >= 1636 or not ts <= 1637) and (not user_id = 1 or not user_id is not null or not ts >= 1638 or not ts <= 1639) and (not user_id = 1 or not user_id is not null or not ts >= 1640 or not ts <= 1641) and (not user_id = 1 or not user_id is not null or not ts >= 1642 or not ts <= 1643) and (not user_id = 1 or not user_id is not null or not ts >= 1644 or not ts <= 1645) and (not user_id = 1 or not user_id is not null or not ts >= 1646 or not ts <= 1647) and (not user_id = 1 or not user_id is not null or not ts >= 1648 or not ts <= 1649) and (not user_id = 1 or not user_id is not null or not ts >= 1650 or not ts <= 1651) and (not user_id = 1 or not user_id is not null or not ts >= 1652 or not ts <= 1653) and (not user_id = 1 or not user_id is not null or not ts >= 1654 or not ts <= 1655) and (not user_id = 1 or not user_id is not null or not ts >= 1656 or not ts <= 1657) and (not user_id = 1 or not user_id is not null or not ts >= 1658 or not ts <= 1659) and (not user_id = 1 or not user_id is not null or not ts >= 1660 or not ts <= 1661) and (not user_id = 1 or not user_id is not null or not ts >= 1662 or not ts <= 1663) and (not user_id = 1 or not user_id is not null or not ts >= 1664 or not ts <= 1665) and (not user_id = 1 or not user_id is not null or not ts >= 1666 or not ts <= 1667) and (not user_id = 1 or not user_id is not null or not ts >= 1668 or not ts <= 1669) and (not user_id = 1 or not user_id is not null or not ts >= 1670 or not ts <= 1671) and (not user_id = 1 or not user_id is not null or not ts >= 1672 or not ts <= 1673) and (not user_id = 1 or not user_id is not null or not ts >= 1674 or not ts <= 1675) and (not user_id = 1 or not user_id is not null or not ts >= 1676 or not ts <= 1677) and (not user_id = 1 or not user_id is not null or not ts >= 1678 or not ts <= 1679) and (not user_id = 1 or not user_id is not null or not ts >= 1680 or not ts <= 1681) and (not user_id = 1 or not user_id is not null or not ts >= 1682 or not ts <= 1683) and (not user_id = 1 or not user_id is not null or not ts >= 1684 or not ts <= 1685) and (not user_id = 1 or not user_id is not null or not ts >= 1686 or not ts <= 1687) and (not user_id = 1 or not user_id is not null or not ts >= 1688 or not ts <= 1689) and (not user_id = 1 or not user_id is not null or not ts >= 1690 or not ts <= 1691) and (not user_id = 1 or not user_id is not null or not ts >= 1692 or not ts <= 1693) and (not user_id = 1 or not user_id is not null or not ts >= 1694 or not ts <= 1695) and (not user_id = 1 or not user_id is not null or not ts >= 1696 or not ts <= 1697) and (not user_id = 1 or not user_id is not null or not ts >= 1698 or not ts <= 1699) and (not user_id = 1 or not user_id is not null or not ts >= 1700 or not ts <= 1701) and (not user_id = 1 or not user_id is not null or not ts >= 1702 or not ts <= 1703) and (not user_id = 1 or not user_id is not null or not ts >= 1704 or not ts <= 1705) and (not user_id = 1 or not user_id is not null or not ts >= 1706 or not ts <= 1707) and (not user_id = 1 or not user_id is not null or not ts >= 1708 or not ts <= 1709) and (not user_id = 1 or not user_id is not null or not ts >= 1710 or not ts <= 1711) and (not user_id = 1 or not user_id is not null or not ts >= 1712 or not ts <= 1713) and (not user_id = 1 or not user_id is not null or not ts >= 1714 or not ts <= 1715) and (not user_id = 1 or not user_id is not null or not ts >= 1716 or not ts <= 1717) and (not user_id = 1 or not user_id is not null or not ts >= 1718 or not ts <= 1719) and (not user_id = 1 or not user_id is not null or not ts >= 1720 or not ts <= 1721) and (not user_id = 1 or not user_id is not null or not ts >= 1722 or not ts <= 1723) and (not user_id = 1 or not user_id is not null or not ts >= 1724 or not ts <= 1725) and (not user_id = 1 or not user_id is not null or not ts >= 1726 or not ts <= 1727) and (not user_id = 1 or not user_id is not null or not ts >= 1728 or not ts <= 1729) and (not user_id = 1 or not user_id is not null or not ts >= 1730 or not ts <= 1731) and (not user_id = 1 or not user_id is not null or not ts >= 1732 or not ts <= 1733) and (not user_id = 1 or not user_id is not null or not ts >= 1734 or not ts <= 1735) and (not user_id = 1 or not user_id is not null or not ts >= 1736 or not ts <= 1737) and (not user_id = 1 or not user_id is not null or not ts >= 1738 or not ts <= 1739) and (not user_id = 1 or not user_id is not null or not ts >= 1740 or not ts <= 1741) and (not user_id = 1 or not user_id is not null or not ts >= 1742 or not ts <= 1743) and (not user_id = 1 or not user_id is not null or not ts >= 1744 or not ts <= 1745) and (not user_id = 1 or not user_id is not null or not ts >= 1746 or not ts <= 1747) and (not user_id = 1 or not user_id is not null or not ts >= 1748 or not ts <= 1749) and (not user_id = 1 or not user_id is not null or not ts >= 1750 or not ts <= 1751) and (not user_id = 1 or not user_id is not null or not ts >= 1752 or not ts <= 1753) and (not user_id = 1 or not user_id is not null or not ts >= 1754 or not ts <= 1755) and (not user_id = 1 or not user_id is not null or not ts >= 1756 or not ts <= 1757) and (not user_id = 1 or not user_id is not null or not ts >= 1758 or not ts <= 1759) and (not user_id = 1 or not user_id is not null or not ts >= 1760 or not ts <= 1761) and (not user_id = 1 or not user_id is not null or not ts >= 1762 or not ts <= 1763) and (not user_id = 1 or not user_id is not null or not ts >= 1764 or not ts <= 1765) and (not user_id = 1 or not user_id is not null or not ts >= 1766 or not ts <= 1767) and (not user_id = 1 or not user_id is not null or not ts >= 1768 or not ts <= 1769) and (not user_id = 1 or not user_id is not null or not ts >= 1770 or not ts <= 1771) and (not user_id = 1 or not user_id is not null or not ts >= 1772 or not ts <= 1773) and (not user_id = 1 or not user_id is not null or not ts >= 1774 or not ts <= 1775) and (not user_id = 1 or not user_id is not null or not ts >= 1776 or not ts <= 1777) and (not user_id = 1 or not user_id is not null or not ts >= 1778 or not ts <= 1779) and (not user_id = 1 or not user_id is not null or not ts >= 1780 or not ts <= 1781) and (not user_id = 1 or not user_id is not null or not ts >= 1782 or not ts <= 1783) and (not user_id = 1 or not user_id is not null or not ts >= 1784 or not ts <= 1785) and (not user_id = 1 or not user_id is not null or not ts >= 1786 or not ts <= 1787) and (not user_id = 1 or not user_id is not null or not ts >= 1788 or not ts <= 1789) and (not user_id = 1 or not user_id is not null or not ts >= 1790 or not ts <= 1791) and (not user_id = 1 or not user_id is not null or not ts >= 1792 or not ts <= 1793) and (not user_id = 1 or not user_id is not null or not ts >= 1794 or not ts <= 1795) and (not user_id = 1 or not user_id is not null or not ts >= 1796 or not ts <= 1797) and (not user_id = 1 or not user_id is not null or not ts >= 1798 or not ts <= 1799) and (not user_id = 1 or not user_id is not null or not ts >= 1800 or not ts <= 1801) and (not user_id = 1 or not user_id is not null or not ts >= 1802 or not ts <= 1803) and (not user_id = 1 or not user_id is not null or not ts >= 1804 or not ts <= 1805) and (not user_id = 1 or not user_id is not null or not ts >= 1806 or not ts <= 1807) and (not user_id = 1 or not user_id is not null or not ts >= 1808 or not ts <= 1809) and (not user_id = 1 or not user_id is not null or not ts >= 1810 or not ts <= 1811) and (not user_id = 1 or not user_id is not null or not ts >= 1812 or not ts <= 1813) and (not user_id = 1 or not user_id is not null or not ts >= 1814 or not ts <= 1815) and (not user_id = 1 or not user_id is not null or not ts >= 1816 or not ts <= 1817) and (not user_id = 1 or not user_id is not null or not ts >= 1818 or not ts <= 1819) and (not user_id = 1 or not user_id is not null or not ts >= 1820 or not ts <= 1821) and (not user_id = 1 or not user_id is not null or not ts >= 1822 or not ts <= 1823) and (not user_id = 1 or not user_id is not null or not ts >= 1824 or not ts <= 1825) and (not user_id = 1 or not user_id is not null or not ts >= 1826 or not ts <= 1827) and (not user_id = 1 or not user_id is not null or not ts >= 1828 or not ts <= 1829) and (not user_id = 1 or not user_id is not null or not ts >= 1830 or not ts <= 1831) and (not user_id = 1 or not user_id is not null or not ts >= 1832 or not ts <= 1833) and (not user_id = 1 or not user_id is not null or not ts >= 1834 or not ts <= 1835) and (not user_id = 1 or not user_id is not null or not ts >= 1836 or not ts <= 1837) and (not user_id = 1 or not user_id is not null or not ts >= 1838 or not ts <= 1839) and (not user_id = 1 or not user_id is not null or not ts >= 1840 or not ts <= 1841) and (not user_id = 1 or not user_id is not null or not ts >= 1842 or not ts <= 1843) and (not user_id = 1 or not user_id is not null or not ts >= 1844 or not ts <= 1845) and (not user_id = 1 or not user_id is not null or not ts >= 1846 or not ts <= 1847) and (not user_id = 1 or not user_id is not null or not ts >= 1848 or not ts <= 1849) and (not user_id = 1 or not user_id is not null or not ts >= 1850 or not ts <= 1851) and (not user_id = 1 or not user_id is not null or not ts >= 1852 or not ts <= 1853) and (not user_id = 1 or not user_id is not null or not ts >= 1854 or not ts <= 1855) and (not user_id = 1 or not user_id is not null or not ts >= 1856 or not ts <= 1857) and (not user_id = 1 or not user_id is not null or not ts >= 1858 or not ts <= 1859) and (not user_id = 1 or not user_id is not null or not ts >= 1860 or not ts <= 1861) and (not user_id = 1 or not user_id is not null or not ts >= 1862 or not ts <= 1863) and (not user_id = 1 or not user_id is not null or not ts >= 1864 or not ts <= 1865) and (not user_id = 1 or not user_id is not null or not ts >= 1866 or not ts <= 1867) and (not user_id = 1 or not user_id is not null or not ts >= 1868 or not ts <= 1869) and (not user_id = 1 or not user_id is not null or not ts >= 1870 or not ts <= 1871) and (not user_id = 1 or not user_id is not null or not ts >= 1872 or not ts <= 1873) and (not user_id = 1 or not user_id is not null or not ts >= 1874 or not ts <= 1875) and (not user_id = 1 or not user_id is not null or not ts >= 1876 or not ts <= 1877) and (not user_id = 1 or not user_id is not null or not ts >= 1878 or not ts <= 1879) and (not user_id = 1 or not user_id is not null or not ts >= 1880 or not ts <= 1881) and (not user_id = 1 or not user_id is not null or not ts >= 1882 or not ts <= 1883) and (not user_id = 1 or not user_id is not null or not ts >= 1884 or not ts <= 1885) and (not user_id = 1 or not user_id is not null or not ts >= 1886 or not ts <= 1887) and (not user_id = 1 or not user_id is not null or not ts >= 1888 or not ts <= 1889) and (not user_id = 1 or not user_id is not null or not ts >= 1890 or not ts <= 1891) and (not user_id = 1 or not user_id is not null or not ts >= 1892 or not ts <= 1893) and (not user_id = 1 or not user_id is not null or not ts >= 1894 or not ts <= 1895) and (not user_id = 1 or not user_id is not null or not ts >= 1896 or not ts <= 1897) and (not user_id = 1 or not user_id is not null or not ts >= 1898 or not ts <= 1899) and (not user_id = 1 or not user_id is not null or not ts >= 1900 or not ts <= 1901) and (not user_id = 1 or not user_id is not null or not ts >= 1902 or not ts <= 1903) and (not user_id = 1 or not user_id is not null or not ts >= 1904 or not ts <= 1905) and (not user_id = 1 or not user_id is not null or not ts >= 1906 or not ts <= 1907) and (not user_id = 1 or not user_id is not null or not ts >= 1908 or not ts <= 1909) and (not user_id = 1 or not user_id is not null or not ts >= 1910 or not ts <= 1911) and (not user_id = 1 or not user_id is not null or not ts >= 1912 or not ts <= 1913) and (not user_id = 1 or not user_id is not null or not ts >= 1914 or not ts <= 1915) and (not user_id = 1 or not user_id is not null or not ts >= 1916 or not ts <= 1917) and (not user_id = 1 or not user_id is not null or not ts >= 1918 or not ts <= 1919) and (not user_id = 1 or not user_id is not null or not ts >= 1920 or not ts <= 1921) and (not user_id = 1 or not user_id is not null or not ts >= 1922 or not ts <= 1923) and (not user_id = 1 or not user_id is not null or not ts >= 1924 or not ts <= 1925) and (not user_id = 1 or not user_id is not null or not ts >= 1926 or not ts <= 1927) and (not user_id = 1 or not user_id is not null or not ts >= 1928 or not ts <= 1929) and (not user_id = 1 or not user_id is not null or not ts >= 1930 or not ts <= 1931) and (not user_id = 1 or not user_id is not null or not ts >= 1932 or not ts <= 1933) and (not user_id = 1 or not user_id is not null or not ts >= 1934 or not ts <= 1935) and (not user_id = 1 or not user_id is not null or not ts >= 1936 or not ts <= 1937) and (not user_id = 1 or not user_id is not null or not ts >= 1938 or not ts <= 1939) and (not user_id = 1 or not user_id is not null or not ts >= 1940 or not ts <= 1941) and (not user_id = 1 or not user_id is not null or not ts >= 1942 or not ts <= 1943) and (not user_id = 1 or not user_id is not null or not ts >= 1944 or not ts <= 1945) and (not user_id = 1 or not user_id is not null or not ts >= 1946 or not ts <= 1947) and (not user_id = 1 or not user_id is not null or not ts >= 1948 or not ts <= 1949) and (not user_id = 1 or not user_id is not null or not ts >= 1950 or not ts <= 1951) and (not user_id = 1 or not user_id is not null or not ts >= 1952 or not ts <= 1953) and (not user_id = 1 or not user_id is not null or not ts >= 1954 or not ts <= 1955) and (not user_id = 1 or not user_id is not null or not ts >= 1956 or not ts <= 1957) and (not user_id = 1 or not user_id is not null or not ts >= 1958 or not ts <= 1959) and (not user_id = 1 or not user_id is not null or not ts >= 1960 or not ts <= 1961) and (not user_id = 1 or not user_id is not null or not ts >= 1962 or not ts <= 1963) and (not user_id = 1 or not user_id is not null or not ts >= 1964 or not ts <= 1965) and (not user_id = 1 or not user_id is not null or not ts >= 1966 or not ts <= 1967) and (not user_id = 1 or not user_id is not null or not ts >= 1968 or not ts <= 1969) and (not user_id = 1 or not user_id is not null or not ts >= 1970 or not ts <= 1971) and (not user_id = 1 or not user_id is not null or not ts >= 1972 or not ts <= 1973) and (not user_id = 1 or not user_id is not null or not ts >= 1974 or not ts <= 1975) and (not user_id = 1 or not user_id is not null or not ts >= 1976 or not ts <= 1977) and (not user_id = 1 or not user_id is not null or not ts >= 1978 or not ts <= 1979) and (not user_id = 1 or not user_id is not null or not ts >= 1980 or not ts <= 1981) and (not user_id = 1 or not user_id is not null or not ts >= 1982 or not ts <= 1983) and (not user_id = 1 or not user_id is not null or not ts >= 1984 or not ts <= 1985) and (not user_id = 1 or not user_id is not null or not ts >= 1986 or not ts <= 1987) and (not user_id = 1 or not user_id is not null or not ts >= 1988 or not ts <= 1989) and (not user_id = 1 or not user_id is not null or not ts >= 1990 or not ts <= 1991) and (not user_id = 1 or not user_id is not null or not ts >= 1992 or not ts <= 1993) and (not user_id = 1 or not user_id is not null or not ts >= 1994 or not ts <= 1995) and (not user_id = 1 or not user_id is not null or not ts >= 1996 or not ts <= 1997) and (not user_id = 1 or not user_id is not null or not ts >= 1998 or not ts <= 1999) and (not user_id = 1 or not user_id is not null or not ts >= 11000 or not ts <= 11001) and (not user_id = 1 or not user_id is not null or not ts >= 11002 or not ts <= 11003) and (not user_id = 1 or not user_id is not null or not ts >= 11004 or not ts <= 11005) and (not user_id = 1 or not user_id is not null or not ts >= 11006 or not ts <= 11007) and (not user_id = 1 or not user_id is not null or not ts >= 11008 or not ts <= 11009) and (not user_id = 1 or not user_id is not null or not ts >= 11010 or not ts <= 11011) and (not user_id = 1 or not user_id is not null or not ts >= 11012 or not ts <= 11013) and (not user_id = 1 or not user_id is not null or not ts >= 11014 or not ts <= 11015) and (not user_id = 1 or not user_id is not null or not ts >= 11016 or not ts <= 11017) and (not user_id = 1 or not user_id is not null or not ts >= 11018 or not ts <= 11019) and (not user_id = 1 or not user_id is not null or not ts >= 11020 or not ts <= 11021) and (not user_id = 1 or not user_id is not null or not ts >= 11022 or not ts <= 11023) and (not user_id = 1 or not user_id is not null or not ts >= 11024 or not ts <= 11025) and (not user_id = 1 or not user_id is not null or not ts >= 11026 or not ts <= 11027) and (not user_id = 1 or not user_id is not null or not ts >= 11028 or not ts <= 11029) and (not user_id = 1 or not user_id is not null or not ts >= 11030 or not ts <= 11031) and (not user_id = 1 or not user_id is not null or not ts >= 11032 or not ts <= 11033) and (not user_id = 1 or not user_id is not null or not ts >= 11034 or not ts <= 11035) and (not user_id = 1 or not user_id is not null or not ts >= 11036 or not ts <= 11037) and (not user_id = 1 or not user_id is not null or not ts >= 11038 or not ts <= 11039) and (not user_id = 1 or not user_id is not null or not ts >= 11040 or not ts <= 11041) and (not user_id = 1 or not user_id is not null or not ts >= 11042 or not ts <= 11043) and (not user_id = 1 or not user_id is not null or not ts >= 11044 or not ts <= 11045) and (not user_id = 1 or not user_id is not null or not ts >= 11046 or not ts <= 11047) and (not user_id = 1 or not user_id is not null or not ts >= 11048 or not ts <= 11049) and (not user_id = 1 or not user_id is not null or not ts >= 11050 or not ts <= 11051) and (not user_id = 1 or not user_id is not null or not ts >= 11052 or not ts <= 11053) and (not user_id = 1 or not user_id is not null or not ts >= 11054 or not ts <= 11055) and (not user_id = 1 or not user_id is not null or not ts >= 11056 or not ts <= 11057) and (not user_id = 1 or not user_id is not null or not ts >= 11058 or not ts <= 11059) and (not user_id = 1 or not user_id is not null or not ts >= 11060 or not ts <= 11061) and (not user_id = 1 or not user_id is not null or not ts >= 11062 or not ts <= 11063) and (not user_id = 1 or not user_id is not null or not ts >= 11064 or not ts <= 11065) and (not user_id = 1 or not user_id is not null or not ts >= 11066 or not ts <= 11067) and (not user_id = 1 or not user_id is not null or not ts >= 11068 or not ts <= 11069) and (not user_id = 1 or not user_id is not null or not ts >= 11070 or not ts <= 11071) and (not user_id = 1 or not user_id is not null or not ts >= 11072 or not ts <= 11073) and (not user_id = 1 or not user_id is not null or not ts >= 11074 or not ts <= 11075) and (not user_id = 1 or not user_id is not null or not ts >= 11076 or not ts <= 11077) and (not user_id = 1 or not user_id is not null or not ts >= 11078 or not ts <= 11079) and (not user_id = 1 or not user_id is not null or not ts >= 11080 or not ts <= 11081) and (not user_id = 1 or not user_id is not null or not ts >= 11082 or not ts <= 11083) and (not user_id = 1 or not user_id is not null or not ts >= 11084 or not ts <= 11085) and (not user_id = 1 or not user_id is not null or not ts >= 11086 or not ts <= 11087) and (not user_id = 1 or not user_id is not null or not ts >= 11088 or not ts <= 11089) and (not user_id = 1 or not user_id is not null or not ts >= 11090 or not ts <= 11091) and (not user_id = 1 or not user_id is not null or not ts >= 11092 or not ts <= 11093) and (not user_id = 1 or not user_id is not null or not ts >= 11094 or not ts <= 11095) and (not user_id = 1 or not user_id is not null or not ts >= 11096 or not ts <= 11097) and (not user_id = 1 or not user_id is not null or not ts >= 11098 or not ts <= 11099) and (not user_id = 1 or not user_id is not null or not ts >= 11100 or not ts <= 11101) and (not user_id = 1 or not user_id is not null or not ts >= 11102 or not ts <= 11103) and (not user_id = 1 or not user_id is not null or not ts >= 11104 or not ts <= 11105) and (not user_id = 1 or not user_id is not null or not ts >= 11106 or not ts <= 11107) and (not user_id = 1 or not user_id is not null or not ts >= 11108 or not ts <= 11109) and (not user_id = 1 or not user_id is not null or not ts >= 11110 or not ts <= 11111) and (not user_id = 1 or not user_id is not null or not ts >= 11112 or not ts <= 11113) and (not user_id = 1 or not user_id is not null or not ts >= 11114 or not ts <= 11115) and (not user_id = 1 or not user_id is not null or not ts >= 11116 or not ts <= 11117) and (not user_id = 1 or not user_id is not null or not ts >= 11118 or not ts <= 11119) and (not user_id = 1 or not user_id is not null or not ts >= 11120 or not ts <= 11121) and (not user_id = 1 or not user_id is not null or not ts >= 11122 or not ts <= 11123) and (not user_id = 1 or not user_id is not null or not ts >= 11124 or not ts <= 11125) and (not user_id = 1 or not user_id is not null or not ts >= 11126 or not ts <= 11127) and (not user_id = 1 or not user_id is not null or not ts >= 11128 or not ts <= 11129) and (not user_id = 1 or not user_id is not null or not ts >= 11130 or not ts <= 11131) and (not user_id = 1 or not user_id is not null or not ts >= 11132 or not ts <= 11133) and (not user_id = 1 or not user_id is not null or not ts >= 11134 or not ts <= 11135) and (not user_id = 1 or not user_id is not null or not ts >= 11136 or not ts <= 11137) and (not user_id = 1 or not user_id is not null or not ts >= 11138 or not ts <= 11139) and (not user_id = 1 or not user_id is not null or not ts >= 11140 or not ts <= 11141) and (not user_id = 1 or not user_id is not null or not ts >= 11142 or not ts <= 11143) and (not user_id = 1 or not user_id is not null or not ts >= 11144 or not ts <= 11145) and (not user_id = 1 or not user_id is not null or not ts >= 11146 or not ts <= 11147) and (not user_id = 1 or not user_id is not null or not ts >= 11148 or not ts <= 11149) and (not user_id = 1 or not user_id is not null or not ts >= 11150 or not ts <= 11151) and (not user_id = 1 or not user_id is not null or not ts >= 11152 or not ts <= 11153) and (not user_id = 1 or not user_id is not null or not ts >= 11154 or not ts <= 11155) and (not user_id = 1 or not user_id is not null or not ts >= 11156 or not ts <= 11157) and (not user_id = 1 or not user_id is not null or not ts >= 11158 or not ts <= 11159) and (not user_id = 1 or not user_id is not null or not ts >= 11160 or not ts <= 11161) and (not user_id = 1 or not user_id is not null or not ts >= 11162 or not ts <= 11163) and (not user_id = 1 or not user_id is not null or not ts >= 11164 or not ts <= 11165) and (not user_id = 1 or not user_id is not null or not ts >= 11166 or not ts <= 11167) and (not user_id = 1 or not user_id is not null or not ts >= 11168 or not ts <= 11169) and (not user_id = 1 or not user_id is not null or not ts >= 11170 or not ts <= 11171) and (not user_id = 1 or not user_id is not null or not ts >= 11172 or not ts <= 11173) and (not user_id = 1 or not user_id is not null or not ts >= 11174 or not ts <= 11175) and (not user_id = 1 or not user_id is not null or not ts >= 11176 or not ts <= 11177) and (not user_id = 1 or not user_id is not null or not ts >= 11178 or not ts <= 11179) and (not user_id = 1 or not user_id is not null or not ts >= 11180 or not ts <= 11181) and (not user_id = 1 or not user_id is not null or not ts >= 11182 or not ts <= 11183) and (not user_id = 1 or not user_id is not null or not ts >= 11184 or not ts <= 11185) and (not user_id = 1 or not user_id is not null or not ts >= 11186 or not ts <= 11187) and (not user_id = 1 or not user_id is not null or not ts >= 11188 or not ts <= 11189) and (not user_id = 1 or not user_id is not null or not ts >= 11190 or not ts <= 11191) and (not user_id = 1 or not user_id is not null or not ts >= 11192 or not ts <= 11193) and (not user_id = 1 or not user_id is not null or not ts >= 11194 or not ts <= 11195) and (not user_id = 1 or not user_id is not null or not ts >= 11196 or not ts <= 11197) and (not user_id = 1 or not user_id is not null or not ts >= 11198 or not ts <= 11199) and (not user_id = 1 or not user_id is not null or not ts >= 11200 or not ts <= 11201) and (not user_id = 1 or not user_id is not null or not ts >= 11202 or not ts <= 11203) and (not user_id = 1 or not user_id is not null or not ts >= 11204 or not ts <= 11205) and (not user_id = 1 or not user_id is not null or not ts >= 11206 or not ts <= 11207) and (not user_id = 1 or not user_id is not null or not ts >= 11208 or not ts <= 11209) and (not user_id = 1 or not user_id is not null or not ts >= 11210 or not ts <= 11211) and (not user_id = 1 or not user_id is not null or not ts >= 11212 or not ts <= 11213) and (not user_id = 1 or not user_id is not null or not ts >= 11214 or not ts <= 11215) and (not user_id = 1 or not user_id is not null or not ts >= 11216 or not ts <= 11217) and (not user_id = 1 or not user_id is not null or not ts >= 11218 or not ts <= 11219) and (not user_id = 1 or not user_id is not null or not ts >= 11220 or not ts <= 11221) and (not user_id = 1 or not user_id is not null or not ts >= 11222 or not ts <= 11223) and (not user_id = 1 or not user_id is not null or not ts >= 11224 or not ts <= 11225) and (not user_id = 1 or not user_id is not null or not ts >= 11226 or not ts <= 11227) and (not user_id = 1 or not user_id is not null or not ts >= 11228 or not ts <= 11229) and (not user_id = 1 or not user_id is not null or not ts >= 11230 or not ts <= 11231) and (not user_id = 1 or not user_id is not null or not ts >= 11232 or not ts <= 11233) and (not user_id = 1 or not user_id is not null or not ts >= 11234 or not ts <= 11235) and (not user_id = 1 or not user_id is not null or not ts >= 11236 or not ts <= 11237) and (not user_id = 1 or not user_id is not null or not ts >= 11238 or not ts <= 11239) and (not user_id = 1 or not user_id is not null or not ts >= 11240 or not ts <= 11241) and (not user_id = 1 or not user_id is not null or not ts >= 11242 or not ts <= 11243) and (not user_id = 1 or not user_id is not null or not ts >= 11244 or not ts <= 11245) and (not user_id = 1 or not user_id is not null or not ts >= 11246 or not ts <= 11247) and (not user_id = 1 or not user_id is not null or not ts >= 11248 or not ts <= 11249) and (not user_id = 1 or not user_id is not null or not ts >= 11250 or not ts <= 11251) and (not user_id = 1 or not user_id is not null or not ts >= 11252 or not ts <= 11253) and (not user_id = 1 or not user_id is not null or not ts >= 11254 or not ts <= 11255) and (not user_id = 1 or not user_id is not null or not ts >= 11256 or not ts <= 11257) and (not user_id = 1 or not user_id is not null or not ts >= 11258 or not ts <= 11259) and (not user_id = 1 or not user_id is not null or not ts >= 11260 or not ts <= 11261) and (not user_id = 1 or not user_id is not null or not ts >= 11262 or not ts <= 11263) and (not user_id = 1 or not user_id is not null or not ts >= 11264 or not ts <= 11265) and (not user_id = 1 or not user_id is not null or not ts >= 11266 or not ts <= 11267) and (not user_id = 1 or not user_id is not null or not ts >= 11268 or not ts <= 11269) and (not user_id = 1 or not user_id is not null or not ts >= 11270 or not ts <= 11271) and (not user_id = 1 or not user_id is not null or not ts >= 11272 or not ts <= 11273) and (not user_id = 1 or not user_id is not null or not ts >= 11274 or not ts <= 11275) and (not user_id = 1 or not user_id is not null or not ts >= 11276 or not ts <= 11277) and (not user_id = 1 or not user_id is not null or not ts >= 11278 or not ts <= 11279) and (not user_id = 1 or not user_id is not null or not ts >= 11280 or not ts <= 11281) and (not user_id = 1 or not user_id is not null or not ts >= 11282 or not ts <= 11283) and (not user_id = 1 or not user_id is not null or not ts >= 11284 or not ts <= 11285) and (not user_id = 1 or not user_id is not null or not ts >= 11286 or not ts <= 11287) and (not user_id = 1 or not user_id is not null or not ts >= 11288 or not ts <= 11289) and (not user_id = 1 or not user_id is not null or not ts >= 11290 or not ts <= 11291) and (not user_id = 1 or not user_id is not null or not ts >= 11292 or not ts <= 11293) and (not user_id = 1 or not user_id is not null or not ts >= 11294 or not ts <= 11295) and (not user_id = 1 or not user_id is not null or not ts >= 11296 or not ts <= 11297) and (not user_id = 1 or not user_id is not null or not ts >= 11298 or not ts <= 11299) and (not user_id = 1 or not user_id is not null or not ts >= 11300 or not ts <= 11301) and (not user_id = 1 or not user_id is not null or not ts >= 11302 or not ts <= 11303) and (not user_id = 1 or not user_id is not null or not ts >= 11304 or not ts <= 11305) and (not user_id = 1 or not user_id is not null or not ts >= 11306 or not ts <= 11307) and (not user_id = 1 or not user_id is not null or not ts >= 11308 or not ts <= 11309) and (not user_id = 1 or not user_id is not null or not ts >= 11310 or not ts <= 11311) and (not user_id = 1 or not user_id is not null or not ts >= 11312 or not ts <= 11313) and (not user_id = 1 or not user_id is not null or not ts >= 11314 or not ts <= 11315) and (not user_id = 1 or not user_id is not null or not ts >= 11316 or not ts <= 11317) and (not user_id = 1 or not user_id is not null or not ts >= 11318 or not ts <= 11319) and (not user_id = 1 or not user_id is not null or not ts >= 11320 or not ts <= 11321) and (not user_id = 1 or not user_id is not null or not ts >= 11322 or not ts <= 11323) and (not user_id = 1 or not user_id is not null or not ts >= 11324 or not ts <= 11325) and (not user_id = 1 or not user_id is not null or not ts >= 11326 or not ts <= 11327) and (not user_id = 1 or not user_id is not null or not ts >= 11328 or not ts <= 11329) and (not user_id = 1 or not user_id is not null or not ts >= 11330 or not ts <= 11331) and (not user_id = 1 or not user_id is not null or not ts >= 11332 or not ts <= 11333) and (not user_id = 1 or not user_id is not null or not ts >= 11334 or not ts <= 11335) and (not user_id = 1 or not user_id is not null or not ts >= 11336 or not ts <= 11337) and (not user_id = 1 or not user_id is not null or not ts >= 11338 or not ts <= 11339) and (not user_id = 1 or not user_id is not null or not ts >= 11340 or not ts <= 11341) and (not user_id = 1 or not user_id is not null or not ts >= 11342 or not ts <= 11343) and (not user_id = 1 or not user_id is not null or not ts >= 11344 or not ts <= 11345) and (not user_id = 1 or not user_id is not null or not ts >= 11346 or not ts <= 11347) and (not user_id = 1 or not user_id is not null or not ts >= 11348 or not ts <= 11349) and (not user_id = 1 or not user_id is not null or not ts >= 11350 or not ts <= 11351) and (not user_id = 1 or not user_id is not null or not ts >= 11352 or not ts <= 11353) and (not user_id = 1 or not user_id is not null or not ts >= 11354 or not ts <= 11355) and (not user_id = 1 or not user_id is not null or not ts >= 11356 or not ts <= 11357) and (not user_id = 1 or not user_id is not null or not ts >= 11358 or not ts <= 11359) and (not user_id = 1 or not user_id is not null or not ts >= 11360 or not ts <= 11361) and (not user_id = 1 or not user_id is not null or not ts >= 11362 or not ts <= 11363) and (not user_id = 1 or not user_id is not null or not ts >= 11364 or not ts <= 11365) and (not user_id = 1 or not user_id is not null or not ts >= 11366 or not ts <= 11367) and (not user_id = 1 or not user_id is not null or not ts >= 11368 or not ts <= 11369) and (not user_id = 1 or not user_id is not null or not ts >= 11370 or not ts <= 11371) and (not user_id = 1 or not user_id is not null or not ts >= 11372 or not ts <= 11373) and (not user_id = 1 or not user_id is not null or not ts >= 11374 or not ts <= 11375) and (not user_id = 1 or not user_id is not null or not ts >= 11376 or not ts <= 11377) and (not user_id = 1 or not user_id is not null or not ts >= 11378 or not ts <= 11379) and (not user_id = 1 or not user_id is not null or not ts >= 11380 or not ts <= 11381) and (not user_id = 1 or not user_id is not null or not ts >= 11382 or not ts <= 11383) and (not user_id = 1 or not user_id is not null or not ts >= 11384 or not ts <= 11385) and (not user_id = 1 or not user_id is not null or not ts >= 11386 or not ts <= 11387) and (not user_id = 1 or not user_id is not null or not ts >= 11388 or not ts <= 11389) and (not user_id = 1 or not user_id is not null or not ts >= 11390 or not ts <= 11391) and (not user_id = 1 or not user_id is not null or not ts >= 11392 or not ts <= 11393) and (not user_id = 1 or not user_id is not null or not ts >= 11394 or not ts <= 11395) and (not user_id = 1 or not user_id is not null or not ts >= 11396 or not ts <= 11397) and (not user_id = 1 or not user_id is not null or not ts >= 11398 or not ts <= 11399) and (not user_id = 1 or not user_id is not null or not ts >= 11400 or not ts <= 11401) and (not user_id = 1 or not user_id is not null or not ts >= 11402 or not ts <= 11403) and (not user_id = 1 or not user_id is not null or not ts >= 11404 or not ts <= 11405) and (not user_id = 1 or not user_id is not null or not ts >= 11406 or not ts <= 11407) and (not user_id = 1 or not user_id is not null or not ts >= 11408 or not ts <= 11409) and (not user_id = 1 or not user_id is not null or not ts >= 11410 or not ts <= 11411) and (not user_id = 1 or not user_id is not null or not ts >= 11412 or not ts <= 11413) and (not user_id = 1 or not user_id is not null or not ts >= 11414 or not ts <= 11415) and (not user_id = 1 or not user_id is not null or not ts >= 11416 or not ts <= 11417) and (not user_id = 1 or not user_id is not null or not ts >= 11418 or not ts <= 11419) and (not user_id = 1 or not user_id is not null or not ts >= 11420 or not ts <= 11421) and (not user_id = 1 or not user_id is not null or not ts >= 11422 or not ts <= 11423) and (not user_id = 1 or not user_id is not null or not ts >= 11424 or not ts <= 11425) and (not user_id = 1 or not user_id is not null or not ts >= 11426 or not ts <= 11427) and (not user_id = 1 or not user_id is not null or not ts >= 11428 or not ts <= 11429) and (not user_id = 1 or not user_id is not null or not ts >= 11430 or not ts <= 11431) and (not user_id = 1 or not user_id is not null or not ts >= 11432 or not ts <= 11433) and (not user_id = 1 or not user_id is not null or not ts >= 11434 or not ts <= 11435) and (not user_id = 1 or not user_id is not null or not ts >= 11436 or not ts <= 11437) and (not user_id = 1 or not user_id is not null or not ts >= 11438 or not ts <= 11439) and (not user_id = 1 or not user_id is not null or not ts >= 11440 or not ts <= 11441) and (not user_id = 1 or not user_id is not null or not ts >= 11442 or not ts <= 11443) and (not user_id = 1 or not user_id is not null or not ts >= 11444 or not ts <= 11445) and (not user_id = 1 or not user_id is not null or not ts >= 11446 or not ts <= 11447) and (not user_id = 1 or not user_id is not null or not ts >= 11448 or not ts <= 11449) and (not user_id = 1 or not user_id is not null or not ts >= 11450 or not ts <= 11451) and (not user_id = 1 or not user_id is not null or not ts >= 11452 or not ts <= 11453) and (not user_id = 1 or not user_id is not null or not ts >= 11454 or not ts <= 11455) and (not user_id = 1 or not user_id is not null or not ts >= 11456 or not ts <= 11457) and (not user_id = 1 or not user_id is not null or not ts >= 11458 or not ts <= 11459) and (not user_id = 1 or not user_id is not null or not ts >= 11460 or not ts <= 11461) and (not user_id = 1 or not user_id is not null or not ts >= 11462 or not ts <= 11463) and (not user_id = 1 or not user_id is not null or not ts >= 11464 or not ts <= 11465) and (not user_id = 1 or not user_id is not null or not ts >= 11466 or not ts <= 11467) and (not user_id = 1 or not user_id is not null or not ts >= 11468 or not ts <= 11469) and (not user_id = 1 or not user_id is not null or not ts >= 11470 or not ts <= 11471) and (not user_id = 1 or not user_id is not null or not ts >= 11472 or not ts <= 11473) and (not user_id = 1 or not user_id is not null or not ts >= 11474 or not ts <= 11475) and (not user_id = 1 or not user_id is not null or not ts >= 11476 or not ts <= 11477) and (not user_id = 1 or not user_id is not null or not ts >= 11478 or not ts <= 11479) and (not user_id = 1 or not user_id is not null or not ts >= 11480 or not ts <= 11481) and (not user_id = 1 or not user_id is not null or not ts >= 11482 or not ts <= 11483) and (not user_id = 1 or not user_id is not null or not ts >= 11484 or not ts <= 11485) and (not user_id = 1 or not user_id is not null or not ts >= 11486 or not ts <= 11487) and (not user_id = 1 or not user_id is not null or not ts >= 11488 or not ts <= 11489) and (not user_id = 1 or not user_id is not null or not ts >= 11490 or not ts <= 11491) and (not user_id = 1 or not user_id is not null or not ts >= 11492 or not ts <= 11493) and (not user_id = 1 or not user_id is not null or not ts >= 11494 or not ts <= 11495) and (not user_id = 1 or not user_id is not null or not ts >= 11496 or not ts <= 11497) and (not user_id = 1 or not user_id is not null or not ts >= 11498 or not ts <= 11499) and (not user_id = 1 or not user_id is not null or not ts >= 11500 or not ts <= 11501) and (not user_id = 1 or not user_id is not null or not ts >= 11502 or not ts <= 11503) and (not user_id = 1 or not user_id is not null or not ts >= 11504 or not ts <= 11505) and (not user_id = 1 or not user_id is not null or not ts >= 11506 or not ts <= 11507) and (not user_id = 1 or not user_id is not null or not ts >= 11508 or not ts <= 11509) and (not user_id = 1 or not user_id is not null or not ts >= 11510 or not ts <= 11511) and (not user_id = 1 or not user_id is not null or not ts >= 11512 or not ts <= 11513) and (not user_id = 1 or not user_id is not null or not ts >= 11514 or not ts <= 11515) and (not user_id = 1 or not user_id is not null or not ts >= 11516 or not ts <= 11517) and (not user_id = 1 or not user_id is not null or not ts >= 11518 or not ts <= 11519) and (not user_id = 1 or not user_id is not null or not ts >= 11520 or not ts <= 11521) and (not user_id = 1 or not user_id is not null or not ts >= 11522 or not ts <= 11523) and (not user_id = 1 or not user_id is not null or not ts >= 11524 or not ts <= 11525) and (not user_id = 1 or not user_id is not null or not ts >= 11526 or not ts <= 11527) and (not user_id = 1 or not user_id is not null or not ts >= 11528 or not ts <= 11529) and (not user_id = 1 or not user_id is not null or not ts >= 11530 or not ts <= 11531) and (not user_id = 1 or not user_id is not null or not ts >= 11532 or not ts <= 11533) and (not user_id = 1 or not user_id is not null or not ts >= 11534 or not ts <= 11535) and (not user_id = 1 or not user_id is not null or not ts >= 11536 or not ts <= 11537) and (not user_id = 1 or not user_id is not null or not ts >= 11538 or not ts <= 11539) and (not user_id = 1 or not user_id is not null or not ts >= 11540 or not ts <= 11541) and (not user_id = 1 or not user_id is not null or not ts >= 11542 or not ts <= 11543) and (not user_id = 1 or not user_id is not null or not ts >= 11544 or not ts <= 11545) and (not user_id = 1 or not user_id is not null or not ts >= 11546 or not ts <= 11547) and (not user_id = 1 or not user_id is not null or not ts >= 11548 or not ts <= 11549) and (not user_id = 1 or not user_id is not null or not ts >= 11550 or not ts <= 11551) and (not user_id = 1 or not user_id is not null or not ts >= 11552 or not ts <= 11553) and (not user_id = 1 or not user_id is not null or not ts >= 11554 or not ts <= 11555) and (not user_id = 1 or not user_id is not null or not ts >= 11556 or not ts <= 11557) and (not user_id = 1 or not user_id is not null or not ts >= 11558 or not ts <= 11559) and (not user_id = 1 or not user_id is not null or not ts >= 11560 or not ts <= 11561) and (not user_id = 1 or not user_id is not null or not ts >= 11562 or not ts <= 11563) and (not user_id = 1 or not user_id is not null or not ts >= 11564 or not ts <= 11565) and (not user_id = 1 or not user_id is not null or not ts >= 11566 or not ts <= 11567) and (not user_id = 1 or not user_id is not null or not ts >= 11568 or not ts <= 11569) and (not user_id = 1 or not user_id is not null or not ts >= 11570 or not ts <= 11571) and (not user_id = 1 or not user_id is not null or not ts >= 11572 or not ts <= 11573) and (not user_id = 1 or not user_id is not null or not ts >= 11574 or not ts <= 11575) and (not user_id = 1 or not user_id is not null or not ts >= 11576 or not ts <= 11577) and (not user_id = 1 or not user_id is not null or not ts >= 11578 or not ts <= 11579) and (not user_id = 1 or not user_id is not null or not ts >= 11580 or not ts <= 11581) and (not user_id = 1 or not user_id is not null or not ts >= 11582 or not ts <= 11583) and (not user_id = 1 or not user_id is not null or not ts >= 11584 or not ts <= 11585) and (not user_id = 1 or not user_id is not null or not ts >= 11586 or not ts <= 11587) and (not user_id = 1 or not user_id is not null or not ts >= 11588 or not ts <= 11589) and (not user_id = 1 or not user_id is not null or not ts >= 11590 or not ts <= 11591) and (not user_id = 1 or not user_id is not null or not ts >= 11592 or not ts <= 11593) and (not user_id = 1 or not user_id is not null or not ts >= 11594 or not ts <= 11595) and (not user_id = 1 or not user_id is not null or not ts >= 11596 or not ts <= 11597) and (not user_id = 1 or not user_id is not null or not ts >= 11598 or not ts <= 11599) and (not user_id = 1 or not user_id is not null or not ts >= 11600 or not ts <= 11601) and (not user_id = 1 or not user_id is not null or not ts >= 11602 or not ts <= 11603) and (not user_id = 1 or not user_id is not null or not ts >= 11604 or not ts <= 11605) and (not user_id = 1 or not user_id is not null or not ts >= 11606 or not ts <= 11607) and (not user_id = 1 or not user_id is not null or not ts >= 11608 or not ts <= 11609) and (not user_id = 1 or not user_id is not null or not ts >= 11610 or not ts <= 11611) and (not user_id = 1 or not user_id is not null or not ts >= 11612 or not ts <= 11613) and (not user_id = 1 or not user_id is not null or not ts >= 11614 or not ts <= 11615) and (not user_id = 1 or not user_id is not null or not ts >= 11616 or not ts <= 11617) and (not user_id = 1 or not user_id is not null or not ts >= 11618 or not ts <= 11619) and (not user_id = 1 or not user_id is not null or not ts >= 11620 or not ts <= 11621) and (not user_id = 1 or not user_id is not null or not ts >= 11622 or not ts <= 11623) and (not user_id = 1 or not user_id is not null or not ts >= 11624 or not ts <= 11625) and (not user_id = 1 or not user_id is not null or not ts >= 11626 or not ts <= 11627) and (not user_id = 1 or not user_id is not null or not ts >= 11628 or not ts <= 11629) and (not user_id = 1 or not user_id is not null or not ts >= 11630 or not ts <= 11631) and (not user_id = 1 or not user_id is not null or not ts >= 11632 or not ts <= 11633) and (not user_id = 1 or not user_id is not null or not ts >= 11634 or not ts <= 11635) and (not user_id = 1 or not user_id is not null or not ts >= 11636 or not ts <= 11637) and (not user_id = 1 or not user_id is not null or not ts >= 11638 or not ts <= 11639) and (not user_id = 1 or not user_id is not null or not ts >= 11640 or not ts <= 11641) and (not user_id = 1 or not user_id is not null or not ts >= 11642 or not ts <= 11643) and (not user_id = 1 or not user_id is not null or not ts >= 11644 or not ts <= 11645) and (not user_id = 1 or not user_id is not null or not ts >= 11646 or not ts <= 11647) and (not user_id = 1 or not user_id is not null or not ts >= 11648 or not ts <= 11649) and (not user_id = 1 or not user_id is not null or not ts >= 11650 or not ts <= 11651) and (not user_id = 1 or not user_id is not null or not ts >= 11652 or not ts <= 11653) and (not user_id = 1 or not user_id is not null or not ts >= 11654 or not ts <= 11655) and (not user_id = 1 or not user_id is not null or not ts >= 11656 or not ts <= 11657) and (not user_id = 1 or not user_id is not null or not ts >= 11658 or not ts <= 11659) and (not user_id = 1 or not user_id is not null or not ts >= 11660 or not ts <= 11661) and (not user_id = 1 or not user_id is not null or not ts >= 11662 or not ts <= 11663) and (not user_id = 1 or not user_id is not null or not ts >= 11664 or not ts <= 11665) and (not user_id = 1 or not user_id is not null or not ts >= 11666 or not ts <= 11667) and (not user_id = 1 or not user_id is not null or not ts >= 11668 or not ts <= 11669) and (not user_id = 1 or not user_id is not null or not ts >= 11670 or not ts <= 11671) and (not user_id = 1 or not user_id is not null or not ts >= 11672 or not ts <= 11673) and (not user_id = 1 or not user_id is not null or not ts >= 11674 or not ts <= 11675) and (not user_id = 1 or not user_id is not null or not ts >= 11676 or not ts <= 11677) and (not user_id = 1 or not user_id is not null or not ts >= 11678 or not ts <= 11679) and (not user_id = 1 or not user_id is not null or not ts >= 11680 or not ts <= 11681) and (not user_id = 1 or not user_id is not null or not ts >= 11682 or not ts <= 11683) and (not user_id = 1 or not user_id is not null or not ts >= 11684 or not ts <= 11685) and (not user_id = 1 or not user_id is not null or not ts >= 11686 or not ts <= 11687) and (not user_id = 1 or not user_id is not null or not ts >= 11688 or not ts <= 11689) and (not user_id = 1 or not user_id is not null or not ts >= 11690 or not ts <= 11691) and (not user_id = 1 or not user_id is not null or not ts >= 11692 or not ts <= 11693) and (not user_id = 1 or not user_id is not null or not ts >= 11694 or not ts <= 11695) and (not user_id = 1 or not user_id is not null or not ts >= 11696 or not ts <= 11697) and (not user_id = 1 or not user_id is not null or not ts >= 11698 or not ts <= 11699) and (not user_id = 1 or not user_id is not null or not ts >= 11700 or not ts <= 11701) and (not user_id = 1 or not user_id is not null or not ts >= 11702 or not ts <= 11703) and (not user_id = 1 or not user_id is not null or not ts >= 11704 or not ts <= 11705) and (not user_id = 1 or not user_id is not null or not ts >= 11706 or not ts <= 11707) and (not user_id = 1 or not user_id is not null or not ts >= 11708 or not ts <= 11709) and (not user_id = 1 or not user_id is not null or not ts >= 11710 or not ts <= 11711) and (not user_id = 1 or not user_id is not null or not ts >= 11712 or not ts <= 11713) and (not user_id = 1 or not user_id is not null or not ts >= 11714 or not ts <= 11715) and (not user_id = 1 or not user_id is not null or not ts >= 11716 or not ts <= 11717) and (not user_id = 1 or not user_id is not null or not ts >= 11718 or not ts <= 11719) and (not user_id = 1 or not user_id is not null or not ts >= 11720 or not ts <= 11721) and (not user_id = 1 or not user_id is not null or not ts >= 11722 or not ts <= 11723) and (not user_id = 1 or not user_id is not null or not ts >= 11724 or not ts <= 11725) and (not user_id = 1 or not user_id is not null or not ts >= 11726 or not ts <= 11727) and (not user_id = 1 or not user_id is not null or not ts >= 11728 or not ts <= 11729) and (not user_id = 1 or not user_id is not null or not ts >= 11730 or not ts <= 11731) and (not user_id = 1 or not user_id is not null or not ts >= 11732 or not ts <= 11733) and (not user_id = 1 or not user_id is not null or not ts >= 11734 or not ts <= 11735) and (not user_id = 1 or not user_id is not null or not ts >= 11736 or not ts <= 11737) and (not user_id = 1 or not user_id is not null or not ts >= 11738 or not ts <= 11739) and (not user_id = 1 or not user_id is not null or not ts >= 11740 or not ts <= 11741) and (not user_id = 1 or not user_id is not null or not ts >= 11742 or not ts <= 11743) and (not user_id = 1 or not user_id is not null or not ts >= 11744 or not ts <= 11745) and (not user_id = 1 or not user_id is not null or not ts >= 11746 or not ts <= 11747) and (not user_id = 1 or not user_id is not null or not ts >= 11748 or not ts <= 11749) and (not user_id = 1 or not user_id is not null or not ts >= 11750 or not ts <= 11751) and (not user_id = 1 or not user_id is not null or not ts >= 11752 or not ts <= 11753) and (not user_id = 1 or not user_id is not null or not ts >= 11754 or not ts <= 11755) and (not user_id = 1 or not user_id is not null or not ts >= 11756 or not ts <= 11757) and (not user_id = 1 or not user_id is not null or not ts >= 11758 or not ts <= 11759) and (not user_id = 1 or not user_id is not null or not ts >= 11760 or not ts <= 11761) and (not user_id = 1 or not user_id is not null or not ts >= 11762 or not ts <= 11763) and (not user_id = 1 or not user_id is not null or not ts >= 11764 or not ts <= 11765) and (not user_id = 1 or not user_id is not null or not ts >= 11766 or not ts <= 11767) and (not user_id = 1 or not user_id is not null or not ts >= 11768 or not ts <= 11769) and (not user_id = 1 or not user_id is not null or not ts >= 11770 or not ts <= 11771) and (not user_id = 1 or not user_id is not null or not ts >= 11772 or not ts <= 11773) and (not user_id = 1 or not user_id is not null or not ts >= 11774 or not ts <= 11775) and (not user_id = 1 or not user_id is not null or not ts >= 11776 or not ts <= 11777) and (not user_id = 1 or not user_id is not null or not ts >= 11778 or not ts <= 11779) and (not user_id = 1 or not user_id is not null or not ts >= 11780 or not ts <= 11781) and (not user_id = 1 or not user_id is not null or not ts >= 11782 or not ts <= 11783) and (not user_id = 1 or not user_id is not null or not ts >= 11784 or not ts <= 11785) and (not user_id = 1 or not user_id is not null or not ts >= 11786 or not ts <= 11787) and (not user_id = 1 or not user_id is not null or not ts >= 11788 or not ts <= 11789) and (not user_id = 1 or not user_id is not null or not ts >= 11790 or not ts <= 11791) and (not user_id = 1 or not user_id is not null or not ts >= 11792 or not ts <= 11793) and (not user_id = 1 or not user_id is not null or not ts >= 11794 or not ts <= 11795) and (not user_id = 1 or not user_id is not null or not ts >= 11796 or not ts <= 11797) and (not user_id = 1 or not user_id is not null or not ts >= 11798 or not ts <= 11799) and (not user_id = 1 or not user_id is not null or not ts >= 11800 or not ts <= 11801) and (not user_id = 1 or not user_id is not null or not ts >= 11802 or not ts <= 11803) and (not user_id = 1 or not user_id is not null or not ts >= 11804 or not ts <= 11805) and (not user_id = 1 or not user_id is not null or not ts >= 11806 or not ts <= 11807) and (not user_id = 1 or not user_id is not null or not ts >= 11808 or not ts <= 11809) and (not user_id = 1 or not user_id is not null or not ts >= 11810 or not ts <= 11811) and (not user_id = 1 or not user_id is not null or not ts >= 11812 or not ts <= 11813) and (not user_id = 1 or not user_id is not null or not ts >= 11814 or not ts <= 11815) and (not user_id = 1 or not user_id is not null or not ts >= 11816 or not ts <= 11817) and (not user_id = 1 or not user_id is not null or not ts >= 11818 or not ts <= 11819) and (not user_id = 1 or not user_id is not null or not ts >= 11820 or not ts <= 11821) and (not user_id = 1 or not user_id is not null or not ts >= 11822 or not ts <= 11823) and (not user_id = 1 or not user_id is not null or not ts >= 11824 or not ts <= 11825) and (not user_id = 1 or not user_id is not null or not ts >= 11826 or not ts <= 11827) and (not user_id = 1 or not user_id is not null or not ts >= 11828 or not ts <= 11829) and (not user_id = 1 or not user_id is not null or not ts >= 11830 or not ts <= 11831) and (not user_id = 1 or not user_id is not null or not ts >= 11832 or not ts <= 11833) and (not user_id = 1 or not user_id is not null or not ts >= 11834 or not ts <= 11835) and (not user_id = 1 or not user_id is not null or not ts >= 11836 or not ts <= 11837) and (not user_id = 1 or not user_id is not null or not ts >= 11838 or not ts <= 11839) and (not user_id = 1 or not user_id is not null or not ts >= 11840 or not ts <= 11841) and (not user_id = 1 or not user_id is not null or not ts >= 11842 or not ts <= 11843) and (not user_id = 1 or not user_id is not null or not ts >= 11844 or not ts <= 11845) and (not user_id = 1 or not user_id is not null or not ts >= 11846 or not ts <= 11847) and (not user_id = 1 or not user_id is not null or not ts >= 11848 or not ts <= 11849) and (not user_id = 1 or not user_id is not null or not ts >= 11850 or not ts <= 11851) and (not user_id = 1 or not user_id is not null or not ts >= 11852 or not ts <= 11853) and (not user_id = 1 or not user_id is not null or not ts >= 11854 or not ts <= 11855) and (not user_id = 1 or not user_id is not null or not ts >= 11856 or not ts <= 11857) and (not user_id = 1 or not user_id is not null or not ts >= 11858 or not ts <= 11859) and (not user_id = 1 or not user_id is not null or not ts >= 11860 or not ts <= 11861) and (not user_id = 1 or not user_id is not null or not ts >= 11862 or not ts <= 11863) and (not user_id = 1 or not user_id is not null or not ts >= 11864 or not ts <= 11865) and (not user_id = 1 or not user_id is not null or not ts >= 11866 or not ts <= 11867) and (not user_id = 1 or not user_id is not null or not ts >= 11868 or not ts <= 11869) and (not user_id = 1 or not user_id is not null or not ts >= 11870 or not ts <= 11871) and (not user_id = 1 or not user_id is not null or not ts >= 11872 or not ts <= 11873) and (not user_id = 1 or not user_id is not null or not ts >= 11874 or not ts <= 11875) and (not user_id = 1 or not user_id is not null or not ts >= 11876 or not ts <= 11877) and (not user_id = 1 or not user_id is not null or not ts >= 11878 or not ts <= 11879) and (not user_id = 1 or not user_id is not null or not ts >= 11880 or not ts <= 11881) and (not user_id = 1 or not user_id is not null or not ts >= 11882 or not ts <= 11883) and (not user_id = 1 or not user_id is not null or not ts >= 11884 or not ts <= 11885) and (not user_id = 1 or not user_id is not null or not ts >= 11886 or not ts <= 11887) and (not user_id = 1 or not user_id is not null or not ts >= 11888 or not ts <= 11889) and (not user_id = 1 or not user_id is not null or not ts >= 11890 or not ts <= 11891) and (not user_id = 1 or not user_id is not null or not ts >= 11892 or not ts <= 11893) and (not user_id = 1 or not user_id is not null or not ts >= 11894 or not ts <= 11895) and (not user_id = 1 or not user_id is not null or not ts >= 11896 or not ts <= 11897) and (not user_id = 1 or not user_id is not null or not ts >= 11898 or not ts <= 11899) and (not user_id = 1 or not user_id is not null or not ts >= 11900 or not ts <= 11901) and (not user_id = 1 or not user_id is not null or not ts >= 11902 or not ts <= 11903) and (not user_id = 1 or not user_id is not null or not ts >= 11904 or not ts <= 11905) and (not user_id = 1 or not user_id is not null or not ts >= 11906 or not ts <= 11907) and (not user_id = 1 or not user_id is not null or not ts >= 11908 or not ts <= 11909) and (not user_id = 1 or not user_id is not null or not ts >= 11910 or not ts <= 11911) and (not user_id = 1 or not user_id is not null or not ts >= 11912 or not ts <= 11913) and (not user_id = 1 or not user_id is not null or not ts >= 11914 or not ts <= 11915) and (not user_id = 1 or not user_id is not null or not ts >= 11916 or not ts <= 11917) and (not user_id = 1 or not user_id is not null or not ts >= 11918 or not ts <= 11919) and (not user_id = 1 or not user_id is not null or not ts >= 11920 or not ts <= 11921) and (not user_id = 1 or not user_id is not null or not ts >= 11922 or not ts <= 11923) and (not user_id = 1 or not user_id is not null or not ts >= 11924 or not ts <= 11925) and (not user_id = 1 or not user_id is not null or not ts >= 11926 or not ts <= 11927) and (not user_id = 1 or not user_id is not null or not ts >= 11928 or not ts <= 11929) and (not user_id = 1 or not user_id is not null or not ts >= 11930 or not ts <= 11931) and (not user_id = 1 or not user_id is not null or not ts >= 11932 or not ts <= 11933) and (not user_id = 1 or not user_id is not null or not ts >= 11934 or not ts <= 11935) and (not user_id = 1 or not user_id is not null or not ts >= 11936 or not ts <= 11937) and (not user_id = 1 or not user_id is not null or not ts >= 11938 or not ts <= 11939) and (not user_id = 1 or not user_id is not null or not ts >= 11940 or not ts <= 11941) and (not user_id = 1 or not user_id is not null or not ts >= 11942 or not ts <= 11943) and (not user_id = 1 or not user_id is not null or not ts >= 11944 or not ts <= 11945) and (not user_id = 1 or not user_id is not null or not ts >= 11946 or not ts <= 11947) and (not user_id = 1 or not user_id is not null or not ts >= 11948 or not ts <= 11949) and (not user_id = 1 or not user_id is not null or not ts >= 11950 or not ts <= 11951) and (not user_id = 1 or not user_id is not null or not ts >= 11952 or not ts <= 11953) and (not user_id = 1 or not user_id is not null or not ts >= 11954 or not ts <= 11955) and (not user_id = 1 or not user_id is not null or not ts >= 11956 or not ts <= 11957) and (not user_id = 1 or not user_id is not null or not ts >= 11958 or not ts <= 11959) and (not user_id = 1 or not user_id is not null or not ts >= 11960 or not ts <= 11961) and (not user_id = 1 or not user_id is not null or not ts >= 11962 or not ts <= 11963) and (not user_id = 1 or not user_id is not null or not ts >= 11964 or not ts <= 11965) and (not user_id = 1 or not user_id is not null or not ts >= 11966 or not ts <= 11967) and (not user_id = 1 or not user_id is not null or not ts >= 11968 or not ts <= 11969) and (not user_id = 1 or not user_id is not null or not ts >= 11970 or not ts <= 11971) and (not user_id = 1 or not user_id is not null or not ts >= 11972 or not ts <= 11973) and (not user_id = 1 or not user_id is not null or not ts >= 11974 or not ts <= 11975) and (not user_id = 1 or not user_id is not null or not ts >= 11976 or not ts <= 11977) and (not user_id = 1 or not user_id is not null or not ts >= 11978 or not ts <= 11979) and (not user_id = 1 or not user_id is not null or not ts >= 11980 or not ts <= 11981) and (not user_id = 1 or not user_id is not null or not ts >= 11982 or not ts <= 11983) and (not user_id = 1 or not user_id is not null or not ts >= 11984 or not ts <= 11985) and (not user_id = 1 or not user_id is not null or not ts >= 11986 or not ts <= 11987) and (not user_id = 1 or not user_id is not null or not ts >= 11988 or not ts <= 11989) and (not user_id = 1 or not user_id is not null or not ts >= 11990 or not ts <= 11991) and (not user_id = 1 or not user_id is not null or not ts >= 11992 or not ts <= 11993) and ts >= 113898 and parent_id = 1 order by ts asc limit 100",
-            "ResultColumns": 1,
-            "Table": "`user`"
+            "ResultColumns": 1
           }
         ]
       },
@@ -4443,7 +4252,6 @@
         },
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where id = 12 and exists (select 1 from music where user_id = 12 union select 1 from user_extra where user_id = 12)",
-        "Table": "`user`",
         "Values": [
           "12"
         ],
@@ -4471,7 +4279,6 @@
         },
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where (id, col) in ::vals",
-        "Table": "`user`",
         "Values": [
           "vals:0"
         ],
@@ -4497,7 +4304,6 @@
         },
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where (col, id) in ::vals",
-        "Table": "`user`",
         "Values": [
           "vals:1"
         ],
@@ -4523,7 +4329,6 @@
         },
         "FieldQuery": "select 1 from multicol_tbl where 1 != 1",
         "Query": "select 1 from multicol_tbl where (cola, colb) in ::vals",
-        "Table": "multicol_tbl",
         "Values": [
           "vals:0",
           "vals:1"
@@ -4550,7 +4355,6 @@
         },
         "FieldQuery": "select 1 from multicol_tbl where 1 != 1",
         "Query": "select 1 from multicol_tbl where cola in ::__vals0",
-        "Table": "multicol_tbl",
         "Values": [
           "::vals"
         ],
@@ -4576,7 +4380,6 @@
         },
         "FieldQuery": "select 1 from multicol_tbl where 1 != 1",
         "Query": "select 1 from multicol_tbl where (cola, colx, colb) in ::vals",
-        "Table": "multicol_tbl",
         "Values": [
           "vals:0",
           "vals:2"
@@ -4603,7 +4406,6 @@
         },
         "FieldQuery": "select 1 from multicol_tbl where 1 != 1",
         "Query": "select 1 from multicol_tbl where (colb, colx, cola) in ::vals",
-        "Table": "multicol_tbl",
         "Values": [
           "vals:2",
           "vals:0"
@@ -4630,7 +4432,6 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "Query": "select col from `user` where id = 1 order by `user`.user_id asc",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -4656,7 +4457,6 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1 group by `user`.user_id",
         "Query": "select col from `user` where id = 1 group by `user`.user_id",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -4682,7 +4482,6 @@
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
         "Query": "select user_id, col1, col2 from authoritative where user_id = 5 order by authoritative.user_id asc",
-        "Table": "authoritative",
         "Values": [
           "5"
         ],
@@ -4708,7 +4507,6 @@
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1 group by user_id",
         "Query": "select user_id, col1, col2 from authoritative where user_id = 5 group by user_id having count(user_id) = 6 order by authoritative.user_id asc",
-        "Table": "authoritative",
         "Values": [
           "5"
         ],

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -19,7 +19,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into tbl2(col2, coly) values (:_col2_0, 3)",
-        "TableName": "tbl2",
         "VindexValues": {
           "hash_vin": "1"
         }
@@ -44,7 +43,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into multicol_tbl2(cola, colb, colc) values (:_cola_0, :_colb_0, :_colc_0)",
-        "TableName": "multicol_tbl2",
         "VindexValues": {
           "multicolIdx": "1, 2, 3"
         }
@@ -83,7 +81,6 @@
             },
             "FieldQuery": "select multicol_tbl1.colb, multicol_tbl1.cola, multicol_tbl1.y, multicol_tbl1.colc, multicol_tbl1.x from multicol_tbl1 where 1 != 1",
             "Query": "select multicol_tbl1.colb, multicol_tbl1.cola, multicol_tbl1.y, multicol_tbl1.colc, multicol_tbl1.x from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3 for update",
-            "Table": "multicol_tbl1",
             "Values": [
               "1",
               "2",
@@ -109,7 +106,6 @@
               4
             ],
             "Query": "delete from multicol_tbl2 where (colb, cola, x, colc, y) in ::fkc_vals",
-            "Table": "multicol_tbl2",
             "Values": [
               "fkc_vals:1",
               "fkc_vals:0",
@@ -127,7 +123,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
-            "Table": "multicol_tbl1",
             "Values": [
               "1",
               "2",
@@ -161,8 +156,7 @@
               "Sharded": true
             },
             "FieldQuery": "select tbl5.col5, tbl5.t5col5 from tbl5 where 1 != 1",
-            "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 for update",
-            "Table": "tbl5"
+            "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -178,7 +172,6 @@
               0
             ],
             "Query": "delete from tbl4 where (col4) in ::fkc_vals",
-            "Table": "tbl4",
             "Values": [
               "fkc_vals:0"
             ],
@@ -197,8 +190,7 @@
             "Cols": [
               1
             ],
-            "Query": "delete from tbl4 where (t4col4) in ::fkc_vals1",
-            "Table": "tbl4"
+            "Query": "delete from tbl4 where (t4col4) in ::fkc_vals1"
           },
           {
             "InputName": "Parent",
@@ -209,8 +201,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete from tbl5",
-            "Table": "tbl5"
+            "Query": "delete from tbl5"
           }
         ]
       },
@@ -243,8 +234,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-            "Query": "select u_tbl9.col9 from u_tbl9 where col9 = 5 for update nowait",
-            "Table": "u_tbl9"
+            "Query": "select u_tbl9.col9 from u_tbl9 where col9 = 5 for update nowait"
           },
           {
             "InputName": "CascadeChild-1",
@@ -259,8 +249,7 @@
             "Cols": [
               0
             ],
-            "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals",
-            "Table": "u_tbl8"
+            "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals"
           },
           {
             "InputName": "Parent",
@@ -271,8 +260,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete from u_tbl9 where col9 = 5",
-            "Table": "u_tbl9"
+            "Query": "delete from u_tbl9 where col9 = 5"
           }
         ]
       },
@@ -296,8 +284,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update u_tbl5 set col5 = 'foo' where id = 1",
-        "Table": "u_tbl5"
+        "Query": "update u_tbl5 set col5 = 'foo' where id = 1"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl5"
@@ -322,8 +309,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update",
-            "Table": "u_tbl2"
+            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -338,8 +324,7 @@
             "Cols": [
               0
             ],
-            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))",
-            "Table": "u_tbl3"
+            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))"
           },
           {
             "InputName": "Parent",
@@ -350,8 +335,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl2 set col2 = 'bar' where id = 1",
-            "Table": "u_tbl2"
+            "Query": "update u_tbl2 set col2 = 'bar' where id = 1"
           }
         ]
       },
@@ -375,8 +359,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update u_tbl2 set col_no_ref = 'baz' where id = 1",
-        "Table": "u_tbl2"
+        "Query": "update u_tbl2 set col_no_ref = 'baz' where id = 1"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl2"
@@ -402,8 +385,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update tbl1 set not_ref_col = 'foo' where id = 1",
-        "Table": "tbl1"
+        "Query": "update tbl1 set not_ref_col = 'foo' where id = 1"
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl1"
@@ -433,8 +415,7 @@
               "Sharded": true
             },
             "FieldQuery": "select tbl5.t5col5 from tbl5 where 1 != 1",
-            "Query": "select tbl5.t5col5 from tbl5 for update",
-            "Table": "tbl5"
+            "Query": "select tbl5.t5col5 from tbl5 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -449,8 +430,7 @@
             "Cols": [
               0
             ],
-            "Query": "update tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in (('foo'))",
-            "Table": "tbl4"
+            "Query": "update tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in (('foo'))"
           },
           {
             "InputName": "Parent",
@@ -461,8 +441,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update tbl5 set t5col5 = 'foo'",
-            "Table": "tbl5"
+            "Query": "update tbl5 set t5col5 = 'foo'"
           }
         ]
       },
@@ -491,8 +470,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update tbl2 set col = 'foo'",
-        "Table": "tbl2"
+        "Query": "update tbl2 set col = 'foo'"
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl2"
@@ -527,7 +505,6 @@
                         "OperatorType": "Join",
                         "Variant": "LeftJoin",
                         "JoinColumnIndexes": "R:0",
-                        "TableName": "tbl10_tbl3",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -537,8 +514,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select 1 from tbl10 where 1 != 1",
-                            "Query": "select 1 from tbl10 where not (tbl10.col) <=> ('foo') for share",
-                            "Table": "tbl10"
+                            "Query": "select 1 from tbl10 where not (tbl10.col) <=> ('foo') for share"
                           },
                           {
                             "OperatorType": "Route",
@@ -548,8 +524,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl3.col from tbl3 where 1 != 1",
-                            "Query": "select tbl3.col from tbl3 where tbl3.col = 'foo' for share",
-                            "Table": "tbl3"
+                            "Query": "select tbl3.col from tbl3 where tbl3.col = 'foo' for share"
                           }
                         ]
                       }
@@ -568,8 +543,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update tbl10 set col = 'foo'",
-            "Table": "tbl10"
+            "Query": "update tbl10 set col = 'foo'"
           }
         ]
       },
@@ -603,7 +577,6 @@
             },
             "FieldQuery": "select tbl9.col9 from tbl9 where 1 != 1",
             "Query": "select tbl9.col9 from tbl9 where col9 = 34 for update",
-            "Table": "tbl9",
             "Values": [
               "34"
             ],
@@ -622,8 +595,7 @@
             "Cols": [
               0
             ],
-            "Query": "update tbl4 set col_ref = null where (col_ref) in ::fkc_vals",
-            "Table": "tbl4"
+            "Query": "update tbl4 set col_ref = null where (col_ref) in ::fkc_vals"
           },
           {
             "InputName": "Parent",
@@ -635,7 +607,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete from tbl9 where col9 = 34",
-            "Table": "tbl9",
             "Values": [
               "34"
             ],
@@ -667,8 +638,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.col1 from u_tbl1 for update",
-            "Table": "u_tbl1"
+            "Query": "select u_tbl1.col1 from u_tbl1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -687,8 +657,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -703,8 +672,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))"
               },
               {
                 "InputName": "Parent",
@@ -715,8 +683,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals"
               }
             ]
           },
@@ -737,8 +704,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait",
-                "Table": "u_tbl9"
+                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -753,8 +719,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                "Table": "u_tbl8"
+                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
               },
               {
                 "InputName": "Parent",
@@ -765,8 +730,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))",
-                "Table": "u_tbl9"
+                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))"
               }
             ]
           },
@@ -779,8 +743,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl1 set col1 = 'foo'",
-            "Table": "u_tbl1"
+            "Query": "update u_tbl1 set col1 = 'foo'"
           }
         ]
       },
@@ -811,8 +774,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where 1 != 1",
-            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where u_tbl1.col1 is null and cast(u_tbl2.col1 + 'bar' as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.col1 + 'bar' as CHAR)) and u_tbl2.id = 1 limit 1 for share",
-            "Table": "u_tbl1, u_tbl2"
+            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where u_tbl1.col1 is null and cast(u_tbl2.col1 + 'bar' as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.col1 + 'bar' as CHAR)) and u_tbl2.id = 1 limit 1 for share"
           },
           {
             "InputName": "PostVerify",
@@ -827,8 +789,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where id = 1 for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where id = 1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -850,8 +811,7 @@
                     "UpdateExprBvName": "fkc_upd"
                   }
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (:fkc_upd is null or (col3) not in ((:fkc_upd)))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (:fkc_upd is null or (col3) not in ((:fkc_upd)))"
               },
               {
                 "InputName": "Parent",
@@ -862,8 +822,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set m = 2, col2 = col1 + 'bar' where id = 1",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set m = 2, col2 = col1 + 'bar' where id = 1"
               }
             ]
           }
@@ -894,8 +853,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where id = 1 for update",
-            "Table": "u_tbl1"
+            "Query": "select u_tbl1.col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -921,8 +879,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -937,8 +894,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:fkc_upd as CHAR) is null or (col3) not in ((cast(:fkc_upd as CHAR))))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:fkc_upd as CHAR) is null or (col3) not in ((cast(:fkc_upd as CHAR))))"
               },
               {
                 "InputName": "Parent",
@@ -949,8 +905,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = :fkc_upd where (col2) in ::fkc_vals",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = :fkc_upd where (col2) in ::fkc_vals"
               }
             ]
           },
@@ -978,8 +933,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1))) for update nowait",
-                "Table": "u_tbl9"
+                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1))) for update nowait"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -994,8 +948,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                "Table": "u_tbl8"
+                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
               },
               {
                 "InputName": "Parent",
@@ -1006,8 +959,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1)))",
-                "Table": "u_tbl9"
+                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1)))"
               }
             ]
           },
@@ -1020,8 +972,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl1 set m = 2, col1 = x + 'bar' where id = 1",
-            "Table": "u_tbl1"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl1 set m = 2, col1 = x + 'bar' where id = 1"
           }
         ]
       },
@@ -1052,8 +1003,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update",
-            "Table": "u_tbl2"
+            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1068,8 +1018,7 @@
             "Cols": [
               0
             ],
-            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast(2 as CHAR)))",
-            "Table": "u_tbl3"
+            "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast(2 as CHAR)))"
           },
           {
             "InputName": "Parent",
@@ -1080,8 +1029,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl2 set m = col1 + 'bar', col2 = 2 where id = 1",
-            "Table": "u_tbl2"
+            "Query": "update u_tbl2 set m = col1 + 'bar', col2 = 2 where id = 1"
           }
         ]
       },
@@ -1109,8 +1057,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update",
-            "Table": "u_tbl1"
+            "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1129,8 +1076,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1145,8 +1091,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(2 as CHAR)))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(2 as CHAR)))"
               },
               {
                 "InputName": "Parent",
@@ -1157,8 +1102,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 2 where (col2) in ::fkc_vals",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 2 where (col2) in ::fkc_vals"
               }
             ]
           },
@@ -1179,8 +1123,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR))) for update nowait",
-                "Table": "u_tbl9"
+                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR))) for update nowait"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1195,8 +1138,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                "Table": "u_tbl8"
+                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
               },
               {
                 "InputName": "Parent",
@@ -1207,8 +1149,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR)))",
-                "Table": "u_tbl9"
+                "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR)))"
               }
             ]
           },
@@ -1221,8 +1162,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl1 set m = x + 'bar', col1 = 2 where id = 1",
-            "Table": "u_tbl1"
+            "Query": "update u_tbl1 set m = x + 'bar', col1 = 2 where id = 1"
           }
         ]
       },
@@ -1261,8 +1201,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
-            "Query": "select u_tbl2.id from u_tbl2 limit 2 for update",
-            "Table": "u_tbl2"
+            "Query": "select u_tbl2.id from u_tbl2 limit 2 for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -1276,8 +1215,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1292,8 +1230,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -1304,8 +1241,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl2 where u_tbl2.id in ::dml_vals",
-                "Table": "u_tbl2"
+                "Query": "delete from u_tbl2 where u_tbl2.id in ::dml_vals"
               }
             ]
           }
@@ -1348,7 +1284,6 @@
                         "JoinVars": {
                           "tbl3_colx": 0
                         },
-                        "TableName": "tbl3_tbl1",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -1358,8 +1293,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl3.colx from tbl3 where 1 != 1",
-                            "Query": "select tbl3.colx from tbl3 where tbl3.colx + 10 is not null and not (tbl3.coly) <=> (tbl3.colx + 10) and tbl3.coly = 10 for share",
-                            "Table": "tbl3"
+                            "Query": "select tbl3.colx from tbl3 where tbl3.colx + 10 is not null and not (tbl3.coly) <=> (tbl3.colx + 10) and tbl3.coly = 10 for share"
                           },
                           {
                             "OperatorType": "Route",
@@ -1369,8 +1303,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl1.t1col1 from tbl1 where 1 != 1",
-                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = :tbl3_colx + 10 for share",
-                            "Table": "tbl1"
+                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = :tbl3_colx + 10 for share"
                           }
                         ]
                       }
@@ -1389,8 +1322,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ tbl3 set coly = colx + 10 where coly = 10",
-            "Table": "tbl3"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ tbl3 set coly = colx + 10 where coly = 10"
           }
         ]
       },
@@ -1428,7 +1360,6 @@
                         "OperatorType": "Join",
                         "Variant": "LeftJoin",
                         "JoinColumnIndexes": "R:0",
-                        "TableName": "tbl3_tbl1",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -1438,8 +1369,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select 1 from tbl3 where 1 != 1",
-                            "Query": "select 1 from tbl3 where not (tbl3.coly) <=> (20) and tbl3.coly = 10 for share",
-                            "Table": "tbl3"
+                            "Query": "select 1 from tbl3 where not (tbl3.coly) <=> (20) and tbl3.coly = 10 for share"
                           },
                           {
                             "OperatorType": "Route",
@@ -1449,8 +1379,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl1.t1col1 from tbl1 where 1 != 1",
-                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = 20 for share",
-                            "Table": "tbl1"
+                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = 20 for share"
                           }
                         ]
                       }
@@ -1469,8 +1398,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update tbl3 set coly = 20 where coly = 10",
-            "Table": "tbl3"
+            "Query": "update tbl3 set coly = 20 where coly = 10"
           }
         ]
       },
@@ -1498,8 +1426,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl6.col6 from u_tbl6 where 1 != 1",
-            "Query": "select u_tbl6.col6 from u_tbl6 for update",
-            "Table": "u_tbl6"
+            "Query": "select u_tbl6.col6 from u_tbl6 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1518,8 +1445,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
-                "Table": "u_tbl8, u_tbl9"
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait"
               },
               {
                 "InputName": "PostVerify",
@@ -1530,8 +1456,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl8 set col8 = 'foo' where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl8 set col8 = 'foo' where (col8) in ::fkc_vals"
               }
             ]
           },
@@ -1544,8 +1469,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl6 set col6 = 'foo'",
-            "Table": "u_tbl6"
+            "Query": "update u_tbl6 set col6 = 'foo'"
           }
         ]
       },
@@ -1574,8 +1498,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl7.col7 from u_tbl7 where 1 != 1",
-            "Query": "select u_tbl7.col7 from u_tbl7 for update",
-            "Table": "u_tbl7"
+            "Query": "select u_tbl7.col7 from u_tbl7 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1594,8 +1517,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and cast('foo' as CHAR) is not null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
-                "Table": "u_tbl3, u_tbl4"
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and cast('foo' as CHAR) is not null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share"
               },
               {
                 "InputName": "VerifyChild-2",
@@ -1606,8 +1528,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast('foo' as CHAR) is null or (u_tbl9.col9) not in ((cast('foo' as CHAR)))) limit 1 for share",
-                "Table": "u_tbl4, u_tbl9"
+                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast('foo' as CHAR) is null or (u_tbl9.col9) not in ((cast('foo' as CHAR)))) limit 1 for share"
               },
               {
                 "InputName": "PostVerify",
@@ -1618,8 +1539,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = 'foo' where (col4) in ::fkc_vals",
-                "Table": "u_tbl4"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = 'foo' where (col4) in ::fkc_vals"
               }
             ]
           },
@@ -1632,8 +1552,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl7 set col7 = 'foo'",
-            "Table": "u_tbl7"
+            "Query": "update u_tbl7 set col7 = 'foo'"
           }
         ]
       },
@@ -1663,8 +1582,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl7.col7 from u_tbl7 where 1 != 1",
-            "Query": "select u_tbl7.col7 from u_tbl7 for update",
-            "Table": "u_tbl7"
+            "Query": "select u_tbl7.col7 from u_tbl7 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1683,8 +1601,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where u_tbl3.col3 is null and cast(:v1 as CHAR) is not null and not (u_tbl4.col4) <=> (cast(:v1 as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
-                "Table": "u_tbl3, u_tbl4"
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where u_tbl3.col3 is null and cast(:v1 as CHAR) is not null and not (u_tbl4.col4) <=> (cast(:v1 as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share"
               },
               {
                 "InputName": "VerifyChild-2",
@@ -1695,8 +1612,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast(:v1 as CHAR) is null or (u_tbl9.col9) not in ((cast(:v1 as CHAR)))) limit 1 for share",
-                "Table": "u_tbl4, u_tbl9"
+                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast(:v1 as CHAR) is null or (u_tbl9.col9) not in ((cast(:v1 as CHAR)))) limit 1 for share"
               },
               {
                 "InputName": "PostVerify",
@@ -1707,8 +1623,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = :v1 where (col4) in ::fkc_vals",
-                "Table": "u_tbl4"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = :v1 where (col4) in ::fkc_vals"
               }
             ]
           },
@@ -1721,8 +1636,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl7 set col7 = :v1",
-            "Table": "u_tbl7"
+            "Query": "update u_tbl7 set col7 = :v1"
           }
         ]
       },
@@ -1754,8 +1668,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert into u_tbl1(id, col1) values (1, 3)",
-            "TableName": "u_tbl1"
+            "Query": "insert into u_tbl1(id, col1) values (1, 3)"
           },
           {
             "InputName": "Update-1",
@@ -1770,8 +1683,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1790,8 +1702,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -1806,8 +1717,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(5 as CHAR)))",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(5 as CHAR)))"
                   },
                   {
                     "InputName": "Parent",
@@ -1818,8 +1728,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 5 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 5 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -1840,8 +1749,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR))) for update nowait",
-                    "Table": "u_tbl9"
+                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR))) for update nowait"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -1856,8 +1764,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                    "Table": "u_tbl8"
+                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
                   },
                   {
                     "InputName": "Parent",
@@ -1868,8 +1775,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR)))",
-                    "Table": "u_tbl9"
+                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR)))"
                   }
                 ]
               },
@@ -1882,8 +1788,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl1 set col1 = 5 where id = 1",
-                "Table": "u_tbl1"
+                "Query": "update u_tbl1 set col1 = 5 where id = 1"
               }
             ]
           }
@@ -1912,8 +1817,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into u_tbl1(id, col1, foo) values (1, 3, 'bar') on duplicate key update foo = 'baz'",
-        "TableName": "u_tbl1"
+        "Query": "insert into u_tbl1(id, col1, foo) values (1, 3, 'bar') on duplicate key update foo = 'baz'"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl1"
@@ -1946,8 +1850,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 where (id) in ((1)) for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 where (id) in ((1)) for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1966,8 +1869,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -1982,8 +1884,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1"
                   },
                   {
                     "InputName": "Parent",
@@ -1994,8 +1895,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "delete from u_tbl2 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "delete from u_tbl2 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -2008,8 +1908,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl1 where (id) in ((1))",
-                "Table": "u_tbl1"
+                "Query": "delete from u_tbl1 where (id) in ((1))"
               }
             ]
           },
@@ -2022,8 +1921,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert into u_tbl1(id, col1) values (1, 2)",
-            "TableName": "u_tbl1"
+            "Query": "insert into u_tbl1(id, col1) values (1, 2)"
           }
         ]
       },
@@ -2052,8 +1950,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where 1 != 1",
-            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = 3 for update",
-            "Table": "u_multicol_tbl1"
+            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = 3 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -2073,8 +1970,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where 1 != 1",
-                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2)) for update",
-                "Table": "u_multicol_tbl2"
+                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2)) for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2090,8 +1986,7 @@
                   0,
                   1
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1",
-                "Table": "u_multicol_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1"
               },
               {
                 "InputName": "Parent",
@@ -2102,8 +1997,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2))",
-                "Table": "u_multicol_tbl2"
+                "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2))"
               }
             ]
           },
@@ -2116,8 +2010,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_multicol_tbl1 set cola = 1, colb = 2 where id = 3",
-            "Table": "u_multicol_tbl1"
+            "Query": "update u_multicol_tbl1 set cola = 1, colb = 2 where id = 3"
           }
         ]
       },
@@ -2146,8 +2039,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where 1 != 1",
-            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = :v3 for update",
-            "Table": "u_multicol_tbl1"
+            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = :v3 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -2167,8 +2059,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where 1 != 1",
-                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2)))) for update",
-                "Table": "u_multicol_tbl2"
+                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2)))) for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2184,8 +2075,7 @@
                   0,
                   1
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1",
-                "Table": "u_multicol_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1"
               },
               {
                 "InputName": "Parent",
@@ -2196,8 +2086,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2))))",
-                "Table": "u_multicol_tbl2"
+                "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2))))"
               }
             ]
           },
@@ -2210,8 +2099,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_multicol_tbl1 set cola = :v1, colb = :v2 where id = :v3",
-            "Table": "u_multicol_tbl1"
+            "Query": "update u_multicol_tbl1 set cola = :v1, colb = :v2 where id = :v3"
           }
         ]
       },
@@ -2246,8 +2134,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select tbl5.col5, tbl5.t5col5 from tbl5 where 1 != 1",
-                "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 where id = :v1 for update",
-                "Table": "tbl5"
+                "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 where id = :v1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2263,7 +2150,6 @@
                   0
                 ],
                 "Query": "delete from tbl4 where (col4) in ::fkc_vals",
-                "Table": "tbl4",
                 "Values": [
                   "fkc_vals:0"
                 ],
@@ -2282,8 +2168,7 @@
                 "Cols": [
                   1
                 ],
-                "Query": "delete from tbl4 where (t4col4) in ::fkc_vals1",
-                "Table": "tbl4"
+                "Query": "delete from tbl4 where (t4col4) in ::fkc_vals1"
               },
               {
                 "InputName": "Parent",
@@ -2294,8 +2179,7 @@
                   "Sharded": true
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from tbl5 where id = :v1",
-                "Table": "tbl5"
+                "Query": "delete from tbl5 where id = :v1"
               }
             ]
           }
@@ -2330,8 +2214,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl7.col7, col7 <=> cast(baz + 1 + col7 as CHAR), cast(baz + 1 + col7 as CHAR) from u_tbl7 where 1 != 1",
-            "Query": "select u_tbl7.col7, col7 <=> cast(baz + 1 + col7 as CHAR), cast(baz + 1 + col7 as CHAR) from u_tbl7 where bar = 42 for update",
-            "Table": "u_tbl7"
+            "Query": "select u_tbl7.col7, col7 <=> cast(baz + 1 + col7 as CHAR), cast(baz + 1 + col7 as CHAR) from u_tbl7 where bar = 42 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -2357,8 +2240,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:fkc_upd as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:fkc_upd as CHAR) where u_tbl3.col3 is null and cast(:fkc_upd as CHAR) is not null and not (u_tbl4.col4) <=> (cast(:fkc_upd as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
-                "Table": "u_tbl3, u_tbl4"
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:fkc_upd as CHAR) where u_tbl3.col3 is null and cast(:fkc_upd as CHAR) is not null and not (u_tbl4.col4) <=> (cast(:fkc_upd as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share"
               },
               {
                 "InputName": "VerifyChild-2",
@@ -2369,8 +2251,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast(:fkc_upd as CHAR) is null or (u_tbl9.col9) not in ((cast(:fkc_upd as CHAR)))) limit 1 for share",
-                "Table": "u_tbl4, u_tbl9"
+                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast(:fkc_upd as CHAR) is null or (u_tbl9.col9) not in ((cast(:fkc_upd as CHAR)))) limit 1 for share"
               },
               {
                 "InputName": "PostVerify",
@@ -2381,8 +2262,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = :fkc_upd where (col4) in ::fkc_vals",
-                "Table": "u_tbl4"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = :fkc_upd where (col4) in ::fkc_vals"
               }
             ]
           },
@@ -2395,8 +2275,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl7 set foo = 100, col7 = baz + 1 + col7 where bar = 42",
-            "Table": "u_tbl7"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl7 set foo = 100, col7 = baz + 1 + col7 where bar = 42"
           }
         ]
       },
@@ -2426,8 +2305,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb, cola <=> cola + 3, cola + 3 from u_multicol_tbl1 where 1 != 1",
-            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb, cola <=> cola + 3, cola + 3 from u_multicol_tbl1 where id = 3 for update",
-            "Table": "u_multicol_tbl1"
+            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb, cola <=> cola + 3, cola + 3 from u_multicol_tbl1 where id = 3 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -2454,8 +2332,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where 1 != 1",
-                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (:fkc_upd is null or (cola) not in ((:fkc_upd))) for update",
-                "Table": "u_multicol_tbl2"
+                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (:fkc_upd is null or (cola) not in ((:fkc_upd))) for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2471,8 +2348,7 @@
                   0,
                   1
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1",
-                "Table": "u_multicol_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1"
               },
               {
                 "InputName": "Parent",
@@ -2483,8 +2359,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (:fkc_upd is null or (cola) not in ((:fkc_upd)))",
-                "Table": "u_multicol_tbl2"
+                "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (:fkc_upd is null or (cola) not in ((:fkc_upd)))"
               }
             ]
           },
@@ -2497,8 +2372,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl1 set cola = cola + 3 where id = 3",
-            "Table": "u_multicol_tbl1"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl1 set cola = cola + 3 where id = 3"
           }
         ]
       },
@@ -2532,8 +2406,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from u_multicol_tbl2 left join u_multicol_tbl1 on u_multicol_tbl1.cola = 2 and u_multicol_tbl1.colb = u_multicol_tbl2.colc - 2 where 1 != 1",
-            "Query": "select 1 from u_multicol_tbl2 left join u_multicol_tbl1 on u_multicol_tbl1.cola = 2 and u_multicol_tbl1.colb = u_multicol_tbl2.colc - 2 where u_multicol_tbl1.cola is null and 2 is not null and u_multicol_tbl1.colb is null and u_multicol_tbl2.colc - 2 is not null and not (u_multicol_tbl2.cola, u_multicol_tbl2.colb) <=> (2, u_multicol_tbl2.colc - 2) and u_multicol_tbl2.id = 7 limit 1 for share",
-            "Table": "u_multicol_tbl1, u_multicol_tbl2"
+            "Query": "select 1 from u_multicol_tbl2 left join u_multicol_tbl1 on u_multicol_tbl1.cola = 2 and u_multicol_tbl1.colb = u_multicol_tbl2.colc - 2 where u_multicol_tbl1.cola is null and 2 is not null and u_multicol_tbl1.colb is null and u_multicol_tbl2.colc - 2 is not null and not (u_multicol_tbl2.cola, u_multicol_tbl2.colb) <=> (2, u_multicol_tbl2.colc - 2) and u_multicol_tbl2.id = 7 limit 1 for share"
           },
           {
             "InputName": "PostVerify",
@@ -2548,8 +2421,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb, cola <=> 2, 2, colb <=> colc - 2, colc - 2 from u_multicol_tbl2 where 1 != 1",
-                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb, cola <=> 2, 2, colb <=> colc - 2, colc - 2 from u_multicol_tbl2 where id = 7 for update",
-                "Table": "u_multicol_tbl2"
+                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb, cola <=> 2, 2, colb <=> colc - 2, colc - 2 from u_multicol_tbl2 where id = 7 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2577,8 +2449,7 @@
                     "UpdateExprBvName": "fkc_upd1"
                   }
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = :fkc_upd, colb = :fkc_upd1 where (cola, colb) in ::fkc_vals",
-                "Table": "u_multicol_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = :fkc_upd, colb = :fkc_upd1 where (cola, colb) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -2589,8 +2460,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl2 set cola = 2, colb = colc - 2 where id = 7",
-                "Table": "u_multicol_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl2 set cola = 2, colb = colc - 2 where id = 7"
               }
             ]
           }
@@ -2624,8 +2494,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ((10), (20), (30)) or (col9 * foo) in ((10 * null), (20 * null), (30 * null)) or (bar, col9) in ((1, 10), (1, 20), (1, 30)) or (id) in ((1), (2), (3)) for update nowait",
-                "Table": "u_tbl9"
+                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ((10), (20), (30)) or (col9 * foo) in ((10 * null), (20 * null), (30 * null)) or (bar, col9) in ((1, 10), (1, 20), (1, 30)) or (id) in ((1), (2), (3)) for update nowait"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2640,8 +2509,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
+                "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -2652,8 +2520,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl9 where (col9) in ((10), (20), (30)) or (col9 * foo) in ((10 * null), (20 * null), (30 * null)) or (bar, col9) in ((1, 10), (1, 20), (1, 30)) or (id) in ((1), (2), (3))",
-                "Table": "u_tbl9"
+                "Query": "delete from u_tbl9 where (col9) in ((10), (20), (30)) or (col9 * foo) in ((10 * null), (20 * null), (30 * null)) or (bar, col9) in ((1, 10), (1, 20), (1, 30)) or (id) in ((1), (2), (3))"
               }
             ]
           },
@@ -2666,8 +2533,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert into u_tbl9(id, col9) values (1, 10), (2, 20), (3, 30)",
-            "TableName": "u_tbl9"
+            "Query": "insert into u_tbl9(id, col9) values (1, 10), (2, 20), (3, 30)"
           }
         ]
       },
@@ -2692,7 +2558,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
-        "Table": "multicol_tbl1",
         "Values": [
           "1",
           "2",
@@ -2719,8 +2584,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3",
-        "Table": "u_multicol_tbl1"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_multicol_tbl1"
@@ -2742,7 +2606,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=Off) */ into tbl3(col3, coly) values (:_col3_0, 3)",
-        "TableName": "tbl3",
         "VindexValues": {
           "hash_vin": "1"
         }
@@ -2772,8 +2635,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert into u_tbl1(id, col1) values (1, 3)",
-            "TableName": "u_tbl1"
+            "Query": "insert into u_tbl1(id, col1) values (1, 3)"
           },
           {
             "InputName": "Update-1",
@@ -2788,8 +2650,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2808,8 +2669,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -2824,8 +2684,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(3 as CHAR)))",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(3 as CHAR)))"
                   },
                   {
                     "InputName": "Parent",
@@ -2836,8 +2695,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 3 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 3 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -2858,8 +2716,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(3 as CHAR))) for update nowait",
-                    "Table": "u_tbl9"
+                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(3 as CHAR))) for update nowait"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -2874,8 +2731,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                    "Table": "u_tbl8"
+                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
                   },
                   {
                     "InputName": "Parent",
@@ -2886,8 +2742,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(3 as CHAR)))",
-                    "Table": "u_tbl9"
+                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(3 as CHAR)))"
                   }
                 ]
               },
@@ -2900,8 +2755,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl1 set col1 = 3 where id = 1",
-                "Table": "u_tbl1"
+                "Query": "update u_tbl1 set col1 = 3 where id = 1"
               }
             ]
           }
@@ -2936,8 +2790,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert into u_tbl2(id, col2) values (:v1, :v2)",
-            "TableName": "u_tbl2"
+            "Query": "insert into u_tbl2(id, col2) values (:v1, :v2)"
           },
           {
             "InputName": "Update-1",
@@ -2952,8 +2805,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where id = :v1 for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where id = :v1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2968,8 +2820,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (cast(:v2 as CHAR) is null or (col3) not in ((cast(:v2 as CHAR))))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (cast(:v2 as CHAR) is null or (col3) not in ((cast(:v2 as CHAR))))"
               },
               {
                 "InputName": "Parent",
@@ -2980,8 +2831,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl2 set col2 = :v2 where id = :v1",
-                "Table": "u_tbl2"
+                "Query": "update u_tbl2 set col2 = :v2 where id = :v1"
               }
             ]
           },
@@ -2995,8 +2845,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert into u_tbl2(id, col2) values (:v3, :v4)",
-            "TableName": "u_tbl2"
+            "Query": "insert into u_tbl2(id, col2) values (:v3, :v4)"
           },
           {
             "InputName": "Update-2",
@@ -3011,8 +2860,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where id = :v3 for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where id = :v3 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3027,8 +2875,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:v4 as CHAR) is null or (col3) not in ((cast(:v4 as CHAR))))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:v4 as CHAR) is null or (col3) not in ((cast(:v4 as CHAR))))"
               },
               {
                 "InputName": "Parent",
@@ -3039,8 +2886,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl2 set col2 = :v4 where id = :v3",
-                "Table": "u_tbl2"
+                "Query": "update u_tbl2 set col2 = :v4 where id = :v3"
               }
             ]
           },
@@ -3054,8 +2900,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert into u_tbl2(id, col2) values (:v5, :v6)",
-            "TableName": "u_tbl2"
+            "Query": "insert into u_tbl2(id, col2) values (:v5, :v6)"
           },
           {
             "InputName": "Update-3",
@@ -3070,8 +2915,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where id = :v5 for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where id = :v5 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3086,8 +2930,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals2 and (cast(:v6 as CHAR) is null or (col3) not in ((cast(:v6 as CHAR))))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals2 and (cast(:v6 as CHAR) is null or (col3) not in ((cast(:v6 as CHAR))))"
               },
               {
                 "InputName": "Parent",
@@ -3098,8 +2941,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl2 set col2 = :v6 where id = :v5",
-                "Table": "u_tbl2"
+                "Query": "update u_tbl2 set col2 = :v6 where id = :v5"
               }
             ]
           }
@@ -3137,8 +2979,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u.id from u_tbl6 as u, u_tbl5 as m where 1 != 1",
-            "Query": "select u.id from u_tbl6 as u, u_tbl5 as m where u.col2 = 4 and m.col3 = 6 and u.col = m.col for update",
-            "Table": "u_tbl5, u_tbl6"
+            "Query": "select u.id from u_tbl6 as u, u_tbl5 as m where u.col2 = 4 and m.col3 = 6 and u.col = m.col for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -3152,8 +2993,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u.col6 from u_tbl6 as u where 1 != 1",
-                "Query": "select u.col6 from u_tbl6 as u where u.id in ::dml_vals for update",
-                "Table": "u_tbl6"
+                "Query": "select u.col6 from u_tbl6 as u where u.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3168,8 +3008,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "delete from u_tbl8 where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
+                "Query": "delete from u_tbl8 where (col8) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -3180,8 +3019,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl6 as u where u.id in ::dml_vals",
-                "Table": "u_tbl6"
+                "Query": "delete from u_tbl6 as u where u.id in ::dml_vals"
               }
             ]
           }
@@ -3215,8 +3053,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl10.id from u_tbl10, u_tbl11 where 1 != 1",
-            "Query": "select u_tbl10.id from u_tbl10, u_tbl11 where u_tbl10.id = 5 and u_tbl10.id = u_tbl11.id for update",
-            "Table": "u_tbl10, u_tbl11"
+            "Query": "select u_tbl10.id from u_tbl10, u_tbl11 where u_tbl10.id = 5 and u_tbl10.id = u_tbl11.id for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -3230,8 +3067,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl10.col from u_tbl10 where 1 != 1",
-                "Query": "select u_tbl10.col from u_tbl10 where u_tbl10.id in ::dml_vals for update",
-                "Table": "u_tbl10"
+                "Query": "select u_tbl10.col from u_tbl10 where u_tbl10.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3246,8 +3082,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "delete from u_tbl11 where (col) in ::fkc_vals",
-                "Table": "u_tbl11"
+                "Query": "delete from u_tbl11 where (col) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -3258,8 +3093,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl10 where u_tbl10.id in ::dml_vals",
-                "Table": "u_tbl10"
+                "Query": "delete from u_tbl10 where u_tbl10.id in ::dml_vals"
               }
             ]
           }
@@ -3292,8 +3126,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.id from u_tbl10, u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.id from u_tbl10, u_tbl1 where u_tbl10.col = u_tbl1.col for update",
-            "Table": "u_tbl1, u_tbl10"
+            "Query": "select u_tbl1.id from u_tbl10, u_tbl1 where u_tbl10.col = u_tbl1.col for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -3307,8 +3140,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 where u_tbl1.id in ::dml_vals for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 where u_tbl1.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3327,8 +3159,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -3343,8 +3174,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1"
                   },
                   {
                     "InputName": "Parent",
@@ -3355,8 +3185,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "delete from u_tbl2 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "delete from u_tbl2 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -3369,8 +3198,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl1 where u_tbl1.id in ::dml_vals",
-                "Table": "u_tbl1"
+                "Query": "delete from u_tbl1 where u_tbl1.id in ::dml_vals"
               }
             ]
           }
@@ -3405,8 +3233,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.id from u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.id from u_tbl1 order by id asc limit 1 for update",
-            "Table": "u_tbl1"
+            "Query": "select u_tbl1.id from u_tbl1 order by id asc limit 1 for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -3420,8 +3247,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 where u_tbl1.id in ::dml_vals for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 where u_tbl1.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3440,8 +3266,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -3456,8 +3281,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1"
                   },
                   {
                     "InputName": "Parent",
@@ -3468,8 +3292,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "delete from u_tbl2 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "delete from u_tbl2 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -3482,8 +3305,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl1 where u_tbl1.id in ::dml_vals",
-                "Table": "u_tbl1"
+                "Query": "delete from u_tbl1 where u_tbl1.id in ::dml_vals"
               }
             ]
           }
@@ -3518,8 +3340,7 @@
               "Sharded": false
             },
             "FieldQuery": "select col14 from u_tbl1 where 1 != 1",
-            "Query": "select col14 from u_tbl1 where x = 2 and y = 4 lock in share mode",
-            "Table": "u_tbl1"
+            "Query": "select col14 from u_tbl1 where x = 2 and y = 4 lock in share mode"
           },
           {
             "InputName": "Outer",
@@ -3534,8 +3355,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl1 on u_tbl1.col14 = cast(:__sq1 as SIGNED) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl1 on u_tbl1.col14 = cast(:__sq1 as SIGNED) where u_tbl1.col14 is null and cast(:__sq1 as SIGNED) is not null and not (u_tbl4.col41) <=> (cast(:__sq1 as SIGNED)) and u_tbl4.col4 = 3 limit 1 for share",
-                "Table": "u_tbl1, u_tbl4"
+                "Query": "select 1 from u_tbl4 left join u_tbl1 on u_tbl1.col14 = cast(:__sq1 as SIGNED) where u_tbl1.col14 is null and cast(:__sq1 as SIGNED) is not null and not (u_tbl4.col41) <=> (cast(:__sq1 as SIGNED)) and u_tbl4.col4 = 3 limit 1 for share"
               },
               {
                 "InputName": "PostVerify",
@@ -3546,8 +3366,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col41 = :__sq1 where col4 = 3",
-                "Table": "u_tbl4"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col41 = :__sq1 where col4 = 3"
               }
             ]
           }
@@ -3581,8 +3400,7 @@
               "Sharded": false
             },
             "FieldQuery": "select foo from u_tbl1 where 1 != 1",
-            "Query": "select foo from u_tbl1 where id = 1 lock in share mode",
-            "Table": "u_tbl1"
+            "Query": "select foo from u_tbl1 where id = 1 lock in share mode"
           },
           {
             "InputName": "Outer",
@@ -3597,8 +3415,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 order by id desc for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 order by id desc for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3617,8 +3434,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -3633,8 +3449,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:__sq1 as CHAR) is null or (col3) not in ((cast(:__sq1 as CHAR))))",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:__sq1 as CHAR) is null or (col3) not in ((cast(:__sq1 as CHAR))))"
                   },
                   {
                     "InputName": "Parent",
@@ -3645,8 +3460,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = :__sq1 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = :__sq1 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -3667,8 +3481,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (cast(:__sq1 as CHAR) is null or (col9) not in ((cast(:__sq1 as CHAR)))) for update nowait",
-                    "Table": "u_tbl9"
+                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (cast(:__sq1 as CHAR) is null or (col9) not in ((cast(:__sq1 as CHAR)))) for update nowait"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -3683,8 +3496,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                    "Table": "u_tbl8"
+                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
                   },
                   {
                     "InputName": "Parent",
@@ -3695,8 +3507,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (cast(:__sq1 as CHAR) is null or (col9) not in ((cast(:__sq1 as CHAR))))",
-                    "Table": "u_tbl9"
+                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (cast(:__sq1 as CHAR) is null or (col9) not in ((cast(:__sq1 as CHAR))))"
                   }
                 ]
               },
@@ -3709,8 +3520,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl1 set col1 = :__sq1 order by id desc",
-                "Table": "u_tbl1"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl1 set col1 = :__sq1 order by id desc"
               }
             ]
           }
@@ -3746,8 +3556,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl6.id from u_tbl6, u_tbl8 where 1 != 1",
-            "Query": "select u_tbl6.id from u_tbl6, u_tbl8 where u_tbl6.id = 4 and u_tbl6.id = u_tbl8.id for update",
-            "Table": "u_tbl6, u_tbl8"
+            "Query": "select u_tbl6.id from u_tbl6, u_tbl8 where u_tbl6.id = 4 and u_tbl6.id = u_tbl8.id for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -3761,8 +3570,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl6.col6 from u_tbl6 where 1 != 1",
-                "Query": "select u_tbl6.col6 from u_tbl6 where u_tbl6.id in ::dml_vals for update",
-                "Table": "u_tbl6"
+                "Query": "select u_tbl6.col6 from u_tbl6 where u_tbl6.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3777,8 +3585,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "delete from u_tbl8 where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
+                "Query": "delete from u_tbl8 where (col8) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -3789,8 +3596,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl6 where u_tbl6.id in ::dml_vals",
-                "Table": "u_tbl6"
+                "Query": "delete from u_tbl6 where u_tbl6.id in ::dml_vals"
               }
             ]
           }
@@ -3824,8 +3630,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u.id, m.id from u_tbl6 as u, u_tbl5 as m where 1 != 1",
-            "Query": "select u.id, m.id from u_tbl6 as u, u_tbl5 as m where u.col2 = 4 and m.col3 = 6 and u.col = m.col for update",
-            "Table": "u_tbl5, u_tbl6"
+            "Query": "select u.id, m.id from u_tbl6 as u, u_tbl5 as m where u.col2 = 4 and m.col3 = 6 and u.col = m.col for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -3839,8 +3644,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u.col6 from u_tbl6 as u where 1 != 1",
-                "Query": "select u.col6 from u_tbl6 as u where u.id in ::dml_vals for update",
-                "Table": "u_tbl6"
+                "Query": "select u.col6 from u_tbl6 as u where u.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3855,8 +3659,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "delete from u_tbl8 where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
+                "Query": "delete from u_tbl8 where (col8) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -3867,8 +3670,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete from u_tbl6 as u where u.id in ::dml_vals",
-                "Table": "u_tbl6"
+                "Query": "delete from u_tbl6 as u where u.id in ::dml_vals"
               }
             ]
           },
@@ -3880,8 +3682,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete from u_tbl5 as m where m.id in ::dml_vals",
-            "Table": "u_tbl5"
+            "Query": "delete from u_tbl5 as m where m.id in ::dml_vals"
           }
         ]
       },
@@ -3913,8 +3714,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
-            "Query": "select u_tbl2.id from u_tbl2 limit 2 for update",
-            "Table": "u_tbl2"
+            "Query": "select u_tbl2.id from u_tbl2 limit 2 for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -3928,8 +3728,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -3944,8 +3743,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))",
-                "Table": "u_tbl3"
+                "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))"
               },
               {
                 "InputName": "Parent",
@@ -3956,8 +3754,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl2 set col2 = 'bar' where u_tbl2.id in ::dml_vals",
-                "Table": "u_tbl2"
+                "Query": "update u_tbl2 set col2 = 'bar' where u_tbl2.id in ::dml_vals"
               }
             ]
           }
@@ -3990,8 +3787,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
-            "Query": "select u_tbl2.id from u_tbl2 order by id asc limit 2 for update",
-            "Table": "u_tbl2"
+            "Query": "select u_tbl2.id from u_tbl2 order by id asc limit 2 for update"
           },
           {
             "OperatorType": "FKVerify",
@@ -4005,8 +3801,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.id + 1 as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.id + 1 as CHAR) where u_tbl1.col1 is null and cast(u_tbl2.id + 1 as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.id + 1 as CHAR)) and u_tbl2.id in ::dml_vals limit 1 for share",
-                "Table": "u_tbl1, u_tbl2"
+                "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.id + 1 as CHAR) where u_tbl1.col1 is null and cast(u_tbl2.id + 1 as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.id + 1 as CHAR)) and u_tbl2.id in ::dml_vals limit 1 for share"
               },
               {
                 "InputName": "PostVerify",
@@ -4021,8 +3816,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2, col2 <=> cast(id + 1 as CHAR), cast(id + 1 as CHAR) from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2, col2 <=> cast(id + 1 as CHAR), cast(id + 1 as CHAR) from u_tbl2 where u_tbl2.id in ::dml_vals order by id asc for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2, col2 <=> cast(id + 1 as CHAR), cast(id + 1 as CHAR) from u_tbl2 where u_tbl2.id in ::dml_vals order by id asc for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -4044,8 +3838,7 @@
                         "UpdateExprBvName": "fkc_upd"
                       }
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (:fkc_upd is null or (col3) not in ((:fkc_upd)))",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals and (:fkc_upd is null or (col3) not in ((:fkc_upd)))"
                   },
                   {
                     "InputName": "Parent",
@@ -4056,8 +3849,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = id + 1 where u_tbl2.id in ::dml_vals order by id asc",
-                    "Table": "u_tbl2"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = id + 1 where u_tbl2.id in ::dml_vals order by id asc"
                   }
                 ]
               }
@@ -4090,8 +3882,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u.col6 from u_tbl6 as u, u_tbl5 as m where 1 != 1",
-            "Query": "select u.col6 from u_tbl6 as u, u_tbl5 as m where u.col = m.col and u.col2 = 4 and m.col3 = 6 for update",
-            "Table": "u_tbl5, u_tbl6"
+            "Query": "select u.col6 from u_tbl6 as u, u_tbl5 as m where u.col = m.col and u.col2 = 4 and m.col3 = 6 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -4110,8 +3901,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
-                "Table": "u_tbl8, u_tbl9"
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait"
               },
               {
                 "InputName": "PostVerify",
@@ -4122,8 +3912,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl8 set col8 = 'foo' where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl8 set col8 = 'foo' where (col8) in ::fkc_vals"
               }
             ]
           },
@@ -4136,8 +3925,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update u_tbl6 as u, u_tbl5 as m set u.col6 = 'foo' where u.col2 = 4 and m.col3 = 6 and u.col = m.col",
-            "Table": "u_tbl6"
+            "Query": "update u_tbl6 as u, u_tbl5 as m set u.col6 = 'foo' where u.col2 = 4 and m.col3 = 6 and u.col = m.col"
           }
         ]
       },
@@ -4171,8 +3959,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u.id, m.id from u_tbl1 as u, u_multicol_tbl1 as m where 1 != 1",
-            "Query": "select u.id, m.id from u_tbl1 as u, u_multicol_tbl1 as m where u.foo = 4 and m.bar = 6 and u.col = m.col for update",
-            "Table": "u_multicol_tbl1, u_tbl1"
+            "Query": "select u.id, m.id from u_tbl1 as u, u_multicol_tbl1 as m where u.foo = 4 and m.bar = 6 and u.col = m.col for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -4186,8 +3973,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u.col1 from u_tbl1 as u where 1 != 1",
-                "Query": "select u.col1 from u_tbl1 as u where u.id in ::dml_vals for update",
-                "Table": "u_tbl1"
+                "Query": "select u.col1 from u_tbl1 as u where u.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -4206,8 +3992,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -4222,8 +4007,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))",
-                    "Table": "u_tbl3"
+                    "Query": "update u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))"
                   },
                   {
                     "InputName": "Parent",
@@ -4234,8 +4018,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -4256,8 +4039,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait",
-                    "Table": "u_tbl9"
+                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -4272,8 +4054,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                    "Table": "u_tbl8"
+                    "Query": "update u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
                   },
                   {
                     "InputName": "Parent",
@@ -4284,8 +4065,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))",
-                    "Table": "u_tbl9"
+                    "Query": "update u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))"
                   }
                 ]
               },
@@ -4298,8 +4078,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_tbl1 as u set u.col1 = 'foo' where u.id in ::dml_vals",
-                "Table": "u_tbl1"
+                "Query": "update u_tbl1 as u set u.col1 = 'foo' where u.id in ::dml_vals"
               }
             ]
           },
@@ -4315,8 +4094,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select m.cola, m.colb from u_multicol_tbl1 as m where 1 != 1",
-                "Query": "select m.cola, m.colb from u_multicol_tbl1 as m where m.id in ::dml_vals for update",
-                "Table": "u_multicol_tbl1"
+                "Query": "select m.cola, m.colb from u_multicol_tbl1 as m where m.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -4336,8 +4114,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where 1 != 1",
-                    "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals4 and (cola) not in (('bar')) for update",
-                    "Table": "u_multicol_tbl2"
+                    "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals4 and (cola) not in (('bar')) for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -4353,8 +4130,7 @@
                       0,
                       1
                     ],
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals5",
-                    "Table": "u_multicol_tbl3"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals5"
                   },
                   {
                     "InputName": "Parent",
@@ -4365,8 +4141,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals4 and (cola) not in (('bar'))",
-                    "Table": "u_multicol_tbl2"
+                    "Query": "update u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals4 and (cola) not in (('bar'))"
                   }
                 ]
               },
@@ -4379,8 +4154,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update u_multicol_tbl1 as m set m.cola = 'bar' where m.id in ::dml_vals",
-                "Table": "u_multicol_tbl1"
+                "Query": "update u_multicol_tbl1 as m set m.cola = 'bar' where m.id in ::dml_vals"
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_off_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_off_cases.json
@@ -14,7 +14,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=Off) */ into tbl3(col3, coly) values (:_col3_0, 3)",
-        "TableName": "tbl3",
         "VindexValues": {
           "hash_vin": "1"
         }
@@ -39,7 +38,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=Off) */ into multicol_tbl2(cola, colb, colc) values (:_cola_0, :_colb_0, :_colc_0)",
-        "TableName": "multicol_tbl2",
         "VindexValues": {
           "multicolIdx": "1, 2, 3"
         }
@@ -63,8 +61,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from tbl1",
-        "Table": "tbl1"
+        "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from tbl1"
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl1"
@@ -85,8 +82,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from tbl7",
-        "Table": "tbl7"
+        "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from tbl7"
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl7"
@@ -112,7 +108,6 @@
             },
             "FieldQuery": "select multicol_tbl1.colb, multicol_tbl1.cola, multicol_tbl1.y, multicol_tbl1.colc, multicol_tbl1.x from multicol_tbl1 where 1 != 1",
             "Query": "select multicol_tbl1.colb, multicol_tbl1.cola, multicol_tbl1.y, multicol_tbl1.colc, multicol_tbl1.x from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3 for update",
-            "Table": "multicol_tbl1",
             "Values": [
               "1",
               "2",
@@ -138,7 +133,6 @@
               4
             ],
             "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from multicol_tbl2 where (colb, cola, x, colc, y) in ::fkc_vals",
-            "Table": "multicol_tbl2",
             "Values": [
               "fkc_vals:1",
               "fkc_vals:0",
@@ -156,7 +150,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
-            "Table": "multicol_tbl1",
             "Values": [
               "1",
               "2",
@@ -187,7 +180,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from tbl8 where col8 = 1",
-        "Table": "tbl8",
         "Values": [
           "1"
         ],
@@ -213,7 +205,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ tbl1 set t1col1 = 'foo' where col1 = 1",
-        "Table": "tbl1",
         "Values": [
           "1"
         ],
@@ -238,8 +229,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ tbl7 set t7col7 = 'foo', t7col72 = 42",
-        "Table": "tbl7"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ tbl7 set t7col7 = 'foo', t7col72 = 42"
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl7"
@@ -264,8 +254,7 @@
               "Sharded": true
             },
             "FieldQuery": "select tbl5.t5col5 from tbl5 where 1 != 1",
-            "Query": "select tbl5.t5col5 from tbl5 for update",
-            "Table": "tbl5"
+            "Query": "select tbl5.t5col5 from tbl5 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -280,8 +269,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in (('foo'))",
-            "Table": "tbl4"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in (('foo'))"
           },
           {
             "InputName": "Parent",
@@ -292,8 +280,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl5 set t5col5 = 'foo'",
-            "Table": "tbl5"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl5 set t5col5 = 'foo'"
           }
         ]
       },
@@ -318,7 +305,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=Off) */ into tbl6(col6, t6col6) values (:_col6_0, 'foo')",
-        "TableName": "tbl6",
         "VindexValues": {
           "hash_vin": "100"
         }
@@ -343,7 +329,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from tbl20 where col = 'bar'",
-        "Table": "tbl20",
         "Values": [
           "'bar'"
         ],
@@ -373,7 +358,6 @@
             },
             "FieldQuery": "select tbl9.col9 from tbl9 where 1 != 1",
             "Query": "select tbl9.col9 from tbl9 where col9 = 34 for update",
-            "Table": "tbl9",
             "Values": [
               "34"
             ],
@@ -392,8 +376,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set col_ref = null where (col_ref) in ::fkc_vals",
-            "Table": "tbl4"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set col_ref = null where (col_ref) in ::fkc_vals"
           },
           {
             "InputName": "Parent",
@@ -405,7 +388,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from tbl9 where col9 = 34",
-            "Table": "tbl9",
             "Values": [
               "34"
             ],
@@ -434,7 +416,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
-        "Table": "multicol_tbl1",
         "Values": [
           "1",
           "2",
@@ -461,8 +442,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3",
-        "Table": "u_multicol_tbl1"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_multicol_tbl1"
@@ -484,7 +464,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=Off) */ into tbl3(col3, coly) values (:_col3_0, 3)",
-        "TableName": "tbl3",
         "VindexValues": {
           "hash_vin": "1"
         }

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
@@ -19,7 +19,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into tbl2(col2, coly) values (:_col2_0, 3)",
-        "TableName": "tbl2",
         "VindexValues": {
           "hash_vin": "1"
         }
@@ -44,7 +43,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into multicol_tbl2(cola, colb, colc) values (:_cola_0, :_colb_0, :_colc_0)",
-        "TableName": "multicol_tbl2",
         "VindexValues": {
           "multicolIdx": "1, 2, 3"
         }
@@ -83,7 +81,6 @@
             },
             "FieldQuery": "select multicol_tbl1.colb, multicol_tbl1.cola, multicol_tbl1.y, multicol_tbl1.colc, multicol_tbl1.x from multicol_tbl1 where 1 != 1",
             "Query": "select multicol_tbl1.colb, multicol_tbl1.cola, multicol_tbl1.y, multicol_tbl1.colc, multicol_tbl1.x from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3 for update",
-            "Table": "multicol_tbl1",
             "Values": [
               "1",
               "2",
@@ -109,7 +106,6 @@
               4
             ],
             "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from multicol_tbl2 where (colb, cola, x, colc, y) in ::fkc_vals",
-            "Table": "multicol_tbl2",
             "Values": [
               "fkc_vals:1",
               "fkc_vals:0",
@@ -127,7 +123,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
-            "Table": "multicol_tbl1",
             "Values": [
               "1",
               "2",
@@ -161,8 +156,7 @@
               "Sharded": true
             },
             "FieldQuery": "select tbl5.col5, tbl5.t5col5 from tbl5 where 1 != 1",
-            "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 for update",
-            "Table": "tbl5"
+            "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -178,7 +172,6 @@
               0
             ],
             "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from tbl4 where (col4) in ::fkc_vals",
-            "Table": "tbl4",
             "Values": [
               "fkc_vals:0"
             ],
@@ -197,8 +190,7 @@
             "Cols": [
               1
             ],
-            "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from tbl4 where (t4col4) in ::fkc_vals1",
-            "Table": "tbl4"
+            "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from tbl4 where (t4col4) in ::fkc_vals1"
           },
           {
             "InputName": "Parent",
@@ -209,8 +201,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from tbl5",
-            "Table": "tbl5"
+            "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from tbl5"
           }
         ]
       },
@@ -243,8 +234,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-            "Query": "select u_tbl9.col9 from u_tbl9 where col9 = 5 for update nowait",
-            "Table": "u_tbl9"
+            "Query": "select u_tbl9.col9 from u_tbl9 where col9 = 5 for update nowait"
           },
           {
             "InputName": "CascadeChild-1",
@@ -259,8 +249,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals",
-            "Table": "u_tbl8"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals"
           },
           {
             "InputName": "Parent",
@@ -271,8 +260,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from u_tbl9 where col9 = 5",
-            "Table": "u_tbl9"
+            "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from u_tbl9 where col9 = 5"
           }
         ]
       },
@@ -296,8 +284,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl5 set col5 = 'foo' where id = 1",
-        "Table": "u_tbl5"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl5 set col5 = 'foo' where id = 1"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl5"
@@ -322,8 +309,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update",
-            "Table": "u_tbl2"
+            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -338,8 +324,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))",
-            "Table": "u_tbl3"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))"
           },
           {
             "InputName": "Parent",
@@ -350,8 +335,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set col2 = 'bar' where id = 1",
-            "Table": "u_tbl2"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set col2 = 'bar' where id = 1"
           }
         ]
       },
@@ -375,8 +359,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set col_no_ref = 'baz' where id = 1",
-        "Table": "u_tbl2"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set col_no_ref = 'baz' where id = 1"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl2"
@@ -402,8 +385,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl1 set not_ref_col = 'foo' where id = 1",
-        "Table": "tbl1"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl1 set not_ref_col = 'foo' where id = 1"
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl1"
@@ -433,8 +415,7 @@
               "Sharded": true
             },
             "FieldQuery": "select tbl5.t5col5 from tbl5 where 1 != 1",
-            "Query": "select tbl5.t5col5 from tbl5 for update",
-            "Table": "tbl5"
+            "Query": "select tbl5.t5col5 from tbl5 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -449,8 +430,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in (('foo'))",
-            "Table": "tbl4"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set t4col4 = null where (t4col4) in ::fkc_vals and (t4col4) not in (('foo'))"
           },
           {
             "InputName": "Parent",
@@ -461,8 +441,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl5 set t5col5 = 'foo'",
-            "Table": "tbl5"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl5 set t5col5 = 'foo'"
           }
         ]
       },
@@ -491,8 +470,7 @@
           "Sharded": true
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl2 set col = 'foo'",
-        "Table": "tbl2"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl2 set col = 'foo'"
       },
       "TablesUsed": [
         "sharded_fk_allow.tbl2"
@@ -527,7 +505,6 @@
                         "OperatorType": "Join",
                         "Variant": "LeftJoin",
                         "JoinColumnIndexes": "R:0",
-                        "TableName": "tbl10_tbl3",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -537,8 +514,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select 1 from tbl10 where 1 != 1",
-                            "Query": "select 1 from tbl10 where not (tbl10.col) <=> ('foo') for share",
-                            "Table": "tbl10"
+                            "Query": "select 1 from tbl10 where not (tbl10.col) <=> ('foo') for share"
                           },
                           {
                             "OperatorType": "Route",
@@ -548,8 +524,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl3.col from tbl3 where 1 != 1",
-                            "Query": "select tbl3.col from tbl3 where tbl3.col = 'foo' for share",
-                            "Table": "tbl3"
+                            "Query": "select tbl3.col from tbl3 where tbl3.col = 'foo' for share"
                           }
                         ]
                       }
@@ -568,8 +543,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl10 set col = 'foo'",
-            "Table": "tbl10"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl10 set col = 'foo'"
           }
         ]
       },
@@ -603,7 +577,6 @@
             },
             "FieldQuery": "select tbl9.col9 from tbl9 where 1 != 1",
             "Query": "select tbl9.col9 from tbl9 where col9 = 34 for update",
-            "Table": "tbl9",
             "Values": [
               "34"
             ],
@@ -622,8 +595,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set col_ref = null where (col_ref) in ::fkc_vals",
-            "Table": "tbl4"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ tbl4 set col_ref = null where (col_ref) in ::fkc_vals"
           },
           {
             "InputName": "Parent",
@@ -635,7 +607,6 @@
             },
             "TargetTabletType": "PRIMARY",
             "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from tbl9 where col9 = 34",
-            "Table": "tbl9",
             "Values": [
               "34"
             ],
@@ -667,8 +638,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.col1 from u_tbl1 for update",
-            "Table": "u_tbl1"
+            "Query": "select u_tbl1.col1 from u_tbl1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -687,8 +657,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -703,8 +672,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))",
-                "Table": "u_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast('foo' as CHAR)))"
               },
               {
                 "InputName": "Parent",
@@ -715,8 +683,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 'foo' where (col2) in ::fkc_vals"
               }
             ]
           },
@@ -737,8 +704,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait",
-                "Table": "u_tbl9"
+                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR))) for update nowait"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -753,8 +719,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                "Table": "u_tbl8"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
               },
               {
                 "InputName": "Parent",
@@ -765,8 +730,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))",
-                "Table": "u_tbl9"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast('foo' as CHAR)))"
               }
             ]
           },
@@ -779,8 +743,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl1 set col1 = 'foo'",
-            "Table": "u_tbl1"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl1 set col1 = 'foo'"
           }
         ]
       },
@@ -814,8 +777,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
-            "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 limit 2 for update",
-            "Table": "u_tbl2"
+            "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 limit 2 for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -829,8 +791,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -845,8 +806,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))",
-                "Table": "u_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast('bar' as CHAR)))"
               },
               {
                 "InputName": "Parent",
@@ -857,8 +817,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set col2 = 'bar' where u_tbl2.id in ::dml_vals",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set col2 = 'bar' where u_tbl2.id in ::dml_vals"
               }
             ]
           }
@@ -888,8 +847,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where 1 != 1",
-            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where u_tbl1.col1 is null and cast(u_tbl2.col1 + 'bar' as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.col1 + 'bar' as CHAR)) and u_tbl2.id = 1 limit 1 for share",
-            "Table": "u_tbl1, u_tbl2"
+            "Query": "select 1 from u_tbl2 left join u_tbl1 on u_tbl1.col1 = cast(u_tbl2.col1 + 'bar' as CHAR) where u_tbl1.col1 is null and cast(u_tbl2.col1 + 'bar' as CHAR) is not null and not (u_tbl2.col2) <=> (cast(u_tbl2.col1 + 'bar' as CHAR)) and u_tbl2.id = 1 limit 1 for share"
           },
           {
             "InputName": "PostVerify",
@@ -904,8 +862,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where id = 1 for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2, col2 <=> cast(col1 + 'bar' as CHAR), cast(col1 + 'bar' as CHAR) from u_tbl2 where id = 1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -927,8 +884,7 @@
                     "UpdateExprBvName": "fkc_upd"
                   }
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (:fkc_upd is null or (col3) not in ((:fkc_upd)))",
-                "Table": "u_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (:fkc_upd is null or (col3) not in ((:fkc_upd)))"
               },
               {
                 "InputName": "Parent",
@@ -939,8 +895,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set m = 2, col2 = col1 + 'bar' where id = 1",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set m = 2, col2 = col1 + 'bar' where id = 1"
               }
             ]
           }
@@ -971,8 +926,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where id = 1 for update",
-            "Table": "u_tbl1"
+            "Query": "select u_tbl1.col1, col1 <=> cast(x + 'bar' as CHAR), cast(x + 'bar' as CHAR) from u_tbl1 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -998,8 +952,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1014,8 +967,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:fkc_upd as CHAR) is null or (col3) not in ((cast(:fkc_upd as CHAR))))",
-                "Table": "u_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (cast(:fkc_upd as CHAR) is null or (col3) not in ((cast(:fkc_upd as CHAR))))"
               },
               {
                 "InputName": "Parent",
@@ -1026,8 +978,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = :fkc_upd where (col2) in ::fkc_vals",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = :fkc_upd where (col2) in ::fkc_vals"
               }
             ]
           },
@@ -1055,8 +1006,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1))) for update nowait",
-                "Table": "u_tbl9"
+                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1))) for update nowait"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1071,8 +1021,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                "Table": "u_tbl8"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
               },
               {
                 "InputName": "Parent",
@@ -1083,8 +1032,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1)))",
-                "Table": "u_tbl9"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (:fkc_upd1 is null or (col9) not in ((:fkc_upd1)))"
               }
             ]
           },
@@ -1097,8 +1045,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl1 set m = 2, col1 = x + 'bar' where id = 1",
-            "Table": "u_tbl1"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl1 set m = 2, col1 = x + 'bar' where id = 1"
           }
         ]
       },
@@ -1129,8 +1076,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update",
-            "Table": "u_tbl2"
+            "Query": "select u_tbl2.col2 from u_tbl2 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1145,8 +1091,7 @@
             "Cols": [
               0
             ],
-            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast(2 as CHAR)))",
-            "Table": "u_tbl3"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals and (col3) not in ((cast(2 as CHAR)))"
           },
           {
             "InputName": "Parent",
@@ -1157,8 +1102,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set m = col1 + 'bar', col2 = 2 where id = 1",
-            "Table": "u_tbl2"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2 set m = col1 + 'bar', col2 = 2 where id = 1"
           }
         ]
       },
@@ -1186,8 +1130,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-            "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update",
-            "Table": "u_tbl1"
+            "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1206,8 +1149,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1222,8 +1164,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(2 as CHAR)))",
-                "Table": "u_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(2 as CHAR)))"
               },
               {
                 "InputName": "Parent",
@@ -1234,8 +1175,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 2 where (col2) in ::fkc_vals",
-                "Table": "u_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 2 where (col2) in ::fkc_vals"
               }
             ]
           },
@@ -1256,8 +1196,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR))) for update nowait",
-                "Table": "u_tbl9"
+                "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR))) for update nowait"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1272,8 +1211,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                "Table": "u_tbl8"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
               },
               {
                 "InputName": "Parent",
@@ -1284,8 +1222,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR)))",
-                "Table": "u_tbl9"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(2 as CHAR)))"
               }
             ]
           },
@@ -1298,8 +1235,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl1 set m = x + 'bar', col1 = 2 where id = 1",
-            "Table": "u_tbl1"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl1 set m = x + 'bar', col1 = 2 where id = 1"
           }
         ]
       },
@@ -1338,8 +1274,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
-            "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 limit 2 for update",
-            "Table": "u_tbl2"
+            "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 limit 2 for update"
           },
           {
             "OperatorType": "FkCascade",
@@ -1353,8 +1288,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update",
-                "Table": "u_tbl2"
+                "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1369,8 +1303,7 @@
                 "Cols": [
                   0
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals",
-                "Table": "u_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals"
               },
               {
                 "InputName": "Parent",
@@ -1381,8 +1314,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from u_tbl2 where u_tbl2.id in ::dml_vals",
-                "Table": "u_tbl2"
+                "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from u_tbl2 where u_tbl2.id in ::dml_vals"
               }
             ]
           }
@@ -1425,7 +1357,6 @@
                         "JoinVars": {
                           "tbl3_colx": 0
                         },
-                        "TableName": "tbl3_tbl1",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -1435,8 +1366,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl3.colx from tbl3 where 1 != 1",
-                            "Query": "select tbl3.colx from tbl3 where tbl3.colx + 10 is not null and not (tbl3.coly) <=> (tbl3.colx + 10) and tbl3.coly = 10 for share",
-                            "Table": "tbl3"
+                            "Query": "select tbl3.colx from tbl3 where tbl3.colx + 10 is not null and not (tbl3.coly) <=> (tbl3.colx + 10) and tbl3.coly = 10 for share"
                           },
                           {
                             "OperatorType": "Route",
@@ -1446,8 +1376,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl1.t1col1 from tbl1 where 1 != 1",
-                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = :tbl3_colx + 10 for share",
-                            "Table": "tbl1"
+                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = :tbl3_colx + 10 for share"
                           }
                         ]
                       }
@@ -1466,8 +1395,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ tbl3 set coly = colx + 10 where coly = 10",
-            "Table": "tbl3"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ tbl3 set coly = colx + 10 where coly = 10"
           }
         ]
       },
@@ -1505,7 +1433,6 @@
                         "OperatorType": "Join",
                         "Variant": "LeftJoin",
                         "JoinColumnIndexes": "R:0",
-                        "TableName": "tbl3_tbl1",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -1515,8 +1442,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select 1 from tbl3 where 1 != 1",
-                            "Query": "select 1 from tbl3 where not (tbl3.coly) <=> (20) and tbl3.coly = 10 for share",
-                            "Table": "tbl3"
+                            "Query": "select 1 from tbl3 where not (tbl3.coly) <=> (20) and tbl3.coly = 10 for share"
                           },
                           {
                             "OperatorType": "Route",
@@ -1526,8 +1452,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select tbl1.t1col1 from tbl1 where 1 != 1",
-                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = 20 for share",
-                            "Table": "tbl1"
+                            "Query": "select tbl1.t1col1 from tbl1 where tbl1.t1col1 = 20 for share"
                           }
                         ]
                       }
@@ -1546,8 +1471,7 @@
               "Sharded": true
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl3 set coly = 20 where coly = 10",
-            "Table": "tbl3"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ tbl3 set coly = 20 where coly = 10"
           }
         ]
       },
@@ -1575,8 +1499,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl6.col6 from u_tbl6 where 1 != 1",
-            "Query": "select u_tbl6.col6 from u_tbl6 for update",
-            "Table": "u_tbl6"
+            "Query": "select u_tbl6.col6 from u_tbl6 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1595,8 +1518,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
-                "Table": "u_tbl8, u_tbl9"
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait"
               },
               {
                 "InputName": "PostVerify",
@@ -1607,8 +1529,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl8 set col8 = 'foo' where (col8) in ::fkc_vals",
-                "Table": "u_tbl8"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl8 set col8 = 'foo' where (col8) in ::fkc_vals"
               }
             ]
           },
@@ -1621,8 +1542,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl6 set col6 = 'foo'",
-            "Table": "u_tbl6"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl6 set col6 = 'foo'"
           }
         ]
       },
@@ -1651,8 +1571,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl7.col7 from u_tbl7 where 1 != 1",
-            "Query": "select u_tbl7.col7 from u_tbl7 for update",
-            "Table": "u_tbl7"
+            "Query": "select u_tbl7.col7 from u_tbl7 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1671,8 +1590,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and cast('foo' as CHAR) is not null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
-                "Table": "u_tbl3, u_tbl4"
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and cast('foo' as CHAR) is not null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share"
               },
               {
                 "InputName": "VerifyChild-2",
@@ -1683,8 +1601,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast('foo' as CHAR) is null or (u_tbl9.col9) not in ((cast('foo' as CHAR)))) limit 1 for share",
-                "Table": "u_tbl4, u_tbl9"
+                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast('foo' as CHAR) is null or (u_tbl9.col9) not in ((cast('foo' as CHAR)))) limit 1 for share"
               },
               {
                 "InputName": "PostVerify",
@@ -1695,8 +1612,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = 'foo' where (col4) in ::fkc_vals",
-                "Table": "u_tbl4"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = 'foo' where (col4) in ::fkc_vals"
               }
             ]
           },
@@ -1709,8 +1625,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl7 set col7 = 'foo'",
-            "Table": "u_tbl7"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl7 set col7 = 'foo'"
           }
         ]
       },
@@ -1740,8 +1655,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_tbl7.col7 from u_tbl7 where 1 != 1",
-            "Query": "select u_tbl7.col7 from u_tbl7 for update",
-            "Table": "u_tbl7"
+            "Query": "select u_tbl7.col7 from u_tbl7 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -1760,8 +1674,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where u_tbl3.col3 is null and cast(:v1 as CHAR) is not null and not (u_tbl4.col4) <=> (cast(:v1 as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
-                "Table": "u_tbl3, u_tbl4"
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast(:v1 as CHAR) where u_tbl3.col3 is null and cast(:v1 as CHAR) is not null and not (u_tbl4.col4) <=> (cast(:v1 as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share"
               },
               {
                 "InputName": "VerifyChild-2",
@@ -1772,8 +1685,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast(:v1 as CHAR) is null or (u_tbl9.col9) not in ((cast(:v1 as CHAR)))) limit 1 for share",
-                "Table": "u_tbl4, u_tbl9"
+                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast(:v1 as CHAR) is null or (u_tbl9.col9) not in ((cast(:v1 as CHAR)))) limit 1 for share"
               },
               {
                 "InputName": "PostVerify",
@@ -1784,8 +1696,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = :v1 where (col4) in ::fkc_vals",
-                "Table": "u_tbl4"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl4 set col4 = :v1 where (col4) in ::fkc_vals"
               }
             ]
           },
@@ -1798,8 +1709,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl7 set col7 = :v1",
-            "Table": "u_tbl7"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl7 set col7 = :v1"
           }
         ]
       },
@@ -1831,8 +1741,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into u_tbl1(id, col1) values (1, 3)",
-            "TableName": "u_tbl1"
+            "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into u_tbl1(id, col1) values (1, 3)"
           },
           {
             "InputName": "Update-1",
@@ -1847,8 +1756,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 where id = 1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -1867,8 +1775,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -1883,8 +1790,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(5 as CHAR)))",
-                    "Table": "u_tbl3"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1 and (col3) not in ((cast(5 as CHAR)))"
                   },
                   {
                     "InputName": "Parent",
@@ -1895,8 +1801,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 5 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_tbl2 set col2 = 5 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -1917,8 +1822,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl9.col9 from u_tbl9 where 1 != 1",
-                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR))) for update nowait",
-                    "Table": "u_tbl9"
+                    "Query": "select u_tbl9.col9 from u_tbl9 where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR))) for update nowait"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -1933,8 +1837,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3",
-                    "Table": "u_tbl8"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl8 set col8 = null where (col8) in ::fkc_vals3"
                   },
                   {
                     "InputName": "Parent",
@@ -1945,8 +1848,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR)))",
-                    "Table": "u_tbl9"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl9 set col9 = null where (col9) in ::fkc_vals2 and (col9) not in ((cast(5 as CHAR)))"
                   }
                 ]
               },
@@ -1959,8 +1861,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl1 set col1 = 5 where id = 1",
-                "Table": "u_tbl1"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_tbl1 set col1 = 5 where id = 1"
               }
             ]
           }
@@ -1989,8 +1890,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into u_tbl1(id, col1, foo) values (1, 3, 'bar') on duplicate key update foo = 'baz'",
-        "TableName": "u_tbl1"
+        "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into u_tbl1(id, col1, foo) values (1, 3, 'bar') on duplicate key update foo = 'baz'"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_tbl1"
@@ -2023,8 +1923,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_tbl1.col1 from u_tbl1 where 1 != 1",
-                "Query": "select u_tbl1.col1 from u_tbl1 where (id) in ((1)) for update",
-                "Table": "u_tbl1"
+                "Query": "select u_tbl1.col1 from u_tbl1 where (id) in ((1)) for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2043,8 +1942,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
-                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update",
-                    "Table": "u_tbl2"
+                    "Query": "select u_tbl2.col2 from u_tbl2 where (col2) in ::fkc_vals for update"
                   },
                   {
                     "InputName": "CascadeChild-1",
@@ -2059,8 +1957,7 @@
                     "Cols": [
                       0
                     ],
-                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1",
-                    "Table": "u_tbl3"
+                    "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_tbl3 set col3 = null where (col3) in ::fkc_vals1"
                   },
                   {
                     "InputName": "Parent",
@@ -2071,8 +1968,7 @@
                       "Sharded": false
                     },
                     "TargetTabletType": "PRIMARY",
-                    "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from u_tbl2 where (col2) in ::fkc_vals",
-                    "Table": "u_tbl2"
+                    "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from u_tbl2 where (col2) in ::fkc_vals"
                   }
                 ]
               },
@@ -2085,8 +1981,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from u_tbl1 where (id) in ((1))",
-                "Table": "u_tbl1"
+                "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from u_tbl1 where (id) in ((1))"
               }
             ]
           },
@@ -2099,8 +1994,7 @@
             },
             "TargetTabletType": "PRIMARY",
             "NoAutoCommit": true,
-            "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into u_tbl1(id, col1) values (1, 2)",
-            "TableName": "u_tbl1"
+            "Query": "insert /*+ SET_VAR(foreign_key_checks=On) */ into u_tbl1(id, col1) values (1, 2)"
           }
         ]
       },
@@ -2129,8 +2023,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where 1 != 1",
-            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = 3 for update",
-            "Table": "u_multicol_tbl1"
+            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = 3 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -2150,8 +2043,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where 1 != 1",
-                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2)) for update",
-                "Table": "u_multicol_tbl2"
+                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2)) for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2167,8 +2059,7 @@
                   0,
                   1
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1",
-                "Table": "u_multicol_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1"
               },
               {
                 "InputName": "Parent",
@@ -2179,8 +2070,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2))",
-                "Table": "u_multicol_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (cola, colb) not in ((1, 2))"
               }
             ]
           },
@@ -2193,8 +2083,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3",
-            "Table": "u_multicol_tbl1"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3"
           }
         ]
       },
@@ -2223,8 +2112,7 @@
               "Sharded": false
             },
             "FieldQuery": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where 1 != 1",
-            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = :v3 for update",
-            "Table": "u_multicol_tbl1"
+            "Query": "select u_multicol_tbl1.cola, u_multicol_tbl1.colb from u_multicol_tbl1 where id = :v3 for update"
           },
           {
             "InputName": "CascadeChild-1",
@@ -2244,8 +2132,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where 1 != 1",
-                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2)))) for update",
-                "Table": "u_multicol_tbl2"
+                "Query": "select u_multicol_tbl2.cola, u_multicol_tbl2.colb from u_multicol_tbl2 where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2)))) for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2261,8 +2148,7 @@
                   0,
                   1
                 ],
-                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1",
-                "Table": "u_multicol_tbl3"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=OFF) */ u_multicol_tbl3 set cola = null, colb = null where (cola, colb) in ::fkc_vals1"
               },
               {
                 "InputName": "Parent",
@@ -2273,8 +2159,7 @@
                   "Sharded": false
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2))))",
-                "Table": "u_multicol_tbl2"
+                "Query": "update /*+ SET_VAR(foreign_key_checks=ON) */ u_multicol_tbl2 set cola = null, colb = null where (cola, colb) in ::fkc_vals and (:v2 is null or (:v1 is null or (cola, colb) not in ((:v1, :v2))))"
               }
             ]
           },
@@ -2287,8 +2172,7 @@
               "Sharded": false
             },
             "TargetTabletType": "PRIMARY",
-            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_multicol_tbl1 set cola = :v1, colb = :v2 where id = :v3",
-            "Table": "u_multicol_tbl1"
+            "Query": "update /*+ SET_VAR(foreign_key_checks=On) */ u_multicol_tbl1 set cola = :v1, colb = :v2 where id = :v3"
           }
         ]
       },
@@ -2323,8 +2207,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select tbl5.col5, tbl5.t5col5 from tbl5 where 1 != 1",
-                "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 where id = :v1 for update",
-                "Table": "tbl5"
+                "Query": "select tbl5.col5, tbl5.t5col5 from tbl5 where id = :v1 for update"
               },
               {
                 "InputName": "CascadeChild-1",
@@ -2340,7 +2223,6 @@
                   0
                 ],
                 "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from tbl4 where (col4) in ::fkc_vals",
-                "Table": "tbl4",
                 "Values": [
                   "fkc_vals:0"
                 ],
@@ -2359,8 +2241,7 @@
                 "Cols": [
                   1
                 ],
-                "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from tbl4 where (t4col4) in ::fkc_vals1",
-                "Table": "tbl4"
+                "Query": "delete /*+ SET_VAR(foreign_key_checks=ON) */ from tbl4 where (t4col4) in ::fkc_vals1"
               },
               {
                 "InputName": "Parent",
@@ -2371,8 +2252,7 @@
                   "Sharded": true
                 },
                 "TargetTabletType": "PRIMARY",
-                "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from tbl5 where id = :v1",
-                "Table": "tbl5"
+                "Query": "delete /*+ SET_VAR(foreign_key_checks=On) */ from tbl5 where id = :v1"
               }
             ]
           }
@@ -2399,7 +2279,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete /*+ SET_VAR(foreign_key_checks=Off) */ from multicol_tbl1 where cola = 1 and colb = 2 and colc = 3",
-        "Table": "multicol_tbl1",
         "Values": [
           "1",
           "2",
@@ -2426,8 +2305,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3",
-        "Table": "u_multicol_tbl1"
+        "Query": "update /*+ SET_VAR(foreign_key_checks=Off) */ u_multicol_tbl1 set cola = 1, colb = 2 where id = 3"
       },
       "TablesUsed": [
         "unsharded_fk_allow.u_multicol_tbl1"
@@ -2449,7 +2327,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert /*+ SET_VAR(foreign_key_checks=Off) */ into tbl3(col3, coly) values (:_col3_0, 3)",
-        "TableName": "tbl3",
         "VindexValues": {
           "hash_vin": "1"
         }

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -13,8 +13,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
-        "Table": "`user`"
+        "Query": "select col from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -35,8 +34,7 @@
           "Sharded": false
         },
         "FieldQuery": "select col from unsharded where 1 != 1",
-        "Query": "select col from unsharded",
-        "Table": "unsharded"
+        "Query": "select col from unsharded"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -57,8 +55,7 @@
           "Sharded": false
         },
         "FieldQuery": "select next 2 values from seq where 1 != 1",
-        "Query": "select next 2 values from seq",
-        "Table": "seq"
+        "Query": "select next 2 values from seq"
       },
       "TablesUsed": [
         "main.seq"
@@ -104,8 +101,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from ref where 1 != 1",
-        "Query": "select * from ref",
-        "Table": "ref"
+        "Query": "select * from ref"
       },
       "TablesUsed": [
         "user.ref"
@@ -126,8 +122,7 @@
           "Sharded": false
         },
         "FieldQuery": "select m1.col from unsharded as m1 join unsharded as m2 where 1 != 1",
-        "Query": "select m1.col from unsharded as m1 join unsharded as m2",
-        "Table": "unsharded"
+        "Query": "select m1.col from unsharded as m1 join unsharded as m2"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -144,7 +139,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -154,8 +148,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
-            "Query": "select 1 from `user`",
-            "Table": "`user`"
+            "Query": "select 1 from `user`"
           },
           {
             "OperatorType": "Route",
@@ -165,8 +158,7 @@
               "Sharded": true
             },
             "FieldQuery": "select music.col from music where 1 != 1",
-            "Query": "select music.col from music",
-            "Table": "music"
+            "Query": "select music.col from music"
           }
         ]
       },
@@ -190,8 +182,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from `user` where 1 != 1",
-        "Query": "select * from `user`",
-        "Table": "`user`"
+        "Query": "select * from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -212,8 +203,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from `user` as a where 1 != 1",
-        "Query": "select * from `user` as a",
-        "Table": "`user`"
+        "Query": "select * from `user` as a"
       },
       "TablesUsed": [
         "user.user"
@@ -234,8 +224,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from `user` as route1 where 1 != 1",
-        "Query": "select * from `user` as route1",
-        "Table": "`user`"
+        "Query": "select * from `user` as route1"
       },
       "TablesUsed": [
         "user.user"
@@ -256,8 +245,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from `user` as a where 1 != 1",
-        "Query": "select * from `user` as a",
-        "Table": "`user`"
+        "Query": "select * from `user` as a"
       },
       "TablesUsed": [
         "user.user"
@@ -278,8 +266,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from `user` as primary_redirect where 1 != 1",
-        "Query": "select * from `user` as primary_redirect",
-        "Table": "`user`"
+        "Query": "select * from `user` as primary_redirect"
       },
       "TablesUsed": [
         "user.user"
@@ -310,8 +297,7 @@
           "Sharded": true
         },
         "FieldQuery": "select foo.col from `user` as foo, `user` where 1 != 1",
-        "Query": "select foo.col from `user` as foo, `user` where foo.col = 42 and foo.id = `user`.id",
-        "Table": "`user`"
+        "Query": "select foo.col from `user` as foo, `user` where foo.col = 42 and foo.id = `user`.id"
       },
       "TablesUsed": [
         "user.user"
@@ -331,7 +317,6 @@
         "JoinVars": {
           "music_id": 1
         },
-        "TableName": "music_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -341,8 +326,7 @@
               "Sharded": true
             },
             "FieldQuery": "select music.foo, music.id from music where 1 != 1",
-            "Query": "select music.foo, music.id from music where music.col = 42",
-            "Table": "music"
+            "Query": "select music.foo, music.id from music where music.col = 42"
           },
           {
             "OperatorType": "Route",
@@ -353,7 +337,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where `user`.id = :music_id",
-            "Table": "`user`",
             "Values": [
               ":music_id"
             ],
@@ -377,7 +360,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -387,8 +369,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
-            "Query": "select 1 from `user`",
-            "Table": "`user`"
+            "Query": "select 1 from `user`"
           },
           {
             "OperatorType": "Route",
@@ -398,8 +379,7 @@
               "Sharded": true
             },
             "FieldQuery": "select music.col from music where 1 != 1",
-            "Query": "select music.col from music",
-            "Table": "music"
+            "Query": "select music.col from music"
           }
         ]
       },
@@ -423,8 +403,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `name` from (select `name` from `user` where 1 != 1) as t where 1 != 1",
-        "Query": "select `name` from (select distinct `name` from `user`) as t",
-        "Table": "`user`"
+        "Query": "select `name` from (select distinct `name` from `user`) as t"
       },
       "TablesUsed": [
         "user.user"
@@ -445,8 +424,7 @@
           "Sharded": false
         },
         "FieldQuery": "select u1.a, u2.a from unsharded as u1, unsharded as u2 where 1 != 1",
-        "Query": "select u1.a, u2.a from unsharded as u1, unsharded as u2",
-        "Table": "unsharded"
+        "Query": "select u1.a, u2.a from unsharded as u1, unsharded as u2"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -467,8 +445,7 @@
           "Sharded": false
         },
         "FieldQuery": "select u1.a, u2.a from unsharded as u1, unsharded as u2, unsharded as u3 where 1 != 1",
-        "Query": "select u1.a, u2.a from unsharded as u1, unsharded as u2, unsharded as u3",
-        "Table": "unsharded"
+        "Query": "select u1.a, u2.a from unsharded as u1, unsharded as u2, unsharded as u3"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -489,8 +466,7 @@
           "Sharded": false
         },
         "FieldQuery": "select m1.col from unsharded as m1 left join unsharded as m2 on m1.a = m2.b where 1 != 1",
-        "Query": "select m1.col from unsharded as m1 left join unsharded as m2 on m1.a = m2.b",
-        "Table": "unsharded"
+        "Query": "select m1.col from unsharded as m1 left join unsharded as m2 on m1.a = m2.b"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -510,7 +486,6 @@
         "JoinVars": {
           "u_a": 1
         },
-        "TableName": "`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -520,8 +495,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.col, u.a from `user` as u where 1 != 1",
-            "Query": "select u.col, u.a from `user` as u",
-            "Table": "`user`"
+            "Query": "select u.col, u.a from `user` as u"
           },
           {
             "OperatorType": "Route",
@@ -531,8 +505,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded as m where 1 != 1",
-            "Query": "select 1 from unsharded as m where m.b = :u_a",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded as m where m.b = :u_a"
           }
         ]
       },
@@ -555,7 +528,6 @@
         "JoinVars": {
           "m1_col": 1
         },
-        "TableName": "`user`_unsharded_unsharded",
         "Inputs": [
           {
             "OperatorType": "Join",
@@ -564,7 +536,6 @@
             "JoinVars": {
               "user_col": 0
             },
-            "TableName": "`user`_unsharded",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -574,8 +545,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -585,8 +555,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select m1.col from unsharded as m1 where 1 != 1",
-                "Query": "select m1.col from unsharded as m1 where m1.col = :user_col /* INT16 */",
-                "Table": "unsharded"
+                "Query": "select m1.col from unsharded as m1 where m1.col = :user_col /* INT16 */"
               }
             ]
           },
@@ -598,8 +567,7 @@
               "Sharded": false
             },
             "FieldQuery": "select m2.foo from unsharded as m2 where 1 != 1",
-            "Query": "select m2.foo from unsharded as m2 where m2.col = :m1_col",
-            "Table": "unsharded"
+            "Query": "select m2.foo from unsharded as m2 where m2.col = :m1_col"
           }
         ]
       },
@@ -622,7 +590,6 @@
         "JoinVars": {
           "user_col": 0
         },
-        "TableName": "`user`_user_extra_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -632,8 +599,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user`"
           },
           {
             "OperatorType": "Join",
@@ -641,7 +607,6 @@
             "JoinVars": {
               "e_col": 0
             },
-            "TableName": "user_extra_unsharded",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -651,8 +616,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select e.col from user_extra as e where 1 != 1",
-                "Query": "select e.col from user_extra as e where e.col = :user_col /* INT16 */",
-                "Table": "user_extra"
+                "Query": "select e.col from user_extra as e where e.col = :user_col /* INT16 */"
               },
               {
                 "OperatorType": "Route",
@@ -662,8 +626,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded as m1 where 1 != 1",
-                "Query": "select 1 from unsharded as m1 where m1.col = :e_col /* INT16 */",
-                "Table": "unsharded"
+                "Query": "select 1 from unsharded as m1 where m1.col = :e_col /* INT16 */"
               }
             ]
           }
@@ -690,8 +653,7 @@
           "Sharded": false
         },
         "FieldQuery": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a = m2.b where 1 != 1",
-        "Query": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a = m2.b",
-        "Table": "unsharded"
+        "Query": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a = m2.b"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -712,8 +674,7 @@
           "Sharded": false
         },
         "FieldQuery": "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a = m2.b where 1 != 1",
-        "Query": "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a = m2.b",
-        "Table": "unsharded"
+        "Query": "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a = m2.b"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -734,8 +695,7 @@
           "Sharded": false
         },
         "FieldQuery": "select m1.col from unsharded as m1 straight_join unsharded as m2 where 1 != 1",
-        "Query": "select m1.col from unsharded as m1 straight_join unsharded as m2",
-        "Table": "unsharded"
+        "Query": "select m1.col from unsharded as m1 straight_join unsharded as m2"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -752,7 +712,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -762,8 +721,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -773,8 +731,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded as m1, unsharded as m2 where 1 != 1",
-            "Query": "select 1 from unsharded as m1, unsharded as m2",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded as m1, unsharded as m2"
           }
         ]
       },
@@ -803,7 +760,6 @@
               "user_bar": 1,
               "user_foo": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -813,8 +769,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.foo, `user`.bar from `user` where 1 != 1",
-                "Query": "select `user`.foo, `user`.bar from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.foo, `user`.bar from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -824,8 +779,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra where user_extra.bar = :user_bar and :user_foo = 42",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra where user_extra.bar = :user_bar and :user_foo = 42"
               }
             ]
           }
@@ -847,7 +801,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -857,8 +810,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -868,8 +820,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded as m1, unsharded as m2 where 1 != 1",
-            "Query": "select 1 from unsharded as m1, unsharded as m2",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded as m1, unsharded as m2"
           }
         ]
       },
@@ -889,7 +840,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "`user`_`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -899,14 +849,12 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` as u1 where 1 != 1",
-            "Query": "select 1 from `user` as u1",
-            "Table": "`user`"
+            "Query": "select 1 from `user` as u1"
           },
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
-            "TableName": "`user`_unsharded",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -916,8 +864,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -927,8 +874,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded where 1 != 1",
-                "Query": "select 1 from unsharded",
-                "Table": "unsharded"
+                "Query": "select 1 from unsharded"
               }
             ]
           }
@@ -954,8 +900,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user` use index (a) where 1 != 1",
-        "Query": "select `user`.col from `user` use index (a)",
-        "Table": "`user`"
+        "Query": "select `user`.col from `user` use index (a)"
       },
       "TablesUsed": [
         "user.user"
@@ -976,8 +921,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user` use index (a) use index for group by (b) where 1 != 1",
-        "Query": "select `user`.col from `user` use index (a) use index for group by (b)",
-        "Table": "`user`"
+        "Query": "select `user`.col from `user` use index (a) use index for group by (b)"
       },
       "TablesUsed": [
         "user.user"
@@ -998,8 +942,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, user_extra where 1 != 1",
-        "Query": "select `user`.col from `user`, user_extra where `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.col from `user`, user_extra where `user`.id = user_extra.user_id"
       },
       "TablesUsed": [
         "user.user",
@@ -1021,8 +964,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, user_extra where 1 != 1",
-        "Query": "select `user`.col from `user`, user_extra where `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.col from `user`, user_extra where `user`.id = user_extra.user_id"
       },
       "TablesUsed": [
         "user.user",
@@ -1044,8 +986,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, user_extra where 1 != 1",
-        "Query": "select `user`.col from `user`, user_extra where `user`.col between 1 and 2 and `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.col from `user`, user_extra where `user`.col between 1 and 2 and `user`.id = user_extra.user_id"
       },
       "TablesUsed": [
         "user.user",
@@ -1067,8 +1008,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, user_extra where 1 != 1",
-        "Query": "select `user`.col from `user`, user_extra where user_extra.user_id = `user`.id",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.col from `user`, user_extra where user_extra.user_id = `user`.id"
       },
       "TablesUsed": [
         "user.user",
@@ -1091,7 +1031,6 @@
         },
         "FieldQuery": "select `user`.col from `user`, user_extra where 1 != 1",
         "Query": "select `user`.col from `user`, user_extra where `user`.id = 5 and `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1116,7 +1055,6 @@
         "JoinVars": {
           "user_id": 1
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1126,8 +1064,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col, `user`.id from `user` where 1 != 1",
-            "Query": "select `user`.col, `user`.id from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col, `user`.id from `user`"
           },
           {
             "OperatorType": "Route",
@@ -1137,8 +1074,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra where :user_id < user_extra.user_id",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra where :user_id < user_extra.user_id"
           }
         ]
       },
@@ -1158,7 +1094,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1169,7 +1104,6 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select `user`.col from `user` where `user`.id = 5",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -1183,8 +1117,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -1204,7 +1137,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1215,7 +1147,6 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select `user`.col from `user` where `user`.id = 5",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -1229,8 +1160,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -1253,7 +1183,6 @@
         "JoinVars": {
           "user_extra_col": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1263,8 +1192,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.col from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.col from user_extra"
           },
           {
             "OperatorType": "Route",
@@ -1275,7 +1203,6 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select `user`.col from `user` where `user`.id = :user_extra_col /* INT16 */",
-            "Table": "`user`",
             "Values": [
               ":user_extra_col"
             ],
@@ -1302,7 +1229,6 @@
         "JoinVars": {
           "user_name": 1
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1312,8 +1238,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col, `user`.`name` from `user` where 1 != 1",
-            "Query": "select `user`.col, `user`.`name` from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col, `user`.`name` from `user`"
           },
           {
             "OperatorType": "Route",
@@ -1324,7 +1249,6 @@
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
             "Query": "select 1 from user_extra where user_extra.user_id = :user_name",
-            "Table": "user_extra",
             "Values": [
               ":user_name"
             ],
@@ -1352,8 +1276,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, ref where 1 != 1",
-        "Query": "select `user`.col from `user`, ref",
-        "Table": "`user`, ref"
+        "Query": "select `user`.col from `user`, ref"
       },
       "TablesUsed": [
         "user.ref",
@@ -1375,8 +1298,7 @@
           "Sharded": true
         },
         "FieldQuery": "select r1.col from ref as r1, ref where 1 != 1",
-        "Query": "select r1.col from ref as r1, ref",
-        "Table": "ref"
+        "Query": "select r1.col from ref as r1, ref"
       },
       "TablesUsed": [
         "user.ref"
@@ -1397,8 +1319,7 @@
           "Sharded": true
         },
         "FieldQuery": "select ref.col from ref, `user` where 1 != 1",
-        "Query": "select ref.col from ref, `user`",
-        "Table": "`user`, ref"
+        "Query": "select ref.col from ref, `user`"
       },
       "TablesUsed": [
         "user.ref",
@@ -1421,7 +1342,6 @@
         },
         "FieldQuery": "select ref.col from (select aa from `user` where 1 != 1) as `user`, ref where 1 != 1",
         "Query": "select ref.col from (select aa from `user` where `user`.id = 1) as `user`, ref",
-        "Table": "`user`, ref",
         "Values": [
           "1"
         ],
@@ -1443,7 +1363,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "unsharded_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1453,8 +1372,7 @@
               "Sharded": false
             },
             "FieldQuery": "select route2.col from unsharded as route2 where 1 != 1",
-            "Query": "select route2.col from unsharded as route2",
-            "Table": "unsharded"
+            "Query": "select route2.col from unsharded as route2"
           },
           {
             "OperatorType": "Route",
@@ -1464,8 +1382,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -1490,7 +1407,6 @@
         },
         "FieldQuery": "select id from (select id, col from `user` where 1 != 1) as t where 1 != 1",
         "Query": "select id from (select id, col from `user` where id = 5) as t",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1516,7 +1432,6 @@
         },
         "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t, user_extra where 1 != 1",
         "Query": "select t.id from (select id from `user` where id = 5) as t, user_extra where t.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1543,7 +1458,6 @@
         },
         "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t, user_extra where 1 != 1",
         "Query": "select t.id from (select `user`.id from `user` where `user`.id = 5) as t, user_extra where t.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1575,7 +1489,6 @@
         },
         "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t, user_extra where 1 != 1",
         "Query": "select t.id from (select id from `user` where id = 5) as t, user_extra where t.id = user_extra.user_id",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1600,7 +1513,6 @@
         "JoinVars": {
           "t_id": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1611,7 +1523,6 @@
             },
             "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t where 1 != 1",
             "Query": "select t.id from (select id from `user` where id = 5) as t",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -1625,8 +1536,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra where user_extra.col = :t_id",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra where user_extra.col = :t_id"
           }
         ]
       },
@@ -1651,7 +1561,6 @@
         },
         "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
         "Query": "select id from (select id, col from `user` as route1 where id = 5) as t",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1682,7 +1591,6 @@
         },
         "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
         "Query": "select id from (select id, col from `user` as route1 where id = 5) as t",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1712,8 +1620,7 @@
           "Sharded": true
         },
         "FieldQuery": "select t.id from (select id, textcol1 as baz from `user` as route1 where 1 != 1) as t, (select id, textcol1 + textcol1 as baz from `user` where 1 != 1) as s where 1 != 1",
-        "Query": "select t.id from (select id, textcol1 as baz from `user` as route1 where textcol1 = '3') as t, (select id, textcol1 + textcol1 as baz from `user` where textcol1 + textcol1 = '3') as s where t.id = s.id",
-        "Table": "`user`"
+        "Query": "select t.id from (select id, textcol1 as baz from `user` as route1 where textcol1 = '3') as t, (select id, textcol1 + textcol1 as baz from `user` where textcol1 + textcol1 = '3') as s where t.id = s.id"
       },
       "TablesUsed": [
         "user.user"
@@ -1734,8 +1641,7 @@
           "Sharded": true
         },
         "FieldQuery": "select bar from (select foo + 4 as bar from (select colA + colB as foo from `user` where 1 != 1) as u where 1 != 1) as t where 1 != 1",
-        "Query": "select bar from (select foo + 4 as bar from (select colA + colB as foo from `user` where colA + colB + 4 = 5) as u) as t",
-        "Table": "`user`"
+        "Query": "select bar from (select foo + 4 as bar from (select colA + colB as foo from `user` where colA + colB + 4 = 5) as u) as t"
       },
       "TablesUsed": [
         "user.user"
@@ -1757,7 +1663,6 @@
         },
         "FieldQuery": "select id from (select id from (select id from `user` where 1 != 1) as u where 1 != 1) as t where 1 != 1",
         "Query": "select id from (select id from (select id from `user` where id = 5) as u) as t",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1783,7 +1688,6 @@
         },
         "FieldQuery": "select u.col, e.col from (select col from `user` where 1 != 1) as u, (select col from user_extra where 1 != 1) as e where 1 != 1",
         "Query": "select u.col, e.col from (select col from `user` where id = 5) as u, (select col from user_extra where user_id = 5) as e",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1805,7 +1709,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1815,8 +1718,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt1.id from (select id from `user` where 1 != 1) as dt1 where 1 != 1",
-            "Query": "select dt1.id from (select id from `user`) as dt1",
-            "Table": "`user`"
+            "Query": "select dt1.id from (select id from `user`) as dt1"
           },
           {
             "OperatorType": "Route",
@@ -1826,8 +1728,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt2.id from (select id from `user` where 1 != 1) as dt2 where 1 != 1",
-            "Query": "select dt2.id from (select id from `user`) as dt2",
-            "Table": "`user`"
+            "Query": "select dt2.id from (select id from `user`) as dt2"
           }
         ]
       },
@@ -1846,7 +1747,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "information_schema.CHARACTER_SETS_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1856,8 +1756,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from information_schema.CHARACTER_SETS where 1 != 1",
-            "Query": "select 1 from information_schema.CHARACTER_SETS",
-            "Table": "information_schema.CHARACTER_SETS"
+            "Query": "select 1 from information_schema.CHARACTER_SETS"
           },
           {
             "OperatorType": "Route",
@@ -1867,8 +1766,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.foo from unsharded where 1 != 1",
-            "Query": "select unsharded.foo from unsharded",
-            "Table": "unsharded"
+            "Query": "select unsharded.foo from unsharded"
           }
         ]
       },
@@ -1891,8 +1789,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 42 from `user` as u, user_extra as ue, music as m where 1 != 1",
-        "Query": "select 42 from `user` as u, user_extra as ue, music as m where u.id = ue.user_id and m.user_id = u.id and (u.foo or m.foo or ue.foo)",
-        "Table": "`user`, music, user_extra"
+        "Query": "select 42 from `user` as u, user_extra as ue, music as m where u.id = ue.user_id and m.user_id = u.id and (u.foo or m.foo or ue.foo)"
       },
       "TablesUsed": [
         "user.music",
@@ -1911,7 +1808,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "unsharded_information_schema.CHARACTER_SETS",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1921,8 +1817,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.foo from unsharded where 1 != 1",
-            "Query": "select unsharded.foo from unsharded",
-            "Table": "unsharded"
+            "Query": "select unsharded.foo from unsharded"
           },
           {
             "OperatorType": "Route",
@@ -1932,8 +1827,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from information_schema.CHARACTER_SETS where 1 != 1",
-            "Query": "select 1 from information_schema.CHARACTER_SETS",
-            "Table": "information_schema.CHARACTER_SETS"
+            "Query": "select 1 from information_schema.CHARACTER_SETS"
           }
         ]
       },
@@ -1956,13 +1850,11 @@
           "t_col1": 0,
           "t_id": 1
         },
-        "TableName": "`user`_user_extra_unsharded",
         "Inputs": [
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:1,L:0",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1972,8 +1864,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
-                "Table": "`user`"
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t"
               },
               {
                 "OperatorType": "Route",
@@ -1983,8 +1874,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra"
               }
             ]
           },
@@ -1996,8 +1886,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded where 1 != 1",
-            "Query": "select 1 from unsharded where unsharded.id = :t_id and unsharded.col1 = :t_col1",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded where unsharded.id = :t_id and unsharded.col1 = :t_col1"
           }
         ]
       },
@@ -2021,7 +1910,6 @@
         "JoinVars": {
           "user_col": 2
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2031,8 +1919,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t",
-            "Table": "`user`"
+            "Query": "select t.id, t.col1, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t"
           },
           {
             "OperatorType": "Route",
@@ -2042,8 +1929,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra where user_extra.col = :user_col /* INT16 */",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra where user_extra.col = :user_col /* INT16 */"
           }
         ]
       },
@@ -2063,7 +1949,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "unsharded_a_`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2073,14 +1958,12 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded_a as ua where 1 != 1",
-            "Query": "select 1 from unsharded_a as ua",
-            "Table": "unsharded_a"
+            "Query": "select 1 from unsharded_a as ua"
           },
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2090,8 +1973,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
-                "Table": "`user`"
+                "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user`) as t"
               },
               {
                 "OperatorType": "Route",
@@ -2101,8 +1983,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra"
               }
             ]
           }
@@ -2128,7 +2009,6 @@
         "JoinVars": {
           "ua_id": 0
         },
-        "TableName": "unsharded_a_`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2138,14 +2018,12 @@
               "Sharded": false
             },
             "FieldQuery": "select ua.id from unsharded_a as ua where 1 != 1",
-            "Query": "select ua.id from unsharded_a as ua",
-            "Table": "unsharded_a"
+            "Query": "select ua.id from unsharded_a as ua"
           },
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2156,7 +2034,6 @@
                 },
                 "FieldQuery": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
                 "Query": "select t.id, t.col1 from (select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id) as t",
-                "Table": "`user`",
                 "Values": [
                   ":ua_id"
                 ],
@@ -2170,8 +2047,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra"
               }
             ]
           }
@@ -2206,8 +2082,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -2218,8 +2093,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded_a.col from unsharded_a, unsharded_b where 1 != 1",
-            "Query": "select unsharded_a.col from unsharded_a, unsharded_b where :__sq1",
-            "Table": "unsharded_a, unsharded_b"
+            "Query": "select unsharded_a.col from unsharded_a, unsharded_b where :__sq1"
           }
         ]
       },
@@ -2252,8 +2126,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -2264,8 +2137,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded_a.col from unsharded_a, unsharded_b where 1 != 1",
-            "Query": "select unsharded_a.col from unsharded_a, unsharded_b where unsharded_a.col + :__sq1",
-            "Table": "unsharded_a, unsharded_b"
+            "Query": "select unsharded_a.col from unsharded_a, unsharded_b where unsharded_a.col + :__sq1"
           }
         ]
       },
@@ -2299,8 +2171,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -2311,8 +2182,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded_a.col from unsharded_a, unsharded_b where 1 != 1",
-            "Query": "select unsharded_a.col from unsharded_a, unsharded_b where :__sq_has_values and unsharded_a.col in ::__sq1",
-            "Table": "unsharded_a, unsharded_b"
+            "Query": "select unsharded_a.col from unsharded_a, unsharded_b where :__sq_has_values and unsharded_a.col in ::__sq1"
           }
         ]
       },
@@ -2346,8 +2216,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -2359,7 +2228,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0",
-                "TableName": "unsharded_`user`",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2369,8 +2237,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select unsharded.col from unsharded where 1 != 1",
-                    "Query": "select unsharded.col from unsharded",
-                    "Table": "unsharded"
+                    "Query": "select unsharded.col from unsharded"
                   },
                   {
                     "OperatorType": "Route",
@@ -2380,8 +2247,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                    "Query": "select `user`.col from `user`",
-                    "Table": "`user`"
+                    "Query": "select `user`.col from `user`"
                   }
                 ]
               }
@@ -2405,7 +2271,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "unsharded_`user`_unsharded_a",
         "Inputs": [
           {
             "OperatorType": "UncorrelatedSubquery",
@@ -2424,8 +2289,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select col from `user` where 1 != 1",
-                "Query": "select col from `user`",
-                "Table": "`user`"
+                "Query": "select col from `user`"
               },
               {
                 "InputName": "Outer",
@@ -2436,7 +2300,6 @@
                     "OperatorType": "Join",
                     "Variant": "Join",
                     "JoinColumnIndexes": "L:0,R:0",
-                    "TableName": "unsharded_`user`",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -2446,8 +2309,7 @@
                           "Sharded": false
                         },
                         "FieldQuery": "select unsharded.col from unsharded where 1 != 1",
-                        "Query": "select unsharded.col from unsharded",
-                        "Table": "unsharded"
+                        "Query": "select unsharded.col from unsharded"
                       },
                       {
                         "OperatorType": "Route",
@@ -2457,8 +2319,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                        "Query": "select `user`.col from `user`",
-                        "Table": "`user`"
+                        "Query": "select `user`.col from `user`"
                       }
                     ]
                   }
@@ -2474,8 +2335,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded_a where 1 != 1",
-            "Query": "select 1 from unsharded_a",
-            "Table": "unsharded_a"
+            "Query": "select 1 from unsharded_a"
           }
         ]
       },
@@ -2499,7 +2359,6 @@
         "JoinVars": {
           "user_col2": 1
         },
-        "TableName": "`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2509,8 +2368,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col1, `user`.col2 from `user` where 1 != 1",
-            "Query": "select `user`.col1, `user`.col2 from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col1, `user`.col2 from `user`"
           },
           {
             "OperatorType": "Route",
@@ -2520,8 +2378,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.col1 from unsharded where 1 != 1",
-            "Query": "select unsharded.col1 from unsharded where unsharded.col2 = :user_col2",
-            "Table": "unsharded"
+            "Query": "select unsharded.col1 from unsharded where unsharded.col2 = :user_col2"
           }
         ]
       },
@@ -2545,8 +2402,7 @@
           "Sharded": false
         },
         "FieldQuery": "select foo.col from foo where 1 != 1",
-        "Query": "select foo.col from foo",
-        "Table": "foo"
+        "Query": "select foo.col from foo"
       },
       "TablesUsed": [
         "main.foo"
@@ -2567,8 +2423,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, user_extra where 1 != 1",
-        "Query": "select `user`.col from `user`, user_extra where `user`.ID = user_extra.User_Id",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.col from `user`, user_extra where `user`.ID = user_extra.User_Id"
       },
       "TablesUsed": [
         "user.user",
@@ -2586,7 +2441,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2596,8 +2450,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id from (select `user`.id from `user`) as t",
-            "Table": "`user`"
+            "Query": "select t.id from (select `user`.id from `user`) as t"
           },
           {
             "OperatorType": "Route",
@@ -2607,8 +2460,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -2632,8 +2484,7 @@
           "Sharded": false
         },
         "FieldQuery": "select u1.a from unsharded as u1 join unsharded as u2 on database() where 1 != 1",
-        "Query": "select u1.a from unsharded as u1 join unsharded as u2 on database()",
-        "Table": "unsharded"
+        "Query": "select u1.a from unsharded as u1 join unsharded as u2 on database()"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2676,8 +2527,7 @@
           "Sharded": true
         },
         "FieldQuery": "select :__lastInsertId as `last_insert_id()` from `user` where 1 != 1",
-        "Query": "select :__lastInsertId as `last_insert_id()` from `user`",
-        "Table": "`user`"
+        "Query": "select :__lastInsertId as `last_insert_id()` from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -2698,8 +2548,7 @@
           "Sharded": false
         },
         "FieldQuery": "select :__lastInsertId as `last_insert_id()` from unsharded where 1 != 1",
-        "Query": "select :__lastInsertId as `last_insert_id()` from unsharded",
-        "Table": "unsharded"
+        "Query": "select :__lastInsertId as `last_insert_id()` from unsharded"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2719,7 +2568,6 @@
         "JoinVars": {
           "user_extra_assembly_id": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2730,7 +2578,6 @@
             },
             "FieldQuery": "select user_extra.assembly_id from user_extra where 1 != 1",
             "Query": "select user_extra.assembly_id from user_extra where user_extra.user_id = 2",
-            "Table": "user_extra",
             "Values": [
               "2"
             ],
@@ -2745,7 +2592,6 @@
             },
             "FieldQuery": "select `user`.id from `user` where 1 != 1",
             "Query": "select `user`.id from `user` where `user`.id = :user_extra_assembly_id",
-            "Table": "`user`",
             "Values": [
               ":user_extra_assembly_id"
             ],
@@ -2773,8 +2619,7 @@
           "Sharded": false
         },
         "FieldQuery": "select u1.a from unsharded as u1, unsharded as u2 join unsharded as u3 on u1.a = u2.a where 1 != 1",
-        "Query": "select u1.a from unsharded as u1, unsharded as u2 join unsharded as u3 on u1.a = u2.a",
-        "Table": "unsharded"
+        "Query": "select u1.a from unsharded as u1, unsharded as u2 join unsharded as u3 on u1.a = u2.a"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2800,8 +2645,7 @@
           "Sharded": false
         },
         "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-        "Query": "select unsharded.id from unsharded where Unsharded.val = 1",
-        "Table": "unsharded"
+        "Query": "select unsharded.id from unsharded where Unsharded.val = 1"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2852,8 +2696,7 @@
           "Sharded": false
         },
         "FieldQuery": "select m1.col from (unsharded as m1, unsharded as m2) where 1 != 1",
-        "Query": "select m1.col from (unsharded as m1, unsharded as m2)",
-        "Table": "unsharded"
+        "Query": "select m1.col from (unsharded as m1, unsharded as m2)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2873,7 +2716,6 @@
         "JoinVars": {
           "ue_id": 1
         },
-        "TableName": "music, user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2883,8 +2725,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1, ue.id from user_extra as ue, music as m where 1 != 1",
-            "Query": "select 1, ue.id from user_extra as ue, music as m where m.user_id = ue.user_id",
-            "Table": "music, user_extra"
+            "Query": "select 1, ue.id from user_extra as ue, music as m where m.user_id = ue.user_id"
           },
           {
             "OperatorType": "Route",
@@ -2895,7 +2736,6 @@
             },
             "FieldQuery": "select 1 from `user` as u where 1 != 1",
             "Query": "select 1 from `user` as u where u.id = :ue_id",
-            "Table": "`user`",
             "Values": [
               ":ue_id"
             ],
@@ -2923,7 +2763,6 @@
         "JoinVars": {
           "ue_id": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2933,8 +2772,7 @@
               "Sharded": true
             },
             "FieldQuery": "select ue.id as ueid from user_extra as ue where 1 != 1",
-            "Query": "select ue.id as ueid from user_extra as ue",
-            "Table": "user_extra"
+            "Query": "select ue.id as ueid from user_extra as ue"
           },
           {
             "OperatorType": "Route",
@@ -2945,7 +2783,6 @@
             },
             "FieldQuery": "select u.id as uid from `user` as u where 1 != 1",
             "Query": "select u.id as uid from `user` as u where u.id = :ue_id",
-            "Table": "`user`",
             "Values": [
               ":ue_id"
             ],
@@ -2971,7 +2808,6 @@
         "ComparisonType": "-1",
         "JoinColumnIndexes": "-1",
         "Predicate": "u.id = ue.user_id",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Limit",
@@ -2985,8 +2821,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id from (select id from `user` where 1 != 1) as u where 1 != 1",
-                "Query": "select u.id from (select id from `user`) as u limit 10",
-                "Table": "`user`"
+                "Query": "select u.id from (select id from `user`) as u limit 10"
               }
             ]
           },
@@ -3002,8 +2837,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.user_id from (select user_id from user_extra where 1 != 1) as ue where 1 != 1",
-                "Query": "select ue.user_id from (select user_id from user_extra) as ue limit 10",
-                "Table": "user_extra"
+                "Query": "select ue.user_id from (select user_id from user_extra) as ue limit 10"
               }
             ]
           }
@@ -3040,8 +2874,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -3066,8 +2899,7 @@
           "Sharded": false
         },
         "FieldQuery": "select u.* from (select * from unsharded where 1 != 1) as u where 1 != 1",
-        "Query": "select u.* from (select * from unsharded) as u",
-        "Table": "unsharded"
+        "Query": "select u.* from (select * from unsharded) as u"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -3084,7 +2916,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3095,7 +2926,6 @@
             },
             "FieldQuery": "select t.id, t.col from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
             "Query": "select t.id, t.col from (select `user`.id, `user`.col from `user` where `user`.id = 5) as t",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -3109,8 +2939,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -3130,7 +2959,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3140,8 +2968,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id + 1 from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select id + 1 from (select `user`.id, `user`.col from `user`) as t",
-            "Table": "`user`"
+            "Query": "select id + 1 from (select `user`.id, `user`.col from `user`) as t"
           },
           {
             "OperatorType": "Route",
@@ -3151,8 +2978,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -3189,7 +3015,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -3203,8 +3028,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.a from (select id as b, `name` from `user` where 1 != 1) as u(a, n) where 1 != 1",
-            "Query": "select u.a from (select id as b, `name` from `user` where `name` = 1) as u(a, n)",
-            "Table": "`user`"
+            "Query": "select u.a from (select id as b, `name` from `user` where `name` = 1) as u(a, n)"
           }
         ]
       },
@@ -3240,7 +3064,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -3254,8 +3077,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.a from (select id as b, `name` from `user` where 1 != 1) as u(a, n) where 1 != 1",
-            "Query": "select u.a from (select id as b, `name` from `user` where b = 1 and `name` = 1) as u(a, n)",
-            "Table": "`user`"
+            "Query": "select u.a from (select id as b, `name` from `user` where b = 1 and `name` = 1) as u(a, n)"
           }
         ]
       },
@@ -3274,7 +3096,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3284,8 +3105,7 @@
               "Sharded": true
             },
             "FieldQuery": "select i + 1 from (select `user`.id from `user` where 1 != 1) as t(i) where 1 != 1",
-            "Query": "select i + 1 from (select `user`.id from `user`) as t(i)",
-            "Table": "`user`"
+            "Query": "select i + 1 from (select `user`.id from `user`) as t(i)"
           },
           {
             "OperatorType": "Route",
@@ -3295,8 +3115,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -3332,8 +3151,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_id from user_extra where 1 != 1",
-                "Query": "select user_id from user_extra limit 1",
-                "Table": "user_extra"
+                "Query": "select user_id from user_extra limit 1"
               }
             ]
           },
@@ -3355,8 +3173,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id from user_extra where 1 != 1",
-                "Query": "select id from user_extra",
-                "Table": "user_extra"
+                "Query": "select id from user_extra"
               },
               {
                 "InputName": "Outer",
@@ -3368,7 +3185,6 @@
                 },
                 "FieldQuery": "select id from `user` where 1 != 1",
                 "Query": "select id from `user` where :__sq_has_values and id in ::__vals and col = :__sq2",
-                "Table": "`user`",
                 "Values": [
                   "::__sq1"
                 ],
@@ -3397,7 +3213,6 @@
         "JoinVars": {
           "u_intcol": 1
         },
-        "TableName": "`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3407,8 +3222,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.id, u.intcol from `user` as u where 1 != 1",
-            "Query": "select u.id, u.intcol from `user` as u",
-            "Table": "`user`"
+            "Query": "select u.id, u.intcol from `user` as u"
           },
           {
             "OperatorType": "Route",
@@ -3418,8 +3232,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` as uu where 1 != 1",
-            "Query": "select 1 from `user` as uu where uu.intcol = :u_intcol /* INT16 */",
-            "Table": "`user`"
+            "Query": "select 1 from `user` as uu where uu.intcol = :u_intcol /* INT16 */"
           }
         ]
       },
@@ -3441,13 +3254,11 @@
         "JoinVars": {
           "t_col1": 1
         },
-        "TableName": "`user`_unsharded_unsharded",
         "Inputs": [
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_unsharded",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3457,8 +3268,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 0, t.col1 from (select `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select 0, t.col1 from (select `user`.col1 from `user`) as t",
-                "Table": "`user`"
+                "Query": "select 0, t.col1 from (select `user`.col1 from `user`) as t"
               },
               {
                 "OperatorType": "Route",
@@ -3468,8 +3278,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded where 1 != 1",
-                "Query": "select 1 from unsharded",
-                "Table": "unsharded"
+                "Query": "select 1 from unsharded"
               }
             ]
           },
@@ -3481,8 +3290,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded where 1 != 1",
-            "Query": "select 1 from unsharded where unsharded.a = :t_col1 and unsharded.col1 = :t_col1",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded where unsharded.a = :t_col1 and unsharded.col1 = :t_col1"
           }
         ]
       },
@@ -3510,7 +3318,6 @@
             "JoinVars": {
               "user_col": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3520,8 +3327,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.id, `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.id, `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -3531,8 +3337,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */",
-                "Table": "user_extra"
+                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */"
               }
             ]
           }
@@ -3554,7 +3359,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "unsharded_unsharded_tab",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3564,8 +3368,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded where 1 != 1",
-            "Query": "select 1 from unsharded",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded"
           },
           {
             "OperatorType": "Route",
@@ -3575,8 +3378,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded_tab where 1 != 1",
-            "Query": "select 1 from unsharded_tab",
-            "Table": "unsharded_tab"
+            "Query": "select 1 from unsharded_tab"
           }
         ]
       },
@@ -3600,8 +3402,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from unsharded_a join unsharded_b using (propertyId) where 1 != 1",
-        "Query": "select * from unsharded_a join unsharded_b using (propertyId)",
-        "Table": "unsharded_a, unsharded_b"
+        "Query": "select * from unsharded_a join unsharded_b using (propertyId)"
       },
       "TablesUsed": [
         "main.unsharded_a",
@@ -3623,8 +3424,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id2 from (select id from `user` where 1 != 1) as x(id2) where 1 != 1",
-        "Query": "select id2 from (select id from `user`) as x(id2)",
-        "Table": "`user`"
+        "Query": "select id2 from (select id from `user`) as x(id2)"
       },
       "TablesUsed": [
         "user.user"
@@ -3645,8 +3445,7 @@
           "Sharded": false
         },
         "FieldQuery": "select col from (select col from unsharded join unsharded_b where 1 != 1) as u join unsharded_a as ua where 1 != 1",
-        "Query": "select col from (select col from unsharded join unsharded_b) as u join unsharded_a as ua limit 1",
-        "Table": "unsharded, unsharded_a, unsharded_b"
+        "Query": "select col from (select col from unsharded join unsharded_b) as u join unsharded_a as ua limit 1"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -3669,13 +3468,11 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
-            "TableName": "`user`_user_extra_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -3685,8 +3482,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select u.col from (select `user`.col from `user` where 1 != 1) as u where 1 != 1",
-                    "Query": "select u.col from (select `user`.col from `user`) as u",
-                    "Table": "`user`"
+                    "Query": "select u.col from (select `user`.col from `user`) as u"
                   },
                   {
                     "OperatorType": "Route",
@@ -3696,8 +3492,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra"
                   }
                 ]
               },
@@ -3713,8 +3508,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
-                    "Query": "select 1 from user_extra as ue limit 1",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra as ue limit 1"
                   }
                 ]
               }
@@ -3747,7 +3541,6 @@
             "JoinVars": {
               "user_col": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3757,8 +3550,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -3768,8 +3560,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */",
-                "Table": "user_extra"
+                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */"
               }
             ]
           }
@@ -3791,7 +3582,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,L:1",
-        "TableName": "`user`_user_extra_user_extra",
         "Inputs": [
           {
             "OperatorType": "Projection",
@@ -3807,7 +3597,6 @@
                 "JoinVars": {
                   "user_col": 1
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -3817,8 +3606,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col from `user`",
-                    "Table": "`user`"
+                    "Query": "select `user`.id, `user`.col from `user`"
                   },
                   {
                     "OperatorType": "Route",
@@ -3828,8 +3616,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-                    "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */",
-                    "Table": "user_extra"
+                    "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */"
                   }
                 ]
               }
@@ -3843,8 +3630,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra as e where 1 != 1",
-            "Query": "select 1 from user_extra as e",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra as e"
           }
         ]
       },
@@ -3873,7 +3659,6 @@
             "JoinVars": {
               "user_col": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3883,8 +3668,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.foo, `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.foo, `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.foo, `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -3894,8 +3678,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */",
-                "Table": "user_extra"
+                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */"
               }
             ]
           }
@@ -3929,8 +3712,7 @@
             },
             "FieldQuery": "select col1, count(*), weight_string(col1) from (select colC + colD as col1 from `user` where 1 != 1) as tbl where 1 != 1 group by col1, weight_string(col1)",
             "OrderBy": "(0|2) ASC",
-            "Query": "select col1, count(*), weight_string(col1) from (select colC + colD as col1 from `user`) as tbl group by col1, weight_string(col1) order by col1 asc",
-            "Table": "`user`"
+            "Query": "select col1, count(*), weight_string(col1) from (select colC + colD as col1 from `user`) as tbl group by col1, weight_string(col1) order by col1 asc"
           }
         ]
       },
@@ -3952,7 +3734,6 @@
         "JoinVars": {
           "authoritative_col1": 0
         },
-        "TableName": "authoritative_unsharded_authoritative",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3962,8 +3743,7 @@
               "Sharded": true
             },
             "FieldQuery": "select authoritative.col1, authoritative.user_id, authoritative.col2 from authoritative where 1 != 1",
-            "Query": "select authoritative.col1, authoritative.user_id, authoritative.col2 from authoritative",
-            "Table": "authoritative"
+            "Query": "select authoritative.col1, authoritative.user_id, authoritative.col2 from authoritative"
           },
           {
             "OperatorType": "Route",
@@ -3973,8 +3753,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded_authoritative.col2 from unsharded_authoritative where 1 != 1",
-            "Query": "select unsharded_authoritative.col2 from unsharded_authoritative where unsharded_authoritative.col1 = :authoritative_col1 /* VARCHAR */",
-            "Table": "unsharded_authoritative"
+            "Query": "select unsharded_authoritative.col2 from unsharded_authoritative where unsharded_authoritative.col1 = :authoritative_col1 /* VARCHAR */"
           }
         ]
       },
@@ -3999,7 +3778,6 @@
         },
         "FieldQuery": "select push_it from (select bar as push_it from (select foo as bar from (select id as foo from `user` where 1 != 1) as t1 where 1 != 1) as t2 where 1 != 1) as t3 where 1 != 1",
         "Query": "select push_it from (select bar as push_it from (select foo as bar from (select id as foo from `user` where id = 12) as t1) as t2) as t3",
-        "Table": "`user`",
         "Values": [
           "12"
         ],
@@ -4024,8 +3802,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id, col from (select `user`.id, user_extra.col from `user`, user_extra where 1 != 1) as user_details_view where 1 != 1",
-        "Query": "select id, col from (select `user`.id, user_extra.col from `user`, user_extra where `user`.id = user_extra.user_id) as user_details_view",
-        "Table": "`user`, user_extra"
+        "Query": "select id, col from (select `user`.id, user_extra.col from `user`, user_extra where `user`.id = user_extra.user_id) as user_details_view"
       },
       "TablesUsed": [
         "user.user",
@@ -4047,8 +3824,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id, col from (select `user`.id, user_extra.col from `user`, user_extra where 1 != 1) as user_details_view where 1 != 1",
-        "Query": "select id, col from (select `user`.id, user_extra.col from `user`, user_extra where `user`.id = user_extra.user_id) as user_details_view",
-        "Table": "`user`, user_extra"
+        "Query": "select id, col from (select `user`.id, user_extra.col from `user`, user_extra where `user`.id = user_extra.user_id) as user_details_view"
       },
       "TablesUsed": [
         "user.user",
@@ -4074,7 +3850,6 @@
             "JoinVars": {
               "user_col": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -4084,8 +3859,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.id, `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.id, `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -4095,8 +3869,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */",
-                "Table": "user_extra"
+                "Query": "select user_extra.col from user_extra where user_extra.col = :user_col /* INT16 */"
               }
             ]
           }
@@ -4122,8 +3895,7 @@
           "Sharded": false
         },
         "FieldQuery": "select missing_column from unsharded, unsharded_a where 1 != 1",
-        "Query": "select missing_column from unsharded, unsharded_a",
-        "Table": "unsharded, unsharded_a"
+        "Query": "select missing_column from unsharded, unsharded_a"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -4146,7 +3918,6 @@
         "OperatorType": "Join",
         "Variant": "LeftJoin",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "t1_t1",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4156,8 +3927,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t1.id1 from t1 where 1 != 1",
-            "Query": "select t1.id1 from t1",
-            "Table": "t1"
+            "Query": "select t1.id1 from t1"
           },
           {
             "OperatorType": "Route",
@@ -4167,8 +3937,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t2.id1 from t1 as t2 where 1 != 1",
-            "Query": "select t2.id1 from t1 as t2 where t2.id1 = t2.id2",
-            "Table": "t1"
+            "Query": "select t2.id1 from t1 as t2 where t2.id1 = t2.id2"
           }
         ]
       },
@@ -4191,8 +3960,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from unsharded_authoritative as A left join unsharded_authoritative as B using (col1) where 1 != 1",
-        "Query": "select * from unsharded_authoritative as A left join unsharded_authoritative as B using (col1)",
-        "Table": "unsharded_authoritative"
+        "Query": "select * from unsharded_authoritative as A left join unsharded_authoritative as B using (col1)"
       },
       "TablesUsed": [
         "main.unsharded_authoritative"
@@ -4212,7 +3980,6 @@
         "JoinVars": {
           "m1_cola": 1
         },
-        "TableName": "multicol_tbl_multicol_tbl",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4222,8 +3989,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1, m1.cola from multicol_tbl as m1 where 1 != 1",
-            "Query": "select 1, m1.cola from multicol_tbl as m1",
-            "Table": "multicol_tbl"
+            "Query": "select 1, m1.cola from multicol_tbl as m1"
           },
           {
             "OperatorType": "Route",
@@ -4234,7 +4000,6 @@
             },
             "FieldQuery": "select 1 from multicol_tbl as m2 where 1 != 1",
             "Query": "select 1 from multicol_tbl as m2 where m2.cola = :m1_cola",
-            "Table": "multicol_tbl",
             "Values": [
               ":m1_cola"
             ],
@@ -4265,7 +4030,6 @@
         "ComparisonType": "INT16",
         "JoinColumnIndexes": "-2",
         "Predicate": "`user`.col = ue.col",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4275,8 +4039,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col, id from `user` where 1 != 1",
-            "Query": "select `user`.col, id from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col, id from `user`"
           },
           {
             "OperatorType": "Limit",
@@ -4290,8 +4053,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.col from (select col from user_extra where 1 != 1) as ue where 1 != 1",
-                "Query": "select ue.col from (select col from user_extra) as ue limit 10",
-                "Table": "user_extra"
+                "Query": "select ue.col from (select col from user_extra) as ue limit 10"
               }
             ]
           }
@@ -4316,7 +4078,6 @@
         "ComparisonType": "INT16",
         "JoinColumnIndexes": "-1,2",
         "Predicate": "u.col = ue.col",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Limit",
@@ -4330,8 +4091,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col from (select id, col from `user` where 1 != 1) as u where 1 != 1",
-                "Query": "select u.id, u.col from (select id, col from `user`) as u limit 10",
-                "Table": "`user`"
+                "Query": "select u.id, u.col from (select id, col from `user`) as u limit 10"
               }
             ]
           },
@@ -4347,8 +4107,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.col, ue.user_id from (select col, user_id from user_extra where 1 != 1) as ue where 1 != 1",
-                "Query": "select ue.col, ue.user_id from (select col, user_id from user_extra) as ue limit 10",
-                "Table": "user_extra"
+                "Query": "select ue.col, ue.user_id from (select col, user_id from user_extra) as ue limit 10"
               }
             ]
           }
@@ -4375,7 +4134,6 @@
         },
         "FieldQuery": "select id, user_id from (select id, col from `user` where 1 != 1) as u, (select col, user_id from user_extra where 1 != 1) as ue where 1 != 1",
         "Query": "select id, user_id from (select id, col from `user` where id = 17 limit 10) as u, (select col, user_id from user_extra where user_id = 17 limit 10) as ue where u.col = ue.col",
-        "Table": "`user`, user_extra",
         "Values": [
           "17"
         ],
@@ -4407,7 +4165,6 @@
             "ComparisonType": "INT16",
             "JoinColumnIndexes": "-1,2,-3,3",
             "Predicate": "u.col = ue.col",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -4417,8 +4174,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col, weight_string(u.id) from (select id, col from `user` where 1 != 1) as u where 1 != 1",
-                "Query": "select distinct u.id, u.col, weight_string(u.id) from (select id, col from `user`) as u",
-                "Table": "`user`"
+                "Query": "select distinct u.id, u.col, weight_string(u.id) from (select id, col from `user`) as u"
               },
               {
                 "OperatorType": "Limit",
@@ -4432,8 +4188,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select ue.col, ue.user_id, weight_string(ue.user_id) from (select col, user_id from user_extra where 1 != 1) as ue where 1 != 1",
-                    "Query": "select ue.col, ue.user_id, weight_string(ue.user_id) from (select col, user_id from user_extra) as ue limit 10",
-                    "Table": "user_extra"
+                    "Query": "select ue.col, ue.user_id, weight_string(ue.user_id) from (select col, user_id from user_extra) as ue limit 10"
                   }
                 ]
               }
@@ -4461,8 +4216,7 @@
           "Sharded": false
         },
         "FieldQuery": "select x from (select t.*, 1 as x from unsharded as t where 1 != 1 union select t.*, 1 as x from unsharded as t where 1 != 1) as x where 1 != 1",
-        "Query": "select x from (select t.*, 1 as x from unsharded as t union select t.*, 1 as x from unsharded as t) as x",
-        "Table": "unsharded"
+        "Query": "select x from (select t.*, 1 as x from unsharded as t union select t.*, 1 as x from unsharded as t) as x"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -4498,7 +4252,6 @@
                     "JoinVars": {
                       "m_id": 0
                     },
-                    "TableName": "music_`user`, user_extra",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -4508,8 +4261,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select subquery_for_count.`m.id`, 1 from (select m.id as `m.id` from music as m where 1 != 1) as subquery_for_count where 1 != 1",
-                        "Query": "select distinct subquery_for_count.`m.id`, 1 from (select m.id as `m.id` from music as m) as subquery_for_count",
-                        "Table": "music"
+                        "Query": "select distinct subquery_for_count.`m.id`, 1 from (select m.id as `m.id` from music as m) as subquery_for_count"
                       },
                       {
                         "OperatorType": "Route",
@@ -4520,7 +4272,6 @@
                         },
                         "FieldQuery": "select subquery_for_count.user_id, weight_string(subquery_for_count.user_id) from (select u.user_id from `user` as u, user_extra as ue where 1 != 1) as subquery_for_count where 1 != 1",
                         "Query": "select distinct subquery_for_count.user_id, weight_string(subquery_for_count.user_id) from (select u.user_id from `user` as u, user_extra as ue where u.id = :m_id and u.id = ue.user_id) as subquery_for_count",
-                        "Table": "`user`, user_extra",
                         "Values": [
                           ":m_id"
                         ],
@@ -4554,7 +4305,6 @@
         "JoinVars": {
           "u_col": 2
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "VindexLookup",
@@ -4577,7 +4327,6 @@
                 },
                 "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
                 "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                "Table": "name_user_vdx",
                 "Values": [
                   "::name"
                 ],
@@ -4591,8 +4340,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.intcol, u.id, u.col from `user` as u where 1 != 1",
-                "Query": "select u.intcol, u.id, u.col from `user` as u where u.`name` = 'bb' and u.id = 3",
-                "Table": "`user`"
+                "Query": "select u.intcol, u.id, u.col from `user` as u where u.`name` = 'bb' and u.id = 3"
               }
             ]
           },
@@ -4605,7 +4353,6 @@
             },
             "FieldQuery": "select 1 from music as m where 1 != 1",
             "Query": "select 1 from music as m where m.user_id = 5 and m.id = 20 and m.col = :u_col /* INT16 */",
-            "Table": "music",
             "Values": [
               "20"
             ],
@@ -4632,7 +4379,6 @@
         "JoinVars": {
           "t1_id": 1
         },
-        "TableName": "t1_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4642,8 +4388,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1, t1.id from t1 where 1 != 1",
-            "Query": "select 1, t1.id from t1",
-            "Table": "t1"
+            "Query": "select 1, t1.id from t1"
           },
           {
             "OperatorType": "Route",
@@ -4654,7 +4399,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where `user`.id = :t1_id",
-            "Table": "`user`",
             "Values": [
               ":t1_id"
             ],
@@ -4681,7 +4425,6 @@
         "JoinVars": {
           "u_foo": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4691,8 +4434,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.foo from (select u.foo from `user` as u where 1 != 1) as dt where 1 != 1",
-            "Query": "select dt.foo from (select u.foo from `user` as u) as dt",
-            "Table": "`user`"
+            "Query": "select dt.foo from (select u.foo from `user` as u) as dt"
           },
           {
             "OperatorType": "Route",
@@ -4702,8 +4444,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.`u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue where 1 != 1) as dt where 1 != 1",
-            "Query": "select dt.`u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue) as dt",
-            "Table": "user_extra"
+            "Query": "select dt.`u.foo * ue.bar` from (select :u_foo * ue.bar as `u.foo * ue.bar` from user_extra as ue) as dt"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -13,8 +13,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_NAME from information_schema.`TABLES` where 1 != 1",
-        "Query": "select TABLE_NAME from information_schema.`TABLES`",
-        "Table": "information_schema.`TABLES`"
+        "Query": "select TABLE_NAME from information_schema.`TABLES`"
       }
     }
   },
@@ -32,8 +31,7 @@
           "Sharded": false
         },
         "FieldQuery": "select a.`ENGINE`, b.DATA_TYPE from information_schema.`TABLES` as a, information_schema.`COLUMNS` as b where 1 != 1",
-        "Query": "select a.`ENGINE`, b.DATA_TYPE from information_schema.`TABLES` as a, information_schema.`COLUMNS` as b",
-        "Table": "information_schema.`COLUMNS`, information_schema.`TABLES`"
+        "Query": "select a.`ENGINE`, b.DATA_TYPE from information_schema.`TABLES` as a, information_schema.`COLUMNS` as b"
       }
     }
   },
@@ -51,8 +49,7 @@
           "Sharded": false
         },
         "FieldQuery": "select column_name from information_schema.`columns` where 1 != 1",
-        "Query": "select column_name from information_schema.`columns` where table_schema = schema()",
-        "Table": "information_schema.`columns`"
+        "Query": "select column_name from information_schema.`columns` where table_schema = schema()"
       }
     }
   },
@@ -70,8 +67,7 @@
           "Sharded": false
         },
         "FieldQuery": "select `tables`.TABLE_SCHEMA, files.`STATUS` from information_schema.`tables`, information_schema.files where 1 != 1",
-        "Query": "select `tables`.TABLE_SCHEMA, files.`STATUS` from information_schema.`tables`, information_schema.files",
-        "Table": "information_schema.`tables`, information_schema.files"
+        "Query": "select `tables`.TABLE_SCHEMA, files.`STATUS` from information_schema.`tables`, information_schema.files"
       }
     }
   },
@@ -89,8 +85,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, CHARACTER_OCTET_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, CHARACTER_SET_NAME, COLLATION_NAME, COLUMN_TYPE, COLUMN_KEY, EXTRA, `PRIVILEGES`, COLUMN_COMMENT, GENERATION_EXPRESSION from information_schema.`COLUMNS` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, CHARACTER_OCTET_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, CHARACTER_SET_NAME, COLLATION_NAME, COLUMN_TYPE, COLUMN_KEY, EXTRA, `PRIVILEGES`, COLUMN_COMMENT, GENERATION_EXPRESSION from information_schema.`COLUMNS` where `COLUMNS`.COLUMN_NAME = 'toto'",
-        "Table": "information_schema.`COLUMNS`"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, CHARACTER_OCTET_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, CHARACTER_SET_NAME, COLLATION_NAME, COLUMN_TYPE, COLUMN_KEY, EXTRA, `PRIVILEGES`, COLUMN_COMMENT, GENERATION_EXPRESSION from information_schema.`COLUMNS` where `COLUMNS`.COLUMN_NAME = 'toto'"
       }
     }
   },
@@ -117,8 +112,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select TABLE_NAME from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct TABLE_NAME from information_schema.`columns`",
-                "Table": "information_schema.`columns`"
+                "Query": "select distinct TABLE_NAME from information_schema.`columns`"
               },
               {
                 "OperatorType": "Route",
@@ -128,8 +122,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select table_schema from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_schema from information_schema.`tables`",
-                "Table": "information_schema.`tables`"
+                "Query": "select distinct table_schema from information_schema.`tables`"
               }
             ]
           }
@@ -181,8 +174,7 @@
                 },
                 "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
                 "Query": "select distinct TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['user']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['user']"
               },
               {
                 "OperatorType": "Route",
@@ -193,8 +185,7 @@
                 },
                 "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
                 "Query": "select distinct TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['main']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['main']"
               }
             ]
           }
@@ -218,8 +209,7 @@
         "FieldQuery": "select RC.CONSTRAINT_NAME, ORDINAL_POSITION from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC where 1 != 1",
         "Query": "select RC.CONSTRAINT_NAME, ORDINAL_POSITION from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC where KCU.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and KCU.TABLE_NAME = :KCU_TABLE_NAME /* VARCHAR */ and KCU.COLUMN_NAME = 'id' and KCU.REFERENCED_TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and KCU.CONSTRAINT_NAME = 'data_type_table_id_fkey' and KCU.CONSTRAINT_NAME = RC.CONSTRAINT_NAME order by KCU.CONSTRAINT_NAME asc, KCU.COLUMN_NAME asc",
         "SysTableTableName": "[KCU_TABLE_NAME:'data_type_table']",
-        "SysTableTableSchema": "['test']",
-        "Table": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS"
+        "SysTableTableSchema": "['test']"
       }
     }
   },
@@ -239,8 +229,7 @@
         "FieldQuery": "select KCU.TABLE_NAME, S.TABLE_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC, INFORMATION_SCHEMA.`TABLES` as S where 1 != 1",
         "Query": "select KCU.TABLE_NAME, S.TABLE_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC, INFORMATION_SCHEMA.`TABLES` as S where S.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and S.TABLE_NAME = :S_TABLE_NAME /* VARCHAR */ and KCU.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and KCU.TABLE_NAME = :KCU_TABLE_NAME /* VARCHAR */ and KCU.CONSTRAINT_NAME = RC.CONSTRAINT_NAME order by KCU.CONSTRAINT_NAME asc, KCU.COLUMN_NAME asc",
         "SysTableTableName": "[KCU_TABLE_NAME:'data_type_table', S_TABLE_NAME:'sc']",
-        "SysTableTableSchema": "['test']",
-        "Table": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS, INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['test']"
       }
     }
   },
@@ -259,8 +248,7 @@
         },
         "FieldQuery": "select routine_name as `name`, routine_definition as definition from information_schema.routines where 1 != 1",
         "Query": "select routine_name as `name`, routine_definition as definition from information_schema.routines where ROUTINE_SCHEMA = :__vtschemaname /* VARCHAR */ and ROUTINE_TYPE = 'PROCEDURE'",
-        "SysTableTableSchema": "[:v1]",
-        "Table": "information_schema.routines"
+        "SysTableTableSchema": "[:v1]"
       }
     }
   },
@@ -279,8 +267,7 @@
         },
         "FieldQuery": "select sum(data_length + index_length) as size from information_schema.`TABLES` where 1 != 1",
         "Query": "select sum(data_length + index_length) as size from information_schema.`TABLES` where table_schema = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "[:v1]",
-        "Table": "information_schema.`TABLES`"
+        "SysTableTableSchema": "[:v1]"
       }
     }
   },
@@ -297,7 +284,6 @@
         "JoinVars": {
           "kcu_constraint_name": 0
         },
-        "TableName": "information_schema.key_column_usage_information_schema.referential_constraints",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -308,8 +294,7 @@
             },
             "FieldQuery": "select kcu.constraint_name as constraint_name, kcu.column_name as column_name, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.table_name as table_name from information_schema.key_column_usage as kcu where 1 != 1",
             "Query": "select kcu.constraint_name as constraint_name, kcu.column_name as column_name, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.table_name as table_name from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.referenced_column_name is not null order by kcu.ordinal_position asc",
-            "SysTableTableSchema": "[:v1]",
-            "Table": "information_schema.key_column_usage"
+            "SysTableTableSchema": "[:v1]"
           },
           {
             "OperatorType": "Route",
@@ -320,8 +305,7 @@
             },
             "FieldQuery": "select rc.delete_rule as delete_rule, rc.update_rule as update_rule from information_schema.referential_constraints as rc where 1 != 1",
             "Query": "select rc.delete_rule as delete_rule, rc.update_rule as update_rule from information_schema.referential_constraints as rc where rc.constraint_schema = :__vtschemaname /* VARCHAR */ and rc.constraint_name = :kcu_constraint_name /* VARCHAR(64) */",
-            "SysTableTableSchema": "[:v2]",
-            "Table": "information_schema.referential_constraints"
+            "SysTableTableSchema": "[:v2]"
           }
         ]
       }
@@ -342,8 +326,7 @@
         },
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
         "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = database() and rc.table_name = :rc_table_name /* VARCHAR */ and fk.referenced_column_name is not null and fk.table_schema = database() and fk.table_name = :fk_table_name /* VARCHAR */ and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
-        "SysTableTableName": "[fk_table_name:':vtg1', rc_table_name:':vtg1']",
-        "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
+        "SysTableTableName": "[fk_table_name:':vtg1', rc_table_name:':vtg1']"
       }
     }
   },
@@ -362,8 +345,7 @@
         },
         "FieldQuery": "select CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH from information_schema.schemata where 1 != 1",
         "Query": "select CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH from information_schema.schemata where schema_name = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "['user']",
-        "Table": "information_schema.schemata"
+        "SysTableTableSchema": "['user']"
       }
     }
   },
@@ -383,8 +365,7 @@
         "FieldQuery": "select table_comment from information_schema.`tables` where 1 != 1",
         "Query": "select table_comment from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */",
         "SysTableTableName": "[table_name:'table_name']",
-        "SysTableTableSchema": "['schema_name']",
-        "Table": "information_schema.`tables`"
+        "SysTableTableSchema": "['schema_name']"
       }
     }
   },
@@ -404,8 +385,7 @@
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
         "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = :__vtschemaname /* VARCHAR */ and rc.table_name = :rc_table_name /* VARCHAR */ and fk.referenced_column_name is not null and fk.table_schema = :__vtschemaname /* VARCHAR */ and fk.table_name = :fk_table_name /* VARCHAR */ and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
         "SysTableTableName": "[fk_table_name:'table_name', rc_table_name:'table_name']",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -425,8 +405,7 @@
         "FieldQuery": "select column_name from information_schema.statistics where 1 != 1",
         "Query": "select column_name from information_schema.statistics where index_name = 'PRIMARY' and table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */ order by seq_in_index asc",
         "SysTableTableName": "[table_name:'table_name']",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.statistics"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -446,8 +425,7 @@
         "FieldQuery": "select generation_expression from information_schema.`columns` where 1 != 1",
         "Query": "select generation_expression from information_schema.`columns` where table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */ and column_name = 'column_name'",
         "SysTableTableName": "[table_name:'table_name']",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.`columns`"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -465,8 +443,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id from information_schema.`processlist` where 1 != 1",
-        "Query": "select id from information_schema.`processlist` where info like '% FOR UPDATE'",
-        "Table": "information_schema.`processlist`"
+        "Query": "select id from information_schema.`processlist` where info like '% FOR UPDATE'"
       }
     }
   },
@@ -485,8 +462,7 @@
         },
         "FieldQuery": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1) as _subquery where 1 != 1",
         "Query": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */) as _subquery",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.`tables`"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -505,8 +481,7 @@
         },
         "FieldQuery": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1) as _subquery where 1 != 1",
         "Query": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_type = 'table_type' and table_name = 'table_name') as _subquery",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.`tables`"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -526,8 +501,7 @@
         "FieldQuery": "select count(*) from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select count(*) from INFORMATION_SCHEMA.`TABLES` where table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */",
         "SysTableTableName": "[table_name:'foo']",
-        "SysTableTableSchema": "['performance_schema']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['performance_schema']"
       }
     }
   },
@@ -545,8 +519,7 @@
           "Sharded": false
         },
         "FieldQuery": "select `TABLES`.`CHECKSUM` from information_schema.`TABLES` where 1 != 1",
-        "Query": "select `TABLES`.`CHECKSUM` from information_schema.`TABLES` where TABLE_NAME in (select TABLE_NAME from information_schema.`COLUMNS`)",
-        "Table": "information_schema.`TABLES`"
+        "Query": "select `TABLES`.`CHECKSUM` from information_schema.`TABLES` where TABLE_NAME in (select TABLE_NAME from information_schema.`COLUMNS`)"
       }
     }
   },
@@ -565,8 +538,7 @@
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "['user', 'main']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['user', 'main']"
       }
     }
   },
@@ -584,8 +556,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = database()",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = database()"
       }
     }
   },
@@ -604,8 +575,7 @@
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -625,8 +595,7 @@
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and TABLE_NAME = :TABLE_NAME /* VARCHAR */",
         "SysTableTableName": "[TABLE_NAME:'route1']",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -645,8 +614,7 @@
         },
         "FieldQuery": "select TABLE_NAME from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_NAME from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and DATA_FREE = 42",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -665,8 +633,7 @@
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and (DATA_FREE = 42 or `CHECKSUM` = 'value')",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -684,8 +651,7 @@
           "Sharded": false
         },
         "FieldQuery": "select x.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where 1 != 1) as x where 1 != 1",
-        "Query": "select x.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x",
-        "Table": "information_schema.key_column_usage"
+        "Query": "select x.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x"
       }
     }
   },
@@ -702,7 +668,6 @@
         "JoinVars": {
           "x_COLUMN_NAME": 1
         },
-        "TableName": "information_schema.key_column_usage_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -712,8 +677,7 @@
               "Sharded": false
             },
             "FieldQuery": "select x.table_name, x.COLUMN_NAME from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where 1 != 1) as x where 1 != 1",
-            "Query": "select x.table_name, x.COLUMN_NAME from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x",
-            "Table": "information_schema.key_column_usage"
+            "Query": "select x.table_name, x.COLUMN_NAME from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x"
           },
           {
             "OperatorType": "Route",
@@ -724,7 +688,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where `user`.id = :x_COLUMN_NAME /* VARCHAR(64) */",
-            "Table": "`user`",
             "Values": [
               ":x_COLUMN_NAME"
             ],
@@ -751,8 +714,7 @@
           "Sharded": false
         },
         "FieldQuery": "select a.VARIABLE_NAME, a.VARIABLE_VALUE, b.CHARACTER_SET_NAME, b.DEFAULT_COLLATE_NAME, b.DESCRIPTION, b.MAXLEN from information_schema.GLOBAL_STATUS as a, information_schema.CHARACTER_SETS as b where 1 != 1",
-        "Query": "select a.VARIABLE_NAME, a.VARIABLE_VALUE, b.CHARACTER_SET_NAME, b.DEFAULT_COLLATE_NAME, b.DESCRIPTION, b.MAXLEN from information_schema.GLOBAL_STATUS as a, information_schema.CHARACTER_SETS as b",
-        "Table": "information_schema.CHARACTER_SETS, information_schema.GLOBAL_STATUS"
+        "Query": "select a.VARIABLE_NAME, a.VARIABLE_VALUE, b.CHARACTER_SET_NAME, b.DEFAULT_COLLATE_NAME, b.DESCRIPTION, b.MAXLEN from information_schema.GLOBAL_STATUS as a, information_schema.CHARACTER_SETS as b"
       }
     }
   },
@@ -771,8 +733,7 @@
         },
         "FieldQuery": "select a.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where 1 != 1) as a, (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, UNIQUE_CONSTRAINT_CATALOG, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME, MATCH_OPTION, UPDATE_RULE, DELETE_RULE, TABLE_NAME, REFERENCED_TABLE_NAME from information_schema.referential_constraints where 1 != 1) as b where 1 != 1",
         "Query": "select a.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where a.table_name = :a_table_name /* VARCHAR */) as a, (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, UNIQUE_CONSTRAINT_CATALOG, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME, MATCH_OPTION, UPDATE_RULE, DELETE_RULE, TABLE_NAME, REFERENCED_TABLE_NAME from information_schema.referential_constraints where table_name = :table_name /* VARCHAR */) as b",
-        "SysTableTableName": "[a_table_name:'users', table_name:'users']",
-        "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
+        "SysTableTableName": "[a_table_name:'users', table_name:'users']"
       }
     }
   },
@@ -799,8 +760,7 @@
                 },
                 "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
                 "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['music']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['music']"
               },
               {
                 "OperatorType": "Route",
@@ -811,8 +771,7 @@
                 },
                 "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
                 "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-                "SysTableTableSchema": "['music']",
-                "Table": "information_schema.views"
+                "SysTableTableSchema": "['music']"
               }
             ]
           }
@@ -838,8 +797,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableSchema": "['music']"
           },
           {
             "OperatorType": "Route",
@@ -850,8 +808,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
             "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music']",
-            "Table": "information_schema.views"
+            "SysTableTableSchema": "['music']"
           }
         ]
       }
@@ -875,8 +832,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableSchema": "['music', 'Music']"
           },
           {
             "OperatorType": "Route",
@@ -887,8 +843,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
             "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']",
-            "Table": "information_schema.views"
+            "SysTableTableSchema": "['music', 'user']"
           }
         ]
       }
@@ -912,8 +867,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableSchema": "['music', 'Music']"
           },
           {
             "OperatorType": "Route",
@@ -924,8 +878,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
             "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']",
-            "Table": "information_schema.views"
+            "SysTableTableSchema": "['music', 'user']"
           }
         ]
       }
@@ -961,8 +914,7 @@
                     },
                     "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
                     "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name1 /* VARCHAR */ and table_name = :table_name1 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name1:'Music']",
-                    "Table": "information_schema.`tables`"
+                    "SysTableTableName": "[table_name1:'Music']"
                   },
                   {
                     "OperatorType": "Route",
@@ -973,8 +925,7 @@
                     },
                     "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
                     "Query": "select 1 as found from information_schema.views where table_name = :table_name2 /* VARCHAR */ and table_name = :table_name2 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name2:'user']",
-                    "Table": "information_schema.views"
+                    "SysTableTableName": "[table_name2:'user']"
                   }
                 ]
               }
@@ -990,8 +941,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name /* VARCHAR */ and table_name = :table_name /* VARCHAR */ and :__sq_has_values",
-            "SysTableTableName": "[table_name:'Music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableName": "[table_name:'Music']"
           }
         ]
       }
@@ -1021,8 +971,7 @@
                 },
                 "FieldQuery": "select TABLE_NAME from information_schema.`tables` as t where 1 != 1",
                 "Query": "select distinct TABLE_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['a']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['a']"
               },
               {
                 "OperatorType": "Route",
@@ -1032,8 +981,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select TABLE_NAME from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct TABLE_NAME from information_schema.`columns`",
-                "Table": "information_schema.`columns`"
+                "Query": "select distinct TABLE_NAME from information_schema.`columns`"
               }
             ]
           }
@@ -1074,8 +1022,7 @@
                     },
                     "FieldQuery": "select TABLE_NAME from information_schema.`tables` as t where 1 != 1",
                     "Query": "select distinct TABLE_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                    "SysTableTableSchema": "['a']",
-                    "Table": "information_schema.`tables`"
+                    "SysTableTableSchema": "['a']"
                   },
                   {
                     "OperatorType": "Route",
@@ -1085,8 +1032,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select COLUMN_NAME from information_schema.`columns` where 1 != 1",
-                    "Query": "select distinct COLUMN_NAME from information_schema.`columns`",
-                    "Table": "information_schema.`columns`"
+                    "Query": "select distinct COLUMN_NAME from information_schema.`columns`"
                   }
                 ]
               }
@@ -1101,8 +1047,7 @@
               "Sharded": false
             },
             "FieldQuery": "select COLLATION_NAME from information_schema.`COLUMNS` as t where 1 != 1",
-            "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where :__sq_has_values and COLUMN_NAME in ::__sq1",
-            "Table": "information_schema.`COLUMNS`"
+            "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where :__sq_has_values and COLUMN_NAME in ::__sq1"
           }
         ]
       }
@@ -1122,8 +1067,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = 'ks' or TABLE_SCHEMA = 'main'",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = 'ks' or TABLE_SCHEMA = 'main'"
       }
     }
   },
@@ -1141,8 +1085,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_NAME from information_schema.apa where 1 != 1",
-        "Query": "select TABLE_NAME from information_schema.apa",
-        "Table": "information_schema.apa"
+        "Query": "select TABLE_NAME from information_schema.apa"
       }
     }
   },
@@ -1159,7 +1102,6 @@
         "JoinVars": {
           "tables_table_name": 0
         },
-        "TableName": "information_schema.`tables`_information_schema.`columns`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1169,8 +1111,7 @@
               "Sharded": false
             },
             "FieldQuery": "select `tables`.table_name from (select table_name from information_schema.`tables` where 1 != 1) as `tables` where 1 != 1",
-            "Query": "select `tables`.table_name from (select table_name from information_schema.`tables` where table_schema != 'information_schema' limit 1) as `tables`",
-            "Table": "information_schema.`tables`"
+            "Query": "select `tables`.table_name from (select table_name from information_schema.`tables` where table_schema != 'information_schema' limit 1) as `tables`"
           },
           {
             "OperatorType": "Route",
@@ -1181,8 +1122,7 @@
             },
             "FieldQuery": "select c.column_name from information_schema.`columns` as c where 1 != 1",
             "Query": "select c.column_name from information_schema.`columns` as c where c.table_name = :c_table_name /* VARCHAR */",
-            "SysTableTableName": "[c_table_name::tables_table_name]",
-            "Table": "information_schema.`columns`"
+            "SysTableTableName": "[c_table_name::tables_table_name]"
           }
         ]
       }

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -13,8 +13,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_NAME from information_schema.`TABLES` where 1 != 1",
-        "Query": "select TABLE_NAME from information_schema.`TABLES`",
-        "Table": "information_schema.`TABLES`"
+        "Query": "select TABLE_NAME from information_schema.`TABLES`"
       }
     }
   },
@@ -32,8 +31,7 @@
           "Sharded": false
         },
         "FieldQuery": "select a.`ENGINE`, b.DATA_TYPE from information_schema.`TABLES` as a, information_schema.`COLUMNS` as b where 1 != 1",
-        "Query": "select a.`ENGINE`, b.DATA_TYPE from information_schema.`TABLES` as a, information_schema.`COLUMNS` as b",
-        "Table": "information_schema.`COLUMNS`, information_schema.`TABLES`"
+        "Query": "select a.`ENGINE`, b.DATA_TYPE from information_schema.`TABLES` as a, information_schema.`COLUMNS` as b"
       }
     }
   },
@@ -51,8 +49,7 @@
           "Sharded": false
         },
         "FieldQuery": "select column_name from information_schema.`columns` where 1 != 1",
-        "Query": "select column_name from information_schema.`columns` where table_schema = schema()",
-        "Table": "information_schema.`columns`"
+        "Query": "select column_name from information_schema.`columns` where table_schema = schema()"
       }
     }
   },
@@ -70,8 +67,7 @@
           "Sharded": false
         },
         "FieldQuery": "select `tables`.TABLE_SCHEMA, files.`STATUS` from information_schema.`tables`, information_schema.files where 1 != 1",
-        "Query": "select `tables`.TABLE_SCHEMA, files.`STATUS` from information_schema.`tables`, information_schema.files",
-        "Table": "information_schema.`tables`, information_schema.files"
+        "Query": "select `tables`.TABLE_SCHEMA, files.`STATUS` from information_schema.`tables`, information_schema.files"
       }
     }
   },
@@ -89,8 +85,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, CHARACTER_OCTET_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, CHARACTER_SET_NAME, COLLATION_NAME, COLUMN_TYPE, COLUMN_KEY, EXTRA, `PRIVILEGES`, COLUMN_COMMENT, GENERATION_EXPRESSION, SRS_ID from information_schema.`COLUMNS` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, CHARACTER_OCTET_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, CHARACTER_SET_NAME, COLLATION_NAME, COLUMN_TYPE, COLUMN_KEY, EXTRA, `PRIVILEGES`, COLUMN_COMMENT, GENERATION_EXPRESSION, SRS_ID from information_schema.`COLUMNS` where `COLUMNS`.COLUMN_NAME = 'toto'",
-        "Table": "information_schema.`COLUMNS`"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, CHARACTER_OCTET_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, CHARACTER_SET_NAME, COLLATION_NAME, COLUMN_TYPE, COLUMN_KEY, EXTRA, `PRIVILEGES`, COLUMN_COMMENT, GENERATION_EXPRESSION, SRS_ID from information_schema.`COLUMNS` where `COLUMNS`.COLUMN_NAME = 'toto'"
       }
     }
   },
@@ -117,8 +112,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select TABLE_NAME from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct TABLE_NAME from information_schema.`columns`",
-                "Table": "information_schema.`columns`"
+                "Query": "select distinct TABLE_NAME from information_schema.`columns`"
               },
               {
                 "OperatorType": "Route",
@@ -128,8 +122,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select table_schema from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_schema from information_schema.`tables`",
-                "Table": "information_schema.`tables`"
+                "Query": "select distinct table_schema from information_schema.`tables`"
               }
             ]
           }
@@ -181,8 +174,7 @@
                 },
                 "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
                 "Query": "select distinct TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['user']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['user']"
               },
               {
                 "OperatorType": "Route",
@@ -193,8 +185,7 @@
                 },
                 "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
                 "Query": "select distinct TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['main']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['main']"
               }
             ]
           }
@@ -218,8 +209,7 @@
         "FieldQuery": "select RC.CONSTRAINT_NAME, ORDINAL_POSITION from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC where 1 != 1",
         "Query": "select RC.CONSTRAINT_NAME, ORDINAL_POSITION from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC where KCU.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and KCU.TABLE_NAME = :KCU_TABLE_NAME /* VARCHAR */ and KCU.COLUMN_NAME = 'id' and KCU.REFERENCED_TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and KCU.CONSTRAINT_NAME = 'data_type_table_id_fkey' and KCU.CONSTRAINT_NAME = RC.CONSTRAINT_NAME order by KCU.CONSTRAINT_NAME asc, KCU.COLUMN_NAME asc",
         "SysTableTableName": "[KCU_TABLE_NAME:'data_type_table']",
-        "SysTableTableSchema": "['test']",
-        "Table": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS"
+        "SysTableTableSchema": "['test']"
       }
     }
   },
@@ -239,8 +229,7 @@
         "FieldQuery": "select KCU.TABLE_NAME, S.TABLE_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC, INFORMATION_SCHEMA.`TABLES` as S where 1 != 1",
         "Query": "select KCU.TABLE_NAME, S.TABLE_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS as RC, INFORMATION_SCHEMA.`TABLES` as S where S.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and S.TABLE_NAME = :S_TABLE_NAME /* VARCHAR */ and KCU.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and KCU.TABLE_NAME = :KCU_TABLE_NAME /* VARCHAR */ and KCU.CONSTRAINT_NAME = RC.CONSTRAINT_NAME order by KCU.CONSTRAINT_NAME asc, KCU.COLUMN_NAME asc",
         "SysTableTableName": "[KCU_TABLE_NAME:'data_type_table', S_TABLE_NAME:'sc']",
-        "SysTableTableSchema": "['test']",
-        "Table": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS, INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['test']"
       }
     }
   },
@@ -259,8 +248,7 @@
         },
         "FieldQuery": "select routine_name as `name`, routine_definition as definition from information_schema.routines where 1 != 1",
         "Query": "select routine_name as `name`, routine_definition as definition from information_schema.routines where ROUTINE_SCHEMA = :__vtschemaname /* VARCHAR */ and ROUTINE_TYPE = 'PROCEDURE'",
-        "SysTableTableSchema": "[:v1]",
-        "Table": "information_schema.routines"
+        "SysTableTableSchema": "[:v1]"
       }
     }
   },
@@ -279,8 +267,7 @@
         },
         "FieldQuery": "select sum(data_length + index_length) as size from information_schema.`TABLES` where 1 != 1",
         "Query": "select sum(data_length + index_length) as size from information_schema.`TABLES` where table_schema = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "[:v1]",
-        "Table": "information_schema.`TABLES`"
+        "SysTableTableSchema": "[:v1]"
       }
     }
   },
@@ -297,7 +284,6 @@
         "JoinVars": {
           "kcu_constraint_name": 0
         },
-        "TableName": "information_schema.key_column_usage_information_schema.referential_constraints",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -308,8 +294,7 @@
             },
             "FieldQuery": "select kcu.constraint_name as constraint_name, kcu.column_name as column_name, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.table_name as table_name from information_schema.key_column_usage as kcu where 1 != 1",
             "Query": "select kcu.constraint_name as constraint_name, kcu.column_name as column_name, kcu.referenced_table_name as referenced_table_name, kcu.referenced_column_name as referenced_column_name, kcu.ordinal_position as ordinal_position, kcu.table_name as table_name from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.referenced_column_name is not null order by kcu.ordinal_position asc",
-            "SysTableTableSchema": "[:v1]",
-            "Table": "information_schema.key_column_usage"
+            "SysTableTableSchema": "[:v1]"
           },
           {
             "OperatorType": "Route",
@@ -320,8 +305,7 @@
             },
             "FieldQuery": "select rc.delete_rule as delete_rule, rc.update_rule as update_rule from information_schema.referential_constraints as rc where 1 != 1",
             "Query": "select rc.delete_rule as delete_rule, rc.update_rule as update_rule from information_schema.referential_constraints as rc where rc.constraint_schema = :__vtschemaname /* VARCHAR */ and rc.constraint_name = :kcu_constraint_name /* VARCHAR(64) */",
-            "SysTableTableSchema": "[:v2]",
-            "Table": "information_schema.referential_constraints"
+            "SysTableTableSchema": "[:v2]"
           }
         ]
       }
@@ -342,8 +326,7 @@
         },
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
         "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = database() and rc.table_name = :rc_table_name /* VARCHAR */ and fk.referenced_column_name is not null and fk.table_schema = database() and fk.table_name = :fk_table_name /* VARCHAR */ and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
-        "SysTableTableName": "[fk_table_name:':vtg1', rc_table_name:':vtg1']",
-        "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
+        "SysTableTableName": "[fk_table_name:':vtg1', rc_table_name:':vtg1']"
       }
     }
   },
@@ -362,8 +345,7 @@
         },
         "FieldQuery": "select CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH, DEFAULT_ENCRYPTION from information_schema.schemata where 1 != 1",
         "Query": "select CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH, DEFAULT_ENCRYPTION from information_schema.schemata where schema_name = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "['user']",
-        "Table": "information_schema.schemata"
+        "SysTableTableSchema": "['user']"
       }
     }
   },
@@ -383,8 +365,7 @@
         "FieldQuery": "select table_comment from information_schema.`tables` where 1 != 1",
         "Query": "select table_comment from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */",
         "SysTableTableName": "[table_name:'table_name']",
-        "SysTableTableSchema": "['schema_name']",
-        "Table": "information_schema.`tables`"
+        "SysTableTableSchema": "['schema_name']"
       }
     }
   },
@@ -404,8 +385,7 @@
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
         "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = :__vtschemaname /* VARCHAR */ and rc.table_name = :rc_table_name /* VARCHAR */ and fk.referenced_column_name is not null and fk.table_schema = :__vtschemaname /* VARCHAR */ and fk.table_name = :fk_table_name /* VARCHAR */ and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
         "SysTableTableName": "[fk_table_name:'table_name', rc_table_name:'table_name']",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -423,7 +403,6 @@
           "cc_constraint_name": 0,
           "cc_constraint_schema": 2
         },
-        "TableName": "information_schema.check_constraints_information_schema.table_constraints",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -434,8 +413,7 @@
             },
             "FieldQuery": "select cc.constraint_name as `name`, cc.check_clause as expression, cc.constraint_schema from information_schema.check_constraints as cc where 1 != 1",
             "Query": "select cc.constraint_name as `name`, cc.check_clause as expression, cc.constraint_schema from information_schema.check_constraints as cc where cc.constraint_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['constraint_schema']",
-            "Table": "information_schema.check_constraints"
+            "SysTableTableSchema": "['constraint_schema']"
           },
           {
             "OperatorType": "Route",
@@ -447,8 +425,7 @@
             "FieldQuery": "select 1 from information_schema.table_constraints as tc where 1 != 1",
             "Query": "select 1 from information_schema.table_constraints as tc where tc.table_schema = :__vtschemaname /* VARCHAR */ and tc.table_name = :tc_table_name /* VARCHAR */ and tc.constraint_name = :cc_constraint_name /* VARCHAR(64) */ and tc.constraint_schema = :__vtschemaname /* VARCHAR */",
             "SysTableTableName": "[tc_table_name:'table_name']",
-            "SysTableTableSchema": "['table_schema', :cc_constraint_schema]",
-            "Table": "information_schema.table_constraints"
+            "SysTableTableSchema": "['table_schema', :cc_constraint_schema]"
           }
         ]
       }
@@ -470,8 +447,7 @@
         "FieldQuery": "select column_name from information_schema.statistics where 1 != 1",
         "Query": "select column_name from information_schema.statistics where index_name = 'PRIMARY' and table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */ order by seq_in_index asc",
         "SysTableTableName": "[table_name:'table_name']",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.statistics"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -491,8 +467,7 @@
         "FieldQuery": "select generation_expression from information_schema.`columns` where 1 != 1",
         "Query": "select generation_expression from information_schema.`columns` where table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */ and column_name = 'column_name'",
         "SysTableTableName": "[table_name:'table_name']",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.`columns`"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -510,8 +485,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id from information_schema.`processlist` where 1 != 1",
-        "Query": "select id from information_schema.`processlist` where info like '% FOR UPDATE'",
-        "Table": "information_schema.`processlist`"
+        "Query": "select id from information_schema.`processlist` where info like '% FOR UPDATE'"
       }
     }
   },
@@ -530,8 +504,7 @@
         },
         "FieldQuery": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1) as _subquery where 1 != 1",
         "Query": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */) as _subquery",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.`tables`"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -550,8 +523,7 @@
         },
         "FieldQuery": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1) as _subquery where 1 != 1",
         "Query": "select table_name from (select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_type = 'table_type' and table_name = 'table_name') as _subquery",
-        "SysTableTableSchema": "['table_schema']",
-        "Table": "information_schema.`tables`"
+        "SysTableTableSchema": "['table_schema']"
       }
     }
   },
@@ -570,8 +542,7 @@
         },
         "FieldQuery": "select cc.constraint_name as `name` from information_schema.check_constraints as cc where 1 != 1",
         "Query": "select cc.constraint_name as `name` from information_schema.check_constraints as cc where cc.constraint_schema = :__vtschemaname /* VARCHAR */ and cc.CONSTRAINT_CATALOG = 'a'",
-        "SysTableTableSchema": "['a']",
-        "Table": "information_schema.check_constraints"
+        "SysTableTableSchema": "['a']"
       }
     }
   },
@@ -591,8 +562,7 @@
         "FieldQuery": "select count(*) from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select count(*) from INFORMATION_SCHEMA.`TABLES` where table_schema = :__vtschemaname /* VARCHAR */ and table_name = :table_name /* VARCHAR */",
         "SysTableTableName": "[table_name:'foo']",
-        "SysTableTableSchema": "['performance_schema']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['performance_schema']"
       }
     }
   },
@@ -610,8 +580,7 @@
           "Sharded": false
         },
         "FieldQuery": "select `TABLES`.`CHECKSUM` from information_schema.`TABLES` where 1 != 1",
-        "Query": "select `TABLES`.`CHECKSUM` from information_schema.`TABLES` where TABLE_NAME in (select TABLE_NAME from information_schema.`COLUMNS`)",
-        "Table": "information_schema.`TABLES`"
+        "Query": "select `TABLES`.`CHECKSUM` from information_schema.`TABLES` where TABLE_NAME in (select TABLE_NAME from information_schema.`COLUMNS`)"
       }
     }
   },
@@ -630,8 +599,7 @@
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "['user', 'main']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['user', 'main']"
       }
     }
   },
@@ -649,8 +617,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = database()",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = database()"
       }
     }
   },
@@ -669,8 +636,7 @@
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -690,8 +656,7 @@
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and TABLE_NAME = :TABLE_NAME /* VARCHAR */",
         "SysTableTableName": "[TABLE_NAME:'route1']",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -710,8 +675,7 @@
         },
         "FieldQuery": "select TABLE_NAME from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_NAME from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and DATA_FREE = 42",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -730,8 +694,7 @@
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ and (DATA_FREE = 42 or `CHECKSUM` = 'value')",
-        "SysTableTableSchema": "['ks']",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "SysTableTableSchema": "['ks']"
       }
     }
   },
@@ -749,8 +712,7 @@
           "Sharded": false
         },
         "FieldQuery": "select x.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where 1 != 1) as x where 1 != 1",
-        "Query": "select x.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x",
-        "Table": "information_schema.key_column_usage"
+        "Query": "select x.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x"
       }
     }
   },
@@ -767,7 +729,6 @@
         "JoinVars": {
           "x_COLUMN_NAME": 1
         },
-        "TableName": "information_schema.key_column_usage_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -777,8 +738,7 @@
               "Sharded": false
             },
             "FieldQuery": "select x.table_name, x.COLUMN_NAME from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where 1 != 1) as x where 1 != 1",
-            "Query": "select x.table_name, x.COLUMN_NAME from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x",
-            "Table": "information_schema.key_column_usage"
+            "Query": "select x.table_name, x.COLUMN_NAME from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a) as x"
           },
           {
             "OperatorType": "Route",
@@ -789,7 +749,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where `user`.id = :x_COLUMN_NAME /* VARCHAR(64) */",
-            "Table": "`user`",
             "Values": [
               ":x_COLUMN_NAME"
             ],
@@ -816,8 +775,7 @@
           "Sharded": false
         },
         "FieldQuery": "select a.CONSTRAINT_CATALOG, a.CONSTRAINT_SCHEMA, a.CONSTRAINT_NAME, a.CHECK_CLAUSE, b.CHARACTER_SET_NAME, b.DEFAULT_COLLATE_NAME, b.DESCRIPTION, b.MAXLEN from information_schema.CHECK_CONSTRAINTS as a, information_schema.CHARACTER_SETS as b where 1 != 1",
-        "Query": "select a.CONSTRAINT_CATALOG, a.CONSTRAINT_SCHEMA, a.CONSTRAINT_NAME, a.CHECK_CLAUSE, b.CHARACTER_SET_NAME, b.DEFAULT_COLLATE_NAME, b.DESCRIPTION, b.MAXLEN from information_schema.CHECK_CONSTRAINTS as a, information_schema.CHARACTER_SETS as b",
-        "Table": "information_schema.CHARACTER_SETS, information_schema.CHECK_CONSTRAINTS"
+        "Query": "select a.CONSTRAINT_CATALOG, a.CONSTRAINT_SCHEMA, a.CONSTRAINT_NAME, a.CHECK_CLAUSE, b.CHARACTER_SET_NAME, b.DEFAULT_COLLATE_NAME, b.DESCRIPTION, b.MAXLEN from information_schema.CHECK_CONSTRAINTS as a, information_schema.CHARACTER_SETS as b"
       }
     }
   },
@@ -836,8 +794,7 @@
         },
         "FieldQuery": "select a.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where 1 != 1) as a, (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, UNIQUE_CONSTRAINT_CATALOG, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME, MATCH_OPTION, UPDATE_RULE, DELETE_RULE, TABLE_NAME, REFERENCED_TABLE_NAME from information_schema.referential_constraints where 1 != 1) as b where 1 != 1",
         "Query": "select a.table_name from (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as a where a.table_name = :a_table_name /* VARCHAR */) as a, (select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, UNIQUE_CONSTRAINT_CATALOG, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME, MATCH_OPTION, UPDATE_RULE, DELETE_RULE, TABLE_NAME, REFERENCED_TABLE_NAME from information_schema.referential_constraints where table_name = :table_name /* VARCHAR */) as b",
-        "SysTableTableName": "[a_table_name:'users', table_name:'users']",
-        "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
+        "SysTableTableName": "[a_table_name:'users', table_name:'users']"
       }
     }
   },
@@ -864,8 +821,7 @@
                 },
                 "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
                 "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['music']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['music']"
               },
               {
                 "OperatorType": "Route",
@@ -876,8 +832,7 @@
                 },
                 "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
                 "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-                "SysTableTableSchema": "['music']",
-                "Table": "information_schema.views"
+                "SysTableTableSchema": "['music']"
               }
             ]
           }
@@ -903,8 +858,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableSchema": "['music']"
           },
           {
             "OperatorType": "Route",
@@ -915,8 +869,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
             "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music']",
-            "Table": "information_schema.views"
+            "SysTableTableSchema": "['music']"
           }
         ]
       }
@@ -940,8 +893,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableSchema": "['music', 'Music']"
           },
           {
             "OperatorType": "Route",
@@ -952,8 +904,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
             "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']",
-            "Table": "information_schema.views"
+            "SysTableTableSchema": "['music', 'user']"
           }
         ]
       }
@@ -977,8 +928,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableSchema": "['music', 'Music']"
           },
           {
             "OperatorType": "Route",
@@ -989,8 +939,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
             "Query": "select 1 as found from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']",
-            "Table": "information_schema.views"
+            "SysTableTableSchema": "['music', 'user']"
           }
         ]
       }
@@ -1026,8 +975,7 @@
                     },
                     "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
                     "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name1 /* VARCHAR */ and table_name = :table_name1 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name1:'Music']",
-                    "Table": "information_schema.`tables`"
+                    "SysTableTableName": "[table_name1:'Music']"
                   },
                   {
                     "OperatorType": "Route",
@@ -1038,8 +986,7 @@
                     },
                     "FieldQuery": "select 1 as found from information_schema.views where 1 != 1",
                     "Query": "select 1 as found from information_schema.views where table_name = :table_name2 /* VARCHAR */ and table_name = :table_name2 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name2:'user']",
-                    "Table": "information_schema.views"
+                    "SysTableTableName": "[table_name2:'user']"
                   }
                 ]
               }
@@ -1055,8 +1002,7 @@
             },
             "FieldQuery": "select 1 as found from information_schema.`tables` where 1 != 1",
             "Query": "select 1 as found from information_schema.`tables` where table_name = :table_name /* VARCHAR */ and table_name = :table_name /* VARCHAR */ and :__sq_has_values",
-            "SysTableTableName": "[table_name:'Music']",
-            "Table": "information_schema.`tables`"
+            "SysTableTableName": "[table_name:'Music']"
           }
         ]
       }
@@ -1086,8 +1032,7 @@
                 },
                 "FieldQuery": "select TABLE_NAME from information_schema.`tables` as t where 1 != 1",
                 "Query": "select distinct TABLE_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['a']",
-                "Table": "information_schema.`tables`"
+                "SysTableTableSchema": "['a']"
               },
               {
                 "OperatorType": "Route",
@@ -1097,8 +1042,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select TABLE_NAME from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct TABLE_NAME from information_schema.`columns`",
-                "Table": "information_schema.`columns`"
+                "Query": "select distinct TABLE_NAME from information_schema.`columns`"
               }
             ]
           }
@@ -1139,8 +1083,7 @@
                     },
                     "FieldQuery": "select TABLE_NAME from information_schema.`tables` as t where 1 != 1",
                     "Query": "select distinct TABLE_NAME from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                    "SysTableTableSchema": "['a']",
-                    "Table": "information_schema.`tables`"
+                    "SysTableTableSchema": "['a']"
                   },
                   {
                     "OperatorType": "Route",
@@ -1150,8 +1093,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select COLUMN_NAME from information_schema.`columns` where 1 != 1",
-                    "Query": "select distinct COLUMN_NAME from information_schema.`columns`",
-                    "Table": "information_schema.`columns`"
+                    "Query": "select distinct COLUMN_NAME from information_schema.`columns`"
                   }
                 ]
               }
@@ -1166,8 +1108,7 @@
               "Sharded": false
             },
             "FieldQuery": "select COLLATION_NAME from information_schema.`COLUMNS` as t where 1 != 1",
-            "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where :__sq_has_values and COLUMN_NAME in ::__sq1",
-            "Table": "information_schema.`COLUMNS`"
+            "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where :__sq_has_values and COLUMN_NAME in ::__sq1"
           }
         ]
       }
@@ -1187,8 +1128,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = 'ks' or TABLE_SCHEMA = 'main'",
-        "Table": "INFORMATION_SCHEMA.`TABLES`"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = 'ks' or TABLE_SCHEMA = 'main'"
       }
     }
   },
@@ -1206,8 +1146,7 @@
           "Sharded": false
         },
         "FieldQuery": "select variable, value from sys.sys_config where 1 != 1",
-        "Query": "select variable, value from sys.sys_config",
-        "Table": "sys.sys_config"
+        "Query": "select variable, value from sys.sys_config"
       }
     }
   },
@@ -1225,8 +1164,7 @@
           "Sharded": false
         },
         "FieldQuery": "select host, db from mysql.db where 1 != 1",
-        "Query": "select host, db from mysql.db",
-        "Table": "mysql.db"
+        "Query": "select host, db from mysql.db"
       }
     }
   },
@@ -1244,8 +1182,7 @@
           "Sharded": false
         },
         "FieldQuery": "select logged, prio from performance_schema.error_log where 1 != 1",
-        "Query": "select logged, prio from performance_schema.error_log",
-        "Table": "performance_schema.error_log"
+        "Query": "select logged, prio from performance_schema.error_log"
       }
     }
   },
@@ -1263,8 +1200,7 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_NAME from information_schema.apa where 1 != 1",
-        "Query": "select TABLE_NAME from information_schema.apa",
-        "Table": "information_schema.apa"
+        "Query": "select TABLE_NAME from information_schema.apa"
       }
     }
   },
@@ -1281,7 +1217,6 @@
         "JoinVars": {
           "tables_table_name": 0
         },
-        "TableName": "information_schema.`tables`_information_schema.`columns`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1291,8 +1226,7 @@
               "Sharded": false
             },
             "FieldQuery": "select `tables`.table_name from (select table_name from information_schema.`tables` where 1 != 1) as `tables` where 1 != 1",
-            "Query": "select `tables`.table_name from (select table_name from information_schema.`tables` where table_schema != 'information_schema' limit 1) as `tables`",
-            "Table": "information_schema.`tables`"
+            "Query": "select `tables`.table_name from (select table_name from information_schema.`tables` where table_schema != 'information_schema' limit 1) as `tables`"
           },
           {
             "OperatorType": "Route",
@@ -1303,8 +1237,7 @@
             },
             "FieldQuery": "select c.column_name from information_schema.`columns` as c where 1 != 1",
             "Query": "select c.column_name from information_schema.`columns` as c where c.table_name = :c_table_name /* VARCHAR */",
-            "SysTableTableName": "[c_table_name::tables_table_name]",
-            "Table": "information_schema.`columns`"
+            "SysTableTableName": "[c_table_name::tables_table_name]"
           }
         ]
       }

--- a/go/vt/vtgate/planbuilder/testdata/large_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/large_cases.json
@@ -9,7 +9,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "music, music_extra_`user`, user_extra, user_metadata_unsharded, unsharded_a, unsharded_auto, unsharded_b",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -19,14 +18,12 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from music, music_extra where 1 != 1",
-            "Query": "select 1 from music, music_extra where music.id = music_extra.music_id",
-            "Table": "music, music_extra"
+            "Query": "select 1 from music, music_extra where music.id = music_extra.music_id"
           },
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
-            "TableName": "`user`, user_extra, user_metadata_unsharded, unsharded_a, unsharded_auto, unsharded_b",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -36,8 +33,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.id from `user`, user_extra, user_metadata where 1 != 1",
-                "Query": "select `user`.id from `user`, user_extra, user_metadata where `user`.id = user_extra.user_id and user_metadata.user_id = user_extra.user_id",
-                "Table": "`user`, user_extra, user_metadata"
+                "Query": "select `user`.id from `user`, user_extra, user_metadata where `user`.id = user_extra.user_id and user_metadata.user_id = user_extra.user_id"
               },
               {
                 "OperatorType": "Route",
@@ -47,8 +43,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded, unsharded_a, unsharded_b, unsharded_auto where 1 != 1",
-                "Query": "select 1 from unsharded, unsharded_a, unsharded_b, unsharded_auto where unsharded.x = unsharded_a.y",
-                "Table": "unsharded, unsharded_a, unsharded_auto, unsharded_b"
+                "Query": "select 1 from unsharded, unsharded_a, unsharded_b, unsharded_auto where unsharded.x = unsharded_a.y"
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/large_union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/large_union_cases.json
@@ -25,7 +25,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from ((select content, user_id from music where 1 != 1) union (select content, user_id from music where 1 != 1)) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from ((select content, user_id from music where user_id = 1270698330 order by created_at asc, id asc limit 11) union (select content, user_id from music where user_id = 1270698330 order by created_at asc, id asc limit 11)) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270698330"
                 ],
@@ -40,7 +39,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from ((select content, user_id from music where 1 != 1) union (select content, user_id from music where 1 != 1)) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from ((select content, user_id from music where user_id = 1270699497 order by created_at asc, id asc limit 11) union (select content, user_id from music where user_id = 1270699497 order by created_at asc, id asc limit 11)) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270699497"
                 ],
@@ -55,7 +53,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270703806 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270703806"
                 ],
@@ -70,7 +67,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270707364 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270707364"
                 ],
@@ -85,7 +81,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270714657 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270714657"
                 ],
@@ -100,7 +95,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270721330 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270721330"
                 ],
@@ -115,7 +109,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270812079 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270812079"
                 ],
@@ -130,7 +123,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271011532 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271011532"
                 ],
@@ -145,7 +137,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271034164 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271034164"
                 ],
@@ -160,7 +151,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271034177 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271034177"
                 ],
@@ -175,7 +165,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271066849 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271066849"
                 ],
@@ -190,7 +179,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271098740 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271098740"
                 ],
@@ -205,7 +193,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271355000 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271355000"
                 ],
@@ -220,7 +207,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271639345 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271639345"
                 ],
@@ -235,7 +221,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271914117 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271914117"
                 ],
@@ -250,7 +235,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271924504 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271924504"
                 ],
@@ -265,7 +249,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272086055 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272086055"
                 ],
@@ -280,7 +263,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272127855 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272127855"
                 ],
@@ -295,7 +277,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272191137 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272191137"
                 ],
@@ -310,7 +291,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272468271 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272468271"
                 ],
@@ -325,7 +305,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270637436 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270637436"
                 ],
@@ -340,7 +319,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270644941 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270644941"
                 ],
@@ -355,7 +333,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270650576 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270650576"
                 ],
@@ -370,7 +347,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270652906 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270652906"
                 ],
@@ -385,7 +361,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270660650 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270660650"
                 ],
@@ -400,7 +375,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270670201 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270670201"
                 ],
@@ -415,7 +389,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270707364 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270707364"
                 ],
@@ -430,7 +403,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271365691 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271365691"
                 ],
@@ -445,7 +417,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271799956 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271799956"
                 ],
@@ -460,7 +431,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271914117 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271914117"
                 ],
@@ -475,7 +445,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270637436 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270637436"
                 ],
@@ -490,7 +459,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271799956 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271799956"
                 ],
@@ -505,7 +473,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270637436 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270637436"
                 ],
@@ -520,7 +487,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271639345 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271639345"
                 ],
@@ -535,7 +501,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270644941 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270644941"
                 ],
@@ -550,7 +515,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270649256 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270649256"
                 ],
@@ -565,7 +529,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270653671 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270653671"
                 ],
@@ -580,7 +543,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270670201 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270670201"
                 ],
@@ -595,7 +557,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270717223 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270717223"
                 ],
@@ -610,7 +571,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270720898 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270720898"
                 ],
@@ -625,7 +585,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270982590 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270982590"
                 ],
@@ -640,7 +599,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271346411 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271346411"
                 ],
@@ -655,7 +613,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271352121 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271352121"
                 ],
@@ -670,7 +627,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271354908 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271354908"
                 ],
@@ -685,7 +641,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271365691 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271365691"
                 ],
@@ -700,7 +655,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271367516 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271367516"
                 ],
@@ -715,7 +669,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271472522 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271472522"
                 ],
@@ -730,7 +683,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271607757 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271607757"
                 ],
@@ -745,7 +697,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271639345 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271639345"
                 ],
@@ -760,7 +711,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271821733 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271821733"
                 ],
@@ -775,7 +725,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271914117 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271914117"
                 ],
@@ -790,7 +739,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272068709 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272068709"
                 ],
@@ -805,7 +753,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272127855 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272127855"
                 ],
@@ -820,7 +767,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272191137 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272191137"
                 ],
@@ -835,7 +781,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272244005 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272244005"
                 ],
@@ -850,7 +795,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272468271 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272468271"
                 ],
@@ -865,7 +809,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270982590 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270982590"
                 ],
@@ -880,7 +823,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271365691 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271365691"
                 ],
@@ -895,7 +837,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271607757 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271607757"
                 ],
@@ -910,7 +851,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1270982590 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1270982590"
                 ],
@@ -925,7 +865,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271365691 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271365691"
                 ],
@@ -940,7 +879,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1271607757 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1271607757"
                 ],
@@ -955,7 +893,6 @@
                 },
                 "FieldQuery": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select content, user_id from music where 1 != 1) as dt(c0, c1) where 1 != 1",
                 "Query": "select dt.c0 as content, dt.c1 as user_id, weight_string(dt.c0), weight_string(dt.c1) from (select distinct content, user_id from music where user_id = 1272244005 order by created_at asc, id asc limit 11) as dt(c0, c1)",
-                "Table": "music",
                 "Values": [
                   "1272244005"
                 ],

--- a/go/vt/vtgate/planbuilder/testdata/lock_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/lock_cases.json
@@ -138,7 +138,6 @@
         "JoinVars": {
           "u_foo": 2
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -148,8 +147,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.col, u.bar, u.foo from `user` as u where 1 != 1",
-            "Query": "select u.col, u.bar, u.foo from `user` as u for update nowait",
-            "Table": "`user`"
+            "Query": "select u.col, u.bar, u.foo from `user` as u for update nowait"
           },
           {
             "OperatorType": "Route",
@@ -159,8 +157,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from music as m where 1 != 1",
-            "Query": "select 1 from music as m where m.foo = :u_foo for update nowait",
-            "Table": "music"
+            "Query": "select 1 from music as m where m.foo = :u_foo for update nowait"
           }
         ]
       },
@@ -183,7 +180,6 @@
         "JoinVars": {
           "u_foo": 2
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -193,8 +189,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.col, u.bar, u.foo from `user` as u where 1 != 1",
-            "Query": "select u.col, u.bar, u.foo from `user` as u for share skip locked",
-            "Table": "`user`"
+            "Query": "select u.col, u.bar, u.foo from `user` as u for share skip locked"
           },
           {
             "OperatorType": "Route",
@@ -204,8 +199,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from music as m where 1 != 1",
-            "Query": "select 1 from music as m where m.foo = :u_foo for share skip locked",
-            "Table": "music"
+            "Query": "select 1 from music as m where m.foo = :u_foo for share skip locked"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -27,8 +27,7 @@
                 },
                 "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(`user`.b) from `user` where 1 != 1 group by a, weight_string(a)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*), weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc",
-                "Table": "`user`"
+                "Query": "select a, b, count(*), weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc"
               }
             ]
           }
@@ -66,8 +65,7 @@
                 },
                 "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
-                "Table": "`user`"
+                "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc"
               }
             ]
           }
@@ -106,8 +104,7 @@
                 },
                 "FieldQuery": "select a, b, count(*) as k, weight_string(a), weight_string(`user`.b) from `user` where 1 != 1 group by a, weight_string(a)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*) as k, weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc",
-                "Table": "`user`"
+                "Query": "select a, b, count(*) as k, weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc"
               }
             ]
           }
@@ -149,8 +146,7 @@
                     },
                     "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
                     "OrderBy": "(0|3) ASC",
-                    "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
-                    "Table": "`user`"
+                    "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc"
                   }
                 ]
               }
@@ -191,8 +187,7 @@
                 },
                 "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
-                "Table": "`user`"
+                "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc"
               }
             ]
           }
@@ -229,8 +224,7 @@
                 },
                 "FieldQuery": "select textcol1 as t, count(*) as k from `user` where 1 != 1 group by textcol1",
                 "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-                "Query": "select textcol1 as t, count(*) as k from `user` group by textcol1 order by textcol1 asc",
-                "Table": "`user`"
+                "Query": "select textcol1 as t, count(*) as k from `user` group by textcol1 order by textcol1 asc"
               }
             ]
           }
@@ -251,7 +245,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -262,8 +255,7 @@
             },
             "FieldQuery": "select t.id, t.col, weight_string(t.id) from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
             "OrderBy": "(0|2) ASC",
-            "Query": "select t.id, t.col, weight_string(t.id) from (select `user`.id, `user`.col from `user`) as t order by t.id asc",
-            "Table": "`user`"
+            "Query": "select t.id, t.col, weight_string(t.id) from (select `user`.id, `user`.col from `user`) as t order by t.id asc"
           },
           {
             "OperatorType": "Route",
@@ -273,8 +265,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -303,7 +294,6 @@
             "JoinVars": {
               "user_id": 2
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -314,7 +304,6 @@
                 },
                 "FieldQuery": "select `user`.col1 as a, `user`.col2 as b, `user`.id from `user` where 1 != 1",
                 "Query": "select `user`.col1 as a, `user`.col2 as b, `user`.id from `user` where `user`.id = 1",
-                "Table": "`user`",
                 "Values": [
                   "1"
                 ],
@@ -329,7 +318,6 @@
                 },
                 "FieldQuery": "select music.col3 as c, weight_string(music.col3) from music where 1 != 1",
                 "Query": "select music.col3 as c, weight_string(music.col3) from music where music.id = :user_id",
-                "Table": "music",
                 "Values": [
                   ":user_id"
                 ],
@@ -364,7 +352,6 @@
             "JoinVars": {
               "user_id": 4
             },
-            "TableName": "`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -375,7 +362,6 @@
                 },
                 "FieldQuery": "select `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2), `user`.id from `user` where 1 != 1",
                 "Query": "select `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2), `user`.id from `user` where `user`.id = 1",
-                "Table": "`user`",
                 "Values": [
                   "1"
                 ],
@@ -390,7 +376,6 @@
                 },
                 "FieldQuery": "select music.col3, weight_string(music.col3) from music where 1 != 1",
                 "Query": "select music.col3, weight_string(music.col3) from music where music.id = :user_id",
-                "Table": "music",
                 "Values": [
                   ":user_id"
                 ],
@@ -422,7 +407,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,L:1,R:0,R:1",
-            "TableName": "`user`_unsharded",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -432,8 +416,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.a, u.textcol1 from `user` as u where 1 != 1",
-                "Query": "select u.a, u.textcol1 from `user` as u",
-                "Table": "`user`"
+                "Query": "select u.a, u.textcol1 from `user` as u"
               },
               {
                 "OperatorType": "Route",
@@ -443,8 +426,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select un.col2, weight_string(un.col2) from unsharded as un where 1 != 1",
-                "Query": "select un.col2, weight_string(un.col2) from unsharded as un",
-                "Table": "unsharded"
+                "Query": "select un.col2, weight_string(un.col2) from unsharded as un"
               }
             ]
           }
@@ -472,7 +454,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "R:0,R:1,L:0,L:1",
-            "TableName": "unsharded_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -482,8 +463,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select un.col2, weight_string(un.col2) from unsharded as un where 1 != 1",
-                "Query": "select un.col2, weight_string(un.col2) from unsharded as un",
-                "Table": "unsharded"
+                "Query": "select un.col2, weight_string(un.col2) from unsharded as un"
               },
               {
                 "OperatorType": "Route",
@@ -493,8 +473,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.a, u.textcol1 from `user` as u where 1 != 1",
-                "Query": "select u.a, u.textcol1 from `user` as u",
-                "Table": "`user`"
+                "Query": "select u.a, u.textcol1 from `user` as u"
               }
             ]
           }
@@ -558,8 +537,7 @@
         "FieldQuery": "select a, convert(`user`.a, binary), weight_string(convert(`user`.a, binary)) from `user` where 1 != 1",
         "OrderBy": "(1|2) DESC",
         "Query": "select a, convert(`user`.a, binary), weight_string(convert(`user`.a, binary)) from `user` order by convert(`user`.a, binary) desc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -579,7 +557,6 @@
         "JoinVars": {
           "u_a": 0
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -590,8 +567,7 @@
             },
             "FieldQuery": "select u.a, convert(u.a, binary), weight_string(convert(u.a, binary)) from `user` as u where 1 != 1",
             "OrderBy": "(1|2) DESC",
-            "Query": "select u.a, convert(u.a, binary), weight_string(convert(u.a, binary)) from `user` as u order by convert(u.a, binary) desc",
-            "Table": "`user`"
+            "Query": "select u.a, convert(u.a, binary), weight_string(convert(u.a, binary)) from `user` as u order by convert(u.a, binary) desc"
           },
           {
             "OperatorType": "Route",
@@ -601,8 +577,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from music as m where 1 != 1",
-            "Query": "select 1 from music as m where m.a = :u_a",
-            "Table": "music"
+            "Query": "select 1 from music as m where m.a = :u_a"
           }
         ]
       },
@@ -627,8 +602,7 @@
         },
         "FieldQuery": "select id, intcol from `user` where 1 != 1",
         "OrderBy": "1 ASC",
-        "Query": "select id, intcol from `user` order by `user`.intcol asc",
-        "Table": "`user`"
+        "Query": "select id, intcol from `user` order by `user`.intcol asc"
       },
       "TablesUsed": [
         "user.user"
@@ -651,8 +625,7 @@
         "FieldQuery": "select col, id, weight_string(id) from `user` where 1 != 1",
         "OrderBy": "(1|2) ASC",
         "Query": "select col, id, weight_string(id) from `user` order by id asc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -675,7 +648,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,R:0,R:1,L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -685,8 +657,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select tbl.foo, weight_string(tbl.foo) from (select u.foo from `user` as u where 1 != 1) as tbl where 1 != 1",
-                "Query": "select tbl.foo, weight_string(tbl.foo) from (select u.foo from `user` as u) as tbl",
-                "Table": "`user`"
+                "Query": "select tbl.foo, weight_string(tbl.foo) from (select u.foo from `user` as u) as tbl"
               },
               {
                 "OperatorType": "Route",
@@ -696,8 +667,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select tbl.bar, weight_string(tbl.bar) from (select ue.bar from user_extra as ue where 1 != 1) as tbl where 1 != 1",
-                "Query": "select tbl.bar, weight_string(tbl.bar) from (select ue.bar from user_extra as ue) as tbl",
-                "Table": "user_extra"
+                "Query": "select tbl.bar, weight_string(tbl.bar) from (select ue.bar from user_extra as ue) as tbl"
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/misc_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/misc_cases.json
@@ -86,7 +86,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where id = :v1",
-            "Table": "`user`",
             "Values": [
               ":v1"
             ],
@@ -121,7 +120,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where id in ::__vals",
-            "Table": "`user`",
             "Values": [
               "(:v1, :v2)"
             ],
@@ -152,8 +150,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
-            "Query": "select 1 from `user`",
-            "Table": "`user`"
+            "Query": "select 1 from `user`"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/oltp_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/oltp_cases.json
@@ -14,7 +14,6 @@
         },
         "FieldQuery": "select c from sbtest34 where 1 != 1",
         "Query": "select c from sbtest34 where id = 15",
-        "Table": "sbtest34",
         "Values": [
           "15"
         ],
@@ -39,8 +38,7 @@
           "Sharded": true
         },
         "FieldQuery": "select c from sbtest12 where 1 != 1",
-        "Query": "select c from sbtest12 where id between 1 and 10",
-        "Table": "sbtest12"
+        "Query": "select c from sbtest12 where id between 1 and 10"
       },
       "TablesUsed": [
         "main.sbtest12"
@@ -66,8 +64,7 @@
               "Sharded": true
             },
             "FieldQuery": "select sum(k) from sbtest43 where 1 != 1",
-            "Query": "select sum(k) from sbtest43 where id between 90 and 990",
-            "Table": "sbtest43"
+            "Query": "select sum(k) from sbtest43 where id between 90 and 990"
           }
         ]
       },
@@ -91,8 +88,7 @@
         },
         "FieldQuery": "select c from sbtest1 where 1 != 1",
         "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-        "Query": "select c from sbtest1 where id between 50 and 235 order by sbtest1.c asc",
-        "Table": "sbtest1"
+        "Query": "select c from sbtest1 where id between 50 and 235 order by sbtest1.c asc"
       },
       "TablesUsed": [
         "main.sbtest1"
@@ -119,8 +115,7 @@
             },
             "FieldQuery": "select c from sbtest30 where 1 != 1 group by c",
             "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-            "Query": "select c from sbtest30 where id between 1 and 10 group by c order by sbtest30.c asc",
-            "Table": "sbtest30"
+            "Query": "select c from sbtest30 where id between 1 and 10 group by c order by sbtest30.c asc"
           }
         ]
       },
@@ -144,7 +139,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update sbtest6 set k = k + 1 where id = 5",
-        "Table": "sbtest6",
         "Values": [
           "5"
         ],
@@ -170,7 +164,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update sbtest9 set c = 7 where id = 8",
-        "Table": "sbtest9",
         "Values": [
           "8"
         ],
@@ -196,7 +189,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete from sbtest15 where id = 7525",
-        "Table": "sbtest15",
         "Values": [
           "7525"
         ],
@@ -222,7 +214,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into sbtest16(id, k, c, pad) values (:_id_0, 1, 2, 50)",
-        "TableName": "sbtest16",
         "VindexValues": {
           "hash": "42"
         }

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -13,8 +13,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col1 from `user` where 1 != 1",
-        "Query": "select `user`.col1 from `user` where col2 = 2",
-        "Table": "`user`"
+        "Query": "select `user`.col1 from `user` where col2 = 2"
       },
       "TablesUsed": [
         "user.user"
@@ -36,7 +35,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -46,8 +44,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col1 from `user` where 1 != 1",
-            "Query": "select `user`.col1 from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col1 from `user`"
           },
           {
             "OperatorType": "Route",
@@ -57,8 +54,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col1 from user_extra where 1 != 1",
-            "Query": "select user_extra.col1 from user_extra where user_extra.col1 = 2",
-            "Table": "user_extra"
+            "Query": "select user_extra.col1 from user_extra where user_extra.col1 = 2"
           }
         ]
       },
@@ -78,7 +74,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,L:1,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -88,8 +83,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col1 as a, `user`.col2 from `user` where 1 != 1",
-            "Query": "select `user`.col1 as a, `user`.col2 from `user` where `user`.col1 = 1 and `user`.col1 = `user`.col2",
-            "Table": "`user`"
+            "Query": "select `user`.col1 as a, `user`.col2 from `user` where `user`.col1 = 1 and `user`.col1 = `user`.col2"
           },
           {
             "OperatorType": "Route",
@@ -99,8 +93,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col3 from user_extra where 1 != 1",
-            "Query": "select user_extra.col3 from user_extra where user_extra.col3 = 1",
-            "Table": "user_extra"
+            "Query": "select user_extra.col3 from user_extra where user_extra.col3 = 1"
           }
         ]
       },
@@ -133,8 +126,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -146,7 +138,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where :__sq_has_values and `user`.id in ::__vals",
-            "Table": "`user`",
             "Values": [
               "::__sq1"
             ],
@@ -174,7 +165,6 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "Query": "select col from `user` where id = 5 order by aa asc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -200,7 +190,6 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "Query": "select col from `user` where id = 1 order by col asc",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -226,8 +215,7 @@
         },
         "FieldQuery": "select col from `user` where 1 != 1",
         "OrderBy": "0 ASC",
-        "Query": "select col from `user` order by `user`.col asc",
-        "Table": "`user`"
+        "Query": "select col from `user` order by `user`.col asc"
       },
       "TablesUsed": [
         "user.user"
@@ -250,8 +238,7 @@
         "FieldQuery": "select user_id, col1, col2, weight_string(user_id) from authoritative where 1 != 1",
         "OrderBy": "(0|3) ASC",
         "Query": "select user_id, col1, col2, weight_string(user_id) from authoritative order by authoritative.user_id asc",
-        "ResultColumns": 3,
-        "Table": "authoritative"
+        "ResultColumns": 3
       },
       "TablesUsed": [
         "user.authoritative"
@@ -275,7 +262,6 @@
             "JoinVars": {
               "user_c": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Limit",
@@ -289,8 +275,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select `user`.c from `user` where 1 != 1",
-                    "Query": "select `user`.c from `user` where `user`.a = 1 limit 1",
-                    "Table": "`user`"
+                    "Query": "select `user`.c from `user` where `user`.a = 1 limit 1"
                   }
                 ]
               },
@@ -306,8 +291,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-                    "Query": "select user_extra.id from user_extra where user_extra.c = :user_c and user_extra.b = 2 limit 1",
-                    "Table": "user_extra"
+                    "Query": "select user_extra.id from user_extra where user_extra.c = :user_c and user_extra.b = 2 limit 1"
                   }
                 ]
               }
@@ -336,8 +320,7 @@
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
         "OrderBy": "1 ASC COLLATE latin1_swedish_ci",
-        "Query": "select user_id, col1, col2 from authoritative order by authoritative.col1 asc",
-        "Table": "authoritative"
+        "Query": "select user_id, col1, col2 from authoritative order by authoritative.col1 asc"
       },
       "TablesUsed": [
         "user.authoritative"
@@ -360,8 +343,7 @@
         "FieldQuery": "select a, textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1",
         "OrderBy": "(0|3) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|4) ASC",
         "Query": "select a, textcol1, b, weight_string(a), weight_string(b) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
-        "ResultColumns": 3,
-        "Table": "`user`"
+        "ResultColumns": 3
       },
       "TablesUsed": [
         "user.user"
@@ -384,8 +366,7 @@
         "FieldQuery": "select a, `user`.textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1",
         "OrderBy": "(0|3) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|4) ASC",
         "Query": "select a, `user`.textcol1, b, weight_string(a), weight_string(b) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
-        "ResultColumns": 3,
-        "Table": "`user`"
+        "ResultColumns": 3
       },
       "TablesUsed": [
         "user.user"
@@ -408,8 +389,7 @@
         "FieldQuery": "select a, textcol1, b, textcol2, weight_string(a), weight_string(b), weight_string(textcol2) from `user` where 1 != 1",
         "OrderBy": "(0|4) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|5) ASC, (3|6) ASC COLLATE ",
         "Query": "select a, textcol1, b, textcol2, weight_string(a), weight_string(b), weight_string(textcol2) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc, `user`.textcol2 asc",
-        "ResultColumns": 4,
-        "Table": "`user`"
+        "ResultColumns": 4
       },
       "TablesUsed": [
         "user.user"
@@ -437,8 +417,7 @@
         "FieldQuery": "select id as foo, weight_string(id) from music where 1 != 1",
         "OrderBy": "(0|1) ASC",
         "Query": "select id as foo, weight_string(id) from music order by id asc",
-        "ResultColumns": 1,
-        "Table": "music"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.music"
@@ -459,8 +438,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` order by null",
-        "Table": "`user`"
+        "Query": "select col from `user` order by null"
       },
       "TablesUsed": [
         "user.user"
@@ -490,8 +468,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col2 from `user` where 1 != 1",
-            "Query": "select col2 from `user`",
-            "Table": "`user`"
+            "Query": "select col2 from `user`"
           },
           {
             "InputName": "Outer",
@@ -503,8 +480,7 @@
             },
             "FieldQuery": "select col from `user` where 1 != 1",
             "OrderBy": "0 ASC",
-            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1 order by `user`.col asc",
-            "Table": "`user`"
+            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1 order by `user`.col asc"
           }
         ]
       },
@@ -526,7 +502,6 @@
         "JoinVars": {
           "user_id": 2
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -537,7 +512,6 @@
             },
             "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
             "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1",
-            "Table": "`user`",
             "Values": [
               "1"
             ],
@@ -552,7 +526,6 @@
             },
             "FieldQuery": "select music.col3 from music where 1 != 1",
             "Query": "select music.col3 from music where music.id = :user_id",
-            "Table": "music",
             "Values": [
               ":user_id"
             ],
@@ -579,7 +552,6 @@
         "JoinVars": {
           "user_id": 2
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -590,7 +562,6 @@
             },
             "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
             "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by `user`.col1 asc",
-            "Table": "`user`",
             "Values": [
               "1"
             ],
@@ -605,7 +576,6 @@
             },
             "FieldQuery": "select music.col3 from music where 1 != 1",
             "Query": "select music.col3 from music where music.id = :user_id",
-            "Table": "music",
             "Values": [
               ":user_id"
             ],
@@ -632,7 +602,6 @@
         "JoinVars": {
           "user_id": 2
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -643,7 +612,6 @@
             },
             "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
             "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by `user`.col1 asc",
-            "Table": "`user`",
             "Values": [
               "1"
             ],
@@ -658,7 +626,6 @@
             },
             "FieldQuery": "select music.col3 from music where 1 != 1",
             "Query": "select music.col3 from music where music.id = :user_id",
-            "Table": "music",
             "Values": [
               ":user_id"
             ],
@@ -695,8 +662,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col2 from `user` where 1 != 1",
-            "Query": "select col2 from `user`",
-            "Table": "`user`"
+            "Query": "select col2 from `user`"
           },
           {
             "InputName": "Outer",
@@ -707,8 +673,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1",
-            "Table": "`user`"
+            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1"
           }
         ]
       },
@@ -731,8 +696,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` order by RAND()",
-        "Table": "`user`"
+        "Query": "select col from `user` order by RAND()"
       },
       "TablesUsed": [
         "user.user"
@@ -752,7 +716,6 @@
         "JoinVars": {
           "user_id": 2
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -763,7 +726,6 @@
             },
             "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
             "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by RAND()",
-            "Table": "`user`",
             "Values": [
               "1"
             ],
@@ -778,7 +740,6 @@
             },
             "FieldQuery": "select music.col3 from music where 1 != 1",
             "Query": "select music.col3 from music where music.id = :user_id",
-            "Table": "music",
             "Values": [
               ":user_id"
             ],
@@ -815,8 +776,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col2 from `user` where 1 != 1",
-            "Query": "select col2 from `user`",
-            "Table": "`user`"
+            "Query": "select col2 from `user`"
           },
           {
             "InputName": "Outer",
@@ -827,8 +787,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1 order by rand()",
-            "Table": "`user`"
+            "Query": "select col from `user` where :__sq_has_values and col in ::__sq1 order by rand()"
           }
         ]
       },
@@ -852,7 +811,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 5 order by col asc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -878,7 +836,6 @@
         },
         "FieldQuery": "select `user`.* from `user` where 1 != 1",
         "Query": "select `user`.* from `user` where id = 5 order by `user`.col asc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -904,7 +861,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 5 order by `user`.col asc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -928,7 +884,6 @@
         "JoinVars": {
           "u_col": 1
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -938,8 +893,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
-            "Query": "select u.id, u.col from `user` as u where u.col in (select * from `user` where `user`.id = u.id order by col asc)",
-            "Table": "`user`"
+            "Query": "select u.id, u.col from `user` as u where u.col in (select * from `user` where `user`.id = u.id order by col asc)"
           },
           {
             "OperatorType": "Route",
@@ -949,8 +903,7 @@
               "Sharded": true
             },
             "FieldQuery": "select e.id from user_extra as e where 1 != 1",
-            "Query": "select e.id from user_extra as e where e.col = :u_col /* INT16 */",
-            "Table": "user_extra"
+            "Query": "select e.id from user_extra as e where e.col = :u_col /* INT16 */"
           }
         ]
       },
@@ -974,8 +927,7 @@
           "Sharded": true
         },
         "FieldQuery": "select u.id from `user` as u where 1 != 1",
-        "Query": "select u.id from `user` as u where u.id in (select col2 from `user` where `user`.id = u.id order by u.col asc)",
-        "Table": "`user`"
+        "Query": "select u.id from `user` as u where u.id in (select col2 from `user` where `user`.id = u.id order by u.col asc)"
       },
       "TablesUsed": [
         "user.user"
@@ -1012,7 +964,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 5 order by `user`.col collate utf8_general_ci asc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1038,7 +989,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 5 order by -col1 asc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1064,7 +1014,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 5 order by concat(col, col1) collate utf8_general_ci desc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1090,7 +1039,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 5 order by id + col collate utf8_general_ci desc",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1116,7 +1064,6 @@
         },
         "FieldQuery": "select * from (select user_id from user_extra where 1 != 1) as eu, `user` as u where 1 != 1",
         "Query": "select * from (select user_id from user_extra where user_id = 5) as eu, `user` as u where u.id = 5 and u.id = eu.user_id order by eu.user_id asc",
-        "Table": "`user`, user_extra",
         "Values": [
           "5"
         ],
@@ -1143,7 +1090,6 @@
         },
         "FieldQuery": "select col from `user` as route1 where 1 != 1",
         "Query": "select col from `user` as route1 where id = 1 order by route1.col asc",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1169,7 +1115,6 @@
         },
         "FieldQuery": "select col1 from `user` where 1 != 1",
         "Query": "select col1 from `user` where id = 1 limit 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1194,7 +1139,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1204,8 +1148,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select `user`.col from `user`"
               },
               {
                 "OperatorType": "Limit",
@@ -1219,8 +1162,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra limit 1",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra limit 1"
                   }
                 ]
               }
@@ -1252,8 +1194,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user` limit 1",
-            "Table": "`user`"
+            "Query": "select col from `user` limit 1"
           }
         ]
       },
@@ -1280,8 +1221,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user` limit :a",
-            "Table": "`user`"
+            "Query": "select col from `user` limit :a"
           }
         ]
       },
@@ -1308,8 +1248,7 @@
               "Sharded": true
             },
             "FieldQuery": "select * from `user` where 1 != 1",
-            "Query": "select * from `user` where id1 = 4 and name1 = 'abc' limit 5",
-            "Table": "`user`"
+            "Query": "select * from `user` where id1 = 4 and name1 = 'abc' limit 5"
           }
         ]
       },
@@ -1345,8 +1284,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select col1 from `user` where 1 != 1",
-                "Query": "select col1 from `user`",
-                "Table": "`user`"
+                "Query": "select col1 from `user`"
               },
               {
                 "InputName": "Outer",
@@ -1357,8 +1295,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select col from `user` where 1 != 1",
-                "Query": "select col from `user` where :__sq_has_values and col in ::__sq1",
-                "Table": "`user`"
+                "Query": "select col from `user` where :__sq_has_values and col in ::__sq1"
               }
             ]
           }
@@ -1383,8 +1320,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from ref where 1 != 1",
-        "Query": "select col from ref limit 1",
-        "Table": "ref"
+        "Query": "select col from ref limit 1"
       },
       "TablesUsed": [
         "user.ref"
@@ -1409,8 +1345,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` limit 1 + 1",
-            "Table": "`user`"
+            "Query": "select id from `user` limit 1 + 1"
           }
         ]
       },
@@ -1435,8 +1370,7 @@
         "FieldQuery": "select id as foo, weight_string(id) from music where 1 != 1",
         "OrderBy": "(0|1) ASC",
         "Query": "select id as foo, weight_string(id) from music order by music.id asc",
-        "ResultColumns": 1,
-        "Table": "music"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.music"
@@ -1459,8 +1393,7 @@
         "FieldQuery": "select id as foo, id2 as id, weight_string(id2) from music where 1 != 1",
         "OrderBy": "(1|2) ASC",
         "Query": "select id as foo, id2 as id, weight_string(id2) from music order by music.id2 asc",
-        "ResultColumns": 2,
-        "Table": "music"
+        "ResultColumns": 2
       },
       "TablesUsed": [
         "user.music"
@@ -1477,7 +1410,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1488,8 +1420,7 @@
             },
             "FieldQuery": "select `name`, weight_string(`name`) from `user` where 1 != 1",
             "OrderBy": "(0|1) ASC",
-            "Query": "select `name`, weight_string(`name`) from `user` order by `user`.`name` asc",
-            "Table": "`user`"
+            "Query": "select `name`, weight_string(`name`) from `user` order by `user`.`name` asc"
           },
           {
             "OperatorType": "Route",
@@ -1499,8 +1430,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from music where 1 != 1",
-            "Query": "select 1 from music",
-            "Table": "music"
+            "Query": "select 1 from music"
           }
         ]
       },
@@ -1529,8 +1459,7 @@
               "Sharded": true
             },
             "FieldQuery": "select count(id), num from `user` where 1 != 1",
-            "Query": "select count(id), num from `user`",
-            "Table": "`user`"
+            "Query": "select count(id), num from `user`"
           }
         ]
       },
@@ -1564,8 +1493,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(id), num, weight_string(num) from `user` where 1 != 1",
-                "Query": "select count(id), num, weight_string(num) from `user`",
-                "Table": "`user`"
+                "Query": "select count(id), num, weight_string(num) from `user`"
               }
             ]
           }
@@ -1598,8 +1526,7 @@
             },
             "FieldQuery": "select count(id), num, weight_string(num) from `user` where 1 != 1 group by num, weight_string(num)",
             "OrderBy": "(1|2) ASC",
-            "Query": "select count(id), num, weight_string(num) from `user` group by num, weight_string(num) order by num asc",
-            "Table": "`user`"
+            "Query": "select count(id), num, weight_string(num) from `user` group by num, weight_string(num) order by num asc"
           }
         ]
       },
@@ -1635,8 +1562,7 @@
                 },
                 "FieldQuery": "select count(id), num, weight_string(num) from `user` where 1 != 1 group by num, weight_string(num)",
                 "OrderBy": "(1|2) ASC",
-                "Query": "select count(id), num, weight_string(num) from `user` group by num, weight_string(num) order by num asc",
-                "Table": "`user`"
+                "Query": "select count(id), num, weight_string(num) from `user` group by num, weight_string(num) order by num asc"
               }
             ]
           }
@@ -1657,7 +1583,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,L:0",
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1668,8 +1593,7 @@
             },
             "FieldQuery": "select `name`, `name`, weight_string(`name`) from `user` where 1 != 1",
             "OrderBy": "(0|2) ASC",
-            "Query": "select `name`, `name`, weight_string(`name`) from `user` order by `user`.`name` asc",
-            "Table": "`user`"
+            "Query": "select `name`, `name`, weight_string(`name`) from `user` order by `user`.`name` asc"
           },
           {
             "OperatorType": "Route",
@@ -1679,8 +1603,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from music where 1 != 1",
-            "Query": "select 1 from music",
-            "Table": "music"
+            "Query": "select 1 from music"
           }
         ]
       },
@@ -1706,8 +1629,7 @@
         "FieldQuery": "select id, id, weight_string(id) from `user` where 1 != 1",
         "OrderBy": "(0|2) ASC",
         "Query": "select id, id, weight_string(id) from `user` order by `user`.id asc",
-        "ResultColumns": 2,
-        "Table": "`user`"
+        "ResultColumns": 2
       },
       "TablesUsed": [
         "user.user"
@@ -1741,8 +1663,7 @@
                 },
                 "FieldQuery": "select col, count(*), c1, weight_string(c1) from `user` where 1 != 1 group by col",
                 "OrderBy": "0 ASC",
-                "Query": "select col, count(*), c1, weight_string(c1) from `user` group by col order by col asc",
-                "Table": "`user`"
+                "Query": "select col, count(*), c1, weight_string(c1) from `user` group by col order by col asc"
               }
             ]
           }
@@ -1770,7 +1691,6 @@
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1780,8 +1700,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.a, weight_string(`user`.a) from `user` where 1 != 1",
-                "Query": "select distinct `user`.a, weight_string(`user`.a) from `user`",
-                "Table": "`user`"
+                "Query": "select distinct `user`.a, weight_string(`user`.a) from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -1791,8 +1710,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select distinct 1 from user_extra",
-                "Table": "user_extra"
+                "Query": "select distinct 1 from user_extra"
               }
             ]
           }
@@ -1826,8 +1744,7 @@
               "Sharded": true
             },
             "FieldQuery": "select a as c, a, weight_string(a) from `user` where 1 != 1",
-            "Query": "select distinct a as c, a, weight_string(a) from `user`",
-            "Table": "`user`"
+            "Query": "select distinct a as c, a, weight_string(a) from `user`"
           }
         ]
       },
@@ -1858,8 +1775,7 @@
               "Sharded": true
             },
             "FieldQuery": "select a, a, weight_string(a) from `user` where 1 != 1",
-            "Query": "select distinct a, a, weight_string(a) from `user`",
-            "Table": "`user`"
+            "Query": "select distinct a, a, weight_string(a) from `user`"
           }
         ]
       },
@@ -1882,8 +1798,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id from unsharded where 1 != 1",
-        "Query": "select id from unsharded order by (select id from unsharded) asc",
-        "Table": "unsharded"
+        "Query": "select id from unsharded order by (select id from unsharded) asc"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1913,8 +1828,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) as a from `user` where 1 != 1",
-                "Query": "select count(*) as a from `user`",
-                "Table": "`user`"
+                "Query": "select count(*) as a from `user`"
               }
             ]
           }
@@ -1941,8 +1855,7 @@
         "FieldQuery": "select id, id + 1, weight_string(id + 1) from `user` where 1 != 1",
         "OrderBy": "(1|2) ASC",
         "Query": "select id, id + 1, weight_string(id + 1) from `user` order by id + 1 asc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -1965,8 +1878,7 @@
         "FieldQuery": "select `user`.col1 as a, `user`.col1 collate utf8_general_ci, weight_string(`user`.col1 collate utf8_general_ci) from `user` where 1 != 1",
         "OrderBy": "(1|2) ASC",
         "Query": "select `user`.col1 as a, `user`.col1 collate utf8_general_ci, weight_string(`user`.col1 collate utf8_general_ci) from `user` order by `user`.col1 collate utf8_general_ci asc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -1989,8 +1901,7 @@
         "FieldQuery": "select id, id + 1, weight_string(id + 1) from `user` where 1 != 1",
         "OrderBy": "(1|2) ASC",
         "Query": "select id, id + 1, weight_string(id + 1) from `user` order by id + 1 asc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -2013,8 +1924,7 @@
         "FieldQuery": "select `user`.col1 as a, `user`.col1 collate utf8_general_ci, weight_string(`user`.col1 collate utf8_general_ci) from `user` where 1 != 1",
         "OrderBy": "(1|2) ASC",
         "Query": "select `user`.col1 as a, `user`.col1 collate utf8_general_ci, weight_string(`user`.col1 collate utf8_general_ci) from `user` order by `user`.col1 collate utf8_general_ci asc",
-        "ResultColumns": 1,
-        "Table": "`user`"
+        "ResultColumns": 1
       },
       "TablesUsed": [
         "user.user"
@@ -2040,7 +1950,6 @@
             "JoinVars": {
               "user_col": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2050,8 +1959,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id, `user`.col from `user` where 1 != 1",
-                "Query": "select id, `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select id, `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -2061,8 +1969,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select coalesce(:user_col /* INT16 */, user_extra.col) from user_extra where 1 != 1",
-                "Query": "select coalesce(:user_col /* INT16 */, user_extra.col) from user_extra",
-                "Table": "user_extra"
+                "Query": "select coalesce(:user_col /* INT16 */, user_extra.col) from user_extra"
               }
             ]
           }
@@ -2099,7 +2006,6 @@
                 "JoinVars": {
                   "a_tcol1": 1
                 },
-                "TableName": "`user`_music",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2110,8 +2016,7 @@
                     },
                     "FieldQuery": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1), weight_string(a.id)",
                     "OrderBy": "(1|2) ASC",
-                    "Query": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a group by a.tcol1, weight_string(a.tcol1), weight_string(a.id) order by a.tcol1 asc",
-                    "Table": "`user`"
+                    "Query": "select min(a.id), a.tcol1, weight_string(a.tcol1), weight_string(a.id) from `user` as a group by a.tcol1, weight_string(a.tcol1), weight_string(a.id) order by a.tcol1 asc"
                   },
                   {
                     "OperatorType": "Route",
@@ -2121,8 +2026,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from music as b where 1 != 1 group by .0",
-                    "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by .0",
-                    "Table": "music"
+                    "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by .0"
                   }
                 ]
               }
@@ -2156,8 +2060,7 @@
             },
             "FieldQuery": "select col from `user` where 1 != 1 group by col",
             "OrderBy": "0 ASC",
-            "Query": "select col from `user` where id between :vtg1 and :vtg2 group by col order by `user`.col asc",
-            "Table": "`user`"
+            "Query": "select col from `user` where id between :vtg1 and :vtg2 group by col order by `user`.col asc"
           }
         ]
       },
@@ -2187,8 +2090,7 @@
             },
             "FieldQuery": "select foo, col, weight_string(foo) from `user` where 1 != 1 group by foo, col, weight_string(foo)",
             "OrderBy": "1 ASC, (0|2) ASC",
-            "Query": "select foo, col, weight_string(foo) from `user` where id between :vtg1 and :vtg2 group by foo, col, weight_string(foo) order by `user`.col asc, foo asc",
-            "Table": "`user`"
+            "Query": "select foo, col, weight_string(foo) from `user` where id between :vtg1 and :vtg2 group by foo, col, weight_string(foo) order by `user`.col asc, foo asc"
           }
         ]
       },
@@ -2224,8 +2126,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select foo, col, weight_string(foo) from `user` where 1 != 1",
-                "Query": "select distinct foo, col, weight_string(foo) from `user` where id between :vtg1 and :vtg2",
-                "Table": "`user`"
+                "Query": "select distinct foo, col, weight_string(foo) from `user` where id between :vtg1 and :vtg2"
               }
             ]
           }
@@ -2257,8 +2158,7 @@
               "Sharded": true
             },
             "FieldQuery": "select textcol2, weight_string(textcol2) from `user` where 1 != 1",
-            "Query": "select distinct textcol2, weight_string(textcol2) from `user`",
-            "Table": "`user`"
+            "Query": "select distinct textcol2, weight_string(textcol2) from `user`"
           }
         ]
       },
@@ -2287,8 +2187,7 @@
               "Sharded": true
             },
             "FieldQuery": "select textcol1 from `user` where 1 != 1 union select textcol1 from `user` where 1 != 1",
-            "Query": "select textcol1 from `user` union select textcol1 from `user`",
-            "Table": "`user`"
+            "Query": "select textcol1 from `user` union select textcol1 from `user`"
           }
         ]
       },
@@ -2316,7 +2215,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0,L:1",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2326,8 +2224,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select a.id, weight_string(a.id) from `user` as a where 1 != 1",
-                    "Query": "select a.id, weight_string(a.id) from `user` as a",
-                    "Table": "`user`"
+                    "Query": "select a.id, weight_string(a.id) from `user` as a"
                   },
                   {
                     "OperatorType": "Route",
@@ -2337,8 +2234,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select b.id from user_extra as b where 1 != 1",
-                    "Query": "select b.id from user_extra as b",
-                    "Table": "user_extra"
+                    "Query": "select b.id from user_extra as b"
                   }
                 ]
               },
@@ -2350,8 +2246,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select dt.c0 as `1`, dt.c1 as `2`, weight_string(dt.c0) from (select 1, 2 from dual where 1 != 1) as dt(c0, c1) where 1 != 1",
-                "Query": "select dt.c0 as `1`, dt.c1 as `2`, weight_string(dt.c0) from (select 1, 2 from dual) as dt(c0, c1)",
-                "Table": "dual"
+                "Query": "select dt.c0 as `1`, dt.c1 as `2`, weight_string(dt.c0) from (select 1, 2 from dual) as dt(c0, c1)"
               }
             ]
           }
@@ -2383,7 +2278,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,R:0,R:1",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2393,8 +2287,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select a.id from `user` as a where 1 != 1",
-                    "Query": "select a.id from `user` as a",
-                    "Table": "`user`"
+                    "Query": "select a.id from `user` as a"
                   },
                   {
                     "OperatorType": "Route",
@@ -2404,8 +2297,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select b.id, weight_string(b.id) from user_extra as b where 1 != 1",
-                    "Query": "select b.id, weight_string(b.id) from user_extra as b",
-                    "Table": "user_extra"
+                    "Query": "select b.id, weight_string(b.id) from user_extra as b"
                   }
                 ]
               },
@@ -2417,8 +2309,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select dt.c0 as `1`, dt.c1 as `2`, weight_string(dt.c1) from (select 1, 2 from dual where 1 != 1) as dt(c0, c1) where 1 != 1",
-                "Query": "select dt.c0 as `1`, dt.c1 as `2`, weight_string(dt.c1) from (select 1, 2 from dual) as dt(c0, c1)",
-                "Table": "dual"
+                "Query": "select dt.c0 as `1`, dt.c1 as `2`, weight_string(dt.c1) from (select 1, 2 from dual) as dt(c0, c1)"
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/rails_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/rails_cases.json
@@ -12,7 +12,6 @@
         "JoinVars": {
           "order2s_id": 0
         },
-        "TableName": "customer2s, order2s_author5s, book6s_book6s_order2s_supplier5s",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -22,8 +21,7 @@
               "Sharded": true
             },
             "FieldQuery": "select order2s.id from order2s, customer2s where 1 != 1",
-            "Query": "select order2s.id from order2s, customer2s where customer2s.id = order2s.customer2_id",
-            "Table": "customer2s, order2s"
+            "Query": "select order2s.id from order2s, customer2s where customer2s.id = order2s.customer2_id"
           },
           {
             "OperatorType": "Join",
@@ -32,7 +30,6 @@
             "JoinVars": {
               "book6s_supplier5_id": 4
             },
-            "TableName": "author5s, book6s_book6s_order2s_supplier5s",
             "Inputs": [
               {
                 "OperatorType": "Join",
@@ -41,7 +38,6 @@
                 "JoinVars": {
                   "book6s_id": 5
                 },
-                "TableName": "author5s, book6s_book6s_order2s",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -51,8 +47,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select author5s.id, author5s.`name`, author5s.created_at, author5s.updated_at, book6s.supplier5_id, book6s.id from author5s, book6s where 1 != 1",
-                    "Query": "select author5s.id, author5s.`name`, author5s.created_at, author5s.updated_at, book6s.supplier5_id, book6s.id from author5s, book6s where book6s.author5_id = author5s.id",
-                    "Table": "author5s, book6s"
+                    "Query": "select author5s.id, author5s.`name`, author5s.created_at, author5s.updated_at, book6s.supplier5_id, book6s.id from author5s, book6s where book6s.author5_id = author5s.id"
                   },
                   {
                     "OperatorType": "Route",
@@ -63,7 +58,6 @@
                     },
                     "FieldQuery": "select 1 from book6s_order2s where 1 != 1",
                     "Query": "select 1 from book6s_order2s where book6s_order2s.order2_id = :order2s_id /* INT64 */ and book6s_order2s.book6_id = :book6s_id /* INT64 */",
-                    "Table": "book6s_order2s",
                     "Values": [
                       ":book6s_id"
                     ],
@@ -80,7 +74,6 @@
                 },
                 "FieldQuery": "select 1 from supplier5s where 1 != 1",
                 "Query": "select 1 from supplier5s where supplier5s.id = :book6s_supplier5_id /* INT64 */",
-                "Table": "supplier5s",
                 "Values": [
                   ":book6s_supplier5_id"
                 ],

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -13,8 +13,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from ambiguous_ref_with_source where 1 != 1",
-        "Query": "select * from ambiguous_ref_with_source",
-        "Table": "ambiguous_ref_with_source"
+        "Query": "select * from ambiguous_ref_with_source"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -35,8 +34,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, ambiguous_ref_with_source where 1 != 1",
-        "Query": "select `user`.col from `user`, ambiguous_ref_with_source",
-        "Table": "`user`, ambiguous_ref_with_source"
+        "Query": "select `user`.col from `user`, ambiguous_ref_with_source"
       },
       "TablesUsed": [
         "user.ambiguous_ref_with_source",
@@ -58,8 +56,7 @@
           "Sharded": false
         },
         "FieldQuery": "select r1.col from ambiguous_ref_with_source as r1 join ambiguous_ref_with_source where 1 != 1",
-        "Query": "select r1.col from ambiguous_ref_with_source as r1 join ambiguous_ref_with_source",
-        "Table": "ambiguous_ref_with_source"
+        "Query": "select r1.col from ambiguous_ref_with_source as r1 join ambiguous_ref_with_source"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -80,8 +77,7 @@
           "Sharded": true
         },
         "FieldQuery": "select ambiguous_ref_with_source.col from ambiguous_ref_with_source, `user` where 1 != 1",
-        "Query": "select ambiguous_ref_with_source.col from ambiguous_ref_with_source, `user`",
-        "Table": "`user`, ambiguous_ref_with_source"
+        "Query": "select ambiguous_ref_with_source.col from ambiguous_ref_with_source, `user`"
       },
       "TablesUsed": [
         "user.ambiguous_ref_with_source",
@@ -104,7 +100,6 @@
         },
         "FieldQuery": "select ambiguous_ref_with_source.col from (select aa from `user` where 1 != 1) as `user`, ambiguous_ref_with_source where 1 != 1",
         "Query": "select ambiguous_ref_with_source.col from (select aa from `user` where `user`.id = 1) as `user`, ambiguous_ref_with_source",
-        "Table": "`user`, ambiguous_ref_with_source",
         "Values": [
           "1"
         ],
@@ -130,8 +125,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, ambiguous_ref_with_source where 1 != 1",
-        "Query": "select `user`.col from `user`, ambiguous_ref_with_source",
-        "Table": "`user`, ambiguous_ref_with_source"
+        "Query": "select `user`.col from `user`, ambiguous_ref_with_source"
       },
       "TablesUsed": [
         "user.ambiguous_ref_with_source",
@@ -153,8 +147,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into ambiguous_ref_with_source(col) values (1)",
-        "TableName": "ambiguous_ref_with_source"
+        "Query": "insert into ambiguous_ref_with_source(col) values (1)"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -174,7 +167,6 @@
         "JoinVars": {
           "u_u_id": 1
         },
-        "TableName": "ref_with_source_ref_with_source",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -184,8 +176,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.id, u.u_id from (select a.id, a.u_id from ref_with_source as a where 1 != 1) as u where 1 != 1",
-            "Query": "select u.id, u.u_id from (select a.id, a.u_id from ref_with_source as a where a.id in (3) order by a.d_at asc limit 1) as u order by u.id asc",
-            "Table": "ref_with_source"
+            "Query": "select u.id, u.u_id from (select a.id, a.u_id from ref_with_source as a where a.id in (3) order by a.d_at asc limit 1) as u order by u.id asc"
           },
           {
             "OperatorType": "Route",
@@ -195,8 +186,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from ref_with_source as u0 where 1 != 1",
-            "Query": "select 1 from ref_with_source as u0 where u0.u_uid = :u_u_id",
-            "Table": "ref_with_source"
+            "Query": "select 1 from ref_with_source as u0 where u0.u_uid = :u_u_id"
           }
         ]
       },
@@ -219,8 +209,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into ambiguous_ref_with_source(col) values (1)",
-        "TableName": "ambiguous_ref_with_source"
+        "Query": "insert into ambiguous_ref_with_source(col) values (1)"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -241,8 +230,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update ambiguous_ref_with_source set col = 1",
-        "Table": "ambiguous_ref_with_source"
+        "Query": "update ambiguous_ref_with_source set col = 1"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -263,8 +251,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update ambiguous_ref_with_source set col = 1",
-        "Table": "ambiguous_ref_with_source"
+        "Query": "update ambiguous_ref_with_source set col = 1"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -285,8 +272,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from ambiguous_ref_with_source where col = 1",
-        "Table": "ambiguous_ref_with_source"
+        "Query": "delete from ambiguous_ref_with_source where col = 1"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -307,8 +293,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from ambiguous_ref_with_source where col = 1",
-        "Table": "ambiguous_ref_with_source"
+        "Query": "delete from ambiguous_ref_with_source where col = 1"
       },
       "TablesUsed": [
         "main.ambiguous_ref_with_source"
@@ -329,8 +314,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, ref_with_source where 1 != 1",
-        "Query": "select `user`.col from `user`, ref_with_source",
-        "Table": "`user`, ref_with_source"
+        "Query": "select `user`.col from `user`, ref_with_source"
       },
       "TablesUsed": [
         "user.ref_with_source",
@@ -352,8 +336,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, ref_with_source as source_of_ref where 1 != 1",
-        "Query": "select `user`.col from `user`, ref_with_source as source_of_ref",
-        "Table": "`user`, ref_with_source"
+        "Query": "select `user`.col from `user`, ref_with_source as source_of_ref"
       },
       "TablesUsed": [
         "user.ref_with_source",
@@ -375,8 +358,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, ref as rerouted_ref where 1 != 1",
-        "Query": "select `user`.col from `user`, ref as rerouted_ref",
-        "Table": "`user`, ref"
+        "Query": "select `user`.col from `user`, ref as rerouted_ref"
       },
       "TablesUsed": [
         "user.ref",
@@ -398,8 +380,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user`, global_ref where 1 != 1",
-        "Query": "select `user`.col from `user`, global_ref",
-        "Table": "`user`, global_ref"
+        "Query": "select `user`.col from `user`, global_ref"
       },
       "TablesUsed": [
         "user.global_ref",
@@ -421,8 +402,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into global_ref(col) values (1)",
-        "TableName": "global_ref"
+        "Query": "insert into global_ref(col) values (1)"
       },
       "TablesUsed": [
         "main.global_ref"
@@ -443,8 +423,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from source_of_ref where col = 1",
-        "Table": "source_of_ref"
+        "Query": "delete from source_of_ref where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -465,8 +444,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update source_of_ref set x = 4 where col = 1",
-        "Table": "source_of_ref"
+        "Query": "update source_of_ref set x = 4 where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -487,8 +465,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into source_of_ref(x) values (4)",
-        "TableName": "source_of_ref"
+        "Query": "insert into source_of_ref(x) values (4)"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -509,8 +486,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from source_of_ref where col = 1",
-        "Table": "source_of_ref"
+        "Query": "delete from source_of_ref where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -531,8 +507,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update source_of_ref set x = 4 where col = 1",
-        "Table": "source_of_ref"
+        "Query": "update source_of_ref set x = 4 where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -553,8 +528,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into source_of_ref(x) values (4)",
-        "TableName": "source_of_ref"
+        "Query": "insert into source_of_ref(x) values (4)"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -575,8 +549,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from source_of_ref where col = 1",
-        "Table": "source_of_ref"
+        "Query": "delete from source_of_ref where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -597,8 +570,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update source_of_ref set x = 4 where col = 1",
-        "Table": "source_of_ref"
+        "Query": "update source_of_ref set x = 4 where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -619,8 +591,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into source_of_ref(x) values (4)",
-        "TableName": "source_of_ref"
+        "Query": "insert into source_of_ref(x) values (4)"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -641,8 +612,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "delete from source_of_ref where col = 1",
-        "Table": "source_of_ref"
+        "Query": "delete from source_of_ref where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -663,8 +633,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "update source_of_ref set x = 4 where col = 1",
-        "Table": "source_of_ref"
+        "Query": "update source_of_ref set x = 4 where col = 1"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -685,8 +654,7 @@
           "Sharded": false
         },
         "TargetTabletType": "PRIMARY",
-        "Query": "insert into source_of_ref(x) values (4)",
-        "TableName": "source_of_ref"
+        "Query": "insert into source_of_ref(x) values (4)"
       },
       "TablesUsed": [
         "main.source_of_ref"
@@ -700,19 +668,18 @@
       "QueryType": "SELECT",
       "Original": "select * from user.ref_with_source ref, `user`.`user` u where ref.id = u.ref_id and u.id = 2",
       "Instructions": {
-        "FieldQuery": "select * from ref_with_source as ref, `user` as u where 1 != 1",
         "OperatorType": "Route",
         "Variant": "EqualUnique",
-        "Vindex": "user_index",
         "Keyspace": {
           "Name": "user",
           "Sharded": true
         },
+        "FieldQuery": "select * from ref_with_source as ref, `user` as u where 1 != 1",
         "Query": "select * from ref_with_source as ref, `user` as u where u.id = 2 and ref.id = u.ref_id",
-        "Table": "`user`, ref_with_source",
         "Values": [
           "2"
-        ]
+        ],
+        "Vindex": "user_index"
       },
       "TablesUsed": [
         "user.ref_with_source",
@@ -727,19 +694,18 @@
       "QueryType": "SELECT",
       "Original": "select * from source_of_ref ref, `user`.`user` u where ref.id = u.ref_id and u.id = 2",
       "Instructions": {
-        "FieldQuery": "select * from ref_with_source as ref, `user` as u where 1 != 1",
         "OperatorType": "Route",
         "Variant": "EqualUnique",
-        "Vindex": "user_index",
         "Keyspace": {
           "Name": "user",
           "Sharded": true
         },
+        "FieldQuery": "select * from ref_with_source as ref, `user` as u where 1 != 1",
         "Query": "select * from ref_with_source as ref, `user` as u where u.id = 2 and ref.id = u.ref_id",
-        "Table": "`user`, ref_with_source",
         "Values": [
           "2"
-        ]
+        ],
+        "Vindex": "user_index"
       },
       "TablesUsed": [
         "user.ref_with_source",
@@ -761,8 +727,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where 1 != 1",
-        "Query": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where rr.bar = sr.bar and u.id = ue.user_id and sr.foo = ue.foo",
-        "Table": "`user`, ref, ref_with_source, user_extra"
+        "Query": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where rr.bar = sr.bar and u.id = ue.user_id and sr.foo = ue.foo"
       },
       "TablesUsed": [
         "user.ref",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -13,8 +13,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 1 from `user` where 1 != 1",
-        "Query": "select 1 from `user`",
-        "Table": "`user`"
+        "Query": "select 1 from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -35,8 +34,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.* from `user` where 1 != 1",
-        "Query": "select `user`.* from `user`",
-        "Table": "`user`"
+        "Query": "select `user`.* from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -57,8 +55,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from `user` where 1 != 1",
-        "Query": "select * from `user`",
-        "Table": "`user`"
+        "Query": "select * from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -80,8 +77,7 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from `user`",
-        "QueryTimeout": 1000,
-        "Table": "`user`"
+        "QueryTimeout": 1000
       },
       "TablesUsed": [
         "user.user"
@@ -108,8 +104,7 @@
             },
             "FieldQuery": "select count(*) from `user` where 1 != 1",
             "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from `user`",
-            "QueryTimeout": 1000,
-            "Table": "`user`"
+            "QueryTimeout": 1000
           }
         ]
       },
@@ -137,8 +132,7 @@
             },
             "FieldQuery": "select * from `user` where 1 != 1",
             "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from `user` limit 10",
-            "QueryTimeout": 1000,
-            "Table": "`user`"
+            "QueryTimeout": 1000
           }
         ]
       },
@@ -162,8 +156,7 @@
         },
         "FieldQuery": "select * from unsharded where 1 != 1",
         "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded limit 10",
-        "QueryTimeout": 1000,
-        "Table": "unsharded"
+        "QueryTimeout": 1000
       },
       "TablesUsed": [
         "main.unsharded"
@@ -185,8 +178,7 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS */ * from `user`",
-        "ScatterErrorsAsWarnings": true,
-        "Table": "`user`"
+        "ScatterErrorsAsWarnings": true
       },
       "TablesUsed": [
         "user.user"
@@ -213,8 +205,7 @@
             },
             "FieldQuery": "select count(*) from `user` where 1 != 1",
             "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from `user`",
-            "ScatterErrorsAsWarnings": true,
-            "Table": "`user`"
+            "ScatterErrorsAsWarnings": true
           }
         ]
       },
@@ -243,8 +234,7 @@
             },
             "FieldQuery": "select count(*) from `user` where 1 != 1",
             "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from `user`",
-            "ScatterErrorsAsWarnings": true,
-            "Table": "`user`"
+            "ScatterErrorsAsWarnings": true
           }
         ]
       },
@@ -272,8 +262,7 @@
             },
             "FieldQuery": "select * from `user` where 1 != 1",
             "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ * from `user` limit 10",
-            "ScatterErrorsAsWarnings": true,
-            "Table": "`user`"
+            "ScatterErrorsAsWarnings": true
           }
         ]
       },
@@ -296,8 +285,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.* from `user` where 1 != 1",
-        "Query": "select `user`.* from `user`",
-        "Table": "`user`"
+        "Query": "select `user`.* from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -318,8 +306,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.* from `user` where 1 != 1",
-        "Query": "select `user`.* from `user`",
-        "Table": "`user`"
+        "Query": "select `user`.* from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -340,8 +327,7 @@
           "Sharded": true
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
-        "Query": "select user_id, col1, col2 from authoritative",
-        "Table": "authoritative"
+        "Query": "select user_id, col1, col2 from authoritative"
       },
       "TablesUsed": [
         "user.authoritative"
@@ -362,8 +348,7 @@
           "Sharded": true
         },
         "FieldQuery": "select a.user_id, a.col1, a.col2, b.user_id, b.col1, b.col2 from authoritative as a, authoritative as b where 1 != 1",
-        "Query": "select a.user_id, a.col1, a.col2, b.user_id, b.col1, b.col2 from authoritative as a, authoritative as b where a.user_id = b.user_id",
-        "Table": "authoritative"
+        "Query": "select a.user_id, a.col1, a.col2, b.user_id, b.col1, b.col2 from authoritative as a, authoritative as b where a.user_id = b.user_id"
       },
       "TablesUsed": [
         "user.authoritative"
@@ -389,8 +374,7 @@
           "Sharded": true
         },
         "FieldQuery": "select user_id, col1, col2 from authoritative as a where 1 != 1",
-        "Query": "select user_id, col1, col2 from authoritative as a",
-        "Table": "authoritative"
+        "Query": "select user_id, col1, col2 from authoritative as a"
       },
       "TablesUsed": [
         "user.authoritative"
@@ -411,8 +395,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from authoritative, `user` where 1 != 1",
-        "Query": "select * from authoritative, `user` where authoritative.user_id = `user`.id",
-        "Table": "`user`, authoritative"
+        "Query": "select * from authoritative, `user` where authoritative.user_id = `user`.id"
       },
       "TablesUsed": [
         "user.authoritative",
@@ -434,8 +417,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.id, a.user_id, a.col1, a.col2, `user`.col1 from authoritative as a, `user` where 1 != 1",
-        "Query": "select `user`.id, a.user_id, a.col1, a.col2, `user`.col1 from authoritative as a, `user` where a.user_id = `user`.id",
-        "Table": "`user`, authoritative"
+        "Query": "select `user`.id, a.user_id, a.col1, a.col2, `user`.col1 from authoritative as a, `user` where a.user_id = `user`.id"
       },
       "TablesUsed": [
         "user.authoritative",
@@ -457,8 +439,7 @@
           "Sharded": true
         },
         "FieldQuery": "select anon_col from `user`, user_extra where 1 != 1",
-        "Query": "select anon_col from `user`, user_extra where `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra"
+        "Query": "select anon_col from `user`, user_extra where `user`.id = user_extra.user_id"
       },
       "TablesUsed": [
         "user.user",
@@ -481,7 +462,6 @@
         },
         "FieldQuery": "select count(1) from `user` where 1 != 1 group by n_id",
         "Query": "select count(1) from `user` where id = 'abc' group by n_id having json_arrayagg(a_id) = '[]'",
-        "Table": "`user`",
         "Values": [
           "'abc'"
         ],
@@ -507,7 +487,6 @@
         },
         "FieldQuery": "select count(1) from `user` where 1 != 1 group by n_id",
         "Query": "select count(1) from `user` where id = 'abc' group by n_id having json_objectagg(a_id, b_id) = '[]'",
-        "Table": "`user`",
         "Values": [
           "'abc'"
         ],
@@ -538,7 +517,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -548,8 +526,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user`",
-            "Table": "`user`"
+            "Query": "select id from `user`"
           },
           {
             "OperatorType": "Route",
@@ -559,8 +536,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_id from user_extra where 1 != 1",
-            "Query": "select user_id from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_id from user_extra"
           }
         ]
       },
@@ -606,8 +582,7 @@
           "Sharded": false
         },
         "FieldQuery": "select :__lastInsertId as x from unsharded where 1 != 1",
-        "Query": "select :__lastInsertId as x from unsharded",
-        "Table": "unsharded"
+        "Query": "select :__lastInsertId as x from unsharded"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -628,8 +603,7 @@
           "Sharded": false
         },
         "FieldQuery": "select @@auto_increment_increment from dual where 1 != 1",
-        "Query": "select @@auto_increment_increment from dual",
-        "Table": "dual"
+        "Query": "select @@auto_increment_increment from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -651,7 +625,6 @@
         },
         "FieldQuery": "select * from pin_test where 1 != 1",
         "Query": "select * from pin_test",
-        "Table": "pin_test",
         "Values": [
           "'\ufffd'"
         ],
@@ -677,7 +650,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -687,8 +659,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
-            "Query": "select 1 from `user`",
-            "Table": "`user`"
+            "Query": "select 1 from `user`"
           },
           {
             "OperatorType": "Route",
@@ -698,8 +669,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-            "Query": "select user_extra.id from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.id from user_extra"
           }
         ]
       },
@@ -719,7 +689,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -729,8 +698,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -740,8 +708,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-            "Query": "select user_extra.id from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.id from user_extra"
           }
         ]
       },
@@ -761,7 +728,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -771,8 +737,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -782,8 +747,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.id + user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.id + user_extra.col from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.id + user_extra.col from user_extra"
           }
         ]
       },
@@ -808,7 +772,6 @@
         },
         "FieldQuery": "select col, trim((select user_name from `user` where 1 != 1)) as val from user_extra where 1 != 1 group by col",
         "Query": "select col, trim((select user_name from `user` where id = 3)) as val from user_extra where user_id = 3 group by col order by trim((select `user`.user_name from `user` where `user`.id = 3)) asc",
-        "Table": "user_extra",
         "Values": [
           "3"
         ],
@@ -830,7 +793,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0,L:1",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -840,8 +802,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col, `user`.col2 from `user` where 1 != 1",
-            "Query": "select `user`.col, `user`.col2 from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.col, `user`.col2 from `user`"
           },
           {
             "OperatorType": "Route",
@@ -851,8 +812,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-            "Query": "select user_extra.id from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.id from user_extra"
           }
         ]
       },
@@ -872,7 +832,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -882,8 +841,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select /* comment */ `user`.col from `user`",
-            "Table": "`user`"
+            "Query": "select /* comment */ `user`.col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -893,8 +851,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select /* comment */ 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select /* comment */ 1 from user_extra"
           }
         ]
       },
@@ -914,7 +871,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -924,8 +880,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user` for update",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user` for update"
           },
           {
             "OperatorType": "Route",
@@ -935,8 +890,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra for update",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra for update"
           }
         ]
       },
@@ -959,7 +913,6 @@
         "JoinVars": {
           "user_id": 0
         },
-        "TableName": "`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -969,8 +922,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.id, `user`.id from `user` where 1 != 1",
-            "Query": "select `user`.id, `user`.id from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.id, `user`.id from `user`"
           },
           {
             "OperatorType": "Route",
@@ -980,8 +932,7 @@
               "Sharded": false
             },
             "FieldQuery": "select (select :user_id + outm.m + unsharded.m from unsharded where 1 != 1) as `(select ``user``.id + outm.m + unsharded.m from unsharded)` from unsharded as outm where 1 != 1",
-            "Query": "select (select :user_id + outm.m + unsharded.m from unsharded) as `(select ``user``.id + outm.m + unsharded.m from unsharded)` from unsharded as outm",
-            "Table": "unsharded"
+            "Query": "select (select :user_id + outm.m + unsharded.m from unsharded) as `(select ``user``.id + outm.m + unsharded.m from unsharded)` from unsharded as outm"
           }
         ]
       },
@@ -1001,7 +952,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1011,8 +961,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.Col from `user` where 1 != 1",
-            "Query": "select `user`.Col from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.Col from `user`"
           },
           {
             "OperatorType": "Route",
@@ -1022,8 +971,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.Id from user_extra where 1 != 1",
-            "Query": "select user_extra.Id from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.Id from user_extra"
           }
         ]
       },
@@ -1053,7 +1001,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 0x04",
-        "Table": "`user`",
         "Values": [
           "'\u0004'"
         ],
@@ -1078,8 +1025,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from `user` where 1 != 1",
-        "Query": "select * from `user` where id = 1",
-        "Table": "`user`"
+        "Query": "select * from `user` where id = 1"
       },
       "TablesUsed": [
         "user.user"
@@ -1113,7 +1059,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -1127,8 +1072,7 @@
               "Sharded": true
             },
             "FieldQuery": "select intcol, id from `user` where 1 != 1",
-            "Query": "select intcol, id from `user` where costly = 'aa' and `name` = 'bb' and id = 3",
-            "Table": "`user`"
+            "Query": "select intcol, id from `user` where costly = 'aa' and `name` = 'bb' and id = 3"
           }
         ]
       },
@@ -1163,8 +1107,7 @@
             "FieldQuery": "select user_id, weight_string(user_id) from music where 1 != 1",
             "OrderBy": "(0|1) ASC",
             "Query": "select user_id, weight_string(user_id) from music order by music.user_id asc limit 30",
-            "ResultColumns": 1,
-            "Table": "music"
+            "ResultColumns": 1
           }
         ]
       },
@@ -1194,8 +1137,7 @@
             "FieldQuery": "select user_id, weight_string(user_id) from music where 1 != 1",
             "OrderBy": "(0|1) ASC",
             "Query": "select user_id, weight_string(user_id) from music order by music.user_id asc limit :__upper_limit",
-            "ResultColumns": 1,
-            "Table": "music"
+            "ResultColumns": 1
           }
         ]
       },
@@ -1219,7 +1161,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where `name` = 'abc' and id = 4 limit 5",
-        "Table": "`user`",
         "Values": [
           "4"
         ],
@@ -1245,7 +1186,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
-        "Table": "`user`",
         "Values": [
           "4"
         ],
@@ -1271,7 +1211,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
-        "Table": "`user`",
         "Values": [
           "4"
         ],
@@ -1297,7 +1236,6 @@
         },
         "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
         "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by user0_.col desc limit 2",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1323,7 +1261,6 @@
         },
         "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
         "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by user0_.col desc limit 3",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1349,7 +1286,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 1 and `name` = true limit 5",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1375,7 +1311,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 1 and `name` limit 5",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -1401,7 +1336,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 5 and `name` = true limit 5",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -1434,8 +1368,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -1446,8 +1379,7 @@
               "Sharded": false
             },
             "FieldQuery": "select a, :__sq1 /* INT16 */ as `(select col from ``user``)` from unsharded where 1 != 1",
-            "Query": "select a, :__sq1 /* INT16 */ as `(select col from ``user``)` from unsharded",
-            "Table": "unsharded"
+            "Query": "select a, :__sq1 /* INT16 */ as `(select col from ``user``)` from unsharded"
           }
         ]
       },
@@ -1479,8 +1411,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
+            "Query": "select col from `user`"
           },
           {
             "InputName": "Outer",
@@ -1491,8 +1422,7 @@
               "Sharded": false
             },
             "FieldQuery": "select a, 1 + :__sq1 /* INT16 */ as `1 + (select col from ``user``)` from unsharded where 1 != 1",
-            "Query": "select a, 1 + :__sq1 /* INT16 */ as `1 + (select col from ``user``)` from unsharded",
-            "Table": "unsharded"
+            "Query": "select a, 1 + :__sq1 /* INT16 */ as `1 + (select col from ``user``)` from unsharded"
           }
         ]
       },
@@ -1512,7 +1442,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1522,8 +1451,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t.id1 from (select `user`.id as id1 from `user` where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id1 from (select `user`.id as id1 from `user`) as t",
-            "Table": "`user`"
+            "Query": "select t.id1 from (select `user`.id as id1 from `user`) as t"
           },
           {
             "OperatorType": "Route",
@@ -1533,8 +1461,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t.id2 from (select user_extra.id as id2 from user_extra where 1 != 1) as t where 1 != 1",
-            "Query": "select t.id2 from (select user_extra.id as id2 from user_extra) as t",
-            "Table": "user_extra"
+            "Query": "select t.id2 from (select user_extra.id as id2 from user_extra) as t"
           }
         ]
       },
@@ -1569,7 +1496,6 @@
         },
         "FieldQuery": "select * from music where 1 != 1 union select * from `user` where 1 != 1",
         "Query": "select * from music where user_id = 1 union select * from `user` where id = 1",
-        "Table": "`user`, music",
         "Values": [
           "1"
         ],
@@ -1596,7 +1522,6 @@
         },
         "FieldQuery": "select *, :__lastInsertId as `last_insert_id()` from music where 1 != 1 union select * from `user` where 1 != 1",
         "Query": "select *, :__lastInsertId as `last_insert_id()` from music where user_id = 1 union select * from `user` where id = 1",
-        "Table": "`user`, music",
         "Values": [
           "1"
         ],
@@ -1622,8 +1547,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from (select col1, col2 from unsharded where 1 != 1 union select col1, col2 from unsharded where 1 != 1) as a where 1 != 1",
-        "Query": "select * from (select col1, col2 from unsharded where id = 1 union select col1, col2 from unsharded where id = 3) as a",
-        "Table": "unsharded"
+        "Query": "select * from (select col1, col2 from unsharded where id = 1 union select col1, col2 from unsharded where id = 3) as a"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1644,8 +1568,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id, `name` from unsharded where 1 != 1",
-        "Query": "select id, `name` from unsharded where id in (select id from unsharded where id = 1 union select id from unsharded where id = 3)",
-        "Table": "unsharded"
+        "Query": "select id, `name` from unsharded where id in (select id from unsharded where id = 1 union select id from unsharded where id = 3)"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1666,8 +1589,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id from unsharded where 1 != 1 union select id from unsharded_auto where 1 != 1",
-        "Query": "select id from unsharded union select id from unsharded_auto order by id asc limit 5",
-        "Table": "unsharded, unsharded_auto"
+        "Query": "select id from unsharded union select id from unsharded_auto order by id asc limit 5"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -1689,8 +1611,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id from unsharded where 1 != 1 union select id from unsharded_auto where 1 != 1 union select id from unsharded_auto where 1 != 1",
-        "Query": "select id from unsharded union select id from unsharded_auto union select id from unsharded_auto where id in (132)",
-        "Table": "unsharded, unsharded_auto"
+        "Query": "select id from unsharded union select id from unsharded_auto union select id from unsharded_auto where id in (132)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -1712,8 +1633,7 @@
           "Sharded": false
         },
         "FieldQuery": "select id from unsharded where 1 != 1 union select id from unsharded_auto where 1 != 1 union select id from unsharded_auto where 1 != 1 union select `name` from unsharded where 1 != 1",
-        "Query": "select id from unsharded union select id from unsharded_auto union select id from unsharded_auto union select `name` from unsharded",
-        "Table": "unsharded, unsharded_auto"
+        "Query": "select id from unsharded union select id from unsharded_auto union select id from unsharded_auto union select `name` from unsharded"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -1735,8 +1655,7 @@
           "Sharded": false
         },
         "FieldQuery": "(select id from unsharded where 1 != 1) union (select id from unsharded where 1 != 1)",
-        "Query": "(select id from unsharded order by id asc limit 1) union (select id from unsharded order by id desc limit 1) order by id asc limit 1",
-        "Table": "unsharded"
+        "Query": "(select id from unsharded order by id asc limit 1) union (select id from unsharded order by id desc limit 1) order by id asc limit 1"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1758,8 +1677,7 @@
         },
         "FieldQuery": "select * from unsharded as route2 where 1 != 1",
         "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded as route2",
-        "QueryTimeout": 1000,
-        "Table": "unsharded"
+        "QueryTimeout": 1000
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1780,8 +1698,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from music as bar where 1 != 1",
-        "Query": "select * from music as bar where id > 2",
-        "Table": "music"
+        "Query": "select * from music as bar where id > 2"
       },
       "TablesUsed": [
         "user.music"
@@ -1847,8 +1764,7 @@
                     },
                     "FieldQuery": "select sum(intcol) as avg_col, textcol1, textcol2, count(intcol), weight_string(textcol2) from `user` where 1 != 1 group by textcol1, textcol2, weight_string(textcol2)",
                     "OrderBy": "1 ASC COLLATE latin1_swedish_ci, (2|4) ASC COLLATE ",
-                    "Query": "select sum(intcol) as avg_col, textcol1, textcol2, count(intcol), weight_string(textcol2) from `user` group by textcol1, textcol2, weight_string(textcol2) order by textcol1 asc, textcol2 asc",
-                    "Table": "`user`"
+                    "Query": "select sum(intcol) as avg_col, textcol1, textcol2, count(intcol), weight_string(textcol2) from `user` group by textcol1, textcol2, weight_string(textcol2) order by textcol1 asc, textcol2 asc"
                   }
                 ]
               }
@@ -1875,8 +1791,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 42 from dual where 1 != 1",
-        "Query": "select 42 from dual where false",
-        "Table": "dual"
+        "Query": "select 42 from dual where false"
       },
       "TablesUsed": [
         "main.dual"
@@ -1911,8 +1826,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select id from unsharded_a where 1 != 1",
-                "Query": "select id from unsharded_a where colb = 2",
-                "Table": "unsharded_a"
+                "Query": "select id from unsharded_a where colb = 2"
               },
               {
                 "InputName": "Outer",
@@ -1923,8 +1837,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) from `user` where 1 != 1",
-                "Query": "select count(*) from `user` where `user`.id = 2 or :__sq_has_values and `user`.id in ::__sq1",
-                "Table": "`user`"
+                "Query": "select count(*) from `user` where `user`.id = 2 or :__sq_has_values and `user`.id in ::__sq1"
               }
             ]
           }
@@ -1964,8 +1877,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select id from unsharded_a where 1 != 1",
-                "Query": "select id from unsharded_a where colb = 2",
-                "Table": "unsharded_a"
+                "Query": "select id from unsharded_a where colb = 2"
               },
               {
                 "InputName": "Outer",
@@ -1976,8 +1888,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) from `user` where 1 != 1",
-                "Query": "select count(*) from `user` where `user`.id = 2 or (not :__sq_has_values or `user`.id not in ::__sq1)",
-                "Table": "`user`"
+                "Query": "select count(*) from `user` where `user`.id = 2 or (not :__sq_has_values or `user`.id not in ::__sq1)"
               }
             ]
           }
@@ -2026,7 +1937,6 @@
         },
         "FieldQuery": "select * from music where 1 != 1",
         "Query": "select * from music where user_id = 1",
-        "Table": "music",
         "Values": [
           "1"
         ],
@@ -2058,8 +1968,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select * from music where 1 != 1",
-                "Query": "select * from music limit 100",
-                "Table": "music"
+                "Query": "select * from music limit 100"
               }
             ]
           },
@@ -2076,8 +1985,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) from music where 1 != 1",
-                "Query": "select count(*) from music",
-                "Table": "music"
+                "Query": "select count(*) from music"
               }
             ]
           }
@@ -2106,7 +2014,6 @@
             },
             "FieldQuery": "select * from music where 1 != 1",
             "Query": "select * from music where user_id = 1 limit 2",
-            "Table": "music",
             "Values": [
               "1"
             ],
@@ -2121,7 +2028,6 @@
             },
             "FieldQuery": "select count(*) from music where 1 != 1",
             "Query": "select count(*) from music where user_id = 1",
-            "Table": "music",
             "Values": [
               "1"
             ],
@@ -2157,8 +2063,7 @@
                 "FieldQuery": "select user_id, count(id), weight_string(user_id) from music where 1 != 1 group by user_id",
                 "OrderBy": "(0|2) ASC",
                 "Query": "select user_id, count(id), weight_string(user_id) from music group by user_id having count(user_id) = 1 order by music.user_id asc limit 2",
-                "ResultColumns": 2,
-                "Table": "music"
+                "ResultColumns": 2
               }
             ]
           },
@@ -2175,8 +2080,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select count(*) from (select user_id, count(id) from music where 1 != 1 group by user_id) as t where 1 != 1",
-                "Query": "select count(*) from (select user_id, count(id) from music group by user_id having count(user_id) = 1) as t",
-                "Table": "music"
+                "Query": "select count(*) from (select user_id, count(id) from music group by user_id having count(user_id) = 1) as t"
               }
             ]
           }
@@ -2211,8 +2115,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from unsharded where 1 != 1",
-        "Query": "select * from unsharded into dumpfile 'x.txt'",
-        "Table": "unsharded"
+        "Query": "select * from unsharded into dumpfile 'x.txt'"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2233,8 +2136,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from unsharded where 1 != 1",
-        "Query": "select * from unsharded into outfile 'x.txt' character set binary fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\\n'",
-        "Table": "unsharded"
+        "Query": "select * from unsharded into outfile 'x.txt' character set binary fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\\n'"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2255,8 +2157,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from unsharded where 1 != 1",
-        "Query": "select * from unsharded into outfile s3 'out_file_name' character set binary format csv header fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\\n' manifest on overwrite off",
-        "Table": "unsharded"
+        "Query": "select * from unsharded into outfile s3 'out_file_name' character set binary format csv header fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\\n' manifest on overwrite off"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -2278,7 +2179,6 @@
         },
         "FieldQuery": "select t.title, `user`.col from (select 'hello' as title from dual where 1 != 1) as t left join `user` on `user`.id = 1 where 1 != 1",
         "Query": "select t.title, `user`.col from (select 'hello' as title from dual) as t left join `user` on `user`.id = 1",
-        "Table": "`user`, dual",
         "Values": [
           "1"
         ],
@@ -2300,7 +2200,6 @@
         "OperatorType": "Join",
         "Variant": "LeftJoin",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "dual_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2310,8 +2209,7 @@
               "Sharded": false
             },
             "FieldQuery": "select t.title from (select 'hello' as title from dual where 1 != 1) as t where 1 != 1",
-            "Query": "select t.title from (select 'hello' as title from dual) as t",
-            "Table": "dual"
+            "Query": "select t.title from (select 'hello' as title from dual) as t"
           },
           {
             "OperatorType": "Route",
@@ -2321,8 +2219,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user` where `user`.id <= 4",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user` where `user`.id <= 4"
           }
         ]
       },
@@ -2345,7 +2242,6 @@
         "JoinVars": {
           "t_title": 0
         },
-        "TableName": "dual_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2355,8 +2251,7 @@
               "Sharded": false
             },
             "FieldQuery": "select t.title from (select 'hello' as title from dual where 1 != 1) as t where 1 != 1",
-            "Query": "select t.title from (select 'hello' as title from dual) as t",
-            "Table": "dual"
+            "Query": "select t.title from (select 'hello' as title from dual) as t"
           },
           {
             "OperatorType": "Route",
@@ -2366,8 +2261,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user` where `user`.col = :t_title /* VARCHAR */ and `user`.id <= 4",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user` where `user`.col = :t_title /* VARCHAR */ and `user`.id <= 4"
           }
         ]
       },
@@ -2391,8 +2285,7 @@
           "Sharded": true
         },
         "FieldQuery": "select t.title, `user`.col from `user` left join (select 'hello' as title from dual where 1 != 1) as t on `user`.id <= 4 where 1 != 1",
-        "Query": "select t.title, `user`.col from `user` left join (select 'hello' as title from dual) as t on `user`.id <= 4",
-        "Table": "`user`, dual"
+        "Query": "select t.title, `user`.col from `user` left join (select 'hello' as title from dual) as t on `user`.id <= 4"
       },
       "TablesUsed": [
         "main.dual",
@@ -2415,7 +2308,6 @@
         },
         "FieldQuery": "select t.title, `user`.col from (select 'hello' as title from dual where 1 != 1) as t left join `user` on `user`.id = 1 where 1 != 1",
         "Query": "select t.title, `user`.col from (select 'hello' as title from dual) as t left join `user` on `user`.id = 1",
-        "Table": "`user`, dual",
         "Values": [
           "1"
         ],
@@ -2437,7 +2329,6 @@
         "OperatorType": "Join",
         "Variant": "LeftJoin",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "dual_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2447,8 +2338,7 @@
               "Sharded": false
             },
             "FieldQuery": "select t.title from (select 'hello' as title from dual where 1 != 1) as t where 1 != 1",
-            "Query": "select t.title from (select 'hello' as title from dual) as t",
-            "Table": "dual"
+            "Query": "select t.title from (select 'hello' as title from dual) as t"
           },
           {
             "OperatorType": "Route",
@@ -2458,8 +2348,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user` where `user`.id >= 4",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user` where `user`.id >= 4"
           }
         ]
       },
@@ -2499,7 +2388,6 @@
         },
         "FieldQuery": "select (select u.id from `user` as u where 1 != 1), a.id from `user` as a where 1 != 1",
         "Query": "select (select u.id from `user` as u where u.id = 1), a.id from `user` as a where a.id = 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -2520,7 +2408,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0,R:1",
-        "TableName": "unsharded_`user`, user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2530,8 +2417,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded where 1 != 1",
-            "Query": "select 1 from unsharded",
-            "Table": "unsharded"
+            "Query": "select 1 from unsharded"
           },
           {
             "OperatorType": "Route",
@@ -2541,8 +2427,7 @@
               "Sharded": true
             },
             "FieldQuery": "select t.id, s.id from `user` as t, user_extra as s where 1 != 1",
-            "Query": "select t.id, s.id from `user` as t, user_extra as s where t.id = s.user_id",
-            "Table": "`user`, user_extra"
+            "Query": "select t.id, s.id from `user` as t, user_extra as s where t.id = s.user_id"
           }
         ]
       },
@@ -2589,8 +2474,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 42, id from dual, `user` where 1 != 1",
-        "Query": "select 42, id from dual, `user`",
-        "Table": "`user`, dual"
+        "Query": "select 42, id from dual, `user`"
       },
       "TablesUsed": [
         "main.dual",
@@ -2608,7 +2492,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "UncorrelatedSubquery",
@@ -2630,8 +2513,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select col from `user` where 1 != 1",
-                    "Query": "select col from `user` limit 1",
-                    "Table": "`user`"
+                    "Query": "select col from `user` limit 1"
                   }
                 ]
               },
@@ -2644,8 +2526,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select t.a from (select :__sq1 /* INT16 */ as a from `user` where 1 != 1) as t where 1 != 1",
-                "Query": "select t.a from (select :__sq1 /* INT16 */ as a from `user`) as t",
-                "Table": "`user`"
+                "Query": "select t.a from (select :__sq1 /* INT16 */ as a from `user`) as t"
               }
             ]
           },
@@ -2657,8 +2538,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -2678,7 +2558,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "UncorrelatedSubquery",
@@ -2700,8 +2579,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select col from `user` where 1 != 1",
-                    "Query": "select col from `user` limit 1",
-                    "Table": "`user`"
+                    "Query": "select col from `user` limit 1"
                   }
                 ]
               },
@@ -2714,8 +2592,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select :__sq1 /* INT16 */ as a from `user` where 1 != 1",
-                "Query": "select :__sq1 /* INT16 */ as a from `user`",
-                "Table": "`user`"
+                "Query": "select :__sq1 /* INT16 */ as a from `user`"
               }
             ]
           },
@@ -2727,8 +2604,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from user_extra where 1 != 1",
-            "Query": "select 1 from user_extra",
-            "Table": "user_extra"
+            "Query": "select 1 from user_extra"
           }
         ]
       },
@@ -2773,7 +2649,6 @@
         "JoinVars": {
           "user_id": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2783,8 +2658,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.id from `user` where 1 != 1",
-            "Query": "select `user`.id from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.id from `user`"
           },
           {
             "OperatorType": "Route",
@@ -2794,8 +2668,7 @@
               "Sharded": true
             },
             "FieldQuery": "select :user_id * user_id as amount from user_extra where 1 != 1",
-            "Query": "select :user_id * user_id as amount from user_extra",
-            "Table": "user_extra"
+            "Query": "select :user_id * user_id as amount from user_extra"
           }
         ]
       },
@@ -2818,7 +2691,6 @@
         "JoinVars": {
           "user_id": 0
         },
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2828,8 +2700,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.id from `user` where 1 != 1",
-            "Query": "select `user`.id from `user`",
-            "Table": "`user`"
+            "Query": "select `user`.id from `user`"
           },
           {
             "OperatorType": "Route",
@@ -2839,8 +2710,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.user_id from user_extra where 1 != 1",
-            "Query": "select user_extra.user_id from user_extra where user_extra.foo = :user_id",
-            "Table": "user_extra"
+            "Query": "select user_extra.user_id from user_extra where user_extra.foo = :user_id"
           }
         ]
       },
@@ -2899,8 +2769,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select sum(col) from `user` where 1 != 1",
-                "Query": "select sum(col) from `user`",
-                "Table": "`user`"
+                "Query": "select sum(col) from `user`"
               }
             ]
           },
@@ -2913,8 +2782,7 @@
               "Sharded": true
             },
             "FieldQuery": "select CAST(:__sq1 AS DECIMAL(0, 0)) as `(select sum(col) from ``user``)` from user_extra where 1 != 1",
-            "Query": "select CAST(:__sq1 AS DECIMAL(0, 0)) as `(select sum(col) from ``user``)` from user_extra",
-            "Table": "user_extra"
+            "Query": "select CAST(:__sq1 AS DECIMAL(0, 0)) as `(select sum(col) from ``user``)` from user_extra"
           }
         ]
       },
@@ -2938,8 +2806,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.id, user_extra.user_id from `user` straight_join user_extra on `user`.id = user_extra.user_id where 1 != 1",
-        "Query": "select `user`.id, user_extra.user_id from `user` straight_join user_extra on `user`.id = user_extra.user_id",
-        "Table": "`user`, user_extra"
+        "Query": "select `user`.id, user_extra.user_id from `user` straight_join user_extra on `user`.id = user_extra.user_id"
       },
       "TablesUsed": [
         "user.user",
@@ -2965,7 +2832,6 @@
             "JoinVars": {
               "user_id": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "InputName": "Outer",
@@ -2976,8 +2842,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select col, `user`.id from `user` where 1 != 1",
-                "Query": "select col, `user`.id from `user`",
-                "Table": "`user`"
+                "Query": "select col, `user`.id from `user`"
               },
               {
                 "InputName": "SubQuery",
@@ -2989,7 +2854,6 @@
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
                 "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id limit 1",
-                "Table": "user_extra",
                 "Values": [
                   "3"
                 ],
@@ -3023,7 +2887,6 @@
             "JoinVars": {
               "user_id": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "InputName": "Outer",
@@ -3035,8 +2898,7 @@
                 },
                 "FieldQuery": "select col, `user`.id from `user` where 1 != 1",
                 "OrderBy": "0 ASC",
-                "Query": "select col, `user`.id from `user` order by `user`.col asc",
-                "Table": "`user`"
+                "Query": "select col, `user`.id from `user` order by `user`.col asc"
               },
               {
                 "InputName": "SubQuery",
@@ -3048,7 +2910,6 @@
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
                 "Query": "select 1 from user_extra where user_id = 3 and user_id < :user_id limit 1",
-                "Table": "user_extra",
                 "Values": [
                   "3"
                 ],
@@ -3077,7 +2938,6 @@
         "JoinVars": {
           "u1_col": 1
         },
-        "TableName": "`user`_`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3087,15 +2947,13 @@
               "Sharded": true
             },
             "FieldQuery": "select 1, u1.col from `user` as u1 where 1 != 1",
-            "Query": "select 1, u1.col from `user` as u1",
-            "Table": "`user`"
+            "Query": "select 1, u1.col from `user` as u1"
           },
           {
             "OperatorType": "SemiJoin",
             "JoinVars": {
               "u2_col": 0
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "InputName": "Outer",
@@ -3106,8 +2964,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u2.col from `user` as u2 where 1 != 1",
-                "Query": "select u2.col from `user` as u2",
-                "Table": "`user`"
+                "Query": "select u2.col from `user` as u2"
               },
               {
                 "InputName": "SubQuery",
@@ -3122,8 +2979,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
-                    "Query": "select 1 from user_extra as ue where ue.col = :u1_col /* INT16 */ and ue.col = :u2_col /* INT16 */ limit 1",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra as ue where ue.col = :u1_col /* INT16 */ and ue.col = :u2_col /* INT16 */ limit 1"
                   }
                 ]
               }
@@ -3152,7 +3008,6 @@
             "JoinVars": {
               "u_col": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "InputName": "Outer",
@@ -3163,8 +3018,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1, u.col from `user` as u where 1 != 1",
-                "Query": "select 1, u.col from `user` as u",
-                "Table": "`user`"
+                "Query": "select 1, u.col from `user` as u"
               },
               {
                 "InputName": "SubQuery",
@@ -3179,8 +3033,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra as ue where 1 != 1",
-                    "Query": "select 1 from user_extra as ue where ue.col = :u_col /* INT16 */ and ue.col2 = :u_col /* INT16 */ limit 1",
-                    "Table": "user_extra"
+                    "Query": "select 1 from user_extra as ue where ue.col = :u_col /* INT16 */ and ue.col2 = :u_col /* INT16 */ limit 1"
                   }
                 ]
               }
@@ -3209,7 +3062,6 @@
         },
         "FieldQuery": "select music.id from music, `user` where 1 != 1",
         "Query": "select music.id from music, `user` where music.user_id = 5 and music.user_id = `user`.id and music.id = (select max(m2.id) from music as m2 where m2.user_id = `user`.id)",
-        "Table": "`user`, music",
         "Values": [
           "5"
         ],
@@ -3235,8 +3087,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 0 from `user` as u, user_extra as s, music as m where 1 != 1",
-        "Query": "select 0 from `user` as u, user_extra as s, music as m where u.id = s.user_id and m.user_id = u.id and (s.foo or m.bar)",
-        "Table": "`user`, music, user_extra"
+        "Query": "select 0 from `user` as u, user_extra as s, music as m where u.id = s.user_id and m.user_id = u.id and (s.foo or m.bar)"
       },
       "TablesUsed": [
         "user.music",
@@ -3262,8 +3113,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id as found from `user` where 1 != 1",
-            "Query": "select id as found from `user`",
-            "Table": "`user`"
+            "Query": "select id as found from `user`"
           },
           {
             "OperatorType": "Route",
@@ -3273,8 +3123,7 @@
               "Sharded": false
             },
             "FieldQuery": "select id from unsharded where 1 != 1",
-            "Query": "select id from unsharded",
-            "Table": "unsharded"
+            "Query": "select id from unsharded"
           }
         ]
       },
@@ -3298,7 +3147,6 @@
           "user_extra_col": 0,
           "user_extra_id": 1
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3308,8 +3156,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.col, user_extra.id from user_extra where 1 != 1",
-            "Query": "select user_extra.col, user_extra.id from user_extra",
-            "Table": "user_extra"
+            "Query": "select user_extra.col, user_extra.id from user_extra"
           },
           {
             "OperatorType": "Route",
@@ -3320,7 +3167,6 @@
             },
             "FieldQuery": "select :user_extra_col /* INT16 */ + `user`.col as `user_extra.col + ``user``.col` from `user` where 1 != 1",
             "Query": "select :user_extra_col /* INT16 */ + `user`.col as `user_extra.col + ``user``.col` from `user` where `user`.id = :user_extra_id",
-            "Table": "`user`",
             "Values": [
               ":user_extra_id"
             ],
@@ -3348,8 +3194,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 1 from (select col from unsharded where 1 != 1) as f left join unsharded as u on f.col = u.id where 1 != 1",
-        "Query": "select 1 from (select col from unsharded order by unsharded.col1 desc limit 0, 12) as f left join unsharded as u on f.col = u.id",
-        "Table": "unsharded"
+        "Query": "select 1 from (select col from unsharded order by unsharded.col1 desc limit 0, 12) as f left join unsharded as u on f.col = u.id"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -3370,8 +3215,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 1 from (select col, count(*) as a from unsharded where 1 != 1 group by col) as f left join unsharded as u on f.col = u.id where 1 != 1",
-        "Query": "select 1 from (select col, count(*) as a from unsharded group by col having a > 0 limit 0, 12) as f left join unsharded as u on f.col = u.id",
-        "Table": "unsharded"
+        "Query": "select 1 from (select col, count(*) as a from unsharded group by col having a > 0 limit 0, 12) as f left join unsharded as u on f.col = u.id"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -3392,8 +3236,7 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.id, trim(leading 'x' from `user`.`name`) from `user` where 1 != 1",
-        "Query": "select `user`.id, trim(leading 'x' from `user`.`name`) from `user`",
-        "Table": "`user`"
+        "Query": "select `user`.id, trim(leading 'x' from `user`.`name`) from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -3414,8 +3257,7 @@
           "Sharded": true
         },
         "FieldQuery": "select jcol, json_storage_size(jcol), json_storage_free(jcol), json_pretty(jcol) from `user` where 1 != 1",
-        "Query": "select jcol, json_storage_size(jcol), json_storage_free(jcol), json_pretty(jcol) from `user`",
-        "Table": "`user`"
+        "Query": "select jcol, json_storage_size(jcol), json_storage_free(jcol), json_pretty(jcol) from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -3438,8 +3280,7 @@
         "FieldQuery": "select 1 from dual where 1 != 1",
         "Query": "select 1 from dual where exists (select 1 from information_schema.`TABLES` where `TABLES`.TABLE_NAME = :TABLES_TABLE_NAME /* VARCHAR */ and `TABLES`.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */)",
         "SysTableTableName": "[TABLES_TABLE_NAME:'proc']",
-        "SysTableTableSchema": "['mysql']",
-        "Table": "dual"
+        "SysTableTableSchema": "['mysql']"
       },
       "TablesUsed": [
         "main.dual"
@@ -3460,8 +3301,7 @@
           "Sharded": false
         },
         "FieldQuery": "select json_quote('null'), json_quote('\"null\"'), json_object(BIN(1), 2, 'abc', ASCII(4)), json_array(1, 'abc', null, true, curtime()) from dual where 1 != 1",
-        "Query": "select json_quote('null'), json_quote('\"null\"'), json_object(BIN(1), 2, 'abc', ASCII(4)), json_array(1, 'abc', null, true, curtime()) from dual",
-        "Table": "dual"
+        "Query": "select json_quote('null'), json_quote('\"null\"'), json_object(BIN(1), 2, 'abc', ASCII(4)), json_array(1, 'abc', null, true, curtime()) from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3495,8 +3335,7 @@
                 },
                 "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit 1",
-                "Table": "`user`"
+                "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit 1"
               }
             ]
           },
@@ -3509,8 +3348,7 @@
               "Sharded": true
             },
             "FieldQuery": "select :__sq1 as `(select id from ``user`` order by ``user``.id asc limit 1)` from user_extra where 1 != 1",
-            "Query": "select :__sq1 as `(select id from ``user`` order by ``user``.id asc limit 1)` from user_extra",
-            "Table": "user_extra"
+            "Query": "select :__sq1 as `(select id from ``user`` order by ``user``.id asc limit 1)` from user_extra"
           }
         ]
       },
@@ -3535,7 +3373,6 @@
         },
         "FieldQuery": "select exists (select 1 from dual where 1 != 1) from `user` where 1 != 1",
         "Query": "select exists (select 1 from dual) from `user` where id = 5",
-        "Table": "`user`",
         "Values": [
           "5"
         ],
@@ -3561,8 +3398,7 @@
           "Sharded": false
         },
         "FieldQuery": "select json_schema_valid('{\"type\":\"string\",\"pattern\":\"(\"}', '\"abc\"'), json_schema_validation_report('{\"type\":\"string\",\"pattern\":\"(\"}', '\"abc\"') from dual where 1 != 1",
-        "Query": "select json_schema_valid('{\"type\":\"string\",\"pattern\":\"(\"}', '\"abc\"'), json_schema_validation_report('{\"type\":\"string\",\"pattern\":\"(\"}', '\"abc\"') from dual",
-        "Table": "dual"
+        "Query": "select json_schema_valid('{\"type\":\"string\",\"pattern\":\"(\"}', '\"abc\"'), json_schema_validation_report('{\"type\":\"string\",\"pattern\":\"(\"}', '\"abc\"') from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3583,8 +3419,7 @@
           "Sharded": false
         },
         "FieldQuery": "select json_contains('{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}', '1'), json_contains_path('{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}', 'one', '$.a', '$.e'), json_extract('[10, 20, [30, 40]]', '$[1]'), json_unquote(json_extract('[\"a\",\"b\"]', '$[1]')), json_keys('{\"a\": 1, \"b\": {\"c\": 30}}'), json_overlaps('[1,3,5,7]', '[2,5,7]'), json_search('[\"abc\"]', 'one', 'abc'), json_value('{\"fname\": \"Joe\", \"lname\": \"Palmer\"}', '$.fname'), json_array(4, 5) member of ('[[3,4],[4,5]]') from dual where 1 != 1",
-        "Query": "select json_contains('{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}', '1'), json_contains_path('{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}', 'one', '$.a', '$.e'), json_extract('[10, 20, [30, 40]]', '$[1]'), json_unquote(json_extract('[\"a\",\"b\"]', '$[1]')), json_keys('{\"a\": 1, \"b\": {\"c\": 30}}'), json_overlaps('[1,3,5,7]', '[2,5,7]'), json_search('[\"abc\"]', 'one', 'abc'), json_value('{\"fname\": \"Joe\", \"lname\": \"Palmer\"}', '$.fname'), json_array(4, 5) member of ('[[3,4],[4,5]]') from dual",
-        "Table": "dual"
+        "Query": "select json_contains('{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}', '1'), json_contains_path('{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}', 'one', '$.a', '$.e'), json_extract('[10, 20, [30, 40]]', '$[1]'), json_unquote(json_extract('[\"a\",\"b\"]', '$[1]')), json_keys('{\"a\": 1, \"b\": {\"c\": 30}}'), json_overlaps('[1,3,5,7]', '[2,5,7]'), json_search('[\"abc\"]', 'one', 'abc'), json_value('{\"fname\": \"Joe\", \"lname\": \"Palmer\"}', '$.fname'), json_array(4, 5) member of ('[[3,4],[4,5]]') from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3605,8 +3440,7 @@
           "Sharded": true
         },
         "FieldQuery": "select a -> '$[4]', a ->> '$[3]' from `user` where 1 != 1",
-        "Query": "select a -> '$[4]', a ->> '$[3]' from `user`",
-        "Table": "`user`"
+        "Query": "select a -> '$[4]', a ->> '$[3]' from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -3627,8 +3461,7 @@
           "Sharded": true
         },
         "FieldQuery": "select u.id, u.age from `user` as u where 1 != 1 group by u.id",
-        "Query": "select u.id, u.age from `user` as u group by u.id",
-        "Table": "`user`"
+        "Query": "select u.id, u.age from `user` as u group by u.id"
       },
       "TablesUsed": [
         "user.user"
@@ -3649,8 +3482,7 @@
           "Sharded": false
         },
         "FieldQuery": "select json_depth('{}'), json_length('{\"a\": 1, \"b\": {\"c\": 30}}', '$.b'), json_type(json_extract('{\"a\": [10, true]}', '$.a')), json_valid('{\"a\": 1}') from dual where 1 != 1",
-        "Query": "select json_depth('{}'), json_length('{\"a\": 1, \"b\": {\"c\": 30}}', '$.b'), json_type(json_extract('{\"a\": [10, true]}', '$.a')), json_valid('{\"a\": 1}') from dual",
-        "Table": "dual"
+        "Query": "select json_depth('{}'), json_length('{\"a\": 1, \"b\": {\"c\": 30}}', '$.b'), json_type(json_extract('{\"a\": [10, true]}', '$.a')), json_valid('{\"a\": 1}') from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3671,8 +3503,7 @@
           "Sharded": false
         },
         "FieldQuery": "select json_array_append('{\"a\": 1}', '$', 'z'), json_array_insert('[\"a\", {\"b\": [1, 2]}, [3, 4]]', '$[0]', 'x', '$[2][1]', 'y'), json_insert('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', cast('[true, false]' as JSON)) from dual where 1 != 1",
-        "Query": "select json_array_append('{\"a\": 1}', '$', 'z'), json_array_insert('[\"a\", {\"b\": [1, 2]}, [3, 4]]', '$[0]', 'x', '$[2][1]', 'y'), json_insert('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', cast('[true, false]' as JSON)) from dual",
-        "Table": "dual"
+        "Query": "select json_array_append('{\"a\": 1}', '$', 'z'), json_array_insert('[\"a\", {\"b\": [1, 2]}, [3, 4]]', '$[0]', 'x', '$[2][1]', 'y'), json_insert('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', cast('[true, false]' as JSON)) from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3693,8 +3524,7 @@
           "Sharded": false
         },
         "FieldQuery": "select json_merge('[1, 2]', '[true, false]'), json_merge_patch('{\"name\": \"x\"}', '{\"id\": 47}'), json_merge_preserve('[1, 2]', '{\"id\": 47}') from dual where 1 != 1",
-        "Query": "select json_merge('[1, 2]', '[true, false]'), json_merge_patch('{\"name\": \"x\"}', '{\"id\": 47}'), json_merge_preserve('[1, 2]', '{\"id\": 47}') from dual",
-        "Table": "dual"
+        "Query": "select json_merge('[1, 2]', '[true, false]'), json_merge_patch('{\"name\": \"x\"}', '{\"id\": 47}'), json_merge_preserve('[1, 2]', '{\"id\": 47}') from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3715,8 +3545,7 @@
           "Sharded": false
         },
         "FieldQuery": "select json_remove('[1, [2, 3], 4]', '$[1]'), json_replace('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', '[true, false]'), json_set('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', '[true, false]'), json_unquote('\"abc\"') from dual where 1 != 1",
-        "Query": "select json_remove('[1, [2, 3], 4]', '$[1]'), json_replace('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', '[true, false]'), json_set('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', '[true, false]'), json_unquote('\"abc\"') from dual",
-        "Table": "dual"
+        "Query": "select json_remove('[1, [2, 3], 4]', '$[1]'), json_replace('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', '[true, false]'), json_set('{ \"a\": 1, \"b\": [2, 3]}', '$.a', 10, '$.c', '[true, false]'), json_unquote('\"abc\"') from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3738,7 +3567,6 @@
         },
         "FieldQuery": "select exists (select 1 from `user` where 1 != 1) from dual where 1 != 1",
         "Query": "select exists (select 1 from `user` where id = 4) from dual",
-        "Table": "dual",
         "Values": [
           "4"
         ],
@@ -3773,8 +3601,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
-            "Query": "select 1 from `user`",
-            "Table": "`user`"
+            "Query": "select 1 from `user`"
           },
           {
             "InputName": "Outer",
@@ -3785,8 +3612,7 @@
               "Sharded": false
             },
             "FieldQuery": "select :__sq_has_values2 as `exists (select 1 from ``user``)` from dual where 1 != 1",
-            "Query": "select :__sq_has_values2 as `exists (select 1 from ``user``)` from dual",
-            "Table": "dual"
+            "Query": "select :__sq_has_values2 as `exists (select 1 from ``user``)` from dual"
           }
         ]
       },
@@ -3832,8 +3658,7 @@
           "Sharded": true
         },
         "FieldQuery": "select insert(tcol1, id, 3, tcol2) from `user` where 1 != 1",
-        "Query": "select insert(tcol1, id, 3, tcol2) from `user`",
-        "Table": "`user`"
+        "Query": "select insert(tcol1, id, 3, tcol2) from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -3854,8 +3679,7 @@
           "Sharded": false
         },
         "FieldQuery": "select gtid_subset('3E11FA47-71CA-11E1-9E33-C80AA9429562:23', '3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57'), gtid_subtract('3E11FA47-71CA-11E1-9E33-C80AA9429562:23', '3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57') from dual where 1 != 1",
-        "Query": "select gtid_subset('3E11FA47-71CA-11E1-9E33-C80AA9429562:23', '3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57'), gtid_subtract('3E11FA47-71CA-11E1-9E33-C80AA9429562:23', '3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57') from dual",
-        "Table": "dual"
+        "Query": "select gtid_subset('3E11FA47-71CA-11E1-9E33-C80AA9429562:23', '3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57'), gtid_subtract('3E11FA47-71CA-11E1-9E33-C80AA9429562:23', '3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57') from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -3875,7 +3699,6 @@
         "JoinVars": {
           "user_col": 0
         },
-        "TableName": "`user`_user_extra, user_metadata",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3885,8 +3708,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user` where `user`.textcol1 = 'alice@gmail.com'",
-            "Table": "`user`"
+            "Query": "select `user`.col from `user` where `user`.textcol1 = 'alice@gmail.com'"
           },
           {
             "OperatorType": "Route",
@@ -3896,8 +3718,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_metadata.user_id from user_extra, user_metadata where 1 != 1",
-            "Query": "select user_metadata.user_id from user_extra, user_metadata where user_extra.col = :user_col /* INT16 */ and user_extra.user_id = user_metadata.user_id",
-            "Table": "user_extra, user_metadata"
+            "Query": "select user_metadata.user_id from user_extra, user_metadata where user_extra.col = :user_col /* INT16 */ and user_extra.user_id = user_metadata.user_id"
           }
         ]
       },
@@ -3923,7 +3744,6 @@
         },
         "FieldQuery": "select `user`.id from `user`, music_extra, music where 1 != 1",
         "Query": "select `user`.id from `user`, music_extra, music where music.id = 456 and `user`.id = 123 and `user`.id = music_extra.user_id and music_extra.user_id = music.user_id",
-        "Table": "`user`, music, music_extra",
         "Values": [
           "123"
         ],
@@ -3970,7 +3790,6 @@
                     },
                     "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
                     "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                    "Table": "name_user_vdx",
                     "Values": [
                       "::name"
                     ],
@@ -3986,8 +3805,7 @@
                     "FieldQuery": "select id, `name`, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|2) ASC",
                     "Query": "select id, `name`, weight_string(id) from `user` where `name` = 'aa' order by `user`.id asc limit 2",
-                    "ResultColumns": 2,
-                    "Table": "`user`"
+                    "ResultColumns": 2
                   }
                 ]
               }
@@ -4019,7 +3837,6 @@
                     },
                     "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
                     "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                    "Table": "name_user_vdx",
                     "Values": [
                       "::name"
                     ],
@@ -4033,8 +3850,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from `user` where 1 != 1",
-                    "Query": "select count(*) from `user` where `name` = 'aa'",
-                    "Table": "`user`"
+                    "Query": "select count(*) from `user` where `name` = 'aa'"
                   }
                 ]
               }
@@ -4061,8 +3877,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music, `user` where 1 != 1",
-        "Query": "select music.id from music, `user` where music.user_id in (null) and `user`.id = 5 and music.user_id = `user`.id",
-        "Table": "`user`, music"
+        "Query": "select music.id from music, `user` where music.user_id in (null) and `user`.id = 5 and music.user_id = `user`.id"
       },
       "TablesUsed": [
         "user.music",
@@ -4085,7 +3900,6 @@
         },
         "FieldQuery": "select music.id from music where 1 != 1",
         "Query": "select music.id from music where music.user_id = 5 and music.id in (select music.id from music where music.user_id in (5))",
-        "Table": "music",
         "Values": [
           "5"
         ],
@@ -4111,7 +3925,6 @@
         },
         "FieldQuery": "select music.id from music where 1 != 1",
         "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (1, 2, 3))",
-        "Table": "music",
         "Values": [
           "(1, 2, 3)"
         ],
@@ -4137,7 +3950,6 @@
         },
         "FieldQuery": "select music.id from music where 1 != 1",
         "Query": "select music.id from music where music.id in (select id from (select music.id from music where music.user_id in (1, 2, 3)) as _inner)",
-        "Table": "music",
         "Values": [
           "(1, 2, 3)"
         ],
@@ -4163,7 +3975,6 @@
         },
         "FieldQuery": "select music.id from music where 1 != 1",
         "Query": "select music.id from music where music.user_id in ::__vals and music.id in (select music.id from music where music.foo = 'bar')",
-        "Table": "music",
         "Values": [
           "(3, 4, 5)"
         ],
@@ -4189,7 +4000,6 @@
         },
         "FieldQuery": "select music.id from music where 1 != 1",
         "Query": "select music.id from music where music.user_id = 5 and music.id in (select music.id from music where music.user_id in (1, 2, 3))",
-        "Table": "music",
         "Values": [
           "5"
         ],
@@ -4214,8 +4024,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (1, 2, 3)) or music.user_id = 5",
-        "Table": "music"
+        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (1, 2, 3)) or music.user_id = 5"
       },
       "TablesUsed": [
         "user.music"
@@ -4236,8 +4045,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.user_id = 5 and music.id in (select music.id from music where music.user_id in (null))",
-        "Table": "music"
+        "Query": "select music.id from music where music.user_id = 5 and music.id in (select music.id from music where music.user_id in (null))"
       },
       "TablesUsed": [
         "user.music"
@@ -4258,8 +4066,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (null)) or music.user_id = 5",
-        "Table": "music"
+        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (null)) or music.user_id = 5"
       },
       "TablesUsed": [
         "user.music"
@@ -4280,8 +4087,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.id in (select music.id from music where music.genre = 'pop')",
-        "Table": "music"
+        "Query": "select music.id from music where music.id in (select music.id from music where music.genre = 'pop')"
       },
       "TablesUsed": [
         "user.music"
@@ -4302,8 +4108,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.id in (select music.id from music where music.genre = 'pop' group by music.id)",
-        "Table": "music"
+        "Query": "select music.id from music where music.id in (select music.id from music where music.genre = 'pop' group by music.id)"
       },
       "TablesUsed": [
         "user.music"
@@ -4341,8 +4146,7 @@
                 },
                 "FieldQuery": "select music.id, music.genre, weight_string(music.genre) from music where 1 != 1 group by music.genre, weight_string(music.genre)",
                 "OrderBy": "(1|2) ASC",
-                "Query": "select music.id, music.genre, weight_string(music.genre) from music where music.genre = 'pop' group by music.genre, weight_string(music.genre) order by music.genre asc",
-                "Table": "music"
+                "Query": "select music.id, music.genre, weight_string(music.genre) from music where music.genre = 'pop' group by music.genre, weight_string(music.genre) order by music.genre asc"
               }
             ]
           },
@@ -4356,7 +4160,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4396,8 +4199,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select music.id from music where 1 != 1",
-                "Query": "select music.id from music where music.genre = 'pop' limit 10",
-                "Table": "music"
+                "Query": "select music.id from music where music.genre = 'pop' limit 10"
               }
             ]
           },
@@ -4411,7 +4213,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4448,7 +4249,6 @@
             },
             "FieldQuery": "select max(music.id) from music where 1 != 1 group by music.user_id",
             "Query": "select max(music.id) from music where music.user_id in ::__vals group by music.user_id",
-            "Table": "music",
             "Values": [
               "(5, 6)"
             ],
@@ -4464,7 +4264,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4507,7 +4306,6 @@
                 },
                 "FieldQuery": "select max(music.id), weight_string(max(music.id)) from music where 1 != 1",
                 "Query": "select max(music.id), weight_string(max(music.id)) from music where music.user_id in ::__vals",
-                "Table": "music",
                 "Values": [
                   "(5, 6)"
                 ],
@@ -4525,7 +4323,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4562,7 +4359,6 @@
             },
             "FieldQuery": "select max(music.id) from music where 1 != 1",
             "Query": "select max(music.id) from music where music.user_id = 5",
-            "Table": "music",
             "Values": [
               "5"
             ],
@@ -4578,7 +4374,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4615,7 +4410,6 @@
             },
             "FieldQuery": "select max(music.id) from music where 1 != 1",
             "Query": "select max(music.id) from music where music.user_id = 5 limit 10",
-            "Table": "music",
             "Values": [
               "5"
             ],
@@ -4631,7 +4425,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4659,7 +4452,6 @@
         },
         "FieldQuery": "select music.id from music where 1 != 1",
         "Query": "select music.id from music where music.id in (select id from (select id from (select music.id from music where music.user_id = 5 limit 10) as subquery_for_limit) as subquery_for_limit)",
-        "Table": "music",
         "Values": [
           "5"
         ],
@@ -4685,7 +4477,6 @@
         },
         "FieldQuery": "select music.id from music where 1 != 1",
         "Query": "select music.id from music where music.id in (select id from (select id from (select music.id from music where music.user_id in (5) limit 10) as subquery_for_limit) as subquery_for_limit)",
-        "Table": "music",
         "Values": [
           "5"
         ],
@@ -4724,7 +4515,6 @@
                 },
                 "FieldQuery": "select id from (select id from (select music.id from music where 1 != 1) as subquery_for_limit where 1 != 1) as subquery_for_limit where 1 != 1",
                 "Query": "select id from (select id from (select music.id from music where music.user_id in ::__vals) as subquery_for_limit limit 10) as subquery_for_limit",
-                "Table": "music",
                 "Values": [
                   "(5, 6)"
                 ],
@@ -4742,7 +4532,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4782,8 +4571,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id from (select id from (select music.id from music where 1 != 1) as subquery_for_limit where 1 != 1) as subquery_for_limit where 1 != 1",
-                "Query": "select id from (select id from (select music.id from music) as subquery_for_limit limit 10) as subquery_for_limit",
-                "Table": "music"
+                "Query": "select id from (select id from (select music.id from music) as subquery_for_limit limit 10) as subquery_for_limit"
               }
             ]
           },
@@ -4797,7 +4585,6 @@
             },
             "FieldQuery": "select music.id from music where 1 != 1",
             "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals",
-            "Table": "music",
             "Values": [
               "::__sq1"
             ],
@@ -4824,8 +4611,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (null))",
-        "Table": "music"
+        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (null))"
       },
       "TablesUsed": [
         "user.music"
@@ -4846,8 +4632,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.user_id = 5 and music.id in (select music.id from music where music.user_id in (null))",
-        "Table": "music"
+        "Query": "select music.id from music where music.user_id = 5 and music.id in (select music.id from music where music.user_id in (null))"
       },
       "TablesUsed": [
         "user.music"
@@ -4868,8 +4653,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from music where 1 != 1",
-        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (null)) or music.user_id = 5",
-        "Table": "music"
+        "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (null)) or music.user_id = 5"
       },
       "TablesUsed": [
         "user.music"
@@ -4891,7 +4675,6 @@
         },
         "FieldQuery": "select music.id from (select max(id) as maxt from music where 1 != 1) as other, music where 1 != 1",
         "Query": "select music.id from (select max(id) as maxt from music where music.user_id = 5) as other, music where other.maxt = music.id",
-        "Table": "music",
         "Values": [
           "5"
         ],
@@ -4917,7 +4700,6 @@
         },
         "FieldQuery": "select music.id from (select id from music where 1 != 1) as other, music where 1 != 1",
         "Query": "select music.id from (select id from music where music.user_id = 5) as other, music where other.id = music.id",
-        "Table": "music",
         "Values": [
           "5"
         ],
@@ -4943,7 +4725,6 @@
         },
         "FieldQuery": "select music.id from (select id from music where 1 != 1) as other, music where 1 != 1",
         "Query": "select music.id from (select id from music where music.user_id in ::__vals) as other, music where other.id = music.id",
-        "Table": "music",
         "Values": [
           "(5, 6, 7)"
         ],
@@ -4967,7 +4748,6 @@
         "JoinVars": {
           "ue_user_id": 0
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Limit",
@@ -4981,8 +4761,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select ue.user_id from (select user_id from user_extra where 1 != 1) as ue where 1 != 1",
-                "Query": "select ue.user_id from (select user_id from user_extra) as ue limit 10",
-                "Table": "user_extra"
+                "Query": "select ue.user_id from (select user_id from user_extra) as ue limit 10"
               }
             ]
           },
@@ -4995,7 +4774,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where `user`.id = :ue_user_id",
-            "Table": "`user`",
             "Values": [
               ":ue_user_id"
             ],
@@ -5022,7 +4800,6 @@
         "JoinVars": {
           "t_id": 1
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "SimpleProjection",
@@ -5044,8 +4821,7 @@
                     },
                     "FieldQuery": "select id, count(*) as b, req, weight_string(req), weight_string(id) from user_extra where 1 != 1 group by req, id, weight_string(req), weight_string(id)",
                     "OrderBy": "(2|3) ASC, (0|4) ASC",
-                    "Query": "select id, count(*) as b, req, weight_string(req), weight_string(id) from user_extra group by req, id, weight_string(req), weight_string(id) order by req asc, id asc",
-                    "Table": "user_extra"
+                    "Query": "select id, count(*) as b, req, weight_string(req), weight_string(id) from user_extra group by req, id, weight_string(req), weight_string(id) order by req asc, id asc"
                   }
                 ]
               }
@@ -5060,7 +4836,6 @@
             },
             "FieldQuery": "select `user`.a from `user` where 1 != 1",
             "Query": "select `user`.a from `user` where `user`.id = :t_id",
-            "Table": "`user`",
             "Values": [
               ":t_id"
             ],
@@ -5089,7 +4864,6 @@
         },
         "FieldQuery": "select music.id from (select max(id) as maxt from music where 1 != 1) as other, music where 1 != 1",
         "Query": "select music.id from (select max(id) as maxt from music where music.user_id = 5) as other, music where other.maxt = music.id",
-        "Table": "music",
         "Values": [
           "5"
         ],
@@ -5114,8 +4888,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 1 as x, (select x from dual where 1 != 1) from dual where 1 != 1",
-        "Query": "select 1 as x, (select x from dual) from dual",
-        "Table": "dual"
+        "Query": "select 1 as x, (select x from dual) from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -5137,7 +4910,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -5163,7 +4935,6 @@
         },
         "FieldQuery": "select * from `user` where 1 != 1",
         "Query": "select * from `user` where id = 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -5188,8 +4959,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a where 1 != 1)) as `name` from dual where 1 != 1) as t2 where 1 != 1",
-        "Query": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a)) as `name` from dual) as t2 where t1.`name` >= t2.`name` order by t1.`name` asc limit 1",
-        "Table": "dual, unsharded_a"
+        "Query": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a)) as `name` from dual) as t2 where t1.`name` >= t2.`name` order by t1.`name` asc limit 1"
       },
       "TablesUsed": [
         "main.dual",
@@ -5212,7 +4982,6 @@
         },
         "FieldQuery": "select (select 1 from `user` as u1 join `user` as u2 on u1.id = u2.id and u1.id = u3.id where 1 != 1) as subquery from `user` as u3 where 1 != 1",
         "Query": "select (select 1 from `user` as u1 join `user` as u2 on u1.id = u2.id and u1.id = u3.id) as subquery from `user` as u3 where u3.id = 1",
-        "Table": "`user`",
         "Values": [
           "1"
         ],
@@ -5237,8 +5006,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 1 from unsharded where 1 != 1",
-        "Query": "select 1 from unsharded where foo = any (select 1 from unsharded_a where foo = 1)",
-        "Table": "unsharded, unsharded_a"
+        "Query": "select 1 from unsharded where foo = any (select 1 from unsharded_a where foo = 1)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -5260,8 +5028,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 1 from unsharded where 1 != 1",
-        "Query": "select 1 from unsharded where foo = all (select 1 from unsharded_a where foo = 1)",
-        "Table": "unsharded, unsharded_a"
+        "Query": "select 1 from unsharded where foo = all (select 1 from unsharded_a where foo = 1)"
       },
       "TablesUsed": [
         "main.unsharded",
@@ -5283,8 +5050,7 @@
           "Sharded": true
         },
         "FieldQuery": "select last_insert_id(id) from `user` where 1 != 1",
-        "Query": "select last_insert_id(id) from `user`",
-        "Table": "`user`"
+        "Query": "select last_insert_id(id) from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -5305,8 +5071,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 1 from `user`, music_extra where 1 != 1",
-        "Query": "select 1 from `user`, music_extra where `user`.id = music_extra.user_id and music_extra.music_id = (select max(music_id) from music_extra where user_id = `user`.id)",
-        "Table": "`user`, music_extra"
+        "Query": "select 1 from `user`, music_extra where `user`.id = music_extra.user_id and music_extra.music_id = (select max(music_id) from music_extra where user_id = `user`.id)"
       },
       "TablesUsed": [
         "user.music_extra",
@@ -5329,7 +5094,6 @@
         },
         "FieldQuery": "select * from user_metadata where 1 != 1",
         "Query": "select * from user_metadata where user_metadata.non_planable = 'foo'",
-        "Table": "user_metadata",
         "Values": [
           "'foo'"
         ],
@@ -5367,7 +5131,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -5381,8 +5144,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.id from `user` as u, user_metadata as um where 1 != 1",
-            "Query": "select u.id from `user` as u, user_metadata as um where u.`name` = 'foo' and u.id = um.user_id",
-            "Table": "`user`, user_metadata"
+            "Query": "select u.id from `user` as u, user_metadata as um where u.`name` = 'foo' and u.id = um.user_id"
           }
         ]
       },
@@ -5419,7 +5181,6 @@
             },
             "FieldQuery": "select unq_key, keyspace_id from unq_lkp_idx where 1 != 1",
             "Query": "select unq_key, keyspace_id from unq_lkp_idx where unq_key in ::__vals",
-            "Table": "unq_lkp_idx",
             "Values": [
               "::unq_key"
             ],
@@ -5433,8 +5194,7 @@
               "Sharded": true
             },
             "FieldQuery": "select * from customer where 1 != 1",
-            "Query": "select * from customer where email = 'a@mail.com'",
-            "Table": "customer"
+            "Query": "select * from customer where email = 'a@mail.com'"
           }
         ]
       },
@@ -5457,8 +5217,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from customer where 1 != 1",
-        "Query": "select * from customer where phone = 123456",
-        "Table": "customer"
+        "Query": "select * from customer where phone = 123456"
       },
       "TablesUsed": [
         "user.customer"
@@ -5479,8 +5238,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from customer where 1 != 1",
-        "Query": "select * from customer where `name` = 'x'",
-        "Table": "customer"
+        "Query": "select * from customer where `name` = 'x'"
       },
       "TablesUsed": [
         "user.customer"
@@ -5514,7 +5272,6 @@
             },
             "FieldQuery": "select unq_key, keyspace_id from unq_lkp_idx where 1 != 1",
             "Query": "select unq_key, keyspace_id from unq_lkp_idx where unq_key in ::__vals",
-            "Table": "unq_lkp_idx",
             "Values": [
               "::unq_key"
             ],
@@ -5528,8 +5285,7 @@
               "Sharded": true
             },
             "FieldQuery": "select * from customer where 1 != 1",
-            "Query": "select * from customer where email = 'a@mail.com' and phone = 123456",
-            "Table": "customer"
+            "Query": "select * from customer where email = 'a@mail.com' and phone = 123456"
           }
         ]
       },
@@ -5565,7 +5321,6 @@
             },
             "FieldQuery": "select unq_key, keyspace_id from unq_lkp_idx where 1 != 1",
             "Query": "select unq_key, keyspace_id from unq_lkp_idx where unq_key in ::__vals",
-            "Table": "unq_lkp_idx",
             "Values": [
               "::unq_key"
             ],
@@ -5579,8 +5334,7 @@
               "Sharded": true
             },
             "FieldQuery": "select * from customer where 1 != 1",
-            "Query": "select * from customer where phone = 123456 and email = 'a@mail.com'",
-            "Table": "customer"
+            "Query": "select * from customer where phone = 123456 and email = 'a@mail.com'"
           }
         ]
       },
@@ -5603,8 +5357,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col from samecolvin where 1 != 1",
-        "Query": "select col from samecolvin where secret = 12",
-        "Table": "samecolvin"
+        "Query": "select col from samecolvin where secret = 12"
       },
       "TablesUsed": [
         "user.samecolvin"
@@ -5621,7 +5374,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "`user`_user_extra",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -5632,8 +5384,7 @@
             },
             "FieldQuery": "select u.foo, weight_string(u.foo) from `user` as u where 1 != 1",
             "OrderBy": "(0|1) ASC",
-            "Query": "select u.foo, weight_string(u.foo) from `user` as u order by u.foo asc",
-            "Table": "`user`"
+            "Query": "select u.foo, weight_string(u.foo) from `user` as u order by u.foo asc"
           },
           {
             "OperatorType": "Route",
@@ -5643,8 +5394,7 @@
               "Sharded": true
             },
             "FieldQuery": "select ue.foo as apa from user_extra as ue where 1 != 1",
-            "Query": "select ue.foo as apa from user_extra as ue",
-            "Table": "user_extra"
+            "Query": "select ue.foo as apa from user_extra as ue"
           }
         ]
       },
@@ -5667,7 +5417,6 @@
         "JoinVars": {
           "tables_table_name": 0
         },
-        "TableName": "unsharded_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -5677,8 +5426,7 @@
               "Sharded": false
             },
             "FieldQuery": "select `tables`.table_name from (select table_name from unsharded where 1 != 1) as `tables` where 1 != 1",
-            "Query": "select `tables`.table_name from (select table_name from unsharded limit 1) as `tables`",
-            "Table": "unsharded"
+            "Query": "select `tables`.table_name from (select table_name from unsharded limit 1) as `tables`"
           },
           {
             "OperatorType": "Route",
@@ -5688,8 +5436,7 @@
               "Sharded": true
             },
             "FieldQuery": "select c.column_name from `user` as c where 1 != 1",
-            "Query": "select c.column_name from `user` as c where c.table_name = :tables_table_name",
-            "Table": "`user`"
+            "Query": "select c.column_name from `user` as c where c.table_name = :tables_table_name"
           }
         ]
       },
@@ -5720,7 +5467,6 @@
             "JoinVars": {
               "user_cola": 2
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5730,8 +5476,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `name` as t0, `name` as t1, `user`.cola from `user` where 1 != 1",
-                "Query": "select `name` as t0, `name` as t1, `user`.cola from `user`",
-                "Table": "`user`"
+                "Query": "select `name` as t0, `name` as t1, `user`.cola from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -5741,8 +5486,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra where user_extra.cola = :user_cola",
-                "Table": "user_extra"
+                "Query": "select 1 from user_extra where user_extra.cola = :user_cola"
               }
             ]
           }
@@ -5768,8 +5512,7 @@
           "Sharded": false
         },
         "FieldQuery": "select val, cume_dist() over w, row_number() over w, dense_rank() over w, percent_rank() over w, rank() over w as cd from unsharded_a where 1 != 1",
-        "Query": "select val, cume_dist() over w, row_number() over w, dense_rank() over w, percent_rank() over w, rank() over w as cd from unsharded_a",
-        "Table": "unsharded_a"
+        "Query": "select val, cume_dist() over w, row_number() over w, dense_rank() over w, percent_rank() over w, rank() over w as cd from unsharded_a"
       },
       "TablesUsed": [
         "main.unsharded_a"
@@ -5790,8 +5533,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 1 from (select id as uid from `user` where 1 != 1) as t, `user` where 1 != 1",
-        "Query": "select 1 from (select id as uid from `user`) as t, `user` where t.uid = `user`.id",
-        "Table": "`user`"
+        "Query": "select 1 from (select id as uid from `user`) as t, `user` where t.uid = `user`.id"
       },
       "TablesUsed": [
         "user.user"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases_with_default.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases_with_default.json
@@ -14,7 +14,6 @@
         },
         "FieldQuery": "select exists (select 1 from `user` where 1 != 1) from dual where 1 != 1",
         "Query": "select exists (select 1 from `user` where id = 5) from dual",
-        "Table": "dual",
         "Values": [
           "5"
         ],

--- a/go/vt/vtgate/planbuilder/testdata/select_cases_with_user_as_default.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases_with_user_as_default.json
@@ -14,7 +14,6 @@
         },
         "FieldQuery": "select exists (select 1 from `user` where 1 != 1) from dual where 1 != 1",
         "Query": "select exists (select 1 from `user` where id = 5) from dual",
-        "Table": "dual",
         "Values": [
           "5"
         ],

--- a/go/vt/vtgate/planbuilder/testdata/symtab_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/symtab_cases.json
@@ -12,7 +12,6 @@
         "JoinVars": {
           "predef2": 0
         },
-        "TableName": "`user`_unsharded",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -22,8 +21,7 @@
               "Sharded": true
             },
             "FieldQuery": "select predef2 from `user` where 1 != 1",
-            "Query": "select predef2 from `user`",
-            "Table": "`user`"
+            "Query": "select predef2 from `user`"
           },
           {
             "OperatorType": "Route",
@@ -33,8 +31,7 @@
               "Sharded": false
             },
             "FieldQuery": "select predef3 from unsharded where 1 != 1",
-            "Query": "select predef3 from unsharded where predef3 = :predef2",
-            "Table": "unsharded"
+            "Query": "select predef3 from unsharded where predef3 = :predef2"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/sysschema_default.json
+++ b/go/vt/vtgate/planbuilder/testdata/sysschema_default.json
@@ -13,8 +13,7 @@
           "Sharded": false
         },
         "FieldQuery": "select @@max_allowed_packet from dual where 1 != 1",
-        "Query": "select @@max_allowed_packet from dual",
-        "Table": "dual"
+        "Query": "select @@max_allowed_packet from dual"
       },
       "TablesUsed": [
         "main.dual"
@@ -36,8 +35,7 @@
         },
         "FieldQuery": "select t.table_schema, t.table_name, c.column_name, c.column_type from information_schema.`tables` as t, information_schema.`columns` as c where 1 != 1",
         "Query": "select t.table_schema, t.table_name, c.column_name, c.column_type from information_schema.`tables` as t, information_schema.`columns` as c where t.table_schema = :__vtschemaname /* VARCHAR */ and c.table_schema = :__vtschemaname /* VARCHAR */ and c.table_schema = t.table_schema and c.table_name = t.table_name order by t.table_schema asc, t.table_name asc, c.column_name asc",
-        "SysTableTableSchema": "['user']",
-        "Table": "information_schema.`columns`, information_schema.`tables`"
+        "SysTableTableSchema": "['user']"
       }
     }
   },
@@ -56,8 +54,7 @@
         },
         "FieldQuery": "select (select 1 from information_schema.schemata where 1 != 1) as `(select 1 from information_schema.schemata where schema_name = 'MyDatabase' limit 1)` from dual where 1 != 1",
         "Query": "select (select 1 from information_schema.schemata where schema_name = :__vtschemaname /* VARCHAR */ limit 1) as `(select 1 from information_schema.schemata where schema_name = 'MyDatabase' limit 1)` from dual",
-        "SysTableTableSchema": "['MyDatabase']",
-        "Table": "dual"
+        "SysTableTableSchema": "['MyDatabase']"
       },
       "TablesUsed": [
         "main.dual"
@@ -79,8 +76,7 @@
         },
         "FieldQuery": "select `1` from (select 1 from information_schema.schemata where 1 != 1) as x where 1 != 1",
         "Query": "select `1` from (select 1 from information_schema.schemata where schema_name = :__vtschemaname /* VARCHAR */ limit 1) as x",
-        "SysTableTableSchema": "['MyDatabase']",
-        "Table": "information_schema.schemata"
+        "SysTableTableSchema": "['MyDatabase']"
       }
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.json
@@ -14,7 +14,6 @@
         },
         "FieldQuery": "select c_discount, c_last, c_credit, w_tax from customer1 as c, warehouse1 as w where 1 != 1",
         "Query": "select c_discount, c_last, c_credit, w_tax from customer1 as c, warehouse1 as w where c_d_id = 15 and c_id = 10 and w_id = 1 and c_w_id = w_id",
-        "Table": "customer1, warehouse1",
         "Values": [
           "1"
         ],
@@ -41,7 +40,6 @@
         },
         "FieldQuery": "select d_next_o_id, d_tax from district1 where 1 != 1",
         "Query": "select d_next_o_id, d_tax from district1 where d_w_id = 15 and d_id = 95 for update",
-        "Table": "district1",
         "Values": [
           "15"
         ],
@@ -67,7 +65,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update district1 set d_next_o_id = 56 where d_id = 9842 and d_w_id = 8546",
-        "Table": "district1",
         "Values": [
           "8546"
         ],
@@ -93,7 +90,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into orders1(o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) values (334983, 59896, :_o_w_id_0, 156, now(), 781038, 'hello')",
-        "TableName": "orders1",
         "VindexValues": {
           "hash": "99"
         }
@@ -118,7 +114,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into new_orders1(no_o_id, no_d_id, no_w_id) values (8, 9, :_no_w_id_0)",
-        "TableName": "new_orders1",
         "VindexValues": {
           "hash": "48"
         }
@@ -143,7 +138,6 @@
         },
         "FieldQuery": "select i_price, i_name, i_data from item1 where 1 != 1",
         "Query": "select i_price, i_name, i_data from item1 where i_id = 9654",
-        "Table": "item1",
         "Values": [
           "9654"
         ],
@@ -169,7 +163,6 @@
         },
         "FieldQuery": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where 1 != 1",
         "Query": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where s_i_id = 2198 and s_w_id = 89 for update",
-        "Table": "stock1",
         "Values": [
           "89"
         ],
@@ -195,7 +188,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update stock1 set s_quantity = 894 where s_i_id = 156 and s_w_id = 6",
-        "Table": "stock1",
         "Values": [
           "6"
         ],
@@ -221,7 +213,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into order_line1(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) values (648, 36812, :_ol_w_id_0, 4946378, 3, 7, 89, 1, 'info')",
-        "TableName": "order_line1",
         "VindexValues": {
           "hash": "3201"
         }
@@ -246,7 +237,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update warehouse1 set w_ytd = w_ytd + 946879 where w_id = 3",
-        "Table": "warehouse1",
         "Values": [
           "3"
         ],
@@ -272,7 +262,6 @@
         },
         "FieldQuery": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where 1 != 1",
         "Query": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where w_id = 998",
-        "Table": "warehouse1",
         "Values": [
           "998"
         ],
@@ -298,7 +287,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update district1 set d_ytd = d_ytd + 2 where d_w_id = 89 and d_id = 9",
-        "Table": "district1",
         "Values": [
           "89"
         ],
@@ -324,7 +312,6 @@
         },
         "FieldQuery": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where 1 != 1",
         "Query": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where d_w_id = 896 and d_id = 9",
-        "Table": "district1",
         "Values": [
           "896"
         ],
@@ -350,7 +337,6 @@
         },
         "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
         "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 5 and c_d_id = 1 and c_last = 'last'",
-        "Table": "customer1",
         "Values": [
           "5"
         ],
@@ -376,7 +362,6 @@
         },
         "FieldQuery": "select c_id from customer1 where 1 != 1",
         "Query": "select c_id from customer1 where c_w_id = 8 and c_d_id = 5 and c_last = 'item_last' order by c_first asc",
-        "Table": "customer1",
         "Values": [
           "8"
         ],
@@ -402,7 +387,6 @@
         },
         "FieldQuery": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where 1 != 1",
         "Query": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where c_w_id = 8965 and c_d_id = 1 and c_id = 9 for update",
-        "Table": "customer1",
         "Values": [
           "8965"
         ],
@@ -428,7 +412,6 @@
         },
         "FieldQuery": "select c_data from customer1 where 1 != 1",
         "Query": "select c_data from customer1 where c_w_id = 32 and c_d_id = 68 and c_id = 5",
-        "Table": "customer1",
         "Values": [
           "32"
         ],
@@ -454,7 +437,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update customer1 set c_balance = 508.98, c_ytd_payment = 48941.980301, c_data = 'i am data' where c_w_id = 20 and c_d_id = 387 and c_id = 98",
-        "Table": "customer1",
         "Values": [
           "20"
         ],
@@ -480,7 +462,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update customer1 set c_balance = 508.98, c_ytd_payment = 48941.980301 where c_w_id = 20 and c_d_id = 387 and c_id = 98",
-        "Table": "customer1",
         "Values": [
           "20"
         ],
@@ -506,7 +487,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "insert into history1(h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data) values (6809887, 38748, 8746, 210, :_h_w_id_0, now(), 8907, 'data')",
-        "TableName": "history1",
         "VindexValues": {
           "hash": "8"
         }
@@ -531,7 +511,6 @@
         },
         "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
         "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 870 and c_d_id = 780 and c_last = 'last'",
-        "Table": "customer1",
         "Values": [
           "870"
         ],
@@ -557,7 +536,6 @@
         },
         "FieldQuery": "select c_balance, c_first, c_middle, c_id from customer1 where 1 != 1",
         "Query": "select c_balance, c_first, c_middle, c_id from customer1 where c_w_id = 840 and c_d_id = 1 and c_last = 'test' order by customer1.c_first asc",
-        "Table": "customer1",
         "Values": [
           "840"
         ],
@@ -583,7 +561,6 @@
         },
         "FieldQuery": "select c_balance, c_first, c_middle, c_last from customer1 where 1 != 1",
         "Query": "select c_balance, c_first, c_middle, c_last from customer1 where c_w_id = 15 and c_d_id = 5169 and c_id = 1",
-        "Table": "customer1",
         "Values": [
           "15"
         ],
@@ -609,7 +586,6 @@
         },
         "FieldQuery": "select o_id, o_carrier_id, o_entry_d from orders1 where 1 != 1",
         "Query": "select o_id, o_carrier_id, o_entry_d from orders1 where o_w_id = 9894 and o_d_id = 3 and o_c_id = 159 order by orders1.o_id desc",
-        "Table": "orders1",
         "Values": [
           "9894"
         ],
@@ -635,7 +611,6 @@
         },
         "FieldQuery": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where 1 != 1",
         "Query": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where ol_w_id = 92 and ol_d_id = 5 and ol_o_id = 1",
-        "Table": "order_line1",
         "Values": [
           "92"
         ],
@@ -661,7 +636,6 @@
         },
         "FieldQuery": "select no_o_id from new_orders1 where 1 != 1",
         "Query": "select no_o_id from new_orders1 where no_d_id = 689 and no_w_id = 15 order by new_orders1.no_o_id asc limit 1 for update",
-        "Table": "new_orders1",
         "Values": [
           "15"
         ],
@@ -687,7 +661,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete from new_orders1 where no_o_id = 2218 and no_d_id = 358 and no_w_id = 98465",
-        "Table": "new_orders1",
         "Values": [
           "98465"
         ],
@@ -713,7 +686,6 @@
         },
         "FieldQuery": "select o_c_id from orders1 where 1 != 1",
         "Query": "select o_c_id from orders1 where o_id = 6 and o_d_id = 1983 and o_w_id = 894605",
-        "Table": "orders1",
         "Values": [
           "894605"
         ],
@@ -739,7 +711,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update orders1 set o_carrier_id = 9 where o_id = 56 and o_d_id = 98 and o_w_id = 897",
-        "Table": "orders1",
         "Values": [
           "897"
         ],
@@ -765,7 +736,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update order_line1 set ol_delivery_d = now() where ol_o_id = 235 and ol_d_id = 315 and ol_w_id = 8",
-        "Table": "order_line1",
         "Values": [
           "8"
         ],
@@ -791,7 +761,6 @@
         },
         "FieldQuery": "select sum(ol_amount) as sm from order_line1 where 1 != 1",
         "Query": "select sum(ol_amount) as sm from order_line1 where ol_o_id = 680 and ol_d_id = 201 and ol_w_id = 87",
-        "Table": "order_line1",
         "Values": [
           "87"
         ],
@@ -817,7 +786,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "update customer1 set c_balance = c_balance + 988.01, c_delivery_cnt = c_delivery_cnt + 1 where c_id = 6 and c_d_id = 5 and c_w_id = 160",
-        "Table": "customer1",
         "Values": [
           "160"
         ],
@@ -843,7 +811,6 @@
         },
         "FieldQuery": "select d_next_o_id from district1 where 1 != 1",
         "Query": "select d_next_o_id from district1 where d_id = 6 and d_w_id = 21",
-        "Table": "district1",
         "Values": [
           "21"
         ],
@@ -869,7 +836,6 @@
         },
         "FieldQuery": "select count(distinct s.s_i_id) from stock1 as s, order_line1 as ol where 1 != 1",
         "Query": "select count(distinct s.s_i_id) from stock1 as s, order_line1 as ol where s.s_w_id = 12 and s.s_quantity < 10 and ol.ol_w_id = 12 and ol.ol_d_id = 1908 and ol.ol_o_id < 30 and ol.ol_o_id >= 15 and ol.ol_w_id = s.s_w_id and ol.ol_i_id = s.s_i_id",
-        "Table": "order_line1, stock1",
         "Values": [
           "12"
         ],
@@ -896,7 +862,6 @@
         },
         "FieldQuery": "select ol_i_id from order_line1 where 1 != 1",
         "Query": "select distinct ol_i_id from order_line1 where ol_w_id = 1 and ol_d_id = 156 and ol_o_id < 500 and ol_o_id >= 56",
-        "Table": "order_line1",
         "Values": [
           "1"
         ],
@@ -922,7 +887,6 @@
         },
         "FieldQuery": "select count(*) from stock1 where 1 != 1",
         "Query": "select count(*) from stock1 where s_w_id = 1 and s_i_id = 8 and s_quantity < 1000",
-        "Table": "stock1",
         "Values": [
           "1"
         ],
@@ -948,7 +912,6 @@
         },
         "FieldQuery": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where 1 != 1 group by o_c_id, o_d_id, o_w_id) as t, orders1 as o where 1 != 1",
         "Query": "select o.o_id, o.o_d_id from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id > 2100 and o_id < 11153 group by o_c_id, o_d_id, o_w_id having count(distinct o_id) > 1 limit 1) as t, orders1 as o where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
-        "Table": "orders1",
         "Values": [
           "1"
         ],
@@ -974,7 +937,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete from order_line1 where ol_w_id = 178 and ol_d_id = 1 and ol_o_id = 84",
-        "Table": "order_line1",
         "Values": [
           "178"
         ],
@@ -1000,7 +962,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete from orders1 where o_w_id = 1 and o_d_id = 3 and o_id = 384",
-        "Table": "orders1",
         "Values": [
           "1"
         ],
@@ -1026,7 +987,6 @@
         },
         "TargetTabletType": "PRIMARY",
         "Query": "delete from history1 where h_w_id = 75 and h_d_id = 102 limit 10",
-        "Table": "history1",
         "Values": [
           "75"
         ],

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -36,8 +36,7 @@
                 },
                 "FieldQuery": "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, sum(l_quantity) as avg_qty, sum(l_extendedprice) as avg_price, sum(l_discount) as avg_disc, count(*) as count_order, count(l_quantity), count(l_extendedprice), count(l_discount), weight_string(l_returnflag), weight_string(l_linestatus) from lineitem where 1 != 1 group by l_returnflag, l_linestatus, weight_string(l_returnflag), weight_string(l_linestatus)",
                 "OrderBy": "(0|13) ASC, (1|14) ASC",
-                "Query": "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, sum(l_quantity) as avg_qty, sum(l_extendedprice) as avg_price, sum(l_discount) as avg_disc, count(*) as count_order, count(l_quantity), count(l_extendedprice), count(l_discount), weight_string(l_returnflag), weight_string(l_linestatus) from lineitem where l_shipdate <= '1998-12-01' - interval '108' day group by l_returnflag, l_linestatus, weight_string(l_returnflag), weight_string(l_linestatus) order by lineitem.l_returnflag asc, lineitem.l_linestatus asc",
-                "Table": "lineitem"
+                "Query": "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, sum(l_quantity) as avg_qty, sum(l_extendedprice) as avg_price, sum(l_discount) as avg_disc, count(*) as count_order, count(l_quantity), count(l_extendedprice), count(l_discount), weight_string(l_returnflag), weight_string(l_linestatus) from lineitem where l_shipdate <= '1998-12-01' - interval '108' day group by l_returnflag, l_linestatus, weight_string(l_returnflag), weight_string(l_linestatus) order by lineitem.l_returnflag asc, lineitem.l_linestatus asc"
               }
             ]
           }
@@ -100,7 +99,6 @@
                             "JoinVars": {
                               "l_orderkey": 1
                             },
-                            "TableName": "lineitem_orders_customer",
                             "Inputs": [
                               {
                                 "OperatorType": "Route",
@@ -110,8 +108,7 @@
                                   "Sharded": true
                                 },
                                 "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
-                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
-                                "Table": "lineitem"
+                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)"
                               },
                               {
                                 "OperatorType": "Projection",
@@ -130,7 +127,6 @@
                                     "JoinVars": {
                                       "o_custkey": 3
                                     },
-                                    "TableName": "orders_customer",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -141,7 +137,6 @@
                                         },
                                         "FieldQuery": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where 1 != 1 group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
                                         "Query": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where o_orderdate < date('1995-03-15') and o_orderkey = :l_orderkey group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
-                                        "Table": "orders",
                                         "Values": [
                                           ":l_orderkey"
                                         ],
@@ -156,7 +151,6 @@
                                         },
                                         "FieldQuery": "select count(*) from customer where 1 != 1 group by .0",
                                         "Query": "select count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by .0",
-                                        "Table": "customer",
                                         "Values": [
                                           ":o_custkey"
                                         ],
@@ -203,7 +197,6 @@
             "JoinVars": {
               "o_orderkey": 2
             },
-            "TableName": "orders_lineitem",
             "Inputs": [
               {
                 "InputName": "Outer",
@@ -215,8 +208,7 @@
                 },
                 "FieldQuery": "select o_orderpriority, count(*) as order_count, o_orderkey, weight_string(o_orderpriority) from orders where 1 != 1 group by o_orderpriority, o_orderkey, weight_string(o_orderpriority)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select o_orderpriority, count(*) as order_count, o_orderkey, weight_string(o_orderpriority) from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-07-01') + interval '3' month group by o_orderpriority, o_orderkey, weight_string(o_orderpriority) order by orders.o_orderpriority asc",
-                "Table": "orders"
+                "Query": "select o_orderpriority, count(*) as order_count, o_orderkey, weight_string(o_orderpriority) from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-07-01') + interval '3' month group by o_orderpriority, o_orderkey, weight_string(o_orderpriority) order by orders.o_orderpriority asc"
               },
               {
                 "InputName": "SubQuery",
@@ -240,7 +232,6 @@
                     },
                     "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
                     "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                    "Table": "lineitem_map",
                     "Values": [
                       "::l_orderkey"
                     ],
@@ -254,8 +245,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from lineitem where 1 != 1",
-                    "Query": "select 1 from lineitem where l_orderkey = :o_orderkey and l_commitdate < l_receiptdate limit 1",
-                    "Table": "lineitem"
+                    "Query": "select 1 from lineitem where l_orderkey = :o_orderkey and l_commitdate < l_receiptdate limit 1"
                   }
                 ]
               }
@@ -307,7 +297,6 @@
                         "JoinVars": {
                           "s_nationkey": 1
                         },
-                        "TableName": "orders_customer_lineitem_supplier_nation_region",
                         "Inputs": [
                           {
                             "OperatorType": "Projection",
@@ -324,7 +313,6 @@
                                   "c_nationkey": 2,
                                   "o_orderkey": 1
                                 },
-                                "TableName": "orders_customer_lineitem_supplier",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Projection",
@@ -341,7 +329,6 @@
                                         "JoinVars": {
                                           "o_custkey": 2
                                         },
-                                        "TableName": "orders_customer",
                                         "Inputs": [
                                           {
                                             "OperatorType": "Route",
@@ -351,8 +338,7 @@
                                               "Sharded": true
                                             },
                                             "FieldQuery": "select count(*), o_orderkey, o_custkey from orders where 1 != 1 group by o_orderkey, o_custkey",
-                                            "Query": "select count(*), o_orderkey, o_custkey from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year group by o_orderkey, o_custkey",
-                                            "Table": "orders"
+                                            "Query": "select count(*), o_orderkey, o_custkey from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year group by o_orderkey, o_custkey"
                                           },
                                           {
                                             "OperatorType": "Route",
@@ -363,7 +349,6 @@
                                             },
                                             "FieldQuery": "select count(*), c_nationkey from customer where 1 != 1 group by c_nationkey",
                                             "Query": "select count(*), c_nationkey from customer where c_custkey = :o_custkey group by c_nationkey",
-                                            "Table": "customer",
                                             "Values": [
                                               ":o_custkey"
                                             ],
@@ -387,7 +372,6 @@
                                         "JoinVars": {
                                           "l_suppkey": 1
                                         },
-                                        "TableName": "lineitem_supplier",
                                         "Inputs": [
                                           {
                                             "OperatorType": "VindexLookup",
@@ -410,7 +394,6 @@
                                                 },
                                                 "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
                                                 "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                                "Table": "lineitem_map",
                                                 "Values": [
                                                   "::l_orderkey"
                                                 ],
@@ -424,8 +407,7 @@
                                                   "Sharded": true
                                                 },
                                                 "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where 1 != 1 group by l_suppkey",
-                                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where l_orderkey = :o_orderkey group by l_suppkey",
-                                                "Table": "lineitem"
+                                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where l_orderkey = :o_orderkey group by l_suppkey"
                                               }
                                             ]
                                           },
@@ -438,7 +420,6 @@
                                             },
                                             "FieldQuery": "select count(*), s_nationkey from supplier where 1 != 1 group by s_nationkey",
                                             "Query": "select count(*), s_nationkey from supplier where s_nationkey = :c_nationkey and s_suppkey = :l_suppkey group by s_nationkey",
-                                            "Table": "supplier",
                                             "Values": [
                                               ":l_suppkey"
                                             ],
@@ -467,7 +448,6 @@
                                 "JoinVars": {
                                   "n_regionkey": 2
                                 },
-                                "TableName": "nation_region",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Route",
@@ -478,7 +458,6 @@
                                     },
                                     "FieldQuery": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where 1 != 1 group by n_name, n_regionkey, weight_string(n_name)",
                                     "Query": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where n_nationkey = :s_nationkey group by n_name, n_regionkey, weight_string(n_name)",
-                                    "Table": "nation",
                                     "Values": [
                                       ":s_nationkey"
                                     ],
@@ -493,7 +472,6 @@
                                     },
                                     "FieldQuery": "select count(*) from region where 1 != 1 group by .0",
                                     "Query": "select count(*) from region where r_name = 'ASIA' and r_regionkey = :n_regionkey group by .0",
-                                    "Table": "region",
                                     "Values": [
                                       ":n_regionkey"
                                     ],
@@ -542,8 +520,7 @@
               "Sharded": true
             },
             "FieldQuery": "select sum(l_extendedprice * l_discount) as revenue from lineitem where 1 != 1",
-            "Query": "select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate >= date('1994-01-01') and l_shipdate < date('1994-01-01') + interval '1' year and l_discount between 0.06 - 0.01 and 0.06 + 0.01 and l_quantity < 24",
-            "Table": "lineitem"
+            "Query": "select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate >= date('1994-01-01') and l_shipdate < date('1994-01-01') + interval '1' year and l_discount between 0.06 - 0.01 and 0.06 + 0.01 and l_quantity < 24"
           }
         ]
       },
@@ -590,7 +567,6 @@
                       "n1_n_name": 1,
                       "o_custkey": 3
                     },
-                    "TableName": "lineitem_orders_supplier_nation_customer_nation",
                     "Inputs": [
                       {
                         "OperatorType": "Projection",
@@ -610,7 +586,6 @@
                             "JoinVars": {
                               "l_suppkey": 3
                             },
-                            "TableName": "lineitem_orders_supplier_nation",
                             "Inputs": [
                               {
                                 "OperatorType": "Projection",
@@ -629,7 +604,6 @@
                                     "JoinVars": {
                                       "l_orderkey": 3
                                     },
-                                    "TableName": "lineitem_orders",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -639,8 +613,7 @@
                                           "Sharded": true
                                         },
                                         "FieldQuery": "select sum(volume) as revenue, l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year) from (select extract(year from l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume, l_suppkey as l_suppkey, l_orderkey as l_orderkey from lineitem where 1 != 1) as shipping where 1 != 1 group by l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year)",
-                                        "Query": "select sum(volume) as revenue, l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year) from (select extract(year from l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume, l_suppkey as l_suppkey, l_orderkey as l_orderkey from lineitem where l_shipdate between date('1995-01-01') and date('1996-12-31')) as shipping group by l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year)",
-                                        "Table": "lineitem"
+                                        "Query": "select sum(volume) as revenue, l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year) from (select extract(year from l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume, l_suppkey as l_suppkey, l_orderkey as l_orderkey from lineitem where l_shipdate between date('1995-01-01') and date('1996-12-31')) as shipping group by l_year, shipping.l_suppkey, shipping.l_orderkey, weight_string(l_year)"
                                       },
                                       {
                                         "OperatorType": "Route",
@@ -651,7 +624,6 @@
                                         },
                                         "FieldQuery": "select count(*), shipping.o_custkey from (select o_custkey as o_custkey from orders where 1 != 1) as shipping where 1 != 1 group by shipping.o_custkey",
                                         "Query": "select count(*), shipping.o_custkey from (select o_custkey as o_custkey from orders where o_orderkey = :l_orderkey) as shipping group by shipping.o_custkey",
-                                        "Table": "orders",
                                         "Values": [
                                           ":l_orderkey"
                                         ],
@@ -676,7 +648,6 @@
                                     "JoinVars": {
                                       "s_nationkey": 1
                                     },
-                                    "TableName": "supplier_nation",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -687,7 +658,6 @@
                                         },
                                         "FieldQuery": "select count(*), shipping.s_nationkey from (select s_nationkey as s_nationkey from supplier where 1 != 1) as shipping where 1 != 1 group by shipping.s_nationkey",
                                         "Query": "select count(*), shipping.s_nationkey from (select s_nationkey as s_nationkey from supplier where s_suppkey = :l_suppkey) as shipping group by shipping.s_nationkey",
-                                        "Table": "supplier",
                                         "Values": [
                                           ":l_suppkey"
                                         ],
@@ -702,7 +672,6 @@
                                         },
                                         "FieldQuery": "select count(*), supp_nation, weight_string(supp_nation) from (select n1.n_name as supp_nation from nation as n1 where 1 != 1) as shipping where 1 != 1 group by supp_nation, weight_string(supp_nation)",
                                         "Query": "select count(*), supp_nation, weight_string(supp_nation) from (select n1.n_name as supp_nation from nation as n1 where n1.n_nationkey = :s_nationkey) as shipping group by supp_nation, weight_string(supp_nation)",
-                                        "Table": "nation",
                                         "Values": [
                                           ":s_nationkey"
                                         ],
@@ -731,7 +700,6 @@
                             "JoinVars": {
                               "c_nationkey": 1
                             },
-                            "TableName": "customer_nation",
                             "Inputs": [
                               {
                                 "OperatorType": "Route",
@@ -742,7 +710,6 @@
                                 },
                                 "FieldQuery": "select count(*), shipping.c_nationkey from (select c_nationkey as c_nationkey from customer where 1 != 1) as shipping where 1 != 1 group by shipping.c_nationkey",
                                 "Query": "select count(*), shipping.c_nationkey from (select c_nationkey as c_nationkey from customer where c_custkey = :o_custkey) as shipping group by shipping.c_nationkey",
-                                "Table": "customer",
                                 "Values": [
                                   ":o_custkey"
                                 ],
@@ -757,7 +724,6 @@
                                 },
                                 "FieldQuery": "select count(*), cust_nation, weight_string(cust_nation) from (select n2.n_name as cust_nation from nation as n2 where 1 != 1) as shipping where 1 != 1 group by cust_nation, weight_string(cust_nation)",
                                 "Query": "select count(*), cust_nation, weight_string(cust_nation) from (select n2.n_name as cust_nation from nation as n2 where (:n1_n_name = 'FRANCE' and n2.n_name = 'GERMANY' or :n1_n_name = 'GERMANY' and n2.n_name = 'FRANCE') and n2.n_nationkey = :c_nationkey) as shipping group by cust_nation, weight_string(cust_nation)",
-                                "Table": "nation",
                                 "Values": [
                                   ":c_nationkey"
                                 ],
@@ -825,7 +791,6 @@
                         "JoinVars": {
                           "l_orderkey": 2
                         },
-                        "TableName": "lineitem_part_supplier_nation_orders_customer_nation_region",
                         "Inputs": [
                           {
                             "OperatorType": "Aggregate",
@@ -842,7 +807,6 @@
                                   "l_suppkey": 2,
                                   "volume": 0
                                 },
-                                "TableName": "lineitem_part_supplier_nation",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Join",
@@ -851,7 +815,6 @@
                                     "JoinVars": {
                                       "l_partkey": 3
                                     },
-                                    "TableName": "lineitem_part",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -862,8 +825,7 @@
                                         },
                                         "FieldQuery": "select all_nations.volume, all_nations.l_orderkey, all_nations.l_suppkey, all_nations.l_partkey, weight_string(all_nations.l_orderkey) from (select l_extendedprice * (1 - l_discount) as volume, l_orderkey as l_orderkey, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as all_nations where 1 != 1",
                                         "OrderBy": "(1|4) ASC",
-                                        "Query": "select all_nations.volume, all_nations.l_orderkey, all_nations.l_suppkey, all_nations.l_partkey, weight_string(all_nations.l_orderkey) from (select l_extendedprice * (1 - l_discount) as volume, l_orderkey as l_orderkey, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem) as all_nations order by all_nations.l_orderkey asc",
-                                        "Table": "lineitem"
+                                        "Query": "select all_nations.volume, all_nations.l_orderkey, all_nations.l_suppkey, all_nations.l_partkey, weight_string(all_nations.l_orderkey) from (select l_extendedprice * (1 - l_discount) as volume, l_orderkey as l_orderkey, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem) as all_nations order by all_nations.l_orderkey asc"
                                       },
                                       {
                                         "OperatorType": "Route",
@@ -874,7 +836,6 @@
                                         },
                                         "FieldQuery": "select 1 from part where 1 != 1",
                                         "Query": "select 1 from part where p_type = 'ECONOMY ANODIZED STEEL' and p_partkey = :l_partkey",
-                                        "Table": "part",
                                         "Values": [
                                           ":l_partkey"
                                         ],
@@ -889,7 +850,6 @@
                                     "JoinVars": {
                                       "s_nationkey": 0
                                     },
-                                    "TableName": "supplier_nation",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -900,7 +860,6 @@
                                         },
                                         "FieldQuery": "select all_nations.s_nationkey from (select s_nationkey as s_nationkey from supplier where 1 != 1) as all_nations where 1 != 1",
                                         "Query": "select all_nations.s_nationkey from (select s_nationkey as s_nationkey from supplier where s_suppkey = :l_suppkey) as all_nations",
-                                        "Table": "supplier",
                                         "Values": [
                                           ":l_suppkey"
                                         ],
@@ -915,7 +874,6 @@
                                         },
                                         "FieldQuery": "select all_nations.nation, case when nation = 'BRAZIL' then :volume else 0 end from (select n2.n_name as nation from nation as n2 where 1 != 1) as all_nations where 1 != 1",
                                         "Query": "select all_nations.nation, case when nation = 'BRAZIL' then :volume else 0 end from (select n2.n_name as nation from nation as n2 where n2.n_nationkey = :s_nationkey) as all_nations",
-                                        "Table": "nation",
                                         "Values": [
                                           ":s_nationkey"
                                         ],
@@ -942,7 +900,6 @@
                                 "JoinVars": {
                                   "c_nationkey": 2
                                 },
-                                "TableName": "orders_customer_nation_region",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Projection",
@@ -960,7 +917,6 @@
                                         "JoinVars": {
                                           "o_custkey": 2
                                         },
-                                        "TableName": "orders_customer",
                                         "Inputs": [
                                           {
                                             "OperatorType": "Route",
@@ -971,7 +927,6 @@
                                             },
                                             "FieldQuery": "select count(*), o_year, all_nations.o_custkey, weight_string(o_year) from (select extract(year from o_orderdate) as o_year, o_custkey as o_custkey from orders where 1 != 1) as all_nations where 1 != 1 group by o_year, all_nations.o_custkey, weight_string(o_year)",
                                             "Query": "select count(*), o_year, all_nations.o_custkey, weight_string(o_year) from (select extract(year from o_orderdate) as o_year, o_custkey as o_custkey from orders where o_orderdate between date'1995-01-01' and date('1996-12-31') and o_orderkey = :l_orderkey) as all_nations group by o_year, all_nations.o_custkey, weight_string(o_year)",
-                                            "Table": "orders",
                                             "Values": [
                                               ":l_orderkey"
                                             ],
@@ -986,7 +941,6 @@
                                             },
                                             "FieldQuery": "select count(*), all_nations.c_nationkey from (select c_nationkey as c_nationkey from customer where 1 != 1) as all_nations where 1 != 1 group by all_nations.c_nationkey",
                                             "Query": "select count(*), all_nations.c_nationkey from (select c_nationkey as c_nationkey from customer where c_custkey = :o_custkey) as all_nations group by all_nations.c_nationkey",
-                                            "Table": "customer",
                                             "Values": [
                                               ":o_custkey"
                                             ],
@@ -1009,7 +963,6 @@
                                         "JoinVars": {
                                           "n1_n_regionkey": 1
                                         },
-                                        "TableName": "nation_region",
                                         "Inputs": [
                                           {
                                             "OperatorType": "Route",
@@ -1020,7 +973,6 @@
                                             },
                                             "FieldQuery": "select count(*), n1.n_regionkey from nation as n1 where 1 != 1 group by n1.n_regionkey",
                                             "Query": "select count(*), n1.n_regionkey from nation as n1 where n1.n_nationkey = :c_nationkey group by n1.n_regionkey",
-                                            "Table": "nation",
                                             "Values": [
                                               ":c_nationkey"
                                             ],
@@ -1035,7 +987,6 @@
                                             },
                                             "FieldQuery": "select count(*) from region where 1 != 1 group by .0",
                                             "Query": "select count(*) from region where r_name = 'AMERICA' and r_regionkey = :n1_n_regionkey group by .0",
-                                            "Table": "region",
                                             "Values": [
                                               ":n1_n_regionkey"
                                             ],
@@ -1105,7 +1056,6 @@
                     "JoinVars": {
                       "l_suppkey": 2
                     },
-                    "TableName": "orders_lineitem_part_partsupp_supplier_nation",
                     "Inputs": [
                       {
                         "OperatorType": "Aggregate",
@@ -1125,7 +1075,6 @@
                               "l_quantity": 3,
                               "l_suppkey": 4
                             },
-                            "TableName": "orders_lineitem_part_partsupp",
                             "Inputs": [
                               {
                                 "OperatorType": "Sort",
@@ -1139,7 +1088,6 @@
                                     "JoinVars": {
                                       "o_orderkey": 1
                                     },
-                                    "TableName": "orders_lineitem_part",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -1149,8 +1097,7 @@
                                           "Sharded": true
                                         },
                                         "FieldQuery": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders where 1 != 1) as profit where 1 != 1",
-                                        "Query": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders) as profit",
-                                        "Table": "orders"
+                                        "Query": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders) as profit"
                                       },
                                       {
                                         "OperatorType": "Join",
@@ -1159,7 +1106,6 @@
                                         "JoinVars": {
                                           "l_partkey": 4
                                         },
-                                        "TableName": "lineitem_part",
                                         "Inputs": [
                                           {
                                             "OperatorType": "VindexLookup",
@@ -1182,7 +1128,6 @@
                                                 },
                                                 "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
                                                 "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                                "Table": "lineitem_map",
                                                 "Values": [
                                                   "::l_orderkey"
                                                 ],
@@ -1196,8 +1141,7 @@
                                                   "Sharded": true
                                                 },
                                                 "FieldQuery": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as profit where 1 != 1",
-                                                "Query": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit",
-                                                "Table": "lineitem"
+                                                "Query": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit"
                                               }
                                             ]
                                           },
@@ -1210,7 +1154,6 @@
                                             },
                                             "FieldQuery": "select 1 from part where 1 != 1",
                                             "Query": "select 1 from part where p_name like '%green%' and p_partkey = :l_partkey",
-                                            "Table": "part",
                                             "Values": [
                                               ":l_partkey"
                                             ],
@@ -1243,7 +1186,6 @@
                                     },
                                     "FieldQuery": "select ps_partkey, ps_suppkey from partsupp_map where 1 != 1",
                                     "Query": "select ps_partkey, ps_suppkey from partsupp_map where ps_partkey in ::__vals",
-                                    "Table": "partsupp_map",
                                     "Values": [
                                       "::ps_partkey"
                                     ],
@@ -1257,8 +1199,7 @@
                                       "Sharded": true
                                     },
                                     "FieldQuery": "select profit.amount from (select :l_extendedprice * (1 - :l_discount) - ps_supplycost * :l_quantity as amount from partsupp where 1 != 1) as profit where 1 != 1",
-                                    "Query": "select profit.amount from (select :l_extendedprice * (1 - :l_discount) - ps_supplycost * :l_quantity as amount from partsupp where ps_partkey = :l_partkey and ps_suppkey = :l_suppkey) as profit",
-                                    "Table": "partsupp"
+                                    "Query": "select profit.amount from (select :l_extendedprice * (1 - :l_discount) - ps_supplycost * :l_quantity as amount from partsupp where ps_partkey = :l_partkey and ps_suppkey = :l_suppkey) as profit"
                                   }
                                 ]
                               }
@@ -1281,7 +1222,6 @@
                             "JoinVars": {
                               "s_nationkey": 1
                             },
-                            "TableName": "supplier_nation",
                             "Inputs": [
                               {
                                 "OperatorType": "Route",
@@ -1292,7 +1232,6 @@
                                 },
                                 "FieldQuery": "select count(*), profit.s_nationkey from (select s_nationkey as s_nationkey from supplier where 1 != 1) as profit where 1 != 1 group by profit.s_nationkey",
                                 "Query": "select count(*), profit.s_nationkey from (select s_nationkey as s_nationkey from supplier where s_suppkey = :l_suppkey) as profit group by profit.s_nationkey",
-                                "Table": "supplier",
                                 "Values": [
                                   ":l_suppkey"
                                 ],
@@ -1307,7 +1246,6 @@
                                 },
                                 "FieldQuery": "select count(*), nation, weight_string(nation) from (select n_name as nation from nation where 1 != 1) as profit where 1 != 1 group by nation, weight_string(nation)",
                                 "Query": "select count(*), nation, weight_string(nation) from (select n_name as nation from nation where n_nationkey = :s_nationkey) as profit group by nation, weight_string(nation)",
-                                "Table": "nation",
                                 "Values": [
                                   ":s_nationkey"
                                 ],
@@ -1389,7 +1327,6 @@
                             "JoinVars": {
                               "o_custkey": 1
                             },
-                            "TableName": "orders_lineitem_customer_nation",
                             "Inputs": [
                               {
                                 "OperatorType": "Projection",
@@ -1405,7 +1342,6 @@
                                     "JoinVars": {
                                       "o_orderkey": 2
                                     },
-                                    "TableName": "orders_lineitem",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -1415,8 +1351,7 @@
                                           "Sharded": true
                                         },
                                         "FieldQuery": "select count(*), o_custkey, o_orderkey from orders where 1 != 1 group by o_custkey, o_orderkey",
-                                        "Query": "select count(*), o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_custkey, o_orderkey",
-                                        "Table": "orders"
+                                        "Query": "select count(*), o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_custkey, o_orderkey"
                                       },
                                       {
                                         "OperatorType": "VindexLookup",
@@ -1439,7 +1374,6 @@
                                             },
                                             "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
                                             "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                            "Table": "lineitem_map",
                                             "Values": [
                                               "::l_orderkey"
                                             ],
@@ -1453,8 +1387,7 @@
                                               "Sharded": true
                                             },
                                             "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where 1 != 1 group by .0",
-                                            "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by .0",
-                                            "Table": "lineitem"
+                                            "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by .0"
                                           }
                                         ]
                                       }
@@ -1489,7 +1422,6 @@
                                     "JoinVars": {
                                       "c_nationkey": 7
                                     },
-                                    "TableName": "customer_nation",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -1500,7 +1432,6 @@
                                         },
                                         "FieldQuery": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where 1 != 1 group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
                                         "Query": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where c_custkey = :o_custkey group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
-                                        "Table": "customer",
                                         "Values": [
                                           ":o_custkey"
                                         ],
@@ -1515,7 +1446,6 @@
                                         },
                                         "FieldQuery": "select count(*), n_name, weight_string(n_name) from nation where 1 != 1 group by n_name, weight_string(n_name)",
                                         "Query": "select count(*), n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey group by n_name, weight_string(n_name)",
-                                        "Table": "nation",
                                         "Values": [
                                           ":c_nationkey"
                                         ],
@@ -1584,7 +1514,6 @@
                         "JoinVars": {
                           "s_nationkey1": 2
                         },
-                        "TableName": "partsupp_supplier_nation",
                         "Inputs": [
                           {
                             "OperatorType": "Projection",
@@ -1601,7 +1530,6 @@
                                 "JoinVars": {
                                   "ps_suppkey1": 2
                                 },
-                                "TableName": "partsupp_supplier",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Route",
@@ -1611,8 +1539,7 @@
                                       "Sharded": true
                                     },
                                     "FieldQuery": "select sum(ps_supplycost * ps_availqty), 0.00001000000, ps_suppkey from partsupp where 1 != 1 group by ps_suppkey",
-                                    "Query": "select sum(ps_supplycost * ps_availqty), 0.00001000000, ps_suppkey from partsupp group by ps_suppkey",
-                                    "Table": "partsupp"
+                                    "Query": "select sum(ps_supplycost * ps_availqty), 0.00001000000, ps_suppkey from partsupp group by ps_suppkey"
                                   },
                                   {
                                     "OperatorType": "Route",
@@ -1623,7 +1550,6 @@
                                     },
                                     "FieldQuery": "select count(*), s_nationkey from supplier where 1 != 1 group by s_nationkey",
                                     "Query": "select count(*), s_nationkey from supplier where s_suppkey = :ps_suppkey1 group by s_nationkey",
-                                    "Table": "supplier",
                                     "Values": [
                                       ":ps_suppkey1"
                                     ],
@@ -1642,7 +1568,6 @@
                             },
                             "FieldQuery": "select count(*) from nation where 1 != 1 group by .0",
                             "Query": "select count(*) from nation where n_name = 'GERMANY' and n_nationkey = :s_nationkey1 group by .0",
-                            "Table": "nation",
                             "Values": [
                               ":s_nationkey1"
                             ],
@@ -1688,7 +1613,6 @@
                             "JoinVars": {
                               "s_nationkey": 2
                             },
-                            "TableName": "partsupp_supplier_nation",
                             "Inputs": [
                               {
                                 "OperatorType": "Projection",
@@ -1706,7 +1630,6 @@
                                     "JoinVars": {
                                       "ps_suppkey": 2
                                     },
-                                    "TableName": "partsupp_supplier",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -1717,8 +1640,7 @@
                                         },
                                         "FieldQuery": "select sum(ps_supplycost * ps_availqty) as value, ps_partkey, ps_suppkey, weight_string(ps_partkey) from partsupp where 1 != 1 group by ps_partkey, ps_suppkey, weight_string(ps_partkey)",
                                         "OrderBy": "(1|3) ASC",
-                                        "Query": "select sum(ps_supplycost * ps_availqty) as value, ps_partkey, ps_suppkey, weight_string(ps_partkey) from partsupp group by ps_partkey, ps_suppkey, weight_string(ps_partkey) order by ps_partkey asc",
-                                        "Table": "partsupp"
+                                        "Query": "select sum(ps_supplycost * ps_availqty) as value, ps_partkey, ps_suppkey, weight_string(ps_partkey) from partsupp group by ps_partkey, ps_suppkey, weight_string(ps_partkey) order by ps_partkey asc"
                                       },
                                       {
                                         "OperatorType": "Route",
@@ -1729,7 +1651,6 @@
                                         },
                                         "FieldQuery": "select count(*), s_nationkey from supplier where 1 != 1 group by s_nationkey",
                                         "Query": "select count(*), s_nationkey from supplier where s_suppkey = :ps_suppkey group by s_nationkey",
-                                        "Table": "supplier",
                                         "Values": [
                                           ":ps_suppkey"
                                         ],
@@ -1748,7 +1669,6 @@
                                 },
                                 "FieldQuery": "select count(*) from nation where 1 != 1 group by .0",
                                 "Query": "select count(*) from nation where n_name = 'GERMANY' and n_nationkey = :s_nationkey group by .0",
-                                "Table": "nation",
                                 "Values": [
                                   ":s_nationkey"
                                 ],
@@ -1807,7 +1727,6 @@
                     "JoinVars": {
                       "o_orderkey": 2
                     },
-                    "TableName": "orders_lineitem",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -1817,8 +1736,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, o_orderkey from orders where 1 != 1 group by o_orderkey",
-                        "Query": "select sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, o_orderkey from orders group by o_orderkey",
-                        "Table": "orders"
+                        "Query": "select sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, o_orderkey from orders group by o_orderkey"
                       },
                       {
                         "OperatorType": "VindexLookup",
@@ -1841,7 +1759,6 @@
                             },
                             "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
                             "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                            "Table": "lineitem_map",
                             "Values": [
                               "::l_orderkey"
                             ],
@@ -1855,8 +1772,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select count(*), l_shipmode, weight_string(l_shipmode) from lineitem where 1 != 1 group by l_shipmode, weight_string(l_shipmode)",
-                            "Query": "select count(*), l_shipmode, weight_string(l_shipmode) from lineitem where l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= date('1994-01-01') and l_receiptdate < date('1994-01-01') + interval '1' year and l_orderkey = :o_orderkey group by l_shipmode, weight_string(l_shipmode)",
-                            "Table": "lineitem"
+                            "Query": "select count(*), l_shipmode, weight_string(l_shipmode) from lineitem where l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= date('1994-01-01') and l_receiptdate < date('1994-01-01') + interval '1' year and l_orderkey = :o_orderkey group by l_shipmode, weight_string(l_shipmode)"
                           }
                         ]
                       }
@@ -1923,7 +1839,6 @@
                                 "JoinVars": {
                                   "c_custkey": 1
                                 },
-                                "TableName": "customer_orders",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Route",
@@ -1934,8 +1849,7 @@
                                     },
                                     "FieldQuery": "select count(*), c_custkey, weight_string(c_custkey), 1 from customer where 1 != 1 group by c_custkey, weight_string(c_custkey)",
                                     "OrderBy": "(1|2) ASC",
-                                    "Query": "select count(*), c_custkey, weight_string(c_custkey), 1 from customer group by c_custkey, weight_string(c_custkey) order by c_custkey asc",
-                                    "Table": "customer"
+                                    "Query": "select count(*), c_custkey, weight_string(c_custkey), 1 from customer group by c_custkey, weight_string(c_custkey) order by c_custkey asc"
                                   },
                                   {
                                     "OperatorType": "Route",
@@ -1945,8 +1859,7 @@
                                       "Sharded": true
                                     },
                                     "FieldQuery": "select count(o_orderkey) from orders where 1 != 1 group by .0",
-                                    "Query": "select count(o_orderkey) from orders where o_comment not like '%special%requests%' and o_custkey = :c_custkey group by .0",
-                                    "Table": "orders"
+                                    "Query": "select count(o_orderkey) from orders where o_comment not like '%special%requests%' and o_custkey = :c_custkey group by .0"
                                   }
                                 ]
                               }
@@ -1994,7 +1907,6 @@
                   "l_extendedprice": 1,
                   "l_partkey": 4
                 },
-                "TableName": "lineitem_part",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2004,8 +1916,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 100.00, l_extendedprice, l_discount, l_extendedprice * (1 - l_discount), l_partkey from lineitem where 1 != 1",
-                    "Query": "select 100.00, l_extendedprice, l_discount, l_extendedprice * (1 - l_discount), l_partkey from lineitem where l_shipdate >= date('1995-09-01') and l_shipdate < date('1995-09-01') + interval '1' month",
-                    "Table": "lineitem"
+                    "Query": "select 100.00, l_extendedprice, l_discount, l_extendedprice * (1 - l_discount), l_partkey from lineitem where l_shipdate >= date('1995-09-01') and l_shipdate < date('1995-09-01') + interval '1' month"
                   },
                   {
                     "OperatorType": "Route",
@@ -2016,7 +1927,6 @@
                     },
                     "FieldQuery": "select case when p_type like 'PROMO%' then :l_extendedprice * (1 - :l_discount) else 0 end from part where 1 != 1",
                     "Query": "select case when p_type like 'PROMO%' then :l_extendedprice * (1 - :l_discount) else 0 end from part where p_partkey = :l_partkey",
-                    "Table": "part",
                     "Values": [
                       ":l_partkey"
                     ],
@@ -2062,8 +1972,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select max(total_revenue), weight_string(max(total_revenue)) from revenue0 where 1 != 1",
-                "Query": "select max(total_revenue), weight_string(max(total_revenue)) from revenue0",
-                "Table": "revenue0"
+                "Query": "select max(total_revenue), weight_string(max(total_revenue)) from revenue0"
               }
             ]
           },
@@ -2078,8 +1987,7 @@
             "FieldQuery": "select s_suppkey, s_name, s_address, s_phone, total_revenue, weight_string(s_suppkey) from supplier, revenue0 where 1 != 1",
             "OrderBy": "(0|5) ASC",
             "Query": "select s_suppkey, s_name, s_address, s_phone, total_revenue, weight_string(s_suppkey) from supplier, revenue0 where s_suppkey = supplier_no and total_revenue = :__sq1 order by supplier.s_suppkey asc",
-            "ResultColumns": 5,
-            "Table": "revenue0, supplier"
+            "ResultColumns": 5
           }
         ]
       },
@@ -2121,7 +2029,6 @@
                       "ps_partkey": 2,
                       "ps_suppkey": 0
                     },
-                    "TableName": "partsupp_part",
                     "Inputs": [
                       {
                         "OperatorType": "UncorrelatedSubquery",
@@ -2140,8 +2047,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select s_suppkey from supplier where 1 != 1",
-                            "Query": "select s_suppkey from supplier where s_comment like '%Customer%Complaints%'",
-                            "Table": "supplier"
+                            "Query": "select s_suppkey from supplier where s_comment like '%Customer%Complaints%'"
                           },
                           {
                             "InputName": "Outer",
@@ -2152,8 +2058,7 @@
                               "Sharded": true
                             },
                             "FieldQuery": "select ps_suppkey, weight_string(ps_suppkey), ps_partkey from partsupp where 1 != 1",
-                            "Query": "select ps_suppkey, weight_string(ps_suppkey), ps_partkey from partsupp where not :__sq_has_values or ps_suppkey not in ::__sq1",
-                            "Table": "partsupp"
+                            "Query": "select ps_suppkey, weight_string(ps_suppkey), ps_partkey from partsupp where not :__sq_has_values or ps_suppkey not in ::__sq1"
                           }
                         ]
                       },
@@ -2166,7 +2071,6 @@
                         },
                         "FieldQuery": "select p_brand, p_type, p_size, weight_string(p_brand), weight_string(p_type), weight_string(p_size) from part where 1 != 1",
                         "Query": "select p_brand, p_type, p_size, weight_string(p_brand), weight_string(p_type), weight_string(p_size) from part where p_brand != 'Brand#45' and p_type not like 'MEDIUM POLISHED%' and p_size in (49, 14, 23, 45, 19, 3, 36, 9) and p_partkey = :ps_partkey",
-                        "Table": "part",
                         "Values": [
                           ":ps_partkey"
                         ],
@@ -2226,8 +2130,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select l_orderkey from lineitem where 1 != 1 group by l_orderkey",
-                    "Query": "select l_orderkey from lineitem group by l_orderkey having sum(l_quantity) > 300",
-                    "Table": "lineitem"
+                    "Query": "select l_orderkey from lineitem group by l_orderkey having sum(l_quantity) > 300"
                   },
                   {
                     "InputName": "Outer",
@@ -2262,7 +2165,6 @@
                                 "JoinVars": {
                                   "l_orderkey": 1
                                 },
-                                "TableName": "lineitem_orders_customer",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Route",
@@ -2272,8 +2174,7 @@
                                       "Sharded": true
                                     },
                                     "FieldQuery": "select sum(l_quantity), l_orderkey from lineitem where 1 != 1 group by l_orderkey",
-                                    "Query": "select sum(l_quantity), l_orderkey from lineitem group by l_orderkey",
-                                    "Table": "lineitem"
+                                    "Query": "select sum(l_quantity), l_orderkey from lineitem group by l_orderkey"
                                   },
                                   {
                                     "OperatorType": "Projection",
@@ -2298,7 +2199,6 @@
                                         "JoinVars": {
                                           "o_custkey": 4
                                         },
-                                        "TableName": "orders_customer",
                                         "Inputs": [
                                           {
                                             "OperatorType": "Route",
@@ -2309,7 +2209,6 @@
                                             },
                                             "FieldQuery": "select count(*), o_orderkey, o_orderdate, o_totalprice, o_custkey, weight_string(o_totalprice), weight_string(o_orderdate), weight_string(o_orderkey) from orders where 1 != 1 group by o_orderkey, o_orderdate, o_totalprice, o_custkey, weight_string(o_totalprice), weight_string(o_orderdate), weight_string(o_orderkey)",
                                             "Query": "select count(*), o_orderkey, o_orderdate, o_totalprice, o_custkey, weight_string(o_totalprice), weight_string(o_orderdate), weight_string(o_orderkey) from orders where o_orderkey = :l_orderkey group by o_orderkey, o_orderdate, o_totalprice, o_custkey, weight_string(o_totalprice), weight_string(o_orderdate), weight_string(o_orderkey)",
-                                            "Table": "orders",
                                             "Values": [
                                               ":l_orderkey"
                                             ],
@@ -2324,7 +2223,6 @@
                                             },
                                             "FieldQuery": "select count(*), c_name, c_custkey, weight_string(c_name), weight_string(c_custkey) from customer where 1 != 1 group by c_name, c_custkey, weight_string(c_name), weight_string(c_custkey)",
                                             "Query": "select count(*), c_name, c_custkey, weight_string(c_name), weight_string(c_custkey) from customer where c_custkey = :o_custkey group by c_name, c_custkey, weight_string(c_name), weight_string(c_custkey)",
-                                            "Table": "customer",
                                             "Values": [
                                               ":o_custkey"
                                             ],
@@ -2382,7 +2280,6 @@
                   "l_shipinstruct": 4,
                   "l_shipmode": 3
                 },
-                "TableName": "lineitem_part",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -2392,8 +2289,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_partkey, l_quantity, l_shipmode, l_shipinstruct from lineitem where 1 != 1 group by l_partkey, l_quantity, l_shipmode, l_shipinstruct",
-                    "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_partkey, l_quantity, l_shipmode, l_shipinstruct from lineitem group by l_partkey, l_quantity, l_shipmode, l_shipinstruct",
-                    "Table": "lineitem"
+                    "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_partkey, l_quantity, l_shipmode, l_shipinstruct from lineitem group by l_partkey, l_quantity, l_shipmode, l_shipinstruct"
                   },
                   {
                     "OperatorType": "Route",
@@ -2403,8 +2299,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) from part where 1 != 1 group by .0",
-                    "Query": "select count(*) from part where p_partkey = :l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and :l_quantity >= 1 and :l_quantity <= 1 + 10 and p_size between 1 and 5 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and :l_quantity >= 10 and :l_quantity <= 10 + 10 and p_size between 1 and 10 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#34' and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and :l_quantity >= 20 and :l_quantity <= 20 + 10 and p_size between 1 and 15 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' group by .0",
-                    "Table": "part"
+                    "Query": "select count(*) from part where p_partkey = :l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and :l_quantity >= 1 and :l_quantity <= 1 + 10 and p_size between 1 and 5 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and :l_quantity >= 10 and :l_quantity <= 10 + 10 and p_size between 1 and 10 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#34' and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and :l_quantity >= 20 and :l_quantity <= 20 + 10 and p_size between 1 and 15 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' group by .0"
                   }
                 ]
               }
@@ -2466,7 +2361,6 @@
                             "JoinVars": {
                               "l1_l_suppkey": 1
                             },
-                            "TableName": "lineitem_orders_supplier_nation",
                             "Inputs": [
                               {
                                 "OperatorType": "Projection",
@@ -2483,7 +2377,6 @@
                                       "l1_l_orderkey": 2,
                                       "l1_l_suppkey": 1
                                     },
-                                    "TableName": "lineitem_orders",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -2493,8 +2386,7 @@
                                           "Sharded": true
                                         },
                                         "FieldQuery": "select count(*), l1.l_suppkey, l1.l_orderkey from lineitem as l1 where 1 != 1 group by l1.l_suppkey, l1.l_orderkey",
-                                        "Query": "select count(*), l1.l_suppkey, l1.l_orderkey from lineitem as l1 where l1.l_receiptdate > l1.l_commitdate and exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate > l3.l_commitdate) group by l1.l_suppkey, l1.l_orderkey",
-                                        "Table": "lineitem"
+                                        "Query": "select count(*), l1.l_suppkey, l1.l_orderkey from lineitem as l1 where l1.l_receiptdate > l1.l_commitdate and exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate > l3.l_commitdate) group by l1.l_suppkey, l1.l_orderkey"
                                       },
                                       {
                                         "OperatorType": "Route",
@@ -2505,7 +2397,6 @@
                                         },
                                         "FieldQuery": "select count(*) from orders where 1 != 1 group by .0",
                                         "Query": "select count(*) from orders where o_orderstatus = 'F' and o_orderkey = :l1_l_orderkey group by .0",
-                                        "Table": "orders",
                                         "Values": [
                                           ":l1_l_orderkey"
                                         ],
@@ -2530,7 +2421,6 @@
                                     "JoinVars": {
                                       "s_nationkey": 2
                                     },
-                                    "TableName": "supplier_nation",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
@@ -2541,7 +2431,6 @@
                                         },
                                         "FieldQuery": "select count(*), s_name, s_nationkey, weight_string(s_name) from supplier where 1 != 1 group by s_name, s_nationkey, weight_string(s_name)",
                                         "Query": "select count(*), s_name, s_nationkey, weight_string(s_name) from supplier where s_suppkey = :l1_l_suppkey group by s_name, s_nationkey, weight_string(s_name)",
-                                        "Table": "supplier",
                                         "Values": [
                                           ":l1_l_suppkey"
                                         ],
@@ -2556,7 +2445,6 @@
                                         },
                                         "FieldQuery": "select count(*) from nation where 1 != 1 group by .0",
                                         "Query": "select count(*) from nation where n_name = 'SAUDI ARABIA' and n_nationkey = :s_nationkey group by .0",
-                                        "Table": "nation",
                                         "Values": [
                                           ":s_nationkey"
                                         ],

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -13,8 +13,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1 union all select id from music where 1 != 1",
-        "Query": "select id from `user` union all select id from music",
-        "Table": "`user`, music"
+        "Query": "select id from `user` union all select id from music"
       },
       "TablesUsed": [
         "user.music",
@@ -43,8 +42,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1 union select id from music where 1 != 1) as dt(c0) where 1 != 1",
-            "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select id from music) as dt(c0)",
-            "Table": "`user`, music"
+            "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select id from music) as dt(c0)"
           }
         ]
       },
@@ -72,7 +70,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where id = 1",
-            "Table": "`user`",
             "Values": [
               "1"
             ],
@@ -87,7 +84,6 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where id = 5",
-            "Table": "`user`",
             "Values": [
               "5"
             ],
@@ -129,8 +125,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from `user` order by `user`.id desc limit 1",
-                    "Table": "`user`"
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id desc limit 1"
                   }
                 ]
               },
@@ -147,8 +142,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from music where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from music order by music.id desc limit 1",
-                    "Table": "music"
+                    "Query": "select id, weight_string(id) from music order by music.id desc limit 1"
                   }
                 ]
               }
@@ -176,8 +170,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col1, col2 from `user` where 1 != 1 union all select col1, col2 from user_extra where 1 != 1",
-        "Query": "select col1, col2 from `user` union all select col1, col2 from user_extra",
-        "Table": "`user`, user_extra"
+        "Query": "select col1, col2 from `user` union all select col1, col2 from user_extra"
       },
       "TablesUsed": [
         "user.user",
@@ -199,8 +192,7 @@
           "Sharded": true
         },
         "FieldQuery": "select * from (select * from `user` where 1 != 1 union all select * from user_extra where 1 != 1) as t where 1 != 1",
-        "Query": "select * from (select * from `user` union all select * from user_extra) as t",
-        "Table": "`user`, user_extra"
+        "Query": "select * from (select * from `user` union all select * from user_extra) as t"
       },
       "TablesUsed": [
         "user.user",
@@ -222,8 +214,7 @@
           "Sharded": true
         },
         "FieldQuery": "select col1, col2 from (select col1, col2 from `user` where 1 != 1 union all select col1, col2 from user_extra where 1 != 1) as t where 1 != 1",
-        "Query": "select col1, col2 from (select col1, col2 from `user` union all select col1, col2 from user_extra) as t",
-        "Table": "`user`, user_extra"
+        "Query": "select col1, col2 from (select col1, col2 from `user` union all select col1, col2 from user_extra) as t"
       },
       "TablesUsed": [
         "user.user",
@@ -260,8 +251,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) ASC",
-                    "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit 5",
-                    "Table": "`user`"
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit 5"
                   }
                 ]
               },
@@ -278,8 +268,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from music where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from music order by music.id desc limit 5",
-                    "Table": "music"
+                    "Query": "select id, weight_string(id) from music order by music.id desc limit 5"
                   }
                 ]
               }
@@ -307,8 +296,7 @@
           "Sharded": true
         },
         "FieldQuery": "select id from `user` where 1 != 1 union select id from `user` where 1 != 1 union all select id from `user` where 1 != 1",
-        "Query": "select id from `user` where id = 1 union select id from `user` where id = 1 union all select id from `user`",
-        "Table": "`user`"
+        "Query": "select id from `user` where id = 1 union select id from `user` where id = 1 union all select id from `user`"
       },
       "TablesUsed": [
         "user.user"
@@ -339,8 +327,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select dt.c0 as CHARACTER_SET_NAME, weight_string(dt.c0) from (select CHARACTER_SET_NAME from information_schema.CHARACTER_SETS where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as CHARACTER_SET_NAME, weight_string(dt.c0) from (select distinct CHARACTER_SET_NAME from information_schema.CHARACTER_SETS) as dt(c0)",
-                "Table": "information_schema.CHARACTER_SETS"
+                "Query": "select dt.c0 as CHARACTER_SET_NAME, weight_string(dt.c0) from (select distinct CHARACTER_SET_NAME from information_schema.CHARACTER_SETS) as dt(c0)"
               },
               {
                 "OperatorType": "Route",
@@ -350,8 +337,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select dt.c0 as user_name, weight_string(dt.c0) from (select user_name from unsharded where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as user_name, weight_string(dt.c0) from (select distinct user_name from unsharded) as dt(c0)",
-                "Table": "unsharded"
+                "Query": "select dt.c0 as user_name, weight_string(dt.c0) from (select distinct user_name from unsharded) as dt(c0)"
               }
             ]
           }
@@ -387,8 +373,7 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1 union select id from music where 1 != 1 union select 1 from dual where 1 != 1",
-            "Query": "select id from `user` union select id from music union select 1 from dual",
-            "Table": "`user`, dual, music"
+            "Query": "select id from `user` union select id from music union select 1 from dual"
           }
         ]
       },
@@ -414,7 +399,6 @@
         },
         "FieldQuery": "select * from music where 1 != 1 union select * from `user` where 1 != 1",
         "Query": "select * from music where user_id = 1 union select * from `user` where id = 1",
-        "Table": "`user`, music",
         "Values": [
           "1"
         ],
@@ -455,7 +439,6 @@
                 },
                 "FieldQuery": "select 1 from music where 1 != 1",
                 "Query": "select distinct 1 from music where id = 1",
-                "Table": "music",
                 "Values": [
                   "1"
                 ],
@@ -470,7 +453,6 @@
                 },
                 "FieldQuery": "select 1 from music where 1 != 1",
                 "Query": "select distinct 1 from music where id = 2",
-                "Table": "music",
                 "Values": [
                   "2"
                 ],
@@ -506,8 +488,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from ((select id from `user` where 1 != 1) union (select id from `user` where 1 != 1)) as dt(c0) where 1 != 1",
-            "Query": "select dt.c0 as id, weight_string(dt.c0) from ((select id from `user` order by id desc) union (select id from `user` order by id asc)) as dt(c0)",
-            "Table": "`user`"
+            "Query": "select dt.c0 as id, weight_string(dt.c0) from ((select id from `user` order by id desc) union (select id from `user` order by id asc)) as dt(c0)"
           }
         ]
       },
@@ -536,8 +517,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from dual where 1 != 1 union select null from dual where 1 != 1 union select 1.0 from dual where 1 != 1 union select '1' from dual where 1 != 1 union select 2 from dual where 1 != 1 union select 2.0 from `user` where 1 != 1",
-            "Query": "select 1 from dual union select null from dual union select 1.0 from dual union select '1' from dual union select 2 from dual union select 2.0 from `user`",
-            "Table": "`user`, dual"
+            "Query": "select 1 from dual union select null from dual union select 1.0 from dual union select '1' from dual union select 2 from dual union select 2.0 from `user`"
           }
         ]
       },
@@ -568,7 +548,6 @@
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,L:1,L:2,L:3",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -578,8 +557,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where 1 != 1",
-                    "Query": "select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user`",
-                    "Table": "`user`"
+                    "Query": "select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user`"
                   },
                   {
                     "OperatorType": "Route",
@@ -589,8 +567,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select distinct 1 from user_extra where user_extra.extra = 'asdf'",
-                    "Table": "user_extra"
+                    "Query": "select distinct 1 from user_extra where user_extra.extra = 'asdf'"
                   }
                 ]
               },
@@ -602,8 +579,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select 'b', 'c' from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
-                "Query": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)",
-                "Table": "`user`"
+                "Query": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)"
               }
             ]
           }
@@ -640,14 +616,12 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select 'b', 'c' from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
-                "Query": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)",
-                "Table": "`user`"
+                "Query": "select dt.c0 as b, dt.c1 as c, weight_string(dt.c0), weight_string(dt.c1) from (select distinct 'b', 'c' from `user`) as dt(c0, c1)"
               },
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,L:1,L:2,L:3",
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -657,8 +631,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where 1 != 1",
-                    "Query": "select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user`",
-                    "Table": "`user`"
+                    "Query": "select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user`"
                   },
                   {
                     "OperatorType": "Route",
@@ -668,8 +641,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select distinct 1 from user_extra where user_extra.extra = 'asdf'",
-                    "Table": "user_extra"
+                    "Query": "select distinct 1 from user_extra where user_extra.extra = 'asdf'"
                   }
                 ]
               }
@@ -711,8 +683,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) as s from `user` where 1 != 1",
-                    "Query": "select count(*) as s from `user`",
-                    "Table": "`user`"
+                    "Query": "select count(*) as s from `user`"
                   }
                 ]
               },
@@ -729,8 +700,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select count(*) as s from music where 1 != 1",
-                    "Query": "select count(*) as s from music",
-                    "Table": "music"
+                    "Query": "select count(*) as s from music"
                   }
                 ]
               }
@@ -765,8 +735,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1 union select id + 1 from `user` where 1 != 1 union select user_id from user_extra where 1 != 1) as dt(c0) where 1 != 1",
-            "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select id + 1 from `user` union select user_id from user_extra) as dt(c0)",
-            "Table": "`user`, user_extra"
+            "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select id + 1 from `user` union select user_id from user_extra) as dt(c0)"
           }
         ]
       },
@@ -800,8 +769,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1 union select id from music where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select id from music) as dt(c0)",
-                "Table": "`user`, music"
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select id from music) as dt(c0)"
               },
               {
                 "OperatorType": "Route",
@@ -811,8 +779,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select dt.c0 as `1`, weight_string(dt.c0) from (select 1 from unsharded where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as `1`, weight_string(dt.c0) from (select distinct 1 from unsharded) as dt(c0)",
-                "Table": "unsharded"
+                "Query": "select dt.c0 as `1`, weight_string(dt.c0) from (select distinct 1 from unsharded) as dt(c0)"
               }
             ]
           }
@@ -849,8 +816,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select id from `user` where 1 != 1 union select 3 from dual where 1 != 1",
-                "Query": "select id from `user` union select 3 from dual limit :__upper_limit",
-                "Table": "`user`, dual"
+                "Query": "select id from `user` union select 3 from dual limit :__upper_limit"
               }
             ]
           }
@@ -876,8 +842,7 @@
           "Sharded": false
         },
         "FieldQuery": "(select 1 from unsharded where 1 != 1 union select 1 from unsharded where 1 != 1 union all select 1 from unsharded where 1 != 1) union select 1 from unsharded where 1 != 1 union all select 1 from unsharded where 1 != 1",
-        "Query": "(select 1 from unsharded union select 1 from unsharded union all select 1 from unsharded order by 1 asc) union select 1 from unsharded union all select 1 from unsharded order by 1 asc",
-        "Table": "unsharded"
+        "Query": "(select 1 from unsharded union select 1 from unsharded union all select 1 from unsharded order by 1 asc) union select 1 from unsharded union all select 1 from unsharded order by 1 asc"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -907,8 +872,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select table_comment from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_comment from information_schema.`tables`",
-                "Table": "information_schema.`tables`"
+                "Query": "select distinct table_comment from information_schema.`tables`"
               },
               {
                 "OperatorType": "Route",
@@ -918,8 +882,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select table_comment from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_comment from information_schema.`tables`",
-                "Table": "information_schema.`tables`"
+                "Query": "select distinct table_comment from information_schema.`tables`"
               }
             ]
           }
@@ -951,8 +914,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded where 1 != 1 union select col2 from unsharded where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded union select col2 from unsharded) as dt(c0)",
-                "Table": "unsharded"
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded union select col2 from unsharded) as dt(c0)"
               },
               {
                 "OperatorType": "Route",
@@ -962,8 +924,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1 union select col from user_extra where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select col from user_extra) as dt(c0)",
-                "Table": "`user`, user_extra"
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select col from user_extra) as dt(c0)"
               }
             ]
           }
@@ -989,7 +950,6 @@
         "JoinVars": {
           "tbl1_id": 0
         },
-        "TableName": "`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Concatenate",
@@ -1007,8 +967,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) ASC",
-                    "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit 5",
-                    "Table": "`user`"
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id asc limit 5"
                   }
                 ]
               },
@@ -1025,8 +984,7 @@
                     },
                     "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
                     "OrderBy": "(0|1) DESC",
-                    "Query": "select id, weight_string(id) from `user` order by `user`.id desc limit 5",
-                    "Table": "`user`"
+                    "Query": "select id, weight_string(id) from `user` order by `user`.id desc limit 5"
                   }
                 ]
               }
@@ -1041,7 +999,6 @@
             },
             "FieldQuery": "select tbl2.id from `user` as tbl2 where 1 != 1",
             "Query": "select tbl2.id from `user` as tbl2 where tbl2.id = :tbl1_id",
-            "Table": "`user`",
             "Values": [
               ":tbl1_id"
             ],
@@ -1101,8 +1058,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1 union select 3 from dual where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select 3 from dual) as dt(c0)",
-                "Table": "`user`, dual"
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` union select 3 from dual) as dt(c0)"
               }
             ]
           }
@@ -1142,8 +1098,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as id, dt.c1 as id, weight_string(dt.c0), weight_string(dt.c1) from (select id, id from `user` where 1 != 1 union select id, bar from user_extra where 1 != 1) as dt(c0, c1) where 1 != 1",
-                "Query": "select dt.c0 as id, dt.c1 as id, weight_string(dt.c0), weight_string(dt.c1) from (select id, id from `user` union select id, bar from user_extra) as dt(c0, c1)",
-                "Table": "`user`, user_extra"
+                "Query": "select dt.c0 as id, dt.c1 as id, weight_string(dt.c0), weight_string(dt.c1) from (select id, id from `user` union select id, bar from user_extra) as dt(c0, c1)"
               }
             ]
           }
@@ -1184,8 +1139,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select dt.c0 as foo, weight_string(dt.c0) from (select id + 42 as foo from `user` where 1 != 1) as dt(c0) where 1 != 1",
-                    "Query": "select dt.c0 as foo, weight_string(dt.c0) from (select distinct id + 42 as foo from `user`) as dt(c0)",
-                    "Table": "`user`"
+                    "Query": "select dt.c0 as foo, weight_string(dt.c0) from (select distinct id + 42 as foo from `user`) as dt(c0)"
                   },
                   {
                     "OperatorType": "Route",
@@ -1195,8 +1149,7 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select dt.c0 as foo, weight_string(dt.c0) from (select 1 + id as foo from unsharded where 1 != 1) as dt(c0) where 1 != 1",
-                    "Query": "select dt.c0 as foo, weight_string(dt.c0) from (select distinct 1 + id as foo from unsharded) as dt(c0)",
-                    "Table": "unsharded"
+                    "Query": "select dt.c0 as foo, weight_string(dt.c0) from (select distinct 1 + id as foo from unsharded) as dt(c0)"
                   }
                 ]
               }
@@ -1239,8 +1192,7 @@
                     "FieldQuery": "select kcu.COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
                     "Query": "select distinct kcu.COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.table_name = :kcu_table_name /* VARCHAR */",
                     "SysTableTableName": "[kcu_table_name:'user_extra']",
-                    "SysTableTableSchema": "['user']",
-                    "Table": "information_schema.key_column_usage"
+                    "SysTableTableSchema": "['user']"
                   },
                   {
                     "OperatorType": "Route",
@@ -1252,8 +1204,7 @@
                     "FieldQuery": "select kcu.COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
                     "Query": "select distinct kcu.COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.table_name = :kcu_table_name1 /* VARCHAR */",
                     "SysTableTableName": "[kcu_table_name1:'music']",
-                    "SysTableTableSchema": "['user']",
-                    "Table": "information_schema.key_column_usage"
+                    "SysTableTableSchema": "['user']"
                   }
                 ]
               }
@@ -1278,7 +1229,6 @@
         },
         "FieldQuery": "select `name`, foo from (select `name`, id as foo from `user` where 1 != 1 union select 'extra', user_id from user_extra where 1 != 1) as X where 1 != 1",
         "Query": "select `name`, foo from (select `name`, id as foo from `user` where id = 3 union select 'extra', user_id from user_extra where user_id = 3) as X",
-        "Table": "`user`, user_extra",
         "Values": [
           "3"
         ],
@@ -1330,8 +1280,7 @@
                     "FieldQuery": "select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
                     "Query": "select distinct CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.table_name = :kcu_table_name /* VARCHAR */",
                     "SysTableTableName": "[kcu_table_name:'user_extra']",
-                    "SysTableTableSchema": "['user']",
-                    "Table": "information_schema.key_column_usage"
+                    "SysTableTableSchema": "['user']"
                   },
                   {
                     "OperatorType": "Route",
@@ -1343,8 +1292,7 @@
                     "FieldQuery": "select CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
                     "Query": "select distinct CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.table_name = :kcu_table_name1 /* VARCHAR */",
                     "SysTableTableName": "[kcu_table_name1:'music']",
-                    "SysTableTableSchema": "['user']",
-                    "Table": "information_schema.key_column_usage"
+                    "SysTableTableSchema": "['user']"
                   }
                 ]
               }
@@ -1368,8 +1316,7 @@
           "Sharded": false
         },
         "FieldQuery": "select * from (select * from unsharded where 1 != 1) as last_failed where 1 != 1 union all select * from (select * from unsharded where 1 != 1) as last_succeeded where 1 != 1",
-        "Query": "select * from (select * from unsharded where branchId = 203622 and buildNumber <= 113893 and state = 'FAILED' order by buildNumber desc limit 1) as last_failed union all select * from (select * from unsharded where branchId = 203622 and buildNumber <= 113893 and state = 'SUCCEEDED' order by buildNumber desc limit 1) as last_succeeded order by buildNumber desc limit 1",
-        "Table": "unsharded"
+        "Query": "select * from (select * from unsharded where branchId = 203622 and buildNumber <= 113893 and state = 'FAILED' order by buildNumber desc limit 1) as last_failed union all select * from (select * from unsharded where branchId = 203622 and buildNumber <= 113893 and state = 'SUCCEEDED' order by buildNumber desc limit 1) as last_succeeded order by buildNumber desc limit 1"
       },
       "TablesUsed": [
         "main.unsharded"
@@ -1402,14 +1349,12 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select dt.c0 as id, dt.c1 as foo, dt.c2 as bar, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select id, foo, bar from unsharded where 1 != 1) as dt(c0, c1, c2) where 1 != 1",
-                "Query": "select dt.c0 as id, dt.c1 as foo, dt.c2 as bar, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select distinct id, foo, bar from unsharded) as dt(c0, c1, c2)",
-                "Table": "unsharded"
+                "Query": "select dt.c0 as id, dt.c1 as foo, dt.c2 as bar, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select distinct id, foo, bar from unsharded) as dt(c0, c1, c2)"
               },
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
                 "JoinColumnIndexes": "L:0,L:1,R:0,L:2,L:3,R:1",
-                "TableName": "`user`_authoritative",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -1419,8 +1364,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select `user`.intcol, `user`.textcol2, weight_string(`user`.intcol), weight_string(`user`.textcol2) from `user` where 1 != 1",
-                    "Query": "select distinct `user`.intcol, `user`.textcol2, weight_string(`user`.intcol), weight_string(`user`.textcol2) from `user`",
-                    "Table": "`user`"
+                    "Query": "select distinct `user`.intcol, `user`.textcol2, weight_string(`user`.intcol), weight_string(`user`.textcol2) from `user`"
                   },
                   {
                     "OperatorType": "Route",
@@ -1430,8 +1374,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select authoritative.col2, weight_string(authoritative.col2) from authoritative where 1 != 1",
-                    "Query": "select distinct authoritative.col2, weight_string(authoritative.col2) from authoritative",
-                    "Table": "authoritative"
+                    "Query": "select distinct authoritative.col2, weight_string(authoritative.col2) from authoritative"
                   }
                 ]
               }
@@ -1460,8 +1403,7 @@
           "Sharded": true
         },
         "FieldQuery": "select foo, foo, foo from `user` where 1 != 1 union all select bar, baz, toto from music where 1 != 1",
-        "Query": "select foo, foo, foo from `user` union all select bar, baz, toto from music",
-        "Table": "`user`, music"
+        "Query": "select foo, foo, foo from `user` union all select bar, baz, toto from music"
       },
       "TablesUsed": [
         "user.music",
@@ -1483,8 +1425,7 @@
           "Sharded": true
         },
         "FieldQuery": "select bar, baz, toto from music where 1 != 1 union all select foo, foo, foo from `user` where 1 != 1",
-        "Query": "select bar, baz, toto from music union all select foo, foo, foo from `user`",
-        "Table": "`user`, music"
+        "Query": "select bar, baz, toto from music union all select foo, foo, foo from `user`"
       },
       "TablesUsed": [
         "user.music",
@@ -1515,8 +1456,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.c0 as bar, dt.c1 as baz, dt.c2 as toto, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select bar, baz, toto from music where 1 != 1 union select foo, foo, foo from `user` where 1 != 1) as dt(c0, c1, c2) where 1 != 1",
-            "Query": "select dt.c0 as bar, dt.c1 as baz, dt.c2 as toto, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select bar, baz, toto from music union select foo, foo, foo from `user`) as dt(c0, c1, c2)",
-            "Table": "`user`, music"
+            "Query": "select dt.c0 as bar, dt.c1 as baz, dt.c2 as toto, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select bar, baz, toto from music union select foo, foo, foo from `user`) as dt(c0, c1, c2)"
           }
         ]
       },
@@ -1549,8 +1489,7 @@
               "Sharded": true
             },
             "FieldQuery": "select dt.c0 as foo, dt.c1 as foo, dt.c2 as foo, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select foo, foo, foo from `user` where 1 != 1 union select bar, baz, toto from music where 1 != 1) as dt(c0, c1, c2) where 1 != 1",
-            "Query": "select dt.c0 as foo, dt.c1 as foo, dt.c2 as foo, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select foo, foo, foo from `user` union select bar, baz, toto from music) as dt(c0, c1, c2)",
-            "Table": "`user`, music"
+            "Query": "select dt.c0 as foo, dt.c1 as foo, dt.c2 as foo, weight_string(dt.c0), weight_string(dt.c1), weight_string(dt.c2) from (select foo, foo, foo from `user` union select bar, baz, toto from music) as dt(c0, c1, c2)"
           }
         ]
       },
@@ -1573,7 +1512,6 @@
         "JoinVars": {
           "t1_foo": 0
         },
-        "TableName": "`user`_music",
         "Inputs": [
           {
             "OperatorType": "Distinct",
@@ -1589,8 +1527,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as foo, weight_string(dt.c0) from (select foo from `user` where 1 != 1 union select foo from `user` where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as foo, weight_string(dt.c0) from (select foo from `user` where bar = 12 union select foo from `user` where bar = 134) as dt(c0)",
-                "Table": "`user`"
+                "Query": "select dt.c0 as foo, weight_string(dt.c0) from (select foo from `user` where bar = 12 union select foo from `user` where bar = 134) as dt(c0)"
               }
             ]
           },
@@ -1608,8 +1545,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select dt.c0 as bar, weight_string(dt.c0) from (select bar from music where 1 != 1 union select bar from music where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as bar, weight_string(dt.c0) from (select bar from music where foo = 12 and bar = :t1_foo union select bar from music where foo = 1234 and bar = :t1_foo) as dt(c0)",
-                "Table": "music"
+                "Query": "select dt.c0 as bar, weight_string(dt.c0) from (select bar from music where foo = 12 and bar = :t1_foo union select bar from music where foo = 1234 and bar = :t1_foo) as dt(c0)"
               }
             ]
           }
@@ -1641,8 +1577,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` where 1 != 1 union select 2 from `user` where 1 != 1",
-            "Query": "select 1 from `user` union select 2 from `user`",
-            "Table": "`user`"
+            "Query": "select 1 from `user` union select 2 from `user`"
           }
         ]
       },
@@ -1671,8 +1606,7 @@
               "Sharded": true
             },
             "FieldQuery": "select col1 from `user` where 1 != 1 union select 3 from `user` where 1 != 1",
-            "Query": "select col1 from `user` union select 3 from `user`",
-            "Table": "`user`"
+            "Query": "select col1 from `user` union select 3 from `user`"
           }
         ]
       },
@@ -1701,8 +1635,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 3 from `user` where 1 != 1 union select col1 from `user` where 1 != 1",
-            "Query": "select 3 from `user` union select col1 from `user`",
-            "Table": "`user`"
+            "Query": "select 3 from `user` union select col1 from `user`"
           }
         ]
       },
@@ -1731,8 +1664,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 3 from `user` where 1 != 1 union select now() from `user` where 1 != 1",
-            "Query": "select 3 from `user` union select now() from `user`",
-            "Table": "`user`"
+            "Query": "select 3 from `user` union select now() from `user`"
           }
         ]
       },
@@ -1761,8 +1693,7 @@
               "Sharded": true
             },
             "FieldQuery": "select now() from `user` where 1 != 1 union select 3 from `user` where 1 != 1",
-            "Query": "select now() from `user` union select 3 from `user`",
-            "Table": "`user`"
+            "Query": "select now() from `user` union select 3 from `user`"
           }
         ]
       },
@@ -1791,8 +1722,7 @@
               "Sharded": true
             },
             "FieldQuery": "select now() from `user` where 1 != 1 union select id from `user` where 1 != 1",
-            "Query": "select now() from `user` union select id from `user`",
-            "Table": "`user`"
+            "Query": "select now() from `user` union select id from `user`"
           }
         ]
       },
@@ -1826,8 +1756,7 @@
                 },
                 "FieldQuery": "select 'a' as type, 0 as id, '' from `user` where 1 != 1 group by ''",
                 "OrderBy": "2 ASC COLLATE utf8mb4_0900_ai_ci",
-                "Query": "select 'a' as type, 0 as id, '' from `user` group by '' order by '' asc",
-                "Table": "`user`"
+                "Query": "select 'a' as type, 0 as id, '' from `user` group by '' order by '' asc"
               }
             ]
           },
@@ -1839,8 +1768,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 'c' as type, 0 as id from user_extra as t where 1 != 1",
-            "Query": "select 'c' as type, 0 as id from user_extra as t",
-            "Table": "user_extra"
+            "Query": "select 'c' as type, 0 as id from user_extra as t"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/vexplain_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/vexplain_cases.json
@@ -32,8 +32,7 @@
               "Sharded": true
             },
             "FieldQuery": "select * from `user` where 1 != 1",
-            "Query": "select * from `user`",
-            "Table": "`user`"
+            "Query": "select * from `user`"
           }
         ]
       },
@@ -60,8 +59,7 @@
               "Sharded": true
             },
             "FieldQuery": "select * from `user` where 1 != 1",
-            "Query": "select * from `user`",
-            "Table": "`user`"
+            "Query": "select * from `user`"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.json
@@ -152,7 +152,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "_unsharded",
         "Inputs": [
           {
             "OperatorType": "VindexFunc",
@@ -174,8 +173,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.id from unsharded",
-            "Table": "unsharded"
+            "Query": "select unsharded.id from unsharded"
           }
         ]
       },
@@ -195,7 +193,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0,L:0",
-        "TableName": "unsharded_",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -205,8 +202,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.id from unsharded",
-            "Table": "unsharded"
+            "Query": "select unsharded.id from unsharded"
           },
           {
             "OperatorType": "VindexFunc",
@@ -241,7 +237,6 @@
         "JoinVars": {
           "user_index_id": 0
         },
-        "TableName": "_unsharded",
         "Inputs": [
           {
             "OperatorType": "VindexFunc",
@@ -265,8 +260,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id /* VARBINARY */",
-            "Table": "unsharded"
+            "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id /* VARBINARY */"
           }
         ]
       },
@@ -289,7 +283,6 @@
         "JoinVars": {
           "user_index_id": 1
         },
-        "TableName": "_unsharded",
         "Inputs": [
           {
             "OperatorType": "VindexFunc",
@@ -313,8 +306,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id /* VARBINARY */",
-            "Table": "unsharded"
+            "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id /* VARBINARY */"
           }
         ]
       },
@@ -337,7 +329,6 @@
         "JoinVars": {
           "user_index_id": 1
         },
-        "TableName": "_unsharded",
         "Inputs": [
           {
             "OperatorType": "VindexFunc",
@@ -361,8 +352,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id /* VARBINARY */",
-            "Table": "unsharded"
+            "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id /* VARBINARY */"
           }
         ]
       },
@@ -385,7 +375,6 @@
         "JoinVars": {
           "ui_id": 1
         },
-        "TableName": "_unsharded",
         "Inputs": [
           {
             "OperatorType": "VindexFunc",
@@ -409,8 +398,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.id from unsharded where unsharded.id = :ui_id /* VARBINARY */",
-            "Table": "unsharded"
+            "Query": "select unsharded.id from unsharded where unsharded.id = :ui_id /* VARBINARY */"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
@@ -12,7 +12,6 @@
         "JoinVars": {
           "e_id": 1
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -22,8 +21,7 @@
               "Sharded": true
             },
             "FieldQuery": "select e.col, e.id as eid from user_extra as e where 1 != 1",
-            "Query": "select e.col, e.id as eid from user_extra as e",
-            "Table": "user_extra"
+            "Query": "select e.col, e.id as eid from user_extra as e"
           },
           {
             "OperatorType": "Route",
@@ -34,7 +32,6 @@
             },
             "FieldQuery": "select u.id as uid from `user` as u where 1 != 1",
             "Query": "select u.id as uid from `user` as u where u.id = :e_id",
-            "Table": "`user`",
             "Values": [
               ":e_id"
             ],
@@ -61,7 +58,6 @@
         "JoinVars": {
           "e_id": 1
         },
-        "TableName": "user_extra_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -71,8 +67,7 @@
               "Sharded": true
             },
             "FieldQuery": "select e.col, e.id as eid from user_extra as e where 1 != 1",
-            "Query": "select e.col, e.id as eid from user_extra as e where e.col = :uid",
-            "Table": "user_extra"
+            "Query": "select e.col, e.id as eid from user_extra as e where e.col = :uid"
           },
           {
             "OperatorType": "Route",
@@ -83,7 +78,6 @@
             },
             "FieldQuery": "select u.id as uid from `user` as u where 1 != 1",
             "Query": "select u.id as uid from `user` as u where u.id = :e_id",
-            "Table": "`user`",
             "Values": [
               ":e_id"
             ],
@@ -107,7 +101,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "`user`_`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -117,8 +110,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
-            "Query": "select 1 from `user` as u2",
-            "Table": "`user`"
+            "Query": "select 1 from `user` as u2"
           },
           {
             "OperatorType": "Join",
@@ -127,7 +119,6 @@
             "JoinVars": {
               "u1_col": 1
             },
-            "TableName": "`user`_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -137,8 +128,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u1.id, u1.col from `user` as u1 where 1 != 1",
-                "Query": "select u1.id, u1.col from `user` as u1",
-                "Table": "`user`"
+                "Query": "select u1.id, u1.col from `user` as u1"
               },
               {
                 "OperatorType": "Route",
@@ -148,8 +138,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
-                "Query": "select 1 from `user` as u3 where u3.col = :u1_col /* INT16 */",
-                "Table": "`user`"
+                "Query": "select 1 from `user` as u3 where u3.col = :u1_col /* INT16 */"
               }
             ]
           }
@@ -170,7 +159,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -180,8 +168,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u1.id from `user` as u1 where 1 != 1",
-            "Query": "select u1.id from `user` as u1",
-            "Table": "`user`"
+            "Query": "select u1.id from `user` as u1"
           },
           {
             "OperatorType": "Join",
@@ -189,7 +176,6 @@
             "JoinVars": {
               "u2_col": 0
             },
-            "TableName": "`user`_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -199,8 +185,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u2.col from `user` as u2 where 1 != 1",
-                "Query": "select u2.col from `user` as u2",
-                "Table": "`user`"
+                "Query": "select u2.col from `user` as u2"
               },
               {
                 "OperatorType": "Route",
@@ -210,8 +195,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
-                "Query": "select 1 from `user` as u3 where u3.col = :u2_col /* INT16 */",
-                "Table": "`user`"
+                "Query": "select 1 from `user` as u3 where u3.col = :u2_col /* INT16 */"
               }
             ]
           }
@@ -235,7 +219,6 @@
         "JoinVars": {
           "u3_col": 0
         },
-        "TableName": "`user`_`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -245,8 +228,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u3.col from `user` as u3 where 1 != 1",
-            "Query": "select u3.col from `user` as u3",
-            "Table": "`user`"
+            "Query": "select u3.col from `user` as u3"
           },
           {
             "OperatorType": "Join",
@@ -255,7 +237,6 @@
             "JoinVars": {
               "u1_col": 1
             },
-            "TableName": "`user`_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -265,8 +246,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u1.id, u1.col from `user` as u1 where 1 != 1",
-                "Query": "select u1.id, u1.col from `user` as u1 where u1.col = :u3_col /* INT16 */",
-                "Table": "`user`"
+                "Query": "select u1.id, u1.col from `user` as u1 where u1.col = :u3_col /* INT16 */"
               },
               {
                 "OperatorType": "Route",
@@ -276,8 +256,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
-                "Query": "select 1 from `user` as u2 where u2.col = :u1_col /* INT16 */",
-                "Table": "`user`"
+                "Query": "select 1 from `user` as u2 where u2.col = :u1_col /* INT16 */"
               }
             ]
           }
@@ -298,7 +277,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "R:0",
-        "TableName": "`user`_`user`_`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -308,8 +286,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
-            "Query": "select 1 from `user` as u2",
-            "Table": "`user`"
+            "Query": "select 1 from `user` as u2"
           },
           {
             "OperatorType": "Join",
@@ -318,7 +295,6 @@
             "JoinVars": {
               "u4_col": 0
             },
-            "TableName": "`user`_`user`_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -328,8 +304,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u4.col from `user` as u4 where 1 != 1",
-                "Query": "select u4.col from `user` as u4",
-                "Table": "`user`"
+                "Query": "select u4.col from `user` as u4"
               },
               {
                 "OperatorType": "Join",
@@ -338,7 +313,6 @@
                 "JoinVars": {
                   "u1_col": 1
                 },
-                "TableName": "`user`_`user`",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -348,8 +322,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select u1.id, u1.col from `user` as u1 where 1 != 1",
-                    "Query": "select u1.id, u1.col from `user` as u1 where u1.col = :u4_col /* INT16 */",
-                    "Table": "`user`"
+                    "Query": "select u1.id, u1.col from `user` as u1 where u1.col = :u4_col /* INT16 */"
                   },
                   {
                     "OperatorType": "Route",
@@ -360,7 +333,6 @@
                     },
                     "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
                     "Query": "select 1 from `user` as u3 where u3.id = :u1_col /* INT16 */",
-                    "Table": "`user`",
                     "Values": [
                       ":u1_col"
                     ],
@@ -390,7 +362,6 @@
         "JoinVars": {
           "u1_col": 1
         },
-        "TableName": "`user`_`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Join",
@@ -399,7 +370,6 @@
             "JoinVars": {
               "u1_col": 1
             },
-            "TableName": "`user`_`user`",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -409,8 +379,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u1.id, u1.col from `user` as u1 where 1 != 1",
-                "Query": "select u1.id, u1.col from `user` as u1",
-                "Table": "`user`"
+                "Query": "select u1.id, u1.col from `user` as u1"
               },
               {
                 "OperatorType": "Route",
@@ -421,7 +390,6 @@
                 },
                 "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
                 "Query": "select 1 from `user` as u2 where u2.id = :u1_col /* INT16 */",
-                "Table": "`user`",
                 "Values": [
                   ":u1_col"
                 ],
@@ -438,7 +406,6 @@
             },
             "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
             "Query": "select 1 from `user` as u3 where u3.id = :u1_col /* INT16 */",
-            "Table": "`user`",
             "Values": [
               ":u1_col"
             ],
@@ -464,7 +431,6 @@
         "JoinVars": {
           "unsharded_id": 1
         },
-        "TableName": "unsharded_`weird``name`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -474,8 +440,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.b, unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.b, unsharded.id from unsharded",
-            "Table": "unsharded"
+            "Query": "select unsharded.b, unsharded.id from unsharded"
           },
           {
             "OperatorType": "Route",
@@ -486,7 +451,6 @@
             },
             "FieldQuery": "select `weird``name`.a from `weird``name` where 1 != 1",
             "Query": "select `weird``name`.a from `weird``name` where `weird``name`.`a``b*c` = :unsharded_id",
-            "Table": "`weird``name`",
             "Values": [
               ":unsharded_id"
             ],
@@ -513,7 +477,6 @@
         "JoinVars": {
           "unsharded_id": 1
         },
-        "TableName": "unsharded_`weird``name`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -523,8 +486,7 @@
               "Sharded": false
             },
             "FieldQuery": "select unsharded.b, unsharded.id from unsharded where 1 != 1",
-            "Query": "select unsharded.b, unsharded.id from unsharded",
-            "Table": "unsharded"
+            "Query": "select unsharded.b, unsharded.id from unsharded"
           },
           {
             "OperatorType": "Route",
@@ -535,7 +497,6 @@
             },
             "FieldQuery": "select 1 from `weird``name` where 1 != 1",
             "Query": "select 1 from `weird``name` where `weird``name`.`a``b*c` = :unsharded_id",
-            "Table": "`weird``name`",
             "Values": [
               ":unsharded_id"
             ],
@@ -566,7 +527,6 @@
             "JoinVars": {
               "u_col": 1
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -576,8 +536,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
-                "Query": "select u.id, u.col from `user` as u",
-                "Table": "`user`"
+                "Query": "select u.id, u.col from `user` as u"
               },
               {
                 "OperatorType": "Limit",
@@ -591,8 +550,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select e.id from user_extra as e where 1 != 1",
-                    "Query": "select e.id from user_extra as e where e.id = :u_col /* INT16 */ limit 10",
-                    "Table": "user_extra"
+                    "Query": "select e.id from user_extra as e where e.id = :u_col /* INT16 */ limit 10"
                   }
                 ]
               }
@@ -633,7 +591,6 @@
                   "u_col": 1,
                   "u_id": 0
                 },
-                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -643,8 +600,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
-                    "Query": "select u.id, u.col from `user` as u",
-                    "Table": "`user`"
+                    "Query": "select u.id, u.col from `user` as u"
                   },
                   {
                     "OperatorType": "Limit",
@@ -658,8 +614,7 @@
                           "Sharded": true
                         },
                         "FieldQuery": "select :u_id + e.id as `u.id + e.id` from user_extra as e where 1 != 1",
-                        "Query": "select :u_id + e.id as `u.id + e.id` from user_extra as e where e.id = :u_col /* INT16 */ limit 10",
-                        "Table": "user_extra"
+                        "Query": "select :u_id + e.id as `u.id + e.id` from user_extra as e where e.id = :u_col /* INT16 */ limit 10"
                       }
                     ]
                   }
@@ -677,7 +632,6 @@
             },
             "FieldQuery": "select 1 from `user` where 1 != 1",
             "Query": "select 1 from `user` where :__sq_has_values and id in ::__vals",
-            "Table": "`user`",
             "Values": [
               "::__sq1"
             ],
@@ -708,7 +662,6 @@
             "JoinVars": {
               "u_col": 2
             },
-            "TableName": "`user`_user_extra",
             "Inputs": [
               {
                 "OperatorType": "UncorrelatedSubquery",
@@ -726,8 +679,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select col from `user` where 1 != 1",
-                    "Query": "select col from `user`",
-                    "Table": "`user`"
+                    "Query": "select col from `user`"
                   },
                   {
                     "InputName": "Outer",
@@ -738,8 +690,7 @@
                       "Sharded": true
                     },
                     "FieldQuery": "select u.id, :__sq1 /* INT16 */ as `(select col from ``user``)`, u.col from `user` as u where 1 != 1",
-                    "Query": "select u.id, :__sq1 /* INT16 */ as `(select col from ``user``)`, u.col from `user` as u",
-                    "Table": "`user`"
+                    "Query": "select u.id, :__sq1 /* INT16 */ as `(select col from ``user``)`, u.col from `user` as u"
                   }
                 ]
               },
@@ -751,8 +702,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select e.id from user_extra as e where 1 != 1",
-                "Query": "select e.id from user_extra as e where e.id = :u_col /* INT16 */",
-                "Table": "user_extra"
+                "Query": "select e.id from user_extra as e where e.id = :u_col /* INT16 */"
               }
             ]
           }
@@ -779,7 +729,6 @@
         },
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id in ::__vals",
-        "Table": "`user`",
         "Values": [
           "(18446744073709551616, 1)"
         ],
@@ -800,7 +749,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -811,7 +759,6 @@
             },
             "FieldQuery": "select u1.id from `user` as u1 where 1 != 1",
             "Query": "select u1.id from `user` as u1 where u1.id = 18446744073709551616",
-            "Table": "`user`",
             "Values": [
               "18446744073709551616"
             ],
@@ -825,8 +772,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
-            "Query": "select 1 from `user` as u2",
-            "Table": "`user`"
+            "Query": "select 1 from `user` as u2"
           }
         ]
       },
@@ -845,7 +791,6 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -855,8 +800,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u1.id from `user` as u1 where 1 != 1",
-            "Query": "select u1.id from `user` as u1",
-            "Table": "`user`"
+            "Query": "select u1.id from `user` as u1"
           },
           {
             "OperatorType": "Route",
@@ -867,7 +811,6 @@
             },
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
             "Query": "select 1 from `user` as u2 where u2.id = 18446744073709551616",
-            "Table": "`user`",
             "Values": [
               "18446744073709551616"
             ],
@@ -907,7 +850,6 @@
             },
             "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
             "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-            "Table": "name_user_vdx",
             "Values": [
               "::name"
             ],
@@ -921,8 +863,7 @@
               "Sharded": true
             },
             "FieldQuery": "select u.a from (select id as b, `name` from `user` where 1 != 1) as u(a, n) where 1 != 1",
-            "Query": "select u.a from (select id as b, `name` from `user` where `name` = 1) as u(a, n)",
-            "Table": "`user`"
+            "Query": "select u.a from (select id as b, `name` from `user` where `name` = 1) as u(a, n)"
           }
         ]
       },
@@ -941,13 +882,11 @@
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_unsharded_unsharded",
         "Inputs": [
           {
             "OperatorType": "Join",
             "Variant": "Join",
             "JoinColumnIndexes": "L:0",
-            "TableName": "`user`_unsharded",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -957,8 +896,7 @@
                   "Sharded": true
                 },
                 "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                "Query": "select /*vt+ PLANNER=left2right */ `user`.col from `user`",
-                "Table": "`user`"
+                "Query": "select /*vt+ PLANNER=left2right */ `user`.col from `user`"
               },
               {
                 "OperatorType": "Route",
@@ -968,8 +906,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from unsharded as m1 where 1 != 1",
-                "Query": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m1",
-                "Table": "unsharded"
+                "Query": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m1"
               }
             ]
           },
@@ -981,8 +918,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from unsharded as m2 where 1 != 1",
-            "Query": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m2",
-            "Table": "unsharded"
+            "Query": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m2"
           }
         ]
       },


### PR DESCRIPTION
## Description
The `TableName()` method on the `Primitive` interface is now redundant due to the addition of `TablesUsed` tracking on the `Plan`. This PR removes `TableName()` and utilizes the `TablesUsed` field, simplifying the codebase.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
