### PR TITLE
Flakes: Address TestServerStats flakiness

### DIFF
--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -680,10 +680,10 @@ func TestServerStats(t *testing.T) {
 		return connCount.Get() == int64(0)
 	}, conditionWait, conditionTick, "connCount")
 	assert.Eventually(t, func() bool {
-		return connSlow.Get() == int64(0)
+		return connSlow.Get() == int64(1)
 	}, conditionWait, conditionTick, "connSlow")
 
-	assert.EqualValues(t, 0, connAccept.Get(), "connAccept")
+	assert.EqualValues(t, 1, connAccept.Get(), "connAccept")
 	assert.EqualValues(t, 0, connRefuse.Get(), "connRefuse")
 
 	expectedTimingDeltas := map[string]int64{


### PR DESCRIPTION
## Description

We have seen the `TestServerStats` unit test fail pretty regularly, in particular in the `unit_race` workflow. Example failure:
```
--- FAIL: TestServerStats (0.02s)
    server_test.go:265: listening on address '127.0.0.1' port 41297
    server_test.go:1363: Running mysql command: /usr/bin/mysql [-v -v -v -e error -h 127.0.0.1 -P 41297 -u user1 -ppassword1]
    server_test.go:670: 
        	Error Trace:	/opt/actions-runner/_work/vitess-private/vitess-private/go/mysql/server_test.go:670
        	Error:      	Not equal: 
        	            	expected: int(0)
        	            	actual  : int64(1)
        	Test:       	TestServerStats
        	Messages:   	connCount
```

I could not repeat the failure locally (despite trying many different methods), but in walking through the code it was clear that we had a potential race here. The race is this:
  - The test starts a mysql server component (to handle the mysql protocol and incoming client connections) and uses `mysql` cli invocations to connect and execute queries against this internal server
  - The server component accepts this incoming connection in `Accept`
    - And it starts a goroutine to handle this connection, after it's been accepted, in the `handle` function: https://github.com/vitessio/vitess/blob/dc692fa98fa36b65ce24e37dbe10222ce117fef0/go/mysql/server.go#L327-L359
  - The test immediately checked some stats that are changed in that `handle` function running in the goroutine, most notably `connCount` which is decremented in a defer: https://github.com/vitessio/vitess/blob/dc692fa98fa36b65ce24e37dbe10222ce117fef0/go/mysql/server.go#L390-L391

So in this PR we wait for the expected value to eliminate this race.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required