### PR TITLE
Remove specific Kubernetes version instructions and link to the Vites…

### DIFF
--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -1,5 +1,7 @@
 # Instructions
- **Note**: For the best experience, please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility between your version of Vitess and Kubernetes.
+{{< info >}}
+For the best experience, please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility between your version of Vitess and Kubernetes.
+{{< /info >}}
 ```
 # Start minikube
 minikube start --cpus=8 --memory=11000 --disk-size=50g

--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -1,8 +1,8 @@
 # Instructions
-
+ **Note**: For the best experience, it is recommended to use the latest stable version of Kubernetes. Please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility with your Kube
 ```
 # Start minikube
-minikube start --cpus=8 --memory=11000 --disk-size=50g --kubernetes-version=v1.25.8
+minikube start --cpus=8 --memory=11000 --disk-size=50g
 
 # Install Operator
 kubectl apply -f operator.yaml

--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -1,6 +1,6 @@
 # Instructions
 {{< info >}}
-For the best experience, please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility between your version of Vitess and Kubernetes.
+For the best experience, please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility between your version of Vitess and Kubernetes. You would then specify the appropriate Kubernetes version to Minikube using the `--kubernetes-version` flag.
 {{< /info >}}
 ```
 # Start minikube

--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -1,5 +1,5 @@
 # Instructions
- **Note**: For the best experience, it is recommended to use the latest stable version of Kubernetes. Please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility with your Kube
+ **Note**: For the best experience, Please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility with your Kube
 ```
 # Start minikube
 minikube start --cpus=8 --memory=11000 --disk-size=50g

--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -1,5 +1,5 @@
 # Instructions
- **Note**: For the best experience, Please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility with your Kube
+ **Note**: For the best experience, please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility between your version of Vitess and Kubernetes.
 ```
 # Start minikube
 minikube start --cpus=8 --memory=11000 --disk-size=50g


### PR DESCRIPTION
To update the examples/operator/README.md file by removing the --kubernetes-version=v1.19.5 flag and adding a reference to the compatibility matrix in the official documentation.
- [x] Removed specific Kubernetes version instructions from examples/operator/README.md.
- [x]  Added a link to the Vitess Operator Compatibility Matrix for up-to-date Kubernetes version information.
- [x] This change centralizes Kubernetes version recommendations and ensures users are directed to the most current documentation.
Related Issue:[#1022](https://github.com/vitessio/website/issues/1022)