### PR TITLE
Remove unused `formatRelativeTime` import

### DIFF
--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -20,7 +20,7 @@ import { Link } from 'react-router-dom';
 
 import { useWorkflow } from '../../../hooks/api';
 import { formatAlias } from '../../../util/tablets';
-import { formatDateTime, formatRelativeTime } from '../../../util/time';
+import { formatDateTime } from '../../../util/time';
 import { formatStreamKey, getStreams, getStreamSource, getStreamTarget } from '../../../util/workflows';
 import { DataCell } from '../../dataTable/DataCell';
 import { DataTable } from '../../dataTable/DataTable';


### PR DESCRIPTION
## Description

I noticed a complaint of the linter in #16548. This PR resolve this.

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/ea4506ff-7bd4-4b9d-80ac-6ca3a8f0e521">


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
