### PR TITLE
Move from 4-cores larger runners to `ubuntu-latest`

### DIFF
--- a/.github/workflows/assign_milestone.yml
+++ b/.github/workflows/assign_milestone.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: Assign Milestone
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
 

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   push:
     name: Set push variable
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository == 'vitessio/vitess'
     outputs:
       push: ${{ steps.push.outputs.push }}

--- a/.github/workflows/check_label.yml
+++ b/.github/workflows/check_label.yml
@@ -9,7 +9,7 @@ jobs:
   check_pull_request_labels:
     name: Check Pull Request labels
     timeout-minutes: 10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository == 'vitessio/vitess'
     steps:
       - name: Release Notes label

--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Check Make vtadmin_authz_testgen
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Check Make VTAdmin Web Proto
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/close_stale_pull_requests.yml
+++ b/.github/workflows/close_stale_pull_requests.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   close_stale_pull_requests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
 

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (12)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (13)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (15)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (18)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (21)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_backup_pitr.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (backup_pitr)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (backup_pitr_xtrabackup)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql80)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (mysql_server_vault)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_scheduler)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (schemadiff_vrepl)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_consul)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_topo)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (topo_connection_cache)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_across_db_versions)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_copy_parallel.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_copy_parallel.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_copy_parallel)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_foreign_key_stress)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_mariadb_to_mysql.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_mariadb_to_mysql.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_mariadb_to_mysql)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multi_tenant)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_partial_movetables_and_materialize)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vstream.yml
+++ b/.github/workflows/cluster_endtoend_vstream.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vstream)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtbackup.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtbackup)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtctlbackup_sharded_clustertest_heavy)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_foreignkey_stress.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_foreignkey_stress.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_foreignkey_stress)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_general_heavy)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_godriver)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_partial_keyspace)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_queries)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema_tracker)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_consul)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo_etcd)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex_heavy)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vttablet_prscomplex)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_backup)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -7,7 +7,7 @@ permissions: read-all
 jobs:
   build:
     name: Code Freeze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Fail if Code Freeze is enabled
       run: |

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: Docker Test Cluster 10
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: Docker Test Cluster 25
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: End-to-End Test (Race)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -5,7 +5,7 @@ jobs:
 
   build:
     name: End-to-End Test
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
     steps:
     - name: Skip CI
       run: |

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   build:
     name: Static Code Checks Etc
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Skip CI

--- a/.github/workflows/unit_test_evalengine_mysql57.yml
+++ b/.github/workflows/unit_test_evalengine_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (evalengine_mysql57)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/unit_test_evalengine_mysql80.yml
+++ b/.github/workflows/unit_test_evalengine_mysql80.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (evalengine_mysql80)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/unit_test_evalengine_mysql84.yml
+++ b/.github/workflows/unit_test_evalengine_mysql84.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (evalengine_mysql84)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (mysql57)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (mysql80)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/unit_test_mysql84.yml
+++ b/.github/workflows/unit_test_mysql84.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Unit Test (mysql84)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Vitess Tester (vtgate)
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
     steps:
       - name: Skip CI
         run: |

--- a/.github/workflows/vtadmin_web_lint.yml
+++ b/.github/workflows/vtadmin_web_lint.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Skip CI
         run: |

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   unit-tests:
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
     steps:
       - name: Skip CI
         run: |

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}gh-hosted-runners-4cores-1{{end}}
+    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}ubuntu-latest{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}gh-hosted-runners-4cores-1{{end}}
+    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}ubuntu-latest{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}gh-hosted-runners-4cores-1{{end}}
+    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1{{else}}ubuntu-latest{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_vitess_tester.tpl
+++ b/test/templates/cluster_vitess_tester.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: {{.Name}}
-    runs-on: gh-hosted-runners-4cores-1
+    runs-on: ubuntu-latest
 
     steps:
     - name: Skip CI


### PR DESCRIPTION
## Description

GitHub changed its default hosted runners from 2-cores to 4-cores. Meaning that we no longer need to use the GitHub hosted larger runners that has 4-cores, and can default to `ubuntu-latest`. This cleanup allows 64 workflows to default start using an unlimited resource rather than a limited larger runner.

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

This PR also fixed any inconsistency in the type of OS we were running, now we only run `ubuntu-latest` instead of having some on v20 and some on v22

This needs to be backported to all known releases branches so we can optimize all our workflows.