### PR TITLE
VReplication workflows: retry "wrong tablet type" errors

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -134,7 +134,12 @@ func isUnrecoverableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if vterrors.Code(err) == vtrpcpb.Code_FAILED_PRECONDITION {
+	switch vterrors.Code(err) {
+	case vtrpcpb.Code_FAILED_PRECONDITION:
+		if vterrors.RxWrongTablet.MatchString(err.Error()) {
+			// If the chosen tablet type picked changes, say due to PRS/ERS, we should retry.
+			return false
+		}
 		return true
 	}
 	sqlErr, isSQLErr := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError)


### PR DESCRIPTION
## Description

If a tablet picker is configured to pick `REPLICA` tablet types only, and when it starts streaming the selected tablet is promoted to a `PRIMARY` because of a PRS or ERS, the vttablet returns an grpc error like `"error": "vttablet: rpc error: code = FailedPrecondition desc = wrong tablet type: PRIMARY, want: REPLICA or []",`

Currently all `FailedPrecondition`s are treated as unrecoverable errors for vreplication workflows. This PR adds an exception for  the `wrong tablet` `FailedPrecondition`error treats it as recoverable.

This will resolve situations where there was race where
* the tablet picker on the target chooses a tablet, type `REPLICA`
* the target is about to do a VStream RPC to that tablet. The RPC request has `query.Target` which has the expected `TabletType` 
* there is PRS and the tablet promotes 
* the tablet then responds to the RPC, but fails because the request's tablet type doesn't match the current tablet type

Note:
It is possible that this is not a race, but a missing watcher event. In that case, unless the local health check state gets refreshed with the new info, we will still see the same errors, if that tablet was selected again. 

Backport reason: We should fix this on all supported versions, since it is a long-standing issue.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16646

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

