### PR TITLE
fix: Avoid creating `MoveTables` in case of non-empty target tables

### DIFF
--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1395,29 +1395,6 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 	}
 	s.Logger().Infof("Found tables to move: %s", strings.Join(tables, ","))
 
-	// Check if any table being moved is already non-empty in the target keyspace.
-	// Skip this check for multi-tenant migrations.
-	if req.GetWorkflowOptions().GetTenantId() == "" {
-		targetKeyspaceTables, err := getTablesInKeyspace(ctx, sourceTopo, s.tmc, targetKeyspace)
-		if err != nil {
-			return nil, err
-		}
-
-		var alreadyExistingTables []string
-		for _, t := range targetKeyspaceTables {
-			if slices.Contains(tables, t) {
-				alreadyExistingTables = append(alreadyExistingTables, t)
-			}
-		}
-
-		if len(alreadyExistingTables) > 0 {
-			err = validateEmptyTables(ctx, sourceTopo, s.tmc, targetKeyspace, alreadyExistingTables)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
 	if !vschema.Sharded {
 		// Save the original in case we need to restore it for a late failure
 		// in the defer().

--- a/go/vt/vttablet/tabletmanager/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/framework_test.go
@@ -480,8 +480,8 @@ func (tmc *fakeTMClient) VReplicationExec(ctx context.Context, tablet *topodatap
 	}
 	for qry, res := range tmc.vreQueries[int(tablet.Alias.Uid)] {
 		if strings.HasPrefix(qry, "/") {
-			re := regexp.MustCompile(qry)
-			if re.MatchString(qry) {
+			re := regexp.MustCompile(qry[1:])
+			if re.MatchString(query) {
 				return res, nil
 			}
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds a validation check for empty tables in the target keyspace while creating MoveTables workflow.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #16817 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Screenshot
<img width="1440" alt="Screenshot 2024-09-24 at 12 41 44 AM" src="https://github.com/user-attachments/assets/63dca266-dc0e-4016-ad8f-f11b1b82eb4b">

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
