### PR TITLE
CI: Use valid tag for the ossf-scorecard action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Description

This is a quick follow-up to https://github.com/vitessio/vitess/pull/16538. The workflow has been [failing on main every time since it was merged](https://github.com/vitessio/vitess/commits/main/) with this error:
```
Error: Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

That's because there are no major version tags (nor major.minor) used for this action: https://github.com/ossf/scorecard-action/tags

So this PR addresses that by using the latest version tag of `v2.4.0`.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/16538

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required