### PR TITLE
FindErrantGTIDs: superset is not an errant GTID situation

### DIFF
--- a/go/mysql/replication/replication_status.go
+++ b/go/mysql/replication/replication_status.go
@@ -201,6 +201,14 @@ func (s *ReplicationStatus) FindErrantGTIDs(otherReplicaStatuses []*ReplicationS
 		otherSets = append(otherSets, otherSet)
 	}
 
+	if len(otherSets) == 1 {
+		// If there is only one replica to compare against, and one is a subset of the other, then we consider them not to be errant.
+		// It simply means that one replica might be behind on replication.
+		if relayLogSet.Contains(otherSets[0]) || otherSets[0].Contains(relayLogSet) {
+			return nil, nil
+		}
+	}
+
 	// Copy set for final diffSet so we don't mutate receiver.
 	diffSet := make(Mysql56GTIDSet, len(relayLogSet))
 	for sid, intervals := range relayLogSet {

--- a/go/mysql/replication/replication_status_test.go
+++ b/go/mysql/replication/replication_status_test.go
@@ -105,6 +105,16 @@ func TestFindErrantGTIDs(t *testing.T) {
 		otherRepStatuses: []*ReplicationStatus{{SourceUUID: sid1, RelayLogPosition: Position{GTIDSet: set1}}},
 		// servers with the same GTID sets should not be diagnosed with errant GTIDs
 		want: nil,
+	}, {
+		mainRepStatus:    &ReplicationStatus{SourceUUID: sourceSID, RelayLogPosition: Position{GTIDSet: set2}},
+		otherRepStatuses: []*ReplicationStatus{{SourceUUID: sid1, RelayLogPosition: Position{GTIDSet: set3}}},
+		// set2 is a strict subset of set3
+		want: nil,
+	}, {
+		mainRepStatus:    &ReplicationStatus{SourceUUID: sourceSID, RelayLogPosition: Position{GTIDSet: set3}},
+		otherRepStatuses: []*ReplicationStatus{{SourceUUID: sid1, RelayLogPosition: Position{GTIDSet: set2}}},
+		// set3 is a strict superset of set2
+		want: nil,
 	}}
 
 	for _, testcase := range testcases {

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -123,7 +123,7 @@ func FindValidEmergencyReparentCandidates(
 		case len(errantGTIDs) != 0:
 			// This tablet has errant GTIDs. It's not a valid candidate for
 			// reparent, so don't insert it into the final mapping.
-			log.Errorf("skipping %v because we detected errant GTIDs - %v", alias, errantGTIDs)
+			log.Errorf("skipping %v with GTIDSet:%v because we detected errant GTIDs - %v", alias, relayLogGTIDSet, errantGTIDs)
 			continue
 		}
 

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -176,12 +176,7 @@ func TestFindValidEmergencyReparentCandidates(t *testing.T) {
 					},
 				},
 			},
-			primaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{
-				"p1": {
-					Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
-				},
-			},
-			expected:  []string{"r1", "r2", "p1"},
+			expected:  []string{"r1", "r2"},
 			shouldErr: false,
 		},
 		{
@@ -200,12 +195,7 @@ func TestFindValidEmergencyReparentCandidates(t *testing.T) {
 					},
 				},
 			},
-			primaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{
-				"p1": {
-					Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
-				},
-			},
-			expected:  []string{"p1"},
+			expected:  []string{},
 			shouldErr: false,
 		},
 		{

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -161,7 +161,7 @@ func TestFindValidEmergencyReparentCandidates(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name: "tablet with errant GTIDs is excluded",
+			name: "tablet with superset GTIDs is included",
 			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
 				"r1": {
 					After: &replicationdatapb.Status{
@@ -169,7 +169,7 @@ func TestFindValidEmergencyReparentCandidates(t *testing.T) {
 						RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
 					},
 				},
-				"errant": {
+				"r2": {
 					After: &replicationdatapb.Status{
 						SourceUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
 						RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5,AAAAAAAA-71CA-11E1-9E33-C80AA9429562:1",
@@ -181,7 +181,31 @@ func TestFindValidEmergencyReparentCandidates(t *testing.T) {
 					Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
 				},
 			},
-			expected:  []string{"r1", "p1"},
+			expected:  []string{"r1", "r2", "p1"},
+			shouldErr: false,
+		},
+		{
+			name: "tablets with errant GTIDs are excluded",
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				"r1": {
+					After: &replicationdatapb.Status{
+						SourceUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
+						RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5,AAAAAAAA-71CA-11E1-9E33-C80AA9429562:1",
+					},
+				},
+				"r2": {
+					After: &replicationdatapb.Status{
+						SourceUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
+						RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5,AAAAAAAA-71CA-11E1-9E33-C80AA9429562:2-3",
+					},
+				},
+			},
+			primaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{
+				"p1": {
+					Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
+				},
+			},
+			expected:  []string{"p1"},
 			shouldErr: false,
 		},
 		{


### PR DESCRIPTION
## Description
If there are only two replicas, and one has a GTIDSet that is a superset of the other, do not consider it as errant.
Of the two new unit tests, the second one (superset) fails without the code change in this PR.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This can cause serious issues, so I'm marking this for backport to all supported releases.

## Related Issue(s)
#16724 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
