### PR TITLE
Fail fast when builtinbackup fails to restore a single file

### DIFF
--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -621,7 +621,7 @@ func (be *BuiltinBackupEngine) backupFiles(
 			}
 			defer sema.Release(1)
 
-			// First check if we have any error, if we have, there is no point trying to restore this file.
+			// First check if we have any error, if we have, there is no point trying backing up this file.
 			// We check for errors before checking if the context is canceled on purpose, if there was an
 			// error, the context would have been canceled already.
 			if bh.HasErrors() {
@@ -779,7 +779,7 @@ func (bp *backupPipe) HashString() string {
 	return hex.EncodeToString(bp.crc32.Sum(nil))
 }
 
-func (bp *backupPipe) ReportProgress(period time.Duration, logger logutil.Logger, restore bool) {
+func (bp *backupPipe) ReportProgress(ctx context.Context, period time.Duration, logger logutil.Logger, restore bool) {
 	messageStr := "restoring "
 	if !restore {
 		messageStr = "backing up "
@@ -788,6 +788,9 @@ func (bp *backupPipe) ReportProgress(period time.Duration, logger logutil.Logger
 	defer tick.Stop()
 	for {
 		select {
+		case <-ctx.Done():
+			logger.Infof("Canceled %q", bp.filename)
+			return
 		case <-bp.done:
 			logger.Infof("Completed %s %q", messageStr, bp.filename)
 			return
@@ -830,7 +833,7 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	}
 
 	br := newBackupReader(fe.Name, fi.Size(), timedSource)
-	go br.ReportProgress(builtinBackupProgress, params.Logger, false /*restore*/)
+	go br.ReportProgress(ctx, builtinBackupProgress, params.Logger, false /*restore*/)
 
 	// Open the destination file for writing, and a buffer.
 	params.Logger.Infof("Backing up file: %v", fe.Name)
@@ -1029,43 +1032,53 @@ func (be *BuiltinBackupEngine) restoreFiles(ctx context.Context, params RestoreP
 	sema := semaphore.NewWeighted(int64(params.Concurrency))
 	rec := concurrency.AllErrorRecorder{}
 	wg := sync.WaitGroup{}
+
+	ctxCancel, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	for i := range fes {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			fe := &fes[i]
 			// Wait until we are ready to go, return if we encounter an error
-			acqErr := sema.Acquire(ctx, 1)
+			acqErr := sema.Acquire(ctxCancel, 1)
 			if acqErr != nil {
 				log.Errorf("Unable to acquire semaphore needed to restore file: %s, err: %s", fe.Name, acqErr.Error())
 				rec.RecordError(acqErr)
+				cancel()
 				return
 			}
 			defer sema.Release(1)
+
+			// First check if we have any error, if we have, there is no point trying to restore this file.
+			// We check for errors before checking if the context is canceled on purpose, if there was an
+			// error, the context would have been canceled already.
+			if rec.HasErrors() {
+				params.Logger.Infof("Failed to restore files due to error.")
+				return
+			}
+
 			// Check for context cancellation explicitly because, the way semaphore code is written, theoretically we might
 			// end up not throwing an error even after cancellation. Please see https://cs.opensource.google/go/x/sync/+/refs/tags/v0.1.0:semaphore/semaphore.go;l=66,
 			// which suggests that if the context is already done, `Acquire()` may still succeed without blocking. This introduces
 			// unpredictability in my test cases, so in order to avoid that, I am adding this cancellation check.
 			select {
-			case <-ctx.Done():
+			case <-ctxCancel.Done():
 				log.Errorf("Context canceled or timed out during %q restore", fe.Name)
 				rec.RecordError(vterrors.Errorf(vtrpc.Code_CANCELED, "context canceled"))
 				return
 			default:
 			}
 
-			if rec.HasErrors() {
-				params.Logger.Infof("Failed to restore files due to error.")
-				return
-			}
-
 			fe.ParentPath = createdDir
 			// And restore the file.
 			name := fmt.Sprintf("%v", i)
 			params.Logger.Infof("Copying file %v: %v", name, fe.Name)
-			err := be.restoreFile(ctx, params, bh, fe, bm, name)
+			err := be.restoreFile(ctxCancel, params, bh, fe, bm, name)
 			if err != nil {
 				rec.RecordError(vterrors.Wrapf(err, "can't restore file %v to %v", name, fe.Name))
+				cancel()
 			}
 		}(i)
 	}
@@ -1095,7 +1108,7 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 	}()
 
 	br := newBackupReader(name, 0, timedSource)
-	go br.ReportProgress(builtinBackupProgress, params.Logger, true /*restore*/)
+	go br.ReportProgress(ctx, builtinBackupProgress, params.Logger, true)
 	var reader io.Reader = br
 
 	// Open the destination file for writing.


### PR DESCRIPTION
## Description

This PR fixes https://github.com/vitessio/vitess/issues/16855. Since each file is restored concurrently, we need to cancel all the restore at once as soon as a goroutine fails. This way we prevent the restore process to take forever and stall.

I do not have a programatic E2E test for this PR as it was way to flaky even locally. However, I have described a step-by-step reproduction process on #16855.

## Logs

### Before
On the first line, we detect the error. But we continue restoring all the ongoing file after that, without canceling them.
```
commerce/0 (zone1-0000000102): time:{seconds:1727389202 nanoseconds:504998000} file:"backup.go" line:519 value:"decompressor stderr: /*stdin*\\ : Read error (39) : premature end "
commerce/0 (zone1-0000000102): time:{seconds:1727389202 nanoseconds:524027000} file:"builtinbackupengine.go" line:1145 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727389202 nanoseconds:524051000} file:"builtinbackupengine.go" line:779 value:"Completed restoring  \"173\""
commerce/0 (zone1-0000000102): time:{seconds:1727389202 nanoseconds:564330000} file:"builtinbackupengine.go" line:1145 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727389202 nanoseconds:893811000} file:"builtinbackupengine.go" line:784 value:"restoring  \"34\": 1421.60kb"
commerce/0 (zone1-0000000102): time:{seconds:1727389202 nanoseconds:993136000} file:"builtinbackupengine.go" line:784 value:"restoring  \"171\": 2780.91kb"
commerce/0 (zone1-0000000102): time:{seconds:1727389202 nanoseconds:994575000} file:"builtinbackupengine.go" line:784 value:"restoring  \"172\": 252.01kb"
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:393780000} file:"builtinbackupengine.go" line:784 value:"restoring  \"34\": 1421.60kb"
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:493087000} file:"builtinbackupengine.go" line:784 value:"restoring  \"171\": 2780.91kb"
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:494524000} file:"builtinbackupengine.go" line:784 value:"restoring  \"172\": 252.01kb"
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:601967000} file:"builtinbackupengine.go" line:779 value:"Completed restoring  \"171\""
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:601978000} file:"builtinbackupengine.go" line:1145 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:804764000} file:"builtinbackupengine.go" line:1145 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:804770000} file:"builtinbackupengine.go" line:779 value:"Completed restoring  \"34\""
commerce/0 (zone1-0000000102): time:{seconds:1727389203 nanoseconds:805104000} file:"restore.go" line:283 value:"Restore: got a restore manifest: <nil>, err=can't restore file 172 to vt_commerce/customer.ibd: hash mismatch for vt_commerce/customer.ibd, got 0ca874fd expected ea1dd5df\nfailed to restore files, waitForBackupInterval=0s"
E0926 16:20:03.818039   37724 main.go:56] rpc error: code = Unknown desc = TabletManager.RestoreFromBackup on zone1-0000000102: Can't restore backup: failed to restore files: can't restore file 172 to vt_commerce/customer.ibd: hash mismatch for vt_commerce/customer.ibd, got 0ca874fd expected ea1dd5df
```

### After
Here we can see that current/ongoing restore are getting canceled. Besides file 72, which I think is due to concurrency, we log the error (first line) from the stderr of `ztsd` but there is enough time until we cancel all the context for `72` to begin and finish. But once we detect the error at the top level loop in `restoreFiles`, all executions are canceled.
```
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:213399000} file:"backup.go" line:519 value:"decompressor stderr: /*stdin*\\ : Read error (39) : premature end "
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:221890000} file:"builtinbackupengine.go" line:1171 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:221926000} file:"builtinbackupengine.go" line:795 value:"Completed restoring  \"162\""
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:222180000} file:"builtinbackupengine.go" line:1077 value:"Copying file 76: performance_schema/events_stages_su_116.sdi"
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:222465000} file:"compression.go" line:168 value:"Decompressing using external command: \"nice -n 19 zstd -c -d\""
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:232724000} file:"builtinbackupengine.go" line:1171 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:232753000} file:"builtinbackupengine.go" line:795 value:"Completed restoring  \"76\""
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:274510000} file:"builtinbackupengine.go" line:1171 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:274759000} file:"builtinbackupengine.go" line:792 value:"Canceled \"171\""
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:274767000} file:"builtinbackupengine.go" line:792 value:"Canceled \"34\""
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:274789000} file:"builtinbackupengine.go" line:792 value:"Canceled \"172\""
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:279935000} file:"builtinbackupengine.go" line:1171 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:280043000} file:"builtinbackupengine.go" line:1171 value:"closing decompressor"
commerce/0 (zone1-0000000102): time:{seconds:1727391201 nanoseconds:280295000} file:"restore.go" line:283 value:"Restore: got a restore manifest: <nil>, err=can't restore file 172 to vt_commerce/customer.ibd: hash mismatch for vt_commerce/customer.ibd, got 048f1e72 expected 6e9641a7;can't restore file 171 to vt_commerce/corder.ibd: hash mismatch for vt_commerce/corder.ibd, got aaffb3c0 expected 2d504b92\nfailed to restore files, waitForBackupInterval=0s"
E0926 16:53:21.293970   73953 main.go:56] rpc error: code = Unknown desc = TabletManager.RestoreFromBackup on zone1-0000000102: Can't restore backup: failed to restore files: can't restore file 172 to vt_commerce/customer.ibd: hash mismatch for vt_commerce/customer.ibd, got 048f1e72 expected 6e9641a7;can't restore file 171 to vt_commerce/corder.ibd: hash mismatch for vt_commerce/corder.ibd, got aaffb3c0 expected 2d504b92
```