### PR TITLE
VReplication: Return lock error everywhere that LockName fails

### DIFF
--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -236,10 +236,10 @@ func (env *testEnv) confirmRoutingAllTablesToTarget(t *testing.T) {
 	wantRR := make(map[string][]string)
 	for _, sd := range env.tmc.schema {
 		for _, td := range sd.TableDefinitions {
-			for _, pf := range []string{"", "@rdonly", "@replica"} {
-				wantRR[td.Name+pf] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
-				wantRR[fmt.Sprintf("%s.%s", env.sourceKeyspace.KeyspaceName, td.Name+pf)] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
-				wantRR[fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name+pf)] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
+			for _, tt := range []string{"", "@rdonly", "@replica"} {
+				wantRR[td.Name+tt] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
+				wantRR[fmt.Sprintf("%s.%s", env.sourceKeyspace.KeyspaceName, td.Name+tt)] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
+				wantRR[fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name+tt)] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
 			}
 		}
 	}
@@ -411,7 +411,7 @@ func (tmc *testTMClient) VReplicationExec(ctx context.Context, tablet *topodatap
 		return nil, fmt.Errorf("tablet %v:\nunexpected query\n%s\nwant:\n%s", tablet, query, qrs[0].query)
 	}
 	tmc.vrQueries[int(tablet.Alias.Uid)] = qrs[1:]
-	return qrs[0].result, nil
+	return qrs[0].result, qrs[0].err
 }
 
 func (tmc *testTMClient) ExecuteFetchAsDba(ctx context.Context, tablet *topodatapb.Tablet, usePool bool, req *tabletmanagerdatapb.ExecuteFetchAsDbaRequest) (*querypb.QueryResult, error) {

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -229,6 +229,23 @@ func (env *testEnv) deleteTablet(tablet *topodatapb.Tablet) {
 	delete(env.tablets[tablet.Keyspace], int(tablet.Alias.Uid))
 }
 
+func (env *testEnv) confirmRoutingAllTablesToTarget(t *testing.T) {
+	t.Helper()
+	env.tmc.mu.Lock()
+	defer env.tmc.mu.Unlock()
+	wantRR := make(map[string][]string)
+	for _, sd := range env.tmc.schema {
+		for _, td := range sd.TableDefinitions {
+			for _, pf := range []string{"", "@rdonly", "@replica"} {
+				wantRR[td.Name+pf] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
+				wantRR[fmt.Sprintf("%s.%s", env.sourceKeyspace.KeyspaceName, td.Name+pf)] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
+				wantRR[fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name+pf)] = []string{fmt.Sprintf("%s.%s", env.targetKeyspace.KeyspaceName, td.Name)}
+			}
+		}
+	}
+	checkRouting(t, env.ws, wantRR)
+}
+
 type testTMClient struct {
 	tmclient.TabletManagerClient
 	schema map[string]*tabletmanagerdatapb.SchemaDefinition
@@ -240,6 +257,7 @@ type testTMClient struct {
 
 	env     *testEnv    // For access to the env config from tmc methods.
 	reverse atomic.Bool // Are we reversing traffic?
+	frozen  atomic.Bool // Are the workflows frozen?
 }
 
 func newTestTMClient(env *testEnv) *testTMClient {
@@ -305,6 +323,9 @@ func (tmc *testTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *t
 					Rules: rules,
 				},
 			},
+		}
+		if tmc.frozen.Load() {
+			stream.Message = Frozen
 		}
 		res.Streams = append(res.Streams, stream)
 	}
@@ -390,7 +411,7 @@ func (tmc *testTMClient) VReplicationExec(ctx context.Context, tablet *topodatap
 		return nil, fmt.Errorf("tablet %v:\nunexpected query\n%s\nwant:\n%s", tablet, query, qrs[0].query)
 	}
 	tmc.vrQueries[int(tablet.Alias.Uid)] = qrs[1:]
-	return qrs[0].result, qrs[0].err
+	return qrs[0].result, nil
 }
 
 func (tmc *testTMClient) ExecuteFetchAsDba(ctx context.Context, tablet *topodatapb.Tablet, usePool bool, req *tabletmanagerdatapb.ExecuteFetchAsDbaRequest) (*querypb.QueryResult, error) {
@@ -502,4 +523,93 @@ func (tmc *testTMClient) WaitForPosition(ctx context.Context, tablet *topodatapb
 
 func (tmc *testTMClient) VReplicationWaitForPos(ctx context.Context, tablet *topodatapb.Tablet, id int32, pos string) error {
 	return nil
+}
+
+// Utility / helper functions.
+func checkRouting(t *testing.T, ws *Server, want map[string][]string) {
+	t.Helper()
+	ctx := context.Background()
+	got, err := topotools.GetRoutingRules(ctx, ws.ts)
+	require.NoError(t, err)
+	require.EqualValues(t, got, want, "routing rules don't match: got: %v, want: %v", got, want)
+	cells, err := ws.ts.GetCellInfoNames(ctx)
+	require.NoError(t, err)
+	for _, cell := range cells {
+		checkCellRouting(t, ws, cell, want)
+	}
+}
+
+func checkCellRouting(t *testing.T, ws *Server, cell string, want map[string][]string) {
+	t.Helper()
+	ctx := context.Background()
+	svs, err := ws.ts.GetSrvVSchema(ctx, cell)
+	require.NoError(t, err)
+	got := make(map[string][]string)
+	for _, rr := range svs.RoutingRules.Rules {
+		got[rr.FromTable] = append(got[rr.FromTable], rr.ToTables...)
+	}
+	require.EqualValues(t, got, want, "routing rules don't match for cell %s: got: %v, want: %v", cell, got, want)
+}
+
+func checkDenyList(t *testing.T, ts *topo.Server, keyspaceShard string, want []string) {
+	t.Helper()
+	ctx := context.Background()
+	splits := strings.Split(keyspaceShard, ":")
+	si, err := ts.GetShard(ctx, splits[0], splits[1])
+	require.NoError(t, err)
+	tc := si.GetTabletControl(topodatapb.TabletType_PRIMARY)
+	var got []string
+	if tc != nil {
+		got = tc.DeniedTables
+	}
+	require.EqualValues(t, got, want, "denied tables for %v: got: %v, want: %v", keyspaceShard, got, want)
+}
+
+func checkServedTypes(t *testing.T, ts *topo.Server, keyspaceShard string, want int) {
+	t.Helper()
+	ctx := context.Background()
+	splits := strings.Split(keyspaceShard, ":")
+	si, err := ts.GetShard(ctx, splits[0], splits[1])
+	require.NoError(t, err)
+	servedTypes, err := ts.GetShardServingTypes(ctx, si)
+	require.NoError(t, err)
+	require.Equal(t, want, len(servedTypes), "shard %v has wrong served types: got: %v, want: %v",
+		keyspaceShard, len(servedTypes), want)
+}
+
+func checkCellServedTypes(t *testing.T, ts *topo.Server, keyspaceShard, cell string, want int) {
+	t.Helper()
+	ctx := context.Background()
+	splits := strings.Split(keyspaceShard, ":")
+	srvKeyspace, err := ts.GetSrvKeyspace(ctx, cell, splits[0])
+	require.NoError(t, err)
+	count := 0
+outer:
+	for _, partition := range srvKeyspace.GetPartitions() {
+		for _, ref := range partition.ShardReferences {
+			if ref.Name == splits[1] {
+				count++
+				continue outer
+			}
+		}
+	}
+	require.Equal(t, want, count, "serving types for keyspaceShard %s, cell %s: got: %d, want: %d",
+		keyspaceShard, cell, count, want)
+}
+
+func checkIfPrimaryServing(t *testing.T, ts *topo.Server, keyspaceShard string, want bool) {
+	t.Helper()
+	ctx := context.Background()
+	splits := strings.Split(keyspaceShard, ":")
+	si, err := ts.GetShard(ctx, splits[0], splits[1])
+	require.NoError(t, err)
+	require.Equal(t, want, si.IsPrimaryServing, "primary serving for %v: got: %v, want: %v", keyspaceShard, si.IsPrimaryServing, want)
+}
+
+func checkIfTableExistInVSchema(ctx context.Context, t *testing.T, ts *topo.Server, keyspace string, table string) bool {
+	vschema, err := ts.GetVSchema(ctx, keyspace)
+	require.NoError(t, err)
+	require.NotNil(t, vschema)
+	_, ok := vschema.Tables[table]
+	return ok
 }

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -590,8 +590,7 @@ outer:
 			}
 		}
 	}
-	require.Equal(t, want, count, "serving types for %s/%s in cell %s: got: %d, want: %d",
-		keyspace, shard, cell, count, want)
+	require.Equal(t, want, count, "serving types for %s/%s in cell %s: got: %d, want: %d", keyspace, shard, cell, count, want)
 }
 
 func checkIfPrimaryServing(t *testing.T, ts *topo.Server, keyspace, shard string, want bool) {

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -525,7 +525,10 @@ func (tmc *testTMClient) VReplicationWaitForPos(ctx context.Context, tablet *top
 	return nil
 }
 
+//
 // Utility / helper functions.
+//
+
 func checkRouting(t *testing.T, ws *Server, want map[string][]string) {
 	t.Helper()
 	ctx := context.Background()

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2583,6 +2583,7 @@ func (s *Server) DropTargets(ctx context.Context, ts *trafficSwitcher, keepData,
 	ctx, workflowUnlock, lockErr := s.ts.LockName(ctx, lockName, "DropTargets")
 	if lockErr != nil {
 		ts.Logger().Errorf("Locking the workflow %s failed: %v", lockName, lockErr)
+		return nil, lockErr
 	}
 	defer workflowUnlock(&err)
 	ctx, sourceUnlock, lockErr := sw.lockKeyspace(ctx, ts.SourceKeyspaceName(), "DropTargets")
@@ -2781,6 +2782,7 @@ func (s *Server) dropSources(ctx context.Context, ts *trafficSwitcher, removalTy
 	ctx, workflowUnlock, lockErr := s.ts.LockName(ctx, lockName, "DropSources")
 	if lockErr != nil {
 		ts.Logger().Errorf("Locking the workflow %s failed: %v", lockName, lockErr)
+		return nil, lockErr
 	}
 	defer workflowUnlock(&err)
 	ctx, sourceUnlock, lockErr := sw.lockKeyspace(ctx, ts.SourceKeyspaceName(), "DropSources")
@@ -3022,6 +3024,7 @@ func (s *Server) finalizeMigrateWorkflow(ctx context.Context, ts *trafficSwitche
 	ctx, workflowUnlock, lockErr := s.ts.LockName(ctx, lockName, "completeMigrateWorkflow")
 	if lockErr != nil {
 		ts.Logger().Errorf("Locking the workflow %s failed: %v", lockName, lockErr)
+		return nil, lockErr
 	}
 	defer workflowUnlock(&err)
 	ctx, targetUnlock, lockErr := sw.lockKeyspace(ctx, ts.TargetKeyspaceName(), "completeMigrateWorkflow")

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2581,21 +2581,18 @@ func (s *Server) DropTargets(ctx context.Context, ts *trafficSwitcher, keepData,
 	lockName := fmt.Sprintf("%s/%s", ts.TargetKeyspaceName(), ts.WorkflowName())
 	ctx, workflowUnlock, lockErr := s.ts.LockName(ctx, lockName, "DropTargets")
 	if lockErr != nil {
-		ts.Logger().Errorf("Locking the workflow %s failed: %v", lockName, lockErr)
-		return nil, lockErr
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s workflow", lockName), lockErr)
 	}
 	defer workflowUnlock(&err)
 	ctx, sourceUnlock, lockErr := sw.lockKeyspace(ctx, ts.SourceKeyspaceName(), "DropTargets")
 	if lockErr != nil {
-		ts.Logger().Errorf("Source LockKeyspace failed: %v", lockErr)
-		return nil, lockErr
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s keyspace", ts.SourceKeyspaceName()), lockErr)
 	}
 	defer sourceUnlock(&err)
 	if ts.TargetKeyspaceName() != ts.SourceKeyspaceName() {
 		lockCtx, targetUnlock, lockErr := sw.lockKeyspace(ctx, ts.TargetKeyspaceName(), "DropTargets")
 		if lockErr != nil {
-			ts.Logger().Errorf("Target LockKeyspace failed: %v", lockErr)
-			return nil, lockErr
+			return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s keyspace", ts.TargetKeyspaceName()), lockErr)
 		}
 		defer targetUnlock(&err)
 		ctx = lockCtx
@@ -2780,21 +2777,18 @@ func (s *Server) dropSources(ctx context.Context, ts *trafficSwitcher, removalTy
 	lockName := fmt.Sprintf("%s/%s", ts.TargetKeyspaceName(), ts.WorkflowName())
 	ctx, workflowUnlock, lockErr := s.ts.LockName(ctx, lockName, "DropSources")
 	if lockErr != nil {
-		ts.Logger().Errorf("Locking the workflow %s failed: %v", lockName, lockErr)
-		return nil, lockErr
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s workflow", lockName), lockErr)
 	}
 	defer workflowUnlock(&err)
 	ctx, sourceUnlock, lockErr := sw.lockKeyspace(ctx, ts.SourceKeyspaceName(), "DropSources")
 	if lockErr != nil {
-		ts.Logger().Errorf("Source LockKeyspace failed: %v", lockErr)
-		return nil, lockErr
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s keyspace", ts.SourceKeyspaceName()), lockErr)
 	}
 	defer sourceUnlock(&err)
 	if ts.TargetKeyspaceName() != ts.SourceKeyspaceName() {
 		lockCtx, targetUnlock, lockErr := sw.lockKeyspace(ctx, ts.TargetKeyspaceName(), "DropSources")
 		if lockErr != nil {
-			ts.Logger().Errorf("Target LockKeyspace failed: %v", lockErr)
-			return nil, lockErr
+			return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s keyspace", ts.TargetKeyspaceName()), lockErr)
 		}
 		defer targetUnlock(&err)
 		ctx = lockCtx
@@ -3022,14 +3016,12 @@ func (s *Server) finalizeMigrateWorkflow(ctx context.Context, ts *trafficSwitche
 	lockName := fmt.Sprintf("%s/%s", ts.TargetKeyspaceName(), ts.WorkflowName())
 	ctx, workflowUnlock, lockErr := s.ts.LockName(ctx, lockName, "completeMigrateWorkflow")
 	if lockErr != nil {
-		ts.Logger().Errorf("Locking the workflow %s failed: %v", lockName, lockErr)
-		return nil, lockErr
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s workflow", lockName), lockErr)
 	}
 	defer workflowUnlock(&err)
 	ctx, targetUnlock, lockErr := sw.lockKeyspace(ctx, ts.TargetKeyspaceName(), "completeMigrateWorkflow")
 	if lockErr != nil {
-		ts.Logger().Errorf("Target LockKeyspace failed: %v", lockErr)
-		return nil, lockErr
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s keyspace", ts.TargetKeyspaceName()), lockErr)
 	}
 	defer targetUnlock(&err)
 
@@ -3196,16 +3188,10 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 
 	cellsStr := strings.Join(req.Cells, ",")
 
-	// Consistently handle errors by logging and returning them.
-	handleError := func(message string, err error) (*[]string, error) {
-		werr := vterrors.Wrapf(err, message)
-		ts.Logger().Error(werr)
-		return nil, werr
-	}
-
 	log.Infof("Switching reads: %s.%s tablet types: %s, cells: %s, workflow state: %s", ts.targetKeyspace, ts.workflow, roTypesToSwitchStr, cellsStr, state.String())
 	if !switchReplica && !switchRdonly {
-		return handleError("invalid tablet types", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "tablet types must be REPLICA or RDONLY: %s", roTypesToSwitchStr))
+		return defaultErrorHandler(ts.Logger(), "invalid tablet types",
+			vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "tablet types must be REPLICA or RDONLY: %s", roTypesToSwitchStr))
 	}
 	// For partial (shard-by-shard migrations) or multi-tenant migrations, traffic for all tablet types
 	// is expected to be switched at once. For other MoveTables migrations where we use table routing rules
@@ -3217,7 +3203,8 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 		trafficSwitchingIsAllOrNothing = true
 	case ts.MigrationType() == binlogdatapb.MigrationType_TABLES && ts.IsMultiTenantMigration():
 		if direction == DirectionBackward {
-			return handleError("invalid request", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "requesting reversal of read traffic for multi-tenant migrations is not supported"))
+			return defaultErrorHandler(ts.Logger(), "invalid request", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT,
+				"requesting reversal of read traffic for multi-tenant migrations is not supported"))
 		}
 		// For multi-tenant migrations, we only support switching traffic to all cells at once
 		allCells, err := ts.TopoServer().GetCellInfoNames(ctx)
@@ -3225,16 +3212,19 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 			return nil, err
 		}
 		if len(req.GetCells()) != 0 && len(req.GetCells()) != len(allCells) {
-			return handleError("invalid request", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "requesting read traffic for multi-tenant migrations must include all cells"))
+			return defaultErrorHandler(ts.Logger(), "invalid request", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT,
+				"requesting read traffic for multi-tenant migrations must include all cells"))
 		}
 	}
 
 	if !trafficSwitchingIsAllOrNothing {
 		if direction == DirectionBackward && switchReplica && len(state.ReplicaCellsSwitched) == 0 {
-			return handleError("invalid request", vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "requesting reversal of read traffic for REPLICAs but REPLICA reads have not been switched"))
+			return defaultErrorHandler(ts.Logger(), "invalid request", vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+				"requesting reversal of read traffic for REPLICAs but REPLICA reads have not been switched"))
 		}
 		if direction == DirectionBackward && switchRdonly && len(state.RdonlyCellsSwitched) == 0 {
-			return handleError("invalid request", vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "requesting reversal of SwitchReads for RDONLYs but RDONLY reads have not been switched"))
+			return defaultErrorHandler(ts.Logger(), "invalid request", vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+				"requesting reversal of SwitchReads for RDONLYs but RDONLY reads have not been switched"))
 		}
 	}
 
@@ -3256,7 +3246,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 	// If journals exist notify user and fail.
 	journalsExist, _, err := ts.checkJournals(ctx)
 	if err != nil {
-		return handleError(fmt.Sprintf("failed to read journal in the %s keyspace", ts.SourceKeyspaceName()), err)
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to read journal in the %s keyspace", ts.SourceKeyspaceName()), err)
 	}
 	if journalsExist {
 		log.Infof("Found a previous journal entry for %d", ts.id)
@@ -3269,7 +3259,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 	}
 
 	if err := ts.validate(ctx); err != nil {
-		return handleError("workflow validation failed", err)
+		return defaultErrorHandler(ts.Logger(), "workflow validation failed", err)
 	}
 
 	// For switching reads, locking the source keyspace is sufficient.
@@ -3285,7 +3275,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 	// For reads, locking the source keyspace is sufficient.
 	ctx, unlock, lockErr := sw.lockKeyspace(ctx, ts.SourceKeyspaceName(), "SwitchReads", topo.WithTTL(ksLockTTL))
 	if lockErr != nil {
-		return handleError(fmt.Sprintf("failed to lock the %s keyspace", ts.SourceKeyspaceName()), lockErr)
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to lock the %s keyspace", ts.SourceKeyspaceName()), lockErr)
 	}
 	defer unlock(&err)
 	confirmKeyspaceLocksHeld := func() error {
@@ -3300,7 +3290,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 
 	// Remove mirror rules for the specified tablet types.
 	if err := sw.mirrorTableTraffic(ctx, roTabletTypes, 0); err != nil {
-		return handleError(fmt.Sprintf("failed to remove mirror rules from source keyspace %s to target keyspace %s, workflow %s, for read-only tablet types",
+		return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to remove mirror rules from source keyspace %s to target keyspace %s, workflow %s, for read-only tablet types",
 			ts.SourceKeyspaceName(), ts.TargetKeyspaceName(), ts.WorkflowName()), err)
 	}
 
@@ -3309,7 +3299,7 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 		case ts.IsMultiTenantMigration():
 			err := sw.switchKeyspaceReads(ctx, roTabletTypes)
 			if err != nil {
-				return handleError(fmt.Sprintf("failed to switch read traffic, from source keyspace %s to target keyspace %s, workflow %s",
+				return defaultErrorHandler(ts.Logger(), fmt.Sprintf("failed to switch read traffic, from source keyspace %s to target keyspace %s, workflow %s",
 					ts.SourceKeyspaceName(), ts.TargetKeyspaceName(), ts.WorkflowName()), err)
 			}
 		case ts.isPartialMigration:
@@ -3317,28 +3307,28 @@ func (s *Server) switchReads(ctx context.Context, req *vtctldatapb.WorkflowSwitc
 		default:
 			err := sw.switchTableReads(ctx, req.Cells, roTabletTypes, rebuildSrvVSchema, direction)
 			if err != nil {
-				return handleError("failed to switch read traffic for the tables", err)
+				return defaultErrorHandler(ts.Logger(), "failed to switch read traffic for the tables", err)
 			}
 		}
 		return sw.logs(), nil
 	}
 
 	if err := confirmKeyspaceLocksHeld(); err != nil {
-		return handleError("locks were lost", err)
+		return defaultErrorHandler(ts.Logger(), "locks were lost", err)
 	}
 	ts.Logger().Infof("About to switchShardReads: cells: %s, tablet types: %s, direction: %d", cellsStr, roTypesToSwitchStr, direction)
 	if err := sw.switchShardReads(ctx, req.Cells, roTabletTypes, direction); err != nil {
-		return handleError("failed to switch read traffic for the shards", err)
+		return defaultErrorHandler(ts.Logger(), "failed to switch read traffic for the shards", err)
 	}
 
 	if err := confirmKeyspaceLocksHeld(); err != nil {
-		return handleError("locks were lost", err)
+		return defaultErrorHandler(ts.Logger(), "locks were lost", err)
 	}
 	ts.Logger().Infof("switchShardReads Completed: cells: %s, tablet types: %s, direction: %d", cellsStr, roTypesToSwitchStr, direction)
 	if err := s.ts.ValidateSrvKeyspace(ctx, ts.targetKeyspace, cellsStr); err != nil {
 		err2 := vterrors.Wrapf(err, "after switching shard reads, found SrvKeyspace for %s is corrupt in cell %s",
 			ts.targetKeyspace, cellsStr)
-		return handleError("failed to validate SrvKeyspace record", err2)
+		return defaultErrorHandler(ts.Logger(), "failed to validate SrvKeyspace record", err2)
 	}
 	return sw.logs(), nil
 }

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -720,9 +720,7 @@ func TestWorkflowDelete(t *testing.T) {
 				// DeniedTables live.
 				for _, keyspace := range []*testKeyspace{tc.sourceKeyspace, tc.targetKeyspace} {
 					for _, shardName := range keyspace.ShardNames {
-						si, err := env.ts.GetShard(ctx, keyspace.KeyspaceName, shardName)
-						require.NoError(t, err)
-						require.Zero(t, si.Shard.TabletControls)
+						checkDenyList(t, env.ts, keyspace.KeyspaceName, shardName, nil)
 					}
 				}
 			}

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -415,7 +415,7 @@ func TestMoveTablesComplete(t *testing.T) {
 			postFunc: func(t *testing.T, env *testEnv) {
 				topo.LockTimeout = 45 * time.Second // reset it to the default
 			},
-			wantErr: fmt.Sprintf("deadline exceeded: internal/named_locks/%s", lockName),
+			wantErr: fmt.Sprintf("failed to lock the %s workflow: deadline exceeded: internal/named_locks/%s", lockName, lockName),
 		},
 	}
 	for _, tc := range testcases {
@@ -675,7 +675,7 @@ func TestWorkflowDelete(t *testing.T) {
 			postFunc: func(t *testing.T, env *testEnv) {
 				topo.LockTimeout = 45 * time.Second // reset it to the default
 			},
-			wantErr: fmt.Sprintf("deadline exceeded: internal/named_locks/%s", lockName),
+			wantErr: fmt.Sprintf("failed to lock the %s workflow: deadline exceeded: internal/named_locks/%s", lockName, lockName),
 		},
 	}
 	for _, tc := range testcases {

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -37,6 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
@@ -958,4 +959,12 @@ func IsTableDidNotExistError(err error) bool {
 		return sqlErr.Num == sqlerror.ERNoSuchTable || sqlErr.Num == sqlerror.ERBadTable
 	}
 	return false
+}
+
+// defaultErrorHandler provides a way to consistently handle errors by logging and
+// returning them.
+func defaultErrorHandler(logger logutil.Logger, message string, err error) (*[]string, error) {
+	werr := vterrors.Wrapf(err, message)
+	logger.Error(werr)
+	return nil, werr
 }


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/vitessio/vitess/pull/16260.

Somehow, in 3 places, the return was missed when the `LockName` call failed. That is corrected here, along with unit test additions to cover this scenario.

I also took the opportunity to unify the error handling and error messages.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/16260
  - Fixes: https://github.com/vitessio/vitess/issues/16559

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required