### PR TITLE
Fix `xtrabackup`/`builtin` context when doing `AddFiles`

### DIFF
--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -399,8 +399,8 @@ func (be *BuiltinBackupEngine) executeFullBackup(ctx context.Context, params Bac
 	// Save initial state so we can restore.
 	replicaStartRequired := false
 	sourceIsPrimary := false
-	superReadOnly := true //nolint
-	readOnly := true      //nolint
+	superReadOnly := true // nolint
+	readOnly := true      // nolint
 	var replicationPosition replication.Position
 	semiSyncSource, semiSyncReplica := params.Mysqld.SemiSyncEnabled(ctx)
 
@@ -793,7 +793,11 @@ func (bp *backupPipe) ReportProgress(period time.Duration, logger logutil.Logger
 // backupFile backs up an individual file.
 func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle, fe *FileEntry, name string) (finalErr error) {
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	defer func() {
+		if finalErr != nil {
+			cancel()
+		}
+	}()
 	// Open the source file for reading.
 	openSourceAt := time.Now()
 	source, err := fe.open(params.Cnf, true)

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -44,10 +44,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	transport "github.com/aws/smithy-go/endpoints"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/spf13/pflag"
-
-	smithyendpoints "github.com/aws/smithy-go/endpoints"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
@@ -117,7 +116,7 @@ type endpointResolver struct {
 	endpoint *string
 }
 
-func (er *endpointResolver) ResolveEndpoint(ctx context.Context, params s3.EndpointParameters) (smithyendpoints.Endpoint, error) {
+func (er *endpointResolver) ResolveEndpoint(ctx context.Context, params s3.EndpointParameters) (transport.Endpoint, error) {
 	params.Endpoint = er.endpoint
 	return er.r.ResolveEndpoint(ctx, params)
 }

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -182,8 +182,7 @@ func (bh *S3BackupHandle) AddFile(ctx context.Context, filename string, filesize
 		})
 		object := objName(bh.dir, bh.name, filename)
 		sendStats := bh.bs.params.Stats.Scope(stats.Operation("AWS:Request:Send"))
-		// Using UploadWithContext breaks uploading to Minio and Ceph https://github.com/vitessio/vitess/issues/14188
-		_, err := uploader.Upload(context.Background(), &s3.PutObjectInput{
+		_, err := uploader.Upload(ctx, &s3.PutObjectInput{
 			Bucket:               &bucket,
 			Key:                  &object,
 			Body:                 reader,


### PR DESCRIPTION
## Description

This PR [fixes a long standing issue](https://github.com/vitessio/vitess/issues/14188) in the xtrabackup engine: the context used to `AddFiles` by the backup storage was canceled before `AddFiles` had the chance to complete. This problem can be experienced with the S3 backup storage, as it uploads the file through a goroutine, [Ceph also does that and have been impacted in the past too](https://github.com/vitessio/vitess/issues/8391). That goroutine wouldn't have time to complete before the `XtrabackupEngine.backupFiles` function returned and canceled the context through a `defer` statement. Leading to `AddFiles` failing since the context we pass got canceled.

To avoid this issue, we never really passed the context down to `AddFiles`. We attempted to pass the context in https://github.com/vitessio/vitess/pull/12500 but reverted it in https://github.com/vitessio/vitess/pull/14311 since https://github.com/vitessio/vitess/issues/14188 was raised.

This PR fixes that by not canceling the context automatically, but only when the `backupFiles` return an error. If we have an error anywhere while executing `backupFiles` we should attempt to cancel the addition of the files, otherwise we can assume there is nothing to cancel. A different goroutine already make sure to cancel the context if we reach a certain timeout when closing the files.

cc @L3o-pold @vczyh as the original authors of the two issues. I have tested this on my end with manual tests (only on S3), but do you mind making sure it fixes your issues?

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/14188
- Fixes https://github.com/vitessio/vitess/issues/8391

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
