### PR TITLE
schemadiff: more `INSTANT` algorithm considerations

### DIFF
--- a/go/vt/schemadiff/capability.go
+++ b/go/vt/schemadiff/capability.go
@@ -151,6 +151,13 @@ func alterOptionCapableOfInstantDDL(alterOption sqlparser.AlterOption, createTab
 				// Expression default values are not supported
 				return false, nil
 			}
+			if strings.EqualFold(column.Type.Type, "datetime") {
+				e := &ColumnDefinitionEntity{ColumnDefinition: column}
+				if !e.IsNullable() && !e.HasDefault() {
+					// DATETIME columns must have a default value
+					return false, nil
+				}
+			}
 		}
 		if opt.First || opt.After != nil {
 			// not a "last" column. Only supported as of 8.0.29

--- a/go/vt/schemadiff/capability.go
+++ b/go/vt/schemadiff/capability.go
@@ -185,6 +185,9 @@ func alterOptionCapableOfInstantDDL(alterOption sqlparser.AlterOption, createTab
 		}
 		return capableOf(capabilities.InstantAddDropColumnFlavorCapability)
 	case *sqlparser.ChangeColumn:
+		if opt.First || opt.After != nil {
+			return false, nil
+		}
 		// We do not support INSTANT for renaming a column (ALTER TABLE ...CHANGE) because:
 		// 1. We discourage column rename
 		// 2. We do not produce CHANGE statements in declarative diff
@@ -198,6 +201,9 @@ func alterOptionCapableOfInstantDDL(alterOption sqlparser.AlterOption, createTab
 		}
 		return false, nil
 	case *sqlparser.ModifyColumn:
+		if opt.First || opt.After != nil {
+			return false, nil
+		}
 		if col := findColumn(opt.NewColDefinition.Name.String()); col != nil {
 			return changeModifyColumnCapableOfInstantDDL(col, opt.NewColDefinition)
 		}

--- a/go/vt/schemadiff/capability_test.go
+++ b/go/vt/schemadiff/capability_test.go
@@ -134,6 +134,24 @@ func TestAlterTableCapableOfInstantDDL(t *testing.T) {
 			expectCapableOfInstantDDL: true,
 		},
 		{
+			name:                      "add nullable datetime column",
+			create:                    "create table t(id int, i1 int not null, primary key(id))",
+			alter:                     "alter table t add column dt datetime(3)",
+			expectCapableOfInstantDDL: true,
+		},
+		{
+			name:                      "add default null datetime column",
+			create:                    "create table t(id int, i1 int not null, primary key(id))",
+			alter:                     "alter table t add column dt datetime(3) default null",
+			expectCapableOfInstantDDL: true,
+		},
+		{
+			name:                      "add datetime column without default",
+			create:                    "create table t(id int, i1 int not null, primary key(id))",
+			alter:                     "alter table t add column dt datetime(3) not null",
+			expectCapableOfInstantDDL: false,
+		},
+		{
 			name:                      "add stored column",
 			create:                    "create table t(id int, i1 int not null, primary key(id))",
 			alter:                     "alter table t add column i2 int generated always as (i1 + 1) stored",

--- a/go/vt/schemadiff/capability_test.go
+++ b/go/vt/schemadiff/capability_test.go
@@ -225,10 +225,22 @@ func TestAlterTableCapableOfInstantDDL(t *testing.T) {
 			expectCapableOfInstantDDL: false,
 		},
 		{
-			name:                      "set column dfault value to null",
+			name:                      "set column default value to null",
 			create:                    "create table t(id int, i1 int, primary key(id))",
 			alter:                     "alter table t modify column i1 int default null",
 			expectCapableOfInstantDDL: true,
+		},
+		{
+			name:                      "rearrange column after",
+			create:                    "create table t(id int, i1 int, i2 int, primary key(id))",
+			alter:                     "alter table t modify column i1 int after i2",
+			expectCapableOfInstantDDL: false,
+		},
+		{
+			name:                      "rearrange column first",
+			create:                    "create table t(id int, i1 int, i2 int, primary key(id))",
+			alter:                     "alter table t modify column i1 int first",
+			expectCapableOfInstantDDL: false,
 		},
 		// enum/set:
 		{
@@ -289,6 +301,18 @@ func TestAlterTableCapableOfInstantDDL(t *testing.T) {
 			name:                      "make a column visible with rename",
 			create:                    "create table t1 (id int, i1 int)",
 			alter:                     "alter table t1 change column i1 i2 int visible",
+			expectCapableOfInstantDDL: false,
+		},
+		{
+			name:                      "change column, first",
+			create:                    "create table t1 (id int, i1 int, i2 int)",
+			alter:                     "alter table t1 change column i1 i1 int first",
+			expectCapableOfInstantDDL: false,
+		},
+		{
+			name:                      "change column, after",
+			create:                    "create table t1 (id int, i1 int, i2 int)",
+			alter:                     "alter table t1 change column i1 i1 int after i2",
 			expectCapableOfInstantDDL: false,
 		},
 		{


### PR DESCRIPTION
## Description

Rejecting the following scenarios:

- Reordering columns (either via `MODIFY COLUMN` or `CHANGE COLUMN`), e.g. `alter table t modify column i1 int after i2`
- Adding a non nullable, no-default `DATETIME`: `alter table t add column d5 datetime(3) not null`
  This one is not documented but is nonetheless rejected by MySQL - for non empty tables.
  We've found a myriad of nuances with relation to `DATETIME` and `TIMESTAMP`. The reason MySQL rejects the above is that it assumes the default is `0000-00-00 00:00:00`, which it does not allow. But it does allow the same for `TIMESTAMP`. In both cases, if the table is empty, it is allowed. So it's about _populating_ these columns rather than their definitions. There is further consideration for what constitutes a valid value for a `DATETIME` or a `TIMESTAMP`. e.g. `'1000-01-01 00:00:00'` is invalid for a `TIMESTAMP` as it's out of range (well before the epoch). We may work on those in a later PR.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/14877

## Backporting

~~This is a bugfix, I'll backport to appropriate supported versions.~~ After some deliberation, not going to backport this at this time.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
