### PR TITLE
bugfix: add HAVING columns inside derived tables

### DIFF
--- a/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
+++ b/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
@@ -64,4 +64,4 @@ from (select id, count(*) as num_segments from t1 group by 1 order by 2 desc lim
          join t2 u on u.id = t.id;
 
 select name
-from (select name from t1 group by name having count(t1.id > 1)) t1;
+from (select name from t1 group by name having count(t1.id) > 1) t1;

--- a/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
+++ b/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
@@ -62,3 +62,6 @@ from (select 1 as one
 select u.id, u.t1_id, t.num_segments
 from (select id, count(*) as num_segments from t1 group by 1 order by 2 desc limit 20) t
          join t2 u on u.id = t.id;
+
+select name
+from (select name from t1 group by name having count(t1.id > 1)) t1;

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -78,6 +78,12 @@ func expandSelectHorizon(ctx *plancontext.PlanningContext, horizon *Horizon, sel
 		for _, order := range horizon.Query.GetOrderBy() {
 			qp.addDerivedColumn(ctx, order.Expr)
 		}
+		sel, isSel := horizon.Query.(*sqlparser.Select)
+		if isSel && sel.Having != nil {
+			for _, pred := range sqlparser.SplitAndExpression(nil, sel.Having.Expr) {
+				qp.addDerivedColumn(ctx, pred)
+			}
+		}
 	}
 
 	op := createProjectionFromSelect(ctx, horizon)

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -293,7 +293,7 @@ func (s *planTestSuite) TestViews() {
 	s.testFile("view_cases.json", vschemaWrapper, false)
 }
 
-func (s *planTestSuite) /**/ TestOne() {
+func (s *planTestSuite) TestOne() {
 	reset := operators.EnableDebugPrinting()
 	defer reset()
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -293,7 +293,7 @@ func (s *planTestSuite) TestViews() {
 	s.testFile("view_cases.json", vschemaWrapper, false)
 }
 
-func (s *planTestSuite) TestOne() {
+func (s *planTestSuite) /**/ TestOne() {
 	reset := operators.EnableDebugPrinting()
 	defer reset()
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -3803,25 +3803,42 @@
       "QueryType": "SELECT",
       "Original": "select * from (select id from user having count(*) = 1) s",
       "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "count(*) = 1",
-        "ResultColumns": 1,
+        "OperatorType": "SimpleProjection",
+        "ColumnNames": [
+          "0:id"
+        ],
+        "Columns": "0",
         "Inputs": [
           {
-            "OperatorType": "Aggregate",
-            "Variant": "Scalar",
-            "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*)",
+            "OperatorType": "Projection",
+            "Expressions": [
+              ":0 as id",
+              "count(*) = 1 as count(*) = 1"
+            ],
             "Inputs": [
               {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-                "Query": "select id, count(*) from `user`",
-                "Table": "`user`"
+                "OperatorType": "Filter",
+                "Predicate": "count(*) = 1",
+                "Inputs": [
+                  {
+                    "OperatorType": "Aggregate",
+                    "Variant": "Scalar",
+                    "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*), any_value(2)",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select id, count(*), 1 from `user` where 1 != 1",
+                        "Query": "select id, count(*), 1 from `user`",
+                        "Table": "`user`"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -616,6 +616,35 @@
     }
   },
   {
+    "comment": "using HAVING inside a derived table still produces viable plans",
+    "query": "select id from (select id from user group by id having (count(user.id) = 2) limit 2 offset 0) subquery_for_limit",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select id from (select id from user group by id having (count(user.id) = 2) limit 2 offset 0) subquery_for_limit",
+      "Instructions": {
+        "OperatorType": "Limit",
+        "Count": "2",
+        "Offset": "0",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from (select id, count(`user`.id) = 2 from `user` where 1 != 1 group by id) as subquery_for_limit where 1 != 1",
+            "Query": "select id from (select id, count(`user`.id) = 2 from `user` group by id having count(`user`.id) = 2) as subquery_for_limit limit 2",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "sum with distinct no unique vindex",
     "query": "select col1, sum(distinct col2) from user group by col1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -379,25 +379,42 @@
       "QueryType": "SELECT",
       "Original": "with s as (select id from user having count(*) = 1) select * from s",
       "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "count(*) = 1",
-        "ResultColumns": 1,
+        "OperatorType": "SimpleProjection",
+        "ColumnNames": [
+          "0:id"
+        ],
+        "Columns": "0",
         "Inputs": [
           {
-            "OperatorType": "Aggregate",
-            "Variant": "Scalar",
-            "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*)",
+            "OperatorType": "Projection",
+            "Expressions": [
+              ":0 as id",
+              "count(*) = 1 as count(*) = 1"
+            ],
             "Inputs": [
               {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-                "Query": "select id, count(*) from `user`",
-                "Table": "`user`"
+                "OperatorType": "Filter",
+                "Predicate": "count(*) = 1",
+                "Inputs": [
+                  {
+                    "OperatorType": "Aggregate",
+                    "Variant": "Scalar",
+                    "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*), any_value(2)",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select id, count(*), 1 from `user` where 1 != 1",
+                        "Query": "select id, count(*), 1 from `user`",
+                        "Table": "`user`"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
## Description
Make sure to add columns needed by HAVING to the derived table.

## Related Issue(s)
Fixes #16965

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
