### PR TITLE
Reduce flakiness in TwoPC testing

### DIFF
--- a/go/test/endtoend/cluster/move_tables.go
+++ b/go/test/endtoend/cluster/move_tables.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -31,10 +32,11 @@ type MoveTablesWorkflow struct {
 	targetKs        string
 	srcKs           string
 	tables          string
+	tabletTypes     []string
 }
 
 // NewMoveTables creates a new MoveTablesWorkflow.
-func NewMoveTables(t *testing.T, clusterInstance *LocalProcessCluster, workflowName, targetKs, srcKs, tables string) *MoveTablesWorkflow {
+func NewMoveTables(t *testing.T, clusterInstance *LocalProcessCluster, workflowName, targetKs, srcKs, tables string, tabletTypes []string) *MoveTablesWorkflow {
 	return &MoveTablesWorkflow{
 		t:               t,
 		clusterInstance: clusterInstance,
@@ -42,6 +44,7 @@ func NewMoveTables(t *testing.T, clusterInstance *LocalProcessCluster, workflowN
 		tables:          tables,
 		targetKs:        targetKs,
 		srcKs:           srcKs,
+		tabletTypes:     tabletTypes,
 	}
 }
 
@@ -51,6 +54,10 @@ func (mtw *MoveTablesWorkflow) Create() (string, error) {
 		args = append(args, "--tables="+mtw.tables)
 	} else {
 		args = append(args, "--all-tables")
+	}
+	if len(mtw.tabletTypes) != 0 {
+		args = append(args, "--tablet-types")
+		args = append(args, strings.Join(mtw.tabletTypes, ","))
 	}
 	return mtw.exec(args...)
 }

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -637,7 +637,7 @@ func (vttablet *VttabletProcess) WaitForVReplicationToCatchup(t testing.TB, work
 	for ind, query := range queries {
 		waitDuration := 500 * time.Millisecond
 		for duration > 0 {
-			log.Infof("Executing query %s on %s", query, vttablet.Name)
+			log.Infof("Executing query %s on %s", query, vttablet.TabletPath)
 			lastChecked = time.Now()
 			qr, err := executeQuery(conn, query)
 			if err != nil {

--- a/go/test/endtoend/transaction/twopc/stress/fuzzer_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/fuzzer_test.go
@@ -462,7 +462,7 @@ func moveTablesFuzzer(t *testing.T) {
 		require.NoError(t, err)
 	}
 	log.Errorf("MoveTables from - %v to %v", srcKeyspace, targetKeyspace)
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, targetKeyspace, srcKeyspace, "twopc_fuzzer_update")
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, targetKeyspace, srcKeyspace, "twopc_fuzzer_update", []string{"REPLICA"})
 	// Initiate MoveTables for twopc_fuzzer_update.
 	output, err := mtw.Create()
 	if err != nil {

--- a/go/test/endtoend/transaction/twopc/stress/fuzzer_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/fuzzer_test.go
@@ -37,7 +37,9 @@ import (
 	"vitess.io/vitess/go/syscallutil"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/schema"
+	topoprotopb "vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 var (
@@ -462,7 +464,7 @@ func moveTablesFuzzer(t *testing.T) {
 		require.NoError(t, err)
 	}
 	log.Errorf("MoveTables from - %v to %v", srcKeyspace, targetKeyspace)
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, targetKeyspace, srcKeyspace, "twopc_fuzzer_update", []string{"REPLICA"})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, targetKeyspace, srcKeyspace, "twopc_fuzzer_update", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
 	// Initiate MoveTables for twopc_fuzzer_update.
 	output, err := mtw.Create()
 	if err != nil {

--- a/go/test/endtoend/transaction/twopc/stress/fuzzer_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/fuzzer_test.go
@@ -39,7 +39,6 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/schema"
-	topoprotopb "vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 var (
@@ -464,7 +463,7 @@ func moveTablesFuzzer(t *testing.T) {
 		require.NoError(t, err)
 	}
 	log.Errorf("MoveTables from - %v to %v", srcKeyspace, targetKeyspace)
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, targetKeyspace, srcKeyspace, "twopc_fuzzer_update", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, targetKeyspace, srcKeyspace, "twopc_fuzzer_update", []string{topodatapb.TabletType_REPLICA.String()})
 	// Initiate MoveTables for twopc_fuzzer_update.
 	output, err := mtw.Create()
 	if err != nil {

--- a/go/test/endtoend/transaction/twopc/stress/stress_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/stress_test.go
@@ -258,7 +258,7 @@ func mysqlRestartShard3(t *testing.T) error {
 // moveTablesCancel runs a move tables command that we cancel in the end.
 func moveTablesCancel(t *testing.T) error {
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1")
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{"REPLICA"})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)
@@ -277,7 +277,7 @@ func moveTablesCancel(t *testing.T) error {
 // moveTablesComplete runs a move tables command that we complete in the end.
 func moveTablesComplete(t *testing.T) error {
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1")
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{"REPLICA"})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)
@@ -297,7 +297,7 @@ func moveTablesReset(t *testing.T) {
 	err := clusterInstance.VtctldClientProcess.ApplyVSchema(keyspaceName, VSchema)
 	require.NoError(t, err)
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, keyspaceName, unshardedKeyspaceName, "twopc_t1")
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, keyspaceName, unshardedKeyspaceName, "twopc_t1", []string{"REPLICA"})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)

--- a/go/test/endtoend/transaction/twopc/stress/stress_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/stress_test.go
@@ -39,7 +39,9 @@ import (
 	twopcutil "vitess.io/vitess/go/test/endtoend/transaction/twopc/utils"
 	"vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/schema"
+	topoprotopb "vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 // TestDisruptions tests that atomic transactions persevere through various disruptions.
@@ -258,7 +260,7 @@ func mysqlRestartShard3(t *testing.T) error {
 // moveTablesCancel runs a move tables command that we cancel in the end.
 func moveTablesCancel(t *testing.T) error {
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{"REPLICA"})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)
@@ -277,7 +279,7 @@ func moveTablesCancel(t *testing.T) error {
 // moveTablesComplete runs a move tables command that we complete in the end.
 func moveTablesComplete(t *testing.T) error {
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{"REPLICA"})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)
@@ -297,7 +299,7 @@ func moveTablesReset(t *testing.T) {
 	err := clusterInstance.VtctldClientProcess.ApplyVSchema(keyspaceName, VSchema)
 	require.NoError(t, err)
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, keyspaceName, unshardedKeyspaceName, "twopc_t1", []string{"REPLICA"})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, keyspaceName, unshardedKeyspaceName, "twopc_t1", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)

--- a/go/test/endtoend/transaction/twopc/stress/stress_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/stress_test.go
@@ -41,7 +41,6 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/schema"
-	topoprotopb "vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 // TestDisruptions tests that atomic transactions persevere through various disruptions.
@@ -260,7 +259,7 @@ func mysqlRestartShard3(t *testing.T) error {
 // moveTablesCancel runs a move tables command that we cancel in the end.
 func moveTablesCancel(t *testing.T) error {
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{topodatapb.TabletType_REPLICA.String()})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)
@@ -279,7 +278,7 @@ func moveTablesCancel(t *testing.T) error {
 // moveTablesComplete runs a move tables command that we complete in the end.
 func moveTablesComplete(t *testing.T) error {
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, unshardedKeyspaceName, keyspaceName, "twopc_t1", []string{topodatapb.TabletType_REPLICA.String()})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)
@@ -299,7 +298,7 @@ func moveTablesReset(t *testing.T) {
 	err := clusterInstance.VtctldClientProcess.ApplyVSchema(keyspaceName, VSchema)
 	require.NoError(t, err)
 	workflow := "TestDisruptions"
-	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, keyspaceName, unshardedKeyspaceName, "twopc_t1", []string{topoprotopb.TabletTypeLString(topodatapb.TabletType_REPLICA)})
+	mtw := cluster.NewMoveTables(t, clusterInstance, workflow, keyspaceName, unshardedKeyspaceName, "twopc_t1", []string{topodatapb.TabletType_REPLICA.String()})
 	// Initiate MoveTables for twopc_t1.
 	output, err := mtw.Create()
 	require.NoError(t, err, output)

--- a/go/test/endtoend/transaction/twopc/utils/utils.go
+++ b/go/test/endtoend/transaction/twopc/utils/utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/log"
 )
 
 const (
@@ -48,14 +49,14 @@ func ClearOutTable(t *testing.T, vtParams mysql.ConnParams, tableName string) {
 		}
 		conn, err := mysql.Connect(ctx, &vtParams)
 		if err != nil {
-			fmt.Printf("Error in connection - %v\n", err)
+			log.Errorf("Error in connection - %v\n", err)
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 
 		res, err := conn.ExecuteFetch(fmt.Sprintf("SELECT count(*) FROM %v", tableName), 1, false)
 		if err != nil {
-			fmt.Printf("Error in selecting - %v\n", err)
+			log.Errorf("Error in selecting - %v\n", err)
 			conn.Close()
 			time.Sleep(100 * time.Millisecond)
 			continue
@@ -71,7 +72,7 @@ func ClearOutTable(t *testing.T, vtParams mysql.ConnParams, tableName string) {
 		_, err = conn.ExecuteFetch(fmt.Sprintf("DELETE FROM %v LIMIT 10000", tableName), 10000, false)
 		conn.Close()
 		if err != nil {
-			fmt.Printf("Error in cleanup deletion - %v\n", err)
+			log.Errorf("Error in cleanup deletion - %v\n", err)
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR reduces the flakiness in 2PC testing. There are 2 changes in this PR - 
1. Run `MoveTables Create` with the `--tablet-types REPLICA` flag so that the copier selects a replica to copy from instead of a primary. This is required because we have an open transaction against a primary and that blocks the `lock tables for read` statement that the copier runs.
2. Add a timeout to clearing out the tables data to prevent panics and instead show up an error.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
