### PR TITLE
Fix release-18.0.7

### DIFF
--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - name: Fail if Code Freeze is enabled
       run: |
-        exit 1
+        exit 0

--- a/changelog/18.0/18.0.7/changelog.md
+++ b/changelog/18.0/18.0.7/changelog.md
@@ -1,0 +1,44 @@
+# Changelog of Vitess v18.0.7
+
+### Bug fixes 
+#### Query Serving
+ * [release-18.0] bugfix: don't treat join predicates as filter predicates (#16472) [#16473](https://github.com/vitessio/vitess/pull/16473)
+ * [release-18.0] Fix RegisterNotifier to use a copy of the tables to prevent data races (#14716) [#16490](https://github.com/vitessio/vitess/pull/16490)
+ * [release-18.0] fix: reference table join merge (#16488) [#16495](https://github.com/vitessio/vitess/pull/16495)
+ * [release-18.0] simplify merging logic (#16525) [#16531](https://github.com/vitessio/vitess/pull/16531)
+ * [release-18.0] Fix query plan cache misses metric (#16562) [#16626](https://github.com/vitessio/vitess/pull/16626)
+ * [release-18.0] JSON Encoding: Use Type_RAW for marshalling json (#16637) [#16680](https://github.com/vitessio/vitess/pull/16680) 
+#### Throttler
+ * v18 backport: Throttler/vreplication: fix app name used by VPlayer (#16578) [#16581](https://github.com/vitessio/vitess/pull/16581) 
+#### VReplication
+ * [release-18.0] VStream API: validate that last PK has fields defined (#16478) [#16485](https://github.com/vitessio/vitess/pull/16485) 
+#### VTAdmin
+ * [release-18.0] VTAdmin: Upgrade websockets js package (#16504) [#16511](https://github.com/vitessio/vitess/pull/16511) 
+#### VTGate
+ * [release-18.0] Fix `RemoveTablet` during `TabletExternallyReparented` causing connection issues (#16371) [#16566](https://github.com/vitessio/vitess/pull/16566) 
+#### VTorc
+ * [release-18.0] FindErrantGTIDs: superset is not an errant GTID situation (#16725) [#16727](https://github.com/vitessio/vitess/pull/16727)
+### CI/Build 
+#### General
+ * [release-18.0] Upgrade the Golang version to `go1.21.13` [#16545](https://github.com/vitessio/vitess/pull/16545)
+ * [release-18.0] Bump upgrade tests to `go1.22.7` [#16722](https://github.com/vitessio/vitess/pull/16722) 
+#### VTAdmin
+ * [release-18.0] Update micromatch to 4.0.8 (#16660) [#16665](https://github.com/vitessio/vitess/pull/16665)
+### Enhancement 
+#### Build/CI
+ * [release-18.0] Improve the queries upgrade/downgrade CI workflow by using same test code version as binary (#16494) [#16500](https://github.com/vitessio/vitess/pull/16500) 
+#### Online DDL
+ * v18 backport: Online DDL: avoid SQL's `CONVERT(...)`, convert programmatically if needed [#16604](https://github.com/vitessio/vitess/pull/16604)
+ * [release-18.0] VReplication workflows: retry "wrong tablet type" errors (#16645) [#16651](https://github.com/vitessio/vitess/pull/16651)
+### Internal Cleanup 
+#### Build/CI
+ * [release-18.0] Move from 4-cores larger runners to `ubuntu-latest` (#16714) [#16716](https://github.com/vitessio/vitess/pull/16716)
+### Regression 
+#### Query Serving
+ * [release-18.0] bugfix: Allow cross-keyspace joins (#16520) [#16522](https://github.com/vitessio/vitess/pull/16522)
+### Release 
+#### General
+### Testing 
+#### Query Serving
+ * [release-18.0] Replace ErrorContains checks with Error checks before running upgrade downgrade [#16701](https://github.com/vitessio/vitess/pull/16701)
+

--- a/changelog/18.0/18.0.7/release_notes.md
+++ b/changelog/18.0/18.0.7/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v18.0.7
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/18.0/18.0.7/changelog.md).
+
+The release includes 23 merged Pull Requests.
+
+Thanks to all our contributors: @GuptaManan100, @app/vitess-bot, @frouioui, @shlomi-noach, @vitess-bot
+

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -58,7 +58,7 @@ services:
       - "3306"
 
   vtctld:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15000:$WEB_PORT"
       - "$GRPC_PORT"
@@ -81,7 +81,7 @@ services:
         condition: service_healthy
 
   vtgate:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15099:$WEB_PORT"
       - "$GRPC_PORT"
@@ -111,7 +111,7 @@ services:
         condition: service_healthy
 
   schemaload:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     command:
     - sh
     - -c
@@ -144,12 +144,12 @@ services:
     environment:
       - KEYSPACES=$KEYSPACE
       - GRPC_PORT=15999
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - .:/script
 
   vttablet100:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15100:$WEB_PORT"
       - "$GRPC_PORT"
@@ -181,7 +181,7 @@ services:
       retries: 15
 
   vttablet101:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15101:$WEB_PORT"
       - "$GRPC_PORT"
@@ -213,7 +213,7 @@ services:
       retries: 15
 
   vttablet102:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15102:$WEB_PORT"
       - "$GRPC_PORT"
@@ -245,7 +245,7 @@ services:
       retries: 15
 
   vttablet103:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15103:$WEB_PORT"
       - "$GRPC_PORT"
@@ -277,7 +277,7 @@ services:
       retries: 15
 
   vtorc:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     command: ["sh", "-c", "/script/vtorc-up.sh"]
     depends_on:
       - vtctld
@@ -307,7 +307,7 @@ services:
       retries: 15
 
   vreplication:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - ".:/script"
     environment:

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     - SCHEMA_FILES=lookup_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
     - .:/script
   schemaload_test_keyspace:
@@ -101,7 +101,7 @@ services:
     - SCHEMA_FILES=test_keyspace_schema_file.sql
     - POST_LOAD_FILE=
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
     - .:/script
   set_keyspace_durability_policy:
@@ -115,7 +115,7 @@ services:
     environment:
       - KEYSPACES=test_keyspace lookup_keyspace
       - GRPC_PORT=15999
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - .:/script
   vreplication:
@@ -129,7 +129,7 @@ services:
     - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
       --topo_global_root vitess/global
     - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
     - .:/script
   vtctld:
@@ -143,7 +143,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15000:8080
     - "15999"
@@ -160,7 +160,7 @@ services:
       --normalize_queries=true '
     depends_on:
     - vtctld
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15099:8080
     - "15999"
@@ -182,7 +182,7 @@ services:
     - EXTERNAL_DB=0
     - DB_USER=
     - DB_PASS=
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 13000:8080
     volumes:
@@ -217,7 +217,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15101:8080
     - "15999"
@@ -254,7 +254,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15102:8080
     - "15999"
@@ -291,7 +291,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15201:8080
     - "15999"
@@ -328,7 +328,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15202:8080
     - "15999"
@@ -365,7 +365,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15301:8080
     - "15999"
@@ -402,7 +402,7 @@ services:
       - CMD-SHELL
       - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - 15302:8080
     - "15999"

--- a/examples/compose/vtcompose/docker-compose.test.yml
+++ b/examples/compose/vtcompose/docker-compose.test.yml
@@ -79,7 +79,7 @@ services:
       - SCHEMA_FILES=test_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - .:/script
   schemaload_unsharded_keyspace:
@@ -103,7 +103,7 @@ services:
       - SCHEMA_FILES=unsharded_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - .:/script
   set_keyspace_durability_policy_test_keyspace:
@@ -117,7 +117,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=test_keyspace
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - .:/script
   set_keyspace_durability_policy_unsharded_keyspace:
@@ -130,7 +130,7 @@ services:
     environment:
       - GRPC_PORT=15999
       - KEYSPACES=unsharded_keyspace
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - .:/script
   vreplication:
@@ -144,7 +144,7 @@ services:
       - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
         --topo_global_root vitess/global
       - EXTERNAL_DB=0
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - .:/script
   vtctld:
@@ -159,7 +159,7 @@ services:
     depends_on:
       external_db_host:
         condition: service_healthy
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 15000:8080
       - "15999"
@@ -176,7 +176,7 @@ services:
       ''grpc-vtgateservice'' --normalize_queries=true '
     depends_on:
       - vtctld
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 15099:8080
       - "15999"
@@ -199,7 +199,7 @@ services:
       - EXTERNAL_DB=0
       - DB_USER=
       - DB_PASS=
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 13000:8080
     volumes:
@@ -234,7 +234,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 15101:8080
       - "15999"
@@ -271,7 +271,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 15102:8080
       - "15999"
@@ -308,7 +308,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 15201:8080
       - "15999"
@@ -345,7 +345,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 15202:8080
       - "15999"
@@ -382,7 +382,7 @@ services:
         - CMD-SHELL
         - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - 15301:8080
       - "15999"

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -533,7 +533,7 @@ func generateDefaultShard(tabAlias int, shard string, keyspaceData keyspaceInfo,
 - op: add
   path: /services/init_shard_primary%[2]d
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     command: ["sh", "-c", "/vt/bin/vtctldclient %[5]s InitShardPrimary --force %[4]s/%[3]s %[6]s-%[2]d "]
     %[1]s
 `, dependsOn, aliases[0], shard, keyspaceData.keyspace, opts.topologyFlags, opts.cell)
@@ -565,7 +565,7 @@ func generateExternalPrimary(
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15%[1]d:%[3]d"
       - "%[4]d"
@@ -627,7 +627,7 @@ func generateDefaultTablet(tabAlias int, shard, role, keyspace string, dbInfo ex
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
     - "15%[1]d:%[4]d"
     - "%[5]d"
@@ -665,7 +665,7 @@ func generateVtctld(opts vtOptions) string {
 - op: add
   path: /services/vtctld
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15000:%[1]d"
       - "%[2]d"
@@ -696,7 +696,7 @@ func generateVtgate(opts vtOptions) string {
 - op: add
   path: /services/vtgate
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     ports:
       - "15099:%[1]d"
       - "%[2]d"
@@ -738,7 +738,7 @@ func generateVTOrc(dbInfo externalDbInfo, keyspaceInfoMap map[string]keyspaceInf
 - op: add
   path: /services/vtorc
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - ".:/script"
     environment:
@@ -763,7 +763,7 @@ func generateVreplication(dbInfo externalDbInfo, opts vtOptions) string {
 - op: add
   path: /services/vreplication
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - ".:/script"
     environment:
@@ -791,7 +791,7 @@ func generateSetKeyspaceDurabilityPolicy(
 - op: add
   path: /services/set_keyspace_durability_policy_%[3]s
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - ".:/script"
     environment:
@@ -828,7 +828,7 @@ func generateSchemaload(
 - op: add
   path: /services/schemaload_%[7]s
   value:
-    image: vitess/lite:v18.0.6
+    image: vitess/lite:v18.0.7
     volumes:
       - ".:/script"
     environment:

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,14 +8,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.6
-    vtadmin: vitess/vtadmin:v18.0.6
-    vtgate: vitess/lite:v18.0.6
-    vttablet: vitess/lite:v18.0.6
-    vtbackup: vitess/lite:v18.0.6
-    vtorc: vitess/lite:v18.0.6
+    vtctld: vitess/lite:v18.0.7
+    vtadmin: vitess/vtadmin:v18.0.7
+    vtgate: vitess/lite:v18.0.7
+    vttablet: vitess/lite:v18.0.7
+    vtbackup: vitess/lite:v18.0.7
+    vtorc: vitess/lite:v18.0.7
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.6
+      mysql80Compatible: vitess/lite:v18.0.7
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.6
-    vtadmin: vitess/vtadmin:v18.0.6
-    vtgate: vitess/lite:v18.0.6
-    vttablet: vitess/lite:v18.0.6
-    vtbackup: vitess/lite:v18.0.6
-    vtorc: vitess/lite:v18.0.6
+    vtctld: vitess/lite:v18.0.7
+    vtadmin: vitess/vtadmin:v18.0.7
+    vtgate: vitess/lite:v18.0.7
+    vttablet: vitess/lite:v18.0.7
+    vtbackup: vitess/lite:v18.0.7
+    vtorc: vitess/lite:v18.0.7
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.6
+      mysql80Compatible: vitess/lite:v18.0.7
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.6
-    vtadmin: vitess/vtadmin:v18.0.6
-    vtgate: vitess/lite:v18.0.6
-    vttablet: vitess/lite:v18.0.6
-    vtbackup: vitess/lite:v18.0.6
-    vtorc: vitess/lite:v18.0.6
+    vtctld: vitess/lite:v18.0.7
+    vtadmin: vitess/vtadmin:v18.0.7
+    vtgate: vitess/lite:v18.0.7
+    vttablet: vitess/lite:v18.0.7
+    vtbackup: vitess/lite:v18.0.7
+    vtorc: vitess/lite:v18.0.7
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.6
+      mysql80Compatible: vitess/lite:v18.0.7
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,14 +4,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v18.0.6
-    vtadmin: vitess/vtadmin:v18.0.6
-    vtgate: vitess/lite:v18.0.6
-    vttablet: vitess/lite:v18.0.6
-    vtbackup: vitess/lite:v18.0.6
-    vtorc: vitess/lite:v18.0.6
+    vtctld: vitess/lite:v18.0.7
+    vtadmin: vitess/vtadmin:v18.0.7
+    vtgate: vitess/lite:v18.0.7
+    vttablet: vitess/lite:v18.0.7
+    vtbackup: vitess/lite:v18.0.7
+    vtorc: vitess/lite:v18.0.7
     mysqld:
-      mysql80Compatible: vitess/lite:v18.0.6
+      mysql80Compatible: vitess/lite:v18.0.7
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/go/vt/servenv/version.go
+++ b/go/vt/servenv/version.go
@@ -19,4 +19,4 @@ package servenv
 // DO NOT EDIT
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
-const versionName = "18.0.7-SNAPSHOT"
+const versionName = "18.0.7"

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.7-SNAPSHOT</version>
+    <version>18.0.7</version>
   </parent>
   <artifactId>vitess-client</artifactId>
 

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.7-SNAPSHOT</version>
+    <version>18.0.7</version>
   </parent>
   <artifactId>vitess-example</artifactId>
 

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.7-SNAPSHOT</version>
+    <version>18.0.7</version>
   </parent>
   <artifactId>vitess-grpc-client</artifactId>
 

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>18.0.7-SNAPSHOT</version>
+    <version>18.0.7</version>
   </parent>
   <artifactId>vitess-jdbc</artifactId>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.vitess</groupId>
   <artifactId>vitess-parent</artifactId>
-  <version>18.0.7-SNAPSHOT</version>
+  <version>18.0.7</version>
   <packaging>pom</packaging>
 
   <name>Vitess Java Client libraries [Parent]</name>


### PR DESCRIPTION

## Description

Fixing the mistake of https://github.com/vitessio/vitess/pull/16740#event-14209862684, by rewriting commit history and removing this commit:
```

commit 6937274d9aff8779f3af2ec1840b7f0f843d383d (HEAD -> release-18.0, upstream/release-18.0)
Author: Shlomi Noach <2607934+shlomi-noach@users.noreply.github.com>
Date:   Wed Sep 11 10:54:24 2024 +0300

    [release-18.0] Release of `v18.0.7` (#16749)

    Signed-off-by: Shlomi Noach <2607934+shlomi-noach@users.noreply.github.com>
```

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16739

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
