### PR TITLE
Change upgrade test to still use the older verion of tests

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -117,22 +117,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/vitessio/go-junit-report@HEAD
 
-    # Build current commit's binaries
-    - name: Get dependencies for this commit
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      run: |
-        go mod download
-
-    - name: Building the binaries for this commit
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 10
-      run: |
-        source build.env
-        NOVTADMINBUILD=1 make build
-        mkdir -p /tmp/vitess-build-current/
-        cp -R bin /tmp/vitess-build-current/
-        rm -Rf bin/*
-
     # Checkout to the next release of Vitess
     - name: Check out other version's code (${{ steps.output-next-release-ref.outputs.next_release_ref }})
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -155,6 +139,25 @@ jobs:
         cp -R bin /tmp/vitess-build-other/
         rm -Rf bin/*
 
+    # Checkout to this build's commit
+    - name: Check out commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Get dependencies for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building the binaries for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        NOVTADMINBUILD=1 make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+
     - name: Convert ErrorContains checks to Error checks
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
@@ -166,8 +169,6 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
-
-        cp -r /tmp/vitess-build-current/bin/* $PWD/bin/
         rm -f $PWD/bin/vtgate
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR reverts the changes made to the upgrade tests in #16494. The situation has evolved as follows - 
1. Prior to changes in #16494, we would always run the code in the branch for both upgrade and downgrade tests. This caused us to add `SkipIfBinaryBelowVersion` lines whenever we added a new feature, because the older binaries wouldn't support them, and downgrade tests would fail without them.
2. In #16494, we changed both upgrade and downgrade tests to use the code in the other branch. So, on main running downgrade tests would run tests from v20.0, and running upgrade tests from v20.0 would run tests from main. This caused a different issue where when we add a new test, it doesn't run in downgrade on main, and everything works, but then upgrade tests from v20.0 would run this new test (since it uses main code!), and the test would fail there! So, we had to add the `SkipIf...` lines later.
3. In this PR we propose to use the older version code for running both upgrades and downgrades. This means that the upgrade tests don't change, but the downgrade tests should use their own code instead of the upgrade version's code. This would give us the best of both worlds. When we add new tests we won't need to add `SkipIf..` lines because we're going to use the downgrade versions code for testing. And we won't run into the issue where a test passes in the original PR, but then fails when we create a different PR against v20.0, because when running upgrade tests in v20.0 we would still use the v20.0 code. This means that the upgrade tests from the previous release, and downgrade tests from the current release are symmetrical. So, if a test were to fail, it would fail on main.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
