### PR TITLE
VReplication: Support both vindex col def formats when initing target sequences

### DIFF
--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1431,7 +1431,7 @@ func (ts *trafficSwitcher) getTargetSequenceMetadata(ctx context.Context) (map[s
 			// The table name can be escaped in the vschema definition.
 			unescapedTableName, err := sqlescape.UnescapeID(tableName)
 			if err != nil {
-				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid table name %s in keyspace %s: %v",
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid table name %q in keyspace %s: %v",
 					tableName, keyspace, err)
 			}
 			select {
@@ -1480,7 +1480,7 @@ func (ts *trafficSwitcher) getTargetSequenceMetadata(ctx context.Context) (map[s
 		// The keyspace name could be escaped so we need to unescape it.
 		ks, err := sqlescape.UnescapeID(keyspace)
 		if err != nil { // Should never happen
-			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid keyspace name %s: %v", keyspace, err)
+			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid keyspace name %q: %v", keyspace, err)
 		}
 		searchGroup.Go(func() error {
 			return searchKeyspace(gctx, searchCompleted, ks)
@@ -1533,7 +1533,7 @@ func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspa
 		if strings.Contains(seqTable.AutoIncrement.Sequence, ".") {
 			keyspace, tableName, found := strings.Cut(seqTable.AutoIncrement.Sequence, ".")
 			if !found {
-				return nil, false, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid sequence table name %q defined in the %q keyspace",
+				return nil, false, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid sequence table name %q defined in the %s keyspace",
 					seqTable.AutoIncrement.Sequence, ts.targetKeyspace)
 			}
 			// Unescape the table name and keyspace name as they may be escaped in the
@@ -1571,15 +1571,16 @@ func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspa
 			)
 			if len(seqTable.ColumnVindexes[i].Columns) > 0 {
 				unescapedColumn, err = sqlescape.UnescapeID(seqTable.ColumnVindexes[i].Columns[0]) // AutoIncrement definitions can only be on a single column
+				seqTable.ColumnVindexes[i].Columns[0] = unescapedColumn
 			} else {
 				// This is the legacy vschema definition.
 				unescapedColumn, err = sqlescape.UnescapeID(seqTable.ColumnVindexes[i].Column)
+				seqTable.ColumnVindexes[i].Column = unescapedColumn
 			}
 			if err != nil {
 				return nil, false, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid sequence column vindex name %q defined in sequence table %+v: %v",
 					seqTable.ColumnVindexes[i].Column, seqTable, err)
 			}
-			seqTable.ColumnVindexes[i].Column = unescapedColumn
 		}
 		unescapedAutoIncCol, err := sqlescape.UnescapeID(seqTable.AutoIncrement.Column)
 		if err != nil {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1570,8 +1570,10 @@ func (ts *trafficSwitcher) findSequenceUsageInKeyspace(vschema *vschemapb.Keyspa
 				err             error
 			)
 			if len(seqTable.ColumnVindexes[i].Columns) > 0 {
-				unescapedColumn, err = sqlescape.UnescapeID(seqTable.ColumnVindexes[i].Columns[0]) // AutoIncrement definitions can only be on a single column
-				seqTable.ColumnVindexes[i].Columns[0] = unescapedColumn
+				for n := range seqTable.ColumnVindexes[i].Columns {
+					unescapedColumn, err = sqlescape.UnescapeID(seqTable.ColumnVindexes[i].Columns[n])
+					seqTable.ColumnVindexes[i].Columns[n] = unescapedColumn
+				}
 			} else {
 				// This is the legacy vschema definition.
 				unescapedColumn, err = sqlescape.UnescapeID(seqTable.ColumnVindexes[i].Column)

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -285,6 +285,55 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "sequence with table having mult-col vindex",
+			sourceVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					"seq1": {
+						Type: "sequence",
+					},
+				},
+			},
+			targetVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					table: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:    "xxhash",
+								Columns: []string{"col3", "col4"},
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "col1",
+							Sequence: fmt.Sprintf("%s.seq1", sourceKeyspace.KeyspaceName),
+						},
+					},
+				},
+			},
+			want: map[string]*sequenceMetadata{
+				"seq1": {
+					backingTableName:     "seq1",
+					backingTableKeyspace: "source-ks",
+					backingTableDBName:   "vt_source-ks",
+					usingTableName:       unescapedTable,
+					usingTableDBName:     "vt_targetks",
+					usingTableDefinition: &vschema.Table{
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Columns: []string{"col3", "col4"},
+								Name:    "xxhash",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "col1",
+							Sequence: fmt.Sprintf("%s.seq1", sourceKeyspace.KeyspaceName),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "invalid table name",
 			sourceVSchema: &vschema.Keyspace{
 				Vindexes: vindexes,

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -19,7 +19,6 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -74,6 +73,7 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 	cell := "cell1"
 	workflow := "wf1"
 	table := "`t1`"
+	table2 := "t2"
 	unescapedTable := "t1"
 	sourceKeyspace := &testKeyspace{
 		KeyspaceName: "source-ks",
@@ -202,6 +202,89 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "sequences using vindexes with both column definition structures",
+			sourceVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					"seq1": {
+						Type: "sequence",
+					},
+					"seq2": {
+						Type: "sequence",
+					},
+				},
+			},
+			targetVSchema: &vschema.Keyspace{
+				Vindexes: vindexes,
+				Tables: map[string]*vschema.Table{
+					table: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:   "xxhash",
+								Column: "col1",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "col1",
+							Sequence: fmt.Sprintf("%s.seq1", sourceKeyspace.KeyspaceName),
+						},
+					},
+					table2: {
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Name:    "xxhash",
+								Columns: []string{"col2"},
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "col2",
+							Sequence: fmt.Sprintf("%s.seq2", sourceKeyspace.KeyspaceName),
+						},
+					},
+				},
+			},
+			want: map[string]*sequenceMetadata{
+				"seq1": {
+					backingTableName:     "seq1",
+					backingTableKeyspace: "source-ks",
+					backingTableDBName:   "vt_source-ks",
+					usingTableName:       unescapedTable,
+					usingTableDBName:     "vt_targetks",
+					usingTableDefinition: &vschema.Table{
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Column: "col1",
+								Name:   "xxhash",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "col1",
+							Sequence: fmt.Sprintf("%s.seq1", sourceKeyspace.KeyspaceName),
+						},
+					},
+				},
+				"seq2": {
+					backingTableName:     "seq2",
+					backingTableKeyspace: "source-ks",
+					backingTableDBName:   "vt_source-ks",
+					usingTableName:       table2,
+					usingTableDBName:     "vt_targetks",
+					usingTableDefinition: &vschema.Table{
+						ColumnVindexes: []*vschema.ColumnVindex{
+							{
+								Columns: []string{"col2"},
+								Name:    "xxhash",
+							},
+						},
+						AutoIncrement: &vschema.AutoIncrement{
+							Column:   "col2",
+							Sequence: fmt.Sprintf("%s.seq2", sourceKeyspace.KeyspaceName),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "invalid table name",
 			sourceVSchema: &vschema.Keyspace{
 				Vindexes: vindexes,
@@ -228,7 +311,7 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 					},
 				},
 			},
-			err: "invalid table name `my-`seq1` in keyspace source-ks: UnescapeID err: unexpected single backtick at position 3 in 'my-`seq1'",
+			err: "invalid table name \"`my-`seq1`\" in keyspace source-ks: UnescapeID err: unexpected single backtick at position 3 in 'my-`seq1'",
 		},
 		{
 			name: "invalid keyspace name",
@@ -257,7 +340,7 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 					},
 				},
 			},
-			err: "invalid keyspace in qualified sequence table name `ks`1`.`my-seq1` defined in sequence table column_vindexes:{column:\"`my-col`\" name:\"xxhash\"} auto_increment:{column:\"`my-col`\" sequence:\"`ks`1`.`my-seq1`\"}: UnescapeID err: unexpected single backtick at position 2 in 'ks`1'",
+			err: "invalid keyspace in qualified sequence table name \"`ks`1`.`my-seq1`\" defined in sequence table column_vindexes:{column:\"`my-col`\" name:\"xxhash\"} auto_increment:{column:\"`my-col`\" sequence:\"`ks`1`.`my-seq1`\"}: UnescapeID err: unexpected single backtick at position 2 in 'ks`1'",
 		},
 		{
 			name: "invalid auto-inc column name",
@@ -286,7 +369,7 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 					},
 				},
 			},
-			err: "invalid auto-increment column name `my`-col` defined in sequence table column_vindexes:{column:\"my-col\" name:\"xxhash\"} auto_increment:{column:\"`my`-col`\" sequence:\"my-seq1\"}: UnescapeID err: unexpected single backtick at position 2 in 'my`-col'",
+			err: "invalid auto-increment column name \"`my`-col`\" defined in sequence table column_vindexes:{column:\"my-col\" name:\"xxhash\"} auto_increment:{column:\"`my`-col`\" sequence:\"my-seq1\"}: UnescapeID err: unexpected single backtick at position 2 in 'my`-col'",
 		},
 		{
 			name: "invalid sequence name",
@@ -315,7 +398,7 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 					},
 				},
 			},
-			err: "invalid sequence table name `my-`seq1` defined in sequence table column_vindexes:{column:\"`my-col`\" name:\"xxhash\"} auto_increment:{column:\"`my-col`\" sequence:\"`my-`seq1`\"}: UnescapeID err: unexpected single backtick at position 3 in 'my-`seq1'",
+			err: "invalid sequence table name \"`my-`seq1`\" defined in sequence table column_vindexes:{column:\"`my-col`\" name:\"xxhash\"} auto_increment:{column:\"`my-col`\" sequence:\"`my-`seq1`\"}: UnescapeID err: unexpected single backtick at position 3 in 'my-`seq1'",
 		},
 	}
 
@@ -349,7 +432,7 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 				id:             1,
 				ws:             env.ws,
 				workflow:       workflow,
-				tables:         []string{table},
+				tables:         []string{table, table2},
 				sourceKeyspace: sourceKeyspace.KeyspaceName,
 				targetKeyspace: targetKeyspace.KeyspaceName,
 				sources:        sources,
@@ -361,7 +444,7 @@ func TestGetTargetSequenceMetadata(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.True(t, reflect.DeepEqual(tc.want, got), "want: %v, got: %v", tc.want, got)
+			require.EqualValues(t, tc.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Description

You can specify the columns which make up a vindex in two ways within the vschema:

1. The "legacy" way (a simple string): 
```
    "corder": {
      "column_vindexes": [
        {
          "column": "customer_id",
          "name": "hash"
        }
      ],
      "auto_increment": {
        "column": "order_id",
        "sequence": "order_seq"
      }
    },
```
2. The "new" way (an array):
```
    "product": {
      "column_vindexes": [
        {
          "columns": [
            "product_id"
          ],
          "name": "hash"
        }
      ],
      "auto_increment": {
        "column": "product_id",
        "sequence": "product_seq"
      }
    }
```

The `MoveTables` target sequence initialization work (added in https://github.com/vitessio/vitess/pull/13656) only supports the legacy way. It needs to be updated to support either. 

That's exactly what this PR does. 🙂 

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16861

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required