### PR TITLE
fix distributed transactions disruptions test with move table

### DIFF
--- a/go/test/endtoend/transaction/twopc/fuzz/main_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/main_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzz
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/transaction/twopc/utils"
+)
+
+var (
+	clusterInstance       *cluster.LocalProcessCluster
+	vtParams              mysql.ConnParams
+	vtgateGrpcAddress     string
+	keyspaceName          = "ks"
+	unshardedKeyspaceName = "uks"
+	cell                  = "zone1"
+	hostname              = "localhost"
+
+	//go:embed schema.sql
+	SchemaSQL string
+
+	//go:embed vschema.json
+	VSchema string
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitcode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Reserve vtGate port in order to pass it to vtTablet
+		clusterInstance.VtgateGrpcPort = clusterInstance.GetAndReservePort()
+
+		// Set extra args for twopc
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+			"--transaction_mode", "TWOPC",
+			"--grpc_use_effective_callerid",
+		)
+		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs,
+			"--twopc_enable",
+			"--twopc_abandon_age", "1",
+			"--migration_check_interval", "2s",
+		)
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:             keyspaceName,
+			SchemaSQL:        SchemaSQL,
+			VSchema:          VSchema,
+			DurabilityPolicy: "semi_sync",
+		}
+		if err := clusterInstance.StartKeyspace(*keyspace, []string{"-40", "40-80", "80-"}, 2, false); err != nil {
+			return 1
+		}
+
+		// Start an unsharded keyspace
+		unshardedKeyspace := &cluster.Keyspace{
+			Name:             unshardedKeyspaceName,
+			SchemaSQL:        "",
+			VSchema:          "{}",
+			DurabilityPolicy: "semi_sync",
+		}
+		if err := clusterInstance.StartUnshardedKeyspace(*unshardedKeyspace, 2, false); err != nil {
+			return 1
+		}
+
+		// Start Vtgate
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+		vtParams = clusterInstance.GetVTParams("")
+		vtgateGrpcAddress = fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateGrpcPort)
+
+		return m.Run()
+	}()
+	os.Exit(exitcode)
+}
+
+func start(t *testing.T) (*mysql.Conn, func()) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	cleanup(t)
+
+	return conn, func() {
+		conn.Close()
+		cleanup(t)
+	}
+}
+
+func cleanup(t *testing.T) {
+	cluster.PanicHandler(t)
+
+	utils.ClearOutTable(t, vtParams, "twopc_fuzzer_insert")
+	utils.ClearOutTable(t, vtParams, "twopc_fuzzer_update")
+	utils.ClearOutTable(t, vtParams, "twopc_t1")
+}

--- a/go/test/endtoend/transaction/twopc/fuzz/schema.sql
+++ b/go/test/endtoend/transaction/twopc/fuzz/schema.sql
@@ -1,0 +1,20 @@
+create table twopc_fuzzer_update (
+    id bigint,
+    col bigint,
+    primary key (id)
+) Engine=InnoDB;
+
+create table twopc_fuzzer_insert (
+    id bigint,
+    updateSet bigint,
+    threadId bigint,
+    col bigint auto_increment,
+    key(col),
+    primary key (id, col)
+) Engine=InnoDB;
+
+create table twopc_t1 (
+    id bigint,
+    col bigint,
+    primary key (id)
+) Engine=InnoDB;

--- a/go/test/endtoend/transaction/twopc/fuzz/vschema.json
+++ b/go/test/endtoend/transaction/twopc/fuzz/vschema.json
@@ -1,0 +1,34 @@
+{
+  "sharded":true,
+  "vindexes": {
+    "reverse_bits": {
+      "type": "reverse_bits"
+    }
+  },
+  "tables": {
+    "twopc_fuzzer_update": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "reverse_bits"
+        }
+      ]
+    },
+    "twopc_fuzzer_insert": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "reverse_bits"
+        }
+      ]
+    },
+    "twopc_t1": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "reverse_bits"
+        }
+      ]
+    }
+  }
+}

--- a/test/config.json
+++ b/test/config.json
@@ -851,6 +851,15 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"vtgate_transaction_twopc_fuzz": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/transaction/twopc/fuzz"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_transaction",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtgate_transaction_partial_exec": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/partialfailure"],


### PR DESCRIPTION
## Description

Fuzzer test and Stress test were using common state which sometimes leave `twopc_fuzzer_update` table on 2 keyspaces.
It causes an ambiguous error on running move tables disruption on the stress test after fuzz test have completed.

The PR split these into two different packages so that they do not interact with each other.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
