### PR TITLE
schemadiff: reject non-deterministic function in new column's default value

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -495,5 +495,5 @@ type NonDeterministicDefaultError struct {
 }
 
 func (e *NonDeterministicDefaultError) Error() string {
-	return fmt.Sprintf("column %s.%s default value uses non-deterministic function: %v", sqlescape.EscapeID(e.Table), sqlescape.EscapeID(e.Column), e.Function)
+	return fmt.Sprintf("column %s.%s default value uses non-deterministic function: %s", sqlescape.EscapeID(e.Table), sqlescape.EscapeID(e.Column), e.Function)
 }

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -487,3 +487,13 @@ type PartitionSpecNonExclusiveError struct {
 func (e *PartitionSpecNonExclusiveError) Error() string {
 	return fmt.Sprintf("ALTER TABLE on %s, may only have a single partition spec change, and other changes are not allowed. Found spec: %s; and change: %s", sqlescape.EscapeID(e.Table), sqlparser.CanonicalString(e.PartitionSpec), e.ConflictingStatement)
 }
+
+type NonDeterministicDefaultError struct {
+	Table    string
+	Column   string
+	Function string
+}
+
+func (e *NonDeterministicDefaultError) Error() string {
+	return fmt.Sprintf("column %s.%s default value uses non-deterministic function: %v", sqlescape.EscapeID(e.Table), sqlescape.EscapeID(e.Column), e.Function)
+}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1879,14 +1879,13 @@ func (c *CreateTableEntity) diffColumns(alterTable *sqlparser.AlterTable,
 			addColumn := &sqlparser.AddColumns{
 				Columns: []*sqlparser.ColumnDefinition{t2Col},
 			}
-			if hints.NonDeterministicDefaultStrategy == NonDeterministicDefaultReject {
-				if t2Col.Type.Options.Default != nil && !t2Col.Type.Options.DefaultLiteral {
-					if function := findNoNondeterministicFunction(t2Col.Type.Options.Default); function != "" {
-						return &NonDeterministicDefaultError{
-							Table:    c.Name(),
-							Column:   t2Col.Name.String(),
-							Function: function,
-						}
+			// See whether this ADD COLUMN has a non-deterministic default value
+			if t2Col.Type.Options.Default != nil && !t2Col.Type.Options.DefaultLiteral {
+				if function := findNoNondeterministicFunction(t2Col.Type.Options.Default); function != "" {
+					return &NonDeterministicDefaultError{
+						Table:    c.Name(),
+						Column:   t2Col.Name.String(),
+						Function: function,
 					}
 				}
 			}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1751,13 +1751,6 @@ func findNoNondeterministicFunction(expr sqlparser.Expr) (foundFunction string) 
 			case "uuid", "rand":
 				foundFunction = node.Name.String()
 				return false, nil
-			default:
-				// recurse into function argument expressions
-				for _, exprArg := range node.Exprs {
-					if foundFunction = findNoNondeterministicFunction(exprArg); foundFunction != "" {
-						return false, nil
-					}
-				}
 			}
 		}
 		return true, nil

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -39,16 +39,15 @@ func TestCreateTableDiff(t *testing.T) {
 		cdiffs   []string
 		errorMsg string
 		// hints:
-		autoinc          int
-		rotation         int
-		fulltext         int
-		colrename        int
-		constraint       int
-		charset          int
-		algorithm        int
-		enumreorder      int
-		subsequent       int
-		nondeterministic int
+		autoinc     int
+		rotation    int
+		fulltext    int
+		colrename   int
+		constraint  int
+		charset     int
+		algorithm   int
+		enumreorder int
+		subsequent  int
 		//
 		textdiffs   []string
 		atomicdiffs []string
@@ -453,64 +452,46 @@ func TestCreateTableDiff(t *testing.T) {
 			},
 		},
 		{
-			name:  "added column with non deterministic expression, allow",
-			from:  "create table t1 (id int primary key, a int)",
-			to:    "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid()))",
-			diff:  "alter table t1 add column v varchar(36) not null default (uuid())",
-			cdiff: "ALTER TABLE `t1` ADD COLUMN `v` varchar(36) NOT NULL DEFAULT (uuid())",
-			textdiffs: []string{
-				"+	`v` varchar(36) NOT NULL DEFAULT (uuid()),",
-			},
-			nondeterministic: NonDeterministicDefaultAllow,
+			name:     "added column with non deterministic expression, uuid, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid()))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
 		},
 		{
-			name:             "added column with non deterministic expression, uuid, reject",
-			from:             "create table t1 (id int primary key, a int)",
-			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid()))",
-			nondeterministic: NonDeterministicDefaultReject,
-			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
+			name:     "added column with non deterministic expression, UUID, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (UUID()))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "UUID"}).Error(),
 		},
 		{
-			name:             "added column with non deterministic expression, UUID, reject",
-			from:             "create table t1 (id int primary key, a int)",
-			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (UUID()))",
-			nondeterministic: NonDeterministicDefaultReject,
-			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "UUID"}).Error(),
+			name:     "added column with non deterministic expression, uuid, spacing, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid ()))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
 		},
 		{
-			name:             "added column with non deterministic expression, uuid, spacing, reject",
-			from:             "create table t1 (id int primary key, a int)",
-			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid ()))",
-			nondeterministic: NonDeterministicDefaultReject,
-			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
+			name:     "added column with non deterministic expression, uuid, inner, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (left(uuid(),10)))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
 		},
 		{
-			name:             "added column with non deterministic expression, uuid, inner, reject",
-			from:             "create table t1 (id int primary key, a int)",
-			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (left(uuid(),10)))",
-			nondeterministic: NonDeterministicDefaultReject,
-			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
+			name:     "added column with non deterministic expression, rand, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (2.0 + rand()))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "rand"}).Error(),
 		},
 		{
-			name:             "added column with non deterministic expression, rand, reject",
-			from:             "create table t1 (id int primary key, a int)",
-			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (2.0 + rand()))",
-			nondeterministic: NonDeterministicDefaultReject,
-			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "rand"}).Error(),
+			name:     "added column with non deterministic expression, sysdate, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (sysdate()))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "sysdate"}).Error(),
 		},
 		{
-			name:             "added column with non deterministic expression, sysdate, reject",
-			from:             "create table t1 (id int primary key, a int)",
-			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (sysdate()))",
-			nondeterministic: NonDeterministicDefaultReject,
-			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "sysdate"}).Error(),
-		},
-		{
-			name:             "added column with non deterministic expression, sysdate, reject",
-			from:             "create table t1 (id int primary key, a int)",
-			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (to_days(sysdate())))",
-			nondeterministic: NonDeterministicDefaultReject,
-			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "sysdate"}).Error(),
+			name:     "added column with non deterministic expression, sysdate, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (to_days(sysdate())))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "sysdate"}).Error(),
 		},
 		{
 			name:  "added column with deterministic expression, now, reject does not apply",
@@ -521,7 +502,6 @@ func TestCreateTableDiff(t *testing.T) {
 			textdiffs: []string{
 				"+	`v` varchar(36) NOT NULL DEFAULT (now()),",
 			},
-			nondeterministic: NonDeterministicDefaultReject,
 		},
 		{
 			name:  "added column with deterministic expression, curdate, reject does not apply",
@@ -532,7 +512,6 @@ func TestCreateTableDiff(t *testing.T) {
 			textdiffs: []string{
 				"+	`v` varchar(36) NOT NULL DEFAULT (to_days(curdate())),",
 			},
-			nondeterministic: NonDeterministicDefaultReject,
 		},
 		// enum
 		{
@@ -2175,7 +2154,6 @@ func TestCreateTableDiff(t *testing.T) {
 			hints.AlterTableAlgorithmStrategy = ts.algorithm
 			hints.EnumReorderStrategy = ts.enumreorder
 			hints.SubsequentDiffStrategy = ts.subsequent
-			hints.NonDeterministicDefaultStrategy = ts.nondeterministic
 			alter, err := c.Diff(other, &hints)
 
 			require.Equal(t, len(ts.diffs), len(ts.cdiffs))

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -28,25 +28,28 @@ import (
 
 func TestCreateTableDiff(t *testing.T) {
 	tt := []struct {
-		name        string
-		from        string
-		to          string
-		fromName    string
-		toName      string
-		diff        string
-		diffs       []string
-		cdiff       string
-		cdiffs      []string
-		errorMsg    string
-		autoinc     int
-		rotation    int
-		fulltext    int
-		colrename   int
-		constraint  int
-		charset     int
-		algorithm   int
-		enumreorder int
-		subsequent  int
+		name     string
+		from     string
+		to       string
+		fromName string
+		toName   string
+		diff     string
+		diffs    []string
+		cdiff    string
+		cdiffs   []string
+		errorMsg string
+		// hints:
+		autoinc          int
+		rotation         int
+		fulltext         int
+		colrename        int
+		constraint       int
+		charset          int
+		algorithm        int
+		enumreorder      int
+		subsequent       int
+		nondeterministic int
+		//
 		textdiffs   []string
 		atomicdiffs []string
 	}{
@@ -448,6 +451,88 @@ func TestCreateTableDiff(t *testing.T) {
 				"+	`x` int,",
 				"+	`y` int,",
 			},
+		},
+		{
+			name:  "added column with non deterministic expression, allow",
+			from:  "create table t1 (id int primary key, a int)",
+			to:    "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid()))",
+			diff:  "alter table t1 add column v varchar(36) not null default (uuid())",
+			cdiff: "ALTER TABLE `t1` ADD COLUMN `v` varchar(36) NOT NULL DEFAULT (uuid())",
+			textdiffs: []string{
+				"+	`v` varchar(36) NOT NULL DEFAULT (uuid()),",
+			},
+			nondeterministic: NonDeterministicDefaultAllow,
+		},
+		{
+			name:             "added column with non deterministic expression, uuid, reject",
+			from:             "create table t1 (id int primary key, a int)",
+			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid()))",
+			nondeterministic: NonDeterministicDefaultReject,
+			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
+		},
+		{
+			name:             "added column with non deterministic expression, UUID, reject",
+			from:             "create table t1 (id int primary key, a int)",
+			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (UUID()))",
+			nondeterministic: NonDeterministicDefaultReject,
+			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "UUID"}).Error(),
+		},
+		{
+			name:             "added column with non deterministic expression, uuid, spacing, reject",
+			from:             "create table t1 (id int primary key, a int)",
+			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid ()))",
+			nondeterministic: NonDeterministicDefaultReject,
+			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
+		},
+		{
+			name:             "added column with non deterministic expression, uuid, inner, reject",
+			from:             "create table t1 (id int primary key, a int)",
+			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (left(uuid(),10)))",
+			nondeterministic: NonDeterministicDefaultReject,
+			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
+		},
+		{
+			name:             "added column with non deterministic expression, rand, reject",
+			from:             "create table t1 (id int primary key, a int)",
+			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (2.0 + rand()))",
+			nondeterministic: NonDeterministicDefaultReject,
+			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "rand"}).Error(),
+		},
+		{
+			name:             "added column with non deterministic expression, sysdate, reject",
+			from:             "create table t1 (id int primary key, a int)",
+			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (sysdate()))",
+			nondeterministic: NonDeterministicDefaultReject,
+			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "sysdate"}).Error(),
+		},
+		{
+			name:             "added column with non deterministic expression, sysdate, reject",
+			from:             "create table t1 (id int primary key, a int)",
+			to:               "create table t2 (id int primary key, a int, v varchar(36) not null default (to_days(sysdate())))",
+			nondeterministic: NonDeterministicDefaultReject,
+			errorMsg:         (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "sysdate"}).Error(),
+		},
+		{
+			name:  "added column with deterministic expression, now, reject does not apply",
+			from:  "create table t1 (id int primary key, a int)",
+			to:    "create table t2 (id int primary key, a int, v varchar(36) not null default (now()))",
+			diff:  "alter table t1 add column v varchar(36) not null default (now())",
+			cdiff: "ALTER TABLE `t1` ADD COLUMN `v` varchar(36) NOT NULL DEFAULT (now())",
+			textdiffs: []string{
+				"+	`v` varchar(36) NOT NULL DEFAULT (now()),",
+			},
+			nondeterministic: NonDeterministicDefaultReject,
+		},
+		{
+			name:  "added column with deterministic expression, curdate, reject does not apply",
+			from:  "create table t1 (id int primary key, a int)",
+			to:    "create table t2 (id int primary key, a int, v varchar(36) not null default (to_days(curdate())))",
+			diff:  "alter table t1 add column v varchar(36) not null default (to_days(curdate()))",
+			cdiff: "ALTER TABLE `t1` ADD COLUMN `v` varchar(36) NOT NULL DEFAULT (to_days(curdate()))",
+			textdiffs: []string{
+				"+	`v` varchar(36) NOT NULL DEFAULT (to_days(curdate())),",
+			},
+			nondeterministic: NonDeterministicDefaultReject,
 		},
 		// enum
 		{
@@ -2090,6 +2175,7 @@ func TestCreateTableDiff(t *testing.T) {
 			hints.AlterTableAlgorithmStrategy = ts.algorithm
 			hints.EnumReorderStrategy = ts.enumreorder
 			hints.SubsequentDiffStrategy = ts.subsequent
+			hints.NonDeterministicDefaultStrategy = ts.nondeterministic
 			alter, err := c.Diff(other, &hints)
 
 			require.Equal(t, len(ts.diffs), len(ts.cdiffs))

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -141,27 +141,21 @@ const (
 	SubsequentDiffStrategyReject
 )
 
-const (
-	NonDeterministicDefaultAllow int = iota
-	NonDeterministicDefaultReject
-)
-
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
-	StrictIndexOrdering             bool
-	AutoIncrementStrategy           int
-	RangeRotationStrategy           int
-	ConstraintNamesStrategy         int
-	ColumnRenameStrategy            int
-	TableRenameStrategy             int
-	FullTextKeyStrategy             int
-	TableCharsetCollateStrategy     int
-	TableQualifierHint              int
-	AlterTableAlgorithmStrategy     int
-	EnumReorderStrategy             int
-	ForeignKeyCheckStrategy         int
-	SubsequentDiffStrategy          int
-	NonDeterministicDefaultStrategy int
+	StrictIndexOrdering         bool
+	AutoIncrementStrategy       int
+	RangeRotationStrategy       int
+	ConstraintNamesStrategy     int
+	ColumnRenameStrategy        int
+	TableRenameStrategy         int
+	FullTextKeyStrategy         int
+	TableCharsetCollateStrategy int
+	TableQualifierHint          int
+	AlterTableAlgorithmStrategy int
+	EnumReorderStrategy         int
+	ForeignKeyCheckStrategy     int
+	SubsequentDiffStrategy      int
 }
 
 func EmptyDiffHints() *DiffHints {

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -141,21 +141,27 @@ const (
 	SubsequentDiffStrategyReject
 )
 
+const (
+	NonDeterministicDefaultAllow int = iota
+	NonDeterministicDefaultReject
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
-	StrictIndexOrdering         bool
-	AutoIncrementStrategy       int
-	RangeRotationStrategy       int
-	ConstraintNamesStrategy     int
-	ColumnRenameStrategy        int
-	TableRenameStrategy         int
-	FullTextKeyStrategy         int
-	TableCharsetCollateStrategy int
-	TableQualifierHint          int
-	AlterTableAlgorithmStrategy int
-	EnumReorderStrategy         int
-	ForeignKeyCheckStrategy     int
-	SubsequentDiffStrategy      int
+	StrictIndexOrdering             bool
+	AutoIncrementStrategy           int
+	RangeRotationStrategy           int
+	ConstraintNamesStrategy         int
+	ColumnRenameStrategy            int
+	TableRenameStrategy             int
+	FullTextKeyStrategy             int
+	TableCharsetCollateStrategy     int
+	TableQualifierHint              int
+	AlterTableAlgorithmStrategy     int
+	EnumReorderStrategy             int
+	ForeignKeyCheckStrategy         int
+	SubsequentDiffStrategy          int
+	NonDeterministicDefaultStrategy int
 }
 
 func EmptyDiffHints() *DiffHints {


### PR DESCRIPTION
## Description

~~This PR introduces a new diff hint: `NonDeterministicDefaultStrategy`, which can take these values:~~

~~When it's set to `NonDeterministicDefaultReject`,~~

`schemadiff` now errors on table diffs where:

- A new column is added
- The column has an expression (non-literal) default value
- The expression contains a non-detereministic function, specifically one of:
  - `SYSDATE()`
  - `UUID()`
  - `RAND()`

This matches MySQL behavior as in:
```
alter table t add column v varchar(36) NOT NULL DEFAULT (uuid());
ERROR 1674 (HY000): Statement is unsafe because it uses a system function that may return a different value on the slave.
```

There is no need to handle `MODIFY COLUMN` or `CHANGE COLUMN` statements, because those cannot introduce un-computed column data, and only operate on existing columns. 

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/10203

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
