### PR TITLE
Use time zone correctly when evaluating on vtgate

### DIFF
--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -625,3 +625,21 @@ func TestExecutorSetAndSelect(t *testing.T) {
 		})
 	}
 }
+
+// TestTimeZone verifies that setting different time zones in the session
+// results in different outputs for the `now()` function.
+func TestTimeZone(t *testing.T) {
+	e, _, _, _, ctx := createExecutorEnv(t)
+
+	session := NewAutocommitSession(&vtgatepb.Session{TargetString: KsTestUnsharded, EnableSystemSettings: true})
+	session.SystemVariables = map[string]string{"time_zone": "'+08:00'"}
+	qr, err := e.Execute(ctx, nil, "TestExecutorSetAndSelect", session, "select now()", nil)
+
+	require.NoError(t, err)
+	session.SystemVariables["time_zone"] = "'+02:00'"
+
+	qrWith, err := e.Execute(ctx, nil, "TestExecutorSetAndSelect", session, "select now()", nil)
+	require.NoError(t, err)
+
+	assert.False(t, qr.Rows[0][0].Equal(qrWith.Rows[0][0]), "%v vs %v", qr.Rows[0][0].ToString(), qrWith.Rows[0][0].ToString())
+}

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -25,8 +25,6 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	"vitess.io/vitess/go/mysql/datetime"
-
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/sysvars"
@@ -561,16 +559,10 @@ func (session *SafeSession) HasSystemVariables() (found bool) {
 	return
 }
 
-func (session *SafeSession) TimeZone() *time.Location {
+func (session *SafeSession) TimeZone() string {
 	session.mu.Lock()
-	tz, ok := session.SystemVariables["time_zone"]
-	session.mu.Unlock()
-
-	if !ok {
-		return nil
-	}
-	loc, _ := datetime.ParseTimeZone(tz)
-	return loc
+	defer session.mu.Unlock()
+	return session.SystemVariables["time_zone"]
 }
 
 // ForeignKeyChecks returns the foreign_key_checks stored in system_variables map in the session.

--- a/go/vt/vtgate/safe_session_test.go
+++ b/go/vt/vtgate/safe_session_test.go
@@ -19,9 +19,7 @@ package vtgate
 import (
 	"reflect"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -64,37 +62,5 @@ func TestPrequeries(t *testing.T) {
 
 	if !reflect.DeepEqual(want, preQueries) {
 		t.Errorf("got %v but wanted %v", preQueries, want)
-	}
-}
-
-func TestTimeZone(t *testing.T) {
-	testCases := []struct {
-		tz   string
-		want string
-	}{
-		{
-			tz:   "Europe/Amsterdam",
-			want: "Europe/Amsterdam",
-		},
-		{
-			tz:   "+02:00",
-			want: "UTC+02:00",
-		},
-		{
-			tz:   "foo",
-			want: (*time.Location)(nil).String(),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.tz, func(t *testing.T) {
-			session := NewSafeSession(&vtgatepb.Session{
-				SystemVariables: map[string]string{
-					"time_zone": tc.tz,
-				},
-			})
-
-			assert.Equal(t, tc.want, session.TimeZone().String())
-		})
 	}
 }


### PR DESCRIPTION
## Description
The time zone system setting was not being fetched correctly, which lead to it being ignored when evaluating `now()`.

## Related Issue(s)
Fixes #16820

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required