### PR TITLE
VTTablet: smartconnpool: notify all expired waiters

### DIFF
--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -88,10 +88,13 @@ func (wl *waitlist[C]) expire(force bool) {
 	// or remove everything if force is true
 	for e := wl.list.Front(); e != nil; e = e.Next() {
 		if force || e.Value.ctx.Err() != nil {
-			wl.list.Remove(e)
 			expired = append(expired, e)
 			continue
 		}
+	}
+	// remove the expired waiters from the waitlist after traversing it
+	for _, e := range expired {
+		wl.list.Remove(e)
 	}
 	wl.mu.Unlock()
 

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWaitlistExpireWithMultipleWaiters(t *testing.T) {
@@ -52,11 +53,13 @@ func TestWaitlistExpireWithMultipleWaiters(t *testing.T) {
 
 	// Wait for the notified goroutines to finish
 	timeout := time.After(1 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	for expireCount.Load() != int32(waiterCount) {
 		select {
 		case <-timeout:
-			t.Fatalf("Timed out waiting for all waiters to expire. Wanted %d, got %d", waiterCount, expireCount.Load())
-		case <-time.After(10 * time.Millisecond):
+			require.Failf(t, "Timed out waiting for all waiters to expire", "Wanted %d, got %d", waiterCount, expireCount.Load())
+		case <-ticker.C:
 			// try again
 		}
 	}

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smartconnpool
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitlistExpireWithMultipleWaiters(t *testing.T) {
+	wait := waitlist[*TestConn]{}
+	wait.init()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	waiterCount := 2
+	expireCount := atomic.Int32{}
+
+	for i := 0; i < waiterCount; i++ {
+		go func() {
+			_, err := wait.waitForConn(ctx, nil)
+			if err != nil {
+				expireCount.Add(1)
+			}
+		}()
+	}
+
+	// Wait for the context to expire
+	<-ctx.Done()
+
+	// Expire the waiters
+	wait.expire(false)
+
+	// Wait for the notified goroutines to finish
+	timeout := time.After(1 * time.Second)
+	for expireCount.Load() != int32(waiterCount) {
+		select {
+		case <-timeout:
+			t.Fatalf("Timed out waiting for all waiters to expire. Wanted %d, got %d", waiterCount, expireCount.Load())
+		case <-time.After(10 * time.Millisecond):
+			// try again
+		}
+	}
+
+	assert.Equal(t, int32(waiterCount), expireCount.Load())
+}


### PR DESCRIPTION
## Description

Fixes a bug that causes `waitlist.expire` to only remove the first expired waiter on each invocation. This is due to calling `wl.list.Remove(e)` while traversing the list. This sets `e.Next` to `nil`, which terminates the loop. The fix is to remove waiters from the list after traversing it. 

I think this should be backported to v19+. With the right combination of client behavior, query timeouts, and transaction timeouts, this bug can lead to tablets locking up indefinitely with all attempts to get a connection timing out.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/16896

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

n/a