### PR TITLE
Add savepoint support to atomic distributed transaction

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -170,6 +170,17 @@ func (shard *Shard) PrimaryTablet() *Vttablet {
 	return shard.Vttablets[0]
 }
 
+// FindPrimaryTablet finds the primary tablet in the shard.
+func (shard *Shard) FindPrimaryTablet() *Vttablet {
+	for _, vttablet := range shard.Vttablets {
+		tabletType := vttablet.VttabletProcess.GetTabletType()
+		if tabletType == "primary" {
+			return vttablet
+		}
+	}
+	return nil
+}
+
 // Rdonly get the last tablet which is rdonly
 func (shard *Shard) Rdonly() *Vttablet {
 	for idx, tablet := range shard.Vttablets {

--- a/go/test/endtoend/cluster/reshard.go
+++ b/go/test/endtoend/cluster/reshard.go
@@ -95,7 +95,7 @@ func (rw *ReshardWorkflow) WaitForVreplCatchup(timeToWait time.Duration) {
 			if !slices.Contains(targetShards, shard.Name) {
 				continue
 			}
-			vttablet := shard.PrimaryTablet().VttabletProcess
+			vttablet := shard.FindPrimaryTablet().VttabletProcess
 			vttablet.WaitForVReplicationToCatchup(rw.t, rw.workflowName, fmt.Sprintf("vt_%s", vttablet.Keyspace), "", timeToWait)
 		}
 	}

--- a/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -302,9 +303,11 @@ func (fz *fuzzer) generateAndExecuteTransaction(threadId int) {
 	// for each update set ordered by the auto increment column will not be true.
 	// That assertion depends on all the transactions running updates first to ensure that for any given update set,
 	// no two transactions are running the insert queries.
-	queries := []string{"begin"}
+	var queries []string
 	queries = append(queries, fz.generateUpdateQueries(updateSetVal, incrementVal)...)
 	queries = append(queries, fz.generateInsertQueries(updateSetVal, threadId)...)
+	queries = fz.addRandomSavePoints(queries)
+	queries = append([]string{"begin"}, queries...)
 	finalCommand := "commit"
 	for _, query := range queries {
 		_, err := conn.ExecuteFetch(query, 0, false)
@@ -375,6 +378,45 @@ func (fz *fuzzer) runClusterDisruption(t *testing.T) {
 			return
 		}
 	}
+}
+
+// addRandomSavePoints will add random savepoints and queries to the list of queries.
+// It still ensures that all the new queries added are rolledback so that the assertions of queries
+// don't change.
+func (fz *fuzzer) addRandomSavePoints(queries []string) []string {
+	savePointCount := 1
+	for {
+		shouldAddSavePoint := rand.Intn(2)
+		if shouldAddSavePoint == 0 {
+			return queries
+		}
+
+		savePointQueries := []string{"SAVEPOINT sp" + strconv.Itoa(savePointCount)}
+		randomDmlCount := rand.Intn(2) + 1
+		for i := 0; i < randomDmlCount; i++ {
+			savePointQueries = append(savePointQueries, fz.randomDML())
+		}
+		savePointQueries = append(savePointQueries, "ROLLBACK TO sp"+strconv.Itoa(savePointCount))
+		savePointCount++
+
+		savePointPosition := rand.Intn(len(queries))
+		newQueries := slices.Clone(queries[:savePointPosition])
+		newQueries = append(newQueries, savePointQueries...)
+		newQueries = append(newQueries, queries[savePointPosition:]...)
+		queries = newQueries
+	}
+}
+
+// randomDML generates a random DML to be used.
+func (fz *fuzzer) randomDML() string {
+	queryType := rand.Intn(2)
+	if queryType == 0 {
+		// Generate INSERT
+		return fmt.Sprintf(insertIntoFuzzInsert, updateRowBaseVals[rand.Intn(len(updateRowBaseVals))], rand.Intn(fz.updateSets), rand.Intn(fz.threads))
+	}
+	// Generate UPDATE
+	updateId := fz.updateRowsVals[rand.Intn(len(fz.updateRowsVals))][rand.Intn(len(updateRowBaseVals))]
+	return fmt.Sprintf(updateFuzzUpdate, rand.Intn(100000), updateId)
 }
 
 /*

--- a/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
@@ -127,7 +127,18 @@ func TestTwoPCFuzzTest(t *testing.T) {
 			fz.start(t)
 
 			// Wait for the timeForTesting so that the threads continue to run.
-			time.Sleep(tt.timeForTesting)
+			timeout := time.After(tt.timeForTesting)
+			loop := true
+			for loop {
+				select {
+				case <-timeout:
+					loop = false
+				case <-time.After(1 * time.Second):
+					if t.Failed() {
+						loop = false
+					}
+				}
+			}
 
 			// Signal the fuzzer to stop.
 			fz.stop()

--- a/go/test/endtoend/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/transaction/twopc/twopc_test.go
@@ -1119,10 +1119,8 @@ func TestDTSavepoint(t *testing.T) {
 			"delete:[VARCHAR(\"dtid-1\") VARCHAR(\"PREPARE\")]",
 		},
 		"ks.redo_statement:80-": {
-			"insert:[VARCHAR(\"dtid-1\") INT64(1) BLOB(\"savepoint-1\")]",
-			"insert:[VARCHAR(\"dtid-1\") INT64(2) BLOB(\"insert into twopc_user(id, `name`) values (7, 'foo')\")]",
-			"delete:[VARCHAR(\"dtid-1\") INT64(1) BLOB(\"savepoint-1\")]",
-			"delete:[VARCHAR(\"dtid-1\") INT64(2) BLOB(\"insert into twopc_user(id, `name`) values (7, 'foo')\")]",
+			"insert:[VARCHAR(\"dtid-1\") INT64(1) BLOB(\"insert into twopc_user(id, `name`) values (7, 'foo')\")]",
+			"delete:[VARCHAR(\"dtid-1\") INT64(1) BLOB(\"insert into twopc_user(id, `name`) values (7, 'foo')\")]",
 		},
 		"ks.twopc_user:40-80": {"insert:[INT64(8) VARCHAR(\"bar\")]"},
 		"ks.twopc_user:80-":   {"insert:[INT64(7) VARCHAR(\"foo\")]"},
@@ -1164,20 +1162,6 @@ func TestDTSavepoint(t *testing.T) {
 			"update:[VARCHAR(\"dtid-2\") VARCHAR(\"COMMIT\")]",
 			"delete:[VARCHAR(\"dtid-2\") VARCHAR(\"COMMIT\")]",
 		},
-		"ks.redo_state:80-": {
-			"insert:[VARCHAR(\"dtid-2\") VARCHAR(\"PREPARE\")]",
-			"delete:[VARCHAR(\"dtid-2\") VARCHAR(\"PREPARE\")]",
-		},
-		"ks.redo_statement:80-": {
-			"insert:[VARCHAR(\"dtid-2\") INT64(1) BLOB(\"savepoint-2\")]",
-			"insert:[VARCHAR(\"dtid-2\") INT64(2) BLOB(\"savepoint-3\")]",
-			"insert:[VARCHAR(\"dtid-2\") INT64(3) BLOB(\"update twopc_user set `name` = 'temp' where id = 7 limit 10001 /* INT64 */\")]",
-			"insert:[VARCHAR(\"dtid-2\") INT64(4) BLOB(\"rollback-2\")]",
-			"delete:[VARCHAR(\"dtid-2\") INT64(1) BLOB(\"savepoint-2\")]",
-			"delete:[VARCHAR(\"dtid-2\") INT64(2) BLOB(\"savepoint-3\")]",
-			"delete:[VARCHAR(\"dtid-2\") INT64(3) BLOB(\"update twopc_user set `name` = 'temp' where id = 7 limit 10001 /* INT64 */\")]",
-			"delete:[VARCHAR(\"dtid-2\") INT64(4) BLOB(\"rollback-2\")]",
-		},
 	}
 	assert.Equal(t, expectations, logTable,
 		"mismatch expected: \n got: %s, want: %s", prettyPrint(logTable), prettyPrint(expectations))
@@ -1201,20 +1185,6 @@ func TestDTSavepoint(t *testing.T) {
 			"insert:[VARCHAR(\"dtid-3\") VARCHAR(\"PREPARE\")]",
 			"update:[VARCHAR(\"dtid-3\") VARCHAR(\"COMMIT\")]",
 			"delete:[VARCHAR(\"dtid-3\") VARCHAR(\"COMMIT\")]",
-		},
-		"ks.redo_state:80-": {
-			"insert:[VARCHAR(\"dtid-3\") VARCHAR(\"PREPARE\")]",
-			"delete:[VARCHAR(\"dtid-3\") VARCHAR(\"PREPARE\")]",
-		},
-		"ks.redo_statement:80-": {
-			"insert:[VARCHAR(\"dtid-3\") INT64(1) BLOB(\"savepoint-2\")]",
-			"insert:[VARCHAR(\"dtid-3\") INT64(2) BLOB(\"savepoint-3\")]",
-			"insert:[VARCHAR(\"dtid-3\") INT64(3) BLOB(\"update twopc_user set `name` = 'temp' where id = 7 limit 10001 /* INT64 */\")]",
-			"insert:[VARCHAR(\"dtid-3\") INT64(4) BLOB(\"rollback-3\")]",
-			"delete:[VARCHAR(\"dtid-3\") INT64(1) BLOB(\"savepoint-2\")]",
-			"delete:[VARCHAR(\"dtid-3\") INT64(2) BLOB(\"savepoint-3\")]",
-			"delete:[VARCHAR(\"dtid-3\") INT64(3) BLOB(\"update twopc_user set `name` = 'temp' where id = 7 limit 10001 /* INT64 */\")]",
-			"delete:[VARCHAR(\"dtid-3\") INT64(4) BLOB(\"rollback-3\")]",
 		},
 		"ks.twopc_user:-40": {"insert:[INT64(10) VARCHAR(\"apa\")]"},
 	}
@@ -1246,11 +1216,7 @@ func TestDTSavepoint(t *testing.T) {
 		},
 		"ks.redo_statement:80-": {
 			"insert:[VARCHAR(\"dtid-4\") INT64(1) BLOB(\"update twopc_user set `name` = 'temp1' where id = 7 limit 10001 /* INT64 */\")]",
-			"insert:[VARCHAR(\"dtid-4\") INT64(2) BLOB(\"savepoint-4\")]",
-			"insert:[VARCHAR(\"dtid-4\") INT64(3) BLOB(\"rollback-4\")]",
 			"delete:[VARCHAR(\"dtid-4\") INT64(1) BLOB(\"update twopc_user set `name` = 'temp1' where id = 7 limit 10001 /* INT64 */\")]",
-			"delete:[VARCHAR(\"dtid-4\") INT64(2) BLOB(\"savepoint-4\")]",
-			"delete:[VARCHAR(\"dtid-4\") INT64(3) BLOB(\"rollback-4\")]",
 		},
 		"ks.twopc_user:80-": {"update:[INT64(7) VARCHAR(\"temp1\")]"},
 	}

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2807,17 +2807,6 @@ func TestExecutorRejectTwoPC(t *testing.T) {
 					"1|2|0"),
 			},
 			expErr: "VT12001: unsupported: atomic distributed transaction commit with consistent lookup vindex",
-		}, {
-			sqls: []string{
-				`savepoint x`,
-				`insert into user_extra(user_id) values (1)`,
-				`insert into user_extra(user_id) values (3)`,
-			},
-			testRes: []*sqltypes.Result{
-				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|unq_col|unchanged", "int64|int64|int64"),
-					"1|2|0"),
-			},
-			expErr: "VT12001: unsupported: atomic distributed transaction commit with savepoint",
 		},
 	}
 

--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -280,9 +280,6 @@ func (txc *TxConn) checkValidCondition(session *SafeSession) error {
 	if len(session.PreSessions) != 0 || len(session.PostSessions) != 0 {
 		return vterrors.VT12001("atomic distributed transaction commit with consistent lookup vindex")
 	}
-	if len(session.GetSavepoints()) != 0 {
-		return vterrors.VT12001("atomic distributed transaction commit with savepoint")
-	}
 	if session.GetInReservedConn() {
 		return vterrors.VT12001("atomic distributed transaction commit with system settings")
 	}

--- a/go/vt/vttablet/endtoend/savepoint_test.go
+++ b/go/vt/vttablet/endtoend/savepoint_test.go
@@ -103,7 +103,7 @@ func TestSavepointInTransactionWithRelease(t *testing.T) {
 		diff int
 	}{{
 		tag:  "Queries/Histograms/Savepoint/Count",
-		diff: 1,
+		diff: 2, // savepoint a (post-begin) and savepoint b
 	}, {
 		tag:  "Queries/Histograms/Release/Count",
 		diff: 1,

--- a/go/vt/vttablet/tabletserver/dt_executor.go
+++ b/go/vt/vttablet/tabletserver/dt_executor.go
@@ -313,7 +313,7 @@ func (dte *DTExecutor) ReadTwopcInflight() (distributed []*tx.DistributedTx, pre
 }
 
 func (dte *DTExecutor) inTransaction(f func(*StatefulConnection) error) error {
-	conn, _, _, err := dte.te.txPool.Begin(dte.ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := dte.te.txPool.Begin(dte.ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -205,10 +205,7 @@ func (plan *Plan) TableNames() (names []string) {
 func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[string]*schema.Table, dbName string, viewsEnabled bool) (plan *Plan, err error) {
 	switch stmt := statement.(type) {
 	case *sqlparser.Union:
-		plan, err = &Plan{
-			PlanID:    PlanSelect,
-			FullQuery: GenerateLimitQuery(stmt),
-		}, nil
+		plan = &Plan{PlanID: PlanSelect, FullQuery: GenerateLimitQuery(stmt)}
 	case *sqlparser.Select:
 		plan, err = analyzeSelect(env, stmt, tables)
 	case *sqlparser.Insert:
@@ -218,39 +215,39 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 	case *sqlparser.Delete:
 		plan, err = analyzeDelete(stmt, tables)
 	case *sqlparser.Set:
-		plan, err = analyzeSet(stmt), nil
+		plan = analyzeSet(stmt)
 	case sqlparser.DDLStatement:
 		plan, err = analyzeDDL(stmt)
 	case *sqlparser.AlterMigration:
-		plan, err = &Plan{PlanID: PlanAlterMigration, FullStmt: stmt}, nil
+		plan = &Plan{PlanID: PlanAlterMigration, FullStmt: stmt}
 	case *sqlparser.RevertMigration:
-		plan, err = &Plan{PlanID: PlanRevertMigration, FullStmt: stmt}, nil
+		plan = &Plan{PlanID: PlanRevertMigration, FullStmt: stmt}
 	case *sqlparser.ShowMigrationLogs:
-		plan, err = &Plan{PlanID: PlanShowMigrationLogs, FullStmt: stmt}, nil
+		plan = &Plan{PlanID: PlanShowMigrationLogs, FullStmt: stmt}
 	case *sqlparser.ShowThrottledApps:
-		plan, err = &Plan{PlanID: PlanShowThrottledApps, FullStmt: stmt}, nil
+		plan = &Plan{PlanID: PlanShowThrottledApps, FullStmt: stmt}
 	case *sqlparser.ShowThrottlerStatus:
-		plan, err = &Plan{PlanID: PlanShowThrottlerStatus, FullStmt: stmt}, nil
+		plan = &Plan{PlanID: PlanShowThrottlerStatus, FullStmt: stmt}
 	case *sqlparser.Show:
 		plan, err = analyzeShow(stmt, dbName)
 	case *sqlparser.Analyze, sqlparser.Explain:
-		plan, err = &Plan{PlanID: PlanOtherRead}, nil
+		plan = &Plan{PlanID: PlanOtherRead}
 	case *sqlparser.OtherAdmin:
-		plan, err = &Plan{PlanID: PlanOtherAdmin}, nil
+		plan = &Plan{PlanID: PlanOtherAdmin}
 	case *sqlparser.Savepoint:
-		plan, err = &Plan{PlanID: PlanSavepoint}, nil
+		plan = &Plan{PlanID: PlanSavepoint, FullStmt: stmt}
 	case *sqlparser.Release:
-		plan, err = &Plan{PlanID: PlanRelease}, nil
+		plan = &Plan{PlanID: PlanRelease}
 	case *sqlparser.SRollback:
-		plan, err = &Plan{PlanID: PlanSRollback}, nil
+		plan = &Plan{PlanID: PlanSRollback, FullStmt: stmt}
 	case *sqlparser.Load:
-		plan, err = &Plan{PlanID: PlanLoad}, nil
+		plan = &Plan{PlanID: PlanLoad}
 	case *sqlparser.Flush:
 		plan, err = analyzeFlush(stmt, tables)
 	case *sqlparser.UnlockTables:
-		plan, err = &Plan{PlanID: PlanUnlockTables}, nil
+		plan = &Plan{PlanID: PlanUnlockTables}
 	case *sqlparser.CallProc:
-		plan, err = &Plan{PlanID: PlanCallProc, FullQuery: GenerateFullQuery(stmt)}, nil
+		plan = &Plan{PlanID: PlanCallProc, FullQuery: GenerateFullQuery(stmt)}
 	default:
 		return nil, vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "invalid SQL")
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -288,7 +288,7 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 	case p.PlanOtherRead, p.PlanOtherAdmin, p.PlanFlush, p.PlanUnlockTables:
 		return qre.execStatefulConn(conn, qre.query, true)
 	case p.PlanSavepoint, p.PlanRelease, p.PlanSRollback:
-		return qre.execStatefulConn(conn, qre.query, true)
+		return qre.execTxQuery(conn, qre.query, true)
 	case p.PlanSelect, p.PlanSelectImpossible, p.PlanShow, p.PlanSelectLockFunc:
 		maxrows := qre.getSelectLimit()
 		qre.bindVars["#maxLimit"] = sqltypes.Int64BindVariable(maxrows + 1)
@@ -790,6 +790,11 @@ func (qre *QueryExecutor) txFetch(conn *StatefulConnection, record bool) (*sqlty
 	if err != nil {
 		return nil, err
 	}
+	return qre.execTxQuery(conn, sql, record)
+}
+
+// execTxQuery executes the query provided and record in Tx Property if record is true.
+func (qre *QueryExecutor) execTxQuery(conn *StatefulConnection, sql string, record bool) (*sqltypes.Result, error) {
 	qr, err := qre.execStatefulConn(conn, sql, true)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -287,8 +287,12 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 		return qre.execDMLLimit(conn)
 	case p.PlanOtherRead, p.PlanOtherAdmin, p.PlanFlush, p.PlanUnlockTables:
 		return qre.execStatefulConn(conn, qre.query, true)
-	case p.PlanSavepoint, p.PlanRelease, p.PlanSRollback:
-		return qre.execTxQuery(conn, qre.query, true)
+	case p.PlanSavepoint:
+		return qre.execSavepointQuery(conn, qre.query, qre.plan.FullStmt)
+	case p.PlanSRollback:
+		return qre.execRollbackToSavepoint(conn, qre.query, qre.plan.FullStmt)
+	case p.PlanRelease:
+		return qre.execTxQuery(conn, qre.query, false)
 	case p.PlanSelect, p.PlanSelectImpossible, p.PlanShow, p.PlanSelectLockFunc:
 		maxrows := qre.getSelectLimit()
 		qre.bindVars["#maxLimit"] = sqltypes.Int64BindVariable(maxrows + 1)
@@ -803,6 +807,40 @@ func (qre *QueryExecutor) execTxQuery(conn *StatefulConnection, sql string, reco
 	if record {
 		conn.TxProperties().RecordQueryDetail(sql, qre.plan.TableNames())
 	}
+	return qr, nil
+}
+
+// execTxQuery executes the query provided and record in Tx Property if record is true.
+func (qre *QueryExecutor) execSavepointQuery(conn *StatefulConnection, sql string, ast sqlparser.Statement) (*sqltypes.Result, error) {
+	qr, err := qre.execStatefulConn(conn, sql, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only record successful queries.
+	sp, ok := ast.(*sqlparser.Savepoint)
+	if !ok {
+		return nil, vterrors.VT13001("expected to get a savepoint statement")
+	}
+	conn.TxProperties().RecordSavePointDetail(sp.Name.String())
+
+	return qr, nil
+}
+
+// execTxQuery executes the query provided and record in Tx Property if record is true.
+func (qre *QueryExecutor) execRollbackToSavepoint(conn *StatefulConnection, sql string, ast sqlparser.Statement) (*sqltypes.Result, error) {
+	qr, err := qre.execStatefulConn(conn, sql, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only record successful queries.
+	sp, ok := ast.(*sqlparser.SRollback)
+	if !ok {
+		return nil, vterrors.VT13001("expected to get a rollback statement")
+	}
+
+	_ = conn.TxProperties().RollbackToSavepoint(sp.Name.String())
 	return qr, nil
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -235,7 +235,7 @@ func (qre *QueryExecutor) execAutocommit(f func(conn *StatefulConnection) (*sqlt
 		return nil, errTxThrottled
 	}
 
-	conn, _, _, err := qre.tsv.te.txPool.Begin(qre.ctx, qre.options, false, 0, nil, qre.setting)
+	conn, _, _, err := qre.tsv.te.txPool.Begin(qre.ctx, qre.options, false, 0, qre.setting)
 
 	if err != nil {
 		return nil, err
@@ -249,7 +249,7 @@ func (qre *QueryExecutor) execAsTransaction(f func(conn *StatefulConnection) (*s
 	if qre.tsv.txThrottler.Throttle(qre.tsv.getPriorityFromOptions(qre.options), qre.options.GetWorkloadName()) {
 		return nil, errTxThrottled
 	}
-	conn, beginSQL, _, err := qre.tsv.te.txPool.Begin(qre.ctx, qre.options, false, 0, nil, qre.setting)
+	conn, beginSQL, _, err := qre.tsv.te.txPool.Begin(qre.ctx, qre.options, false, 0, qre.setting)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -513,7 +513,7 @@ func (tsv *TabletServer) Begin(ctx context.Context, target *querypb.Target, opti
 func (tsv *TabletServer) begin(
 	ctx context.Context,
 	target *querypb.Target,
-	savepointQueries []string,
+	postBeginQueries []string,
 	reservedID int64,
 	settings []string,
 	options *querypb.ExecuteOptions,
@@ -535,11 +535,42 @@ func (tsv *TabletServer) begin(
 					return err
 				}
 			}
-			transactionID, beginSQL, sessionStateChanges, err := tsv.te.Begin(ctx, nil, reservedID, connSetting, options)
+			transactionID, beginSQL, sessionStateChanges, err := tsv.te.Begin(ctx, reservedID, connSetting, options)
 			state.TransactionID = transactionID
 			state.SessionStateChanges = sessionStateChanges
 			logStats.TransactionID = transactionID
 			logStats.ReservedID = reservedID
+
+			if err != nil {
+				return err
+			}
+
+			targetType, err := tsv.resolveTargetType(ctx, target)
+			if err != nil {
+				return err
+			}
+			for _, query := range postBeginQueries {
+				plan, err := tsv.qe.GetPlan(ctx, logStats, query, true)
+				if err != nil {
+					return err
+				}
+
+				qre := &QueryExecutor{
+					ctx:              ctx,
+					query:            query,
+					connID:           transactionID,
+					options:          options,
+					plan:             plan,
+					logStats:         logStats,
+					tsv:              tsv,
+					targetTabletType: targetType,
+					setting:          connSetting,
+				}
+				_, err = qre.Execute()
+				if err != nil {
+					return err
+				}
+			}
 
 			// Record the actual statements that were executed in the logStats.
 			// If nothing was actually executed, don't count the operation in
@@ -559,18 +590,6 @@ func (tsv *TabletServer) begin(
 			return err
 		},
 	)
-
-	if err != nil {
-		return
-	}
-
-	for _, savepointQuery := range savepointQueries {
-		_, err = tsv.execute(ctx, target, savepointQuery, nil, state.TransactionID, reservedID, settings, options)
-		if err != nil {
-			return
-		}
-	}
-
 	return
 }
 
@@ -997,7 +1016,7 @@ func (tsv *TabletServer) streamExecute(ctx context.Context, target *querypb.Targ
 }
 
 // BeginExecute combines Begin and Execute.
-func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, *sqltypes.Result, error) {
+func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Target, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, *sqltypes.Result, error) {
 
 	// Disable hot row protection in case of reserve connection.
 	if tsv.enableHotRowProtection && reservedID == 0 {
@@ -1010,7 +1029,7 @@ func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Targe
 		}
 	}
 
-	state, err := tsv.begin(ctx, target, preQueries, reservedID, nil, options)
+	state, err := tsv.begin(ctx, target, postBeginQueries, reservedID, nil, options)
 	if err != nil {
 		return state, nil, err
 	}
@@ -1023,14 +1042,14 @@ func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Targe
 func (tsv *TabletServer) BeginStreamExecute(
 	ctx context.Context,
 	target *querypb.Target,
-	preQueries []string,
+	postBeginQueries []string,
 	sql string,
 	bindVariables map[string]*querypb.BindVariable,
 	reservedID int64,
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
 ) (queryservice.TransactionState, error) {
-	state, err := tsv.begin(ctx, target, preQueries, reservedID, nil, options)
+	state, err := tsv.begin(ctx, target, postBeginQueries, reservedID, nil, options)
 	if err != nil {
 		return state, err
 	}
@@ -1256,8 +1275,8 @@ func (tsv *TabletServer) VStreamResults(ctx context.Context, target *querypb.Tar
 }
 
 // ReserveBeginExecute implements the QueryService interface
-func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (state queryservice.ReservedTransactionState, result *sqltypes.Result, err error) {
-	state, result, err = tsv.beginExecuteWithSettings(ctx, target, preQueries, postBeginQueries, sql, bindVariables, options)
+func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *querypb.Target, settings []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (state queryservice.ReservedTransactionState, result *sqltypes.Result, err error) {
+	state, result, err = tsv.beginExecuteWithSettings(ctx, target, settings, postBeginQueries, sql, bindVariables, options)
 	// If there is an error and the error message is about allowing query in reserved connection only,
 	// then we do not return an error from here and continue to use the reserved connection path.
 	// This is specially for get_lock function call from vtgate that needs a reserved connection.
@@ -1285,12 +1304,35 @@ func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *queryp
 				return err
 			}
 			defer tsv.stats.QueryTimingsByTabletType.Record(targetType.String(), time.Now())
-			connID, sessionStateChanges, err = tsv.te.ReserveBegin(ctx, options, preQueries, postBeginQueries)
+			connID, sessionStateChanges, err = tsv.te.ReserveBegin(ctx, options, settings)
+			logStats.TransactionID = connID
+			logStats.ReservedID = connID
 			if err != nil {
 				return err
 			}
-			logStats.TransactionID = connID
-			logStats.ReservedID = connID
+
+			for _, query := range postBeginQueries {
+				plan, err := tsv.qe.GetPlan(ctx, logStats, query, true)
+				if err != nil {
+					return err
+				}
+
+				qre := &QueryExecutor{
+					ctx:              ctx,
+					query:            query,
+					connID:           connID,
+					options:          options,
+					plan:             plan,
+					logStats:         logStats,
+					tsv:              tsv,
+					targetTabletType: targetType,
+				}
+				_, err = qre.Execute()
+				if err != nil {
+					return err
+				}
+			}
+
 			return nil
 		},
 	)
@@ -1311,13 +1353,13 @@ func (tsv *TabletServer) ReserveBeginStreamExecute(
 	ctx context.Context,
 	target *querypb.Target,
 	settings []string,
-	savepointQueries []string,
+	postBeginQueries []string,
 	sql string,
 	bindVariables map[string]*querypb.BindVariable,
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
 ) (state queryservice.ReservedTransactionState, err error) {
-	txState, err := tsv.begin(ctx, target, savepointQueries, 0, settings, options)
+	txState, err := tsv.begin(ctx, target, postBeginQueries, 0, settings, options)
 	if err != nil {
 		return txToReserveState(txState), err
 	}
@@ -1327,9 +1369,9 @@ func (tsv *TabletServer) ReserveBeginStreamExecute(
 }
 
 // ReserveExecute implements the QueryService interface
-func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (state queryservice.ReservedState, result *sqltypes.Result, err error) {
+func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Target, settings []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (state queryservice.ReservedState, result *sqltypes.Result, err error) {
 
-	result, err = tsv.executeWithSettings(ctx, target, preQueries, sql, bindVariables, transactionID, options)
+	result, err = tsv.executeWithSettings(ctx, target, settings, sql, bindVariables, transactionID, options)
 	// If there is an error and the error message is about allowing query in reserved connection only,
 	// then we do not return an error from here and continue to use the reserved connection path.
 	// This is specially for get_lock function call from vtgate that needs a reserved connection.
@@ -1354,7 +1396,7 @@ func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Tar
 				return err
 			}
 			defer tsv.stats.QueryTimingsByTabletType.Record(targetType.String(), time.Now())
-			state.ReservedID, err = tsv.te.Reserve(ctx, options, transactionID, preQueries)
+			state.ReservedID, err = tsv.te.Reserve(ctx, options, transactionID, settings)
 			if err != nil {
 				return err
 			}
@@ -1376,14 +1418,14 @@ func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Tar
 func (tsv *TabletServer) ReserveStreamExecute(
 	ctx context.Context,
 	target *querypb.Target,
-	preQueries []string,
+	settings []string,
 	sql string,
 	bindVariables map[string]*querypb.BindVariable,
 	transactionID int64,
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
 ) (state queryservice.ReservedState, err error) {
-	return state, tsv.streamExecute(ctx, target, sql, bindVariables, transactionID, 0, preQueries, options, callback)
+	return state, tsv.streamExecute(ctx, target, sql, bindVariables, transactionID, 0, settings, options, callback)
 }
 
 // Release implements the QueryService interface
@@ -1423,8 +1465,8 @@ func (tsv *TabletServer) executeWithSettings(ctx context.Context, target *queryp
 	return tsv.execute(ctx, target, sql, bindVariables, transactionID, 0, settings, options)
 }
 
-func (tsv *TabletServer) beginExecuteWithSettings(ctx context.Context, target *querypb.Target, settings []string, savepointQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (queryservice.ReservedTransactionState, *sqltypes.Result, error) {
-	txState, err := tsv.begin(ctx, target, savepointQueries, 0, settings, options)
+func (tsv *TabletServer) beginExecuteWithSettings(ctx context.Context, target *querypb.Target, settings []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (queryservice.ReservedTransactionState, *sqltypes.Result, error) {
+	txState, err := tsv.begin(ctx, target, postBeginQueries, 0, settings, options)
 	if err != nil {
 		return txToReserveState(txState), nil, err
 	}

--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -22,12 +22,11 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/slice"
-	"vitess.io/vitess/go/vt/vterrors"
-
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 type (
@@ -59,6 +58,11 @@ type (
 
 		Stats *servenv.TimingsWrapper
 	}
+
+	// Query contains the query and involved tables executed inside transaction.
+	// A savepoint is represented by having only the Savepoint field set.
+	// This is used to rollback to a specific savepoint.
+	// The query log on commit, does not need to store the savepoint.
 	Query struct {
 		Savepoint string
 		Sql       string
@@ -206,6 +210,9 @@ func (p *Properties) String(sanitize bool, parser *sqlparser.Parser) string {
 }
 
 func (p *Properties) GetQueries() []Query {
+	if p == nil {
+		return nil
+	}
 	return slice.Filter(p.Queries, func(q Query) bool {
 		return q.Sql != ""
 	})

--- a/go/vt/vttablet/tabletserver/tx/api_test.go
+++ b/go/vt/vttablet/tabletserver/tx/api_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/utils"
+)
+
+/*
+	TestRollbackToSavePointQueryDetails tests the rollback to savepoint query details
+
+s1
+q1
+s2
+r1
+q2
+q3
+s3
+s4
+q4
+q5
+r2 -- error
+r4
+*/
+func TestRollbackToSavePointQueryDetails(t *testing.T) {
+	p := &Properties{}
+	p.RecordSavePointDetail("s1")
+	p.RecordQueryDetail("select 1", nil)
+	p.RecordSavePointDetail("s2")
+	require.NoError(t, p.RollbackToSavepoint("s1"))
+	p.RecordQueryDetail("select 2", nil)
+	p.RecordQueryDetail("select 3", nil)
+	p.RecordSavePointDetail("s3")
+	p.RecordSavePointDetail("s4")
+	p.RecordQueryDetail("select 4", nil)
+	p.RecordQueryDetail("select 5", nil)
+	require.ErrorContains(t, p.RollbackToSavepoint("s2"), "savepoint s2 not found")
+	require.NoError(t, p.RollbackToSavepoint("s4"))
+
+	utils.MustMatch(t, p.GetQueries(), []Query{
+		{Sql: "select 2"},
+		{Sql: "select 3"},
+	})
+}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -280,6 +280,14 @@ func (tp *TxPool) begin(ctx context.Context, options *querypb.ExecuteOptions, re
 	}
 
 	conn.txProps = tp.NewTxProps(immediateCaller, effectiveCaller, autocommit)
+	for _, savepoint := range savepointQueries {
+		if _, err = conn.Exec(ctx, savepoint, 1, false); err != nil {
+			return "", "", err
+		}
+		// Record the query detail for the savepoint.
+		conn.txProps.RecordQueryDetail(savepoint, nil)
+		beginQueries += ";" + savepoint
+	}
 
 	return beginQueries, sessionStateChanges, nil
 }
@@ -343,12 +351,6 @@ func createTransaction(
 		beginQueries += execSQL
 	default:
 		return "", false, "", vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] don't know how to open a transaction of this type: %v", options.GetTransactionIsolation())
-	}
-
-	for _, savepoint := range savepointQueries {
-		if _, err = conn.Exec(ctx, savepoint, 1, false); err != nil {
-			return "", false, "", err
-		}
 	}
 	return
 }

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -280,14 +280,14 @@ func (tp *TxPool) begin(ctx context.Context, options *querypb.ExecuteOptions, re
 	}
 
 	conn.txProps = tp.NewTxProps(immediateCaller, effectiveCaller, autocommit)
-	for _, savepoint := range savepointQueries {
-		if _, err = conn.Exec(ctx, savepoint, 1, false); err != nil {
-			return "", "", err
-		}
-		// Record the query detail for the savepoint.
-		conn.txProps.RecordQueryDetail(savepoint, nil)
-		beginQueries += ";" + savepoint
-	}
+	// for _, savepoint := range savepointQueries {
+	// 	if _, err = conn.Exec(ctx, savepoint, 1, false); err != nil {
+	// 		return "", "", err
+	// 	}
+	// 	// Record the query detail for the savepoint.
+	// 	conn.txProps.RecordQueryDetail(savepoint, nil)
+	// 	beginQueries += ";" + savepoint
+	// }
 
 	return beginQueries, sessionStateChanges, nil
 }

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -48,7 +48,7 @@ func TestTxPoolExecuteCommit(t *testing.T) {
 
 	sql := "select 'this is a query'"
 	// begin a transaction and then return the connection
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 
 	id := conn.ReservedID()
@@ -83,7 +83,7 @@ func TestTxPoolExecuteRollback(t *testing.T) {
 	db, txPool, _, closer := setup(t)
 	defer closer()
 
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	defer conn.Release(tx.TxRollback)
 
@@ -104,7 +104,7 @@ func TestTxPoolExecuteRollbackOnClosedConn(t *testing.T) {
 	db, txPool, _, closer := setup(t)
 	defer closer()
 
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	defer conn.Release(tx.TxRollback)
 
@@ -125,9 +125,9 @@ func TestTxPoolRollbackNonBusy(t *testing.T) {
 	defer closer()
 
 	// start two transactions, and mark one of them as unused
-	conn1, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn1, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
-	conn2, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn2, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn2.Unlock() // this marks conn2 as NonBusy
 
@@ -154,7 +154,7 @@ func TestTxPoolTransactionIsolation(t *testing.T) {
 	db, txPool, _, closer := setup(t)
 	defer closer()
 
-	c2, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED}, false, 0, nil, nil)
+	c2, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED}, false, 0, nil)
 	require.NoError(t, err)
 	c2.Release(tx.TxClose)
 
@@ -172,7 +172,7 @@ func TestTxPoolAutocommit(t *testing.T) {
 	// to mysql.
 	// This test is meaningful because if txPool.Begin were to send a BEGIN statement to the connection, it will fatal
 	// because is not in the list of expected queries (i.e db.AddQuery hasn't been called).
-	conn1, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_AUTOCOMMIT}, false, 0, nil, nil)
+	conn1, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_AUTOCOMMIT}, false, 0, nil)
 	require.NoError(t, err)
 
 	// run a query to see it in the query log
@@ -204,7 +204,7 @@ func TestTxPoolBeginWithPoolConnectionError_Errno2006_Transient(t *testing.T) {
 	err := db.WaitForClose(2 * time.Second)
 	require.NoError(t, err)
 
-	txConn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	txConn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err, "Begin should have succeeded after the retry in DBConn.Exec()")
 	txConn.Release(tx.TxCommit)
 }
@@ -225,7 +225,7 @@ func primeTxPoolWithConnection(t *testing.T, ctx context.Context) (*fakesqldb.DB
 	// reused by subsequent transactions.
 	db.AddQuery("begin", &sqltypes.Result{})
 	db.AddQuery("rollback", &sqltypes.Result{})
-	txConn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	txConn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	txConn.Release(tx.TxCommit)
 
@@ -248,7 +248,7 @@ func TestTxPoolBeginWithError(t *testing.T) {
 	}
 
 	ctxWithCallerID := callerid.NewContext(ctx, ef, im)
-	_, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	_, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error: rejected")
 	require.Equal(t, vtrpcpb.Code_UNKNOWN, vterrors.Code(err), "wrong error code for Begin error")
@@ -270,19 +270,6 @@ func TestTxPoolBeginWithError(t *testing.T) {
 		}, limiter.Actions())
 }
 
-func TestTxPoolBeginWithPreQueryError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	db, txPool, _, closer := setup(t)
-	defer closer()
-	db.AddRejectedQuery("pre_query", errRejected)
-	_, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, []string{"pre_query"}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "error: rejected")
-	require.Equal(t, vtrpcpb.Code_UNKNOWN, vterrors.Code(err), "wrong error code for Begin error")
-}
-
 func TestTxPoolCancelledContextError(t *testing.T) {
 	// given
 	db, txPool, _, closer := setup(t)
@@ -291,7 +278,7 @@ func TestTxPoolCancelledContextError(t *testing.T) {
 	cancel()
 
 	// when
-	_, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	_, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 
 	// then
 	require.Error(t, err)
@@ -312,12 +299,12 @@ func TestTxPoolWaitTimeoutError(t *testing.T) {
 	defer closer()
 
 	// lock the only connection in the pool.
-	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	defer conn.Unlock()
 
 	// try locking one more connection.
-	_, _, _, err = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	_, _, _, err = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 
 	// then
 	require.Error(t, err)
@@ -337,7 +324,7 @@ func TestTxPoolRollbackFailIsPassedThrough(t *testing.T) {
 	defer closer()
 	db.AddRejectedQuery("rollback", errRejected)
 
-	conn1, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn1, _, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 
 	_, err = conn1.Exec(ctx, sql, 1, true)
@@ -357,7 +344,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 
 	db, txPool, _, _ := setup(t)
 	defer db.Close()
-	conn1, _, _, _ := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn1, _, _, _ := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	id := conn1.ReservedID()
 	conn1.Unlock()
 	txPool.Close()
@@ -380,7 +367,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 	params := dbconfigs.New(db.ConnParams())
 	txPool.Open(params, params, params)
 
-	conn1, _, _, _ = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn1, _, _, _ = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	id = conn1.ReservedID()
 	_, err := txPool.Commit(ctx, conn1)
 	require.NoError(t, err)
@@ -396,7 +383,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 	txPool.Open(params, params, params)
 	defer txPool.Close()
 
-	conn1, _, _, err = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn1, _, _, err = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err, "unable to start transaction: %v", err)
 	conn1.Unlock()
 	id = conn1.ReservedID()
@@ -412,7 +399,7 @@ func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
 	startingStray := txPool.env.Stats().InternalErrors.Counts()["StrayTransactions"]
 
 	// Start stray transaction.
-	conn, _, _, err := txPool.Begin(context.Background(), &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := txPool.Begin(context.Background(), &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 
@@ -443,7 +430,7 @@ func TestTxTimeoutKillsTransactions(t *testing.T) {
 	ctxWithCallerID := callerid.NewContext(ctx, ef, im)
 
 	// Start transaction.
-	conn, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 
@@ -491,7 +478,7 @@ func TestTxTimeoutDoesNotKillShortLivedTransactions(t *testing.T) {
 	ctxWithCallerID := callerid.NewContext(ctx, ef, im)
 
 	// Start transaction.
-	conn, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 
@@ -526,7 +513,7 @@ func TestTxTimeoutKillsOlapTransactions(t *testing.T) {
 	// Start transaction.
 	conn, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{
 		Workload: querypb.ExecuteOptions_OLAP,
-	}, false, 0, nil, nil)
+	}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 
@@ -561,11 +548,11 @@ func TestTxTimeoutNotEnforcedForZeroLengthTimeouts(t *testing.T) {
 	ctxWithCallerID := callerid.NewContext(ctx, ef, im)
 
 	// Start transactions.
-	conn0, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil, nil)
+	conn0, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn1, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{
 		Workload: querypb.ExecuteOptions_OLAP,
-	}, false, 0, nil, nil)
+	}, false, 0, nil)
 	require.NoError(t, err)
 	conn0.Unlock()
 	conn1.Unlock()
@@ -606,7 +593,7 @@ func TestTxTimeoutReservedConn(t *testing.T) {
 	// Start OLAP transaction and return it to pool right away.
 	conn0, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{
 		Workload: querypb.ExecuteOptions_OLAP,
-	}, false, 0, nil, nil)
+	}, false, 0, nil)
 	require.NoError(t, err)
 	// Taint the connection.
 	conn0.Taint(ctxWithCallerID, nil)
@@ -648,14 +635,14 @@ func TestTxTimeoutReusedReservedConn(t *testing.T) {
 	// Start OLAP transaction and return it to pool right away.
 	conn0, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{
 		Workload: querypb.ExecuteOptions_OLAP,
-	}, false, 0, nil, nil)
+	}, false, 0, nil)
 	require.NoError(t, err)
 	// Taint the connection.
 	conn0.Taint(ctxWithCallerID, nil)
 	conn0.Unlock()
 
 	// Reuse underlying connection in an OLTP transaction.
-	conn1, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, conn0.ReservedID(), nil, nil)
+	conn1, _, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, conn0.ReservedID(), nil)
 	require.NoError(t, err)
 	require.Equal(t, conn1.ReservedID(), conn0.ReservedID())
 	conn1.Unlock()
@@ -786,7 +773,7 @@ func TestTxPoolBeginStatements(t *testing.T) {
 				TransactionIsolation:  tc.txIsolationLevel,
 				TransactionAccessMode: tc.txAccessModes,
 			}
-			conn, beginSQL, _, err := txPool.Begin(ctx, options, tc.readOnly, 0, nil, nil)
+			conn, beginSQL, _, err := txPool.Begin(ctx, options, tc.readOnly, 0, nil)
 			if tc.expErr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expErr)


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds support for savepoints usage in atomic distributed transaction commit by storing the savepoints in the transaction query log and then reapplying them on a recovery.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #16245 

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
