### PR TITLE
Query serving: incorporate mirror query results in log stats, fix mirror query max lag bug

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -445,9 +445,10 @@ type loggingVCursor struct {
 
 	parser *sqlparser.Parser
 
-	handleMirrorClonesFn   func(context.Context) VCursor
+	onMirrorClonesFn       func(context.Context) VCursor
 	onExecuteMultiShardFn  func(context.Context, Primitive, []*srvtopo.ResolvedShard, []*querypb.BoundQuery, bool, bool)
 	onStreamExecuteMultiFn func(context.Context, Primitive, string, []*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, bool, bool, func(*sqltypes.Result) error)
+	onRecordMirrorStatsFn  func(time.Duration, time.Duration, error)
 }
 
 func (f *loggingVCursor) HasCreatedTempTable() {
@@ -564,8 +565,8 @@ func (f *loggingVCursor) CloneForReplicaWarming(ctx context.Context) VCursor {
 }
 
 func (f *loggingVCursor) CloneForMirroring(ctx context.Context) VCursor {
-	if f.handleMirrorClonesFn != nil {
-		return f.handleMirrorClonesFn(ctx)
+	if f.onMirrorClonesFn != nil {
+		return f.onMirrorClonesFn(ctx)
 	}
 	panic("no mirror clones available")
 }
@@ -886,6 +887,12 @@ func (t *loggingVCursor) SQLParser() *sqlparser.Parser {
 	return t.parser
 }
 
+func (t *loggingVCursor) RecordMirrorStats(sourceExecTime, targetExecTime time.Duration, targetErr error) {
+	if t.onRecordMirrorStatsFn != nil {
+		t.onRecordMirrorStatsFn(sourceExecTime, targetExecTime, targetErr)
+	}
+}
+
 func (t *noopVCursor) VExplainLogging() {}
 func (t *noopVCursor) DisableLogging()  {}
 func (t *noopVCursor) GetVExplainLogs() []ExecuteEntry {
@@ -894,6 +901,10 @@ func (t *noopVCursor) GetVExplainLogs() []ExecuteEntry {
 
 func (t *noopVCursor) GetLogs() ([]ExecuteEntry, error) {
 	return nil, nil
+}
+
+// RecordMirrorStats implements VCursor.
+func (t *noopVCursor) RecordMirrorStats(sourceExecTime, targetExecTime time.Duration, targetErr error) {
 }
 
 func expectResult(t *testing.T, result, want *sqltypes.Result) {

--- a/go/vt/vtgate/engine/mirror_test.go
+++ b/go/vt/vtgate/engine/mirror_test.go
@@ -306,6 +306,7 @@ func TestMirror(t *testing.T) {
 		wg.Wait()
 
 		require.Greater(t, *targetExecTime.Load(), *sourceExecTime.Load())
+		require.ErrorContains(t, *targetErr.Load(), "Mirror target query took too long")
 	})
 
 	t.Run("TryStreamExecute success", func(t *testing.T) {
@@ -543,5 +544,6 @@ func TestMirror(t *testing.T) {
 		})
 
 		require.Greater(t, *targetExecTime.Load(), *sourceExecTime.Load())
+		require.ErrorContains(t, *targetErr.Load(), "Mirror target query took too long")
 	})
 }

--- a/go/vt/vtgate/engine/mirror_test.go
+++ b/go/vt/vtgate/engine/mirror_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -76,6 +77,10 @@ func TestMirror(t *testing.T) {
 		},
 	}
 
+	sourceExecTime := atomic.Pointer[time.Duration]{}
+	targetExecTime := atomic.Pointer[time.Duration]{}
+	targetErr := atomic.Pointer[error]{}
+
 	vc := &loggingVCursor{
 		shards: []string{"0"},
 		ksShardMap: map[string][]string{
@@ -90,8 +95,13 @@ func TestMirror(t *testing.T) {
 				"hello",
 			),
 		},
-		handleMirrorClonesFn: func(ctx context.Context) VCursor {
+		onMirrorClonesFn: func(ctx context.Context) VCursor {
 			return mirrorVC
+		},
+		onRecordMirrorStatsFn: func(sourceTime time.Duration, targetTime time.Duration, err error) {
+			sourceExecTime.Store(&sourceTime)
+			targetExecTime.Store(&targetTime)
+			targetErr.Store(&err)
 		},
 	}
 
@@ -99,6 +109,9 @@ func TestMirror(t *testing.T) {
 		defer func() {
 			vc.Rewind()
 			mirrorVC.Rewind()
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
 		want := vc.results[0]
@@ -114,6 +127,8 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
 		})
+		require.NotNil(t, targetExecTime.Load())
+		require.Nil(t, *targetErr.Load())
 	})
 
 	t.Run("TryExecute return primitive error", func(t *testing.T) {
@@ -124,6 +139,9 @@ func TestMirror(t *testing.T) {
 			vc.results = results
 			vc.resultErr = nil
 			mirrorVC.Rewind()
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
 		vc.results = nil
@@ -143,6 +161,8 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
 		})
+		require.NotNil(t, targetExecTime.Load())
+		require.Nil(t, *targetErr.Load())
 	})
 
 	t.Run("TryExecute ignore mirror target error", func(t *testing.T) {
@@ -153,6 +173,9 @@ func TestMirror(t *testing.T) {
 			mirrorVC.Rewind()
 			mirrorVC.results = results
 			mirrorVC.resultErr = nil
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
 		mirrorVC.results = nil
@@ -171,17 +194,24 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
 		})
+
+		require.NotNil(t, targetExecTime.Load())
+		mirrorErr := targetErr.Load()
+		require.ErrorContains(t, *mirrorErr, "ignore me")
 	})
 
-	t.Run("TryExecute slow mirror target", func(t *testing.T) {
+	t.Run("TryExecute fast mirror target", func(t *testing.T) {
 		defer func() {
 			vc.Rewind()
 			vc.onExecuteMultiShardFn = nil
 			mirrorVC.Rewind()
 			mirrorVC.onExecuteMultiShardFn = nil
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
-		primitiveLatency := maxMirrorTargetLag * 2
+		primitiveLatency := 10 * time.Millisecond
 		vc.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
 			time.Sleep(primitiveLatency)
 			select {
@@ -193,12 +223,67 @@ func TestMirror(t *testing.T) {
 
 		var wg sync.WaitGroup
 		defer wg.Wait()
-		wg.Add(1)
 		mirrorVC.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
+			wg.Add(1)
 			defer wg.Done()
-			time.Sleep(primitiveLatency + (2 * maxMirrorTargetLag))
+			time.Sleep(primitiveLatency / 2)
 			select {
 			case <-ctx.Done():
+				require.Fail(t, "mirror target context done")
+			default:
+			}
+		}
+
+		want := vc.results[0]
+		res, err := mirror.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
+		require.Equal(t, res, want)
+		require.NoError(t, err)
+
+		vc.ExpectLog(t, []string{
+			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
+			"ExecuteMultiShard ks1.0: select f.bar from foo f where f.id = 1 {} false false",
+		})
+		mirrorVC.ExpectLog(t, []string{
+			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
+			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
+		})
+
+		wg.Wait()
+
+		require.Greater(t, *sourceExecTime.Load(), *targetExecTime.Load())
+	})
+
+	t.Run("TryExecute slow mirror target", func(t *testing.T) {
+		defer func() {
+			vc.Rewind()
+			vc.onExecuteMultiShardFn = nil
+			mirrorVC.Rewind()
+			mirrorVC.onExecuteMultiShardFn = nil
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
+		}()
+
+		primitiveLatency := 10 * time.Millisecond
+		vc.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
+			time.Sleep(primitiveLatency)
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "primitive context done")
+			default:
+			}
+		}
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		mirrorVC.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
+			wg.Add(1)
+			defer wg.Done()
+			time.Sleep(primitiveLatency + maxMirrorTargetLag + (5 * time.Millisecond))
+			select {
+			case <-ctx.Done():
+				require.NotNil(t, ctx.Err())
+				require.ErrorContains(t, ctx.Err(), "context canceled")
 			default:
 				require.Fail(t, "mirror target context not done")
 			}
@@ -217,12 +302,19 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
 		})
+
+		wg.Wait()
+
+		require.Greater(t, *targetExecTime.Load(), *sourceExecTime.Load())
 	})
 
 	t.Run("TryStreamExecute success", func(t *testing.T) {
 		defer func() {
 			vc.Rewind()
 			mirrorVC.Rewind()
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
 		want := vc.results[0]
@@ -246,6 +338,9 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
 		})
+
+		require.NotNil(t, targetExecTime.Load())
+		require.Nil(t, *targetErr.Load())
 	})
 
 	t.Run("TryStreamExecute return primitive error", func(t *testing.T) {
@@ -256,6 +351,9 @@ func TestMirror(t *testing.T) {
 			vc.results = results
 			vc.resultErr = nil
 			mirrorVC.Rewind()
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
 		vc.results = nil
@@ -282,6 +380,9 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
 		})
+
+		require.NotNil(t, targetExecTime.Load())
+		require.Nil(t, *targetErr.Load())
 	})
 
 	t.Run("TryStreamExecute ignore mirror target error", func(t *testing.T) {
@@ -292,6 +393,9 @@ func TestMirror(t *testing.T) {
 			mirrorVC.Rewind()
 			mirrorVC.results = results
 			mirrorVC.resultErr = nil
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
 		mirrorVC.results = nil
@@ -318,17 +422,23 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
 		})
+
+		require.NotNil(t, targetExecTime.Load())
+		require.ErrorContains(t, *targetErr.Load(), "ignore me")
 	})
 
-	t.Run("TryStreamExecute slow mirror target", func(t *testing.T) {
+	t.Run("TryStreamExecute fast mirror target", func(t *testing.T) {
 		defer func() {
 			vc.Rewind()
 			vc.onStreamExecuteMultiFn = nil
 			mirrorVC.Rewind()
 			mirrorVC.onStreamExecuteMultiFn = nil
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
 		}()
 
-		primitiveLatency := maxMirrorTargetLag * 2
+		primitiveLatency := 10 * time.Millisecond
 		vc.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
 			time.Sleep(primitiveLatency)
 			select {
@@ -340,10 +450,69 @@ func TestMirror(t *testing.T) {
 
 		var wg sync.WaitGroup
 		defer wg.Wait()
-		wg.Add(1)
 		mirrorVC.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
+			wg.Add(1)
 			defer wg.Done()
-			time.Sleep(primitiveLatency + (2 * maxMirrorTargetLag))
+			time.Sleep(primitiveLatency / 2)
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "mirror target context done")
+			default:
+			}
+		}
+
+		want := vc.results[0]
+		err := mirror.TryStreamExecute(
+			context.Background(),
+			vc,
+			map[string]*querypb.BindVariable{},
+			true,
+			func(result *sqltypes.Result) error {
+				require.Equal(t, want, result)
+				return nil
+			},
+		)
+		require.NoError(t, err)
+
+		vc.ExpectLog(t, []string{
+			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
+			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks1.0: {} ",
+		})
+		mirrorVC.ExpectLog(t, []string{
+			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
+			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
+		})
+
+		require.Greater(t, *sourceExecTime.Load(), *targetExecTime.Load())
+	})
+
+	t.Run("TryStreamExecute slow mirror target", func(t *testing.T) {
+		defer func() {
+			vc.Rewind()
+			vc.onStreamExecuteMultiFn = nil
+			mirrorVC.Rewind()
+			mirrorVC.onStreamExecuteMultiFn = nil
+			sourceExecTime.Store(nil)
+			targetExecTime.Store(nil)
+			targetErr.Store(nil)
+		}()
+
+		primitiveLatency := 10 * time.Millisecond
+		vc.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
+			time.Sleep(primitiveLatency)
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "primitive context done")
+			default:
+			}
+		}
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		mirrorVC.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
+			wg.Add(1)
+			defer wg.Done()
+			time.Sleep(primitiveLatency + maxMirrorTargetLag + (5 * time.Millisecond))
 			select {
 			case <-ctx.Done():
 			default:
@@ -372,5 +541,7 @@ func TestMirror(t *testing.T) {
 			`ResolveDestinations ks2 [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(d46405367612b4b7)`,
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
 		})
+
+		require.Greater(t, *targetExecTime.Load(), *sourceExecTime.Load())
 	})
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -144,6 +144,9 @@ type (
 		// StartPrimitiveTrace starts a trace for the given primitive,
 		// and returns a function to get the trace logs after the primitive execution.
 		StartPrimitiveTrace() func() Stats
+
+		// RecordMirrorStats is used to record stats about a mirror query.
+		RecordMirrorStats(time.Duration, time.Duration, error)
 	}
 
 	// SessionActions gives primitives ability to interact with the session state

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -79,42 +79,42 @@ func TestLogStatsFormat(t *testing.T) {
 		{ // 0
 			redact:   false,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\t0.000000\t0.000000\t\"\"\n",
 			bindVars: intBindVar,
 		}, { // 1
 			redact:   true,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\t0.000000\t0.000000\t\"\"\n",
 			bindVars: intBindVar,
 		}, { // 2
 			redact:   false,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"intVal\":{\"type\":\"INT64\",\"value\":1}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"intVal\":{\"type\":\"INT64\",\"value\":1}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: intBindVar,
 		}, { // 3
 			redact:   true,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: intBindVar,
 		}, { // 4
 			redact:   false,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"strVal\": {\"type\": \"VARCHAR\", \"value\": \"abc\"}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"strVal\": {\"type\": \"VARCHAR\", \"value\": \"abc\"}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\t0.000000\t0.000000\t\"\"\n",
 			bindVars: stringBindVar,
 		}, { // 5
 			redact:   true,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\t0.000000\t0.000000\t\"\"\n",
 			bindVars: stringBindVar,
 		}, { // 6
 			redact:   false,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"strVal\":{\"type\":\"VARCHAR\",\"value\":\"abc\"}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"strVal\":{\"type\":\"VARCHAR\",\"value\":\"abc\"}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: stringBindVar,
 		}, { // 7
 			redact:   true,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: stringBindVar,
 		},
 	}
@@ -156,12 +156,12 @@ func TestLogStatsFilter(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\t0.000000\t0.000000\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	streamlog.SetQueryLogFilterTag("LOG_THIS_QUERY")
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\t0.000000\t0.000000\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	streamlog.SetQueryLogFilterTag("NOT_THIS_QUERY")
@@ -179,12 +179,12 @@ func TestLogStatsRowThreshold(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\t0.000000\t0.000000\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	streamlog.SetQueryLogRowThreshold(0)
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\t0.000000\t0.000000\t\"\"\n"
 	assert.Equal(t, want, got)
 	streamlog.SetQueryLogRowThreshold(1)
 	got = testFormat(t, logStats, params)
@@ -211,6 +211,18 @@ func TestLogStatsErrorStr(t *testing.T) {
 	errStr := "unknown error"
 	logStats.Error = errors.New(errStr)
 	if !strings.Contains(logStats.ErrorStr(), errStr) {
+		t.Fatalf("expect string '%s' in error message, but got: %s", errStr, logStats.ErrorStr())
+	}
+}
+
+func TestLogStatsMirrorTargetErrorStr(t *testing.T) {
+	logStats := NewLogStats(context.Background(), "test", "sql1", "", map[string]*querypb.BindVariable{})
+	if logStats.MirrorTargetErrorStr() != "" {
+		t.Fatalf("should not get error in stats, but got: %s", logStats.ErrorStr())
+	}
+	errStr := "unknown error"
+	logStats.MirrorTargetError = errors.New(errStr)
+	if !strings.Contains(logStats.MirrorTargetErrorStr(), errStr) {
 		t.Fatalf("expect string '%s' in error message, but got: %s", errStr, logStats.ErrorStr())
 	}
 }

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -1535,3 +1535,10 @@ func (vc *vcursorImpl) UpdateForeignKeyChecksState(fkStateFromQuery *bool) {
 func (vc *vcursorImpl) GetForeignKeyChecksState() *bool {
 	return vc.fkChecksState
 }
+
+// RecordMirrorStats is used to record stats about a mirror query.
+func (vc *vcursorImpl) RecordMirrorStats(sourceExecTime, targetExecTime time.Duration, targetErr error) {
+	vc.logStats.MirrorSourceExecuteTime = sourceExecTime
+	vc.logStats.MirrorTargetExecuteTime = targetExecTime
+	vc.logStats.MirrorTargetError = targetErr
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds a few new fields to log stats to provide visibility into traffic mirroring. The idea behind traffic mirroring is to see if the target of a VReplication workflow will perform as well as the source when queries are sent to it. In order to make that determination, we can send mirrored queries to the target with `MirrorTraffic`. However, we also need a way to compare the query execution times and errors of the source vs. target queries.

While working on this PR, I noticed a bug with how mirror target queries are bounded. The VTGate mirror primitive was written with the intention of having the mirror target be canceled if it continues executing for too long (hardcoded at 100ms) after the source primitive finishes executing. However as it is currently written the mirror target will be canceled if it executes for more than 100ms. This PR fixes that.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fix https://github.com/vitessio/vitess/issues/16877
Close https://github.com/vitessio/vitess/issues/16878
Close https://github.com/vitessio/vitess/issues/13772

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation: https://github.com/vitessio/website/pull/1858

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

None
