### PR TITLE
VTAdmin: Address security vuln in path-to-regexp node pkg

### DIFF
--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -14133,6 +14133,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
       "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+      "dev": true,
       "engines": {
         "node": ">=16"
       }
@@ -15481,7 +15482,7 @@
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "path-to-regexp": "^8.0.0",
+        "path-to-regexp": "^1.9.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
@@ -15532,6 +15533,19 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
         "value-equal": "^1.0.1"
+      }
+    },
+    "node_modules/react-router/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "node_modules/react-router/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dependencies": {
+        "isarray": "0.0.1"
       }
     },
     "node_modules/react-router/node_modules/react-is": {

--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -10927,7 +10927,7 @@
         "is-node-process": "^1.0.1",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^2.6.7",
-        "path-to-regexp": "^6.2.0",
+        "path-to-regexp": "^8.0.0",
         "statuses": "^2.0.0",
         "strict-event-emitter": "^0.2.0",
         "type-fest": "^1.2.2",
@@ -14130,10 +14130,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
+      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -15479,7 +15481,7 @@
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
+        "path-to-regexp": "^8.0.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
@@ -15530,19 +15532,6 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
         "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
       }
     },
     "node_modules/react-router/node_modules/react-is": {
@@ -16205,7 +16194,7 @@
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "^8.0.0",
         "range-parser": "1.2.0"
       }
     },
@@ -16229,12 +16218,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-      "dev": true
     },
     "node_modules/serve/node_modules/ajv": {
       "version": "8.12.0",


### PR DESCRIPTION
## Description

This upgrades the `path-to-regexp` node package to the fixed versions recommended in the security alert: https://github.com/vitessio/vitess/security/dependabot/389

We should backport this to all supported Vitess versions (18,19,20) so that it is addressed in any subsequent patch releases.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/security/dependabot/389

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required