### PR TITLE
Fix error contain checks in vtgate package

### DIFF
--- a/go/test/endtoend/utils/cmp.go
+++ b/go/test/endtoend/utils/cmp.go
@@ -138,7 +138,7 @@ func (mcmp *MySQLCompare) AssertContainsError(query, expected string) {
 	mcmp.t.Helper()
 	_, err := mcmp.ExecAllowAndCompareError(query, CompareOptions{})
 	require.Error(mcmp.t, err)
-	assert.Contains(mcmp.t, err.Error(), expected, "actual error: %s", err.Error())
+	assert.ErrorContains(mcmp.t, err, expected, "actual error: %s", err.Error())
 }
 
 // AssertMatchesNoOrder executes the given query against both Vitess and MySQL.

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -114,7 +114,7 @@ func AssertContainsError(t *testing.T, conn *mysql.Conn, query, expected string)
 	t.Helper()
 	_, err := ExecAllowError(t, conn, query)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), expected, "actual error: %s", err.Error())
+	assert.ErrorContains(t, err, expected, "actual error: %s", err.Error())
 }
 
 // AssertMatchesNoOrder executes the given query and makes sure it matches the given `expected` string.

--- a/go/test/endtoend/vtgate/gen4/system_schema_test.go
+++ b/go/test/endtoend/vtgate/gen4/system_schema_test.go
@@ -213,7 +213,7 @@ func TestMultipleSchemaPredicates(t *testing.T) {
 		"where t.table_schema = '%s' and c.table_schema = '%s' and c.table_schema = '%s'", shardedKs, shardedKs, "a")
 	_, err = conn.ExecuteFetch(query, 1000, true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "specifying two different database in the query is not supported")
+	require.ErrorContains(t, err, "specifying two different database in the query is not supported")
 }
 
 func TestQuerySystemTables(t *testing.T) {

--- a/go/test/endtoend/vtgate/grpc_api/acl_test.go
+++ b/go/test/endtoend/vtgate/grpc_api/acl_test.go
@@ -57,8 +57,8 @@ func TestEffectiveCallerIDWithNoAccess(t *testing.T) {
 	ctx = callerid.NewContext(ctx, callerid.NewEffectiveCallerID("user_no_access", "", ""), nil)
 	_, err = session.Execute(ctx, query, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Select command denied to user")
-	assert.Contains(t, err.Error(), "for table 'test_table' (ACL check error)")
+	assert.ErrorContains(t, err, "Select command denied to user")
+	assert.ErrorContains(t, err, "for table 'test_table' (ACL check error)")
 }
 
 // TestAuthenticatedUserWithAccess verifies that an authenticated gRPC static user with ACL access can execute queries
@@ -89,8 +89,8 @@ func TestAuthenticatedUserNoAccess(t *testing.T) {
 	query := "SELECT id FROM test_table"
 	_, err = session.Execute(ctx, query, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Select command denied to user")
-	assert.Contains(t, err.Error(), "for table 'test_table' (ACL check error)")
+	assert.ErrorContains(t, err, "Select command denied to user")
+	assert.ErrorContains(t, err, "for table 'test_table' (ACL check error)")
 }
 
 // TestUnauthenticatedUser verifies that an unauthenticated gRPC user cannot execute queries
@@ -106,5 +106,5 @@ func TestUnauthenticatedUser(t *testing.T) {
 	query := "SELECT id FROM test_table"
 	_, err = session.Execute(ctx, query, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid credentials")
+	assert.ErrorContains(t, err, "invalid credentials")
 }

--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -131,7 +131,7 @@ func TestConsistentLookup(t *testing.T) {
 	mysqlErr := err.(*sqlerror.SQLError)
 	assert.Equal(t, sqlerror.ERDupEntry, mysqlErr.Num)
 	assert.Equal(t, "23000", mysqlErr.State)
-	assert.Contains(t, mysqlErr.Message, "reverted partial DML execution")
+	assert.ErrorContains(t, mysqlErr, "reverted partial DML execution")
 
 	// Simple delete.
 	utils.Exec(t, conn, "begin")

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -756,7 +756,7 @@ func TestDescribeVindex(t *testing.T) {
 	mysqlErr := err.(*sqlerror.SQLError)
 	assert.Equal(t, sqlerror.ERNoSuchTable, mysqlErr.Num)
 	assert.Equal(t, "42S02", mysqlErr.State)
-	assert.Contains(t, mysqlErr.Message, "NotFound desc")
+	assert.ErrorContains(t, mysqlErr, "NotFound desc")
 }
 
 func TestEmptyQuery(t *testing.T) {

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -200,7 +200,7 @@ func TestMultipleSchemaPredicates(t *testing.T) {
 		"where t.table_schema = '%s' and c.table_schema = '%s' and c.table_schema = '%s'", keyspaceName, keyspaceName, "a")
 	_, err := mcmp.VtConn.ExecuteFetch(query, 1000, true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "specifying two different database in the query is not supported")
+	require.ErrorContains(t, err, "specifying two different database in the query is not supported")
 
 	if utils.BinaryIsAtLeastAtVersion(20, "vtgate") {
 		_, _ = mcmp.ExecNoCompare("select * from information_schema.columns where table_schema = '' limit 1")

--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -84,8 +84,8 @@ func TestQueryTimeoutWithTables(t *testing.T) {
 	// the query usually takes more than 5ms to return. So this should fail.
 	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=1 */ count(*) from uks.unsharded where id1 > 31")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
-	assert.Contains(t, err.Error(), "(errno 1317) (sqlstate 70100)")
+	assert.ErrorContains(t, err, "context deadline exceeded")
+	assert.ErrorContains(t, err, "(errno 1317) (sqlstate 70100)")
 
 	// sharded
 	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into ks_misc.t1(id1, id2) values (1,2),(2,4),(3,6),(4,8),(5,10)")
@@ -94,8 +94,8 @@ func TestQueryTimeoutWithTables(t *testing.T) {
 	utils.Exec(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=500 */ sleep(0.1) from t1 where id1 = 1")
 	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=20 */ sleep(0.1) from t1 where id1 = 1")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
-	assert.Contains(t, err.Error(), "(errno 1317) (sqlstate 70100)")
+	assert.ErrorContains(t, err, "context deadline exceeded")
+	assert.ErrorContains(t, err, "(errno 1317) (sqlstate 70100)")
 }
 
 // TestQueryTimeoutWithShardTargeting tests the query timeout with shard targeting.

--- a/go/test/endtoend/vtgate/sequence/seq_test.go
+++ b/go/test/endtoend/vtgate/sequence/seq_test.go
@@ -293,7 +293,7 @@ func TestDotTableSeq(t *testing.T) {
 	mysqlErr := err.(*sqlerror.SQLError)
 	assert.Equal(t, sqlerror.ERDupEntry, mysqlErr.Num)
 	assert.Equal(t, "23000", mysqlErr.State)
-	assert.Contains(t, mysqlErr.Message, "Duplicate entry")
+	assert.ErrorContains(t, mysqlErr, "Duplicate entry")
 }
 
 func TestInsertAllDefaults(t *testing.T) {

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -343,7 +343,7 @@ func TestCallProcedure(t *testing.T) {
 
 	_, err = conn.ExecuteFetch(`CALL out_parameter(@foo)`, 100, true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "OUT and INOUT parameters are not supported")
+	require.ErrorContains(t, err, "OUT and INOUT parameters are not supported")
 }
 
 func TestTempTable(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

We were using some anti-patterns in the testing code for vtgate package like -
```go
assert.Contains(t, err.Error(), ...)
```
instead we should be using 
```go
assert.ErrorContains(t, err, ....)
```

This PR fixes these anti-patterns.

This PR is the first change needed to fix the failing tests as seen in https://github.com/vitessio/vitess/actions/runs/10488116666/job/29052695413?pr=16619. The idea is to fix these anti-patterns, and then while running upgrade downgrade tests, we ignore `assert.ErrorContains` type of checks because we don't need to guarantee that the error messages don't change across version upgrades. 

This is also the reason this PR needs to be backported to release-20.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
