### PR TITLE
Example operator 401_scheduled_backups.yaml incorrect keyspace

### DIFF
--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -42,7 +42,7 @@ spec:
         jobTimeoutMinute: 5
         strategies:
           - name: BackupShard
-            keyspace: "customer"
+            keyspace: "commerce"
             shard: "-"
   images:
     vtctld: vitess/lite:latest


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

In the operator example 401_scheduled_backups.yaml the incorrect keyspace is used. Corrected `customer` to `commerce`

## Related Issue(s)

None

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None
