### PR TITLE
fix sizegen so it handles type aliases

### DIFF
--- a/go/mysql/collations/colldata/cached_size.go
+++ b/go/mysql/collations/colldata/cached_size.go
@@ -19,10 +19,6 @@ package colldata
 
 import hack "vitess.io/vitess/go/hack"
 
-type cachedObject interface {
-	CachedSize(alloc bool) int64
-}
-
 func (cached *eightbitWildcard) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -62,10 +58,6 @@ func (cached *unicodeWildcard) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(48)
-	}
-	// field charset vitess.io/vitess/go/mysql/collations/charset/types.Charset
-	if cc, ok := cached.charset.(cachedObject); ok {
-		size += cc.CachedSize(true)
 	}
 	// field pattern []rune
 	{

--- a/go/sqltypes/cached_size.go
+++ b/go/sqltypes/cached_size.go
@@ -34,17 +34,9 @@ func (cached *Result) CachedSize(alloc bool) int64 {
 			size += elem.CachedSize(true)
 		}
 	}
-	// field Rows [][]vitess.io/vitess/go/sqltypes.Value
+	// field Rows []vitess.io/vitess/go/sqltypes.Row
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Rows)) * int64(24))
-		for _, elem := range cached.Rows {
-			{
-				size += hack.RuntimeAllocSize(int64(cap(elem)) * int64(32))
-				for _, elem := range elem {
-					size += elem.CachedSize(false)
-				}
-			}
-		}
 	}
 	// field SessionStateChanges string
 	size += hack.RuntimeAllocSize(int64(len(cached.SessionStateChanges)))

--- a/go/tools/sizegen/sizegen.go
+++ b/go/tools/sizegen/sizegen.go
@@ -149,11 +149,20 @@ func (sizegen *sizegen) generateType(pkg *types.Package, file *codeFile, named *
 	case *types.Interface:
 		findImplementations(pkg.Scope(), tt, func(tt types.Type) {
 			if _, isStruct := tt.Underlying().(*types.Struct); isStruct {
-				sizegen.generateKnownType(tt.(*types.Named))
+				sizegen.generateTyp(tt)
 			}
 		})
 	default:
 		// no-op
+	}
+}
+
+func (sizegen *sizegen) generateTyp(tt types.Type) {
+	switch tt := tt.(type) {
+	case *types.Named:
+		sizegen.generateKnownType(tt)
+	case *types.Alias:
+		sizegen.generateTyp(types.Unalias(tt))
 	}
 }
 

--- a/go/vt/proto/query/cached_size.go
+++ b/go/vt/proto/query/cached_size.go
@@ -27,10 +27,6 @@ func (cached *BindVariable) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(96)
 	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
-	}
 	// field Value []byte
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Value)))
@@ -51,10 +47,6 @@ func (cached *Field) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(160)
-	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Name string
 	size += hack.RuntimeAllocSize(int64(len(cached.Name)))
@@ -78,10 +70,6 @@ func (cached *QueryWarning) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(64)
 	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
-	}
 	// field Message string
 	size += hack.RuntimeAllocSize(int64(len(cached.Message)))
 	return size
@@ -93,10 +81,6 @@ func (cached *Target) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(96)
-	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Keyspace string
 	size += hack.RuntimeAllocSize(int64(len(cached.Keyspace)))
@@ -113,10 +97,6 @@ func (cached *Value) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(80)
-	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Value []byte
 	{

--- a/go/vt/proto/topodata/cached_size.go
+++ b/go/vt/proto/topodata/cached_size.go
@@ -27,10 +27,6 @@ func (cached *KeyRange) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(96)
 	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
-	}
 	// field Start []byte
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Start)))
@@ -48,10 +44,6 @@ func (cached *ThrottledAppRule) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(80)
-	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Name string
 	size += hack.RuntimeAllocSize(int64(len(cached.Name)))

--- a/go/vt/proto/vttime/cached_size.go
+++ b/go/vt/proto/vttime/cached_size.go
@@ -17,8 +17,6 @@ limitations under the License.
 
 package vttime
 
-import hack "vitess.io/vitess/go/hack"
-
 func (cached *Time) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -26,10 +24,6 @@ func (cached *Time) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(64)
-	}
-	// field unknownFields []byte
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	return size
 }


### PR DESCRIPTION
## Description
The `sizegen` code generator wasn't handling type aliases well, so `make sizegen` was failing:

```
2024/08/26 09:31:48 unhandled type: *types.Alias
panic: interface conversion: types.Type is *types.Alias, not *types.Named

goroutine 1 [running]:
main.(*sizegen).generateType.func1({0x741a58, 0xc09ef28840})
	/home/runner/work/vitess/vitess/go/tools/sizegen/sizegen.go:152 +0x6f
main.findImplementations(0xc0949f9140, 0xc09e30c1e0, 0xc000031890)
	/home/runner/work/vitess/vitess/go/tools/sizegen/sizegen.go:176 +0xee
main.(*sizegen).generateType(0xc000031ce8, 0xc0949f91a0, 0xc051cbe7b0, 0xc09e320e00)
	/home/runner/work/vitess/vitess/go/tools/sizegen/sizegen.go:150 +0x285
main.(*sizegen).generateKnownType(0xc000031ce8, 0xc09e320e00)
```

This PR fixes sizegen so it can handle type aliases.

## Related Issue(s)

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
