### PR TITLE
small fixes for docker-compose setup

### DIFF
--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -67,7 +67,7 @@ vitess/examples/compose$ docker-compose up -d
 ### Check cluster status
 Check the status of the cluster.
 ```
-vitess/examples/compose$ docker-compose ps
+vitess/examples/compose$ docker-compose ps -a
            Name                         Command                  State                                                                     Ports
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 compose_consul1_1                          docker-entrypoint.sh agent ...   Up             8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp,

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -73,10 +73,12 @@ services:
         --grpc_port $GRPC_PORT
         "]
     depends_on:
-      - consul1
-      - consul2
-      - consul3
-    depends_on:
+      consul1:
+        condition: service_started
+      consul2:
+        condition: service_started
+      consul3:
+        condition: service_started
       external_db_host:
         condition: service_healthy
 
@@ -105,8 +107,8 @@ services:
       - KEYSPACE
       - DB
     depends_on:
-      - vtctld
-    depends_on:
+      vtctld:
+        condition: service_started
       vttablet101:
         condition: service_healthy
 

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -158,5 +158,5 @@ exec $VTROOT/bin/vttablet \
   --init_shard $shard \
   --backup_storage_implementation file \
   --file_backup_storage_root $VTDATAROOT/backups \
-  --queryserver-config-schema-reload-time 60 \
+  --queryserver-config-schema-reload-time 60s \
   $external_db_args


### PR DESCRIPTION
examples/compose/
 - docker-compose.beginners.yml: fixed depends_on declarations for vtctld and vtgate services
 - README.md: added ' -a' for 'docker-compose ps' for it to match the example output
 - vttablet-up.sh: added 's' as units for '--queryserver-config-schema-reload-time 60'