### PR TITLE
Update micromatch to 4.0.8

### DIFF
--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -10777,11 +10777,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {


### PR DESCRIPTION
## Description

This PR bumps our npm package `micromatch` from `4.0.5` to `4.0.8`. This fixes a CVE https://github.com/vitessio/vitess/security/dependabot/385 that is fixed in `4.0.8`.