### PR TITLE
vtbackup: allow exiting if failing early

### DIFF
--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -230,8 +230,10 @@ func run(cc *cobra.Command, args []string) error {
 	})
 
 	defer func() {
-		servenv.ExitChan <- syscall.SIGTERM
-		<-ctx.Done()
+		if servenv.ExitChan != nil {
+			servenv.ExitChan <- syscall.SIGTERM
+			<-ctx.Done()
+		}
 	}()
 
 	go servenv.RunDefault()


### PR DESCRIPTION
The control flow in here relies on panic'ing and recovering from that panic.

Exiting the process ends up being blocked on this defer block before the panic recovery handler if we exit before `servenv.ExitChan` is created. We're then ultimately blocking forever and require a kill -9 while we're trying to write into a nil channel.

This is ultimately becuase we start up `servenv.RunDefault()` in a goroutine, and `servenv.ExitChan` ends up being created within that, so it's possible we are trying to exit before the channel is created.

## Related Issue(s)

None

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None
