### PR TITLE
`endtoend`: better error reporting in Online DDL MySQL execution tests

### DIFF
--- a/go/test/endtoend/onlineddl/exec_util.go
+++ b/go/test/endtoend/onlineddl/exec_util.go
@@ -62,6 +62,8 @@ func MysqlClientExecFile(t *testing.T, mysqlParams *mysql.ConnParams, testDataPa
 		bashCommand,
 	).Output()
 
-	require.NoError(t, err)
+	errorContent, readerr := os.ReadFile("/tmp/error.log")
+	require.NoError(t, readerr)
+	require.NoError(t, err, "error details: %s", errorContent)
 	return string(cmd)
 }


### PR DESCRIPTION

## Description

Some Online DDL tests run the `mysql` command line. When that execution fails, all we got was "exit status 1". We now ensure to capture standard error in a temp file, whose contents we read and add to the error message.


## Related Issue(s)

None.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
