### PR TITLE
Fix go.mod files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.23
+go 1.23.0
 
 require (
 	cloud.google.com/go/storage v1.43.0

--- a/vitess-mixin/go.mod
+++ b/vitess-mixin/go.mod
@@ -1,6 +1,6 @@
 module vitess-mixin
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/evanphx/json-patch v5.9.0+incompatible
@@ -130,4 +130,3 @@ require (
 )
 
 replace k8s.io/client-go v2.0.0-alpha.0.0.20181121191925-a47917edff34+incompatible => k8s.io/client-go v2.0.0-alpha.1+incompatible
-e


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/pull/16599 we bumped the go version to 1.23.0, this PR fixes the go.mod files that were incorrectly updated.