### PR TITLE
Fix query plan cache misses metric

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -208,7 +208,7 @@ func NewExecutor(
 			return e.plans.Metrics.Hits()
 		})
 		stats.NewCounterFunc("QueryPlanCacheMisses", "Query plan cache misses", func() int64 {
-			return e.plans.Metrics.Hits()
+			return e.plans.Metrics.Misses()
 		})
 		servenv.HTTPHandle(pathQueryPlans, e)
 		servenv.HTTPHandle(pathScatterStats, e)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Fixes https://github.com/vitessio/vitess/issues/16592

Fixes a bug with the vtgate query plan cache metrics that causes the `QueryPlanCacheMisses` to return hits instead.

The bug seems to have been introduced in https://github.com/vitessio/vitess/pull/13939

What is the policy for backporting metric fixes? Would be ideal for us if backported.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
