### PR TITLE
VTAdmin: Upgrade deps to address security vulns

### DIFF
--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -3860,7 +3860,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.68.0||^3.0.0"
+        "rollup": "^3.29.5"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -3882,7 +3882,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+        "rollup": "^3.29.5"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -16012,10 +16012,11 @@
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17672,7 +17673,7 @@
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
-        "rollup": "^3.27.1"
+        "rollup": "^3.29.5"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -17750,7 +17751,7 @@
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
         "@types/eslint": "^8.4.5",
-        "rollup": "^2.77.2"
+        "rollup": "^3.29.5"
       },
       "peerDependencies": {
         "eslint": ">=7",
@@ -17768,21 +17769,6 @@
       },
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/vite-plugin-eslint/node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/vite-plugin-svgr": {

--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -5239,7 +5239,7 @@
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.1.0-beta.0"
+        "vite": "^4.5.4"
       }
     },
     "node_modules/@vitest/expect": {
@@ -17666,10 +17666,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
-      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -17731,7 +17732,7 @@
         "mlly": "^1.1.0",
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
-        "vite": "^3.0.0 || ^4.0.0"
+        "vite": "^4.5.4"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -17755,7 +17756,7 @@
       },
       "peerDependencies": {
         "eslint": ">=7",
-        "vite": ">=2"
+        "vite": ">=4.5.4"
       }
     },
     "node_modules/vite-plugin-eslint/node_modules/@rollup/pluginutils": {
@@ -17781,7 +17782,7 @@
         "@svgr/core": "^6.5.1"
       },
       "peerDependencies": {
-        "vite": "^2.6.0 || 3 || 4"
+        "vite": "^4.5.4"
       }
     },
     "node_modules/vitest": {
@@ -17811,7 +17812,7 @@
         "tinybench": "^2.3.1",
         "tinypool": "^0.4.0",
         "tinyspy": "^1.0.2",
-        "vite": "^3.0.0 || ^4.0.0",
+        "vite": "^4.5.4",
         "vite-node": "0.29.8",
         "why-is-node-running": "^2.2.2"
       },


### PR DESCRIPTION
## Description

This upgrades JS dependencies to address high CVSS security vulnerabilities.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/security/dependabot/390
  - Fixes: https://github.com/vitessio/vitess/security/dependabot/391
  - Fixes: https://github.com/vitessio/vitess/security/dependabot/393

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required