### PR TITLE
VTAdmin(web): Some tweaks in the workflow details

### DIFF
--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -71,8 +71,13 @@ export const Workflow = () => {
                                 {data?.workflow?.source?.shards?.length! > 1 ? 'Source Shards: ' : 'Source Shard: '}
                                 {data?.workflow?.source?.shards?.map((shard) => (
                                     <code key={`${keyspace}/${shard}`}>
-                                        <ShardLink clusterID={clusterID} keyspace={keyspace} shard={shard}>
-                                            {`${keyspace}/${shard} `}
+                                        <ShardLink
+                                            className="mr-1"
+                                            clusterID={clusterID}
+                                            keyspace={keyspace}
+                                            shard={shard}
+                                        >
+                                            {`${keyspace}/${shard}`}
                                         </ShardLink>
                                     </code>
                                 ))}
@@ -81,8 +86,13 @@ export const Workflow = () => {
                                 {data?.workflow?.target?.shards?.length! > 1 ? 'Target Shards: ' : 'Target Shard: '}
                                 {data?.workflow?.target?.shards?.map((shard) => (
                                     <code key={`${keyspace}/${shard}`}>
-                                        <ShardLink clusterID={clusterID} keyspace={keyspace} shard={shard}>
-                                            {`${keyspace}/${shard} `}
+                                        <ShardLink
+                                            className="mr-1"
+                                            clusterID={clusterID}
+                                            keyspace={keyspace}
+                                            shard={shard}
+                                        >
+                                            {`${keyspace}/${shard}`}
                                         </ShardLink>
                                     </code>
                                 ))}

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -30,6 +30,7 @@ import { TabContainer } from '../../tabs/TabContainer';
 import { Tab } from '../../tabs/Tab';
 import { getStreams } from '../../../util/workflows';
 import { Code } from '../../Code';
+import { ShardLink } from '../../links/ShardLink';
 
 interface RouteParams {
     clusterID: string;
@@ -46,6 +47,11 @@ export const Workflow = () => {
     const { data } = useWorkflow({ clusterID, keyspace, name });
     const streams = getStreams(data);
 
+    let isReshard = false;
+    if (data && data.workflow) {
+        isReshard = data.workflow.workflow_type === 'Reshard';
+    }
+
     return (
         <div>
             <WorkspaceHeader>
@@ -54,6 +60,32 @@ export const Workflow = () => {
                 </NavCrumbs>
 
                 <WorkspaceTitle className="font-mono">{name}</WorkspaceTitle>
+                {isReshard && (
+                    <div className={style.headingMetaContainer}>
+                        <div className={style.headingMeta}>
+                            <span>
+                                {data?.workflow?.source?.shards?.length! > 1 ? 'Source Shards: ' : 'Source Shard: '}
+                                {data?.workflow?.source?.shards?.map((shard) => (
+                                    <code key={`${keyspace}/${shard}`}>
+                                        <ShardLink clusterID={clusterID} keyspace={keyspace} shard={shard}>
+                                            {`${keyspace}/${shard} `}
+                                        </ShardLink>
+                                    </code>
+                                ))}
+                            </span>
+                            <span>
+                                {data?.workflow?.target?.shards?.length! > 1 ? 'Target Shards: ' : 'Target Shard: '}
+                                {data?.workflow?.target?.shards?.map((shard) => (
+                                    <code key={`${keyspace}/${shard}`}>
+                                        <ShardLink clusterID={clusterID} keyspace={keyspace} shard={shard}>
+                                            {`${keyspace}/${shard} `}
+                                        </ShardLink>
+                                    </code>
+                                ))}
+                            </span>
+                        </div>
+                    </div>
+                )}
                 <div className={style.headingMetaContainer}>
                     <div className={style.headingMeta} style={{ float: 'left' }}>
                         <span>

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -60,7 +60,7 @@ export const Workflow = () => {
                             Cluster: <code>{clusterID}</code>
                         </span>
                         <span>
-                            Target keyspace:{' '}
+                            Target Keyspace:{' '}
                             <KeyspaceLink clusterID={clusterID} name={keyspace}>
                                 <code>{keyspace}</code>
                             </KeyspaceLink>

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
+import { Link, Redirect, Route, Switch, useLocation, useParams, useRouteMatch } from 'react-router-dom';
 
 import style from './Workflow.module.scss';
 
@@ -41,11 +41,15 @@ interface RouteParams {
 export const Workflow = () => {
     const { clusterID, keyspace, name } = useParams<RouteParams>();
     const { path, url } = useRouteMatch();
+    const location = useLocation();
 
     useDocumentTitle(`${name} (${keyspace})`);
 
     const { data } = useWorkflow({ clusterID, keyspace, name });
     const streams = getStreams(data);
+
+    const detailsURL = `${url}/details`;
+    const detailsTab = location.pathname === detailsURL;
 
     let isReshard = false;
     if (data && data.workflow) {
@@ -98,16 +102,18 @@ export const Workflow = () => {
                             </KeyspaceLink>
                         </span>
                     </div>
-                    <div style={{ float: 'right' }}>
-                        <a href={`#workflowStreams`}>Scroll To Streams</a>
-                    </div>
+                    {detailsTab && (
+                        <div style={{ float: 'right' }}>
+                            <a href={`#workflowStreams`}>Scroll To Streams</a>
+                        </div>
+                    )}
                 </div>
             </WorkspaceHeader>
 
             <ContentContainer>
                 <TabContainer>
                     <Tab text="Streams" to={`${url}/streams`} count={streams.length} />
-                    <Tab text="Details" to={`${url}/details`} />
+                    <Tab text="Details" to={detailsURL} />
                     <Tab text="JSON" to={`${url}/json`} />
                 </TabContainer>
 

--- a/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
@@ -288,21 +288,21 @@ export const WorkflowDetails = ({ clusterID, keyspace, name }: Props) => {
                     title="Table Copy State"
                 />
             )}
-            {streams.length <= 8 && (
-                <>
-                    <h3 className="mt-8 mb-4">Recent Logs</h3>
-                    {streams.map((stream) => (
-                        <div className="mt-2" key={stream.key}>
-                            <DataTable
-                                columns={LOG_COLUMNS}
-                                data={orderBy(stream.logs, 'id', 'desc')}
-                                renderRows={renderLogRows}
-                                pageSize={10}
-                                title={stream.key!}
-                            />
-                        </div>
-                    ))}
-                </>
+            <h3 className="mt-8 mb-4">Recent Logs</h3>
+            {streams.length <= 8 ? (
+                streams.map((stream) => (
+                    <div className="mt-2" key={stream.key}>
+                        <DataTable
+                            columns={LOG_COLUMNS}
+                            data={orderBy(stream.logs, 'id', 'desc')}
+                            renderRows={renderLogRows}
+                            pageSize={10}
+                            title={stream.key!}
+                        />
+                    </div>
+                ))
+            ) : (
+                <span>Recent logs from streams are not displayed due to the large number of shards.</span>
             )}
         </div>
     );

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -122,29 +122,6 @@ export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
                     <WorkflowStreamsLagChart clusterID={clusterID} keyspace={keyspace} workflowName={name} />
                 </>
             )}
-
-            <h3 className="mt-24 mb-8" id="workflowStreams">
-                Streams
-            </h3>
-            {/* TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340) */}
-            {['Error', 'Copying', 'Running', 'Stopped'].map((streamState) => {
-                if (!Array.isArray(streamsByState[streamState])) {
-                    return null;
-                }
-
-                return (
-                    <div className="my-12" key={streamState}>
-                        <DataTable
-                            columns={COLUMNS}
-                            data={streamsByState[streamState]}
-                            // TODO(doeg): make pagination optional in DataTable https://github.com/vitessio/vitess/projects/12#card-60810231
-                            pageSize={1000}
-                            renderRows={renderRows}
-                            title={streamState}
-                        />
-                    </div>
-                );
-            })}
         </div>
     );
 };

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 
-import { useWorkflow } from '../../../hooks/api';
 import { WorkflowStreamsLagChart } from '../../charts/WorkflowStreamsLagChart';
 import { env } from '../../../util/env';
 

--- a/web/vtadmin/src/util/time.ts
+++ b/web/vtadmin/src/util/time.ts
@@ -40,3 +40,7 @@ export const formatRelativeTime = (timestamp: number | Long | null | undefined):
     const u = parse(timestamp);
     return u ? u.fromNow() : null;
 };
+
+export const formatDateTimeShort = (timestamp: number | Long | null | undefined): string | null => {
+    return format(timestamp, 'MM/DD/YY HH:mm:ss Z');
+};


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Some changes to the `Workflow` screen:
- For Reshard workflows: shows source/target shards in the header
- Capitalize Keyspace: from Target keyspace to Target Keyspace
- Make timestamps more compact to make the display denser, like. mm/dd/yy HH:MM:SS UTC. (no century, 24 hour format)
- Add the units (seconds) to the replication lag
- If more than 8 shards: don’t show logs for now.
- In streams, show the source shard and target shard, and add link to tablet.
- Remove `Streams` Table from the Lag Graph tab
- Remove "Scroll To Streams" from tabs other than "Details"
- Reduce space above the Summary caption
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #16687
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Screenshots
<img width="1440" alt="Screenshot 2024-09-05 at 3 29 07 PM" src="https://github.com/user-attachments/assets/e4bed4bf-a1cb-4abd-84f1-37eac56036f6">

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required


