### PR TITLE
Fix ACL checks for CTEs (#16642)

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/permission_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/permission_test.go
@@ -213,6 +213,45 @@ func TestBuildPermissions(t *testing.T) {
 			TableName: "t1",
 			Role:      tableacl.READER,
 		}},
+	}, {
+		input: "with t as (select count(*) as a from user) select a from t",
+		output: []Permission{{
+			TableName: "user",
+			Role:      tableacl.READER,
+		}},
+	}, {
+		input: "with d as (select id, count(*) as a from user) select d.a from music join d on music.user_id = d.id group by 1",
+		output: []Permission{{
+			TableName: "music",
+			Role:      tableacl.READER,
+		}, {
+			TableName: "user",
+			Role:      tableacl.READER,
+		}},
+	}, {
+		input: "WITH t1 AS ( SELECT id FROM t2 ) SELECT * FROM t1 JOIN ks.t1 AS t3",
+		output: []Permission{{
+			TableName: "t1",
+			Role:      tableacl.READER,
+		}, {
+			TableName: "t2",
+			Role:      tableacl.READER,
+		}},
+	}, {
+		input: "WITH RECURSIVE t1 (n) AS ( SELECT id from t2 UNION ALL SELECT n + 1 FROM t1 WHERE n < 5 ) SELECT * FROM t1 JOIN t1 AS t3",
+		output: []Permission{{
+			TableName: "t2",
+			Role:      tableacl.READER,
+		}},
+	}, {
+		input: "(with t1 as (select count(*) as a from user) select a from t1) union  select * from t1",
+		output: []Permission{{
+			TableName: "user",
+			Role:      tableacl.READER,
+		}, {
+			TableName: "t1",
+			Role:      tableacl.READER,
+		}},
 	}}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
## This PR is a backport of #16642 to latest-20.0

## This PR is the cherry-pick of vitessio/vitess#16642

## Description
This PR fixes the issue described in https://github.com/vitessio/vitess/issues/16542 and supersedes https://github.com/vitessio/vitess/pull/16548.

The ACLs for a CTE were failing because a new table is being defined and it doesn't require any permission checks. This PR fixes the issue by keeping track of the CTE scopes seen while building permissions. We use this to know if the table that we're trying to check permissions for is a CTE or not. If it is, then we conclude that the table doesn't require a permission check.
