### PR TITLE
Online DDL: new `message_timestamp` column in `schema_migrations` table

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -1320,6 +1320,7 @@ func testScheduler(t *testing.T) {
 		for _, row := range rs.Named().Rows {
 			message := row["message"].ToString()
 			require.Contains(t, message, "errno 1146")
+			require.False(t, row["message_timestamp"].IsNull())
 		}
 	})
 
@@ -1463,6 +1464,7 @@ func testScheduler(t *testing.T) {
 				for _, row := range rs.Named().Rows {
 					message := row["message"].ToString()
 					require.Contains(t, message, vuuids[2]) // Indicating this migration failed due to vuuids[2] failure
+					require.False(t, row["message_timestamp"].IsNull())
 				}
 			}
 		})

--- a/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
+++ b/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
     `migration_context`               varchar(1024)    NOT NULL DEFAULT '',
     `ddl_action`                      varchar(16)      NOT NULL DEFAULT '',
     `message`                         text             NOT NULL,
+    `message_timestamp`               timestamp(6)     NULL     DEFAULT NULL,
     `eta_seconds`                     bigint           NOT NULL DEFAULT '-1',
     `rows_copied`                     bigint unsigned  NOT NULL DEFAULT '0',
     `table_rows`                      bigint           NOT NULL DEFAULT '0',

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -209,7 +209,9 @@ const (
 			migration_uuid=%a
 	`
 	sqlUpdateMessage = `UPDATE _vt.schema_migrations
-			SET message=%a
+			SET
+				message=%a,
+				message_timestamp=NOW(6)
 		WHERE
 			migration_uuid=%a
 	`


### PR DESCRIPTION

## Description

This PR introduces `schema_migrations. message_timestamp` column, which gets updated to current timestamp whenever `message` gets updated.

The column gets auto-populated with the same query that updates the `message`. There is thus no actual code change other than an SQL.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/16632

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
