### PR TITLE
Remove former maintainer from areas of expertise section

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,7 +24,7 @@ The following is the full list, alphabetically ordered.
 deepthi, mattlord, derekperkins
 
 ### Builds
-dkhenry, shlomi-noach, ajm188, vmg, GuptaManan100, frouioui
+shlomi-noach, ajm188, vmg, GuptaManan100, frouioui
 
 ### Resharding
 rohit-nayak-ps, deepthi, mattlord
@@ -54,7 +54,7 @@ deepthi, ajm188, GuptaManan100, dbussink
 harshit-gangal
 
 ### Kubernetes
-derekperkins, dkhenry, GuptaManan100, frouioui
+derekperkins, GuptaManan100, frouioui
 
 ### VTAdmin
 ajm188, notfelineit


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR removes Dkhenry from the areas of expertise section of the maintainers file.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
