### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -6,6 +6,7 @@ name: Release
 on:
   release:
     types: [created]
+  pull_request: # So it can run on this PR
 
 permissions: read-all
 
@@ -18,16 +19,13 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: v21.0.0-rc1 # Explicit checkout to v21.0.0-rc1
 
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
         go-version-file: go.mod
-
-    - name: Setup node
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.12.2'
 
     - name: Tune the OS
       run: |
@@ -49,3 +47,4 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         pattern: "releases/*.{tar.gz,rpm,deb}"
+        release-url: https://uploads.github.com/repos/vitessio/vitess/releases/179932186/assets{?name,label} # Adding this line will update this release directly and not depend on the workflow to ran from a 'release' event

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: write
     steps:
+    - name: Check out code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
@@ -30,9 +32,6 @@ jobs:
     - name: Tune the OS
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
-
-    - name: Check out code
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -6,7 +6,6 @@ name: Release
 on:
   release:
     types: [created]
-  pull_request: # So it can run on this PR
 
 permissions: read-all
 
@@ -19,8 +18,6 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        ref: v21.0.0-rc1 # Explicit checkout to v21.0.0-rc1
 
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
@@ -47,4 +44,3 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         pattern: "releases/*.{tar.gz,rpm,deb}"
-        release-url: https://uploads.github.com/repos/vitessio/vitess/releases/179932186/assets{?name,label} # Adding this line will update this release directly and not depend on the workflow to ran from a 'release' event


### PR DESCRIPTION
## Description

This PR fixes the release workflow that build and push the release artefacts to a new release. This failed very recently as we released `v21.0.0-rc1`: https://github.com/vitessio/vitess/actions/runs/11339640858. As of now `v21.0.0-rc1` does not have any release artefacts attached to it.

The problem is that we are attempting to read `go.mod` before checking out the source code. This bug was introduced by https://github.com/vitessio/vitess/pull/16841

Since we will not be able to re-trigger the workflow on a `release` gh event (we can only on branch/tags), and the workflow we use depend on that, I am going to modify the workflow in another commit to allow it to run from this PR and build+push the release artefacts, that way everything is done within CI and not done manually.

As we changed the workflows in v21 too, let's backport this to v21 to avoid the same issue for future releases.

## Building/Pushing `v21.0.0-rc1` artefacts

Commit [`cc0780c` (#16964)](https://github.com/vitessio/vitess/pull/16964/commits/cc0780cd29dab4b7aa14ad6eb91eaeb296db654d) is a squash of all the commits I had to push to get the workflow running correctly, the last commit of this squash (https://github.com/vitessio/vitess/commit/b175de6515cf9d27c3783b177edda344ed7af6ea) [uploaded the release artefacts correctly as seen](https://github.com/vitessio/vitess/actions/runs/11355032904/job/31583597628) on https://github.com/vitessio/vitess/releases/tag/v21.0.0-rc1
