### PR TITLE
feat: add metrics for atomic distributed transactions

### DIFF
--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -309,11 +309,11 @@ func VtgateProcessInstance(
 }
 
 // GetVars returns map of vars
-func (vtgate *VtgateProcess) GetVars() (map[string]any, error) {
+func (vtgate *VtgateProcess) GetVars() map[string]any {
 	resultMap := make(map[string]any)
 	resp, err := http.Get(vtgate.VerifyURL)
 	if err != nil {
-		return nil, fmt.Errorf("error getting response from %s", vtgate.VerifyURL)
+		return nil
 	}
 	defer resp.Body.Close()
 
@@ -321,11 +321,11 @@ func (vtgate *VtgateProcess) GetVars() (map[string]any, error) {
 		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		if err != nil {
-			return nil, fmt.Errorf("not able to parse response body")
+			return nil
 		}
-		return resultMap, nil
+		return resultMap
 	}
-	return nil, fmt.Errorf("unsuccessful response")
+	return nil
 }
 
 // ReadVSchema reads the vschema from the vtgate endpoint for it and returns

--- a/go/test/endtoend/transaction/twopc/metric/main_test.go
+++ b/go/test/endtoend/transaction/twopc/metric/main_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transaction
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	twopcutil "vitess.io/vitess/go/test/endtoend/transaction/twopc/utils"
+)
+
+var (
+	clusterInstance   *cluster.LocalProcessCluster
+	vtParams          mysql.ConnParams
+	vtgateGrpcAddress string
+	keyspaceName      = "ks"
+	cell              = "zone1"
+	hostname          = "localhost"
+	sidecarDBName     = "vt_ks"
+
+	//go:embed schema.sql
+	SchemaSQL string
+
+	//go:embed vschema.json
+	VSchema string
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitcode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Reserve vtGate port in order to pass it to vtTablet
+		clusterInstance.VtgateGrpcPort = clusterInstance.GetAndReservePort()
+
+		// Set extra args for twopc
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+			"--transaction_mode", "TWOPC",
+			"--grpc_use_effective_callerid",
+		)
+		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs,
+			"--twopc_enable",
+			"--twopc_abandon_age", "1",
+			"--queryserver-config-transaction-cap", "100",
+		)
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:             keyspaceName,
+			SchemaSQL:        SchemaSQL,
+			VSchema:          VSchema,
+			SidecarDBName:    sidecarDBName,
+			DurabilityPolicy: "semi_sync",
+		}
+		if err := clusterInstance.StartKeyspace(*keyspace, []string{"-40", "40-80", "80-"}, 2, false); err != nil {
+			return 1
+		}
+
+		// Start Vtgate
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+		vtParams = clusterInstance.GetVTParams(keyspaceName)
+		vtgateGrpcAddress = fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateGrpcPort)
+
+		return m.Run()
+	}()
+	os.Exit(exitcode)
+}
+
+func start(t *testing.T) (*mysql.Conn, func()) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	cleanup(t)
+
+	return conn, func() {
+		conn.Close()
+		cleanup(t)
+	}
+}
+
+func cleanup(t *testing.T) {
+	cluster.PanicHandler(t)
+	twopcutil.ClearOutTable(t, vtParams, "twopc_user")
+}

--- a/go/test/endtoend/transaction/twopc/metric/main_test.go
+++ b/go/test/endtoend/transaction/twopc/metric/main_test.go
@@ -113,4 +113,5 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 func cleanup(t *testing.T) {
 	cluster.PanicHandler(t)
 	twopcutil.ClearOutTable(t, vtParams, "twopc_user")
+	twopcutil.ClearOutTable(t, vtParams, "twopc_t1")
 }

--- a/go/test/endtoend/transaction/twopc/metric/schema.sql
+++ b/go/test/endtoend/transaction/twopc/metric/schema.sql
@@ -1,0 +1,6 @@
+create table twopc_user
+(
+    id   bigint,
+    name varchar(64),
+    primary key (id)
+) Engine=InnoDB;

--- a/go/test/endtoend/transaction/twopc/metric/schema.sql
+++ b/go/test/endtoend/transaction/twopc/metric/schema.sql
@@ -4,3 +4,10 @@ create table twopc_user
     name varchar(64),
     primary key (id)
 ) Engine=InnoDB;
+
+create table twopc_t1
+(
+    id  bigint,
+    col bigint,
+    primary key (id)
+) Engine=InnoDB;

--- a/go/test/endtoend/transaction/twopc/metric/vschema.json
+++ b/go/test/endtoend/transaction/twopc/metric/vschema.json
@@ -3,6 +3,9 @@
   "vindexes": {
     "xxhash": {
       "type": "xxhash"
+    },
+    "reverse_bits": {
+      "type": "reverse_bits"
     }
   },
   "tables": {
@@ -11,6 +14,14 @@
         {
           "column": "id",
           "name": "xxhash"
+        }
+      ]
+    },
+    "twopc_t1": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "reverse_bits"
         }
       ]
     }

--- a/go/test/endtoend/transaction/twopc/metric/vschema.json
+++ b/go/test/endtoend/transaction/twopc/metric/vschema.json
@@ -1,0 +1,18 @@
+{
+  "sharded":true,
+  "vindexes": {
+    "xxhash": {
+      "type": "xxhash"
+    }
+  },
+  "tables": {
+    "twopc_user":{
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    }
+  }
+}

--- a/go/test/endtoend/transaction/twopc/metric_test.go
+++ b/go/test/endtoend/transaction/twopc/metric_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transaction
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+// TestTransactionModes tests transactions using twopc mode
+func TestTransactionModeMetrics(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	tcases := []struct {
+		name  string
+		stmts []string
+		want  commitMetric
+	}{{
+		name:  "nothing to commit: so no change on vars",
+		stmts: []string{"commit"},
+	}, {
+		name:  "begin commit - no dml: so no change on vars",
+		stmts: []string{"begin", "commit"},
+	}, {
+		name: "single shard",
+		stmts: []string{
+			"begin",
+			"insert into twopc_user(id) values (1)",
+			"commit",
+		},
+		want: commitMetric{TotalCount: 1, SingleCount: 1},
+	}, {
+		name: "multi shard insert",
+		stmts: []string{
+			"begin",
+			"insert into twopc_user(id) values (7),(8)",
+			"commit",
+		},
+		want: commitMetric{TotalCount: 1, MultiCount: 1, TwoPCCount: 1},
+	}, {
+		name: "multi shard delete",
+		stmts: []string{
+			"begin",
+			"delete from twopc_user",
+			"commit",
+		},
+		want: commitMetric{TotalCount: 1, MultiCount: 1, TwoPCCount: 1},
+	}}
+
+	initial := getCommitMetric(t)
+	utils.Exec(t, conn, "set transaction_mode = multi")
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, stmt := range tc.stmts {
+				utils.Exec(t, conn, stmt)
+			}
+			updatedMetric := getCommitMetric(t)
+			assert.EqualValues(t, tc.want.TotalCount, updatedMetric.TotalCount-initial.TotalCount, "TotalCount")
+			assert.EqualValues(t, tc.want.SingleCount, updatedMetric.SingleCount-initial.SingleCount, "SingleCount")
+			assert.EqualValues(t, tc.want.MultiCount, updatedMetric.MultiCount-initial.MultiCount, "MultiCount")
+			assert.Zero(t, updatedMetric.TwoPCCount-initial.TwoPCCount, "TwoPCCount")
+			initial = updatedMetric
+		})
+	}
+
+	utils.Exec(t, conn, "set transaction_mode = twopc")
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, stmt := range tc.stmts {
+				utils.Exec(t, conn, stmt)
+			}
+			updatedMetric := getCommitMetric(t)
+			assert.EqualValues(t, tc.want.TotalCount, updatedMetric.TotalCount-initial.TotalCount, "TotalCount")
+			assert.EqualValues(t, tc.want.SingleCount, updatedMetric.SingleCount-initial.SingleCount, "SingleCount")
+			assert.Zero(t, updatedMetric.MultiCount-initial.MultiCount, "MultiCount")
+			assert.EqualValues(t, tc.want.TwoPCCount, updatedMetric.TwoPCCount-initial.TwoPCCount, "TwoPCCount")
+			initial = updatedMetric
+		})
+	}
+}
+
+// TestMetricOnFailure tests unresolved commit metrics.
+func TestMetricOnFailure(t *testing.T) {
+	defer cleanup(t)
+
+	initialCount := GetVarValue[float64](t, "CommitUnresolved")
+
+	vtgateConn, err := cluster.DialVTGate(context.Background(), t.Name(), vtgateGrpcAddress, "dt_user", "")
+	require.NoError(t, err)
+	defer vtgateConn.Close()
+
+	conn := vtgateConn.Session("", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err = conn.Execute(ctx, "begin", nil)
+	require.NoError(t, err)
+	_, err = conn.Execute(ctx, "insert into twopc_user(id, name) values(7,'foo'), (8,'bar')", nil)
+	require.NoError(t, err)
+
+	// fail after mm commit.
+	newCtx := callerid.NewContext(ctx, callerid.NewEffectiveCallerID("MMCommitted_FailNow", "", ""), nil)
+	_, err = conn.Execute(newCtx, "commit", nil)
+	require.ErrorContains(t, err, "Fail After MM commit")
+
+	updatedCount := GetVarValue[float64](t, "CommitUnresolved")
+	assert.EqualValues(t, 1, updatedCount-initialCount, "CommitUnresolved")
+
+	waitForResolve(ctx, t, conn, 5*time.Second)
+
+	_, err = conn.Execute(ctx, "begin", nil)
+	require.NoError(t, err)
+	_, err = conn.Execute(ctx, "insert into twopc_user(id, name) values(9,'foo')", nil)
+	require.NoError(t, err)
+	_, err = conn.Execute(ctx, "insert into twopc_user(id, name) values(10,'apa')", nil)
+	require.NoError(t, err)
+
+	// fail during rm commit.
+	newCtx = callerid.NewContext(ctx, callerid.NewEffectiveCallerID("RMCommit_-40_FailNow", "", ""), nil)
+	_, err = conn.Execute(newCtx, "commit", nil)
+	require.ErrorContains(t, err, "Fail During RM commit")
+
+	updatedCount = GetVarValue[float64](t, "CommitUnresolved")
+	assert.EqualValues(t, 2, updatedCount-initialCount, "CommitUnresolved")
+
+	waitForResolve(ctx, t, conn, 5*time.Second)
+}
+
+type commitMetric struct {
+	TotalCount  float64
+	SingleCount float64
+	MultiCount  float64
+	TwoPCCount  float64
+}
+
+func getCommitMetric(t *testing.T) commitMetric {
+	t.Helper()
+
+	vars, err := clusterInstance.VtgateProcess.GetVars()
+	require.NoError(t, err)
+
+	cm := commitMetric{}
+	commitVars, exists := vars["CommitModeTimings"]
+	if !exists {
+		return cm
+	}
+
+	commitMap, ok := commitVars.(map[string]any)
+	require.True(t, ok, "commit vars is not a map")
+
+	cm.TotalCount = commitMap["TotalCount"].(float64)
+
+	histogram, ok := commitMap["Histograms"].(map[string]any)
+	require.True(t, ok, "commit histogram is not a map")
+
+	if single, ok := histogram["Single"]; ok {
+		singleMap, ok := single.(map[string]any)
+		require.True(t, ok, "single histogram is not a map")
+		cm.SingleCount = singleMap["Count"].(float64)
+	}
+
+	if multi, ok := histogram["Multi"]; ok {
+		multiMap, ok := multi.(map[string]any)
+		require.True(t, ok, "multi histogram is not a map")
+		cm.MultiCount = multiMap["Count"].(float64)
+	}
+
+	if twopc, ok := histogram["TwoPC"]; ok {
+		twopcMap, ok := twopc.(map[string]any)
+		require.True(t, ok, "twopc histogram is not a map")
+		cm.TwoPCCount = twopcMap["Count"].(float64)
+	}
+
+	return cm
+}
+
+func GetVarValue[T any](t *testing.T, key string) T {
+	vars, err := clusterInstance.VtgateProcess.GetVars()
+	require.NoError(t, err)
+
+	value, exists := vars[key]
+	if !exists {
+		return *new(T)
+	}
+	castValue, ok := value.(T)
+	if !ok {
+		t.Errorf("unexpected type, want: %T, got %T", new(T), value)
+	}
+	return castValue
+}
+
+func waitForResolve(ctx context.Context, t *testing.T, conn *vtgateconn.VTGateSession, waitTime time.Duration) {
+	t.Helper()
+
+	qr, err := conn.Execute(ctx, "show warnings", nil)
+	require.NoError(t, err)
+	require.Len(t, qr.Rows, 1)
+
+	// validate warning output
+	w := toWarn(qr.Rows[0])
+	assert.Equal(t, "Warning", w.level)
+	assert.EqualValues(t, 302, w.code)
+
+	// extract transaction ID
+	indx := strings.Index(w.msg, " ")
+	require.Greater(t, indx, 0)
+	dtid := w.msg[:indx]
+
+	unresolved := true
+	totalTime := time.After(waitTime)
+	for unresolved {
+		select {
+		case <-totalTime:
+			t.Errorf("transaction resolution exceeded wait time of %v", waitTime)
+			unresolved = false // break the loop.
+		case <-time.After(100 * time.Millisecond):
+			qr, err = conn.Execute(ctx, fmt.Sprintf(`show transaction status for '%v'`, dtid), nil)
+			require.NoError(t, err)
+			unresolved = len(qr.Rows) != 0
+		}
+	}
+}

--- a/go/test/endtoend/transaction/twopc/utils/utils.go
+++ b/go/test/endtoend/transaction/twopc/utils/utils.go
@@ -221,3 +221,18 @@ func AddShards(t *testing.T, clusterInstance *cluster.LocalProcessCluster, keysp
 		clusterInstance.Keyspaces[0].Shards = append(clusterInstance.Keyspaces[0].Shards, *shard)
 	}
 }
+
+type Warn struct {
+	Level string
+	Code  uint16
+	Msg   string
+}
+
+func ToWarn(row sqltypes.Row) Warn {
+	code, _ := row[1].ToUint16()
+	return Warn{
+		Level: row[0].ToString(),
+		Code:  code,
+		Msg:   row[2].ToString(),
+	}
+}

--- a/go/test/endtoend/transaction/tx_test.go
+++ b/go/test/endtoend/transaction/tx_test.go
@@ -24,12 +24,12 @@ import (
 	"os"
 	"testing"
 
-	"vitess.io/vitess/go/test/endtoend/utils"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
 var (
@@ -232,6 +232,130 @@ func TestTransactionIsolationInTx(t *testing.T) {
 	utils.Exec(t, conn, "begin")
 	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-COMMITTED")]]`)
 	utils.Exec(t, conn, "commit")
+}
+
+type commitMetric struct {
+	TotalCount  float64
+	SingleCount float64
+	MultiCount  float64
+	TwoPCCount  float64
+}
+
+func getCommitMetric(t *testing.T, vtgateProcess cluster.VtgateProcess) commitMetric {
+	t.Helper()
+
+	vars, err := clusterInstance.VtgateProcess.GetVars()
+	require.NoError(t, err)
+
+	cm := commitMetric{}
+	commitVars, exists := vars["CommitModeTimings"]
+	if !exists {
+		return cm
+	}
+
+	commitMap, ok := commitVars.(map[string]any)
+	require.True(t, ok, "commit vars is not a map")
+
+	cm.TotalCount = commitMap["TotalCount"].(float64)
+
+	histogram, ok := commitMap["Histograms"].(map[string]any)
+	require.True(t, ok, "commit histogram is not a map")
+
+	if single, ok := histogram["Single"]; ok {
+		singleMap, ok := single.(map[string]any)
+		require.True(t, ok, "single histogram is not a map")
+		cm.SingleCount = singleMap["Count"].(float64)
+	}
+
+	if multi, ok := histogram["Multi"]; ok {
+		multiMap, ok := multi.(map[string]any)
+		require.True(t, ok, "multi histogram is not a map")
+		cm.MultiCount = multiMap["Count"].(float64)
+	}
+
+	if twopc, ok := histogram["TwoPC"]; ok {
+		twopcMap, ok := twopc.(map[string]any)
+		require.True(t, ok, "twopc histogram is not a map")
+		cm.TwoPCCount = twopcMap["Count"].(float64)
+	}
+
+	return cm
+}
+
+// TestTransactionModes tests transactions using twopc mode
+func TestTransactionModeMetrics(t *testing.T) {
+	closer := start(t)
+	defer closer()
+
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	tcases := []struct {
+		name  string
+		stmts []string
+		want  commitMetric
+	}{{
+		name:  "nothing to commit: so no change on vars",
+		stmts: []string{"commit"},
+	}, {
+		name:  "begin commit - no dml: so no change on vars",
+		stmts: []string{"begin", "commit"},
+	}, {
+		name: "single shard",
+		stmts: []string{
+			"begin",
+			"insert into test(id) values (1)",
+			"commit",
+		},
+		want: commitMetric{TotalCount: 1, SingleCount: 1},
+	}, {
+		name: "multi shard insert",
+		stmts: []string{
+			"begin",
+			"insert into test(id) values (3),(4)",
+			"commit",
+		},
+		want: commitMetric{TotalCount: 1, MultiCount: 1, TwoPCCount: 1},
+	}, {
+		name: "multi shard delete",
+		stmts: []string{
+			"begin",
+			"delete from test",
+			"commit",
+		},
+		want: commitMetric{TotalCount: 1, MultiCount: 1, TwoPCCount: 1},
+	}}
+
+	initial := getCommitMetric(t, clusterInstance.VtgateProcess)
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, stmt := range tc.stmts {
+				utils.Exec(t, conn, stmt)
+			}
+			updatedMetric := getCommitMetric(t, clusterInstance.VtgateProcess)
+			assert.EqualValues(t, tc.want.TotalCount, updatedMetric.TotalCount-initial.TotalCount, "TotalCount")
+			assert.EqualValues(t, tc.want.SingleCount, updatedMetric.SingleCount-initial.SingleCount, "SingleCount")
+			assert.EqualValues(t, tc.want.MultiCount, updatedMetric.MultiCount-initial.MultiCount, "MultiCount")
+			assert.Zero(t, updatedMetric.TwoPCCount-initial.TwoPCCount, "TwoPCCount")
+			initial = updatedMetric
+		})
+	}
+
+	utils.Exec(t, conn, "set transaction_mode = twopc")
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, stmt := range tc.stmts {
+				utils.Exec(t, conn, stmt)
+			}
+			updatedMetric := getCommitMetric(t, clusterInstance.VtgateProcess)
+			assert.EqualValues(t, tc.want.TotalCount, updatedMetric.TotalCount-initial.TotalCount, "TotalCount")
+			assert.EqualValues(t, tc.want.SingleCount, updatedMetric.SingleCount-initial.SingleCount, "SingleCount")
+			assert.Zero(t, updatedMetric.MultiCount-initial.MultiCount, "MultiCount")
+			assert.EqualValues(t, tc.want.TwoPCCount, updatedMetric.TwoPCCount-initial.TwoPCCount, "TwoPCCount")
+			initial = updatedMetric
+		})
+	}
 }
 
 func start(t *testing.T) func() {

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -844,8 +844,8 @@ func getVtgateApiErrorCounts(t *testing.T) float64 {
 }
 
 func getVar(t *testing.T, key string) interface{} {
-	vars, err := clusterInstance.VtgateProcess.GetVars()
-	require.NoError(t, err)
+	vars := clusterInstance.VtgateProcess.GetVars()
+	require.NotNil(t, vars)
 
 	val, exists := vars[key]
 	if !exists {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -77,6 +77,10 @@ var (
 	queriesProcessedByTable = stats.NewCountersWithMultiLabels("QueriesProcessedByTable", "Queries processed at vtgate by plan type, keyspace and table", []string{"Plan", "Keyspace", "Table"})
 	queriesRoutedByTable    = stats.NewCountersWithMultiLabels("QueriesRoutedByTable", "Queries routed from vtgate to vttablet by plan type, keyspace and table", []string{"Plan", "Keyspace", "Table"})
 
+	// commitMode records the timing of the commit phase of a transaction.
+	// It also tracks between different transaction mode i.e. Single, Multi and TwoPC
+	commitMode = stats.NewTimings("CommitModeTimings", "Commit Mode Time", "mode")
+
 	exceedMemoryRowsLogger = logutil.NewThrottledLogger("ExceedMemoryRows", 1*time.Minute)
 
 	errorTransform errorTransformer = nullErrorTransformer{}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -79,7 +79,8 @@ var (
 
 	// commitMode records the timing of the commit phase of a transaction.
 	// It also tracks between different transaction mode i.e. Single, Multi and TwoPC
-	commitMode = stats.NewTimings("CommitModeTimings", "Commit Mode Time", "mode")
+	commitMode       = stats.NewTimings("CommitModeTimings", "Commit Mode Time", "mode")
+	commitUnresolved = stats.NewCounter("CommitUnresolved", "Atomic Commit failed to conclude after commit decision is made")
 
 	exceedMemoryRowsLogger = logutil.NewThrottledLogger("ExceedMemoryRows", 1*time.Minute)
 

--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -313,6 +313,8 @@ func (txc *TxConn) errActionAndLogWarn(ctx context.Context, session *SafeSession
 		if resumeErr := txc.rollbackTx(ctx, dtid, mmShard, rmShards, session.logging); resumeErr != nil {
 			log.Warningf("Rollback failed after Prepare failure: %v", resumeErr)
 		}
+	case Commit2pcStartCommit, Commit2pcPrepareCommit:
+		commitUnresolved.Add(1)
 	}
 	session.RecordWarning(&querypb.QueryWarning{
 		Code:    uint32(sqlerror.ERInAtomicRecovery),

--- a/go/vt/vttablet/tabletserver/production.go
+++ b/go/vt/vttablet/tabletserver/production.go
@@ -18,6 +18,10 @@ limitations under the License.
 
 package tabletserver
 
+import (
+	"context"
+)
+
 // This file defines debug constants that are always false.
 // This file is used for building production code.
 // We use go build directives to include a file that defines the constant to true
@@ -28,3 +32,7 @@ package tabletserver
 const DebugTwoPc = false
 
 func commitPreparedDelayForTest(tsv *TabletServer) {}
+
+func checkTestFailure(context.Context, string) error {
+	return nil
+}

--- a/go/vt/vttablet/tabletserver/tabletenv/stats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/stats.go
@@ -34,7 +34,6 @@ type Stats struct {
 	ErrorCounters          *stats.CountersWithSingleLabel
 	InternalErrors         *stats.CountersWithSingleLabel
 	Warnings               *stats.CountersWithSingleLabel
-	Unresolved             *stats.GaugesWithSingleLabel   // For now, only Prepares are tracked
 	UserTableQueryCount    *stats.CountersWithMultiLabels // Per CallerID/table counts
 	UserTableQueryTimesNs  *stats.CountersWithMultiLabels // Per CallerID/table latencies
 	UserTransactionCount   *stats.CountersWithMultiLabels // Per CallerID transaction counts
@@ -49,6 +48,11 @@ type Stats struct {
 	UserReservedTimesNs     *stats.CountersWithSingleLabel // Per CallerID reserved connection duration
 
 	QueryTimingsByTabletType *servenv.TimingsWrapper // Query timings split by current tablet type
+
+	// Atomic Transactions
+	Unresolved         *stats.GaugesWithSingleLabel
+	CommitPreparedFail *stats.CountersWithSingleLabel
+	RedoPreparedFail   *stats.CountersWithSingleLabel
 }
 
 // NewStats instantiates a new set of stats scoped by exporter.
@@ -83,7 +87,6 @@ func NewStats(exporter *servenv.Exporter) *Stats {
 		),
 		InternalErrors:         exporter.NewCountersWithSingleLabel("InternalErrors", "Internal component errors", "type", "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail", "Messages"),
 		Warnings:               exporter.NewCountersWithSingleLabel("Warnings", "Warnings", "type", "ResultsExceeded"),
-		Unresolved:             exporter.NewGaugesWithSingleLabel("Unresolved", "Unresolved items", "item_type", "Prepares"),
 		UserTableQueryCount:    exporter.NewCountersWithMultiLabels("UserTableQueryCount", "Queries received for each CallerID/table combination", []string{"TableName", "CallerID", "Type"}),
 		UserTableQueryTimesNs:  exporter.NewCountersWithMultiLabels("UserTableQueryTimesNs", "Total latency for each CallerID/table combination", []string{"TableName", "CallerID", "Type"}),
 		UserTransactionCount:   exporter.NewCountersWithMultiLabels("UserTransactionCount", "transactions received for each CallerID", []string{"CallerID", "Conclusion"}),
@@ -98,6 +101,10 @@ func NewStats(exporter *servenv.Exporter) *Stats {
 		UserReservedTimesNs:     exporter.NewCountersWithSingleLabel("UserReservedTimesNs", "Total reserved connection latency for each CallerID", "CallerID"),
 
 		QueryTimingsByTabletType: exporter.NewTimings("QueryTimingsByTabletType", "Query timings broken down by active tablet type", "TabletType"),
+
+		Unresolved:         exporter.NewGaugesWithSingleLabel("UnresolvedTransaction", "Unresolved items", "ManagerType"),
+		CommitPreparedFail: exporter.NewCountersWithSingleLabel("CommitPreparedFail", "failed prepared transactions commit", "FailureType"),
+		RedoPreparedFail:   exporter.NewCountersWithSingleLabel("RedoPreparedFail", "failed prepared transactions on redo", "FailureType"),
 	}
 	stats.QPSRates = exporter.NewRates("QPS", stats.QueryTimings, 15*60/5, 5*time.Second)
 	return stats

--- a/go/vt/vttablet/tabletserver/tabletenv/stats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/stats.go
@@ -102,7 +102,7 @@ func NewStats(exporter *servenv.Exporter) *Stats {
 
 		QueryTimingsByTabletType: exporter.NewTimings("QueryTimingsByTabletType", "Query timings broken down by active tablet type", "TabletType"),
 
-		Unresolved:         exporter.NewGaugesWithSingleLabel("UnresolvedTransaction", "Unresolved items", "ManagerType"),
+		Unresolved:         exporter.NewGaugesWithSingleLabel("UnresolvedTransaction", "Current unresolved transactions", "ManagerType"),
 		CommitPreparedFail: exporter.NewCountersWithSingleLabel("CommitPreparedFail", "failed prepared transactions commit", "FailureType"),
 		RedoPreparedFail:   exporter.NewCountersWithSingleLabel("RedoPreparedFail", "failed prepared transactions on redo", "FailureType"),
 	}

--- a/test/config.json
+++ b/test/config.json
@@ -851,6 +851,15 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"vtgate_transaction_twopc_metric": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/transaction/twopc/metric"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_transaction",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtgate_transaction_twopc_stress": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/transaction/twopc/stress"],


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds metrics to distributed transaction comit flow for tracking timings and failures.

New Metrics:

- VTGate
  - `CommitModeTimings` - Timing metrics for commit (Single, Multi, TwoPC)
  - `CommitUnresolved` - Counter for failure after Prepare

- VTTablet
  - `UnresolvedTransaction` - Gauge to track current unresolved transactions in Metadata and Resource Manager.
  - `CommitPreparedFail` - Transactions that failed to commit after prepare (classified into Retryable and Non-Retryable)
  -  `RedoPreparedFail` - Transactions that failed to re-prepare (classified into Retryable and Non-Retryable)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- #16245 

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
