### PR TITLE
[release-19.0] Remove mysql57 from docker images

### DIFF
--- a/.github/workflows/docker_build_base.yml
+++ b/.github/workflows/docker_build_base.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        branch: [ latest, mysql57, percona57, percona80 ]
+        branch: [ latest, percona80 ]
 
     steps:
       - name: Check out code

--- a/.github/workflows/docker_build_lite.yml
+++ b/.github/workflows/docker_build_lite.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        branch: [ latest, mysql57, mysql80, percona57, percona80 ]
+        branch: [ latest, mysql80, percona80 ]
 
     steps:
       - name: Check out code

--- a/.github/workflows/docker_build_vttestserver.yml
+++ b/.github/workflows/docker_build_vttestserver.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        branch: [ mysql57, mysql80 ]
+        branch: [ mysql80 ]
 
     steps:
       - name: Check out code

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ endef
 docker_base:
 	${call build_docker_image,docker/base/Dockerfile,vitess/base}
 
-DOCKER_BASE_SUFFIX = mysql80 percona57 percona80
+DOCKER_BASE_SUFFIX = mysql80 percona80
 DOCKER_BASE_TARGETS = $(addprefix docker_base_, $(DOCKER_BASE_SUFFIX))
 $(DOCKER_BASE_TARGETS): docker_base_%:
 	${call build_docker_image,docker/base/Dockerfile.$*,vitess/base:$*}
@@ -350,7 +350,7 @@ docker_run_local:
 docker_mini:
 	${call build_docker_image,docker/mini/Dockerfile,vitess/mini}
 
-DOCKER_VTTESTSERVER_SUFFIX = mysql57 mysql80
+DOCKER_VTTESTSERVER_SUFFIX = mysql80
 DOCKER_VTTESTSERVER_TARGETS = $(addprefix docker_vttestserver_,$(DOCKER_VTTESTSERVER_SUFFIX))
 $(DOCKER_VTTESTSERVER_TARGETS): docker_vttestserver_%:
 	${call build_docker_image,docker/vttestserver/Dockerfile.$*,vitess/vttestserver:$*}


### PR DESCRIPTION
## Description

This PR is a follow up of https://github.com/vitessio/vitess/pull/16622 where we removed some of the mysql 57 docker images, but some were forgotten. We were still trying to build mysql57 images for the new v19.0 patch release even though if we don't publish any more mysql57 bootstrap image.
