### PR TITLE
VTGate MoveTables Buffering: Fix panic when buffering is disabled

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1520,6 +1520,20 @@ func TestExecutorUnrecognized(t *testing.T) {
 	require.Error(t, err, "unrecognized statement: invalid statement'")
 }
 
+func TestExecutorDeniedErrorNoBuffer(t *testing.T) {
+	executor, sbc1, _, _, ctx := createExecutorEnv(t)
+	sbc1.EphemeralShardErr = errors.New("enforce denied tables")
+
+	vschemaWaitTimeout = 500 * time.Millisecond
+
+	session := NewAutocommitSession(&vtgatepb.Session{TargetString: "@primary"})
+	startExec := time.Now()
+	_, err := executor.Execute(ctx, nil, "TestExecutorDeniedErrorNoBuffer", session, "select * from user", nil)
+	require.NoError(t, err, "enforce denied tables not buffered")
+	endExec := time.Now()
+	require.GreaterOrEqual(t, endExec.Sub(startExec).Milliseconds(), int64(500))
+}
+
 // TestVSchemaStats makes sure the building and displaying of the
 // VSchemaStats works.
 func TestVSchemaStats(t *testing.T) {

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -105,7 +105,7 @@ func (e *Executor) newExecute(
 			// within the given window of time for most queries and we should not end up waiting too long
 			// after the traffic switch fails or the buffer window has ended, retrying old queries.
 			timeout := 30 * time.Second
-			if e.resolver.scatterConn.gateway.buffer != nil {
+			if e.resolver.scatterConn.gateway.buffer != nil && e.resolver.scatterConn.gateway.buffer.GetConfig() != nil {
 				timeout = e.resolver.scatterConn.gateway.buffer.GetConfig().MaxFailoverDuration / (MaxBufferingRetries - 1)
 			}
 			if waitForNewerVSchema(ctx, e, lastVSchemaCreated, timeout) {

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -104,7 +104,10 @@ func (e *Executor) newExecute(
 			// based on the buffering configuration. This way we should be able to perform the max retries
 			// within the given window of time for most queries and we should not end up waiting too long
 			// after the traffic switch fails or the buffer window has ended, retrying old queries.
-			timeout := e.resolver.scatterConn.gateway.buffer.GetConfig().MaxFailoverDuration / (MaxBufferingRetries - 1)
+			timeout := 30 * time.Second
+			if e.resolver.scatterConn.gateway.buffer != nil {
+				timeout = e.resolver.scatterConn.gateway.buffer.GetConfig().MaxFailoverDuration / (MaxBufferingRetries - 1)
+			}
 			if waitForNewerVSchema(ctx, e, lastVSchemaCreated, timeout) {
 				vs = e.VSchema()
 				lastVSchemaCreated = vs.GetCreated()


### PR DESCRIPTION
## Description

When buffering is turned off in `vtgate` there is a possibility of a panic when a query is retried, because of this code
`timeout := e.resolver.scatterConn.gateway.buffer.GetConfig().MaxFailoverDuration / (MaxBufferingRetries - 1)`  introduced here: https://github.com/vitessio/vitess/pull/15701/files#diff-19aa815da9f21f65b55cc865090e2cefa77af98b30b134936853f7763898d255R107 in v20.0.

This PR uses the default timeout of 30 seconds, used earlier, if buffering is turned off.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16858

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
