### PR TITLE
Fix data race in keyspace event watcher

### DIFF
--- a/go/vt/discovery/keyspace_events.go
+++ b/go/vt/discovery/keyspace_events.go
@@ -118,6 +118,13 @@ type keyspaceState struct {
 	moveTablesState *MoveTablesState
 }
 
+// isConsistent returns whether the keyspace is currently consistent or not.
+func (kss *keyspaceState) isConsistent() bool {
+	kss.mu.Lock()
+	defer kss.mu.Unlock()
+	return kss.consistent
+}
+
 // Format prints the internal state for this keyspace for debug purposes.
 func (kss *keyspaceState) Format(f fmt.State, verb rune) {
 	kss.mu.Lock()
@@ -752,7 +759,7 @@ func (kew *KeyspaceEventWatcher) WaitForConsistentKeyspaces(ctx context.Context,
 			kss := kew.getKeyspaceStatus(ctx, ks)
 			// If kss is nil, then it must be deleted. In that case too it is fine for us to consider
 			// it consistent since the keyspace has been deleted.
-			if kss == nil || kss.consistent {
+			if kss == nil || kss.isConsistent() {
 				keyspaces[i] = ""
 			} else {
 				allConsistent = false


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
In a recent PR of mine https://github.com/vitessio/vitess/pull/16655, I accidentally introduced a data race. We shouldn't be accessing internal elements of a keyspace state without locking the mutex.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
