### PR TITLE
Log and ignore the error in reading udfs in schema tracker

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -592,6 +592,13 @@ func (db *DB) AddQueryPattern(queryPattern string, expectedResult *sqltypes.Resu
 	db.patternData[queryPattern] = exprResult{queryPattern: queryPattern, expr: expr, result: &result}
 }
 
+// RemoveQueryPattern removes a query pattern that was previously added.
+func (db *DB) RemoveQueryPattern(queryPattern string) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	delete(db.patternData, queryPattern)
+}
+
 // RejectQueryPattern allows a query pattern to be rejected with an error
 func (db *DB) RejectQueryPattern(queryPattern, error string) {
 	expr := regexp.MustCompile("(?is)^" + queryPattern + "$")

--- a/go/vt/logutil/throttled.go
+++ b/go/vt/logutil/throttled.go
@@ -54,6 +54,11 @@ var (
 	errorDepth   = log.ErrorDepth
 )
 
+// GetLastLogTime gets the last log time for the throttled logger.
+func (tl *ThrottledLogger) GetLastLogTime() time.Time {
+	return tl.lastlogTime
+}
+
 func (tl *ThrottledLogger) log(logF logFunc, format string, v ...any) {
 	now := time.Now()
 

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -1331,7 +1331,8 @@ func TestEngineReload(t *testing.T) {
 	}
 
 	// adding query pattern for udfs
-	db.AddQueryPattern("SELECT name.*", &sqltypes.Result{})
+	udfQueryPattern := "SELECT name.*"
+	db.AddQueryPattern(udfQueryPattern, &sqltypes.Result{})
 
 	// Verify the list of created, altered and dropped tables seen.
 	se.RegisterNotifier("test", func(full map[string]*Table, created, altered, dropped []*Table, _ bool) {
@@ -1344,6 +1345,16 @@ func TestEngineReload(t *testing.T) {
 	err = se.reload(context.Background(), false)
 	require.NoError(t, err)
 	require.NoError(t, db.LastError())
+	require.Zero(t, se.throttledLogger.GetLastLogTime())
+
+	// Now if we remove the query pattern for udfs, schema engine shouldn't fail.
+	// Instead we should see a log message with the error.
+	db.RemoveQueryPattern(udfQueryPattern)
+	se.UnregisterNotifier("test")
+	err = se.reload(context.Background(), false)
+	require.NoError(t, err)
+	// Check for the udf error being logged. The last log time should be less than a second.
+	require.Less(t, time.Since(se.throttledLogger.GetLastLogTime()), 1*time.Second)
 }
 
 // TestEngineReload tests the vreplication specific GetTableForPos function to ensure


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue described in https://github.com/vitessio/vitess/issues/16629. We will now log the error that we receive while reading the udfs but allow the schema tracker to continue.

We use a throttled logger for logging the error message to ensure we don't flood the logs with this error. We have hard-coded the throttled logger to only log the statement once every minute.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/16629

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
