### PR TITLE
reject atomic distributed transaction on savepoints and modified system settings

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2780,6 +2780,76 @@ func TestExecutorPrepareExecute(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestExecutorRejectTwoPC test all the unsupported cases for multi-shard atomic commit.
+func TestExecutorRejectTwoPC(t *testing.T) {
+	executor, sbc1, sbc2, _, ctx := createExecutorEnv(t)
+	tcases := []struct {
+		sqls    []string
+		testRes []*sqltypes.Result
+
+		expErr string
+	}{
+		{
+			sqls: []string{
+				`set time_zone = "+08:00"`,
+				`insert into user_extra(user_id) values (1)`,
+				`insert into user_extra(user_id) values (2)`,
+				`insert into user_extra(user_id) values (3)`,
+			},
+			expErr: "VT12001: unsupported: atomic distributed transaction commit with system settings",
+		}, {
+			sqls: []string{
+				`update t1 set unq_col = 1 where id = 1`,
+				`update t1 set unq_col = 1 where id = 3`,
+			},
+			testRes: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|unq_col|unchanged", "int64|int64|int64"),
+					"1|2|0"),
+			},
+			expErr: "VT12001: unsupported: atomic distributed transaction commit with consistent lookup vindex",
+		}, {
+			sqls: []string{
+				`savepoint x`,
+				`insert into user_extra(user_id) values (1)`,
+				`insert into user_extra(user_id) values (3)`,
+			},
+			testRes: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|unq_col|unchanged", "int64|int64|int64"),
+					"1|2|0"),
+			},
+			expErr: "VT12001: unsupported: atomic distributed transaction commit with savepoint",
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(fmt.Sprintf("%v", tcase.sqls), func(t *testing.T) {
+			sbc1.SetResults(tcase.testRes)
+			sbc2.SetResults(tcase.testRes)
+
+			// create a new session
+			session := NewSafeSession(&vtgatepb.Session{
+				TargetString:         KsTestSharded,
+				TransactionMode:      vtgatepb.TransactionMode_TWOPC,
+				EnableSystemSettings: true,
+			})
+
+			// start transaction
+			_, err := executor.Execute(ctx, nil, "TestExecutorRejectTwoPC", session, "begin", nil)
+			require.NoError(t, err)
+
+			// execute queries
+			for _, sql := range tcase.sqls {
+				_, err = executor.Execute(ctx, nil, "TestExecutorRejectTwoPC", session, sql, nil)
+				require.NoError(t, err)
+			}
+
+			// commit 2pc
+			_, err = executor.Execute(ctx, nil, "TestExecutorRejectTwoPC", session, "commit", nil)
+			require.ErrorContains(t, err, tcase.expErr)
+		})
+	}
+}
+
 func TestExecutorTruncateErrors(t *testing.T) {
 	executor, _, _, _, ctx := createExecutorEnv(t)
 

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -620,6 +620,6 @@ func newTestScatterConn(ctx context.Context, hc discovery.HealthCheck, serv srvt
 	// in '-cells_to_watch' command line parameter, which is
 	// empty by default. So it's unused in this test, set to nil.
 	gw := NewTabletGateway(ctx, hc, serv, cell)
-	tc := NewTxConn(gw, vtgatepb.TransactionMode_TWOPC)
+	tc := NewTxConn(gw, vtgatepb.TransactionMode_MULTI)
 	return NewScatterConn("", tc, gw)
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR rejects a Atomic Distributed Transaction Commit when the session have modified system settings or using temporary table or have savepoints inside the transaction.

This will be removed when the support is added for it.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #16245 

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
