### PR TITLE
Fix `GetUnresolvedTransactions` command for Vtctld

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -2461,6 +2461,15 @@ func (s *VtctldServer) GetUnresolvedTransactions(ctx context.Context, req *vtctl
 			if err != nil {
 				return err
 			}
+			// The metadata manager is itself not part of the list of participants.
+			// We should it to the list before showing it to the users.
+			for _, trnx := range shardTrnxs {
+				trnx.Participants = append(trnx.Participants, &querypb.Target{
+					Keyspace:   req.Keyspace,
+					Shard:      shard,
+					TabletType: topodatapb.TabletType_PRIMARY,
+				})
+			}
 			mu.Lock()
 			defer mu.Unlock()
 			transactions = append(transactions, shardTrnxs...)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the bug in GetUnresolvedTransactions wherein we don't show the complete list of participants but omit the metadata manager shard.
This is a forward port for https://github.com/vitessio/vitess/pull/16949

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #16245 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
