### PR TITLE
Fix error message check on query timeout

### DIFF
--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -18,6 +18,7 @@ package misc
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -194,13 +195,18 @@ func TestOverallQueryTimeout(t *testing.T) {
 	// take 2 and 3 seconds each to run. If we have an overall timeout for 4 seconds, then it should fail.
 	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=4000 */ sleep(u2.id2), u1.id2 from t1 u1 join t1 u2 where u1.id2 = u2.id1")
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "DeadlineExceeded desc = context deadline exceeded (errno 1317) (sqlstate 70100)")
+	// We can get two different error messages based on whether it is coming from vttablet or vtgate
+	if !strings.Contains(err.Error(), "Query execution was interrupted, maximum statement execution time exceeded") {
+		assert.ErrorContains(t, err, "DeadlineExceeded desc = context deadline exceeded (errno 1317) (sqlstate 70100)")
+	}
 
 	// Let's also check that setting the session variable also works.
 	utils.Exec(t, mcmp.VtConn, "set query_timeout=4000")
 	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select sleep(u2.id2), u1.id2 from t1 u1 join t1 u2 where u1.id2 = u2.id1")
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "DeadlineExceeded desc = context deadline exceeded (errno 1317) (sqlstate 70100)")
+	if !strings.Contains(err.Error(), "Query execution was interrupted, maximum statement execution time exceeded") {
+		assert.ErrorContains(t, err, "DeadlineExceeded desc = context deadline exceeded (errno 1317) (sqlstate 70100)")
+	}
 
 	// Increasing the timeout should pass the query.
 	utils.Exec(t, mcmp.VtConn, "set query_timeout=10000")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the error messages check in the test `TestOverallQueryTimeout`. This is a test we introduced recently and noticed that there are actually two possible error messages that can be received based on whether it was vttablet or vtgate that sent it. 
This PR fixes the test expectations to align with this.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
