### PR TITLE
Performance improvements - Planner

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -80,9 +80,6 @@ func (a *Aggregator) Inputs() []Operator {
 }
 
 func (a *Aggregator) SetInputs(operators []Operator) {
-	if len(operators) != 1 {
-		panic(fmt.Sprintf("unexpected number of operators as input in aggregator: %d", len(operators)))
-	}
 	a.Source = operators[0]
 }
 

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -45,9 +45,6 @@ func (d *Delete) Inputs() []Operator {
 }
 
 func (d *Delete) SetInputs(inputs []Operator) {
-	if len(inputs) != 1 {
-		panic(vterrors.VT13001("unexpected number of inputs for Delete operator"))
-	}
 	d.Source = inputs[0]
 }
 

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -257,16 +257,16 @@ func createDeleteOperator(ctx *plancontext.PlanningContext, del *sqlparser.Delet
 			Ignore:           del.Ignore,
 			Target:           targetTbl,
 			OwnedVindexQuery: ovq,
-			Source:           op,
 		},
 	}
 
 	if del.Limit != nil {
-		addOrdering(ctx, del.OrderBy, delOp)
 		delOp.Source = &Limit{
-			Source: delOp.Source,
+			Source: addOrdering(ctx, op, del.OrderBy),
 			AST:    del.Limit,
 		}
+	} else {
+		delOp.Source = op
 	}
 
 	return sqc.getRootOperator(delOp, nil), vTbl
@@ -299,26 +299,24 @@ func makeColName(col sqlparser.IdentifierCI, table TargetTable, isMultiTbl bool)
 	return sqlparser.NewColName(col.String())
 }
 
-func addOrdering(ctx *plancontext.PlanningContext, orderBy sqlparser.OrderBy, op Operator) {
+func addOrdering(ctx *plancontext.PlanningContext, op Operator, orderBy sqlparser.OrderBy) Operator {
 	es := &expressionSet{}
-	ordering := &Ordering{}
-	ordering.SetInputs(op.Inputs())
-	for _, order := range orderBy {
-		if sqlparser.IsNull(order.Expr) {
-			// ORDER BY null can safely be ignored
+	var order []OrderBy
+	for _, ord := range orderBy {
+		if sqlparser.IsNull(ord.Expr) || !es.add(ctx, ord.Expr) {
+			// ORDER BY null, or expression repeated can safely be ignored
 			continue
 		}
-		if !es.add(ctx, order.Expr) {
-			continue
-		}
-		ordering.Order = append(ordering.Order, OrderBy{
-			Inner:          sqlparser.Clone(order),
-			SimplifiedExpr: order.Expr,
+
+		order = append(order, OrderBy{
+			Inner:          sqlparser.Clone(ord),
+			SimplifiedExpr: ord.Expr,
 		})
 	}
-	if len(ordering.Order) > 0 {
-		op.SetInputs([]Operator{ordering})
+	if len(order) == 0 {
+		return op
 	}
+	return &Ordering{Source: op, Order: order}
 }
 
 func updateQueryGraphWithSource(ctx *plancontext.PlanningContext, input Operator, tblID semantics.TableSet, vTbl *vindexes.Table) *vindexes.Table {

--- a/go/vt/vtgate/planbuilder/operators/dml_with_input.go
+++ b/go/vt/vtgate/planbuilder/operators/dml_with_input.go
@@ -50,9 +50,6 @@ func (d *DMLWithInput) Inputs() []Operator {
 }
 
 func (d *DMLWithInput) SetInputs(inputs []Operator) {
-	if len(inputs) < 2 {
-		panic("unexpected number of inputs for DMLWithInput operator")
-	}
 	d.Source = inputs[0]
 	d.DML = inputs[1:]
 }

--- a/go/vt/vtgate/planbuilder/operators/fk_cascade.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_cascade.go
@@ -61,9 +61,6 @@ func (fkc *FkCascade) Inputs() []Operator {
 
 // SetInputs implements the Operator interface
 func (fkc *FkCascade) SetInputs(operators []Operator) {
-	if len(operators) < 2 {
-		panic("incorrect count of inputs for FkCascade")
-	}
 	fkc.Parent = operators[0]
 	fkc.Selection = operators[1]
 	for idx, operator := range operators {

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -52,9 +52,6 @@ func (fkv *FkVerify) Inputs() []Operator {
 // SetInputs implements the Operator interface
 func (fkv *FkVerify) SetInputs(operators []Operator) {
 	fkv.Input = operators[0]
-	if len(fkv.Verify) != len(operators)-1 {
-		panic("mismatched number of verify inputs")
-	}
 	for i := 1; i < len(operators); i++ {
 		fkv.Verify[i-1].Op = operators[i]
 	}

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -54,7 +54,8 @@ type (
 		// Inputs returns the inputs for this operator
 		Inputs() []Operator
 
-		// SetInputs changes the inputs for this op
+		// SetInputs changes the inputs for this op.
+		// We don't need to check the size of the inputs, as the planner will ensure that the inputs are correct
 		SetInputs([]Operator)
 
 		// AddPredicate is used to push predicates. It pushed it as far down as is possible in the tree.

--- a/go/vt/vtgate/planbuilder/operators/rewriters.go
+++ b/go/vt/vtgate/planbuilder/operators/rewriters.go
@@ -227,7 +227,7 @@ func bottomUp(
 	}
 
 	if anythingChanged.Changed() {
-		root = root.Clone(newInputs)
+		root.SetInputs(newInputs)
 	}
 
 	newOp, treeIdentity := rewriter(root, rootID, isRoot)

--- a/go/vt/vtgate/planbuilder/operators/rewriters.go
+++ b/go/vt/vtgate/planbuilder/operators/rewriters.go
@@ -257,11 +257,7 @@ func breakableTopDown(
 		}
 	}
 
-	if anythingChanged.Changed() {
-		return newOp, NoRewrite, nil
-	}
-
-	return newOp.Clone(newInputs), anythingChanged, nil
+	return newOp, anythingChanged, nil
 }
 
 // topDown is a helper function that recursively traverses the operator tree from the

--- a/go/vt/vtgate/planbuilder/operators/rewriters.go
+++ b/go/vt/vtgate/planbuilder/operators/rewriters.go
@@ -297,7 +297,8 @@ func topDown(
 	}
 
 	if anythingChanged != NoRewrite {
-		return root.Clone(newInputs), anythingChanged
+		root.SetInputs(newInputs)
+		return root, anythingChanged
 	}
 
 	return root, NoRewrite

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -66,9 +66,6 @@ func (u *Update) Inputs() []Operator {
 }
 
 func (u *Update) SetInputs(inputs []Operator) {
-	if len(inputs) != 1 {
-		panic(vterrors.VT13001("unexpected number of inputs for Update operator"))
-	}
 	u.Source = inputs[0]
 }
 

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -385,7 +385,6 @@ func createUpdateOperator(ctx *plancontext.PlanningContext, updStmt *sqlparser.U
 			Ignore:           updStmt.Ignore,
 			Target:           targetTbl,
 			OwnedVindexQuery: ovq,
-			Source:           op,
 		},
 		Assignments:                  assignments,
 		ChangedVindexValues:          cvv,
@@ -394,7 +393,9 @@ func createUpdateOperator(ctx *plancontext.PlanningContext, updStmt *sqlparser.U
 	}
 
 	if len(updStmt.OrderBy) > 0 {
-		addOrdering(ctx, updStmt.OrderBy, updOp)
+		updOp.Source = addOrdering(ctx, op, updStmt.OrderBy)
+	} else {
+		updOp.Source = op
 	}
 
 	if updStmt.Limit != nil {


### PR DESCRIPTION
## Description
This PR focuses on improving the performance of the Vitess planner by analyzing profiler output and implementing optimizations that reduce execution time, memory usage, and allocations. The changes are aimed at making the planner faster and more efficient, especially for complex queries.

### Benchmark Results

The benchmarks were run on an Apple M1 Ultra and demonstrate significant improvements across various metrics:

### Execution Time (sec/op):
 * The execution time for the planner has been reduced by 22.41% on average.
 * Notable improvements include:
 * OLTP/Gen4-20: -27.45%
 * TPCH/Gen4-20: -36.17%
 * Planner/large_cases.json-gen4-20: -49.41%
 * SelectVsDML/DML_(random_sample,_N=32)-20: -28.01%

### Memory Usage (B/op):
 * Memory usage has been reduced by 33.48% on average.
 * Significant reductions were observed in:
 * TPCH/Gen4-20: -55.71%
 * Planner/large_cases.json-gen4-20: -70.67%
 * SelectVsDML/Select_(random_sample,_N=32)-20: -35.78%

### Allocations (allocs/op):
 * Allocations have been reduced by 23.43% on average.
 * Key reductions include:
 * TPCH/Gen4-20: -42.77%
 * Planner/large_cases.json-gen4-20: -53.57%
 * SelectVsDML/Select_(random_sample,_N=32)-20: -29.82%

```
goos: darwin
goarch: arm64
pkg: vitess.io/vitess/go/vt/vtgate/planbuilder
cpu: Apple M1 Ultra
                                            │    before    │              ../after               │
                                            │    sec/op    │   sec/op     vs base                │
OLTP/Gen4-20                                   313.3µ ± 5%   227.3µ ± 2%  -27.45% (p=0.000 n=10)
OLTP/Gen4Greedy-20                             299.4µ ± 0%   225.6µ ± 2%  -24.64% (p=0.000 n=10)
OLTP/Gen4Left2Right-20                         299.7µ ± 0%   227.2µ ± 3%  -24.20% (p=0.000 n=10)
TPCC/Gen4-20                                   2.795m ± 0%   2.342m ± 1%  -16.18% (p=0.000 n=10)
TPCC/Gen4Greedy-20                             2.795m ± 0%   2.346m ± 1%  -16.06% (p=0.000 n=10)
TPCC/Gen4Left2Right-20                         2.754m ± 0%   2.292m ± 1%  -16.80% (p=0.000 n=10)
TPCH/Gen4-20                                   18.16m ± 1%   11.59m ± 1%  -36.17% (p=0.000 n=10)
TPCH/Gen4Greedy-20                             18.12m ± 0%   11.45m ± 1%  -36.78% (p=0.000 n=10)
TPCH/Gen4Left2Right-20                         16.30m ± 0%   10.41m ± 2%  -36.11% (p=0.000 n=10)
Planner/from_cases.json-gen4-20                9.378m ± 0%   7.871m ± 1%  -16.07% (p=0.000 n=10)
Planner/from_cases.json-gen4left2right-20      8.584m ± 1%   7.414m ± 0%  -13.63% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20              199.0m ± 0%   189.9m ± 0%   -4.55% (p=0.000 n=10)
Planner/filter_cases.json-gen4left2right-20    198.0m ± 0%   189.3m ± 1%   -4.40% (p=0.000 n=10)
Planner/large_cases.json-gen4-20              1000.6µ ± 0%   506.2µ ± 1%  -49.41% (p=0.000 n=10)
Planner/large_cases.json-gen4left2right-20     622.2µ ± 1%   315.2µ ± 1%  -49.34% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20                15.97m ± 0%   13.71m ± 1%  -14.11% (p=0.000 n=10)
Planner/aggr_cases.json-gen4left2right-20      15.24m ± 0%   13.17m ± 0%  -13.58% (p=0.000 n=10)
Planner/select_cases.json-gen4-20              12.81m ± 0%   11.07m ± 1%  -13.59% (p=0.000 n=10)
Planner/select_cases.json-gen4left2right-20    12.37m ± 1%   10.71m ± 1%  -13.39% (p=0.000 n=10)
Planner/union_cases.json-gen4-20               4.351m ± 0%   3.959m ± 1%   -9.02% (p=0.000 n=10)
Planner/union_cases.json-gen4left2right-20     4.342m ± 0%   3.962m ± 1%   -8.76% (p=0.000 n=10)
SemAnalysis-20                                 68.30m ± 0%   64.25m ± 1%   -5.93% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20      1078.7µ ± 5%   776.6µ ± 1%  -28.01% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20    2.590m ± 1%   1.771m ± 1%  -31.60% (p=0.000 n=10)
geomean                                        5.596m        4.342m       -22.41%

                                            │    before     │               ../after                │
                                            │     B/op      │     B/op       vs base                │
OLTP/Gen4-20                                   173.4Ki ± 0%    144.9Ki ± 0%  -16.45% (p=0.000 n=10)
OLTP/Gen4Greedy-20                             173.4Ki ± 0%    144.9Ki ± 0%  -16.43% (p=0.000 n=10)
OLTP/Gen4Left2Right-20                         173.4Ki ± 0%    144.9Ki ± 0%  -16.44% (p=0.000 n=10)
TPCC/Gen4-20                                   1.227Mi ± 0%    1.056Mi ± 0%  -13.91% (p=0.000 n=10)
TPCC/Gen4Greedy-20                             1.227Mi ± 0%    1.056Mi ± 0%  -13.90% (p=0.000 n=10)
TPCC/Gen4Left2Right-20                         1.205Mi ± 0%    1.045Mi ± 0%  -13.25% (p=0.000 n=10)
TPCH/Gen4-20                                  12.031Mi ± 0%    5.328Mi ± 0%  -55.71% (p=0.000 n=10)
TPCH/Gen4Greedy-20                            12.032Mi ± 0%    5.328Mi ± 0%  -55.72% (p=0.000 n=10)
TPCH/Gen4Left2Right-20                        11.314Mi ± 0%    4.806Mi ± 0%  -57.52% (p=0.000 n=10)
Planner/from_cases.json-gen4-20                6.173Mi ± 0%    4.504Mi ± 0%  -27.05% (p=0.000 n=10)
Planner/from_cases.json-gen4left2right-20      5.643Mi ± 0%    4.314Mi ± 0%  -23.54% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20              32.24Mi ± 0%    22.39Mi ± 0%  -30.56% (p=0.000 n=10)
Planner/filter_cases.json-gen4left2right-20    32.06Mi ± 0%    22.32Mi ± 0%  -30.39% (p=0.000 n=10)
Planner/large_cases.json-gen4-20               917.1Ki ± 0%    268.9Ki ± 0%  -70.67% (p=0.000 n=10)
Planner/large_cases.json-gen4left2right-20     567.2Ki ± 0%    174.7Ki ± 0%  -69.20% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20                9.879Mi ± 0%    7.183Mi ± 0%  -27.29% (p=0.000 n=10)
Planner/aggr_cases.json-gen4left2right-20      9.464Mi ± 0%    7.001Mi ± 0%  -26.02% (p=0.000 n=10)
Planner/select_cases.json-gen4-20              7.656Mi ± 0%    6.063Mi ± 0%  -20.81% (p=0.000 n=10)
Planner/select_cases.json-gen4left2right-20    7.356Mi ± 0%    5.959Mi ± 0%  -18.99% (p=0.000 n=10)
Planner/union_cases.json-gen4-20               2.661Mi ± 0%    2.215Mi ± 0%  -16.75% (p=0.000 n=10)
Planner/union_cases.json-gen4left2right-20     2.641Mi ± 0%    2.211Mi ± 0%  -16.29% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20       686.7Ki ± 0%    495.4Ki ± 0%  -27.86% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20   1581.4Ki ± 0%   1015.6Ki ± 0%  -35.78% (p=0.000 n=10)
geomean                                        2.720Mi         1.809Mi       -33.48%

                                            │    before    │              ../after               │
                                            │  allocs/op   │  allocs/op   vs base                │
OLTP/Gen4-20                                   4.050k ± 0%   3.612k ± 0%  -10.81% (p=0.000 n=10)
OLTP/Gen4Greedy-20                             4.050k ± 0%   3.612k ± 0%  -10.81% (p=0.000 n=10)
OLTP/Gen4Left2Right-20                         4.050k ± 0%   3.612k ± 0%  -10.81% (p=0.000 n=10)
TPCC/Gen4-20                                   28.28k ± 0%   25.70k ± 0%   -9.13% (p=0.000 n=10)
TPCC/Gen4Greedy-20                             28.28k ± 0%   25.70k ± 0%   -9.13% (p=0.000 n=10)
TPCC/Gen4Left2Right-20                         27.84k ± 0%   25.45k ± 0%   -8.56% (p=0.000 n=10)
TPCH/Gen4-20                                   234.1k ± 0%   134.0k ± 0%  -42.77% (p=0.000 n=10)
TPCH/Gen4Greedy-20                             234.1k ± 0%   134.0k ± 0%  -42.77% (p=0.000 n=10)
TPCH/Gen4Left2Right-20                         216.4k ± 0%   124.1k ± 0%  -42.68% (p=0.000 n=10)
Planner/from_cases.json-gen4-20                135.8k ± 0%   106.7k ± 0%  -21.41% (p=0.000 n=10)
Planner/from_cases.json-gen4left2right-20      124.5k ± 0%   101.5k ± 0%  -18.49% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20              642.7k ± 0%   562.7k ± 0%  -12.44% (p=0.000 n=10)
Planner/filter_cases.json-gen4left2right-20    638.6k ± 0%   560.7k ± 0%  -12.20% (p=0.000 n=10)
Planner/large_cases.json-gen4-20               22.67k ± 0%   10.52k ± 0%  -53.57% (p=0.000 n=10)
Planner/large_cases.json-gen4left2right-20    13.486k ± 0%   6.206k ± 0%  -53.98% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20                202.6k ± 0%   164.8k ± 0%  -18.66% (p=0.000 n=10)
Planner/aggr_cases.json-gen4left2right-20      193.6k ± 0%   160.3k ± 0%  -17.23% (p=0.000 n=10)
Planner/select_cases.json-gen4-20              166.0k ± 0%   140.4k ± 0%  -15.45% (p=0.000 n=10)
Planner/select_cases.json-gen4left2right-20    159.5k ± 0%   137.4k ± 0%  -13.85% (p=0.000 n=10)
Planner/union_cases.json-gen4-20               58.41k ± 0%   52.06k ± 0%  -10.87% (p=0.000 n=10)
Planner/union_cases.json-gen4left2right-20     57.95k ± 0%   51.89k ± 0%  -10.45% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20       13.87k ± 0%   10.27k ± 0%  -25.98% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20    33.14k ± 0%   23.26k ± 0%  -29.82% (p=0.000 n=10)
geomean                                        59.29k        45.40k       -23.43%
```

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
