### PR TITLE
fix: route engine to handle column truncation for execute after lookup

### DIFF
--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -130,25 +130,6 @@ func (route *Route) GetTableName() string {
 
 // TryExecute performs a non-streaming exec.
 func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	qr, err := route.executeInternal(ctx, vcursor, bindVars, wantfields)
-	if err != nil {
-		return nil, err
-	}
-	return qr.Truncate(route.TruncateColumnCount), nil
-}
-
-type cxtKey int
-
-const (
-	IgnoreReserveTxn cxtKey = iota
-)
-
-func (route *Route) executeInternal(
-	ctx context.Context,
-	vcursor VCursor,
-	bindVars map[string]*querypb.BindVariable,
-	wantfields bool,
-) (*sqltypes.Result, error) {
 	rss, bvs, err := route.findRoute(ctx, vcursor, bindVars)
 	if err != nil {
 		return nil, err
@@ -156,6 +137,12 @@ func (route *Route) executeInternal(
 
 	return route.executeShards(ctx, vcursor, bindVars, wantfields, rss, bvs)
 }
+
+type cxtKey int
+
+const (
+	IgnoreReserveTxn cxtKey = iota
+)
 
 func (route *Route) executeShards(
 	ctx context.Context,
@@ -212,11 +199,15 @@ func (route *Route) executeShards(
 		}
 	}
 
-	if len(route.OrderBy) == 0 {
-		return result, nil
+	if len(route.OrderBy) != 0 {
+		var err error
+		result, err = route.sort(result)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return route.sort(result)
+	return result.Truncate(route.TruncateColumnCount), nil
 }
 
 func filterOutNilErrors(errs []error) []error {
@@ -373,10 +364,8 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 	// the contents of any row.
 	out := in.ShallowCopy()
 
-	if err := route.OrderBy.SortResult(out); err != nil {
-		return nil, err
-	}
-	return out.Truncate(route.TruncateColumnCount), nil
+	err := route.OrderBy.SortResult(out)
+	return out, err
 }
 
 func (route *Route) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/vindex_lookup_test.go
+++ b/go/vt/vtgate/engine/vindex_lookup_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+var (
+	vindex, _ = vindexes.CreateVindex("lookup_unique", "", map[string]string{
+		"table":      "lkp",
+		"from":       "from",
+		"to":         "toc",
+		"write_only": "true",
+	})
+	ks = &vindexes.Keyspace{Name: "ks", Sharded: true}
+)
+
+func TestVindexLookup(t *testing.T) {
+	planableVindex, ok := vindex.(vindexes.LookupPlanable)
+	require.True(t, ok, "not a lookup vindex")
+	_, args := planableVindex.Query()
+
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+				"1|\x10"),
+		},
+	}
+	route := NewRoute(ByDestination, ks, "dummy_select", "dummy_select_field")
+	vdxLookup := &VindexLookup{
+		Opcode:    EqualUnique,
+		Keyspace:  ks,
+		Vindex:    planableVindex,
+		Arguments: args,
+		Values:    []evalengine.Expr{evalengine.NewLiteralInt(1)},
+		Lookup:    fp,
+		SendTo:    route,
+	}
+
+	vc := &loggingVCursor{results: []*sqltypes.Result{defaultSelectResult}}
+
+	result, err := vdxLookup.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	fp.ExpectLog(t, []string{`Execute from: type:TUPLE values:{type:INT64 value:"1"} false`})
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(10)`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
+	})
+	expectResult(t, result, defaultSelectResult)
+
+	fp.rewind()
+	vc.Rewind()
+	result, err = wrapStreamExecute(vdxLookup, vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(10)`,
+		`StreamExecuteMulti dummy_select ks.-20: {} `,
+	})
+	expectResult(t, result, defaultSelectResult)
+}
+
+func TestVindexLookupTruncate(t *testing.T) {
+	planableVindex, ok := vindex.(vindexes.LookupPlanable)
+	require.True(t, ok, "not a lookup vindex")
+	_, args := planableVindex.Query()
+
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+				"1|\x10"),
+		},
+	}
+	route := NewRoute(ByDestination, ks, "dummy_select", "dummy_select_field")
+	route.TruncateColumnCount = 1
+	vdxLookup := &VindexLookup{
+		Opcode:    EqualUnique,
+		Keyspace:  ks,
+		Vindex:    planableVindex,
+		Arguments: args,
+		Values:    []evalengine.Expr{evalengine.NewLiteralInt(1)},
+		Lookup:    fp,
+		SendTo:    route,
+	}
+
+	vc := &loggingVCursor{results: []*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("name|morecol", "varchar|int64"),
+			"foo|1", "bar|2", "baz|3"),
+	}}
+
+	wantRes := sqltypes.MakeTestResult(sqltypes.MakeTestFields("name", "varchar"),
+		"foo", "bar", "baz")
+	result, err := vdxLookup.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	fp.ExpectLog(t, []string{`Execute from: type:TUPLE values:{type:INT64 value:"1"} false`})
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(10)`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
+	})
+	expectResult(t, result, wantRes)
+
+	fp.rewind()
+	vc.Rewind()
+	result, err = wrapStreamExecute(vdxLookup, vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(10)`,
+		`StreamExecuteMulti dummy_select ks.-20: {} `,
+	})
+	expectResult(t, result, wantRes)
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the bug with route with lookup vindex where Vindex Lookup operator on calling the Route was not truncating the output. 
This was missed for non-streaming execution mode.

Backport Reason: This is correctness issue with the query result output.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/16965

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
