### PR TITLE
Add release-21.0 to the Golang Upgrade workflow

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-20.0, release-19.0, release-18.0 ]
+        branch: [ main, release-21.0, release-20.0, release-19.0, release-18.0 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Small follow up of the v21.0.0 code freeze. Since we created a new release branch, I am adding it to the Golang Upgrade GH Workflow.