### PR TITLE
VTAdmin(web): Add refresh compatibility to workflow screen (all tabs)

### DIFF
--- a/web/vtadmin/src/components/inputs/Select.tsx
+++ b/web/vtadmin/src/components/inputs/Select.tsx
@@ -37,6 +37,7 @@ interface Props<T> {
     size?: 'large';
     description?: string;
     required?: boolean;
+    disableClearSelection?: boolean;
 }
 
 /**
@@ -60,6 +61,7 @@ export const Select = <T,>({
     size,
     description,
     required,
+    disableClearSelection,
 }: Props<T>) => {
     const _itemToString = React.useCallback(
         (item: T | null): string => {
@@ -146,7 +148,7 @@ export const Select = <T,>({
             </button>
             <div className={style.dropdown} hidden={!isOpen}>
                 {content}
-                {selectedItem && (
+                {selectedItem && !disableClearSelection && (
                     <button className={style.clear} onClick={() => selectItem(null as any)} type="button">
                         Clear selection
                     </button>

--- a/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
@@ -43,6 +43,7 @@ interface Props {
     clusterID: string;
     keyspace: string;
     name: string;
+    refetchInterval: number;
 }
 
 const SUMMARY_COLUMNS = ['Stream Status', 'Traffic Status', 'Max VReplication Lag', 'Reverse Workflow'];
@@ -53,16 +54,21 @@ const TABLE_COPY_STATE_COLUMNS = ['Table Name', 'Total Bytes', 'Bytes Copied', '
 
 const STREAM_COLUMNS = ['Stream', 'Source Shard', 'Target Shard', 'Message', 'Transaction Timestamp', 'Database Name'];
 
-export const WorkflowDetails = ({ clusterID, keyspace, name }: Props) => {
+export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: Props) => {
     const { data: workflowData } = useWorkflow({ clusterID, keyspace, name });
 
-    const { data: workflowsData = [] } = useWorkflows();
+    const { data: workflowsData = [] } = useWorkflows({ refetchInterval });
 
-    const { data: workflowStatus } = useWorkflowStatus({
-        clusterID,
-        keyspace,
-        name,
-    });
+    const { data: workflowStatus } = useWorkflowStatus(
+        {
+            clusterID,
+            keyspace,
+            name,
+        },
+        {
+            refetchInterval,
+        }
+    );
 
     const reverseWorkflow = getReverseWorkflow(workflowsData, workflowData);
 

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -472,7 +472,7 @@ export const useWorkflowStatus = (
     params: Parameters<typeof fetchWorkflowStatus>[0],
     options?: UseQueryOptions<vtctldata.WorkflowStatusResponse, Error> | undefined
 ) => {
-    return useQuery(['workflow_status', params], () => fetchWorkflowStatus(params));
+    return useQuery(['workflow_status', params], () => fetchWorkflowStatus(params), options);
 };
 
 /**


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds refresh compatibility providing the user functionality to enable auto refresh workflow status after some selectable intervals (10s, 30s, 1m, 10m or Never.) Also, removes the redundant "Scroll to streams" link from all workflow pages. This PR is a follow-up to #16706.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- Fixes #16687 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Screenshots
<img width="1440" alt="Screenshot 2024-10-01 at 2 42 19 AM" src="https://github.com/user-attachments/assets/6e7e2f79-59b3-4221-b0e3-9fd4c3c8c813">


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
