### PR TITLE
Count how many shards were hit by routes when using `vexplain`

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -132,7 +132,7 @@ func (t *noopVCursor) UnresolvedTransactions(ctx context.Context, keyspace strin
 	panic("implement me")
 }
 
-func (t *noopVCursor) StartPrimitiveTrace() func() map[Primitive]RowsReceived {
+func (t *noopVCursor) StartPrimitiveTrace() func() Stats {
 	panic("implement me")
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -143,7 +143,7 @@ type (
 
 		// StartPrimitiveTrace starts a trace for the given primitive,
 		// and returns a function to get the trace logs after the primitive execution.
-		StartPrimitiveTrace() func() map[Primitive]RowsReceived
+		StartPrimitiveTrace() func() Stats
 	}
 
 	// SessionActions gives primitives ability to interact with the session state

--- a/go/vt/vtgate/executor_vexplain_test.go
+++ b/go/vt/vtgate/executor_vexplain_test.go
@@ -94,9 +94,10 @@ func TestSimpleVexplainTrace(t *testing.T) {
 				"Name": "TestExecutor",
 				"Sharded": true
 			},
-			"NoOfCalls": 2,
+			"NoOfCalls": 1,
 			"AvgNumberOfRows": 16,
 			"MedianNumberOfRows": 16,
+			"ShardsQueried": 8,
 			"FieldQuery": "select count(*), col2, weight_string(col2) from music where 1 != 1 group by col2, weight_string(col2)",
 			"OrderBy": "(1|2) ASC",
 			"Query": "select count(*), col2, weight_string(col2) from music group by col2, weight_string(col2) order by col2 asc",

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -135,7 +135,8 @@ type (
 
 		// this is a map of the number of rows that every primitive has returned
 		// if this field is nil, it means that we are not logging operator traffic
-		primitiveStats map[engine.Primitive]engine.RowsReceived
+		interOpStats map[engine.Primitive]engine.RowsReceived
+		shardsStats  map[engine.Primitive]engine.ShardsQueried
 	}
 )
 
@@ -285,10 +286,14 @@ func (vc *vcursorImpl) UnresolvedTransactions(ctx context.Context, keyspace stri
 	return vc.executor.UnresolvedTransactions(ctx, targets)
 }
 
-func (vc *vcursorImpl) StartPrimitiveTrace() func() map[engine.Primitive]engine.RowsReceived {
-	vc.primitiveStats = make(map[engine.Primitive]engine.RowsReceived)
-	return func() map[engine.Primitive]engine.RowsReceived {
-		return vc.primitiveStats
+func (vc *vcursorImpl) StartPrimitiveTrace() func() engine.Stats {
+	vc.interOpStats = make(map[engine.Primitive]engine.RowsReceived)
+	vc.shardsStats = make(map[engine.Primitive]engine.ShardsQueried)
+	return func() engine.Stats {
+		return engine.Stats{
+			InterOpStats: vc.interOpStats,
+			ShardsStats:  vc.shardsStats,
+		}
 	}
 }
 
@@ -532,14 +537,20 @@ func (vc *vcursorImpl) ExecutePrimitive(ctx context.Context, primitive engine.Pr
 }
 
 func (vc *vcursorImpl) logOpTraffic(primitive engine.Primitive, res *sqltypes.Result) {
-	if vc.primitiveStats != nil {
-		rows := vc.primitiveStats[primitive]
+	if vc.interOpStats != nil {
+		rows := vc.interOpStats[primitive]
 		if res == nil {
 			rows = append(rows, 0)
 		} else {
 			rows = append(rows, len(res.Rows))
 		}
-		vc.primitiveStats[primitive] = rows
+		vc.interOpStats[primitive] = rows
+	}
+}
+
+func (vc *vcursorImpl) logShardsQueried(primitive engine.Primitive, shardsNb int) {
+	if vc.shardsStats != nil {
+		vc.shardsStats[primitive] += engine.ShardsQueried(shardsNb)
 	}
 }
 
@@ -558,7 +569,7 @@ func (vc *vcursorImpl) ExecutePrimitiveStandalone(ctx context.Context, primitive
 }
 
 func (vc *vcursorImpl) wrapCallback(callback func(*sqltypes.Result) error, primitive engine.Primitive) func(*sqltypes.Result) error {
-	if vc.primitiveStats == nil {
+	if vc.interOpStats == nil {
 		return callback
 	}
 
@@ -650,7 +661,7 @@ func (vc *vcursorImpl) ExecuteMultiShard(ctx context.Context, primitive engine.P
 
 	qr, errs := vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedShardQueries(queries, vc.marginComments), vc.safeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.resultsObserver)
 	vc.setRollbackOnPartialExecIfRequired(len(errs) != len(rss), rollbackOnError)
-	vc.logOpTraffic(primitive, qr)
+	vc.logShardsQueried(primitive, len(rss))
 	return qr, errs
 }
 
@@ -689,7 +700,7 @@ func (vc *vcursorImpl) ExecuteStandalone(ctx context.Context, primitive engine.P
 	// The autocommit flag is always set to false because we currently don't
 	// execute DMLs through ExecuteStandalone.
 	qr, errs := vc.executor.ExecuteMultiShard(ctx, primitive, rss, bqs, NewAutocommitSession(vc.safeSession.Session), false /* autocommit */, vc.ignoreMaxMemoryRows, vc.resultsObserver)
-	vc.logOpTraffic(primitive, qr)
+	vc.logShardsQueried(primitive, len(rss))
 	return qr, vterrors.Aggregate(errs)
 }
 


### PR DESCRIPTION
## Description

With this PR we will now track another metric for `vexplain trace`: the amount of shards hit by each route. This metric will enable us to know if a plan hits more or less shards for the same result, which is an useful indicator of performance.

After running the 30x local examples here is what we get:
```
mysql> vexplain trace select * from corder\G
*************************** 1. row ***************************
Trace: {
        "OperatorType": "Route",
        "Variant": "Scatter",
        "Keyspace": {
                "Name": "customer",
                "Sharded": true
        },
        "NoOfCalls": 1,
        "AvgNumberOfRows": 5,
        "MedianNumberOfRows": 5,
        "ShardsQueried": 2,
        "FieldQuery": "select order_id, customer_id, sku, price from corder where 1 != 1",
        "Query": "select order_id, customer_id, sku, price from corder",
        "Table": "corder"
}
1 row in set (0.00 sec)

mysql> 
```

## Related Issue(s)

- Part of https://github.com/vitessio/vitess-tester/issues/21
