### PR TITLE
schemadiff: reject `uuid_short` and `random_bytes` in new column expression

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1735,7 +1735,9 @@ func evaluateColumnReordering(t1SharedColumns, t2SharedColumns []*sqlparser.Colu
 // If recurses into all function arguments.
 // The known non-deterministic function we handle are:
 // - UUID()
+// - UUID_SHORT()
 // - RAND()
+// - RANDOM_BYTES()
 // - SYSDATE()
 func findNoNondeterministicFunction(expr sqlparser.Expr) (foundFunction string) {
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
@@ -1748,7 +1750,7 @@ func findNoNondeterministicFunction(expr sqlparser.Expr) (foundFunction string) 
 			}
 		case *sqlparser.FuncExpr:
 			switch node.Name.Lowered() {
-			case "uuid", "rand":
+			case "uuid", "uuid_short", "rand", "random_bytes":
 				foundFunction = node.Name.String()
 				return false, nil
 			}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -458,6 +458,12 @@ func TestCreateTableDiff(t *testing.T) {
 			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid"}).Error(),
 		},
 		{
+			name:     "added column with non deterministic expression, uuid, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (uuid_short()))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "uuid_short"}).Error(),
+		},
+		{
 			name:     "added column with non deterministic expression, UUID, reject",
 			from:     "create table t1 (id int primary key, a int)",
 			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (UUID()))",
@@ -480,6 +486,12 @@ func TestCreateTableDiff(t *testing.T) {
 			from:     "create table t1 (id int primary key, a int)",
 			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (2.0 + rand()))",
 			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "rand"}).Error(),
+		},
+		{
+			name:     "added column with non deterministic expression, random_bytes, reject",
+			from:     "create table t1 (id int primary key, a int)",
+			to:       "create table t2 (id int primary key, a int, v varchar(36) not null default (random_bytes(3)))",
+			errorMsg: (&NonDeterministicDefaultError{Table: "t1", Column: "v", Function: "random_bytes"}).Error(),
 		},
 		{
 			name:     "added column with non deterministic expression, sysdate, reject",


### PR DESCRIPTION
## Description

Quick followup to #16684, adding two more known non-deterministic functions.

## Related Issue(s)

#16684

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
