### PR TITLE
evalengine: Implement `PERIOD_DIFF`

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1409,6 +1409,18 @@ func (cached *builtinPeriodAdd) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinPeriodDiff) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinPi) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -4319,6 +4319,26 @@ func (asm *assembler) Fn_PERIOD_ADD() {
 	}, "FN PERIOD_ADD INT64(SP-2) INT64(SP-1)")
 }
 
+func (asm *assembler) Fn_PERIOD_DIFF() {
+	asm.adjustStack(-1)
+	asm.emit(func(env *ExpressionEnv) int {
+		if env.vm.stack[env.vm.sp-2] == nil {
+			env.vm.sp--
+			return 1
+		}
+		period1 := env.vm.stack[env.vm.sp-2].(*evalInt64).i
+		period2 := env.vm.stack[env.vm.sp-1].(*evalInt64).i
+		res, err := periodDiff(period1, period2)
+		if err != nil {
+			env.vm.err = err
+			return 0
+		}
+		env.vm.stack[env.vm.sp-2] = res
+		env.vm.sp--
+		return 1
+	}, "FN PERIOD_DIFF INT64(SP-2) INT64(SP-1)")
+}
+
 func (asm *assembler) Interval(l int) {
 	asm.adjustStack(-l)
 	asm.emit(func(env *ExpressionEnv) int {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -156,6 +156,7 @@ var Cases = []TestCase{
 	{Run: FnYear},
 	{Run: FnYearWeek},
 	{Run: FnPeriodAdd},
+	{Run: FnPeriodDiff},
 	{Run: FnInetAton},
 	{Run: FnInetNtoa},
 	{Run: FnInet6Aton},
@@ -2238,6 +2239,27 @@ func FnPeriodAdd(yield Query) {
 
 	mysqlDocSamples := []string{
 		`PERIOD_ADD(200801,2)`,
+	}
+
+	for _, q := range mysqlDocSamples {
+		yield(q, nil)
+	}
+}
+
+func FnPeriodDiff(yield Query) {
+	for _, p1 := range inputBitwise {
+		for _, p2 := range inputBitwise {
+			yield(fmt.Sprintf("PERIOD_DIFF(%s, %s)", p1, p2), nil)
+		}
+	}
+	for _, p1 := range inputPeriods {
+		for _, p2 := range inputPeriods {
+			yield(fmt.Sprintf("PERIOD_DIFF(%s, %s)", p1, p2), nil)
+		}
+	}
+
+	mysqlDocSamples := []string{
+		`PERIOD_DIFF(200802,200703)`,
 	}
 
 	for _, q := range mysqlDocSamples {

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -535,6 +535,13 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 		default:
 			return nil, argError(method)
 		}
+	case "period_diff":
+		switch len(args) {
+		case 2:
+			return &builtinPeriodDiff{CallExpr: call}, nil
+		default:
+			return nil, argError(method)
+		}
 	case "inet_aton":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds implementation of [`PERIOD_DIFF`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_period-diff) func in evalengine. This PR borrows some changes related to period functions from #16492.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #9647 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
