### PR TITLE
VTAdmin: Fix serve-handler's path-to-regexp dep and add default schema refresh

### DIFF
--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -43,7 +43,7 @@ vtadmin \
   --alsologtostderr \
   --rbac \
   --rbac-config="${script_dir}/../vtadmin/rbac.yaml" \
-  --cluster "id=${cluster_name},name=${cluster_name},discovery=staticfile,discovery-staticfile-path=${script_dir}/../vtadmin/discovery.json,tablet-fqdn-tmpl=http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --cluster "id=${cluster_name},name=${cluster_name},discovery=staticfile,discovery-staticfile-path=${script_dir}/../vtadmin/discovery.json,tablet-fqdn-tmpl=http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }},schema-cache-default-expiration=1m" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &
 
 vtadmin_api_pid=$!

--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -21,6 +21,7 @@
         "highcharts-react-official": "^3.1.0",
         "history": "^5.3.0",
         "lodash-es": "^4.17.21",
+        "path-to-regexp": "^8.1.0",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-preset-env": "^8.0.1",
         "query-string": "^7.1.3",
@@ -14133,7 +14134,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
       "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
       "engines": {
         "node": ">=16"
       }
@@ -16208,7 +16208,7 @@
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "^8.0.0",
+        "path-to-regexp": "^3.3.0",
         "range-parser": "1.2.0"
       }
     },
@@ -16232,6 +16232,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true
     },
     "node_modules/serve/node_modules/ajv": {
       "version": "8.12.0",

--- a/web/vtadmin/package.json
+++ b/web/vtadmin/package.json
@@ -20,6 +20,7 @@
     "highcharts-react-official": "^3.1.0",
     "history": "^5.3.0",
     "lodash-es": "^4.17.21",
+    "path-to-regexp": "^8.1.0",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^8.0.1",
     "query-string": "^7.1.3",


### PR DESCRIPTION
## Description

Firstly, this is a follow-up to https://github.com/vitessio/vitess/pull/16770 and corrects the `path-to-regexp` dependency for `serve-handler` (the core HTTP request handler in `vtadmin-web`)  — it should have been upgraded to `3.3.0` there rather than `8.0.0`. Without this fix it failed to handle incoming requests after starting up:
```
git checkout main && make build

cd examples/local

./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql

curl localhost:14201

❯ cat ${VTDATAROOT}/tmp/vtadmin-web.out
 INFO  Accepting connections at http://localhost:14201/
 HTTP  9/13/2024 8:26:32 AM 127.0.0.1 GET /

 INFO  Gracefully shutting down. Please wait...
/Users/matt/git/vitess/web/vtadmin/node_modules/serve-handler/src/index.js:47
		const expression = pathToRegExp(normalized, keys);
		                   ^

TypeError: pathToRegExp is not a function
    at sourceMatches (/Users/matt/git/vitess/web/vtadmin/node_modules/serve-handler/src/index.js:47:22)
    at toTarget (/Users/matt/git/vitess/web/vtadmin/node_modules/serve-handler/src/index.js:70:18)
    at applyRewrites (/Users/matt/git/vitess/web/vtadmin/node_modules/serve-handler/src/index.js:105:18)
    at module.exports (/Users/matt/git/vitess/web/vtadmin/node_modules/serve-handler/src/index.js:618:24)
    at run (file:///Users/matt/git/vitess/web/vtadmin/node_modules/serve/build/main.js:181:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

We need to backport this all the way to v18 as https://github.com/vitessio/vitess/pull/16770 was backported to v18.

We also add a default schema cache expiration time to the local examples. Users have previously asked why the schema display in VTAdmin does not appear to refresh, and they've asked HOW they can change that behavior ([w/o any value specified it never refreshes](https://github.com/vitessio/vitess/blob/155ede0dea490f998e5927e5382a3ab583cd36a8/doc/vtadmin/clusters.yaml#L67-L70)). This change addresses both issues.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/16770
  - Fixes: https://github.com/vitessio/vitess/issues/16779

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required