### PR TITLE
Atomic Transaction bug fix with PRS disruption

### DIFF
--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -60,15 +60,15 @@ func (vtctl *VtctlProcess) AddCellInfo(Cell string) (err error) {
 }
 
 // CreateKeyspace executes vtctl command to create keyspace
-func (vtctl *VtctlProcess) CreateKeyspace(keyspace, sidecarDBName string) (err error) {
-	var output string
-	// For upgrade/downgrade tests where an older version is also used.
-	if vtctl.VtctlMajorVersion < 17 {
-		log.Errorf("CreateKeyspace does not support the --sidecar-db-name flag in vtctl version %d; ignoring...", vtctl.VtctlMajorVersion)
-		output, err = vtctl.ExecuteCommandWithOutput("CreateKeyspace", keyspace)
-	} else {
-		output, err = vtctl.ExecuteCommandWithOutput("CreateKeyspace", keyspace, "--sidecar-db-name", sidecarDBName)
+func (vtctl *VtctlProcess) CreateKeyspace(keyspace, sidecarDBName, durabilityPolicy string) error {
+	args := []string{
+		"CreateKeyspace", keyspace,
+		"--sidecar-db-name", sidecarDBName,
 	}
+	if durabilityPolicy != "" {
+		args = append(args, "--durability-policy", durabilityPolicy)
+	}
+	output, err := vtctl.ExecuteCommandWithOutput(args...)
 	if err != nil {
 		log.Errorf("CreateKeyspace returned err: %s, output: %s", err, output)
 	}

--- a/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
+++ b/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
@@ -131,7 +131,7 @@ func initializeCluster(t *testing.T) (int, error) {
 	for _, keyspaceStr := range []string{keyspace} {
 		KeyspacePtr := &cluster.Keyspace{Name: keyspaceStr}
 		keyspace := *KeyspacePtr
-		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspace.Name, sidecar.DefaultName); err != nil {
+		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspace.Name, sidecar.DefaultName, ""); err != nil {
 			return 1, err
 		}
 		shard := &cluster.Shard{

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -350,7 +350,7 @@ func clusterSetUp(t *testing.T) (int, error) {
 	for _, keyspaceStr := range []string{keyspace} {
 		KeyspacePtr := &cluster.Keyspace{Name: keyspaceStr}
 		keyspace := *KeyspacePtr
-		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspace.Name, sidecar.DefaultName); err != nil {
+		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspace.Name, sidecar.DefaultName, ""); err != nil {
 			return 1, err
 		}
 		shard := &cluster.Shard{

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName, sidecar.DefaultName); err != nil {
+		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName, sidecar.DefaultName, ""); err != nil {
 			return 1
 		}
 

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName, sidecar.DefaultName); err != nil {
+		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName, sidecar.DefaultName, ""); err != nil {
 			return 1
 		}
 

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -84,7 +84,7 @@ func TestMain(m *testing.M) {
 		if err := clusterInstance.StartTopo(); err != nil {
 			return 1, err
 		}
-		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName, sidecar.DefaultName); err != nil {
+		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName, sidecar.DefaultName, ""); err != nil {
 			return 1, err
 		}
 

--- a/go/test/endtoend/transaction/twopc/schema.sql
+++ b/go/test/endtoend/transaction/twopc/schema.sql
@@ -10,3 +10,9 @@ create table twopc_music (
     title varchar(64),
     primary key (id)
 ) Engine=InnoDB;
+
+create table twopc_t1 (
+    id bigint,
+    col bigint,
+    primary key (id, col)
+) Engine=InnoDB;

--- a/go/test/endtoend/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/transaction/twopc/twopc_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"os"
+	"path"
 	"reflect"
 	"sort"
 	"strings"
@@ -35,9 +37,15 @@ import (
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+const (
+	DebugDelayCommitShard = "VT_DELAY_COMMIT_SHARD"
+	DebugDelayCommitTime  = "VT_DELAY_COMMIT_TIME"
 )
 
 // TestDTCommit tests distributed transaction commit for insert, update and delete operations
@@ -954,4 +962,122 @@ func testWarningAndTransactionStatus(t *testing.T, conn *vtgateconn.VTGateSessio
 		assert.Equal(t, txState, tx.state)
 		assert.Equal(t, txParticipants, tx.participants)
 	}
+}
+
+// TestDisruptions tests that atomic transactions persevere through various disruptions.
+func TestDisruptions(t *testing.T) {
+	testcases := []struct {
+		disruptionName  string
+		commitDelayTime string
+		disruption      func() error
+	}{
+		{
+			disruptionName:  "No Disruption",
+			commitDelayTime: "1",
+			disruption: func() error {
+				return nil
+			},
+		},
+		{
+			disruptionName:  "PlannedReparentShard",
+			commitDelayTime: "5",
+			disruption:      prsShard3,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(fmt.Sprintf("%s-%ss timeout", tt.disruptionName, tt.commitDelayTime), func(t *testing.T) {
+			// Reparent all the shards to first tablet being the primary.
+			reparentToFistTablet(t)
+			// cleanup all the old data.
+			conn, closer := start(t)
+			defer closer()
+			// Start an atomic transaction.
+			utils.Exec(t, conn, "begin")
+			// Insert rows such that they go to all the three shards. Given that we have sharded the table `twopc_t1` on reverse_bits
+			// it is very easy to figure out what value will end up in which shard.
+			utils.Exec(t, conn, "insert into twopc_t1(id, col) values(4, 4)")
+			utils.Exec(t, conn, "insert into twopc_t1(id, col) values(6, 4)")
+			utils.Exec(t, conn, "insert into twopc_t1(id, col) values(9, 4)")
+			// We want to delay the commit on one of the shards to simulate slow commits on a shard.
+			writeTestCommunicationFile(t, DebugDelayCommitShard, "80-")
+			defer deleteFile(DebugDelayCommitShard)
+			writeTestCommunicationFile(t, DebugDelayCommitTime, tt.commitDelayTime)
+			defer deleteFile(DebugDelayCommitTime)
+			// We will execute a commit in a go routine, because we know it will take some time to complete.
+			// While the commit is ongoing, we would like to run the disruption.
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := utils.ExecAllowError(t, conn, "commit")
+				if err != nil {
+					log.Errorf("Error in commit - %v", err)
+				}
+			}()
+			// Allow enough time for the commit to have started.
+			time.Sleep(1 * time.Second)
+			// Run the disruption.
+			err := tt.disruption()
+			require.NoError(t, err)
+			// Wait for the commit to have returned. We don't actually check for an error in the commit because the user might receive an error.
+			// But since we are waiting in CommitPrepared, the decision to commit the transaction should have already been taken.
+			wg.Wait()
+			// Check the data in the table.
+			waitForResults(t, "select id, col from twopc_t1 where col = 4 order by id", `[[INT64(4) INT64(4)] [INT64(6) INT64(4)] [INT64(9) INT64(4)]]`, 10*time.Second)
+		})
+	}
+}
+
+// reparentToFistTablet reparents all the shards to first tablet being the primary.
+func reparentToFistTablet(t *testing.T) {
+	ks := clusterInstance.Keyspaces[0]
+	for _, shard := range ks.Shards {
+		primary := shard.Vttablets[0]
+		err := clusterInstance.VtctldClientProcess.PlannedReparentShard(keyspaceName, shard.Name, primary.Alias)
+		require.NoError(t, err)
+	}
+}
+
+// writeTestCommunicationFile writes the content to the file with the given name.
+// We use these files to coordinate with the vttablets running in the debug mode.
+func writeTestCommunicationFile(t *testing.T, fileName string, content string) {
+	err := os.WriteFile(path.Join(os.Getenv("VTDATAROOT"), fileName), []byte(content), 0644)
+	require.NoError(t, err)
+}
+
+// deleteFile deletes the file specified.
+func deleteFile(fileName string) {
+	_ = os.Remove(path.Join(os.Getenv("VTDATAROOT"), fileName))
+}
+
+// waitForResults waits for the results of the query to be as expected.
+func waitForResults(t *testing.T, query string, resultExpected string, waitTime time.Duration) {
+	timeout := time.After(waitTime)
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("didn't reach expected results for %s", query)
+		default:
+			ctx := context.Background()
+			conn, err := mysql.Connect(ctx, &vtParams)
+			require.NoError(t, err)
+			res := utils.Exec(t, conn, query)
+			conn.Close()
+			if fmt.Sprintf("%v", res.Rows) == resultExpected {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+/*
+Cluster Level Disruptions for the fuzzer
+*/
+
+// prsShard3 runs a PRS in shard 3 of the keyspace. It promotes the second tablet to be the new primary.
+func prsShard3() error {
+	shard := clusterInstance.Keyspaces[0].Shards[2]
+	newPrimary := shard.Vttablets[1]
+	return clusterInstance.VtctldClientProcess.PlannedReparentShard(keyspaceName, shard.Name, newPrimary.Alias)
 }

--- a/go/test/endtoend/transaction/twopc/utils/utils.go
+++ b/go/test/endtoend/transaction/twopc/utils/utils.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/log"
+)
+
+// ClearOutTable deletes everything from a table. Sometimes the table might have more rows than allowed in a single delete query,
+// so we have to do the deletions iteratively.
+func ClearOutTable(t *testing.T, vtParams mysql.ConnParams, tableName string) {
+	ctx := context.Background()
+	for {
+		conn, err := mysql.Connect(ctx, &vtParams)
+		require.NoError(t, err)
+
+		res, err := conn.ExecuteFetch(fmt.Sprintf("SELECT count(*) FROM %v", tableName), 1, false)
+		if err != nil {
+			log.Errorf("Error in selecting - %v", err)
+			conn.Close()
+			continue
+		}
+		require.Len(t, res.Rows, 1)
+		require.Len(t, res.Rows[0], 1)
+		rowCount, err := res.Rows[0][0].ToInt()
+		require.NoError(t, err)
+		if rowCount == 0 {
+			conn.Close()
+			return
+		}
+		_, err = conn.ExecuteFetch(fmt.Sprintf("DELETE FROM %v LIMIT 10000", tableName), 10000, false)
+		if err != nil {
+			log.Errorf("Error in cleanup deletion - %v", err)
+			conn.Close()
+			continue
+		}
+	}
+}

--- a/go/test/endtoend/transaction/twopc/utils/utils.go
+++ b/go/test/endtoend/transaction/twopc/utils/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (

--- a/go/test/endtoend/transaction/twopc/vschema.json
+++ b/go/test/endtoend/transaction/twopc/vschema.json
@@ -3,6 +3,9 @@
   "vindexes": {
     "xxhash": {
       "type": "xxhash"
+    },
+    "reverse_bits": {
+      "type": "reverse_bits"
     }
   },
   "tables": {
@@ -19,6 +22,14 @@
         {
           "column": "user_id",
           "name": "xxhash"
+        }
+      ]
+    },
+    "twopc_t1": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "reverse_bits"
         }
       ]
     }

--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -96,6 +96,7 @@ var (
 	VT09022 = errorWithoutState("VT09022", vtrpcpb.Code_FAILED_PRECONDITION, "Destination does not have exactly one shard: %v", "Cannot send query to multiple shards.")
 	VT09023 = errorWithoutState("VT09023", vtrpcpb.Code_FAILED_PRECONDITION, "could not map %v to a keyspace id", "Unable to determine the shard for the given row.")
 	VT09024 = errorWithoutState("VT09024", vtrpcpb.Code_FAILED_PRECONDITION, "could not map %v to a unique keyspace id: %v", "Unable to determine the shard for the given row.")
+	VT09025 = errorWithoutState("VT09025", vtrpcpb.Code_FAILED_PRECONDITION, "atomic transaction error: %v", "Error in atomic transactions")
 
 	VT10001 = errorWithoutState("VT10001", vtrpcpb.Code_ABORTED, "foreign key constraints are not allowed", "Foreign key constraints are not allowed, see https://vitess.io/blog/2021-06-15-online-ddl-why-no-fk/.")
 	VT10002 = errorWithoutState("VT10002", vtrpcpb.Code_ABORTED, "atomic distributed transaction not allowed: %s", "The distributed transaction cannot be committed. A rollback decision is taken.")

--- a/go/vt/vttablet/tabletserver/debug_2pc.go
+++ b/go/vt/vttablet/tabletserver/debug_2pc.go
@@ -1,0 +1,33 @@
+//go:build debug2PC
+
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"os"
+	"path"
+)
+
+const DebugTwoPc = true
+
+// readFileForTestSynchronization is a test-only function that reads a file
+// that we use for synchronizing some of the tests.
+func readFileForTestSynchronization(fileName string) string {
+	res, _ := os.ReadFile(path.Join(os.Getenv("VTDATAROOT"), fileName))
+	return string(res)
+}

--- a/go/vt/vttablet/tabletserver/debug_2pc.go
+++ b/go/vt/vttablet/tabletserver/debug_2pc.go
@@ -21,6 +21,10 @@ package tabletserver
 import (
 	"os"
 	"path"
+	"strconv"
+	"time"
+
+	"vitess.io/vitess/go/vt/log"
 )
 
 const DebugTwoPc = true
@@ -30,4 +34,15 @@ const DebugTwoPc = true
 func readFileForTestSynchronization(fileName string) string {
 	res, _ := os.ReadFile(path.Join(os.Getenv("VTDATAROOT"), fileName))
 	return string(res)
+}
+
+// commitPreparedDelayForTest is a test-only function that delays the commit that have already been prepared.
+func commitPreparedDelayForTest(tsv *TabletServer) {
+	sh := readFileForTestSynchronization("VT_DELAY_COMMIT_SHARD")
+	if tsv.sm.target.Shard == sh {
+		delay := readFileForTestSynchronization("VT_DELAY_COMMIT_TIME")
+		delVal, _ := strconv.Atoi(delay)
+		log.Infof("Delaying commit for shard %v for %d seconds", sh, delVal)
+		time.Sleep(time.Duration(delVal) * time.Second)
+	}
 }

--- a/go/vt/vttablet/tabletserver/dt_executor.go
+++ b/go/vt/vttablet/tabletserver/dt_executor.go
@@ -96,7 +96,7 @@ func (dte *DTExecutor) CommitPrepared(dtid string) (err error) {
 	var conn *StatefulConnection
 	conn, err = dte.te.preparedPool.FetchForCommit(dtid)
 	if err != nil {
-		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot commit dtid %s, state: %v", dtid, err)
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot commit dtid %s, err: %v", dtid, err)
 	}
 	// No connection means the transaction was already committed.
 	if conn == nil {

--- a/go/vt/vttablet/tabletserver/dt_executor_test.go
+++ b/go/vt/vttablet/tabletserver/dt_executor_test.go
@@ -228,7 +228,7 @@ func TestTxExecutorCommitRedoFail(t *testing.T) {
 	// A retry should fail differently as the prepared transaction is marked as failed.
 	err = txe.CommitPrepared("bb")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot commit dtid bb, state: failed")
+	require.Contains(t, err.Error(), "cannot commit dtid bb, err: VT09025: atomic transaction error: failed to commit")
 
 	require.Contains(t, strings.Join(tl.GetAllLogs(), "|"),
 		"failed to commit the prepared transaction 'bb' with error: unknown error: delete redo log fail")

--- a/go/vt/vttablet/tabletserver/production.go
+++ b/go/vt/vttablet/tabletserver/production.go
@@ -1,0 +1,32 @@
+//go:build !debug2PC
+
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+// This file defines debug constants that are always false.
+// This file is used for building production code.
+// We use go build directives to include a file that defines the constant to true
+// when certain tags are provided while building binaries.
+// This allows to have debugging code written in normal code flow without affecting
+// production performance.
+
+const DebugTwoPc = false
+
+func readFileForTestSynchronization(fileName string) string {
+	return ""
+}

--- a/go/vt/vttablet/tabletserver/production.go
+++ b/go/vt/vttablet/tabletserver/production.go
@@ -27,6 +27,4 @@ package tabletserver
 
 const DebugTwoPc = false
 
-func readFileForTestSynchronization(fileName string) string {
-	return ""
-}
+func commitPreparedDelayForTest(tsv *TabletServer) {}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -661,13 +661,7 @@ func (tsv *TabletServer) CommitPrepared(ctx context.Context, target *querypb.Tar
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			txe := NewDTExecutor(ctx, tsv.te, logStats)
 			if DebugTwoPc {
-				sh := readFileForTestSynchronization("VT_DELAY_COMMIT_SHARD")
-				if tsv.sm.target.Shard == sh {
-					delay := readFileForTestSynchronization("VT_DELAY_COMMIT_TIME")
-					delVal, _ := strconv.Atoi(delay)
-					log.Infof("Delaying commit for shard %v for %d seconds", sh, delVal)
-					time.Sleep(time.Duration(delVal) * time.Second)
-				}
+				commitPreparedDelayForTest(tsv)
 			}
 			return txe.CommitPrepared(dtid)
 		},

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -660,6 +660,15 @@ func (tsv *TabletServer) CommitPrepared(ctx context.Context, target *querypb.Tar
 		target, nil, true, /* allowOnShutdown */
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			txe := NewDTExecutor(ctx, tsv.te, logStats)
+			if DebugTwoPc {
+				sh := readFileForTestSynchronization("VT_DELAY_COMMIT_SHARD")
+				if tsv.sm.target.Shard == sh {
+					delay := readFileForTestSynchronization("VT_DELAY_COMMIT_TIME")
+					delVal, _ := strconv.Atoi(delay)
+					log.Infof("Delaying commit for shard %v for %d seconds", sh, delVal)
+					time.Sleep(time.Duration(delVal) * time.Second)
+				}
+			}
 			return txe.CommitPrepared(dtid)
 		},
 	)

--- a/go/vt/vttablet/tabletserver/tx_prep_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_prep_pool.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
@@ -69,7 +70,7 @@ func (pp *TxPreparedPool) Put(c *StatefulConnection, dtid string) error {
 		return vterrors.VT09025("duplicate DTID in Prepare: " + dtid)
 	}
 	if len(pp.conns) >= pp.capacity {
-		return vterrors.VT09025(fmt.Sprintf("prepared transactions exceeded limit: %d", pp.capacity))
+		return vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, fmt.Sprintf("prepared transactions exceeded limit: %d", pp.capacity))
 	}
 	pp.conns[dtid] = c
 	return nil

--- a/go/vt/vttablet/tabletserver/tx_prep_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_prep_pool_test.go
@@ -113,11 +113,9 @@ func TestPrepFetchAll(t *testing.T) {
 	conn2 := &StatefulConnection{}
 	pp.Put(conn1, "aa")
 	pp.Put(conn2, "bb")
-	got := pp.FetchAll()
-	if len(got) != 2 {
-		t.Errorf("FetchAll len: %d, want 2", len(got))
-	}
-	if len(pp.conns) != 0 {
-		t.Errorf("len(pp.conns): %d, want 0", len(pp.conns))
-	}
+	got := pp.FetchAllForRollback()
+	require.Len(t, got, 2)
+	require.Len(t, pp.conns, 0)
+	_, err := pp.FetchForCommit("aa")
+	require.ErrorContains(t, err, "pool is shutdown")
 }

--- a/go/vt/vttablet/tabletserver/tx_prep_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_prep_pool_test.go
@@ -25,11 +25,8 @@ import (
 
 func TestEmptyPrep(t *testing.T) {
 	pp := NewTxPreparedPool(0)
-	want := "prepared transactions exceeded limit: 0"
 	err := pp.Put(nil, "aa")
-	if err == nil || err.Error() != want {
-		t.Errorf("Put err: %v, want %s", err, want)
-	}
+	require.ErrorContains(t, err, "prepared transactions exceeded limit: 0")
 }
 
 func TestPrepPut(t *testing.T) {
@@ -38,23 +35,15 @@ func TestPrepPut(t *testing.T) {
 	require.NoError(t, err)
 	err = pp.Put(nil, "bb")
 	require.NoError(t, err)
-	want := "prepared transactions exceeded limit: 2"
 	err = pp.Put(nil, "cc")
-	if err == nil || err.Error() != want {
-		t.Errorf("Put err: %v, want %s", err, want)
-	}
+	require.ErrorContains(t, err, "prepared transactions exceeded limit: 2")
 	err = pp.Put(nil, "aa")
-	want = "duplicate DTID in Prepare: aa"
-	if err == nil || err.Error() != want {
-		t.Errorf("Put err: %v, want %s", err, want)
-	}
+	require.ErrorContains(t, err, "duplicate DTID in Prepare: aa")
+
 	_, err = pp.FetchForCommit("aa")
 	require.NoError(t, err)
 	err = pp.Put(nil, "aa")
-	want = "duplicate DTID in Prepare: aa"
-	if err == nil || err.Error() != want {
-		t.Errorf("Put err: %v, want %s", err, want)
-	}
+	require.ErrorContains(t, err, "duplicate DTID in Prepare: aa")
 	pp.Forget("aa")
 	err = pp.Put(nil, "aa")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds an e2e test for testing atomic transactions with a PRS disruption. While adding the test, a bug was also noticed. This PR fixes that bug too. 

These are the following sequence of operations that led to the bug - 
1. Users run an atomic transaction and tries to commit it.
2. As part of the commit, vtgate tries to call `CommitPrepared` on all the tablets.
3. An arbitrary reason can call the `CommitPrepared` on a vttablet to stall (In the test we explicitly sleep for 5 seconds)
4. While the `CommitPrepared` call is stalled, a PRS is issued in that shard that changes the primary tablet.
5. During DemotePrimary, we rollback all the prepared transactions by calling `FetchAll` on the prepared pool.
6. `CommitPrepared` finally runs, but it doesn't find any connection since `FetchAll` already removed them all. So it concludes that there is nothing to commit. It returns a success to the vtgate.
7. Because vtgate gets a success from all the vttablets, it actually marks the transaction as completed! But in reality we didn't commit anything on the shard we ran PRS on!
8. This leads to a transaction that is non-atomic since one shard didn't commit its changes.

The fix is pretty straight-forward. We just mark the pool is shutdown after we have called `FetchAll`. Any calls to `FetchForCommit` return an error until we transition to AcceptingReadWrite state again.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #16245 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
