### PR TITLE
Add blurb about experimental 8.4 support

### DIFF
--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -20,6 +20,7 @@
     - **[New VEXPLAIN Modes: TRACE and KEYS](#new-vexplain-modes)**
     - **[Errant GTID Detection on VTTablets](#errant-gtid-vttablet)**
     - **[Automatically Replace MySQL auto_increment Clauses with Vitess Sequences](#auto-replace-mysql-autoinc-with-seq)**
+    - **[Experimental MySQL 8.4 support](#experimental-mysql-84)**
 
 ## <a id="major-changes"/>Major Changes</a>
 

--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -218,3 +218,7 @@ work automatically during the [`MoveTables`](https://vitess.io/docs/reference/vr
 [`--remove-sharded-auto-increment` boolean flag](https://vitess.io/docs/20.0/reference/programs/vtctldclient/vtctldclient_movetables/vtctldclient_movetables_create/) and you should begin using the new
 [`--sharded-auto-increment-handling` flag](https://vitess.io/docs/21.0/reference/programs/vtctldclient/vtctldclient_movetables/vtctldclient_movetables_create/) instead. Please see the new
 [`MoveTables` Auto Increment Handling](https://vitess.io/docs/21.0/reference/vreplication/movetables/#auto-increment-handling) documentation for additional details.
+
+### <a id="experimental-mysql-84"/>Experimental MySQL 8.4 support
+
+We have added experimental support for MySQL 8.4. It passes the Vitess test suite, but it is otherwise not yet tested. We are looking for feedback from the community to improve this to move support out of the experimental phase in a future release.


### PR DESCRIPTION
MySQL 8.4 passes the test suites, but it's otherwise not yet tested. This should be good enough then to mark it as experimentally supported to ask community feedback and hopefully more people test it out.

## Related Issue(s)

Part of https://github.com/vitessio/vitess/issues/16466

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required