### PR TITLE
MySQL errors: `ERInnodbIndexCorrupt`

### DIFF
--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -42,7 +42,8 @@ const (
 	ERUnknownError = ErrorCode(1105)
 
 	// internal
-	ERInternalError = ErrorCode(1815)
+	ERInternalError      = ErrorCode(1815)
+	ERInnodbIndexCorrupt = ErrorCode(1817)
 
 	// unimplemented
 	ERNotSupportedYet = ErrorCode(1235)

--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -42,8 +42,7 @@ const (
 	ERUnknownError = ErrorCode(1105)
 
 	// internal
-	ERInternalError      = ErrorCode(1815)
-	ERInnodbIndexCorrupt = ErrorCode(1817)
+	ERInternalError = ErrorCode(1815)
 
 	// unimplemented
 	ERNotSupportedYet = ErrorCode(1235)
@@ -124,6 +123,7 @@ const (
 	ErSPNotVarArg                   = ErrorCode(1414)
 	ERRowIsReferenced2              = ErrorCode(1451)
 	ErNoReferencedRow2              = ErrorCode(1452)
+	ERInnodbIndexCorrupt            = ErrorCode(1817)
 	ERDupIndex                      = ErrorCode(1831)
 	ERInnodbReadOnly                = ErrorCode(1874)
 

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1600,7 +1600,7 @@ func convertErrorCode(err error) vtrpcpb.Code {
 		sqlerror.ERTooLongString, sqlerror.ERDelayedInsertTableLocked, sqlerror.ERDupUnique, sqlerror.ERRequiresPrimaryKey, sqlerror.ERCantDoThisDuringAnTransaction, sqlerror.ERReadOnlyTransaction,
 		sqlerror.ERCannotAddForeign, sqlerror.ERNoReferencedRow, sqlerror.ERRowIsReferenced, sqlerror.ERCantUpdateWithReadLock, sqlerror.ERNoDefault, sqlerror.EROperandColumns,
 		sqlerror.ERSubqueryNo1Row, sqlerror.ERNonUpdateableTable, sqlerror.ERFeatureDisabled, sqlerror.ERDuplicatedValueInType, sqlerror.ERRowIsReferenced2,
-		sqlerror.ErNoReferencedRow2, sqlerror.ERWarnDataOutOfRange:
+		sqlerror.ErNoReferencedRow2, sqlerror.ERWarnDataOutOfRange, sqlerror.ERInnodbIndexCorrupt:
 		errCode = vtrpcpb.Code_FAILED_PRECONDITION
 	case sqlerror.EROptionPreventsStatement:
 		errCode = vtrpcpb.Code_CLUSTER_EVENT


### PR DESCRIPTION

## Description

Add `ERInnodbIndexCorrupt` (error 1817) to the list of known MySQL errors. This can be used in the future to recognize terminal `ApplySchema` or Online DDL scenarios.


## Related Issue(s)

none

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
