### PR TITLE
Add a test to verify we respect the overall query timeout

### DIFF
--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -179,3 +179,30 @@ func TestQueryTimeoutWithoutVTGateDefault(t *testing.T) {
 	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(5) from dual")
 	assert.Error(t, err)
 }
+
+// TestOverallQueryTimeout tests that the query timeout is applied to the overall execution of a query
+// and not just individual routes.
+func TestOverallQueryTimeout(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 21, "vtgate")
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into t1(id1, id2) values (2,2),(3,3)")
+
+	// After inserting the rows above, if we run the following query, we will end up doing join on vtgate
+	// that issues one select query on the left side and 2 on the right side. The queries on the right side
+	// take 2 and 3 seconds each to run. If we have an overall timeout for 4 seconds, then it should fail.
+	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=4000 */ sleep(u2.id2), u1.id2 from t1 u1 join t1 u2 where u1.id2 = u2.id1")
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "DeadlineExceeded desc = context deadline exceeded (errno 1317) (sqlstate 70100)")
+
+	// Let's also check that setting the session variable also works.
+	utils.Exec(t, mcmp.VtConn, "set query_timeout=4000")
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(u2.id2), u1.id2 from t1 u1 join t1 u2 where u1.id2 = u2.id1")
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "DeadlineExceeded desc = context deadline exceeded (errno 1317) (sqlstate 70100)")
+
+	// Increasing the timeout should pass the query.
+	utils.Exec(t, mcmp.VtConn, "set query_timeout=10000")
+	_ = utils.Exec(t, mcmp.VtConn, "select sleep(u2.id2), u1.id2 from t1 u1 join t1 u2 where u1.id2 = u2.id1")
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
As pointed out in https://github.com/vitessio/vitess/issues/16624, we weren't respecting overall query timeout. An attempt to fix it was made in https://github.com/vitessio/vitess/pull/16619. An alternate change in https://github.com/vitessio/vitess/pull/16735 has already fixed the issue. This PR adds a test to our test suite to check that is indeed the case.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #16624 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
