### PR TITLE
Flakes: Address flakes in TestMoveTables* unit tests

### DIFF
--- a/go/vt/binlog/binlogplayer/mock_dbclient.go
+++ b/go/vt/binlog/binlogplayer/mock_dbclient.go
@@ -100,14 +100,6 @@ func NewMockDbaClient(t *testing.T) *MockDBClient {
 	}
 }
 
-func (dc *MockDBClient) Reset() {
-	dc.expectMu.Lock()
-	defer dc.expectMu.Unlock()
-	dc.currentResult = 0
-	dc.expect = nil
-	dc.done = make(chan struct{})
-}
-
 // ExpectRequest adds an expected result to the mock.
 // This function should not be called conncurrently with other commands.
 func (dc *MockDBClient) ExpectRequest(query string, result *sqltypes.Result, err error) {

--- a/go/vt/vttablet/tabletmanager/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/framework_test.go
@@ -420,8 +420,6 @@ func (tmc *fakeTMClient) ApplySchema(ctx context.Context, tablet *topodatapb.Tab
 }
 
 func (tmc *fakeTMClient) schemaRequested(uid int) {
-	tmc.mu.Lock()
-	defer tmc.mu.Unlock()
 	key := strconv.Itoa(int(uid))
 	n, ok := tmc.getSchemaCounts[key]
 	if !ok {
@@ -439,6 +437,8 @@ func (tmc *fakeTMClient) getSchemaRequestCount(uid int) int {
 }
 
 func (tmc *fakeTMClient) GetSchema(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.GetSchemaRequest) (*tabletmanagerdatapb.SchemaDefinition, error) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	tmc.schemaRequested(int(tablet.Alias.Uid))
 	// Return the schema for the tablet if it exists.
 	if schema, ok := tmc.tabletSchemas[int(tablet.Alias.Uid)]; ok {
@@ -466,6 +466,8 @@ func (tmc *fakeTMClient) ExecuteFetchAsDba(ctx context.Context, tablet *topodata
 // and their results. You can specify exact strings or strings prefixed with
 // a '/', in which case they will be treated as a valid regexp.
 func (tmc *fakeTMClient) setVReplicationExecResults(tablet *topodatapb.Tablet, query string, result *sqltypes.Result) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	queries, ok := tmc.vreQueries[int(tablet.Alias.Uid)]
 	if !ok {
 		queries = make(map[string]*querypb.QueryResult)
@@ -475,6 +477,8 @@ func (tmc *fakeTMClient) setVReplicationExecResults(tablet *topodatapb.Tablet, q
 }
 
 func (tmc *fakeTMClient) VReplicationExec(ctx context.Context, tablet *topodatapb.Tablet, query string) (*querypb.QueryResult, error) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	if result, ok := tmc.vreQueries[int(tablet.Alias.Uid)][query]; ok {
 		return result, nil
 	}
@@ -514,6 +518,8 @@ func (tmc *fakeTMClient) VDiff(ctx context.Context, tablet *topodatapb.Tablet, r
 }
 
 func (tmc *fakeTMClient) CreateVReplicationWorkflow(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.CreateVReplicationWorkflowRequest) (*tabletmanagerdatapb.CreateVReplicationWorkflowResponse, error) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	return tmc.tablets[int(tablet.Alias.Uid)].tm.CreateVReplicationWorkflow(ctx, req)
 }
 
@@ -529,17 +535,25 @@ func (tmc *fakeTMClient) DeleteVReplicationWorkflow(ctx context.Context, tablet 
 }
 
 func (tmc *fakeTMClient) HasVReplicationWorkflows(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.HasVReplicationWorkflowsRequest) (*tabletmanagerdatapb.HasVReplicationWorkflowsResponse, error) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	return tmc.tablets[int(tablet.Alias.Uid)].tm.HasVReplicationWorkflows(ctx, req)
 }
 
 func (tmc *fakeTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.ReadVReplicationWorkflowRequest) (*tabletmanagerdatapb.ReadVReplicationWorkflowResponse, error) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	return tmc.tablets[int(tablet.Alias.Uid)].tm.ReadVReplicationWorkflow(ctx, req)
 }
 
 func (tmc *fakeTMClient) ReadVReplicationWorkflows(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.ReadVReplicationWorkflowsRequest) (*tabletmanagerdatapb.ReadVReplicationWorkflowsResponse, error) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	return tmc.tablets[int(tablet.Alias.Uid)].tm.ReadVReplicationWorkflows(ctx, req)
 }
 
 func (tmc *fakeTMClient) UpdateVReplicationWorkflow(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.UpdateVReplicationWorkflowRequest) (*tabletmanagerdatapb.UpdateVReplicationWorkflowResponse, error) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
 	return tmc.tablets[int(tablet.Alias.Uid)].tm.UpdateVReplicationWorkflow(ctx, req)
 }

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -472,7 +472,6 @@ func TestMoveTablesUnsharded(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, ftc := range targetShards {
-		ftc.vrdbClient.Reset()
 		ftc.vrdbClient.AddInvariant(binlogplayer.TestGetWorkflowQueryId1, sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(
 				"id|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type|defer_secondary_keys|options",
@@ -732,7 +731,6 @@ func TestMoveTablesSharded(t *testing.T) {
 	})
 	require.NoError(t, err)
 	for _, ftc := range targetShards {
-		ftc.vrdbClient.Reset()
 		ftc.vrdbClient.AddInvariant(binlogplayer.TestGetWorkflowQueryId1, sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields(
 				"id|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type|defer_secondary_keys|options",


### PR DESCRIPTION
## Description

Since https://github.com/vitessio/vitess/pull/16583 we've seen the `TestMoveTablesUnsharded` and `TestMoveTablesSharded` tests become flaky. Especially the Sharded one.

The only directly relevant change made to these unit tests in that PR is adding the `vrdbClient.Reset()` call. That call however is not safe as it modifies the members while holding a mutex, most notably the done channel. The problem, however, is that we explicitly and intentionally do not take that mutex in the `Wait()` function, which is the primary user of that channel. 

It's not 100% clear that this was the cause of the flakiness, but given that it was the only directly relevant change, we know it's unsafe, and CI failures that I saw (I was unable to repeat the test failures locally) seemed to indicate a repeated panic->recover cycle in the TabletManager which could be caused by unsafe channel manipulation:
```
ok  	vitess.io/vitess/go/vt/vttablet/tabletconn	1.035s
W1009 13:10:59.004444   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.005626   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.026628   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.027266   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
E1009 13:10:59.057000   47317 server.go:959] buildTrafficSwitcher failed: no streams found in keyspace sourceks for testwf
--- FAIL: TestMoveTablesSharded (0.03s)

...

W1009 13:10:59.058921   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.059540   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.076345   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.077371   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.

...
E1009 13:10:59.179155   47317 dbclient.go:134] error in stream 1, will retry after 5s: no schema defined
W1009 13:10:59.179357   47317 controller.go:197] context canceled: no schema defined
W1009 13:10:59.180705   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.181630   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.189298   47317 controller.go:187] context canceled: no schema defined
W1009 13:10:59.190224   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
W1009 13:10:59.190957   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
E1009 13:10:59.200891   47317 dbclient.go:134] error in stream 1, will retry after 5s: no schema defined
W1009 13:10:59.202169   47317 controller.go:187] context canceled: no schema defined
W1009 13:10:59.203078   47317 controller.go:197] context canceled: no schema defined
W1009 13:10:59.204084   47317 controller.go:187] context canceled: no schema defined
W1009 13:10:59.205748   47317 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletmanager]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.

...
```

The `Reset()` function was being called for every shard, so that would also explain why the Sharded test was much more flaky than the Unsharded one.

Given all of this AND the fact that using this `Reset()` function is wholly unnecessary we remove its usage in this PR. We will then have to see how much this helps the somewhat random flakiness we've seen in the coming weeks.

While here, I also added mutex usage to the `fakeTMClient` methods that weren't already using it so that we should be concurrent safe if we start doing more tests in parallel in the future.

`unit_race` test re-runs can be seen here: https://github.com/vitessio/vitess/actions/runs/11317748149/job/31471559199?pr=16942

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required