### PR TITLE
Remove mysql parameters from VTOrc setup

### DIFF
--- a/config/vtorc/default.json
+++ b/config/vtorc/default.json
@@ -1,8 +1,4 @@
 {
   "Debug": true,
-  "MySQLTopologyUser": "orc_client_user",
-  "MySQLTopologyPassword": "orc_client_user_password",
-  "MySQLReplicaUser": "vt_repl",
-  "MySQLReplicaPassword": "",
   "RecoveryPeriodBlockSeconds": 5
 }

--- a/examples/common/vtorc/config.json
+++ b/examples/common/vtorc/config.json
@@ -1,8 +1,4 @@
 {
-  "MySQLTopologyUser": "orc_client_user",
-  "MySQLTopologyPassword": "orc_client_user_password",
-  "MySQLReplicaUser": "vt_repl",
-  "MySQLReplicaPassword": "",
   "RecoveryPeriodBlockSeconds": 1,
   "InstancePollSeconds": 1
 }

--- a/examples/compose/vtorc-up.sh
+++ b/examples/compose/vtorc-up.sh
@@ -27,10 +27,6 @@ if [ $external = 1 ] ; then
     # This can be overridden by passing VTORC_CONFIG env variable
     echo "Updating $config..."
     cp /vt/vtorc/default.json /vt/vtorc/tmp.json
-    sed  -i '/MySQLTopologyUser/c\  \"MySQLTopologyUser\" : \"'"$DB_USER"'\",' /vt/vtorc/tmp.json
-    sed  -i '/MySQLTopologyPassword/c\  \"MySQLTopologyPassword\" : \"'"$DB_PASS"'\",' /vt/vtorc/tmp.json
-    sed  -i '/MySQLReplicaUser/c\  \"MySQLReplicaUser\" : \"'"$DB_USER"'\",' /vt/vtorc/tmp.json
-    sed  -i '/MySQLReplicaPassword/c\  \"MySQLReplicaPassword\" : \"'"$DB_PASS"'\",' /vt/vtorc/tmp.json
     cat /vt/vtorc/tmp.json
     cp /vt/vtorc/tmp.json /vt/vtorc/config.json
 else

--- a/examples/compose/vtorc/default.json
+++ b/examples/compose/vtorc/default.json
@@ -1,10 +1,6 @@
 {
   "Debug": true,
   "EnableSyslog": false,
-  "MySQLTopologyUser": "orc_client_user",
-  "MySQLTopologyPassword": "orc_client_user_password",
-  "MySQLReplicaUser": "vt_repl",
-  "MySQLReplicaPassword": "",
   "BackendDB": "sqlite",
   "SQLite3DataFile": "/tmp/vtorc.sqlite3",
   "RecoverMasterClusterFilters": ["*"],

--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -51,10 +51,6 @@ type VTOrcProcess struct {
 type VTOrcConfiguration struct {
 	Debug                                 bool
 	ListenAddress                         string
-	MySQLTopologyUser                     string
-	MySQLTopologyPassword                 string
-	MySQLReplicaUser                      string
-	MySQLReplicaPassword                  string
 	RecoveryPeriodBlockSeconds            int
 	TopologyRefreshSeconds                int    `json:",omitempty"`
 	PreventCrossDataCenterPrimaryFailover bool   `json:",omitempty"`
@@ -71,10 +67,6 @@ func (config *VTOrcConfiguration) ToJSONString() string {
 
 func (config *VTOrcConfiguration) AddDefaults(webPort int) {
 	config.Debug = true
-	config.MySQLTopologyUser = "orc_client_user"
-	config.MySQLTopologyPassword = "orc_client_user_password"
-	config.MySQLReplicaUser = "vt_repl"
-	config.MySQLReplicaPassword = ""
 	if config.RecoveryPeriodBlockSeconds == 0 {
 		config.RecoveryPeriodBlockSeconds = 1
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR cleans up the usage of MySQL parameters that were removed  a while ago from VTOrc. The test code was still setting them, but they're no longer required.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
