### PR TITLE
TabletServer: execute DDLs without timeout

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -822,6 +822,10 @@ func (tsv *TabletServer) execute(ctx context.Context, target *querypb.Target, sq
 			if err != nil {
 				return err
 			}
+			if plan.PlanID == planbuilder.PlanDDL {
+				// DDLs (especially ALTER TABLE, OPTIMIZE TABLE) can run for a very long time, so we don't want to enforce a specific timeout.
+				ctx = context.WithoutCancel(ctx)
+			}
 			qre := &QueryExecutor{
 				query:            query,
 				marginComments:   comments,


### PR DESCRIPTION

## Description

See description in https://github.com/vitessio/vitess/issues/16710

The implementation is:

- Once we get a query `Plan`
- And find that the type is `PlanDDL`
- We replace the existing context (which is a `context.WithTimeout()`) with a `context.WithoutTimeout()` (new in `go1.21`).

**Seeking advice on how to test this.**

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/16710

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
