### PR TITLE
change AndExpr to contain arbitrary many predicates

### DIFF
--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -209,10 +209,10 @@ func TestAndExpressions(t *testing.T) {
 				equalExpr,
 				equalExpr,
 			},
-			expectedOutput: &AndExpr{
-				Left:  greaterThanExpr,
-				Right: equalExpr,
-			},
+			expectedOutput: &AndExpr{Predicates: Exprs{
+				greaterThanExpr,
+				equalExpr,
+			}},
 		},
 		{
 			name: "two equal inputs",

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -720,6 +720,11 @@ type (
 
 	// IndexType is the type of index in a DDL statement
 	IndexType int8
+
+	WhereAble interface {
+		AddWhere(e Expr)
+		GetWherePredicate() Expr
+	}
 )
 
 var _ OrderAndLimit = (*Select)(nil)

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2263,7 +2263,7 @@ type (
 	}
 
 	// AndExpr represents an AND expression.
-	AndExpr struct{ Predicates []Expr }
+	AndExpr struct{ Predicates Exprs }
 
 	// OrExpr represents an OR expression.
 	OrExpr struct {

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2263,9 +2263,7 @@ type (
 	}
 
 	// AndExpr represents an AND expression.
-	AndExpr struct {
-		Left, Right Expr
-	}
+	AndExpr struct{ Predicates []Expr }
 
 	// OrExpr represents an OR expression.
 	OrExpr struct {

--- a/go/vt/sqlparser/ast_clone.go
+++ b/go/vt/sqlparser/ast_clone.go
@@ -744,7 +744,7 @@ func CloneRefOfAndExpr(n *AndExpr) *AndExpr {
 		return nil
 	}
 	out := *n
-	out.Predicates = CloneSliceOfExpr(n.Predicates)
+	out.Predicates = CloneExprs(n.Predicates)
 	return &out
 }
 
@@ -4368,18 +4368,6 @@ func CloneSliceOfIdentifierCI(n []IdentifierCI) []IdentifierCI {
 	return res
 }
 
-// CloneSliceOfExpr creates a deep clone of the input.
-func CloneSliceOfExpr(n []Expr) []Expr {
-	if n == nil {
-		return nil
-	}
-	res := make([]Expr, len(n))
-	for i, x := range n {
-		res[i] = CloneExpr(x)
-	}
-	return res
-}
-
 // CloneSliceOfTxAccessMode creates a deep clone of the input.
 func CloneSliceOfTxAccessMode(n []TxAccessMode) []TxAccessMode {
 	if n == nil {
@@ -4465,6 +4453,18 @@ func CloneSliceOfRefOfVariable(n []*Variable) []*Variable {
 	res := make([]*Variable, len(n))
 	for i, x := range n {
 		res[i] = CloneRefOfVariable(x)
+	}
+	return res
+}
+
+// CloneSliceOfExpr creates a deep clone of the input.
+func CloneSliceOfExpr(n []Expr) []Expr {
+	if n == nil {
+		return nil
+	}
+	res := make([]Expr, len(n))
+	for i, x := range n {
+		res[i] = CloneExpr(x)
 	}
 	return res
 }

--- a/go/vt/sqlparser/ast_clone.go
+++ b/go/vt/sqlparser/ast_clone.go
@@ -744,8 +744,7 @@ func CloneRefOfAndExpr(n *AndExpr) *AndExpr {
 		return nil
 	}
 	out := *n
-	out.Left = CloneExpr(n.Left)
-	out.Right = CloneExpr(n.Right)
+	out.Predicates = CloneSliceOfExpr(n.Predicates)
 	return &out
 }
 
@@ -4369,6 +4368,18 @@ func CloneSliceOfIdentifierCI(n []IdentifierCI) []IdentifierCI {
 	return res
 }
 
+// CloneSliceOfExpr creates a deep clone of the input.
+func CloneSliceOfExpr(n []Expr) []Expr {
+	if n == nil {
+		return nil
+	}
+	res := make([]Expr, len(n))
+	for i, x := range n {
+		res[i] = CloneExpr(x)
+	}
+	return res
+}
+
 // CloneSliceOfTxAccessMode creates a deep clone of the input.
 func CloneSliceOfTxAccessMode(n []TxAccessMode) []TxAccessMode {
 	if n == nil {
@@ -4454,18 +4465,6 @@ func CloneSliceOfRefOfVariable(n []*Variable) []*Variable {
 	res := make([]*Variable, len(n))
 	for i, x := range n {
 		res[i] = CloneRefOfVariable(x)
-	}
-	return res
-}
-
-// CloneSliceOfExpr creates a deep clone of the input.
-func CloneSliceOfExpr(n []Expr) []Expr {
-	if n == nil {
-		return nil
-	}
-	res := make([]Expr, len(n))
-	for i, x := range n {
-		res[i] = CloneExpr(x)
 	}
 	return res
 }

--- a/go/vt/sqlparser/ast_copy_on_rewrite.go
+++ b/go/vt/sqlparser/ast_copy_on_rewrite.go
@@ -953,18 +953,10 @@ func (c *cow) copyOnRewriteRefOfAndExpr(n *AndExpr, parent SQLNode) (out SQLNode
 	}
 	out = n
 	if c.pre == nil || c.pre(n, parent) {
-		var changedPredicates bool
-		_Predicates := make([]Expr, len(n.Predicates))
-		for x, el := range n.Predicates {
-			this, changed := c.copyOnRewriteExpr(el, n)
-			_Predicates[x] = this.(Expr)
-			if changed {
-				changedPredicates = true
-			}
-		}
+		_Predicates, changedPredicates := c.copyOnRewriteExprs(n.Predicates, n)
 		if changedPredicates {
 			res := *n
-			res.Predicates = _Predicates
+			res.Predicates, _ = _Predicates.(Exprs)
 			out = &res
 			if c.cloned != nil {
 				c.cloned(n, out)

--- a/go/vt/sqlparser/ast_copy_on_rewrite.go
+++ b/go/vt/sqlparser/ast_copy_on_rewrite.go
@@ -953,12 +953,18 @@ func (c *cow) copyOnRewriteRefOfAndExpr(n *AndExpr, parent SQLNode) (out SQLNode
 	}
 	out = n
 	if c.pre == nil || c.pre(n, parent) {
-		_Left, changedLeft := c.copyOnRewriteExpr(n.Left, n)
-		_Right, changedRight := c.copyOnRewriteExpr(n.Right, n)
-		if changedLeft || changedRight {
+		var changedPredicates bool
+		_Predicates := make([]Expr, len(n.Predicates))
+		for x, el := range n.Predicates {
+			this, changed := c.copyOnRewriteExpr(el, n)
+			_Predicates[x] = this.(Expr)
+			if changed {
+				changedPredicates = true
+			}
+		}
+		if changedPredicates {
 			res := *n
-			res.Left, _ = _Left.(Expr)
-			res.Right, _ = _Right.(Expr)
+			res.Predicates = _Predicates
 			out = &res
 			if c.cloned != nil {
 				c.cloned(n, out)

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -1863,8 +1863,7 @@ func (cmp *Comparator) RefOfAndExpr(a, b *AndExpr) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return cmp.Expr(a.Left, b.Left) &&
-		cmp.Expr(a.Right, b.Right)
+	return cmp.SliceOfExpr(a.Predicates, b.Predicates)
 }
 
 // RefOfAnyValue does deep equals between the two objects.
@@ -7246,6 +7245,19 @@ func (cmp *Comparator) SliceOfIdentifierCI(a, b []IdentifierCI) bool {
 	return true
 }
 
+// SliceOfExpr does deep equals between the two objects.
+func (cmp *Comparator) SliceOfExpr(a, b []Expr) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if !cmp.Expr(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // SliceOfTxAccessMode does deep equals between the two objects.
 func (cmp *Comparator) SliceOfTxAccessMode(a, b []TxAccessMode) bool {
 	if len(a) != len(b) {
@@ -7348,19 +7360,6 @@ func (cmp *Comparator) SliceOfRefOfVariable(a, b []*Variable) bool {
 	}
 	for i := 0; i < len(a); i++ {
 		if !cmp.RefOfVariable(a[i], b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-// SliceOfExpr does deep equals between the two objects.
-func (cmp *Comparator) SliceOfExpr(a, b []Expr) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if !cmp.Expr(a[i], b[i]) {
 			return false
 		}
 	}

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -1863,7 +1863,7 @@ func (cmp *Comparator) RefOfAndExpr(a, b *AndExpr) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return cmp.SliceOfExpr(a.Predicates, b.Predicates)
+	return cmp.Exprs(a.Predicates, b.Predicates)
 }
 
 // RefOfAnyValue does deep equals between the two objects.
@@ -7245,19 +7245,6 @@ func (cmp *Comparator) SliceOfIdentifierCI(a, b []IdentifierCI) bool {
 	return true
 }
 
-// SliceOfExpr does deep equals between the two objects.
-func (cmp *Comparator) SliceOfExpr(a, b []Expr) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if !cmp.Expr(a[i], b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 // SliceOfTxAccessMode does deep equals between the two objects.
 func (cmp *Comparator) SliceOfTxAccessMode(a, b []TxAccessMode) bool {
 	if len(a) != len(b) {
@@ -7360,6 +7347,19 @@ func (cmp *Comparator) SliceOfRefOfVariable(a, b []*Variable) bool {
 	}
 	for i := 0; i < len(a); i++ {
 		if !cmp.RefOfVariable(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// SliceOfExpr does deep equals between the two objects.
+func (cmp *Comparator) SliceOfExpr(a, b []Expr) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if !cmp.Expr(a[i], b[i]) {
 			return false
 		}
 	}

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1297,7 +1297,13 @@ func (node Exprs) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *AndExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%l and %r", node.Left, node.Right)
+	for idx, expr := range node.Predicates {
+		if idx == len(node.Predicates)-1 {
+			buf.astPrintf(node, "%r", expr)
+			continue
+		}
+		buf.astPrintf(node, "%l and ", expr)
+	}
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1684,9 +1684,14 @@ func (node Exprs) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (node *AndExpr) FormatFast(buf *TrackedBuffer) {
-	buf.printExpr(node, node.Left, true)
-	buf.WriteString(" and ")
-	buf.printExpr(node, node.Right, false)
+	for idx, expr := range node.Predicates {
+		if idx == len(node.Predicates)-1 {
+			buf.printExpr(node, expr, false)
+			continue
+		}
+		buf.printExpr(node, expr, true)
+		buf.WriteString(" and ")
+	}
 }
 
 // FormatFast formats the node.

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -66,7 +66,7 @@ func Append(buf *strings.Builder, node SQLNode) {
 	node.FormatFast(tbuf)
 }
 
-func createAndExpr(exprL, exprR Expr) *AndExpr {
+func CreateAndExpr(exprL, exprR Expr) *AndExpr {
 	leftAnd, isLeftAnd := exprL.(*AndExpr)
 	rightAnd, isRightAnd := exprR.(*AndExpr)
 	if isLeftAnd && isRightAnd {
@@ -1261,7 +1261,7 @@ func addPredicate(where *Where, pred Expr) *Where {
 		}
 	}
 
-	where.Expr = createAndExpr(where.Expr, pred)
+	where.Expr = CreateAndExpr(where.Expr, pred)
 	return where
 }
 
@@ -2358,17 +2358,6 @@ func SplitAndExpression(filters []Expr, node Expr) []Expr {
 		return append(filters, node.Predicates...)
 	}
 	return append(filters, node)
-}
-
-func CreateAndExpr(exprs ...Expr) Expr {
-	switch len(exprs) {
-	case 0:
-		return nil
-	case 1:
-		return exprs[0]
-	default:
-		return &AndExpr{Predicates: exprs}
-	}
 }
 
 // AndExpressions ands together two or more expressions, minimising the expr when possible

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2360,6 +2360,17 @@ func SplitAndExpression(filters []Expr, node Expr) []Expr {
 	return append(filters, node)
 }
 
+func CreateAndExpr(exprs ...Expr) Expr {
+	switch len(exprs) {
+	case 0:
+		return nil
+	case 1:
+		return exprs[0]
+	default:
+		return &AndExpr{Predicates: exprs}
+	}
+}
+
 // AndExpressions ands together two or more expressions, minimising the expr when possible
 func AndExpressions(exprs ...Expr) Expr {
 	switch len(exprs) {

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2391,6 +2391,9 @@ func AndExpressions(exprs ...Expr) Expr {
 				uniqueAdd(expr)
 			}
 		}
+		if len(unique) == 1 {
+			return unique[0]
+		}
 		return &AndExpr{Predicates: unique}
 	}
 }

--- a/go/vt/sqlparser/ast_rewrite.go
+++ b/go/vt/sqlparser/ast_rewrite.go
@@ -1088,14 +1088,10 @@ func (a *application) rewriteRefOfAndExpr(parent SQLNode, node *AndExpr, replace
 			return true
 		}
 	}
-	for x, el := range node.Predicates {
-		if !a.rewriteExpr(node, el, func(idx int) replacerFunc {
-			return func(newNode, parent SQLNode) {
-				parent.(*AndExpr).Predicates[idx] = newNode.(Expr)
-			}
-		}(x)) {
-			return false
-		}
+	if !a.rewriteExprs(node, node.Predicates, func(newNode, parent SQLNode) {
+		parent.(*AndExpr).Predicates = newNode.(Exprs)
+	}) {
+		return false
 	}
 	if a.post != nil {
 		a.cur.replacer = replacer

--- a/go/vt/sqlparser/ast_rewrite.go
+++ b/go/vt/sqlparser/ast_rewrite.go
@@ -1088,15 +1088,14 @@ func (a *application) rewriteRefOfAndExpr(parent SQLNode, node *AndExpr, replace
 			return true
 		}
 	}
-	if !a.rewriteExpr(node, node.Left, func(newNode, parent SQLNode) {
-		parent.(*AndExpr).Left = newNode.(Expr)
-	}) {
-		return false
-	}
-	if !a.rewriteExpr(node, node.Right, func(newNode, parent SQLNode) {
-		parent.(*AndExpr).Right = newNode.(Expr)
-	}) {
-		return false
+	for x, el := range node.Predicates {
+		if !a.rewriteExpr(node, el, func(idx int) replacerFunc {
+			return func(newNode, parent SQLNode) {
+				parent.(*AndExpr).Predicates[idx] = newNode.(Expr)
+			}
+		}(x)) {
+			return false
+		}
 	}
 	if a.post != nil {
 		a.cur.replacer = replacer

--- a/go/vt/sqlparser/ast_visit.go
+++ b/go/vt/sqlparser/ast_visit.go
@@ -811,10 +811,8 @@ func VisitRefOfAndExpr(in *AndExpr, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	for _, el := range in.Predicates {
-		if err := VisitExpr(el, f); err != nil {
-			return err
-		}
+	if err := VisitExprs(in.Predicates, f); err != nil {
+		return err
 	}
 	return nil
 }

--- a/go/vt/sqlparser/ast_visit.go
+++ b/go/vt/sqlparser/ast_visit.go
@@ -811,11 +811,10 @@ func VisitRefOfAndExpr(in *AndExpr, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitExpr(in.Left, f); err != nil {
-		return err
-	}
-	if err := VisitExpr(in.Right, f); err != nil {
-		return err
+	for _, el := range in.Predicates {
+		if err := VisitExpr(el, f); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -319,9 +319,8 @@ func (cached *AndExpr) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(64)
+		size += int64(24)
 	}
-	// field Right vitess.io/vitess/go/vt/sqlparser.Expr
 	// field Predicates vitess.io/vitess/go/vt/sqlparser.Exprs
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Predicates)) * int64(16))

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -319,15 +319,17 @@ func (cached *AndExpr) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(32)
-	}
-	// field Left vitess.io/vitess/go/vt/sqlparser.Expr
-	if cc, ok := cached.Left.(cachedObject); ok {
-		size += cc.CachedSize(true)
+		size += int64(64)
 	}
 	// field Right vitess.io/vitess/go/vt/sqlparser.Expr
-	if cc, ok := cached.Right.(cachedObject); ok {
-		size += cc.CachedSize(true)
+	// field Predicates vitess.io/vitess/go/vt/sqlparser.Exprs
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Predicates)) * int64(16))
+		for _, elem := range cached.Predicates {
+			if cc, ok := elem.(cachedObject); ok {
+				size += cc.CachedSize(true)
+			}
+		}
 	}
 	return size
 }

--- a/go/vt/sqlparser/predicate_rewriting.go
+++ b/go/vt/sqlparser/predicate_rewriting.go
@@ -181,10 +181,13 @@ func simplifyOr(or *OrExpr) (Expr, bool) {
 	// Distribution Law
 	var distributedPredicates []Expr
 	for _, lp := range and.Predicates {
-		distributedPredicates = append(distributedPredicates, &OrExpr{
-			Left:  lp,
-			Right: other,
-		})
+		var or *OrExpr
+		if lok {
+			or = &OrExpr{Left: lp, Right: other}
+		} else {
+			or = &OrExpr{Left: other, Right: lp}
+		}
+		distributedPredicates = append(distributedPredicates, or)
 	}
 	return AndExpressions(distributedPredicates...), true
 }

--- a/go/vt/sqlparser/predicate_rewriting_test.go
+++ b/go/vt/sqlparser/predicate_rewriting_test.go
@@ -44,7 +44,7 @@ func TestSimplifyExpression(in *testing.T) {
 		expected: "(A or C) and (B or C)",
 	}, {
 		in:       "C or (A and B)",
-		expected: "(C or A) and (C or B)",
+		expected: "(A or C) and (B or C)",
 	}, {
 		in:       "A and A",
 		expected: "A",
@@ -111,10 +111,13 @@ func TestRewritePredicate(in *testing.T) {
 		expected: "A and B",
 	}, {
 		in:       "((A and B) OR (A and C) OR (A and D)) and E and F",
-		expected: "A and (B or C or D) and E and F",
+		expected: "E and F and A and (B or C or D)",
 	}, {
-		in:       "(A and B) OR (A and C)",
-		expected: "A and (B or C)",
+		in:       "(A and B) OR (A and C) OR (A and D)",
+		expected: "A and (B or C or D)",
+	}, {
+		in:       "((A and B) OR (A and C)) and E",
+		expected: "E and A and (B or C)",
 	}, {
 		in:       "(A and B) OR (C and A)",
 		expected: "A and (B or C)",
@@ -133,26 +136,26 @@ func TestRewritePredicate(in *testing.T) {
 	}, {
 		in: "(a = 1 and b = 41) or (a = 2 and b = 42)",
 		// this might look weird, but it allows the planner to either a or b in a vindex operation
-		expected: "a in (1, 2) and (a = 1 or b = 42) and ((b = 41 or a = 2) and b in (41, 42))",
+		expected: "a in (2, 1) and (b = 42 or a = 1) and (a = 2 or b = 41) and b in (42, 41)",
 	}, {
 		in:       "(a = 1 and b = 41) or (a = 2 and b = 42) or (a = 3 and b = 43)",
-		expected: "a in (1, 2, 3) and (a in (1, 2) or b = 43) and ((a = 1 or b = 42 or a = 3) and (a = 1 or b = 42 or b = 43)) and ((b = 41 or a = 2 or a = 3) and (b = 41 or a = 2 or b = 43) and ((b in (41, 42) or a = 3) and b in (41, 42, 43)))",
+		expected: "a in (3, 2, 1) and (b = 43 or a in (2, 1)) and (a = 3 or (b = 42 or a = 1)) and (b = 43 or (b = 42 or a = 1)) and (a = 3 or (a = 2 or b = 41)) and (b = 43 or (a = 2 or b = 41)) and (a = 3 or b in (42, 41)) and b in (43, 42, 41)",
 	}, {
 		// the following two tests show some pathological cases that would grow too much, and so we abort the rewriting
 		in:       "a = 1 and b = 41 or a = 2 and b = 42 or a = 3 and b = 43 or a = 4 and b = 44 or a = 5 and b = 45 or a = 6 and b = 46",
 		expected: "a = 1 and b = 41 or a = 2 and b = 42 or a = 3 and b = 43 or a = 4 and b = 44 or a = 5 and b = 45 or a = 6 and b = 46",
 	}, {
 		in:       "a = 5 and B or a = 6 and C",
-		expected: "a in (5, 6) and (a = 5 or C) and ((B or a = 6) and (B or C))",
+		expected: "a in (6, 5) and (C or a = 5) and (a = 6 or B) and (C or B)",
 	}, {
 		in:       "(a = 5 and b = 1 or b = 2 and a = 6)",
-		expected: "(a = 5 or b = 2) and a in (5, 6) and (b in (1, 2) and (b = 1 or a = 6))",
+		expected: "(b = 2 or a = 5) and a in (6, 5) and b in (2, 1) and (a = 6 or b = 1)",
 	}, {
 		in:       "(a in (1,5) and B or C and a = 6)",
-		expected: "(a in (1, 5) or C) and a in (1, 5, 6) and ((B or C) and (B or a = 6))",
+		expected: "(C or a in (1, 5)) and a in (6, 1, 5) and (C or B) and (a = 6 or B)",
 	}, {
 		in:       "(a in (1, 5) and B or C and a in (5, 7))",
-		expected: "(a in (1, 5) or C) and a in (1, 5, 7) and ((B or C) and (B or a in (5, 7)))",
+		expected: "(C or a in (1, 5)) and a in (5, 7, 1) and (C or B) and (a in (5, 7) or B)",
 	}, {
 		in:       "not n0 xor not (n2 and n3) xor (not n2 and (n1 xor n1) xor (n0 xor n0 xor n2))",
 		expected: "not n0 xor not (n2 and n3) xor (not n2 and (n1 xor n1) xor (n0 xor n0 xor n2))",

--- a/go/vt/sqlparser/predicate_rewriting_test.go
+++ b/go/vt/sqlparser/predicate_rewriting_test.go
@@ -44,7 +44,7 @@ func TestSimplifyExpression(in *testing.T) {
 		expected: "(A or C) and (B or C)",
 	}, {
 		in:       "C or (A and B)",
-		expected: "(A or C) and (B or C)",
+		expected: "(C or A) and (C or B)",
 	}, {
 		in:       "A and A",
 		expected: "A",
@@ -136,26 +136,26 @@ func TestRewritePredicate(in *testing.T) {
 	}, {
 		in: "(a = 1 and b = 41) or (a = 2 and b = 42)",
 		// this might look weird, but it allows the planner to either a or b in a vindex operation
-		expected: "a in (2, 1) and (b = 42 or a = 1) and (a = 2 or b = 41) and b in (42, 41)",
+		expected: "a in (1, 2) and (a = 1 or b = 42) and (b = 41 or a = 2) and b in (41, 42)",
 	}, {
 		in:       "(a = 1 and b = 41) or (a = 2 and b = 42) or (a = 3 and b = 43)",
-		expected: "a in (3, 2, 1) and (b = 43 or a in (2, 1)) and (a = 3 or (b = 42 or a = 1)) and (b = 43 or (b = 42 or a = 1)) and (a = 3 or (a = 2 or b = 41)) and (b = 43 or (a = 2 or b = 41)) and (a = 3 or b in (42, 41)) and b in (43, 42, 41)",
+		expected: "a in (1, 2, 3) and (a in (1, 2) or b = 43) and (a = 1 or b = 42 or a = 3) and (a = 1 or b = 42 or b = 43) and (b = 41 or a = 2 or a = 3) and (b = 41 or a = 2 or b = 43) and (b in (41, 42) or a = 3) and b in (41, 42, 43)",
 	}, {
 		// the following two tests show some pathological cases that would grow too much, and so we abort the rewriting
 		in:       "a = 1 and b = 41 or a = 2 and b = 42 or a = 3 and b = 43 or a = 4 and b = 44 or a = 5 and b = 45 or a = 6 and b = 46",
 		expected: "a = 1 and b = 41 or a = 2 and b = 42 or a = 3 and b = 43 or a = 4 and b = 44 or a = 5 and b = 45 or a = 6 and b = 46",
 	}, {
 		in:       "a = 5 and B or a = 6 and C",
-		expected: "a in (6, 5) and (C or a = 5) and (a = 6 or B) and (C or B)",
+		expected: "a in (5, 6) and (a = 5 or C) and (B or a = 6) and (B or C)",
 	}, {
 		in:       "(a = 5 and b = 1 or b = 2 and a = 6)",
-		expected: "(b = 2 or a = 5) and a in (6, 5) and b in (2, 1) and (a = 6 or b = 1)",
+		expected: "(a = 5 or b = 2) and a in (5, 6) and b in (1, 2) and (b = 1 or a = 6)",
 	}, {
 		in:       "(a in (1,5) and B or C and a = 6)",
-		expected: "(C or a in (1, 5)) and a in (6, 1, 5) and (C or B) and (a = 6 or B)",
+		expected: "(a in (1, 5) or C) and a in (1, 5, 6) and (B or C) and (B or a = 6)",
 	}, {
 		in:       "(a in (1, 5) and B or C and a in (5, 7))",
-		expected: "(C or a in (1, 5)) and a in (5, 7, 1) and (C or B) and (a in (5, 7) or B)",
+		expected: "(a in (1, 5) or C) and a in (1, 5, 7) and (B or C) and (B or a in (5, 7))",
 	}, {
 		in:       "not n0 xor not (n2 and n3) xor (not n2 and (n1 xor n1) xor (n0 xor n0 xor n2))",
 		expected: "not n0 xor not (n2 and n3) xor (not n2 and (n1 xor n1) xor (n0 xor n0 xor n2))",

--- a/go/vt/sqlparser/random_expr.go
+++ b/go/vt/sqlparser/random_expr.go
@@ -231,7 +231,7 @@ func (g *Generator) makeAggregateIfNecessary(genConfig ExprGeneratorConfig, expr
 	// if the generated expression must be an aggregate, and it is not,
 	// tack on an extra "and count(*)" to make it aggregate
 	if genConfig.AggrRule == IsAggregate && !g.isAggregate && g.depth == 0 {
-		expr = createAndExpr(expr, &CountStar{})
+		expr = CreateAndExpr(expr, &CountStar{})
 		g.isAggregate = true
 	}
 
@@ -474,7 +474,7 @@ func (g *Generator) randomOfS(options []string) string {
 func (g *Generator) andExpr(genConfig ExprGeneratorConfig) Expr {
 	g.enter()
 	defer g.exit()
-	return createAndExpr(
+	return CreateAndExpr(
 		g.Expression(genConfig),
 		g.Expression(genConfig),
 	)

--- a/go/vt/sqlparser/random_expr.go
+++ b/go/vt/sqlparser/random_expr.go
@@ -231,10 +231,7 @@ func (g *Generator) makeAggregateIfNecessary(genConfig ExprGeneratorConfig, expr
 	// if the generated expression must be an aggregate, and it is not,
 	// tack on an extra "and count(*)" to make it aggregate
 	if genConfig.AggrRule == IsAggregate && !g.isAggregate && g.depth == 0 {
-		expr = &AndExpr{
-			Left:  expr,
-			Right: &CountStar{},
-		}
+		expr = createAndExpr(expr, &CountStar{})
 		g.isAggregate = true
 	}
 
@@ -269,7 +266,7 @@ func (g *Generator) booleanExpr(genConfig ExprGeneratorConfig) Expr {
 		func() Expr { return g.orExpr(genConfig) },
 		func() Expr { return g.comparison(genConfig.intTypeConfig()) },
 		func() Expr { return g.comparison(genConfig.stringTypeConfig()) },
-		//func() Expr { return g.comparison(genConfig) }, // this is not accepted by the parser
+		// func() Expr { return g.comparison(genConfig) }, // this is not accepted by the parser
 		func() Expr { return g.inExpr(genConfig) },
 		func() Expr { return g.existsExpr(genConfig) },
 		func() Expr { return g.between(genConfig.intTypeConfig()) },
@@ -374,7 +371,7 @@ func (g *Generator) randomBool(prob float32) bool {
 }
 
 func (g *Generator) intLiteral() Expr {
-	t := fmt.Sprintf("%d", rand.IntN(100)-rand.IntN(100)) //nolint SA4000
+	t := fmt.Sprintf("%d", rand.IntN(100)-rand.IntN(100)) // nolint SA4000
 
 	return NewIntLiteral(t)
 }
@@ -477,10 +474,10 @@ func (g *Generator) randomOfS(options []string) string {
 func (g *Generator) andExpr(genConfig ExprGeneratorConfig) Expr {
 	g.enter()
 	defer g.exit()
-	return &AndExpr{
-		Left:  g.Expression(genConfig),
-		Right: g.Expression(genConfig),
-	}
+	return createAndExpr(
+		g.Expression(genConfig),
+		g.Expression(genConfig),
+	)
 }
 
 func (g *Generator) orExpr(genConfig ExprGeneratorConfig) Expr {

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -17811,7 +17811,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:5308
 		{
-			yyLOCAL = &AndExpr{Left: yyDollar[1].exprUnion(), Right: yyDollar[3].exprUnion()}
+			yyLOCAL = createAndExpr(yyDollar[1].exprUnion(), yyDollar[3].exprUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 1013:

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -17811,7 +17811,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:5308
 		{
-			yyLOCAL = createAndExpr(yyDollar[1].exprUnion(), yyDollar[3].exprUnion())
+			yyLOCAL = CreateAndExpr(yyDollar[1].exprUnion(), yyDollar[3].exprUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 1013:

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -5306,7 +5306,7 @@ expression:
   }
 | expression AND expression %prec AND
   {
-    $$ = createAndExpr($1,$3)
+    $$ = CreateAndExpr($1, $3)
   }
 | NOT expression %prec NOT
   {

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -5306,7 +5306,7 @@ expression:
   }
 | expression AND expression %prec AND
   {
-    $$ = &AndExpr{Left: $1, Right: $3}
+    $$ = createAndExpr($1,$3)
   }
 | NOT expression %prec NOT
   {

--- a/go/vt/sqlparser/testdata/select_cases.txt
+++ b/go/vt/sqlparser/testdata/select_cases.txt
@@ -3872,7 +3872,7 @@ INPUT
 select a1,a2,b,min(c) from t1 where ((a1 > 'a') or (a1 < '9')) and ((a2 >= 'b') and (a2 < 'z')) and (b = 'a') and ((c < 'h112') or (c = 'j121') or (c > 'k121' and c < 'm122') or (c > 'o122')) group by a1,a2,b;
 END
 OUTPUT
-select a1, a2, b, min(c) from t1 where (a1 > 'a' or a1 < '9') and (a2 >= 'b' and a2 < 'z') and b = 'a' and (c < 'h112' or c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122') group by a1, a2, b
+select a1, a2, b, min(c) from t1 where (a1 > 'a' or a1 < '9') and a2 >= 'b' and a2 < 'z' and b = 'a' and (c < 'h112' or c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122') group by a1, a2, b
 END
 INPUT
 select a, quote(a), isnull(quote(a)), quote(a) is null, ifnull(quote(a), 'n') from t1;
@@ -6434,7 +6434,7 @@ INPUT
 select distinct t1.project_id as project_id, t1.project_name as project_name, t1.client_ptr as client_ptr, t1.comments as comments, sum( t3.amount_received ) + sum( t3.adjustment ) as total_budget from t2 as client_period , t2 as project_period, t3 left join t1 on (t3.project_ptr = t1.project_id and t3.date_received <= '2001-03-22 14:15:09') left join t4 on t4.client_id = t1.client_ptr where 1 and ( client_period.period_type = 'client_table' and client_period.period_key = t4.client_id and ( client_period.start_date <= '2001-03-22 14:15:09' or isnull( client_period.start_date )) and ( client_period.end_date > '2001-03-21 14:15:09' or isnull( client_period.end_date )) ) and ( project_period.period_type = 'project_table' and project_period.period_key = t1.project_id and ( project_period.start_date <= '2001-03-22 14:15:09' or isnull( project_period.start_date )) and ( project_period.end_date > '2001-03-21 14:15:09' or isnull( project_period.end_date )) ) group by client_id, project_id , client_period.period_id , project_period.period_id order by client_name asc, project_name asc;
 END
 OUTPUT
-select distinct t1.project_id as project_id, t1.project_name as project_name, t1.client_ptr as client_ptr, t1.comments as comments, sum(t3.amount_received) + sum(t3.adjustment) as total_budget from t2 as client_period, t2 as project_period, t3 left join t1 on t3.project_ptr = t1.project_id and t3.date_received <= '2001-03-22 14:15:09' left join t4 on t4.client_id = t1.client_ptr where 1 and (client_period.period_type = 'client_table' and client_period.period_key = t4.client_id and (client_period.start_date <= '2001-03-22 14:15:09' or isnull(client_period.start_date)) and (client_period.end_date > '2001-03-21 14:15:09' or isnull(client_period.end_date))) and (project_period.period_type = 'project_table' and project_period.period_key = t1.project_id and (project_period.start_date <= '2001-03-22 14:15:09' or isnull(project_period.start_date)) and (project_period.end_date > '2001-03-21 14:15:09' or isnull(project_period.end_date))) group by client_id, project_id, client_period.period_id, project_period.period_id order by client_name asc, project_name asc
+select distinct t1.project_id as project_id, t1.project_name as project_name, t1.client_ptr as client_ptr, t1.comments as comments, sum(t3.amount_received) + sum(t3.adjustment) as total_budget from t2 as client_period, t2 as project_period, t3 left join t1 on t3.project_ptr = t1.project_id and t3.date_received <= '2001-03-22 14:15:09' left join t4 on t4.client_id = t1.client_ptr where 1 and client_period.period_type = 'client_table' and client_period.period_key = t4.client_id and (client_period.start_date <= '2001-03-22 14:15:09' or isnull(client_period.start_date)) and (client_period.end_date > '2001-03-21 14:15:09' or isnull(client_period.end_date)) and project_period.period_type = 'project_table' and project_period.period_key = t1.project_id and (project_period.start_date <= '2001-03-22 14:15:09' or isnull(project_period.start_date)) and (project_period.end_date > '2001-03-21 14:15:09' or isnull(project_period.end_date)) group by client_id, project_id, client_period.period_id, project_period.period_id order by client_name asc, project_name asc
 END
 INPUT
 select a1,a2,b,min(c) from t2 where b is NULL group by a1,a2;
@@ -9368,7 +9368,7 @@ INPUT
 select a1,a2,b,min(c) from t1 where ((a1 > 'a') or (a1 < '9')) and ((a2 >= 'b') and (a2 < 'z')) and (b = 'a') and ((c = 'j121') or (c > 'k121' and c < 'm122') or (c > 'o122') or (c < 'h112') or (c = 'c111')) group by a1,a2,b;
 END
 OUTPUT
-select a1, a2, b, min(c) from t1 where (a1 > 'a' or a1 < '9') and (a2 >= 'b' and a2 < 'z') and b = 'a' and (c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122' or c < 'h112' or c = 'c111') group by a1, a2, b
+select a1, a2, b, min(c) from t1 where (a1 > 'a' or a1 < '9') and a2 >= 'b' and a2 < 'z' and b = 'a' and (c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122' or c < 'h112' or c = 'c111') group by a1, a2, b
 END
 INPUT
 select count(distinct n1) from t1;
@@ -10886,7 +10886,7 @@ INPUT
 select a1,a2,b,min(c) from t2 where ((a1 > 'a') or (a1 < '9')) and ((a2 >= 'b') and (a2 < 'z')) and (b = 'a') and ((c = 'j121') or (c > 'k121' and c < 'm122') or (c > 'o122') or (c < 'h112') or (c = 'c111')) group by a1,a2,b;
 END
 OUTPUT
-select a1, a2, b, min(c) from t2 where (a1 > 'a' or a1 < '9') and (a2 >= 'b' and a2 < 'z') and b = 'a' and (c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122' or c < 'h112' or c = 'c111') group by a1, a2, b
+select a1, a2, b, min(c) from t2 where (a1 > 'a' or a1 < '9') and a2 >= 'b' and a2 < 'z' and b = 'a' and (c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122' or c < 'h112' or c = 'c111') group by a1, a2, b
 END
 INPUT
 select * from t1 where a > 5 xor a < 10;
@@ -20882,7 +20882,7 @@ INPUT
 select a1,a2,b,min(c) from t2 where ((a1 > 'a') or (a1 < '9')) and ((a2 >= 'b') and (a2 < 'z')) and (b = 'a') and ((c < 'h112') or (c = 'j121') or (c > 'k121' and c < 'm122') or (c > 'o122')) group by a1,a2,b;
 END
 OUTPUT
-select a1, a2, b, min(c) from t2 where (a1 > 'a' or a1 < '9') and (a2 >= 'b' and a2 < 'z') and b = 'a' and (c < 'h112' or c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122') group by a1, a2, b
+select a1, a2, b, min(c) from t2 where (a1 > 'a' or a1 < '9') and a2 >= 'b' and a2 < 'z' and b = 'a' and (c < 'h112' or c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122') group by a1, a2, b
 END
 INPUT
 select group_concat(c1 order by c1) from t1 group by c1 collate utf8_latvian_ci;

--- a/go/vt/sqlparser/utils.go
+++ b/go/vt/sqlparser/utils.go
@@ -97,10 +97,7 @@ func (p *Parser) NormalizeAlphabetically(query string) (normalized string, err e
 					Expr: expr,
 				}
 			} else {
-				newWhere.Expr = &AndExpr{
-					Left:  newWhere.Expr,
-					Right: expr,
-				}
+				newWhere.Expr = AndExpressions(newWhere.Expr, expr)
 			}
 		}
 		switch stmt := stmt.(type) {

--- a/go/vt/vtctl/workflow/materializer.go
+++ b/go/vt/vtctl/workflow/materializer.go
@@ -234,10 +234,10 @@ func (mz *materializer) generateBinlogSources(ctx context.Context, targetShard *
 					Name:  sqlparser.NewIdentifierCI("in_keyrange"),
 					Exprs: subExprs,
 				}
-				addFilter(sel, inKeyRange)
+				sel.AddWhere(inKeyRange)
 			}
 			if tenantClause != nil {
-				addFilter(sel, *tenantClause)
+				sel.AddWhere(*tenantClause)
 			}
 			rule.Filter = sqlparser.String(sel)
 			bls.Filter.Rules = append(bls.Filter.Rules, rule)

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -968,7 +968,7 @@ func (ts *trafficSwitcher) addTenantFilter(ctx context.Context, filter string) (
 	if !ok {
 		return "", fmt.Errorf("unrecognized statement: %s", filter)
 	}
-	addFilter(sel, *tenantClause)
+	sel.AddWhere(*tenantClause)
 	filter = sqlparser.String(sel)
 	return filter, nil
 }

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -793,23 +793,6 @@ func LegacyBuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.Table
 	}, nil
 }
 
-func addFilter(sel *sqlparser.Select, filter sqlparser.Expr) {
-	if sel.Where != nil {
-		sel.Where = &sqlparser.Where{
-			Type: sqlparser.WhereClause,
-			Expr: &sqlparser.AndExpr{
-				Left:  filter,
-				Right: sel.Where.Expr,
-			},
-		}
-	} else {
-		sel.Where = &sqlparser.Where{
-			Type: sqlparser.WhereClause,
-			Expr: filter,
-		}
-	}
-}
-
 func getTenantClause(vrOptions *vtctldatapb.WorkflowOptions,
 	targetVSchema *vindexes.KeyspaceSchema, parser *sqlparser.Parser) (*sqlparser.Expr, error) {
 	if vrOptions.TenantId == "" {

--- a/go/vt/vtctl/workflow/vexec/query_plan.go
+++ b/go/vt/vtctl/workflow/vexec/query_plan.go
@@ -52,22 +52,16 @@ type FixedQueryPlan struct {
 }
 
 // Execute is part of the QueryPlan interface.
-func (qp *FixedQueryPlan) Execute(ctx context.Context, target *topo.TabletInfo) (qr *querypb.QueryResult, err error) {
+func (qp *FixedQueryPlan) Execute(ctx context.Context, target *topo.TabletInfo) (*querypb.QueryResult, error) {
 	if qp.ParsedQuery == nil {
 		return nil, fmt.Errorf("%w: call PlanQuery on a query planner first", ErrUnpreparedQuery)
 	}
 
 	targetAliasStr := target.AliasString()
 
-	defer func() {
-		if err != nil {
-			log.Warningf("Result on %v: %v", targetAliasStr, err)
-			return
-		}
-	}()
-
-	qr, err = qp.tmc.VReplicationExec(ctx, target.Tablet, qp.ParsedQuery.Query)
+	qr, err := qp.tmc.VReplicationExec(ctx, target.Tablet, qp.ParsedQuery.Query)
 	if err != nil {
+		log.Warningf("Result on %v: %v", targetAliasStr, err)
 		return nil, err
 	}
 	return qr, nil

--- a/go/vt/vtctl/workflow/vexec/query_planner.go
+++ b/go/vt/vtctl/workflow/vexec/query_planner.go
@@ -354,10 +354,7 @@ func (planner *VReplicationLogQueryPlanner) planSelect(sel *sqlparser.Select) (Q
 		case nil:
 			targetWhere.Expr = expr
 		default:
-			targetWhere.Expr = &sqlparser.AndExpr{
-				Left:  expr,
-				Right: where.Expr,
-			}
+			targetWhere.Expr = sqlparser.CreateAndExpr(expr, where.Expr)
 		}
 
 		sel.Where = targetWhere
@@ -408,10 +405,7 @@ func addDefaultWheres(planner QueryPlanner, where *sqlparser.Where) *sqlparser.W
 				Expr: expr,
 			}
 		default:
-			newWhere.Expr = &sqlparser.AndExpr{
-				Left:  newWhere.Expr,
-				Right: expr,
-			}
+			newWhere.Expr = sqlparser.CreateAndExpr(newWhere.Expr, expr)
 		}
 	}
 
@@ -424,10 +418,7 @@ func addDefaultWheres(planner QueryPlanner, where *sqlparser.Where) *sqlparser.W
 			Right:    sqlparser.NewStrLiteral(params.Workflow),
 		}
 
-		newWhere.Expr = &sqlparser.AndExpr{
-			Left:  newWhere.Expr,
-			Right: expr,
-		}
+		newWhere.Expr = sqlparser.CreateAndExpr(newWhere.Expr, expr)
 	}
 
 	return newWhere

--- a/go/vt/vtctl/workflow/vexec/query_planner.go
+++ b/go/vt/vtctl/workflow/vexec/query_planner.go
@@ -330,12 +330,11 @@ func (planner *VReplicationLogQueryPlanner) planSelect(sel *sqlparser.Select) (Q
 				Right: sqlparser.NewIntLiteral(fmt.Sprintf("%d", streamIDs[0])),
 			}
 		default: // WHERE vreplication_log.vrepl_id IN (?)
-			vals := []sqlparser.Expr{}
+			var tuple sqlparser.ValTuple
 			for _, streamID := range streamIDs {
-				vals = append(vals, sqlparser.NewIntLiteral(fmt.Sprintf("%d", streamID)))
+				tuple = append(tuple, sqlparser.NewIntLiteral(fmt.Sprintf("%d", streamID)))
 			}
 
-			var tuple sqlparser.ValTuple = vals
 			expr = &sqlparser.ComparisonExpr{
 				Operator: sqlparser.InOp,
 				Left: &sqlparser.ColName{

--- a/go/vt/vtctl/workflow/vexec/query_planner_test.go
+++ b/go/vt/vtctl/workflow/vexec/query_planner_test.go
@@ -246,119 +246,114 @@ func TestVReplicationQueryPlanner_planDelete(t *testing.T) {
 func TestVReplicationLogQueryPlanner(t *testing.T) {
 	t.Parallel()
 
-	t.Run("planSelect", func(t *testing.T) {
-		t.Parallel()
-
-		tests := []struct {
-			name            string
-			targetStreamIDs map[string][]int64
-			query           string
-			assertion       func(t *testing.T, plan QueryPlan)
-			shouldErr       bool
-		}{
-			{
-				targetStreamIDs: map[string][]int64{
-					"a": {1, 2},
-				},
-				query: "select * from _vt.vreplication_log",
-				assertion: func(t *testing.T, plan QueryPlan) {
-					t.Helper()
-					qp, ok := plan.(*PerTargetQueryPlan)
-					if !ok {
-						require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
-					}
-
-					expected := map[string]string{
-						"a": "select * from _vt.vreplication_log where vrepl_id in (1, 2)",
-					}
-					assertQueryMapsMatch(t, expected, qp.ParsedQueries)
-				},
+	tests := []struct {
+		targetStreamIDs map[string][]int64
+		query           string
+		assertion       func(t *testing.T, plan QueryPlan)
+		shouldErr       bool
+	}{
+		{
+			targetStreamIDs: map[string][]int64{
+				"a": {1, 2},
 			},
-			{
-				targetStreamIDs: map[string][]int64{
-					"a": nil,
-				},
-				query: "select * from _vt.vreplication_log",
-				assertion: func(t *testing.T, plan QueryPlan) {
-					t.Helper()
-					qp, ok := plan.(*PerTargetQueryPlan)
-					if !ok {
-						require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
-					}
-
-					expected := map[string]string{
-						"a": "select * from _vt.vreplication_log where 1 != 1",
-					}
-					assertQueryMapsMatch(t, expected, qp.ParsedQueries)
-				},
-			},
-			{
-				targetStreamIDs: map[string][]int64{
-					"a": {1},
-				},
-				query: "select * from _vt.vreplication_log",
-				assertion: func(t *testing.T, plan QueryPlan) {
-					t.Helper()
-					qp, ok := plan.(*PerTargetQueryPlan)
-					if !ok {
-						require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
-					}
-
-					expected := map[string]string{
-						"a": "select * from _vt.vreplication_log where vrepl_id = 1",
-					}
-					assertQueryMapsMatch(t, expected, qp.ParsedQueries)
-				},
-			},
-			{
-				query: "select * from _vt.vreplication_log where vrepl_id = 1",
-				assertion: func(t *testing.T, plan QueryPlan) {
-					t.Helper()
-					qp, ok := plan.(*FixedQueryPlan)
-					if !ok {
-						require.FailNow(t, "failed type check", "expected plan to be FixedQueryPlan, got %T: %v", plan, plan)
-					}
-
-					assert.Equal(t, "select * from _vt.vreplication_log where vrepl_id = 1", qp.ParsedQuery.Query)
-				},
-			},
-			{
-				targetStreamIDs: map[string][]int64{
-					"a": {1, 2},
-				},
-				query: "select * from _vt.vreplication_log where foo = 'bar'",
-				assertion: func(t *testing.T, plan QueryPlan) {
-					t.Helper()
-					qp, ok := plan.(*PerTargetQueryPlan)
-					if !ok {
-						require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
-					}
-
-					expected := map[string]string{
-						"a": "select * from _vt.vreplication_log where vrepl_id in (1, 2) and foo = 'bar'",
-					}
-					assertQueryMapsMatch(t, expected, qp.ParsedQueries)
-				},
-			},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				t.Parallel()
-
-				planner := NewVReplicationLogQueryPlanner(nil, tt.targetStreamIDs)
-				stmt, err := sqlparser.NewTestParser().Parse(tt.query)
-				require.NoError(t, err, "could not parse query %q", tt.query)
-				qp, err := planner.planSelect(stmt.(*sqlparser.Select))
-				if tt.shouldErr {
-					assert.Error(t, err)
-					return
+			query: "select * from _vt.vreplication_log",
+			assertion: func(t *testing.T, plan QueryPlan) {
+				t.Helper()
+				qp, ok := plan.(*PerTargetQueryPlan)
+				if !ok {
+					require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
 				}
 
-				tt.assertion(t, qp)
-			})
-		}
-	})
+				expected := map[string]string{
+					"a": "select * from _vt.vreplication_log where vrepl_id in (1, 2)",
+				}
+				assertQueryMapsMatch(t, expected, qp.ParsedQueries)
+			},
+		},
+		{
+			targetStreamIDs: map[string][]int64{
+				"a": nil,
+			},
+			query: "select * from _vt.vreplication_log",
+			assertion: func(t *testing.T, plan QueryPlan) {
+				t.Helper()
+				qp, ok := plan.(*PerTargetQueryPlan)
+				if !ok {
+					require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
+				}
+
+				expected := map[string]string{
+					"a": "select * from _vt.vreplication_log where 1 != 1",
+				}
+				assertQueryMapsMatch(t, expected, qp.ParsedQueries)
+			},
+		},
+		{
+			targetStreamIDs: map[string][]int64{
+				"a": {1},
+			},
+			query: "select * from _vt.vreplication_log",
+			assertion: func(t *testing.T, plan QueryPlan) {
+				t.Helper()
+				qp, ok := plan.(*PerTargetQueryPlan)
+				if !ok {
+					require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
+				}
+
+				expected := map[string]string{
+					"a": "select * from _vt.vreplication_log where vrepl_id = 1",
+				}
+				assertQueryMapsMatch(t, expected, qp.ParsedQueries)
+			},
+		},
+		{
+			query: "select * from _vt.vreplication_log where vrepl_id = 1",
+			assertion: func(t *testing.T, plan QueryPlan) {
+				t.Helper()
+				qp, ok := plan.(*FixedQueryPlan)
+				if !ok {
+					require.FailNow(t, "failed type check", "expected plan to be FixedQueryPlan, got %T: %v", plan, plan)
+				}
+
+				assert.Equal(t, "select * from _vt.vreplication_log where vrepl_id = 1", qp.ParsedQuery.Query)
+			},
+		},
+		{
+			targetStreamIDs: map[string][]int64{
+				"a": {1, 2},
+			},
+			query: "select * from _vt.vreplication_log where foo = 'bar'",
+			assertion: func(t *testing.T, plan QueryPlan) {
+				t.Helper()
+				qp, ok := plan.(*PerTargetQueryPlan)
+				if !ok {
+					require.FailNow(t, "failed type check", "expected plan to be PerTargetQueryPlan, got %T: %v", plan, plan)
+				}
+
+				expected := map[string]string{
+					"a": "select * from _vt.vreplication_log where foo = 'bar' and vrepl_id in (1, 2)",
+				}
+				assertQueryMapsMatch(t, expected, qp.ParsedQueries)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			t.Parallel()
+
+			planner := NewVReplicationLogQueryPlanner(nil, tt.targetStreamIDs)
+			stmt, err := sqlparser.NewTestParser().Parse(tt.query)
+			require.NoError(t, err, "could not parse query %q", tt.query)
+			qp, err := planner.planSelect(stmt.(*sqlparser.Select))
+			if tt.shouldErr {
+				assert.Error(t, err)
+				return
+			}
+
+			tt.assertion(t, qp)
+		})
+	}
 }
 
 func assertQueryMapsMatch(t *testing.T, expected map[string]string, actual map[string]*sqlparser.ParsedQuery, msgAndArgs ...any) {

--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -50,8 +50,8 @@ func translateQueryToOp(ctx *plancontext.PlanningContext, selStmt sqlparser.Stat
 func createOperatorFromSelect(ctx *plancontext.PlanningContext, sel *sqlparser.Select) Operator {
 	op := crossJoin(ctx, sel.From)
 
-	if sel.Where != nil {
-		op = addWherePredicates(ctx, sel.Where.Expr, op)
+	if expr := sel.GetWherePredicate(); expr != nil {
+		op = addWherePredicates(ctx, expr, op)
 	}
 
 	if sel.Comments != nil || sel.Lock != sqlparser.NoLock {

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -193,7 +193,7 @@ func createDMLWithInput(ctx *plancontext.PlanningContext, op, src Operator, in *
 
 	if in.OwnedVindexQuery != nil {
 		in.OwnedVindexQuery.From = sqlparser.TableExprs{targetQT.Alias}
-		in.OwnedVindexQuery.Where = sqlparser.NewWhere(sqlparser.WhereClause, compExpr)
+		in.OwnedVindexQuery.AddWhere(compExpr)
 		in.OwnedVindexQuery.OrderBy = nil
 		in.OwnedVindexQuery.Limit = nil
 	}

--- a/go/vt/vtgate/planbuilder/operators/querygraph.go
+++ b/go/vt/vtgate/planbuilder/operators/querygraph.go
@@ -141,10 +141,7 @@ func (qg *QueryGraph) addNoDepsPredicate(predicate sqlparser.Expr) {
 	if qg.NoDeps == nil {
 		qg.NoDeps = predicate
 	} else {
-		qg.NoDeps = &sqlparser.AndExpr{
-			Left:  qg.NoDeps,
-			Right: predicate,
-		}
+		qg.NoDeps = sqlparser.AndExpressions(qg.NoDeps, predicate)
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -298,7 +298,7 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 		// lead to better routing. This however might not always be true for example we can have the rhsPred to be something like
 		// `user.id = 2 OR (:__sq_has_values AND user.id IN ::sql1)`
 		if andExpr, isAndExpr := rhsPred.(*sqlparser.AndExpr); isAndExpr {
-			predicates = append(predicates, andExpr.Left, andExpr.Right)
+			predicates = append(predicates, andExpr.Predicates...)
 		} else {
 			predicates = append(predicates, rhsPred)
 		}

--- a/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
@@ -64,10 +64,10 @@ func (tc testCase) createPredicate(lvl int) sqlparser.Expr {
 			Expr: tc.createPredicate(lvl + 1),
 		}
 	case AND:
-		return &sqlparser.AndExpr{
-			Left:  tc.createPredicate(lvl + 1),
-			Right: tc.createPredicate(lvl + 1),
-		}
+		return sqlparser.AndExpressions(
+			tc.createPredicate(lvl+1),
+			tc.createPredicate(lvl+1),
+		)
 	case OR:
 		return &sqlparser.OrExpr{
 			Left:  tc.createPredicate(lvl + 1),

--- a/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/predicate_rewrite_test.go
@@ -85,6 +85,11 @@ func (tc testCase) createPredicate(lvl int) sqlparser.Expr {
 }
 
 func TestOneRewriting(t *testing.T) {
+	// This test is a simple test that takes a single expression and simplifies it.
+	// While simplifying, it also collects all the steps that were taken to simplify the expression,
+	// and then runs both the original and simplified expressions with all possible values for the columns.
+	// If the two expressions do not return the same value, this is considered a test failure.
+	// This test is useful for debugging and understanding how the simplification works.
 	venv := vtenv.NewTestEnv()
 	sqlparser.DebugRewrite = true
 

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -789,7 +789,7 @@
           "Sharded": true
         },
         "FieldQuery": "select Id from `user` where 1 != 1",
-        "Query": "select Id from `user` where 1 in ('aa', 'bb')",
+        "Query": "select Id from `user` where 0",
         "Table": "`user`"
       },
       "TablesUsed": [
@@ -1251,7 +1251,7 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user` where 1 = 1",
+            "Query": "select `user`.col from `user`",
             "Table": "`user`"
           },
           {
@@ -1262,7 +1262,7 @@
               "Sharded": true
             },
             "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-            "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */ and 1 = 1",
+            "Query": "select user_extra.id from user_extra where user_extra.col = :user_col /* INT16 */",
             "Table": "user_extra"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -1606,7 +1606,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast('foo' as CHAR) is null or (u_tbl9.col9) not in ((cast('foo' as CHAR)))) limit 1 for share",
+                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (u_tbl9.col9) not in ((cast('foo' as CHAR))) limit 1 for share",
                 "Table": "u_tbl4, u_tbl9"
               },
               {

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_cases.json
@@ -1518,7 +1518,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
                 "Table": "u_tbl8, u_tbl9"
               },
               {
@@ -1594,7 +1594,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and cast('foo' as CHAR) is not null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
                 "Table": "u_tbl3, u_tbl4"
               },
               {
@@ -2532,7 +2532,7 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from u_multicol_tbl2 left join u_multicol_tbl1 on u_multicol_tbl1.cola = 2 and u_multicol_tbl1.colb = u_multicol_tbl2.colc - 2 where 1 != 1",
-            "Query": "select 1 from u_multicol_tbl2 left join u_multicol_tbl1 on u_multicol_tbl1.cola = 2 and u_multicol_tbl1.colb = u_multicol_tbl2.colc - 2 where u_multicol_tbl1.cola is null and 2 is not null and u_multicol_tbl1.colb is null and u_multicol_tbl2.colc - 2 is not null and not (u_multicol_tbl2.cola, u_multicol_tbl2.colb) <=> (2, u_multicol_tbl2.colc - 2) and u_multicol_tbl2.id = 7 limit 1 for share",
+            "Query": "select 1 from u_multicol_tbl2 left join u_multicol_tbl1 on u_multicol_tbl1.cola = 2 and u_multicol_tbl1.colb = u_multicol_tbl2.colc - 2 where u_multicol_tbl1.cola is null and u_multicol_tbl1.colb is null and u_multicol_tbl2.colc - 2 is not null and not (u_multicol_tbl2.cola, u_multicol_tbl2.colb) <=> (2, u_multicol_tbl2.colc - 2) and u_multicol_tbl2.id = 7 limit 1 for share",
             "Table": "u_multicol_tbl1, u_multicol_tbl2"
           },
           {
@@ -4110,7 +4110,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
                 "Table": "u_tbl8, u_tbl9"
               },
               {

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
@@ -1595,7 +1595,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and cast('foo' as CHAR) is not null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
+                "Query": "select 1 from u_tbl8 left join u_tbl9 on u_tbl9.col9 = cast('foo' as CHAR) where u_tbl9.col9 is null and not (u_tbl8.col8) <=> (cast('foo' as CHAR)) and (u_tbl8.col8) in ::fkc_vals limit 1 for share nowait",
                 "Table": "u_tbl8, u_tbl9"
               },
               {
@@ -1671,7 +1671,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where 1 != 1",
-                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and cast('foo' as CHAR) is not null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
+                "Query": "select 1 from u_tbl4 left join u_tbl3 on u_tbl3.col3 = cast('foo' as CHAR) where u_tbl3.col3 is null and not (u_tbl4.col4) <=> (cast('foo' as CHAR)) and (u_tbl4.col4) in ::fkc_vals limit 1 for share",
                 "Table": "u_tbl3, u_tbl4"
               },
               {

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
@@ -1683,7 +1683,7 @@
                   "Sharded": false
                 },
                 "FieldQuery": "select 1 from u_tbl4, u_tbl9 where 1 != 1",
-                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (cast('foo' as CHAR) is null or (u_tbl9.col9) not in ((cast('foo' as CHAR)))) limit 1 for share",
+                "Query": "select 1 from u_tbl4, u_tbl9 where u_tbl4.col4 = u_tbl9.col9 and (u_tbl4.col4) in ::fkc_vals and (u_tbl9.col9) not in ((cast('foo' as CHAR))) limit 1 for share",
                 "Table": "u_tbl4, u_tbl9"
               },
               {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1874,7 +1874,7 @@
           "Sharded": false
         },
         "FieldQuery": "select 42 from dual where 1 != 1",
-        "Query": "select 42 from dual where false",
+        "Query": "select 42 from dual where 0",
         "Table": "dual"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -50,8 +50,6 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 		return r.handleSelectExprs(cursor, node)
 	case *sqlparser.OrExpr:
 		rewriteOrExpr(r.env, cursor, node)
-	case *sqlparser.AndExpr:
-		rewriteAndExpr(r.env, cursor, node)
 	case *sqlparser.NotExpr:
 		rewriteNotExpr(cursor, node)
 	case *sqlparser.ComparisonExpr:
@@ -860,54 +858,6 @@ func rewriteOrExpr(env *vtenv.Environment, cursor *sqlparser.Cursor, node *sqlpa
 	if newNode != nil {
 		cursor.ReplaceAndRevisit(newNode)
 	}
-}
-
-// rewriteAndExpr rewrites AND expressions when either side is TRUE.
-func rewriteAndExpr(env *vtenv.Environment, cursor *sqlparser.Cursor, node *sqlparser.AndExpr) {
-	newNode := rewriteAndTrue(env, node)
-	if newNode != nil {
-		cursor.ReplaceAndRevisit(newNode)
-	}
-}
-
-func rewriteAndTrue(env *vtenv.Environment, andExpr *sqlparser.AndExpr) sqlparser.Expr {
-	// we are looking for the pattern `WHERE c = 1 AND 1 = 1`
-	isTrue := func(subExpr sqlparser.Expr) bool {
-		coll := env.CollationEnv().DefaultConnectionCharset()
-		evalEnginePred, err := evalengine.Translate(subExpr, &evalengine.Config{
-			Environment: env,
-			Collation:   coll,
-		})
-		if err != nil {
-			return false
-		}
-
-		env := evalengine.EmptyExpressionEnv(env)
-		res, err := env.Evaluate(evalEnginePred)
-		if err != nil {
-			return false
-		}
-
-		boolValue, err := res.Value(coll).ToBool()
-		if err != nil {
-			return false
-		}
-
-		return boolValue
-	}
-
-	var remaining sqlparser.Exprs
-	for _, p := range andExpr.Predicates {
-		if !isTrue(p) {
-			remaining = append(remaining, p)
-		}
-	}
-
-	if len(remaining) == len(andExpr.Predicates) {
-		return nil
-	}
-
-	return sqlparser.AndExpressions(remaining...)
 }
 
 // handleComparisonExpr processes Comparison expressions, specifically for tuples with equal length and EqualOp operator.

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -905,53 +905,6 @@ func TestOrderByDerivedTable(t *testing.T) {
 	}
 }
 
-// TestConstantFolding tests that the rewriter is able to do various constant foldings properly.
-func TestConstantFolding(t *testing.T) {
-	ks := &vindexes.Keyspace{
-		Name:    "main",
-		Sharded: true,
-	}
-	schemaInfo := &FakeSI{
-		Tables: map[string]*vindexes.Table{
-			"t1": {
-				Keyspace: ks,
-				Name:     sqlparser.NewIdentifierCS("t1"),
-				Columns: []vindexes.Column{{
-					Name: sqlparser.NewIdentifierCI("a"),
-					Type: sqltypes.VarChar,
-				}, {
-					Name: sqlparser.NewIdentifierCI("b"),
-					Type: sqltypes.VarChar,
-				}, {
-					Name: sqlparser.NewIdentifierCI("c"),
-					Type: sqltypes.VarChar,
-				}},
-				ColumnListAuthoritative: true,
-			},
-		},
-	}
-	cDB := "db"
-	tcases := []struct {
-		sql    string
-		expSQL string
-	}{{
-		sql:    "select 1 from t1 where (a, b) in ::fkc_vals and (2 is null or (1 is null or a in (1)))",
-		expSQL: "select 1 from t1 where (a, b) in ::fkc_vals and a in (1)",
-	}, {
-		sql:    "select 1 from t1 where (false or (false or a in (1)))",
-		expSQL: "select 1 from t1 where a in (1)",
-	}}
-	for _, tcase := range tcases {
-		t.Run(tcase.sql, func(t *testing.T) {
-			ast, err := sqlparser.NewTestParser().Parse(tcase.sql)
-			require.NoError(t, err)
-			_, err = Analyze(ast, cDB, schemaInfo)
-			require.NoError(t, err)
-			require.Equal(t, tcase.expSQL, sqlparser.String(ast))
-		})
-	}
-}
-
 // TestCTEToDerivedTableRewrite checks that CTEs are correctly rewritten to derived tables
 func TestCTEToDerivedTableRewrite(t *testing.T) {
 	cDB := "db"

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -309,10 +309,7 @@ func (s *scoper) createSpecialScopePostProjection(parent sqlparser.SQLNode) erro
 				// at this stage, we don't store the actual dependencies, we only store the expressions.
 				// only later will we walk the expression tree and figure out the deps. so, we need to create a
 				// composite expression that contains all the expressions in the SELECTs that this UNION consists of
-				tableInfo.cols[i] = &sqlparser.AndExpr{
-					Left:  col,
-					Right: thisTableInfo.cols[i],
-				}
+				tableInfo.cols[i] = sqlparser.CreateAndExpr(col, thisTableInfo.cols[i])
 			}
 		}
 

--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -911,7 +911,7 @@ func (st *SemTable) AndExpressions(exprs ...sqlparser.Expr) sqlparser.Expr {
 					continue outer
 				}
 			}
-			result = &sqlparser.AndExpr{Left: result, Right: expr}
+			result = sqlparser.AndExpressions(result, expr)
 		}
 		return result
 	}

--- a/go/vt/vtgate/simplifier/expression_simplifier.go
+++ b/go/vt/vtgate/simplifier/expression_simplifier.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"vitess.io/vitess/go/slice"
+
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
@@ -97,7 +99,10 @@ func (s *shrinker) fillQueue() bool {
 	before := len(s.queue)
 	switch e := s.orig.(type) {
 	case *sqlparser.AndExpr:
-		s.queue = append(s.queue, e.Left, e.Right)
+		addThese := slice.Map(e.Predicates, func(e sqlparser.Expr) sqlparser.SQLNode {
+			return e
+		})
+		s.queue = append(s.queue, addThese...)
 	case *sqlparser.OrExpr:
 		s.queue = append(s.queue, e.Left, e.Right)
 	case *sqlparser.ComparisonExpr:

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -518,7 +518,7 @@ func (plan *Plan) analyzeWhere(vschema *localVSchema, where *sqlparser.Where) er
 	if where == nil {
 		return nil
 	}
-	exprs := splitAndExpression(nil, where.Expr)
+	exprs := sqlparser.SplitAndExpression(nil, where.Expr)
 	for _, expr := range exprs {
 		switch expr := expr.(type) {
 		case *sqlparser.ComparisonExpr:
@@ -593,21 +593,6 @@ func (plan *Plan) analyzeWhere(vschema *localVSchema, where *sqlparser.Where) er
 		}
 	}
 	return nil
-}
-
-// splitAndExpression breaks up the Expr into AND-separated conditions
-// and appends them to filters, which can be shuffled and recombined
-// as needed.
-func splitAndExpression(filters []sqlparser.Expr, node sqlparser.Expr) []sqlparser.Expr {
-	if node == nil {
-		return filters
-	}
-	switch node := node.(type) {
-	case *sqlparser.AndExpr:
-		filters = splitAndExpression(filters, node.Left)
-		return splitAndExpression(filters, node.Right)
-	}
-	return append(filters, node)
 }
 
 func (plan *Plan) analyzeExprs(vschema *localVSchema, selExprs sqlparser.SelectExprs) error {

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -1405,21 +1405,7 @@ func (mz *materializer) generateInserts(ctx context.Context, sourceShards []*top
 					Name:  sqlparser.NewIdentifierCI("in_keyrange"),
 					Exprs: subExprs,
 				}
-				if sel.Where != nil {
-					sel.Where = &sqlparser.Where{
-						Type: sqlparser.WhereClause,
-						Expr: &sqlparser.AndExpr{
-							Left:  inKeyRange,
-							Right: sel.Where.Expr,
-						},
-					}
-				} else {
-					sel.Where = &sqlparser.Where{
-						Type: sqlparser.WhereClause,
-						Expr: inKeyRange,
-					}
-				}
-
+				sel.AddWhere(inKeyRange)
 				filter = sqlparser.String(sel)
 			}
 

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -1445,7 +1445,7 @@ func removeExprKeyrange(node sqlparser.Expr) sqlparser.Expr {
 				keep = append(keep, removeExprKeyrange(p))
 			}
 		}
-		return sqlparser.CreateAndExpr(keep...)
+		return sqlparser.AndExpressions(keep...)
 	}
 	return node
 }

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -1439,16 +1439,13 @@ func removeKeyrange(where *sqlparser.Where) *sqlparser.Where {
 func removeExprKeyrange(node sqlparser.Expr) sqlparser.Expr {
 	switch node := node.(type) {
 	case *sqlparser.AndExpr:
-		if isFuncKeyrange(node.Left) {
-			return removeExprKeyrange(node.Right)
+		var keep sqlparser.Exprs
+		for _, p := range node.Predicates {
+			if !isFuncKeyrange(p) {
+				keep = append(keep, removeExprKeyrange(p))
+			}
 		}
-		if isFuncKeyrange(node.Right) {
-			return removeExprKeyrange(node.Left)
-		}
-		return &sqlparser.AndExpr{
-			Left:  removeExprKeyrange(node.Left),
-			Right: removeExprKeyrange(node.Right),
-		}
+		return sqlparser.CreateAndExpr(keep...)
 	}
 	return node
 }


### PR DESCRIPTION
## Description
During planning, we often want to have predicates as a slice and not in a tree structure. This PR changes the `AndExpr` to contain a slice if inner predicates instead of `Left/Right` fields.

This PR also moves the checking for constant values in predicates to the planning stage. No need to do these rewrites if the whole query will be sent to MySQL.

## Summary of Performance Changes:

The recent changes introduced in this PR have resulted in mixed performance outcomes across various benchmarks:

1.	Plan Time (sec/op):
 * There is a slight overall increase in execution time with a geometric mean change of +0.48%.
 * The OLTP/Gen4 series saw notable increases in execution time, ranging from +18.33% to +23.20%.
 * Conversely, the TPCC/Gen4 series experienced performance improvements, with execution times decreasing by up to -6.52%.
 * The Planner benchmarks mostly saw increases in execution time, with the largest increase of +8.41% in Planner/from_cases.json-gen4-20.
2.	Memory Usage (B/op):
 * Overall memory usage decreased slightly, with a geometric mean reduction of -2.18%.
 * Significant reductions were observed in Planner/filter_cases.json-gen4 and Planner/filter_cases.json-gen4left2right, both decreasing by over -20%.
 * However, memory usage slightly increased in the OLTP/Gen4 series by approximately +3.6%.
3.	Memory Allocations (allocs/op):
 * The total number of memory allocations showed a minor decrease of -0.65%.
 * Notable increases in allocations occurred in the SelectVsDML/DML_(random_sample,_N=32) benchmark (+11.34%).
 * However, the SelectVsDML/Select_(random_sample,_N=32) benchmark saw a significant reduction in allocations by -17.33%.

These results reflect targeted optimizations and regressions across different query plans and scenarios, highlighting areas where the changes have improved or slightly degraded performance.

Details:
```
                                            │  ../before  │                after                 │
                                            │   sec/op    │    sec/op     vs base                │
OLTP/Gen4-20                                  221.3µ ± 1%    261.9µ ± 1%  +18.33% (p=0.000 n=10)
OLTP/Gen4Greedy-20                            220.9µ ± 0%    270.1µ ± 3%  +22.26% (p=0.000 n=10)
OLTP/Gen4Left2Right-20                        220.1µ ± 2%    271.2µ ± 1%  +23.20% (p=0.000 n=10)
TPCC/Gen4-20                                  2.259m ± 1%    2.189m ± 1%   -3.12% (p=0.000 n=10)
TPCC/Gen4Greedy-20                            2.255m ± 0%    2.170m ± 2%   -3.77% (p=0.000 n=10)
TPCC/Gen4Left2Right-20                        2.225m ± 0%    2.080m ± 1%   -6.52% (p=0.000 n=10)
TPCH/Gen4-20                                  11.16m ± 1%    11.18m ± 1%        ~ (p=0.143 n=10)
TPCH/Gen4Greedy-20                            11.17m ± 0%    11.27m ± 1%        ~ (p=0.353 n=10)
TPCH/Gen4Left2Right-20                        9.988m ± 0%   10.022m ± 1%        ~ (p=0.739 n=10)
Planner/from_cases.json-gen4-20               7.336m ± 1%    7.953m ± 2%   +8.41% (p=0.000 n=10)
Planner/from_cases.json-gen4left2right-20     6.876m ± 1%    7.376m ± 2%   +7.26% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20             181.8m ± 0%    155.2m ± 1%  -14.61% (p=0.000 n=10)
Planner/filter_cases.json-gen4left2right-20   181.9m ± 0%    155.0m ± 1%  -14.82% (p=0.000 n=10)
Planner/large_cases.json-gen4-20              484.6µ ± 1%    500.1µ ± 1%   +3.20% (p=0.000 n=10)
Planner/large_cases.json-gen4left2right-20    301.2µ ± 1%    306.7µ ± 1%   +1.80% (p=0.002 n=10)
Planner/aggr_cases.json-gen4-20               13.04m ± 0%    14.09m ± 1%   +8.13% (p=0.000 n=10)
Planner/aggr_cases.json-gen4left2right-20     12.46m ± 1%    13.42m ± 1%   +7.68% (p=0.000 n=10)
Planner/select_cases.json-gen4-20             10.39m ± 1%    11.17m ± 1%   +7.52% (p=0.000 n=10)
Planner/select_cases.json-gen4left2right-20   10.13m ± 2%    10.91m ± 1%   +7.66% (p=0.000 n=10)
Planner/union_cases.json-gen4-20              3.732m ± 6%    4.009m ± 1%   +7.42% (p=0.000 n=10)
Planner/union_cases.json-gen4left2right-20    3.710m ± 2%    3.990m ± 1%   +7.55% (p=0.000 n=10)
SemAnalysis-20                                62.98m ± 3%    29.67m ± 1%  -52.89% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20      946.7µ ± 2%   1093.3µ ± 1%  +15.49% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20   1.948m ± 5%    1.843m ± 1%   -5.40% (p=0.000 n=10)
geomean                                       4.220m         4.240m        +0.48%

                                            │   ../before   │                after                 │
                                            │     B/op      │     B/op      vs base                │
OLTP/Gen4-20                                   144.9Ki ± 0%   150.1Ki ± 0%   +3.59% (p=0.000 n=10)
OLTP/Gen4Greedy-20                             144.9Ki ± 0%   150.1Ki ± 0%   +3.58% (p=0.000 n=10)
OLTP/Gen4Left2Right-20                         144.9Ki ± 0%   150.1Ki ± 0%   +3.58% (p=0.000 n=10)
TPCC/Gen4-20                                   1.056Mi ± 0%   1.066Mi ± 0%   +0.96% (p=0.000 n=10)
TPCC/Gen4Greedy-20                             1.056Mi ± 0%   1.066Mi ± 0%   +0.96% (p=0.000 n=10)
TPCC/Gen4Left2Right-20                         1.045Mi ± 0%   1.055Mi ± 0%   +0.95% (p=0.000 n=10)
TPCH/Gen4-20                                   5.328Mi ± 0%   5.290Mi ± 0%   -0.70% (p=0.000 n=10)
TPCH/Gen4Greedy-20                             5.328Mi ± 0%   5.289Mi ± 0%   -0.72% (p=0.000 n=10)
TPCH/Gen4Left2Right-20                         4.806Mi ± 0%   4.775Mi ± 0%   -0.64% (p=0.000 n=10)
Planner/from_cases.json-gen4-20                4.503Mi ± 0%   4.521Mi ± 0%   +0.40% (p=0.000 n=10)
Planner/from_cases.json-gen4left2right-20      4.314Mi ± 0%   4.332Mi ± 0%   +0.43% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20              22.39Mi ± 0%   17.75Mi ± 0%  -20.72% (p=0.000 n=10)
Planner/filter_cases.json-gen4left2right-20    22.31Mi ± 0%   17.68Mi ± 0%  -20.76% (p=0.000 n=10)
Planner/large_cases.json-gen4-20               268.9Ki ± 0%   268.6Ki ± 0%   -0.12% (p=0.000 n=10)
Planner/large_cases.json-gen4left2right-20     174.7Ki ± 0%   174.4Ki ± 0%   -0.21% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20                7.183Mi ± 0%   7.215Mi ± 0%   +0.44% (p=0.000 n=10)
Planner/aggr_cases.json-gen4left2right-20      7.001Mi ± 0%   7.033Mi ± 0%   +0.45% (p=0.000 n=10)
Planner/select_cases.json-gen4-20              6.063Mi ± 0%   6.114Mi ± 0%   +0.84% (p=0.000 n=10)
Planner/select_cases.json-gen4left2right-20    5.958Mi ± 0%   6.010Mi ± 0%   +0.86% (p=0.000 n=10)
Planner/union_cases.json-gen4-20               2.215Mi ± 0%   2.230Mi ± 0%   +0.68% (p=0.000 n=10)
Planner/union_cases.json-gen4left2right-20     2.211Mi ± 0%   2.225Mi ± 0%   +0.66% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20       672.3Ki ± 0%   653.8Ki ± 0%   -2.75% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20   1155.5Ki ± 0%   973.9Ki ± 0%  -15.72% (p=0.000 n=10)
geomean                                        1.844Mi        1.804Mi        -2.18%

                                            │  ../before  │                after                │
                                            │  allocs/op  │  allocs/op   vs base                │
OLTP/Gen4-20                                  3.612k ± 0%   3.712k ± 0%   +2.77% (p=0.000 n=10)
OLTP/Gen4Greedy-20                            3.612k ± 0%   3.712k ± 0%   +2.77% (p=0.000 n=10)
OLTP/Gen4Left2Right-20                        3.612k ± 0%   3.712k ± 0%   +2.77% (p=0.000 n=10)
TPCC/Gen4-20                                  25.70k ± 0%   26.56k ± 0%   +3.36% (p=0.000 n=10)
TPCC/Gen4Greedy-20                            25.70k ± 0%   26.56k ± 0%   +3.36% (p=0.000 n=10)
TPCC/Gen4Left2Right-20                        25.45k ± 0%   26.31k ± 0%   +3.39% (p=0.000 n=10)
TPCH/Gen4-20                                  134.0k ± 0%   134.7k ± 0%   +0.55% (p=0.000 n=10)
TPCH/Gen4Greedy-20                            134.0k ± 0%   134.7k ± 0%   +0.55% (p=0.000 n=10)
TPCH/Gen4Left2Right-20                        124.1k ± 0%   124.7k ± 0%   +0.52% (p=0.000 n=10)
Planner/from_cases.json-gen4-20               106.7k ± 0%   107.5k ± 0%   +0.71% (p=0.000 n=10)
Planner/from_cases.json-gen4left2right-20     101.5k ± 0%   102.2k ± 0%   +0.75% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20             562.7k ± 0%   476.1k ± 0%  -15.40% (p=0.000 n=10)
Planner/filter_cases.json-gen4left2right-20   560.7k ± 0%   474.1k ± 0%  -15.45% (p=0.000 n=10)
Planner/large_cases.json-gen4-20              10.52k ± 0%   10.54k ± 0%   +0.17% (p=0.000 n=10)
Planner/large_cases.json-gen4left2right-20    6.206k ± 0%   6.224k ± 0%   +0.29% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20               164.8k ± 0%   165.6k ± 0%   +0.52% (p=0.000 n=10)
Planner/aggr_cases.json-gen4left2right-20     160.2k ± 0%   161.1k ± 0%   +0.54% (p=0.000 n=10)
Planner/select_cases.json-gen4-20             140.4k ± 0%   142.1k ± 0%   +1.20% (p=0.000 n=10)
Planner/select_cases.json-gen4left2right-20   137.4k ± 0%   139.1k ± 0%   +1.22% (p=0.000 n=10)
Planner/union_cases.json-gen4-20              52.06k ± 0%   52.50k ± 0%   +0.85% (p=0.000 n=10)
Planner/union_cases.json-gen4left2right-20    51.89k ± 0%   52.33k ± 0%   +0.85% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20      12.55k ± 0%   13.97k ± 0%  +11.34% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20   26.53k ± 0%   21.93k ± 0%  -17.33% (p=0.000 n=10)
geomean                                       46.06k        45.76k        -0.65%
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
