### PR TITLE
Migrate Workflow: Scope vindex names correctly when target and source keyspace have different names

### DIFF
--- a/go/test/endtoend/vreplication/migrate_test.go
+++ b/go/test/endtoend/vreplication/migrate_test.go
@@ -171,8 +171,15 @@ func TestVtctlMigrate(t *testing.T) {
 func TestVtctldMigrateUnsharded(t *testing.T) {
 	vc = NewVitessCluster(t, nil)
 
+	oldDefaultReplicas := defaultReplicas
+	oldDefaultRdonly := defaultRdonly
 	defaultReplicas = 0
 	defaultRdonly = 0
+	defer func() {
+		defaultReplicas = oldDefaultReplicas
+		defaultRdonly = oldDefaultRdonly
+	}()
+
 	defer vc.TearDown()
 
 	defaultCell := vc.Cells[vc.CellNames[0]]
@@ -303,12 +310,20 @@ func TestVtctldMigrateUnsharded(t *testing.T) {
 	})
 }
 
-// TestShardedMigrate adds a test for a sharded cluster to validate a fix for a bug where the target keyspace name
+// TestVtctldMigrate adds a test for a sharded cluster to validate a fix for a bug where the target keyspace name
 // doesn't match that of the source cluster. The test migrates from a cluster with keyspace customer to an "external"
 // cluster with keyspace rating.
-func TestMigrateSharded(t *testing.T) {
-	setSidecarDBName("_vt")
+func TestVtctldMigrateSharded(t *testing.T) {
+	oldDefaultReplicas := defaultReplicas
+	oldDefaultRdonly := defaultRdonly
+	defaultReplicas = 1
 	defaultRdonly = 1
+	defer func() {
+		defaultReplicas = oldDefaultReplicas
+		defaultRdonly = oldDefaultRdonly
+	}()
+
+	setSidecarDBName("_vt")
 	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
 	vc = setupCluster(t)
 	vtgateConn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
@@ -342,14 +357,14 @@ func TestMigrateSharded(t *testing.T) {
 	var output string
 	if output, err = extVc.VtctldClient.ExecuteCommandWithOutput("Mount", "register", "--name=external", "--topo-type=etcd2",
 		fmt.Sprintf("--topo-server=localhost:%d", vc.ClusterConfig.topoPort), "--topo-root=/vitess/global"); err != nil {
-		t.Fatalf("Mount command failed with %+v : %s\n", err, output)
+		require.FailNow(t, "Mount command failed with %+v : %s\n", err, output)
 	}
 	ksWorkflow := "rating.e1"
 	if output, err = extVc.VtctldClient.ExecuteCommandWithOutput("Migrate",
 		"--target-keyspace", "rating", "--workflow", "e1",
 		"create", "--source-keyspace", "customer", "--mount-name", "external", "--all-tables", "--cells=zone1",
 		"--tablet-types=primary,replica"); err != nil {
-		t.Fatalf("Migrate command failed with %+v : %s\n", err, output)
+		require.FailNow(t, "Migrate command failed with %+v : %s\n", err, output)
 	}
 	waitForWorkflowState(t, extVc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String())
 	// this is because currently doVtctldclientVDiff is using the global vc :-( and we want to run a diff on the extVc cluster
@@ -358,21 +373,16 @@ func TestMigrateSharded(t *testing.T) {
 }
 
 func setupExtKeyspace(t *testing.T, vc *VitessCluster, ksName, cellName string) {
-	rdonly := 0
+	numReplicas := 1
 	shards := []string{"-80", "80-"}
 	if _, err := vc.AddKeyspace(t, []*Cell{vc.Cells[cellName]}, ksName, strings.Join(shards, ","),
-		customerVSchema, customerSchema, defaultReplicas, rdonly, 1200, nil); err != nil {
+		customerVSchema, customerSchema, numReplicas, 0, 1200, nil); err != nil {
 		t.Fatal(err)
 	}
 	vtgate := vc.Cells[cellName].Vtgates[0]
 	for _, shard := range shards {
 		err := cluster.WaitForHealthyShard(vc.VtctldClient, ksName, shard)
 		require.NoError(t, err)
-		if defaultReplicas > 0 {
-			require.NoError(t, vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", ksName, shard), defaultReplicas, waitTimeout))
-		}
-		if rdonly > 0 {
-			require.NoError(t, vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", ksName, shard), defaultRdonly, waitTimeout))
-		}
+		require.NoError(t, vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", ksName, shard), numReplicas, waitTimeout))
 	}
 }

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -962,6 +962,7 @@ func (s *Server) getWorkflowState(ctx context.Context, targetKeyspace, workflowN
 		// Nothing left to do.
 		return ts, state, nil
 	}
+
 	var sourceKeyspace string
 
 	// We reverse writes by using the source_keyspace.workflowname_reverse workflow
@@ -1320,6 +1321,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 		externalTopo *topo.Server
 		sourceTopo   = s.ts
 	)
+
 	// When the source is an external cluster mounted using the Mount command.
 	if req.ExternalClusterName != "" {
 		externalTopo, err = s.ts.OpenExternalVitessClusterServer(ctx, req.ExternalClusterName)
@@ -1418,6 +1420,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 	if req.DropForeignKeys {
 		createDDLMode = createDDLAsCopyDropForeignKeys
 	}
+
 	for _, table := range tables {
 		buf := sqlparser.NewTrackedBuffer(nil)
 		buf.Myprintf("select * from %v", sqlparser.NewIdentifierCS(table))
@@ -1459,6 +1462,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 		return nil, err
 	}
 	sw := &switcher{s: s, ts: ts}
+
 	// When creating the workflow, locking the workflow and its target keyspace is sufficient.
 	lockName := fmt.Sprintf("%s/%s", ts.TargetKeyspaceName(), ts.WorkflowName())
 	ctx, workflowUnlock, lockErr := s.ts.LockName(ctx, lockName, "MoveTablesCreate")
@@ -1494,6 +1498,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 			}
 		}
 	}()
+
 	// Now that the streams have been successfully created, let's put the associated
 	// routing rules and denied tables entries in place.
 	if externalTopo == nil {
@@ -1525,6 +1530,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 	if err != nil {
 		return nil, err
 	}
+
 	migrationID, err := getMigrationID(targetKeyspace, tabletShards)
 	if err != nil {
 		return nil, err
@@ -1544,6 +1550,7 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 			return nil, vterrors.New(vtrpcpb.Code_INTERNAL, msg)
 		}
 	}
+
 	if req.AutoStart {
 		if err := mz.startStreams(ctx); err != nil {
 			return nil, err
@@ -2122,6 +2129,7 @@ func (s *Server) WorkflowStatus(ctx context.Context, req *vtctldatapb.WorkflowSt
 			resp.TableCopyState[table].BytesPercentage = tableSizePct
 		}
 	}
+
 	workflow, err := s.GetWorkflow(ctx, req.Keyspace, req.Workflow, false, req.Shards)
 	if err != nil {
 		return nil, err
@@ -2177,6 +2185,7 @@ func (s *Server) WorkflowStatus(ctx context.Context, req *vtctldatapb.WorkflowSt
 			resp.ShardStreams[ksShard].Streams[i] = ts
 		}
 	}
+
 	return resp, nil
 }
 
@@ -2728,6 +2737,7 @@ func (s *Server) buildTrafficSwitcher(ctx context.Context, targetKeyspace, workf
 	if err != nil {
 		return nil, err
 	}
+
 	sourceShards, targetShards := ts.getSourceAndTargetShardsNames()
 
 	ts.isPartialMigration, err = ts.isPartialMoveTables(sourceShards, targetShards)

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -1398,7 +1398,19 @@ func (mz *materializer) generateInserts(ctx context.Context, sourceShards []*top
 				for _, mappedCol := range mappedCols {
 					subExprs = append(subExprs, mappedCol)
 				}
-				vindexName := fmt.Sprintf("%s.%s", mz.ms.TargetKeyspace, cv.Name)
+				var vindexName string
+				if mz.getWorkflowType() == binlogdatapb.VReplicationWorkflowType_Migrate {
+					// For a Migrate, if the TargetKeyspace name is different from the SourceKeyspace name, we need to use the
+					// SourceKeyspace name to determine the vindex since the TargetKeyspace name is not known to the source.
+					// Note: it is expected that the source and target keyspaces have the same vindex name and data type.
+					keyspace := mz.ms.TargetKeyspace
+					if mz.ms.ExternalCluster != "" {
+						keyspace = mz.ms.SourceKeyspace
+					}
+					vindexName = fmt.Sprintf("%s.%s", keyspace, cv.Name)
+				} else {
+					vindexName = fmt.Sprintf("%s.%s", mz.ms.TargetKeyspace, cv.Name)
+				}
 				subExprs = append(subExprs, sqlparser.NewStrLiteral(vindexName))
 				subExprs = append(subExprs, sqlparser.NewStrLiteral("{{.keyrange}}"))
 				inKeyRange := &sqlparser.FuncExpr{

--- a/test/config.json
+++ b/test/config.json
@@ -1042,7 +1042,7 @@
 		},
 		"vreplication_materialize": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestMaterialize"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "Materialize"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "vreplication_partial_movetables_and_materialize",


### PR DESCRIPTION
## Description

We use the target keyspace’s vindex for filtering out rows from the source intended for each target shard. The vindex is qualified by the target keyspace name. When the source cluster has a different name for the keyspace, it fails while trying to stream from the source cluster, because it cannot locate the vindex.

This PR sets the vindex scope to that of the source keyspace if the keyspace names differ. Note that it is assumed that the same vindexes are used on both keyspaces during a `Migrate`

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16777

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
