### PR TITLE
Fix Precedence rule for Tilda op

### DIFF
--- a/go/test/endtoend/vtgate/vitess_tester/dual/queries.test
+++ b/go/test/endtoend/vtgate/vitess_tester/dual/queries.test
@@ -1,0 +1,4 @@
+# file with tests that only use the dual table
+
+# Dual query that is using tilda operator in a complex expression
+SELECT 1 WHERE (~ (1||0)) IS NULL;

--- a/go/test/endtoend/vtgate/vitess_tester/join/join.test
+++ b/go/test/endtoend/vtgate/vitess_tester/join/join.test
@@ -76,6 +76,3 @@ from t1
          left join (select t4.col, count(*) as count from t4 group by t4.col) t3 on t3.col = t2.id
 where t1.id IN (1, 2)
 group by t2.id, t4.col;
-
-# Dual query that is using tilda operator in a complex expression
-SELECT 1 WHERE (~ (1||0)) IS NULL;

--- a/go/test/endtoend/vtgate/vitess_tester/join/join.test
+++ b/go/test/endtoend/vtgate/vitess_tester/join/join.test
@@ -77,3 +77,5 @@ from t1
 where t1.id IN (1, 2)
 group by t2.id, t4.col;
 
+# Dual query that is using tilda operator in a complex expression
+SELECT 1 WHERE (~ (1||0)) IS NULL;

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -418,6 +418,13 @@ func TestNormalize(t *testing.T) {
 			"bv2": sqltypes.Int64BindVariable(2),
 			"bv3": sqltypes.TestBindVariable([]any{1, 2}),
 		},
+	}, {
+		in:      "SELECT 1 WHERE (~ (1||0)) IS NULL",
+		outstmt: "select :bv1 /* INT64 */ from dual where ~(:bv1 /* INT64 */ or :bv2 /* INT64 */) is null",
+		outbv: map[string]*querypb.BindVariable{
+			"bv1": sqltypes.Int64BindVariable(1),
+			"bv2": sqltypes.Int64BindVariable(0),
+		},
 	}}
 	parser := NewTestParser()
 	for _, tc := range testcases {
@@ -508,6 +515,7 @@ func TestNormalizeOneCasae(t *testing.T) {
 	err = Normalize(tree, NewReservedVars("vtg", known), bv)
 	require.NoError(t, err)
 	normalizerOutput := String(tree)
+	require.EqualValues(t, testOne.output, normalizerOutput)
 	if normalizerOutput == "otheradmin" || normalizerOutput == "otherread" {
 		return
 	}

--- a/go/vt/sqlparser/precedence.go
+++ b/go/vt/sqlparser/precedence.go
@@ -38,7 +38,6 @@ const (
 	P14
 	P15
 	P16
-	P17
 )
 
 // precedenceFor returns the precedence of an expression.
@@ -83,7 +82,7 @@ func precedenceFor(in Expr) Precendence {
 		switch node.Operator {
 		case UPlusOp, UMinusOp:
 			return P4
-		case BangOp:
+		default:
 			return P3
 		}
 	}

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -158,6 +158,7 @@ func TestParens(t *testing.T) {
 		{in: "(10 - 2) - 1", expected: "10 - 2 - 1"},
 		{in: "10 - (2 - 1)", expected: "10 - (2 - 1)"},
 		{in: "0 <=> (1 and 0)", expected: "0 <=> (1 and 0)"},
+		{in: "(~ (1||0)) IS NULL", expected: "~(1 or 0) is null"},
 	}
 
 	parser := NewTestParser()

--- a/go/vt/vtgate/planbuilder/testdata/onecase.json
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.json
@@ -1,7 +1,7 @@
 [
   {
     "comment": "Add your test case here for debugging and run go test -run=One.",
-    "query": "",
+    "query": "SELECT 1 WHERE (~ (1||0)) IS NULL",
     "plan": {
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/onecase.json
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.json
@@ -1,7 +1,7 @@
 [
   {
     "comment": "Add your test case here for debugging and run go test -run=One.",
-    "query": "SELECT 1 WHERE (~ (1||0)) IS NULL",
+    "query": "",
     "plan": {
     }
   }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR the bug described in https://github.com/vitessio/vitess/issues/16590.
The problem with the precedence rules, where-in after normalization, we would print the query as follows - 
```sql
select 1 from dual where ~1 or 0 is null
```
This is different from the original query - 
```sql
select 1 from dual where (~(1 or 0)) is null
```

The problem has been fixed by updating the precedence rules by adding one for tilda op.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/16590

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
