### PR TITLE
vtgate: Use the time zone setting correctly

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"vitess.io/vitess/go/mysql"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
@@ -472,4 +475,50 @@ func TestEnumSetVals(t *testing.T) {
 
 	mcmp.AssertMatches("select id, enum_col, cast(enum_col as signed) from tbl_enum_set order by enum_col, id", `[[INT64(4) ENUM("xsmall") INT64(1)] [INT64(2) ENUM("small") INT64(2)] [INT64(1) ENUM("medium") INT64(3)] [INT64(5) ENUM("medium") INT64(3)] [INT64(3) ENUM("large") INT64(4)]]`)
 	mcmp.AssertMatches("select id, set_col, cast(set_col as unsigned) from tbl_enum_set order by set_col, id", `[[INT64(4) SET("a,b") UINT64(3)] [INT64(3) SET("c") UINT64(4)] [INT64(5) SET("a,d") UINT64(9)] [INT64(1) SET("a,b,e") UINT64(19)] [INT64(2) SET("e,f,g") UINT64(112)]]`)
+}
+
+func TestTimeZones(t *testing.T) {
+	testCases := []struct {
+		name         string
+		targetTZ     string
+		expectedDiff time.Duration
+	}{
+		{"UTC to +08:00", "+08:00", 8 * time.Hour},
+		{"UTC to -08:00", "-08:00", -8 * time.Hour},
+		{"UTC to +05:30", "+05:30", 5*time.Hour + 30*time.Minute},
+		{"UTC to -05:45", "-05:45", -(5*time.Hour + 45*time.Minute)},
+		{"UTC to +09:00", "+09:00", 9 * time.Hour},
+		{"UTC to -12:00", "-12:00", -12 * time.Hour},
+	}
+
+	// Connect to Vitess
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set the initial time zone and get the time
+			utils.Exec(t, conn, "set time_zone = '+00:00'")
+			rs1 := utils.Exec(t, conn, "select now()")
+
+			// Set the target time zone and get the time
+			utils.Exec(t, conn, fmt.Sprintf("set time_zone = '%s'", tc.targetTZ))
+			rs2 := utils.Exec(t, conn, "select now()")
+
+			// Parse the times from the query result
+			layout := "2006-01-02 15:04:05" // MySQL default datetime format
+			time1, err := time.Parse(layout, rs1.Rows[0][0].ToString())
+			require.NoError(t, err)
+			time2, err := time.Parse(layout, rs2.Rows[0][0].ToString())
+			require.NoError(t, err)
+
+			// Calculate the actual difference between time2 and time1
+			actualDiff := time2.Sub(time1)
+			allowableDeviation := time.Second // allow up to 1-second difference
+
+			// Use a range to allow for slight variations
+			require.InDeltaf(t, tc.expectedDiff.Seconds(), actualDiff.Seconds(), allowableDeviation.Seconds(),
+				"time2 should be approximately %v after time1, within 1 second tolerance\n%v vs %v", tc.expectedDiff, time1, time2)
+		})
+	}
 }

--- a/go/vt/vtgate/safe_session_test.go
+++ b/go/vt/vtgate/safe_session_test.go
@@ -73,11 +73,11 @@ func TestTimeZone(t *testing.T) {
 		want string
 	}{
 		{
-			tz:   "Europe/Amsterdam",
+			tz:   "'Europe/Amsterdam'",
 			want: "Europe/Amsterdam",
 		},
 		{
-			tz:   "+02:00",
+			tz:   "'+02:00'",
 			want: "UTC+02:00",
 		},
 		{


### PR DESCRIPTION
## Description

This pull request addresses a critical issue in the handling of time zone settings within our system. The root cause of the problem was that the time zone system setting was not being correctly fetched and interpreted, which led to it being ignored when evaluating the `now()` function.

Specifically, the issue arose because we were storing the time zone variable value using a literal SQL expression. This meant that when we tried to use this value, it was still in its raw, encoded form, rather than being properly decoded into a usable time zone string.

## Related Issue(s)

Fixes #16820

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required