### PR TITLE
Workflow Status: change logic to determine whether `MoveTables` writes are switched

### DIFF
--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -58,6 +58,12 @@ const (
 	tabletUIDStep           = 10
 )
 
+var defaultTabletTypes = []topodatapb.TabletType{
+	topodatapb.TabletType_PRIMARY,
+	topodatapb.TabletType_REPLICA,
+	topodatapb.TabletType_RDONLY,
+}
+
 type testKeyspace struct {
 	KeyspaceName string
 	ShardNames   []string
@@ -209,7 +215,7 @@ func (env *testEnv) updateTableRoutingRules(t *testing.T, ctx context.Context,
 	tabletTypes []topodatapb.TabletType, tables []string, sourceKeyspace, targetKeyspace, toKeyspace string) {
 
 	if len(tabletTypes) == 0 {
-		tabletTypes = []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY}
+		tabletTypes = defaultTabletTypes
 	}
 	rr, err := env.ts.GetRoutingRules(ctx)
 	require.NoError(t, err)

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -261,7 +261,7 @@ type testTMClient struct {
 	mu                                 sync.Mutex
 	vrQueries                          map[int][]*queryResult
 	createVReplicationWorkflowRequests map[uint32]*tabletmanagerdatapb.CreateVReplicationWorkflowRequest
-	readVReplicationWorkflowRequests   map[string]*tabletmanagerdatapb.ReadVReplicationWorkflowRequest
+	readVReplicationWorkflowRequests   map[uint32]*tabletmanagerdatapb.ReadVReplicationWorkflowRequest
 	primaryPositions                   map[uint32]string
 	vdiffRequests                      map[uint32]*vdiffRequestResponse
 
@@ -282,7 +282,7 @@ func newTestTMClient(env *testEnv) *testTMClient {
 		schema:                             make(map[string]*tabletmanagerdatapb.SchemaDefinition),
 		vrQueries:                          make(map[int][]*queryResult),
 		createVReplicationWorkflowRequests: make(map[uint32]*tabletmanagerdatapb.CreateVReplicationWorkflowRequest),
-		readVReplicationWorkflowRequests:   make(map[string]*tabletmanagerdatapb.ReadVReplicationWorkflowRequest),
+		readVReplicationWorkflowRequests:   make(map[uint32]*tabletmanagerdatapb.ReadVReplicationWorkflowRequest),
 		readVReplicationWorkflowsResponses: make(map[string][]*tabletmanagerdatapb.ReadVReplicationWorkflowsResponse),
 		primaryPositions:                   make(map[uint32]string),
 		env:                                env,
@@ -309,8 +309,7 @@ func (tmc *testTMClient) GetWorkflowKey(keyspace, shard string) string {
 func (tmc *testTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.ReadVReplicationWorkflowRequest) (*tabletmanagerdatapb.ReadVReplicationWorkflowResponse, error) {
 	tmc.mu.Lock()
 	defer tmc.mu.Unlock()
-	key := fmt.Sprintf("%d/%s", tablet.Alias.Uid, req.Workflow)
-	if expect := tmc.readVReplicationWorkflowRequests[key]; expect != nil {
+	if expect := tmc.readVReplicationWorkflowRequests[tablet.Alias.Uid]; expect != nil {
 		if !proto.Equal(expect, req) {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected ReadVReplicationWorkflow request: got %+v, want %+v", req, expect)
 		}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -945,6 +945,10 @@ ORDER BY
 	}, nil
 }
 
+func (s *Server) GetWorkflowState(ctx context.Context, targetKeyspace, workflowName string) (*trafficSwitcher, *State, error) {
+	return s.getWorkflowState(ctx, targetKeyspace, workflowName)
+}
+
 func (s *Server) getWorkflowState(ctx context.Context, targetKeyspace, workflowName string) (*trafficSwitcher, *State, error) {
 	ts, err := s.buildTrafficSwitcher(ctx, targetKeyspace, workflowName)
 	if err != nil {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1028,10 +1028,10 @@ func (s *Server) getWorkflowState(ctx context.Context, targetKeyspace, workflowN
 				return nil, nil, err
 			}
 			for _, table := range ts.Tables() {
-				// If a rule for primary exists for any table and points to the target keyspace,
+				// If a rule for the primary tablet type exists for any table and points to the target keyspace,
 				// then writes have been switched.
-				rr := globalRules[fmt.Sprintf("%s.%s", ts.sourceKeyspace, table)]
-				if len(rr) > 0 && rr[0] != fmt.Sprintf("%s.%s", ts.sourceKeyspace, table) {
+				rr := globalRules[fmt.Sprintf("%s.%s", sourceKeyspace, table)]
+				if len(rr) > 0 && rr[0] != fmt.Sprintf("%s.%s", sourceKeyspace, table) {
 					state.WritesSwitched = true
 					break
 				}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1034,8 +1034,9 @@ func (s *Server) getWorkflowState(ctx context.Context, targetKeyspace, workflowN
 			for _, table := range ts.Tables() {
 				// If a rule for the primary tablet type exists for any table and points to the target keyspace,
 				// then writes have been switched.
-				rr := globalRules[fmt.Sprintf("%s.%s", sourceKeyspace, table)]
-				if len(rr) > 0 && rr[0] != fmt.Sprintf("%s.%s", sourceKeyspace, table) {
+				ruleKey := fmt.Sprintf("%s.%s", sourceKeyspace, table)
+				rr := globalRules[ruleKey]
+				if len(rr) > 0 && rr[0] != ruleKey {
 					state.WritesSwitched = true
 					break
 				}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1027,9 +1027,9 @@ func (s *Server) getWorkflowState(ctx context.Context, targetKeyspace, workflowN
 				return nil, nil, err
 			}
 			for _, table := range ts.Tables() {
-				rr := globalRules[table]
-				// If a rule exists for the table and points to the target keyspace, then
-				// writes have been switched.
+				// If a rule exists for any table and points the source to the target keyspace,
+				// then writes have been switched.
+				rr := globalRules[fmt.Sprintf("%s.%s", ts.sourceKeyspace, table)]
 				if len(rr) > 0 && rr[0] == fmt.Sprintf("%s.%s", targetKeyspace, table) {
 					state.WritesSwitched = true
 					break

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -1354,6 +1354,15 @@ func TestMirrorTraffic(t *testing.T) {
 		topodatapb.TabletType_RDONLY,
 	}
 
+	initialRoutingRules := map[string][]string{
+		fmt.Sprintf("%s.%s", sourceKs, table1):         {fmt.Sprintf("%s.%s", sourceKs, table1)},
+		fmt.Sprintf("%s.%s", sourceKs, table2):         {fmt.Sprintf("%s.%s", sourceKs, table2)},
+		fmt.Sprintf("%s.%s@replica", sourceKs, table1): {fmt.Sprintf("%s.%s@replica", sourceKs, table1)},
+		fmt.Sprintf("%s.%s@replica", sourceKs, table2): {fmt.Sprintf("%s.%s@replica", sourceKs, table2)},
+		fmt.Sprintf("%s.%s@rdonly", sourceKs, table1):  {fmt.Sprintf("%s.%s@rdonly", sourceKs, table1)},
+		fmt.Sprintf("%s.%s@rdonly", sourceKs, table2):  {fmt.Sprintf("%s.%s@rdonly", sourceKs, table2)},
+	}
+
 	tests := []struct {
 		name string
 
@@ -1441,8 +1450,8 @@ func TestMirrorTraffic(t *testing.T) {
 				Percent:     50.0,
 			},
 			routingRules: map[string][]string{
-				fmt.Sprintf("%s.%s@rdonly", targetKs, table1): {fmt.Sprintf("%s.%s@rdonly", targetKs, table1)},
-				fmt.Sprintf("%s.%s@rdonly", targetKs, table2): {fmt.Sprintf("%s.%s@rdonly", targetKs, table2)},
+				fmt.Sprintf("%s.%s@rdonly", sourceKs, table1): {fmt.Sprintf("%s.%s@rdonly", targetKs, table1)},
+				fmt.Sprintf("%s.%s@rdonly", sourceKs, table2): {fmt.Sprintf("%s.%s@rdonly", targetKs, table2)},
 			},
 			wantErr:         "cannot mirror [rdonly] traffic for workflow src2target at this time: traffic for those tablet types is switched",
 			wantMirrorRules: make(map[string]map[string]float32),
@@ -1456,8 +1465,8 @@ func TestMirrorTraffic(t *testing.T) {
 				Percent:     50.0,
 			},
 			routingRules: map[string][]string{
-				fmt.Sprintf("%s.%s@replica", targetKs, table1): {fmt.Sprintf("%s.%s@replica", targetKs, table1)},
-				fmt.Sprintf("%s.%s@replica", targetKs, table2): {fmt.Sprintf("%s.%s@replica", targetKs, table2)},
+				fmt.Sprintf("%s.%s@replica", sourceKs, table1): {fmt.Sprintf("%s.%s@replica", targetKs, table1)},
+				fmt.Sprintf("%s.%s@replica", sourceKs, table2): {fmt.Sprintf("%s.%s@replica", targetKs, table2)},
 			},
 			wantErr:         "cannot mirror [replica] traffic for workflow src2target at this time: traffic for those tablet types is switched",
 			wantMirrorRules: make(map[string]map[string]float32),
@@ -1471,8 +1480,8 @@ func TestMirrorTraffic(t *testing.T) {
 				Percent:     50.0,
 			},
 			routingRules: map[string][]string{
-				table1: {fmt.Sprintf("%s.%s", targetKs, table1)},
-				table2: {fmt.Sprintf("%s.%s", targetKs, table2)},
+				fmt.Sprintf("%s.%s", sourceKs, table1): {fmt.Sprintf("%s.%s", targetKs, table1)},
+				fmt.Sprintf("%s.%s", sourceKs, table2): {fmt.Sprintf("%s.%s", targetKs, table2)},
 			},
 			wantErr:         "cannot mirror [primary] traffic for workflow src2target at this time: traffic for those tablet types is switched",
 			wantMirrorRules: make(map[string]map[string]float32),
@@ -1553,6 +1562,7 @@ func TestMirrorTraffic(t *testing.T) {
 				TabletTypes: tabletTypes,
 				Percent:     50.0,
 			},
+			routingRules: initialRoutingRules,
 			wantMirrorRules: map[string]map[string]float32{
 				fmt.Sprintf("%s.%s", sourceKs, table1): {
 					fmt.Sprintf("%s.%s", targetKs, table1): 50.0,
@@ -1587,6 +1597,7 @@ func TestMirrorTraffic(t *testing.T) {
 				TabletTypes: tabletTypes,
 				Percent:     50.0,
 			},
+			routingRules: initialRoutingRules,
 			wantMirrorRules: map[string]map[string]float32{
 				fmt.Sprintf("%s.%s", sourceKs, table1): {
 					fmt.Sprintf("%s.%s", targetKs, table1): 50.0,
@@ -1624,6 +1635,7 @@ func TestMirrorTraffic(t *testing.T) {
 					fmt.Sprintf("%s.%s", targetKs, table1): 25.0,
 				},
 			},
+			routingRules: initialRoutingRules,
 			req: &vtctldatapb.WorkflowMirrorTrafficRequest{
 				Keyspace:    targetKs,
 				Workflow:    workflow,

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -635,7 +635,8 @@ func TestMoveTablesComplete(t *testing.T) {
 				tc.preFunc(t, env)
 			}
 			// Setup the routing rules as they would be after having previously done SwitchTraffic.
-			env.updateTableRoutingRules(t, ctx, nil, []string{table1Name, table2Name, table3Name}, tc.targetKeyspace.KeyspaceName)
+			env.updateTableRoutingRules(t, ctx, nil, []string{table1Name, table2Name, table3Name},
+				tc.sourceKeyspace.KeyspaceName, tc.targetKeyspace.KeyspaceName, tc.targetKeyspace.KeyspaceName)
 			got, err := env.ws.MoveTablesComplete(ctx, tc.req)
 			if tc.wantErr != "" {
 				require.EqualError(t, err, tc.wantErr)
@@ -1098,7 +1099,8 @@ func TestMoveTablesTrafficSwitching(t *testing.T) {
 			} else {
 				env.tmc.reverse.Store(true)
 				// Setup the routing rules as they would be after having previously done SwitchTraffic.
-				env.updateTableRoutingRules(t, ctx, tabletTypes, []string{tableName}, tc.targetKeyspace.KeyspaceName)
+				env.updateTableRoutingRules(t, ctx, tabletTypes, []string{tableName},
+					tc.sourceKeyspace.KeyspaceName, tc.targetKeyspace.KeyspaceName, tc.targetKeyspace.KeyspaceName)
 				env.tmc.expectVRQueryResultOnKeyspaceTablets(tc.sourceKeyspace.KeyspaceName, copyTableQR)
 				for i := 0; i < len(tc.targetKeyspace.ShardNames); i++ { // Per stream
 					env.tmc.expectVRQueryResultOnKeyspaceTablets(tc.sourceKeyspace.KeyspaceName, cutoverQR)
@@ -1312,7 +1314,8 @@ func TestMoveTablesTrafficSwitchingDryRun(t *testing.T) {
 			} else {
 				env.tmc.reverse.Store(true)
 				// Setup the routing rules as they would be after having previously done SwitchTraffic.
-				env.updateTableRoutingRules(t, ctx, tabletTypes, tables, tc.targetKeyspace.KeyspaceName)
+				env.updateTableRoutingRules(t, ctx, tabletTypes, tables,
+					tc.sourceKeyspace.KeyspaceName, tc.targetKeyspace.KeyspaceName, tc.targetKeyspace.KeyspaceName)
 				env.tmc.expectVRQueryResultOnKeyspaceTablets(tc.sourceKeyspace.KeyspaceName, copyTableQR)
 				for i := 0; i < len(tc.targetKeyspace.ShardNames); i++ { // Per stream
 					env.tmc.expectVRQueryResultOnKeyspaceTablets(tc.targetKeyspace.KeyspaceName, journalQR)

--- a/go/vt/vtctl/workflow/workflow_state_test.go
+++ b/go/vt/vtctl/workflow/workflow_state_test.go
@@ -119,7 +119,7 @@ func TestWorkflowStateMoveTables(t *testing.T) {
 		},
 		{
 			name:                   "switch reads and writes",
-			wf1SwitchedTabletTypes: []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY},
+			wf1SwitchedTabletTypes: defaultTabletTypes,
 			wf1ExpectedState:       "All Reads Switched. Writes Switched",
 		},
 		{
@@ -132,7 +132,7 @@ func TestWorkflowStateMoveTables(t *testing.T) {
 			name:                   "switch replica only",
 			wf1SwitchedTabletTypes: []topodatapb.TabletType{topodatapb.TabletType_REPLICA},
 			wf1ExpectedState:       "Reads partially switched. All Replica Reads Switched. Rdonly not switched. Writes Not Switched",
-			wf2SwitchedTabletTypes: []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY},
+			wf2SwitchedTabletTypes: defaultTabletTypes,
 		},
 	}
 	tables := []string{"t1"}
@@ -152,16 +152,14 @@ func TestWorkflowStateMoveTables(t *testing.T) {
 		te.updateTableRoutingRules(t, ctx, nil, tables,
 			"source2", "target2", "source2")
 	}
-	resetRoutingRules()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			resetRoutingRules()
 			te.updateTableRoutingRules(t, ctx, tc.wf1SwitchedTabletTypes, tables,
 				"source", te.targetKeyspace.KeyspaceName, te.targetKeyspace.KeyspaceName)
 			te.updateTableRoutingRules(t, ctx, tc.wf2SwitchedTabletTypes, tables,
 				"source2", "target2", "target2")
 			require.Equal(t, tc.wf1ExpectedState, getStateString("target", "wf1"))
-			// reset to initial state
-			resetRoutingRules()
 		})
 	}
 }

--- a/go/vt/vtctl/workflow/workflow_state_test.go
+++ b/go/vt/vtctl/workflow/workflow_state_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2024 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"vitess.io/vitess/go/vt/log"
-
 	"github.com/stretchr/testify/require"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -30,8 +28,7 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
-func setupMoveTables(t *testing.T) (context.Context, *testEnv) {
-	ctx := context.Background()
+func setupMoveTables(t *testing.T, ctx context.Context) *testEnv {
 	schema := map[string]*tabletmanagerdata.SchemaDefinition{
 		"t1": {
 			TableDefinitions: []*tabletmanagerdata.TableDefinition{
@@ -90,14 +87,15 @@ func setupMoveTables(t *testing.T) (context.Context, *testEnv) {
 	}
 	te.updateTableRoutingRules(t, ctx, nil, []string{"t1"},
 		"source", te.targetKeyspace.KeyspaceName, "source")
-	return ctx, te
+	return te
 }
 
+// TestWorkflowStateMoveTables tests the logic used to determine the state of a MoveTables workflow based on the
+// routing rules. We setup two workflows with the same table in both source and target keyspaces.
 func TestWorkflowStateMoveTables(t *testing.T) {
-	ctx, te := setupMoveTables(t)
+	ctx := context.Background()
+	te := setupMoveTables(t, ctx)
 	require.NotNil(t, te)
-	rules, _ := te.ts.GetRoutingRules(ctx)
-	log.Infof("rules: %v", rules)
 	type testCase struct {
 		name                   string
 		wf1SwitchedTabletTypes []topodatapb.TabletType

--- a/go/vt/vtctl/workflow/workflow_state_test.go
+++ b/go/vt/vtctl/workflow/workflow_state_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	"vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func setupMoveTables(t *testing.T) (context.Context, *testEnv) {
+	ctx := context.Background()
+	schema := map[string]*tabletmanagerdata.SchemaDefinition{
+		"t1": {
+			TableDefinitions: []*tabletmanagerdata.TableDefinition{
+				{
+					Name:   "t1",
+					Schema: fmt.Sprintf("CREATE TABLE %s (id BIGINT, name VARCHAR(64), PRIMARY KEY (id))", "t1"),
+				},
+			},
+		},
+	}
+	sourceKeyspace := &testKeyspace{
+		KeyspaceName: "source",
+		ShardNames:   []string{"0"},
+	}
+	targetKeyspace := &testKeyspace{
+		KeyspaceName: "target",
+		ShardNames:   []string{"0"},
+	}
+	te := newTestEnv(t, ctx, "zone1", sourceKeyspace, targetKeyspace)
+	te.tmc.schema = schema
+	for k := range te.tablets {
+		for k2 := range te.tablets[k] {
+			fmt.Println(k, k2)
+		}
+	}
+	var wfs tabletmanagerdata.ReadVReplicationWorkflowsResponse
+	wfName := "wf1"
+	id := int32(1)
+	wfs.Workflows = append(wfs.Workflows, &tabletmanagerdata.ReadVReplicationWorkflowResponse{
+		Workflow:     wfName,
+		WorkflowType: binlogdatapb.VReplicationWorkflowType_MoveTables,
+	})
+	wfs.Workflows[0].Streams = append(wfs.Workflows[0].Streams, &tabletmanagerdata.ReadVReplicationWorkflowResponse_Stream{
+		Id: id,
+		Bls: &binlogdatapb.BinlogSource{
+			Keyspace: te.sourceKeyspace.KeyspaceName,
+			Shard:    "0",
+			Filter: &binlogdatapb.Filter{
+				Rules: []*binlogdatapb.Rule{
+					{Match: "t1", Filter: "select * from t1"},
+				},
+			},
+			Tables: []string{"t1"},
+		},
+		Pos:   position,
+		State: binlogdatapb.VReplicationWorkflowState_Running,
+	})
+	workflowKey := te.tmc.GetWorkflowKey("target", "wf1")
+	workflowResponses := []*tabletmanagerdata.ReadVReplicationWorkflowsResponse{
+		nil,              // this is the response for getting stopped workflows
+		&wfs, &wfs, &wfs, // return the full list for subsequent GetWorkflows calls
+	}
+	for _, resp := range workflowResponses {
+		te.tmc.AddVReplicationWorkflowsResponse(workflowKey, resp)
+	}
+	te.tmc.readVReplicationWorkflowRequests[200] = &tabletmanagerdata.ReadVReplicationWorkflowRequest{
+		Workflow: wfName,
+	}
+	te.updateTableRoutingRules(t, ctx, nil, []string{"t1"}, te.sourceKeyspace.KeyspaceName)
+	return ctx, te
+}
+
+func TestWorkflowStateMoveTables(t *testing.T) {
+	ctx, te := setupMoveTables(t)
+	require.NotNil(t, te)
+	type testCase struct {
+		name        string
+		tabletTypes []topodatapb.TabletType
+		wantState   string
+	}
+	testCases := []testCase{
+		{
+			name:        "switch reads",
+			tabletTypes: []topodatapb.TabletType{topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY},
+			wantState:   "All Reads Switched. Writes Not Switched",
+		},
+		{
+			name:        "switch writes",
+			tabletTypes: []topodatapb.TabletType{topodatapb.TabletType_PRIMARY},
+			wantState:   "Reads Not Switched. Writes Switched",
+		},
+		{
+			name:        "switch reads and writes",
+			tabletTypes: []topodatapb.TabletType{topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY},
+			wantState:   "All Reads Switched. Writes Switched",
+		},
+		{
+			name:        "switch rdonly only",
+			tabletTypes: []topodatapb.TabletType{topodatapb.TabletType_RDONLY},
+			wantState:   "Reads partially switched. Replica not switched. All Rdonly Reads Switched. Writes Not Switched",
+		},
+		{
+			name:        "switch replica only",
+			tabletTypes: []topodatapb.TabletType{topodatapb.TabletType_REPLICA},
+			wantState:   "Reads partially switched. All Replica Reads Switched. Rdonly not switched. Writes Not Switched",
+		},
+	}
+	tables := []string{"t1"}
+
+	getStateString := func() string {
+		tsw, state, err := te.ws.getWorkflowState(ctx, te.targetKeyspace.KeyspaceName, "wf1")
+		require.NoError(t, err)
+		require.NotNil(t, tsw)
+		require.NotNil(t, state)
+		return state.String()
+	}
+	initState := getStateString()
+	require.Equal(t, "Reads Not Switched. Writes Not Switched", initState)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			te.updateTableRoutingRules(t, ctx, tc.tabletTypes, tables, te.targetKeyspace.KeyspaceName)
+			require.Equal(t, tc.wantState, getStateString())
+			// reset to initial state
+			te.updateTableRoutingRules(t, ctx, tc.tabletTypes, tables, te.sourceKeyspace.KeyspaceName)
+		})
+	}
+}

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -478,7 +478,6 @@ func TestMoveTables(t *testing.T) {
 		AutoStart:      true,
 	})
 	require.NoError(t, err)
-
 	for _, ftc := range targetShards {
 		ftc.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowsLimited, tenv.dbName, wf), sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(
@@ -524,13 +523,13 @@ func TestMoveTables(t *testing.T) {
 		),
 		fmt.Sprintf("%d|%s|%s|NULL|0|0|||1686577659|0|Running||%s|1||0|0|0||0|1", vreplID, bls, position, sourceKs),
 	), nil)
-	sourceTablet.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflowsLimited, tenv.dbName, workflow.ReverseWorkflowName(wf)), sqltypes.MakeTestResult(
+	sourceTablet.vrdbClient.AddInvariant(fmt.Sprintf(readWorkflowsLimited, tenv.dbName, workflow.ReverseWorkflowName(wf)), sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
 			"workflow|id|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type|defer_secondary_keys",
 			"workflow|int64|varchar|blob|varchar|int64|int64|varchar|varchar|int64|int64|varchar|varchar|varchar|int64|varchar|int64|int64|int64|varchar|int64|int64",
 		),
 		fmt.Sprintf("%s|%d|%s|%s|NULL|0|0|||1686577659|0|Running||%s|1||0|0|0||0|1", workflow.ReverseWorkflowName(wf), vreplID, bls, position, sourceKs),
-	), nil)
+	))
 	sourceTablet.vrdbClient.ExpectRequest(fmt.Sprintf(readWorkflow, wf, tenv.dbName), &sqltypes.Result{}, nil)
 
 	_, err = ws.WorkflowSwitchTraffic(ctx, &vtctldatapb.WorkflowSwitchTrafficRequest{

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -278,12 +278,12 @@ func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workfl
 				}
 			}
 		} else {
-			state.RdonlyCellsSwitched, state.RdonlyCellsNotSwitched, err = ws.GetCellsWithTableReadsSwitched(ctx, targetKeyspace, table, topodatapb.TabletType_RDONLY)
+			state.RdonlyCellsSwitched, state.RdonlyCellsNotSwitched, err = ws.GetCellsWithTableReadsSwitched(ctx, sourceKeyspace, targetKeyspace, table, topodatapb.TabletType_RDONLY)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			state.ReplicaCellsSwitched, state.ReplicaCellsNotSwitched, err = ws.GetCellsWithTableReadsSwitched(ctx, targetKeyspace, table, topodatapb.TabletType_REPLICA)
+			state.ReplicaCellsSwitched, state.ReplicaCellsNotSwitched, err = ws.GetCellsWithTableReadsSwitched(ctx, sourceKeyspace, targetKeyspace, table, topodatapb.TabletType_REPLICA)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
## Description

We use the table routing rules to decide where reads and writes are routed for tables which are part of `MoveTables` workflows. 

For each table we have rules like 
```
t1 => source.t1 
source.t1 => source.t1
t1@replica => source.t1@replica
source.t1@replica => source.t1@replica
target.t1 => source.t1
```
when no traffic is switched, or when all traffic is switched:
```
t1 => target.t1 
source.t1 => target.t1
t1@replica => target.t1@replica
source.t1@replica => target.t1@replica
target.t1 => target.t1
```

To determine whether writes are switched, we check the route for `t1`. If it is pointing to `target` it is considered that writes have been switched.

The problem comes the same table exists in different source keyspaces. For example if there are two workflows one from `source1`=>`target1` and another from `source2`=>`target2`, both with a table `t1`.

Now if one workflow's writes are switched we end up with the route for `t1` pointing to `target1.t1`. When the next workflow's writes are switched we now overwrite that rule so that it points to `target2.t1`. The logic now assumes writes for the first workflow have *not* been switched.

Fix:
In general, global routing rules don't make sense in such cases.  But as an initial quick fix we change the logic to looking at the `source.t1` key instead of `t1`. In our case then after the two workflows have been switched we will get `source1.t1` => `target1.t1` and `source2.t1`  => `target2.t1`, resulting in the right state being deduced.

We do the same for for `replica`/`rdonly` types as well.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16733

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
