### PR TITLE
VReplication: Improve replication plan builder and event application errors

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -88,7 +88,7 @@ func (rp *ReplicatorPlan) buildExecutionPlan(fieldEvent *binlogdatapb.FieldEvent
 	// select * construct was used. We need to use the field names.
 	tplan, err := rp.buildFromFields(prelim.TargetName, prelim.Lastpk, fieldEvent.Fields)
 	if err != nil {
-		return nil, err
+		return nil, vterrors.Wrapf(err, "failed to build replication plan for %s table", fieldEvent.TableName)
 	}
 	tplan.Fields = fieldEvent.Fields
 	return tplan, nil

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -559,8 +559,9 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 						if table != "" {
 							tableLogMsg = fmt.Sprintf(" for table %s", table)
 						}
-						if vp.unsavedEvent != nil && vp.unsavedEvent.Gtid != "" {
-							gtidLogMsg = fmt.Sprintf(" that were part of GTID %s", vp.unsavedEvent.Gtid)
+						pos := getNextPosition(items, i, j+1)
+						if pos != "" {
+							gtidLogMsg = fmt.Sprintf(" while processing position %s", pos)
 						}
 						log.Errorf("Error applying event%s%s: %s", tableLogMsg, gtidLogMsg, err.Error())
 						err = vterrors.Wrapf(err, "error applying event%s%s", tableLogMsg, gtidLogMsg)
@@ -594,6 +595,30 @@ func hasAnotherCommit(items [][]*binlogdatapb.VEvent, i, j int) bool {
 		i++
 	}
 	return false
+}
+
+// getNextPosition returns the GTID set/position we would be at if the current
+// transaction was committed. This is useful for error handling as we can then
+// determine which GTID we're failing to process from the source and examine the
+// binlog events for that GTID directly on the source to debug the issue.
+// This is needed as it's not as simple as the user incrementing the current
+// position in the stream by 1 as we may be skipping N intermediate GTIDs in the
+// stream due to filtering. For GTIDs that we filter out we still replicate the
+// GTID event itself, just without any internal events and a COMMIT event (see
+// the unsavedEvent handling).
+func getNextPosition(items [][]*binlogdatapb.VEvent, i, j int) string {
+	for i < len(items) {
+		for j < len(items[i]) {
+			switch items[i][j].Type {
+			case binlogdatapb.VEventType_GTID:
+				return items[i][j].Gtid
+			}
+			j++
+		}
+		j = 0
+		i++
+	}
+	return ""
 }
 
 func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, mustSave bool) error {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -611,7 +611,11 @@ func getNextPosition(items [][]*binlogdatapb.VEvent, i, j int) string {
 		for j < len(items[i]) {
 			switch items[i][j].Type {
 			case binlogdatapb.VEventType_GTID:
-				return items[i][j].Gtid
+				pos, err := binlogplayer.DecodePosition(items[i][j].Gtid)
+				if err != nil {
+					return ""
+				}
+				return pos.String()
 			}
 			j++
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -610,7 +610,7 @@ func TestPlayerStatementModeWithFilter(t *testing.T) {
 	output := qh.Expect(
 		"begin",
 		"rollback",
-		"/update _vt.vreplication set message='filter rules are not supported for SBR",
+		"/update _vt.vreplication set message='error applying event while processing position .* filter rules are not supported for SBR.*",
 	)
 
 	execStatements(t, input)
@@ -1758,8 +1758,8 @@ func TestPlayerDDL(t *testing.T) {
 	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
 	expectDBClientQueries(t, qh.Expect(
 		"alter table t1 add column val2 varchar(128)",
-		"/update _vt.vreplication set message='Duplicate",
-		"/update _vt.vreplication set state='Error', message='Duplicate",
+		"/update _vt.vreplication set message='error applying event: Duplicate",
+		"/update _vt.vreplication set state='Error', message='error applying event: Duplicate",
 	))
 	cancel()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -575,8 +575,19 @@ func TestPlayerForeignKeyCheck(t *testing.T) {
 	cancel()
 }
 
-func TestPlayerStatementModeWithFilter(t *testing.T) {
+// TestPlayerStatementModeWithFilterAndErrorHandling confirms that we get the
+// expected error when using a filter with statement mode. It also tests the
+// general vplayer applyEvent error and log message handling.
+func TestPlayerStatementModeWithFilterAndErrorHandling(t *testing.T) {
 	defer deleteTablet(addTablet(100))
+
+	// We want to check for the expected log message.
+	ole := log.Errorf
+	logger := logutil.NewMemoryLogger()
+	log.Errorf = logger.Errorf
+	defer func() {
+		log.Errorf = ole
+	}()
 
 	execStatements(t, []string{
 		"create table src1(id int, val varbinary(128), primary key(id))",
@@ -600,21 +611,29 @@ func TestPlayerStatementModeWithFilter(t *testing.T) {
 	cancel, _ := startVReplication(t, bls, "")
 	defer cancel()
 
+	const gtid = "37f16b4c-5a74-11ef-87de-56bfd605e62e:100"
 	input := []string{
 		"set @@session.binlog_format='STATEMENT'",
+		fmt.Sprintf("set @@session.gtid_next='%s'", gtid),
 		"insert into src1 values(1, 'aaa')",
+		"set @@session.gtid_next='AUTOMATIC'",
 		"set @@session.binlog_format='ROW'",
 	}
+
+	expectedMsg := fmt.Sprintf("[Ee]rror applying event while processing position .*%s.* filter rules are not supported for SBR.*", gtid)
 
 	// It does not work when filter is enabled
 	output := qh.Expect(
 		"begin",
 		"rollback",
-		"/update _vt.vreplication set message='error applying event while processing position .* filter rules are not supported for SBR.*",
+		fmt.Sprintf("/update _vt.vreplication set message='%s", expectedMsg),
 	)
 
 	execStatements(t, input)
 	expectDBClientQueries(t, output)
+
+	logs := logger.String()
+	require.Regexp(t, expectedMsg, logs)
 }
 
 func TestPlayerStatementMode(t *testing.T) {


### PR DESCRIPTION
## Description

This is a quick bit of internal cleanup that improves the replication plan builder's error messages so that they contain the table name. This is pretty important when a workflow is operating on thousands of tables. This is a sibling PR to: https://github.com/vitessio/vitess/pull/16588

It should have been changed in that PR as well, but here we are... 🙂 

I also took this opportunity to make two improvements to the event application errors in `vplayer`, for which replication plan builder errors would be one cause:
  1. Include the table name in the error message (it was only included in the log message)
  2. Add the stream position we were trying to process when encountering the error

To demonstrate:
```
./101_initial_cluster.sh; ./201_customer_tablets.sh

mysql commerce -e "create table t1 (id int not null, name varchar(100), street varchar(50), primary key(id))"

vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer create --source-keyspace commerce --tables "t1"

mysql commerce -e "alter table t1 drop id, add primary key(name)"

mysql commerce -e "insert into t1 values ('Matt', 'Birch Hill Drive')"

❯ vtctldclient MoveTables --target-keyspace customer --workflow commerce2customer show --compact --include-logs=false | grep message
              "message": "error applying event for table t1 while processing position d77af336-5fc9-11ef-aed0-053911a91e99:1-38: failed to build replication plan for t1 table: primary key column &{id   int int true false} not found in table's select filter or the TableMap event within the GTID",

❯ mysqlbinlog -vvv --base64-output=DECODE-ROWS /opt/vtdataroot/vt_0000000101/bin-logs/vt-0000000101-bin.000001 --include-gtids=d77af336-5fc9-11ef-aed0-053911a91e99:38
...
SET @@SESSION.GTID_NEXT= 'd77af336-5fc9-11ef-aed0-053911a91e99:38'/*!*/;
# at 21837
#240821 10:30:21 server id 1138093001  end_log_pos 21919 CRC32 0x3a40f493 	Query	thread_id=44	exec_time=0	error_code=0
SET TIMESTAMP=1724250621/*!*/;
SET @@session.pseudo_thread_id=44/*!*/;
SET @@session.foreign_key_checks=1, @@session.sql_auto_is_null=0, @@session.unique_checks=1, @@session.autocommit=1/*!*/;
SET @@session.sql_mode=1168113696/*!*/;
SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/;
/*!\C utf8mb4 *//*!*/;
SET @@session.character_set_client=255,@@session.collation_connection=255,@@session.collation_server=255/*!*/;
SET @@session.lc_time_names=0/*!*/;
SET @@session.collation_database=DEFAULT/*!*/;
/*!80011 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
BEGIN
/*!*/;
# at 21919
#240821 10:30:21 server id 1138093001  end_log_pos 21981 CRC32 0xf2caa447 	Table_map: `vt_commerce`.`t1` mapped to number 178
# has_generated_invisible_primary_key=0
# at 21981
#240821 10:30:21 server id 1138093001  end_log_pos 22040 CRC32 0x0c94e906 	Write_rows: table id 178 flags: STMT_END_F
### INSERT INTO `vt_commerce`.`t1`
### SET
###   @1='Matt' /* VARSTRING(400) meta=400 nullable=0 is_null=0 */
###   @2='Birch Hill Drive' /* VARSTRING(200) meta=200 nullable=1 is_null=0 */
...
```

## Related Issue(s)

  - https://github.com/vitessio/vitess/pull/16588

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required