### PR TITLE
Fix `docker_lite_push` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,7 @@ $(DOCKER_LITE_TARGETS): docker_lite_%:
 	${call build_docker_image,docker/lite/Dockerfile.$*,vitess/lite:$*}
 
 docker_lite_push:
+	echo "pushing lite image: latest" && docker push vitess/lite:latest
 	for i in $(DOCKER_LITE_SUFFIX); do echo "pushing lite image: $$i"; docker push vitess/lite:$$i || exit 1; done
 
 docker_lite_all: docker_lite $(DOCKER_LITE_TARGETS)


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/pull/16042 I modified the make targets touching our `vitess/lite` docker image, and the push target is a bit broken, it only pushes suffixed images (`percona80`, etc) and not `latest`. This PR is a merge of what we had before + what was fixed in 16042.

Backporting this to 20.0 as the original PR was merge there too.