### PR TITLE
Update golangci-lint to newer faster version

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Install golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2
 
       - name: Clean Env
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -14,7 +14,33 @@
 # limitations under the License.
 
 # Required version of golangci-lint
-REQUIRED_VERSION="v1.60.1"
+REQUIRED_VERSION="v1.60.2"
+
+# Function to compare versions in pure Bash
+version_greater_or_equal() {
+  local IFS=.
+  local i
+  local ver1=($1)
+  local ver2=($2)
+
+  # Fill empty fields in ver1 with zeros
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+    ver1[i]=0
+  done
+  # Fill empty fields in ver2 with zeros
+  for ((i=${#ver2[@]}; i<${#ver1[@]}; i++)); do
+    ver2[i]=0
+  done
+
+  for ((i=0; i<${#ver1[@]}; i++)); do
+    if ((10#${ver1[i]} > 10#${ver2[i]})); then
+      return 0
+    elif ((10#${ver1[i]} < 10#${ver2[i]})); then
+      return 1
+    fi
+  done
+  return 0
+}
 
 # Check if golangci-lint is installed and capture the version
 if ! command -v golangci-lint >/dev/null 2>&1; then
@@ -22,10 +48,10 @@ if ! command -v golangci-lint >/dev/null 2>&1; then
   go install github.com/golangci/golangci-lint/cmd/golangci-lint@$REQUIRED_VERSION
 else
   VERSION_OUTPUT=$(golangci-lint --version)
-  INSTALLED_VERSION=$(echo "$VERSION_OUTPUT" | sed -n 's/^golangci-lint has version \([v0-9.]*\).*/\1/p')
-  if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
-    echo "golangci-lint version $INSTALLED_VERSION found, but $REQUIRED_VERSION is required."
-    echo "Installing correct version $REQUIRED_VERSION..."
+  INSTALLED_VERSION=$(echo "$VERSION_OUTPUT" | sed -n 's/^golangci-lint has version v\([0-9.]*\).*/\1/p')
+  if ! version_greater_or_equal "$INSTALLED_VERSION" "${REQUIRED_VERSION#v}"; then
+    echo "golangci-lint version $INSTALLED_VERSION found, but $REQUIRED_VERSION or newer is required."
+    echo "Installing version $REQUIRED_VERSION..."
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@$REQUIRED_VERSION
   fi
 fi


### PR DESCRIPTION
## Description
We’ve recently updated to `golangci-lint v1.60.1`, but it was found to be a slower release. This PR upgrades the version to `v1.60.2`, which offers improved performance.

Additionally, this PR enhances the git hook to ensure that golangci-lint is updated only if the installed version is older than the required version. This prevents unnecessary downgrades and ensures that the tool is always up-to-date with the specified or newer version.

## Related Issue(s)
https://github.com/vitessio/vitess/pull/16599

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
