### PR TITLE
v18 backport: Throttler/vreplication: fix app name used by VPlayer (#16578)

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -114,7 +114,7 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 		timeLastSaved:    time.Now(),
 		tablePlans:       make(map[string]*TablePlan),
 		phase:            phase,
-		throttlerAppName: throttlerapp.VCopierName.ConcatenateString(vr.throttlerAppName()),
+		throttlerAppName: throttlerapp.VPlayerName.ConcatenateString(vr.throttlerAppName()),
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -771,7 +771,7 @@ func TestThrottlerAppNames(t *testing.T) {
 	defer dbClient.Close()
 	dbName := dbClient.DBName()
 	// Ensure there's a dummy vreplication workflow record
-	_, err = dbClient.ExecuteFetch(fmt.Sprintf("insert into _vt.vreplication (id, workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, options) values (%d, 'test_workflow', '', '', 99999, 99999, 0, 0, 'Running', '%s', '{}') on duplicate key update workflow='test', source='', pos='', max_tps=99999, max_replication_lag=99999, time_updated=0, transaction_timestamp=0, state='Running', db_name='%s'",
+	_, err = dbClient.ExecuteFetch(fmt.Sprintf("insert into _vt.vreplication (id, workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name) values (%d, 'test_workflow', '', '', 99999, 99999, 0, 0, 'Running', '%s') on duplicate key update workflow='test', source='', pos='', max_tps=99999, max_replication_lag=99999, time_updated=0, transaction_timestamp=0, state='Running', db_name='%s'",
 		id, dbName, dbName), 1)
 	require.NoError(t, err)
 	defer func() {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"
@@ -742,4 +743,60 @@ func waitForQueryResult(t *testing.T, dbc binlogplayer.DBClient, query, val stri
 			time.Sleep(50 * time.Millisecond)
 		}
 	}
+}
+
+func TestThrottlerAppNames(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tablet := addTablet(100)
+	defer deleteTablet(tablet)
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t1",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+	}
+	id := int32(1)
+	vsclient := newTabletConnector(tablet)
+	stats := binlogplayer.NewStats()
+	defer stats.Stop()
+	dbClient := playerEngine.dbClientFactoryFiltered()
+	err := dbClient.Connect()
+	require.NoError(t, err)
+	defer dbClient.Close()
+	dbName := dbClient.DBName()
+	// Ensure there's a dummy vreplication workflow record
+	_, err = dbClient.ExecuteFetch(fmt.Sprintf("insert into _vt.vreplication (id, workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, options) values (%d, 'test_workflow', '', '', 99999, 99999, 0, 0, 'Running', '%s', '{}') on duplicate key update workflow='test', source='', pos='', max_tps=99999, max_replication_lag=99999, time_updated=0, transaction_timestamp=0, state='Running', db_name='%s'",
+		id, dbName, dbName), 1)
+	require.NoError(t, err)
+	defer func() {
+		_, err = dbClient.ExecuteFetch(fmt.Sprintf("delete from _vt.vreplication where id = %d", id), 1)
+		require.NoError(t, err)
+	}()
+	vr := newVReplicator(id, bls, vsclient, stats, dbClient, env.Mysqld, playerEngine)
+	settings, _, err := vr.loadSettings(ctx, newVDBClient(dbClient, stats))
+	require.NoError(t, err)
+
+	throttlerAppName := vr.throttlerAppName()
+	assert.Contains(t, throttlerAppName, "test_workflow")
+	assert.Contains(t, throttlerAppName, "vreplication")
+	assert.NotContains(t, throttlerAppName, "vcopier")
+	assert.NotContains(t, throttlerAppName, "vplayer")
+
+	vp := newVPlayer(vr, settings, nil, replication.Position{}, "")
+	assert.Contains(t, vp.throttlerAppName, "test_workflow")
+	assert.Contains(t, vp.throttlerAppName, "vreplication")
+	assert.Contains(t, vp.throttlerAppName, "vplayer")
+	assert.NotContains(t, vp.throttlerAppName, "vcopier")
+
+	vc := newVCopier(vr)
+	assert.Contains(t, vc.throttlerAppName, "test_workflow")
+	assert.Contains(t, vc.throttlerAppName, "vreplication")
+	assert.Contains(t, vc.throttlerAppName, "vcopier")
+	assert.NotContains(t, vc.throttlerAppName, "vplayer")
 }


### PR DESCRIPTION
# Manual backport of https://github.com/vitessio/vitess/pull/16578 to 18.0

## Description

`VPlayer` was incorrectly identifying itself to the throttler as `vcopier`. As result, running `ApplyThrottlerConfig --throttle-app=vplayer` made no effect on VPlayer. This PR fixes the problem.

## Related Issue(s)

Context: https://github.com/vitessio/vitess/issues/16575 (this PR does not fix this issue, just related)

## Backports

This is a bug. Backporting to 20, 19, 18 where this issue is relevant.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
