### PR TITLE
Small fix to decrease memory allocation

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -52,8 +52,8 @@ func (d *Delete) GetOrdering(*plancontext.PlanningContext) []OrderBy {
 	return nil
 }
 
-func (d *Delete) TablesUsed() []string {
-	return SingleQualifiedIdentifier(d.Target.VTable.Keyspace, d.Target.VTable.Name)
+func (d *Delete) TablesUsed(in []string) []string {
+	return append(in, QualifiedString(d.Target.VTable.Keyspace, d.Target.VTable.Name.String()))
 }
 
 func (d *Delete) ShortDescription() string {

--- a/go/vt/vtgate/planbuilder/operators/insert.go
+++ b/go/vt/vtgate/planbuilder/operators/insert.go
@@ -96,8 +96,12 @@ func (i *Insert) Clone([]Operator) Operator {
 	}
 }
 
-func (i *Insert) TablesUsed() []string {
-	return SingleQualifiedIdentifier(i.VTable.Keyspace, i.VTable.Name)
+func (i *Insert) TablesUsed(in []string) []string {
+	return append(in, i.tableTarget())
+}
+
+func (i *Insert) tableTarget() string {
+	return QualifiedString(i.VTable.Keyspace, i.VTable.Name.String())
 }
 
 func (i *Insert) Statement() sqlparser.Statement {
@@ -423,7 +427,7 @@ func insertSelectPlan(
 	// When the table you are streaming data from and table you are inserting from are same.
 	// Then due to locking of the index range on the table we might not be able to insert into the table.
 	// Therefore, instead of streaming, this flag will ensure the records are first read and then inserted.
-	insertTbl := insOp.TablesUsed()[0]
+	insertTbl := insOp.tableTarget()
 	selTables := TablesUsed(selOp)
 	for _, tbl := range selTables {
 		if insertTbl == tbl {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -717,14 +717,11 @@ func (r *Route) GetOrdering(ctx *plancontext.PlanningContext) []OrderBy {
 
 // TablesUsed returns tables used by MergedWith routes, which are not included
 // in Inputs() and thus not a part of the operator tree
-func (r *Route) TablesUsed() []string {
-	addString, collect := collectSortedUniqueStrings()
+func (r *Route) TablesUsed(in []string) []string {
 	for _, mw := range r.MergedWith {
-		for _, u := range TablesUsed(mw) {
-			addString(u)
-		}
+		in = append(in, mw.TablesUsed(in)...)
 	}
-	return collect()
+	return in
 }
 
 func isSpecialOrderBy(o OrderBy) bool {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -719,7 +719,7 @@ func (r *Route) GetOrdering(ctx *plancontext.PlanningContext) []OrderBy {
 // in Inputs() and thus not a part of the operator tree
 func (r *Route) TablesUsed(in []string) []string {
 	for _, mw := range r.MergedWith {
-		in = append(in, mw.TablesUsed(in)...)
+		in = append(in, TablesUsed(mw)...)
 	}
 	return in
 }

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -107,11 +107,11 @@ func (to *Table) AddCol(col *sqlparser.ColName) {
 	to.Columns = append(to.Columns, col)
 }
 
-func (to *Table) TablesUsed() []string {
+func (to *Table) TablesUsed(in []string) []string {
 	if sqlparser.SystemSchema(to.QTable.Table.Qualifier.String()) {
-		return nil
+		return in
 	}
-	return SingleQualifiedIdentifier(to.VTable.Keyspace, to.VTable.Name)
+	return append(in, QualifiedString(to.VTable.Keyspace, to.VTable.Name.String()))
 }
 
 func addColumn(ctx *plancontext.PlanningContext, op ColNameColumns, e sqlparser.Expr) int {

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -86,8 +86,8 @@ func (u *Update) GetOrdering(*plancontext.PlanningContext) []OrderBy {
 	return nil
 }
 
-func (u *Update) TablesUsed() []string {
-	return SingleQualifiedIdentifier(u.Target.VTable.Keyspace, u.Target.VTable.Name)
+func (u *Update) TablesUsed(in []string) []string {
+	return append(in, QualifiedString(u.Target.VTable.Keyspace, u.Target.VTable.Name.String()))
 }
 
 func (u *Update) ShortDescription() string {

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -164,8 +164,8 @@ func (v *Vindex) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.E
 
 // TablesUsed implements the Operator interface.
 // It is not keyspace-qualified.
-func (v *Vindex) TablesUsed() []string {
-	return []string{v.Table.Table.Name.String()}
+func (v *Vindex) TablesUsed(in []string) []string {
+	return append(in, v.Table.Table.Name.String())
 }
 
 func (v *Vindex) ShortDescription() string {


### PR DESCRIPTION
## Description
Minimal change in how we gather which tables have been used by a query.

```
                                  │  ../before  │              ../after              │
                                  │   sec/op    │   sec/op     vs base               │
Planner/from_cases.json-gen4-20     7.490m ± 1%   7.436m ± 1%       ~ (p=0.089 n=10)
Planner/filter_cases.json-gen4-20   149.7m ± 1%   150.0m ± 1%       ~ (p=0.912 n=10)
Planner/large_cases.json-gen4-20    468.0µ ± 0%   469.9µ ± 1%       ~ (p=0.218 n=10)
Planner/aggr_cases.json-gen4-20     13.26m ± 1%   13.21m ± 1%       ~ (p=0.105 n=10)
Planner/select_cases.json-gen4-20   10.54m ± 1%   10.48m ± 1%       ~ (p=0.089 n=10)
Planner/union_cases.json-gen4-20    3.875m ± 0%   3.824m ± 1%  -1.32% (p=0.000 n=10)
geomean                             8.108m        8.077m       -0.39%

                                  │  ../before   │              ../after               │
                                  │     B/op     │     B/op      vs base               │
Planner/from_cases.json-gen4-20     4.546Mi ± 0%   4.541Mi ± 0%  -0.11% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20   19.74Mi ± 0%   19.73Mi ± 0%  -0.06% (p=0.000 n=10)
Planner/large_cases.json-gen4-20    274.1Ki ± 0%   274.4Ki ± 0%  +0.12% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20     7.245Mi ± 0%   7.241Mi ± 0%  -0.06% (p=0.000 n=10)
Planner/select_cases.json-gen4-20   6.152Mi ± 0%   6.138Mi ± 0%  -0.22% (p=0.000 n=10)
Planner/union_cases.json-gen4-20    2.236Mi ± 0%   2.231Mi ± 0%  -0.19% (p=0.000 n=10)
geomean                             3.657Mi        3.654Mi       -0.09%

                                  │  ../before  │              ../after              │
                                  │  allocs/op  │  allocs/op   vs base               │
Planner/from_cases.json-gen4-20     107.4k ± 0%   107.0k ± 0%  -0.34% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20   523.4k ± 0%   522.7k ± 0%  -0.15% (p=0.000 n=10)
Planner/large_cases.json-gen4-20    10.55k ± 0%   10.49k ± 0%  -0.56% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20     165.7k ± 0%   165.4k ± 0%  -0.18% (p=0.000 n=10)
Planner/select_cases.json-gen4-20   143.2k ± 0%   142.3k ± 0%  -0.63% (p=0.000 n=10)
Planner/union_cases.json-gen4-20    52.40k ± 0%   52.05k ± 0%  -0.66% (p=0.000 n=10)
geomean                             95.05k        94.65k       -0.42%

```

## Related Issue(s)
https://github.com/vitessio/vitess/issues/16789 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
