### PR TITLE
Planner cleaning: cleanup and refactor

### DIFF
--- a/go/vt/vtgate/endtoend/aggr_test.go
+++ b/go/vt/vtgate/endtoend/aggr_test.go
@@ -21,37 +21,35 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/utils"
+
 	"vitess.io/vitess/go/mysql"
 )
 
 func TestAggregateTypes(t *testing.T) {
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer conn.Close()
 
 	exec(t, conn, "insert into aggr_test(id, val1, val2) values(1,'a',1), (2,'A',1), (3,'b',1), (4,'c',3), (5,'c',4)")
 	exec(t, conn, "insert into aggr_test(id, val1, val2) values(6,'d',null), (7,'e',null), (8,'E',1)")
 
 	qr := exec(t, conn, "select val1, count(distinct val2), count(*) from aggr_test group by val1")
-	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("a") INT64(1) INT64(2)] [VARCHAR("b") INT64(1) INT64(1)] [VARCHAR("c") INT64(2) INT64(2)] [VARCHAR("d") INT64(0) INT64(1)] [VARCHAR("e") INT64(1) INT64(2)]]`; got != want {
-		t.Errorf("select:\n%v want\n%v", got, want)
-	}
+	want := `[[VARCHAR("a") INT64(1) INT64(2)] [VARCHAR("b") INT64(1) INT64(1)] [VARCHAR("c") INT64(2) INT64(2)] [VARCHAR("d") INT64(0) INT64(1)] [VARCHAR("e") INT64(1) INT64(2)]]`
+	utils.MustMatch(t, want, fmt.Sprintf("%v", qr.Rows))
 
 	qr = exec(t, conn, "select val1, sum(distinct val2), sum(val2) from aggr_test group by val1")
-	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("a") DECIMAL(1) DECIMAL(2)] [VARCHAR("b") DECIMAL(1) DECIMAL(1)] [VARCHAR("c") DECIMAL(7) DECIMAL(7)] [VARCHAR("d") NULL NULL] [VARCHAR("e") DECIMAL(1) DECIMAL(1)]]`; got != want {
-		t.Errorf("select:\n%v want\n%v", got, want)
-	}
+	want = `[[VARCHAR("a") DECIMAL(1) DECIMAL(2)] [VARCHAR("b") DECIMAL(1) DECIMAL(1)] [VARCHAR("c") DECIMAL(7) DECIMAL(7)] [VARCHAR("d") NULL NULL] [VARCHAR("e") DECIMAL(1) DECIMAL(1)]]`
+	utils.MustMatch(t, want, fmt.Sprintf("%v", qr.Rows))
 
 	qr = exec(t, conn, "select val1, count(distinct val2) k, count(*) from aggr_test group by val1 order by k desc, val1")
-	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("c") INT64(2) INT64(2)] [VARCHAR("a") INT64(1) INT64(2)] [VARCHAR("b") INT64(1) INT64(1)] [VARCHAR("e") INT64(1) INT64(2)] [VARCHAR("d") INT64(0) INT64(1)]]`; got != want {
-		t.Errorf("select:\n%v want\n%v", got, want)
-	}
+	want = `[[VARCHAR("c") INT64(2) INT64(2)] [VARCHAR("a") INT64(1) INT64(2)] [VARCHAR("b") INT64(1) INT64(1)] [VARCHAR("e") INT64(1) INT64(2)] [VARCHAR("d") INT64(0) INT64(1)]]`
+	utils.MustMatch(t, want, fmt.Sprintf("%v", qr.Rows))
 
 	qr = exec(t, conn, "select val1, count(distinct val2) k, count(*) from aggr_test group by val1 order by k desc, val1 limit 4")
-	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("c") INT64(2) INT64(2)] [VARCHAR("a") INT64(1) INT64(2)] [VARCHAR("b") INT64(1) INT64(1)] [VARCHAR("e") INT64(1) INT64(2)]]`; got != want {
-		t.Errorf("select:\n%v want\n%v", got, want)
-	}
+	want = `[[VARCHAR("c") INT64(2) INT64(2)] [VARCHAR("a") INT64(1) INT64(2)] [VARCHAR("b") INT64(1) INT64(1)] [VARCHAR("e") INT64(1) INT64(2)]]`
+	utils.MustMatch(t, want, fmt.Sprintf("%v", qr.Rows))
 }

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -3913,15 +3913,15 @@ func TestSelectAggregationNoData(t *testing.T) {
 		{
 			sql:         `select count(*) from (select col1, col2 from user limit 2) x`,
 			sandboxRes:  sqltypes.MakeTestResult(sqltypes.MakeTestFields("col1|col2|1", "int64|int64|int64")),
-			expSandboxQ: "select x.col1, x.col2, 1 from (select col1, col2 from `user`) as x limit 2",
-			expField:    `[name:"count(*)" type:INT64]`,
+			expSandboxQ: "select 1 from (select col1, col2 from `user`) as x limit 2",
+			expField:    `[name:"count(*)" type:INT64 charset:63 flags:32769]`,
 			expRow:      `[[INT64(0)]]`,
 		},
 		{
 			sql:         `select col2, count(*) from (select col1, col2 from user limit 2) x group by col2`,
 			sandboxRes:  sqltypes.MakeTestResult(sqltypes.MakeTestFields("col1|col2|1|weight_string(col2)", "int64|int64|int64|varbinary")),
-			expSandboxQ: "select x.col1, x.col2, 1, weight_string(x.col2) from (select col1, col2 from `user`) as x limit 2",
-			expField:    `[name:"col2" type:INT64 name:"count(*)" type:INT64]`,
+			expSandboxQ: "select x.col1, x.col2, weight_string(x.col2) from (select col1, col2 from `user`) as x limit 2",
+			expField:    `[name:"col2" type:INT64 charset:63 flags:32768 name:"count(*)" type:INT64 charset:63 flags:32769]`,
 			expRow:      `[]`,
 		},
 	}
@@ -4005,15 +4005,15 @@ func TestSelectAggregationData(t *testing.T) {
 		{
 			sql:         `select count(*) from (select col1, col2 from user limit 2) x`,
 			sandboxRes:  sqltypes.MakeTestResult(sqltypes.MakeTestFields("col1|col2|1", "int64|int64|int64"), "100|200|1", "200|300|1"),
-			expSandboxQ: "select x.col1, x.col2, 1 from (select col1, col2 from `user`) as x limit 2",
-			expField:    `[name:"count(*)" type:INT64]`,
+			expSandboxQ: "select 1 from (select col1, col2 from `user`) as x limit 2",
+			expField:    `[name:"count(*)" type:INT64 charset:63 flags:32769]`,
 			expRow:      `[[INT64(2)]]`,
 		},
 		{
 			sql:         `select col2, count(*) from (select col1, col2 from user limit 9) x group by col2`,
 			sandboxRes:  sqltypes.MakeTestResult(sqltypes.MakeTestFields("col1|col2|1|weight_string(col2)", "int64|int64|int64|varbinary"), "100|3|1|NULL", "200|2|1|NULL"),
-			expSandboxQ: "select x.col1, x.col2, 1, weight_string(x.col2) from (select col1, col2 from `user`) as x limit 9",
-			expField:    `[name:"col2" type:INT64 name:"count(*)" type:INT64]`,
+			expSandboxQ: "select x.col1, x.col2, weight_string(x.col2) from (select col1, col2 from `user`) as x limit 9",
+			expField:    `[name:"col2" type:INT64 charset:63 flags:32768 name:"count(*)" type:INT64 charset:63 flags:32769]`,
 			expRow:      `[[INT64(2) INT64(4)] [INT64(3) INT64(5)]]`,
 		},
 		{

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -302,12 +302,18 @@ func (aj *ApplyJoin) planOffsets(ctx *plancontext.PlanningContext) Operator {
 
 	for _, col := range aj.JoinPredicates.columns {
 		for _, lhsExpr := range col.LHSExprs {
+			if _, found := aj.Vars[lhsExpr.Name]; found {
+				continue
+			}
 			offset := aj.LHS.AddColumn(ctx, true, false, aeWrap(lhsExpr.Expr))
 			aj.Vars[lhsExpr.Name] = offset
 		}
 	}
 
 	for _, lhsExpr := range aj.ExtraLHSVars {
+		if _, found := aj.Vars[lhsExpr.Name]; found {
+			continue
+		}
 		offset := aj.LHS.AddColumn(ctx, true, false, aeWrap(lhsExpr.Expr))
 		aj.Vars[lhsExpr.Name] = offset
 	}

--- a/go/vt/vtgate/planbuilder/operators/expressions.go
+++ b/go/vt/vtgate/planbuilder/operators/expressions.go
@@ -59,3 +59,15 @@ func breakExpressionInLHSandRHS(
 	col.Original = expr
 	return
 }
+
+// nothingNeedsFetching will return true if all the nodes in the expression are constant
+func nothingNeedsFetching(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (constant bool) {
+	constant = true
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		if mustFetchFromInput(ctx, node) {
+			constant = false
+		}
+		return true, nil
+	}, expr)
+	return
+}

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -49,6 +49,8 @@ type Horizon struct {
 	// Columns needed to feed other plans
 	Columns       []*sqlparser.ColName
 	ColumnsOffset []int
+
+	Truncate bool
 }
 
 func newHorizon(src Operator, query sqlparser.SelectStatement) *Horizon {

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -210,6 +210,50 @@ func enableDelegateAggregation(ctx *plancontext.PlanningContext, op Operator) Op
 	return addColumnsToInput(ctx, op)
 }
 
+// addColumnsToInput adds columns needed by an operator to its input.
+// This happens only when the filter expression can be retrieved as an offset from the underlying mysql.
+func addColumnsToInput(ctx *plancontext.PlanningContext, root Operator) Operator {
+
+	addColumnsNeededByFilter := func(in Operator, _ semantics.TableSet, _ bool) (Operator, *ApplyResult) {
+		addedCols := false
+		filter, ok := in.(*Filter)
+		if !ok {
+			return in, NoRewrite
+		}
+
+		var neededAggrs []sqlparser.Expr
+		extractAggrs := func(cursor *sqlparser.CopyOnWriteCursor) {
+			node := cursor.Node()
+			if ctx.IsAggr(node) {
+				neededAggrs = append(neededAggrs, node.(sqlparser.Expr))
+			}
+		}
+
+		for _, expr := range filter.Predicates {
+			_ = sqlparser.CopyOnRewrite(expr, dontEnterSubqueries, extractAggrs, nil)
+		}
+
+		if neededAggrs == nil {
+			return in, NoRewrite
+		}
+
+		aggregator := findAggregatorInSource(filter.Source)
+		for _, aggr := range neededAggrs {
+			if aggregator.FindCol(ctx, aggr, false) == -1 {
+				aggregator.addColumnWithoutPushing(ctx, aeWrap(aggr), false)
+				addedCols = true
+			}
+		}
+
+		if addedCols {
+			return in, Rewrote("added columns because filter needs it")
+		}
+		return in, NoRewrite
+	}
+
+	return TopDown(root, TableID, addColumnsNeededByFilter, stopAtRoute)
+}
+
 // addOrderingForAllAggregations is run we have pushed down Aggregators as far down as possible.
 func addOrderingForAllAggregations(ctx *plancontext.PlanningContext, root Operator) Operator {
 	visitor := func(in Operator, _ semantics.TableSet, isRoot bool) (Operator, *ApplyResult) {

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -334,7 +334,7 @@ func addLiteralGroupingToRHS(in *ApplyJoin) (Operator, *ApplyResult) {
 			return nil
 		}
 		if len(aggr.Grouping) == 0 {
-			gb := sqlparser.NewIntLiteral(".0")
+			gb := sqlparser.NewFloatLiteral(".0")
 			aggr.Grouping = append(aggr.Grouping, NewGroupBy(gb))
 		}
 		return nil

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -87,7 +87,7 @@ type (
 
 	ProjExpr struct {
 		Original *sqlparser.AliasedExpr // this is the expression the user asked for. should only be used to decide on the column alias
-		EvalExpr sqlparser.Expr         // EvalExpr is the expression that will be evaluated at runtime
+		EvalExpr sqlparser.Expr         // EvalExpr represents the expression evaluated at runtime or used when the ProjExpr is pushed under a route
 		ColExpr  sqlparser.Expr         // ColExpr is used during planning to figure out which column this ProjExpr is representing
 		Info     ExprInfo               // Here we store information about evalengine, offsets or subqueries
 	}

--- a/go/vt/vtgate/planbuilder/operators/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/projection_pushing.go
@@ -361,11 +361,10 @@ func splitUnexploredExpression(
 	case col.IsPureRight():
 		rhs.add(pe, alias)
 		col.RHSExpr = colName
-	case col.IsMixedLeftAndRight():
+	default:
 		for _, lhsExpr := range col.LHSExprs {
 			ae := aeWrap(lhsExpr.Expr)
 			columnName := ae.ColumnName()
-			ae.As = sqlparser.NewIdentifierCI(columnName)
 			lhs.add(newProjExpr(ae), columnName)
 		}
 		innerPE := newProjExprWithInner(pe.Original, col.RHSExpr)

--- a/go/vt/vtgate/planbuilder/operators/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/projection_pushing.go
@@ -320,7 +320,7 @@ func splitSubqueryExpression(
 	alias string,
 ) applyJoinColumn {
 	col := join.getJoinColumnFor(ctx, pe.Original, pe.ColExpr, false)
-	return pushDownSplitJoinCol(col, lhs, pe, alias, rhs)
+	return pushDownSplitJoinCol(col, lhs, rhs, pe, alias)
 }
 
 func splitUnexploredExpression(
@@ -334,23 +334,50 @@ func splitUnexploredExpression(
 	original := sqlparser.Clone(pe.Original)
 	expr := pe.ColExpr
 
-	var colName *sqlparser.ColName
-	if dt != nil {
-		if !pe.isSameInAndOut(ctx) {
-			panic(vterrors.VT13001("derived table columns must be the same in and out"))
-		}
-		colName = sqlparser.NewColNameWithQualifier(pe.Original.ColumnName(), sqlparser.NewTableName(dt.Alias))
-		ctx.SemTable.CopySemanticInfo(expr, colName)
-	}
-
 	// Get a applyJoinColumn for the current expression.
 	col := join.getJoinColumnFor(ctx, original, expr, false)
-	col.DTColName = colName
 
-	return pushDownSplitJoinCol(col, lhs, pe, alias, rhs)
+	if dt == nil {
+		return pushDownSplitJoinCol(col, lhs, rhs, pe, alias)
+	}
+
+	if !pe.isSameInAndOut(ctx) {
+		panic(vterrors.VT13001("derived table columns must be the same in and out"))
+	}
+	// we are pushing a derived projection through a join. that means that after this rewrite, we are on top of the
+	// derived table divider, and can only see the projected columns, not the underlying expressions
+	colName := sqlparser.NewColNameWithQualifier(pe.Original.ColumnName(), sqlparser.NewTableName(dt.Alias))
+	ctx.SemTable.CopySemanticInfo(expr, colName)
+	col.Original = colName
+	if alias == "" {
+		alias = pe.Original.ColumnName()
+	}
+
+	// Update the left and right child columns and names based on the applyJoinColumn type.
+	switch {
+	case col.IsPureLeft():
+		lhs.add(pe, alias)
+		col.LHSExprs[0].Expr = colName
+	case col.IsPureRight():
+		rhs.add(pe, alias)
+		col.RHSExpr = colName
+	case col.IsMixedLeftAndRight():
+		for _, lhsExpr := range col.LHSExprs {
+			ae := aeWrap(lhsExpr.Expr)
+			columnName := ae.ColumnName()
+			ae.As = sqlparser.NewIdentifierCI(columnName)
+			lhs.add(newProjExpr(ae), columnName)
+		}
+		innerPE := newProjExprWithInner(pe.Original, col.RHSExpr)
+		innerPE.ColExpr = col.RHSExpr
+		col.RHSExpr = colName
+		innerPE.Info = pe.Info
+		rhs.add(innerPE, alias)
+	}
+	return col
 }
 
-func pushDownSplitJoinCol(col applyJoinColumn, lhs *projector, pe *ProjExpr, alias string, rhs *projector) applyJoinColumn {
+func pushDownSplitJoinCol(col applyJoinColumn, lhs, rhs *projector, pe *ProjExpr, alias string) applyJoinColumn {
 	// Update the left and right child columns and names based on the applyJoinColumn type.
 	switch {
 	case col.IsPureLeft():

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -288,7 +288,8 @@ func requiresSwitchingSides(ctx *plancontext.PlanningContext, op Operator) (requ
 }
 
 func mergeOrJoin(ctx *plancontext.PlanningContext, lhs, rhs Operator, joinPredicates []sqlparser.Expr, joinType sqlparser.JoinType) (Operator, *ApplyResult) {
-	newPlan := mergeJoinInputs(ctx, lhs, rhs, joinPredicates, newJoinMerge(joinPredicates, joinType))
+	jm := newJoinMerge(joinPredicates, joinType)
+	newPlan := jm.mergeJoinInputs(ctx, lhs, rhs, joinPredicates)
 	if newPlan != nil {
 		return newPlan, Rewrote("merge routes into single operator")
 	}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -2918,16 +2918,16 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1,L:2",
+            "JoinColumnIndexes": "L:0,L:1,L:3",
             "JoinVars": {
-              "u2_val2": 3
+              "u2_val2": 2
             },
             "TableName": "`user`_`user`_music",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1,L:2,R:0",
+                "JoinColumnIndexes": "L:0,L:1,R:0,L:2",
                 "JoinVars": {
                   "u_val2": 1
                 },
@@ -5681,7 +5681,6 @@
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "GroupBy": "0, (1|2)",
-                "ResultColumns": 2,
                 "Inputs": [
                   {
                     "OperatorType": "SimpleProjection",
@@ -5690,7 +5689,7 @@
                       {
                         "OperatorType": "Aggregate",
                         "Variant": "Scalar",
-                        "Aggregates": "any_value(0) AS id, sum_count_star(1) AS a, any_value(2)",
+                        "Aggregates": "any_value(0|2) AS id, sum_count_star(1) AS a",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -5699,9 +5698,9 @@
                               "Name": "user",
                               "Sharded": true
                             },
-                            "FieldQuery": "select id, count(*) as a, weight_string(id) from `user` where 1 != 1",
-                            "OrderBy": "1 ASC, (0|2) ASC",
-                            "Query": "select id, count(*) as a, weight_string(id) from `user` order by count(*) asc, id asc",
+                            "FieldQuery": "select dt.c0 as id, dt.c1 as a, weight_string(dt.c0), weight_string(dt.c0) from (select id, count(*) as a from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
+                            "OrderBy": "1 ASC, (0|3) ASC",
+                            "Query": "select dt.c0 as id, dt.c1 as a, weight_string(dt.c0), weight_string(dt.c0) from (select id, count(*) as a from `user` order by count(*) asc, id asc) as dt(c0, c1)",
                             "Table": "`user`"
                           }
                         ]
@@ -5848,14 +5847,13 @@
             "Variant": "Ordered",
             "Aggregates": "group_concat(1) AS group_concat(u.bar), any_value(2|4) AS baz",
             "GroupBy": "(0|3)",
-            "ResultColumns": 5,
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1,L:2,L:3,L:5",
+                "JoinColumnIndexes": "L:0,L:1,L:2,L:4,L:5",
                 "JoinVars": {
-                  "u_col": 4
+                  "u_col": 3
                 },
                 "TableName": "`user`_music",
                 "Inputs": [
@@ -5866,9 +5864,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select u.foo, u.bar, u.baz, weight_string(u.foo), u.col, weight_string(u.baz) from `user` as u where 1 != 1",
-                    "OrderBy": "(0|3) ASC",
-                    "Query": "select u.foo, u.bar, u.baz, weight_string(u.foo), u.col, weight_string(u.baz) from `user` as u order by u.foo asc",
+                    "FieldQuery": "select u.foo, u.bar, u.baz, u.col, weight_string(u.foo), weight_string(u.baz) from `user` as u where 1 != 1",
+                    "OrderBy": "(0|4) ASC",
+                    "Query": "select u.foo, u.bar, u.baz, u.col, weight_string(u.foo), weight_string(u.baz) from `user` as u order by u.foo asc",
                     "Table": "`user`"
                   },
                   {
@@ -6687,7 +6685,6 @@
                         "Variant": "Ordered",
                         "Aggregates": "count_star(0)",
                         "GroupBy": "1, (2|3)",
-                        "ResultColumns": 4,
                         "Inputs": [
                           {
                             "OperatorType": "SimpleProjection",

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -3621,8 +3621,10 @@
         "Aggregates": "count_star(0) AS count(*)",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": "3",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "1 as 1"
+            ],
             "Inputs": [
               {
                 "OperatorType": "Limit",
@@ -3635,8 +3637,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where id > 12) as x limit 10",
+                    "FieldQuery": "select 1 from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
+                    "Query": "select 1 from (select phone, id, city from `user` where id > 12) as x limit 10",
                     "Table": "`user`"
                   }
                 ]
@@ -3734,8 +3736,12 @@
         "ResultColumns": 2,
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": "1,2,3",
+            "OperatorType": "Projection",
+            "Expressions": [
+              ":1 as val1",
+              "1 as 1",
+              ":2 as weight_string(val1)"
+            ],
             "Inputs": [
               {
                 "OperatorType": "Limit",
@@ -3748,9 +3754,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
-                    "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
+                    "FieldQuery": "select x.id, x.val1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
+                    "OrderBy": "(1|2) ASC",
+                    "Query": "select x.id, x.val1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
                     "Table": "`user`"
                   }
                 ]
@@ -6105,15 +6111,18 @@
                     "ResultColumns": 1,
                     "Inputs": [
                       {
-                        "OperatorType": "SimpleProjection",
-                        "Columns": "2,1",
+                        "OperatorType": "Projection",
+                        "Expressions": [
+                          "1 as 1",
+                          "0 as .0"
+                        ],
                         "Inputs": [
                           {
                             "OperatorType": "Aggregate",
                             "Variant": "Ordered",
-                            "Aggregates": "sum_count_star(0) AS count(*), any_value(2)",
+                            "Aggregates": "sum_count_star(0) AS count(*)",
                             "GroupBy": "1",
-                            "ResultColumns": 3,
+                            "ResultColumns": 1,
                             "Inputs": [
                               {
                                 "OperatorType": "Route",
@@ -6122,8 +6131,8 @@
                                   "Name": "user",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select count(*), .0, 1 from `user` where 1 != 1 group by .0",
-                                "Query": "select count(*), .0, 1 from `user` group by .0",
+                                "FieldQuery": "select count(*), .0 from `user` where 1 != 1 group by .0",
+                                "Query": "select count(*), .0 from `user` group by .0",
                                 "Table": "`user`"
                               }
                             ]
@@ -6687,13 +6696,18 @@
                         "GroupBy": "1, (2|3)",
                         "Inputs": [
                           {
-                            "OperatorType": "SimpleProjection",
-                            "Columns": "2,0,1,3",
+                            "OperatorType": "Projection",
+                            "Expressions": [
+                              "1 as 1",
+                              ":0 as col",
+                              ":1 as bar",
+                              ":2 as weight_string(ue.bar)"
+                            ],
                             "Inputs": [
                               {
                                 "OperatorType": "Sort",
                                 "Variant": "Memory",
-                                "OrderBy": "0 ASC, (1|3) ASC",
+                                "OrderBy": "0 ASC, (1|2) ASC",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Limit",
@@ -6706,8 +6720,8 @@
                                           "Name": "user",
                                           "Sharded": true
                                         },
-                                        "FieldQuery": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra where 1 != 1) as ue where 1 != 1",
-                                        "Query": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra) as ue limit 10",
+                                        "FieldQuery": "select ue.col, ue.bar, weight_string(ue.bar) from (select col, bar from user_extra where 1 != 1) as ue where 1 != 1",
+                                        "Query": "select ue.col, ue.bar, weight_string(ue.bar) from (select col, bar from user_extra) as ue limit 10",
                                         "Table": "user_extra"
                                       }
                                     ]
@@ -7253,8 +7267,10 @@
         "Aggregates": "count_star(0) AS count(*)",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": "2",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "1 as 1"
+            ],
             "Inputs": [
               {
                 "OperatorType": "Limit",
@@ -7268,9 +7284,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where 1 != 1) as subquery_for_count where 1 != 1",
-                    "OrderBy": "(1|3) DESC",
-                    "Query": "select subquery_for_count.one, subquery_for_count.id, 1, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where `user`.is_not_deleted = true) as subquery_for_count order by subquery_for_count.id desc limit 25",
+                    "FieldQuery": "select subquery_for_count.one, subquery_for_count.id, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where 1 != 1) as subquery_for_count where 1 != 1",
+                    "OrderBy": "(1|2) DESC",
+                    "Query": "select subquery_for_count.one, subquery_for_count.id, weight_string(subquery_for_count.id) from (select 1 as one, id from `user` where `user`.is_not_deleted = true) as subquery_for_count order by subquery_for_count.id desc limit 25",
                     "Table": "`user`"
                   }
                 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -5846,16 +5846,16 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "group_concat(1) AS group_concat(u.bar), any_value(2) AS baz, any_value(4)",
+            "Aggregates": "group_concat(1) AS group_concat(u.bar), any_value(2|4) AS baz",
             "GroupBy": "(0|3)",
             "ResultColumns": 5,
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1,L:2,L:3,L:4",
+                "JoinColumnIndexes": "L:0,L:1,L:2,L:3,L:5",
                 "JoinVars": {
-                  "u_col": 5
+                  "u_col": 4
                 },
                 "TableName": "`user`_music",
                 "Inputs": [
@@ -5866,9 +5866,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select u.foo, u.bar, u.baz, weight_string(u.foo), weight_string(u.baz), u.col from `user` as u where 1 != 1",
+                    "FieldQuery": "select u.foo, u.bar, u.baz, weight_string(u.foo), u.col, weight_string(u.baz) from `user` as u where 1 != 1",
                     "OrderBy": "(0|3) ASC",
-                    "Query": "select u.foo, u.bar, u.baz, weight_string(u.foo), weight_string(u.baz), u.col from `user` as u order by u.foo asc",
+                    "Query": "select u.foo, u.bar, u.baz, weight_string(u.foo), u.col, weight_string(u.baz) from `user` as u order by u.foo asc",
                     "Table": "`user`"
                   },
                   {
@@ -6663,70 +6663,55 @@
                 "OrderBy": "(4|6) ASC, (5|7) ASC",
                 "Inputs": [
                   {
-                    "OperatorType": "Projection",
-                    "Expressions": [
-                      "count(*) as count(*)",
-                      "count(*) as count(*)",
-                      "`user`.col as col",
-                      "ue.col as col",
-                      "`user`.foo as foo",
-                      "ue.bar as bar",
-                      "weight_string(`user`.foo) as weight_string(`user`.foo)",
-                      "weight_string(ue.bar) as weight_string(ue.bar)"
-                    ],
+                    "OperatorType": "Join",
+                    "Variant": "HashLeftJoin",
+                    "Collation": "binary",
+                    "ComparisonType": "INT16",
+                    "JoinColumnIndexes": "-1,1,-2,2,-3,3,-3,4",
+                    "Predicate": "`user`.col = ue.col",
+                    "TableName": "`user`_user_extra",
                     "Inputs": [
                       {
-                        "OperatorType": "Join",
-                        "Variant": "HashLeftJoin",
-                        "Collation": "binary",
-                        "ComparisonType": "INT16",
-                        "JoinColumnIndexes": "-1,1,-2,2,-3,3,-3,3",
-                        "Predicate": "`user`.col = ue.col",
-                        "TableName": "`user`_user_extra",
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*), `user`.col, `user`.foo from `user` where 1 != 1 group by `user`.col, `user`.foo",
+                        "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo",
+                        "Table": "`user`"
+                      },
+                      {
+                        "OperatorType": "Aggregate",
+                        "Variant": "Ordered",
+                        "Aggregates": "count_star(0)",
+                        "GroupBy": "1, (2|3)",
+                        "ResultColumns": 4,
                         "Inputs": [
                           {
-                            "OperatorType": "Route",
-                            "Variant": "Scatter",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select count(*), `user`.col, `user`.foo from `user` where 1 != 1 group by `user`.col, `user`.foo",
-                            "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo",
-                            "Table": "`user`"
-                          },
-                          {
-                            "OperatorType": "Aggregate",
-                            "Variant": "Ordered",
-                            "Aggregates": "count_star(0)",
-                            "GroupBy": "1, (2|3)",
-                            "ResultColumns": 3,
+                            "OperatorType": "SimpleProjection",
+                            "Columns": "2,0,1,3",
                             "Inputs": [
                               {
-                                "OperatorType": "SimpleProjection",
-                                "Columns": "2,0,1,3",
+                                "OperatorType": "Sort",
+                                "Variant": "Memory",
+                                "OrderBy": "0 ASC, (1|3) ASC",
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Sort",
-                                    "Variant": "Memory",
-                                    "OrderBy": "0 ASC, (1|3) ASC",
+                                    "OperatorType": "Limit",
+                                    "Count": "10",
                                     "Inputs": [
                                       {
-                                        "OperatorType": "Limit",
-                                        "Count": "10",
-                                        "Inputs": [
-                                          {
-                                            "OperatorType": "Route",
-                                            "Variant": "Scatter",
-                                            "Keyspace": {
-                                              "Name": "user",
-                                              "Sharded": true
-                                            },
-                                            "FieldQuery": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra where 1 != 1) as ue where 1 != 1",
-                                            "Query": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra) as ue limit 10",
-                                            "Table": "user_extra"
-                                          }
-                                        ]
+                                        "OperatorType": "Route",
+                                        "Variant": "Scatter",
+                                        "Keyspace": {
+                                          "Name": "user",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra where 1 != 1) as ue where 1 != 1",
+                                        "Query": "select ue.col, ue.bar, 1, weight_string(ue.bar) from (select col, bar from user_extra) as ue limit 10",
+                                        "Table": "user_extra"
                                       }
                                     ]
                                   }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -689,13 +689,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "1 ASC",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "count_distinct(1|3) AS k",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2149,13 +2149,13 @@
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) <= 10",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(1) AS a",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2187,13 +2187,13 @@
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 1.00",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(0) AS a",
             "GroupBy": "(1|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3097,13 +3097,13 @@
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "count(*) = 3",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(1) AS count(*)",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3135,13 +3135,13 @@
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "sum(foo) + sum(bar) = 42",
+        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS sum(foo), sum(2) AS sum(bar)",
             "GroupBy": "(0|3)",
-            "ResultColumns": 3,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3173,13 +3173,13 @@
       "Instructions": {
         "OperatorType": "Filter",
         "Predicate": "sum(`user`.foo) + sum(bar) = 42",
+        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS fooSum, sum(2) AS barSum",
             "GroupBy": "(0|3)",
-            "ResultColumns": 3,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3218,7 +3218,6 @@
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(1) AS count(*)",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3257,7 +3256,6 @@
             "Variant": "Ordered",
             "Aggregates": "sum_count(1) AS count(u.`name`)",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Projection",
@@ -3362,7 +3360,6 @@
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(1) AS count(*)",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Projection",
@@ -4118,7 +4115,6 @@
             "Variant": "Ordered",
             "Aggregates": "max(1|3) AS bazo",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -4157,7 +4153,6 @@
             "Variant": "Ordered",
             "Aggregates": "sum_count(1) AS bazo",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5005,13 +5000,13 @@
         "Collations": [
           "0"
         ],
+        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum_count_star(0) AS count(*)",
             "GroupBy": "1",
-            "ResultColumns": 1,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -6108,7 +6103,6 @@
                     "Variant": "Ordered",
                     "Aggregates": "count_star(0)",
                     "GroupBy": "1",
-                    "ResultColumns": 1,
                     "Inputs": [
                       {
                         "OperatorType": "Projection",
@@ -6122,7 +6116,6 @@
                             "Variant": "Ordered",
                             "Aggregates": "sum_count_star(0) AS count(*)",
                             "GroupBy": "1",
-                            "ResultColumns": 1,
                             "Inputs": [
                               {
                                 "OperatorType": "Route",
@@ -6296,7 +6289,6 @@
                 "Variant": "Ordered",
                 "Aggregates": "sum(1) AS avg(id), sum_count(2) AS count(foo), sum_count(3) AS count(id)",
                 "GroupBy": "(0|4)",
-                "ResultColumns": 4,
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -6346,7 +6338,6 @@
                 "Variant": "Ordered",
                 "Aggregates": "sum(1) AS avg(id), sum_count(2) AS count(foo), sum_count(3) AS count(id)",
                 "GroupBy": "(0|4)",
-                "ResultColumns": 4,
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -6530,7 +6521,6 @@
                         "OperatorType": "Aggregate",
                         "Variant": "Scalar",
                         "Aggregates": "min(0|2) AS min_id, max(1|3) AS max_id",
-                        "ResultColumns": 2,
                         "Inputs": [
                           {
                             "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -223,8 +223,10 @@
         "Aggregates": "count_star(0) AS count(*)",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": "3",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "1 as 1"
+            ],
             "Inputs": [
               {
                 "OperatorType": "Limit",
@@ -237,8 +239,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
-                    "Query": "select x.phone, x.id, x.city, 1 from (select phone, id, city from `user` where id > 12) as x limit 10",
+                    "FieldQuery": "select 1 from (select phone, id, city from `user` where 1 != 1) as x where 1 != 1",
+                    "Query": "select 1 from (select phone, id, city from `user` where id > 12) as x limit 10",
                     "Table": "`user`"
                   }
                 ]
@@ -336,8 +338,12 @@
         "ResultColumns": 2,
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": "1,2,3",
+            "OperatorType": "Projection",
+            "Expressions": [
+              ":1 as val1",
+              "1 as 1",
+              ":2 as weight_string(val1)"
+            ],
             "Inputs": [
               {
                 "OperatorType": "Limit",
@@ -350,9 +356,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
-                    "OrderBy": "(1|3) ASC",
-                    "Query": "select x.id, x.val1, 1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
+                    "FieldQuery": "select x.id, x.val1, weight_string(x.val1) from (select id, val1 from `user` where 1 != 1) as x where 1 != 1",
+                    "OrderBy": "(1|2) ASC",
+                    "Query": "select x.id, x.val1, weight_string(x.val1) from (select id, val1 from `user` where val2 < 4) as x order by x.val1 asc limit 2",
                     "Table": "`user`"
                   }
                 ]
@@ -717,13 +723,15 @@
         "Aggregates": "count_star(0) AS count(*)",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": "1",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "1 as 1"
+            ],
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Scalar",
-                "Aggregates": "sum_count_star(0) AS count(*), any_value(1)",
+                "Aggregates": "sum_count_star(0) AS count(*)",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -732,8 +740,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select count(*), 1 from `user` where 1 != 1",
-                    "Query": "select count(*), 1 from `user`",
+                    "FieldQuery": "select count(*) from `user` where 1 != 1",
+                    "Query": "select count(*) from `user`",
                     "Table": "`user`"
                   }
                 ]
@@ -1998,8 +2006,11 @@
                     "Aggregates": "any_value(0), sum(1) AS sum(num)",
                     "Inputs": [
                       {
-                        "OperatorType": "SimpleProjection",
-                        "Columns": "1,0",
+                        "OperatorType": "Projection",
+                        "Expressions": [
+                          "1000 as 1000",
+                          ":0 as num"
+                        ],
                         "Inputs": [
                           {
                             "OperatorType": "Concatenate",
@@ -2011,11 +2022,13 @@
                                   {
                                     "OperatorType": "Aggregate",
                                     "Variant": "Scalar",
-                                    "Aggregates": "count_star(0) AS num, any_value(1)",
+                                    "Aggregates": "count_star(0) AS num",
                                     "Inputs": [
                                       {
-                                        "OperatorType": "SimpleProjection",
-                                        "Columns": "1,2",
+                                        "OperatorType": "Projection",
+                                        "Expressions": [
+                                          "1 as 1"
+                                        ],
                                         "Inputs": [
                                           {
                                             "OperatorType": "Limit",
@@ -2028,8 +2041,8 @@
                                                   "Name": "user",
                                                   "Sharded": true
                                                 },
-                                                "FieldQuery": "select t.id, 1, 1000 from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-                                                "Query": "select t.id, 1, 1000 from (select `user`.id from `user` where `user`.textcol1 = 'open' and `user`.intcol = 1) as t limit :__upper_limit",
+                                                "FieldQuery": "select 1 from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
+                                                "Query": "select 1 from (select `user`.id from `user` where `user`.textcol1 = 'open' and `user`.intcol = 1) as t limit :__upper_limit",
                                                 "Table": "`user`"
                                               }
                                             ]
@@ -2047,11 +2060,13 @@
                                   {
                                     "OperatorType": "Aggregate",
                                     "Variant": "Scalar",
-                                    "Aggregates": "count_star(0) AS num, any_value(1)",
+                                    "Aggregates": "count_star(0) AS num",
                                     "Inputs": [
                                       {
-                                        "OperatorType": "SimpleProjection",
-                                        "Columns": "1,2",
+                                        "OperatorType": "Projection",
+                                        "Expressions": [
+                                          "1 as 1"
+                                        ],
                                         "Inputs": [
                                           {
                                             "OperatorType": "Limit",
@@ -2064,8 +2079,8 @@
                                                   "Name": "user",
                                                   "Sharded": true
                                                 },
-                                                "FieldQuery": "select t.id, 1, 1000 from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
-                                                "Query": "select t.id, 1, 1000 from (select `user`.id from `user` where `user`.textcol1 = 'closed' and `user`.intcol = 1) as t limit :__upper_limit",
+                                                "FieldQuery": "select 1 from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
+                                                "Query": "select 1 from (select `user`.id from `user` where `user`.textcol1 = 'closed' and `user`.intcol = 1) as t limit :__upper_limit",
                                                 "Table": "`user`"
                                               }
                                             ]

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -565,7 +565,6 @@
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "GroupBy": "0, (1|2)",
-                "ResultColumns": 2,
                 "Inputs": [
                   {
                     "OperatorType": "SimpleProjection",
@@ -574,7 +573,7 @@
                       {
                         "OperatorType": "Aggregate",
                         "Variant": "Scalar",
-                        "Aggregates": "any_value(0) AS id, sum_count_star(1) AS a, any_value(2)",
+                        "Aggregates": "any_value(0|2) AS id, sum_count_star(1) AS a",
                         "Inputs": [
                           {
                             "OperatorType": "Route",
@@ -583,9 +582,9 @@
                               "Name": "user",
                               "Sharded": true
                             },
-                            "FieldQuery": "select id, count(*) as a, weight_string(id) from `user` where 1 != 1",
-                            "OrderBy": "1 ASC, (0|2) ASC",
-                            "Query": "select id, count(*) as a, weight_string(id) from `user` order by count(*) asc, id asc",
+                            "FieldQuery": "select dt.c0 as id, dt.c1 as a, weight_string(dt.c0), weight_string(dt.c0) from (select id, count(*) as a from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
+                            "OrderBy": "1 ASC, (0|3) ASC",
+                            "Query": "select dt.c0 as id, dt.c1 as a, weight_string(dt.c0), weight_string(dt.c0) from (select id, count(*) as a from `user` order by count(*) asc, id asc) as dt(c0, c1)",
                             "Table": "`user`"
                           }
                         ]

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -485,7 +485,6 @@
             "Variant": "Ordered",
             "Aggregates": "max(1|3) AS bazo",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -524,7 +523,6 @@
             "Variant": "Ordered",
             "Aggregates": "sum_count(1) AS bazo",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4593,20 +4593,21 @@
         "Aggregates": "count_star(0) AS count(*)",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": "1",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "1 as 1"
+            ],
             "Inputs": [
               {
                 "OperatorType": "Distinct",
                 "Collations": [
-                  "(0:2)",
-                  "1"
+                  "(0:1)"
                 ],
                 "Inputs": [
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "R:0,L:1,R:1",
+                    "JoinColumnIndexes": "R:0,R:1",
                     "JoinVars": {
                       "m_id": 0
                     },
@@ -4619,8 +4620,8 @@
                           "Name": "user",
                           "Sharded": true
                         },
-                        "FieldQuery": "select subquery_for_count.`m.id`, 1 from (select m.id as `m.id` from music as m where 1 != 1) as subquery_for_count where 1 != 1",
-                        "Query": "select distinct subquery_for_count.`m.id`, 1 from (select m.id as `m.id` from music as m) as subquery_for_count",
+                        "FieldQuery": "select subquery_for_count.`m.id` from (select m.id as `m.id` from music as m where 1 != 1) as subquery_for_count where 1 != 1",
+                        "Query": "select distinct subquery_for_count.`m.id` from (select m.id as `m.id` from music as m) as subquery_for_count",
                         "Table": "music"
                       },
                       {

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4802,8 +4802,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select dt.foo from (select u.foo as foo from `user` as u where 1 != 1) as dt where 1 != 1",
-            "Query": "select dt.foo from (select u.foo as foo from `user` as u) as dt",
+            "FieldQuery": "select dt.foo from (select u.foo from `user` as u where 1 != 1) as dt where 1 != 1",
+            "Query": "select dt.foo from (select u.foo from `user` as u) as dt",
             "Table": "`user`"
           },
           {

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -798,7 +798,6 @@
                             "Variant": "Ordered",
                             "Aggregates": "sum_count_star(1) AS count",
                             "GroupBy": "(0|2)",
-                            "ResultColumns": 3,
                             "Inputs": [
                               {
                                 "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -788,7 +788,6 @@
                     "OperatorType": "Aggregate",
                     "Variant": "Ordered",
                     "GroupBy": "(0|1)",
-                    "ResultColumns": 1,
                     "Inputs": [
                       {
                         "OperatorType": "SimpleProjection",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4803,8 +4803,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select dt.foo from (select u.foo from `user` as u where 1 != 1) as dt where 1 != 1",
-            "Query": "select dt.foo from (select u.foo from `user` as u) as dt",
+            "FieldQuery": "select dt.foo from (select u.foo as foo from `user` as u where 1 != 1) as dt where 1 != 1",
+            "Query": "select dt.foo from (select u.foo as foo from `user` as u) as dt",
             "Table": "`user`"
           },
           {

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -16,7 +16,6 @@
             "Variant": "Ordered",
             "Aggregates": "any_value(1|4) AS b, sum_count_star(2) AS count(*)",
             "GroupBy": "(0|3)",
-            "ResultColumns": 5,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -49,13 +48,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "2 ASC",
+        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "any_value(1) AS b, sum_count_star(2) AS k",
             "GroupBy": "(0|3)",
-            "ResultColumns": 3,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -95,7 +94,6 @@
             "Variant": "Ordered",
             "Aggregates": "any_value(1|4) AS b, sum_count_star(2) AS k",
             "GroupBy": "(0|3)",
-            "ResultColumns": 5,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -132,13 +130,13 @@
             "OperatorType": "Sort",
             "Variant": "Memory",
             "OrderBy": "2 DESC",
+            "ResultColumns": 3,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "any_value(1) AS b, sum_count_star(2) AS k",
                 "GroupBy": "(0|3)",
-                "ResultColumns": 3,
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -173,13 +171,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "(0|3) ASC, 2 ASC",
+        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "any_value(1) AS b, sum_count_star(2) AS k",
             "GroupBy": "(0|3)",
-            "ResultColumns": 3,
             "Inputs": [
               {
                 "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -14,7 +14,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "any_value(1) AS b, sum_count_star(2) AS count(*), any_value(4)",
+            "Aggregates": "any_value(1|4) AS b, sum_count_star(2) AS count(*)",
             "GroupBy": "(0|3)",
             "ResultColumns": 5,
             "Inputs": [
@@ -25,9 +25,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(`user`.b) from `user` where 1 != 1 group by a, weight_string(a)",
+                "FieldQuery": "select dt.c0 as a, dt.c1 as b, dt.c2 as `count(*)`, dt.c3 as `weight_string(a)`, weight_string(dt.c1) from (select a, b, count(*), weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)) as dt(c0, c1, c2, c3) where 1 != 1",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*), weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc",
+                "Query": "select dt.c0 as a, dt.c1 as b, dt.c2 as `count(*)`, dt.c3 as `weight_string(a)`, weight_string(dt.c1) from (select a, b, count(*), weight_string(a) from `user` group by a, weight_string(a) order by a asc) as dt(c0, c1, c2, c3)",
                 "Table": "`user`"
               }
             ]
@@ -93,7 +93,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "any_value(1) AS b, sum_count_star(2) AS k, any_value(4)",
+            "Aggregates": "any_value(1|4) AS b, sum_count_star(2) AS k",
             "GroupBy": "(0|3)",
             "ResultColumns": 5,
             "Inputs": [
@@ -104,9 +104,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select a, b, count(*) as k, weight_string(a), weight_string(`user`.b) from `user` where 1 != 1 group by a, weight_string(a)",
+                "FieldQuery": "select dt.c0 as a, dt.c1 as b, dt.c2 as k, dt.c3 as `weight_string(a)`, weight_string(dt.c1) from (select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)) as dt(c0, c1, c2, c3) where 1 != 1",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*) as k, weight_string(a), weight_string(`user`.b) from `user` group by a, weight_string(a) order by a asc",
+                "Query": "select dt.c0 as a, dt.c1 as b, dt.c2 as k, dt.c3 as `weight_string(a)`, weight_string(dt.c1) from (select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc) as dt(c0, c1, c2, c3)",
                 "Table": "`user`"
               }
             ]
@@ -173,14 +173,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "(0|3) ASC, 2 ASC",
-        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "any_value(1) AS b, sum_count_star(2) AS k",
             "GroupBy": "(0|3)",
-            "ResultColumns": 4,
+            "ResultColumns": 3,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -360,9 +359,9 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1,R:0,L:2,R:1,L:3",
+            "JoinColumnIndexes": "L:0,L:1,R:0,L:3,R:1,L:4",
             "JoinVars": {
-              "user_id": 4
+              "user_id": 2
             },
             "TableName": "`user`_music",
             "Inputs": [
@@ -373,8 +372,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2), `user`.id from `user` where 1 != 1",
-                "Query": "select `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2), `user`.id from `user` where `user`.id = 1",
+                "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1",
+                "Query": "select `user`.col1 as a, `user`.col2, `user`.id, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where `user`.id = 1",
                 "Table": "`user`",
                 "Values": [
                   "1"

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -1554,7 +1554,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "sum_count(0) AS count(id), any_value(1) AS num, any_value(2)",
+            "Aggregates": "sum_count(0) AS count(id), any_value(1|2) AS num",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1729,7 +1729,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum_count_star(1) AS count(*), any_value(2) AS c1, any_value(3)",
+            "Aggregates": "sum_count_star(1) AS count(*), any_value(2|3) AS c1",
             "GroupBy": "0",
             "Inputs": [
               {
@@ -1739,9 +1739,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select col, count(*), c1, weight_string(c1) from `user` where 1 != 1 group by col",
+                "FieldQuery": "select dt.c0 as col, dt.c1 as `count(*)`, dt.c2 as c1, weight_string(dt.c2) from (select col, count(*), c1 from `user` where 1 != 1 group by col) as dt(c0, c1, c2) where 1 != 1",
                 "OrderBy": "0 ASC",
-                "Query": "select col, count(*), c1, weight_string(c1) from `user` group by col order by col asc",
+                "Query": "select dt.c0 as col, dt.c1 as `count(*)`, dt.c2 as c1, weight_string(dt.c2) from (select col, count(*), c1 from `user` group by col order by col asc) as dt(c0, c1, c2)",
                 "Table": "`user`"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -1618,13 +1618,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "0 ASC",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum_count(0) AS count(id)",
             "GroupBy": "(1|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2090,7 +2090,6 @@
             "Variant": "Ordered",
             "Aggregates": "min(1|3) AS min(a.id)",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Join",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1836,7 +1836,6 @@
                 "Variant": "Ordered",
                 "Aggregates": "sum(0) AS avg_col, sum_count(3) AS count(intcol)",
                 "GroupBy": "1 COLLATE latin1_swedish_ci, (2|4) COLLATE ",
-                "ResultColumns": 4,
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4330,7 +4329,6 @@
             "Variant": "Ordered",
             "Aggregates": "any_value(0) AS id",
             "GroupBy": "(1|2)",
-            "ResultColumns": 1,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -4496,7 +4494,6 @@
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
             "Aggregates": "max(0|1) AS max(music.id)",
-            "ResultColumns": 1,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -5033,7 +5030,6 @@
                 "Variant": "Ordered",
                 "Aggregates": "sum_count_star(1) AS b",
                 "GroupBy": "(2|3), (0|4)",
-                "ResultColumns": 3,
                 "Inputs": [
                   {
                     "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -831,7 +831,6 @@
                             "Variant": "Ordered",
                             "Aggregates": "sum(0) AS sum(case when nation = 'BRAZIL' then volume else 0 end), sum(1) AS sum(volume)",
                             "GroupBy": "(2|3)",
-                            "ResultColumns": 3,
                             "Inputs": [
                               {
                                 "OperatorType": "Join",
@@ -1111,12 +1110,11 @@
                         "Variant": "Ordered",
                         "Aggregates": "sum(0) AS sum_profit",
                         "GroupBy": "(1|3), (2|4)",
-                        "ResultColumns": 4,
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "R:0,L:0,L:4,L:6,L:7",
+                            "JoinColumnIndexes": "R:0,L:0,L:4,L:6,L:8",
                             "JoinVars": {
                               "l_discount": 2,
                               "l_extendedprice": 1,
@@ -1129,12 +1127,12 @@
                               {
                                 "OperatorType": "Sort",
                                 "Variant": "Memory",
-                                "OrderBy": "(0|8) ASC, (4|7) ASC",
+                                "OrderBy": "(0|6) ASC, (4|8) ASC",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Join",
                                     "Variant": "Join",
-                                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,L:2,R:5,L:3",
+                                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,L:3,R:5",
                                     "JoinVars": {
                                       "o_orderkey": 1
                                     },
@@ -2098,13 +2096,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "3 DESC, (0|4) ASC, (1|5) ASC, (2|6) ASC",
+        "ResultColumns": 4,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "count_distinct(3|7) AS supplier_cnt",
             "GroupBy": "(0|4), (1|5), (2|6)",
-            "ResultColumns": 4,
             "Inputs": [
               {
                 "OperatorType": "Sort",
@@ -2114,9 +2112,9 @@
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "R:0,R:1,R:2,L:0,R:3,R:4,R:5,L:1",
+                    "JoinColumnIndexes": "R:0,R:1,R:2,L:0,R:3,R:4,R:5,L:2",
                     "JoinVars": {
-                      "ps_partkey": 2,
+                      "ps_partkey": 1,
                       "ps_suppkey": 0
                     },
                     "TableName": "partsupp_part",
@@ -2149,8 +2147,8 @@
                               "Name": "main",
                               "Sharded": true
                             },
-                            "FieldQuery": "select ps_suppkey, weight_string(ps_suppkey), ps_partkey from partsupp where 1 != 1",
-                            "Query": "select ps_suppkey, weight_string(ps_suppkey), ps_partkey from partsupp where not :__sq_has_values or ps_suppkey not in ::__sq1",
+                            "FieldQuery": "select ps_suppkey, ps_partkey, weight_string(ps_suppkey) from partsupp where 1 != 1",
+                            "Query": "select ps_suppkey, ps_partkey, weight_string(ps_suppkey) from partsupp where not :__sq_has_values or ps_suppkey not in ::__sq1",
                             "Table": "partsupp"
                           }
                         ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -25,7 +25,6 @@
             "Variant": "Ordered",
             "Aggregates": "sum(2) AS sum_qty, sum(3) AS sum_base_price, sum(4) AS sum_disc_price, sum(5) AS sum_charge, sum(6) AS avg_qty, sum(7) AS avg_price, sum(8) AS avg_disc, sum_count_star(9) AS count_order, sum_count(10) AS count(l_quantity), sum_count(11) AS count(l_extendedprice), sum_count(12) AS count(l_discount)",
             "GroupBy": "(0|13), (1|14)",
-            "ResultColumns": 13,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -67,13 +66,13 @@
             "OperatorType": "Sort",
             "Variant": "Memory",
             "OrderBy": "1 DESC COLLATE utf8mb4_0900_ai_ci, (2|5) ASC",
+            "ResultColumns": 4,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(1) AS revenue",
                 "GroupBy": "(0|4), (2|5), (3|6)",
-                "ResultColumns": 4,
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
@@ -278,13 +277,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "1 DESC COLLATE utf8mb4_0900_ai_ci",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS revenue",
             "GroupBy": "(0|2)",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Projection",
@@ -801,7 +800,6 @@
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS sum(case when nation = 'BRAZIL' then volume else 0 end), sum(2) AS sum(volume)",
             "GroupBy": "(0|3)",
-            "ResultColumns": 3,
             "Inputs": [
               {
                 "OperatorType": "Projection",
@@ -1346,13 +1344,13 @@
             "OperatorType": "Sort",
             "Variant": "Memory",
             "OrderBy": "2 DESC COLLATE utf8mb4_0900_ai_ci",
+            "ResultColumns": 8,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(2) AS revenue",
                 "GroupBy": "(0|8), (1|9), (3|10), (6|11), (4|12), (5|13), (7|14)",
-                "ResultColumns": 8,
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
@@ -1657,6 +1655,7 @@
             "InputName": "Outer",
             "OperatorType": "Filter",
             "Predicate": "sum(ps_supplycost * ps_availqty) > :__sq1",
+            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Sort",
@@ -1668,7 +1667,6 @@
                     "Variant": "Ordered",
                     "Aggregates": "sum(1) AS value",
                     "GroupBy": "(0|2)",
-                    "ResultColumns": 2,
                     "Inputs": [
                       {
                         "OperatorType": "Projection",
@@ -1900,7 +1898,6 @@
                     "Variant": "Ordered",
                     "Aggregates": "sum_count(1) AS count(o_orderkey)",
                     "GroupBy": "(0|2)",
-                    "ResultColumns": 2,
                     "Inputs": [
                       {
                         "OperatorType": "Projection",
@@ -2061,7 +2058,6 @@
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
             "Aggregates": "max(0|1) AS max(total_revenue)",
-            "ResultColumns": 1,
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -2445,13 +2441,13 @@
             "OperatorType": "Sort",
             "Variant": "Memory",
             "OrderBy": "1 DESC, (0|2) ASC",
+            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum_count_star(1) AS numwait",
                 "GroupBy": "(0|2)",
-                "ResultColumns": 2,
                 "Inputs": [
                   {
                     "OperatorType": "Projection",

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -1889,23 +1889,25 @@
             "GroupBy": "0",
             "Inputs": [
               {
-                "OperatorType": "SimpleProjection",
-                "Columns": "1,3",
+                "OperatorType": "Projection",
+                "Expressions": [
+                  ":1 as c_count",
+                  "1 as 1"
+                ],
                 "Inputs": [
                   {
                     "OperatorType": "Aggregate",
                     "Variant": "Ordered",
-                    "Aggregates": "sum_count(1) AS count(o_orderkey), any_value(3)",
+                    "Aggregates": "sum_count(1) AS count(o_orderkey)",
                     "GroupBy": "(0|2)",
-                    "ResultColumns": 4,
+                    "ResultColumns": 2,
                     "Inputs": [
                       {
                         "OperatorType": "Projection",
                         "Expressions": [
                           ":2 as c_custkey",
                           "count(*) * count(o_orderkey) as count(o_orderkey)",
-                          ":3 as weight_string(c_custkey)",
-                          ":4 as 1"
+                          ":3 as weight_string(c_custkey)"
                         ],
                         "Inputs": [
                           {
@@ -1916,7 +1918,7 @@
                               {
                                 "OperatorType": "Join",
                                 "Variant": "LeftJoin",
-                                "JoinColumnIndexes": "R:0,L:0,L:1,L:2,L:3",
+                                "JoinColumnIndexes": "R:0,L:0,L:1,L:2",
                                 "JoinVars": {
                                   "c_custkey": 1
                                 },
@@ -1929,9 +1931,9 @@
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select count(*), c_custkey, weight_string(c_custkey), 1 from customer where 1 != 1 group by c_custkey, weight_string(c_custkey)",
+                                    "FieldQuery": "select count(*), c_custkey, weight_string(c_custkey) from customer where 1 != 1 group by c_custkey, weight_string(c_custkey)",
                                     "OrderBy": "(1|2) ASC",
-                                    "Query": "select count(*), c_custkey, weight_string(c_custkey), 1 from customer group by c_custkey, weight_string(c_custkey) order by c_custkey asc",
+                                    "Query": "select count(*), c_custkey, weight_string(c_custkey) from customer group by c_custkey, weight_string(c_custkey) order by c_custkey asc",
                                     "Table": "customer"
                                   },
                                   {
@@ -1983,41 +1985,51 @@
             "Aggregates": "any_value(0), sum(1) AS sum(case when p_type like 'PROMO%' then l_extendedprice * (1 - l_discount) else 0 end), sum(2) AS sum(l_extendedprice * (1 - l_discount))",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,R:0,L:3",
-                "JoinVars": {
-                  "l_discount": 2,
-                  "l_extendedprice": 1,
-                  "l_partkey": 4
-                },
-                "TableName": "lineitem_part",
+                "OperatorType": "Projection",
+                "Expressions": [
+                  "100.00 as 100.00",
+                  ":0 as case when p_type like 'PROMO%' then l_extendedprice * (1 - l_discount) else 0 end",
+                  ":1 as l_extendedprice * (1 - l_discount)"
+                ],
                 "Inputs": [
                   {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": true
+                    "OperatorType": "Join",
+                    "Variant": "Join",
+                    "JoinColumnIndexes": "R:0,L:2",
+                    "JoinVars": {
+                      "l_discount": 1,
+                      "l_extendedprice": 0,
+                      "l_partkey": 3
                     },
-                    "FieldQuery": "select 100.00, l_extendedprice, l_discount, l_extendedprice * (1 - l_discount), l_partkey from lineitem where 1 != 1",
-                    "Query": "select 100.00, l_extendedprice, l_discount, l_extendedprice * (1 - l_discount), l_partkey from lineitem where l_shipdate >= date('1995-09-01') and l_shipdate < date('1995-09-01') + interval '1' month",
-                    "Table": "lineitem"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "EqualUnique",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select case when p_type like 'PROMO%' then :l_extendedprice * (1 - :l_discount) else 0 end from part where 1 != 1",
-                    "Query": "select case when p_type like 'PROMO%' then :l_extendedprice * (1 - :l_discount) else 0 end from part where p_partkey = :l_partkey",
-                    "Table": "part",
-                    "Values": [
-                      ":l_partkey"
-                    ],
-                    "Vindex": "hash"
+                    "TableName": "lineitem_part",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "main",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select l_extendedprice, l_discount, l_extendedprice * (1 - l_discount), l_partkey from lineitem where 1 != 1",
+                        "Query": "select l_extendedprice, l_discount, l_extendedprice * (1 - l_discount), l_partkey from lineitem where l_shipdate >= date('1995-09-01') and l_shipdate < date('1995-09-01') + interval '1' month",
+                        "Table": "lineitem"
+                      },
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "EqualUnique",
+                        "Keyspace": {
+                          "Name": "main",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select case when p_type like 'PROMO%' then :l_extendedprice * (1 - :l_discount) else 0 end from part where 1 != 1",
+                        "Query": "select case when p_type like 'PROMO%' then :l_extendedprice * (1 - :l_discount) else 0 end from part where p_partkey = :l_partkey",
+                        "Table": "part",
+                        "Values": [
+                          ":l_partkey"
+                        ],
+                        "Vindex": "hash"
+                      }
+                    ]
                   }
                 ]
               }

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -1132,7 +1132,7 @@
                                   {
                                     "OperatorType": "Join",
                                     "Variant": "Join",
-                                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,L:3,R:5",
+                                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,L:2,R:5",
                                     "JoinVars": {
                                       "o_orderkey": 1
                                     },
@@ -1145,8 +1145,8 @@
                                           "Name": "main",
                                           "Sharded": true
                                         },
-                                        "FieldQuery": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year), weight_string(extract(year from o_orderdate)) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders where 1 != 1) as profit where 1 != 1",
-                                        "Query": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year), weight_string(extract(year from o_orderdate)) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders) as profit",
+                                        "FieldQuery": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders where 1 != 1) as profit where 1 != 1",
+                                        "Query": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders) as profit",
                                         "Table": "orders"
                                       },
                                       {
@@ -1192,8 +1192,8 @@
                                                   "Name": "main",
                                                   "Sharded": true
                                                 },
-                                                "FieldQuery": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as profit where 1 != 1",
-                                                "Query": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit",
+                                                "FieldQuery": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice as l_extendedprice, l_discount as l_discount, l_quantity as l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as profit where 1 != 1",
+                                                "Query": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice as l_extendedprice, l_discount as l_discount, l_quantity as l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit",
                                                 "Table": "lineitem"
                                               }
                                             ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -67,14 +67,13 @@
             "OperatorType": "Sort",
             "Variant": "Memory",
             "OrderBy": "1 DESC COLLATE utf8mb4_0900_ai_ci, (2|5) ASC",
-            "ResultColumns": 4,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(1) AS revenue",
                 "GroupBy": "(0|4), (2|5), (3|6)",
-                "ResultColumns": 6,
+                "ResultColumns": 4,
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
@@ -1130,12 +1129,12 @@
                               {
                                 "OperatorType": "Sort",
                                 "Variant": "Memory",
-                                "OrderBy": "(0|6) ASC, (4|7) ASC",
+                                "OrderBy": "(0|8) ASC, (4|7) ASC",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Join",
                                     "Variant": "Join",
-                                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,L:2,R:5",
+                                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,L:2,R:5,L:3",
                                     "JoinVars": {
                                       "o_orderkey": 1
                                     },
@@ -1148,8 +1147,8 @@
                                           "Name": "main",
                                           "Sharded": true
                                         },
-                                        "FieldQuery": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders where 1 != 1) as profit where 1 != 1",
-                                        "Query": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders) as profit",
+                                        "FieldQuery": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year), weight_string(extract(year from o_orderdate)) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders where 1 != 1) as profit where 1 != 1",
+                                        "Query": "select profit.o_year, profit.o_orderkey, weight_string(profit.o_year), weight_string(extract(year from o_orderdate)) from (select extract(year from o_orderdate) as o_year, o_orderkey as o_orderkey from orders) as profit",
                                         "Table": "orders"
                                       },
                                       {
@@ -2099,14 +2098,13 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "3 DESC, (0|4) ASC, (1|5) ASC, (2|6) ASC",
-        "ResultColumns": 4,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "count_distinct(3|7) AS supplier_cnt",
             "GroupBy": "(0|4), (1|5), (2|6)",
-            "ResultColumns": 7,
+            "ResultColumns": 4,
             "Inputs": [
               {
                 "OperatorType": "Sort",
@@ -2437,14 +2435,13 @@
             "OperatorType": "Sort",
             "Variant": "Memory",
             "OrderBy": "1 DESC, (0|2) ASC",
-            "ResultColumns": 2,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum_count_star(1) AS numwait",
                 "GroupBy": "(0|2)",
-                "ResultColumns": 3,
+                "ResultColumns": 2,
                 "Inputs": [
                   {
                     "OperatorType": "Projection",

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -1190,8 +1190,8 @@
                                                   "Name": "main",
                                                   "Sharded": true
                                                 },
-                                                "FieldQuery": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice as l_extendedprice, l_discount as l_discount, l_quantity as l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as profit where 1 != 1",
-                                                "Query": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice as l_extendedprice, l_discount as l_discount, l_quantity as l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit",
+                                                "FieldQuery": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where 1 != 1) as profit where 1 != 1",
+                                                "Query": "select profit.l_extendedprice, profit.l_discount, profit.l_quantity, profit.l_suppkey, profit.l_partkey, weight_string(profit.l_suppkey) from (select l_extendedprice, l_discount, l_quantity, l_suppkey as l_suppkey, l_partkey as l_partkey from lineitem where l_orderkey = :o_orderkey) as profit",
                                                 "Table": "lineitem"
                                               }
                                             ]


### PR DESCRIPTION
## Description
While working on #16427, I've stumbled across quite a few annoyances in the code that needed fixing before we could finish the CTE work. Instead of making that PR even bigger, I'm extracting all the clean ups into this PR.

The kind of clean ups are:
 * Use `AddWSColumn` instead of `AddColumn` to add `weight_strings`.
 * Don't push down literals - just evaluate them in the vtgate

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
