### PR TITLE
Fix race conditions in the concatenate engine streaming

### DIFF
--- a/go/vt/vtgate/engine/concatenate_test.go
+++ b/go/vt/vtgate/engine/concatenate_test.go
@@ -124,27 +124,24 @@ func TestConcatenate_NoErrors(t *testing.T) {
 			if !tx {
 				txStr = "NotInTx"
 			}
-			t.Run(fmt.Sprintf("%s-%s-Exec", txStr, tc.testName), func(t *testing.T) {
-				qr, err := concatenate.TryExecute(context.Background(), vcursor, nil, true)
+			checkResult := func(t *testing.T, qr *sqltypes.Result, err error) {
 				if tc.expectedError == "" {
 					require.NoError(t, err)
 					utils.MustMatch(t, tc.expectedResult.Fields, qr.Fields, "fields")
-					utils.MustMatch(t, tc.expectedResult.Rows, qr.Rows)
-				} else {
-					require.Error(t, err)
-					require.Contains(t, err.Error(), tc.expectedError)
-				}
-			})
-
-			t.Run(fmt.Sprintf("%s-%s-StreamExec", txStr, tc.testName), func(t *testing.T) {
-				qr, err := wrapStreamExecute(concatenate, vcursor, nil, true)
-				if tc.expectedError == "" {
-					require.NoError(t, err)
 					require.NoError(t, sqltypes.RowsEquals(tc.expectedResult.Rows, qr.Rows))
 				} else {
 					require.Error(t, err)
 					require.Contains(t, err.Error(), tc.expectedError)
 				}
+			}
+			t.Run(fmt.Sprintf("%s-%s-Exec", txStr, tc.testName), func(t *testing.T) {
+				qr, err := concatenate.TryExecute(context.Background(), vcursor, nil, true)
+				checkResult(t, qr, err)
+			})
+
+			t.Run(fmt.Sprintf("%s-%s-StreamExec", txStr, tc.testName), func(t *testing.T) {
+				qr, err := wrapStreamExecute(concatenate, vcursor, nil, true)
+				checkResult(t, qr, err)
 			})
 		}
 	}

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -188,6 +189,15 @@ func wrapStreamExecute(prim Primitive, vcursor VCursor, bindVars map[string]*que
 		if result == nil {
 			result = r
 		} else {
+			if r.Fields != nil {
+				for i, field := range r.Fields {
+					aField := field
+					bField := result.Fields[i]
+					if !proto.Equal(aField, bField) {
+						return fmt.Errorf("fields differ: %s <> %s", aField.String(), bField.String())
+					}
+				}
+			}
 			result.Rows = append(result.Rows, r.Rows...)
 		}
 		return nil

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -112,7 +112,7 @@ func (f *fakePrimitive) syncCall(wantfields bool, callback func(*sqltypes.Result
 		}
 		result := &sqltypes.Result{}
 		for i := 0; i < len(r.Rows); i++ {
-			result.Rows = append(result.Rows, r.Rows[i])
+			result.Rows = append(result.Rows, sqltypes.CopyRow(r.Rows[i]))
 			// Send only two rows at a time.
 			if i%2 == 1 {
 				if err := callback(result); err != nil {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
While looking at the flaky test pointed out in https://github.com/vitessio/vitess/issues/16641 we found several issues in concatenate engine primitive in the streaming mode. The following are the issues and the fixes in this PR - 

1. In the parallel streaming mode, when we calculate the final field types for the result using`getFieldTypes`, we were overriding the fields of one of the result packets that we got. If this was a packet from a source that needed coercion, because we overwrote the fields, with what we expect them to be, when we check if coercion is required we end up with false even when it requires coercion. This is fixed in the PR by storing the result fields separately and checking for needing coercion with the original fields of the result.
2. Another failure that was found was in the sequential streaming mode. This failure was also masked by the fact that we were not copying the rows when returning the result set in fake primitive. So the only time this test would fail was when ☝️ failed too. If that passed this would pass as well. We have fixed the tests as part of this PR to copy the rows as well before returning them since the concatenate engine modifies them so each test wasn't running with the desired inputs. 
The problem was that we were checking for needing coercion per result packet. But in the streaming mode, if a source is sending multiple packets, then only the first packet will have the fields and the others won't. This leads to the concatenate engine only coercing values in the first packet and not in the subsequent ones since there are no fields. The fix was to check for needing coercion once for a given source and use it for all its packets.
3. Final failure was found after noticing that in the test we weren't checking for the fields in the stream execute output. This has been fixed wherein we now verify we get the correct fields from stream execute as well. Moreover, another check has been added that ensures that all the fields returned as part of the results should match. Previously we would only fix the fields in the first packet that was sent, but the remaining packets could have incorrect names and field types in them because we never overwrote them. The fix is to only send fields for the first result and empty them out for all the others.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/16641

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
