### PR TITLE
ReverseTraffic bug fix: allow reversing reads when only reads have been switched

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
+++ b/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
@@ -458,11 +458,11 @@ func splitShard(t *testing.T, keyspace, workflowName, sourceShards, targetShards
 	vdiff(t, keyspace, workflowName, "zone1", false, true, nil)
 
 	shardReadsRouteToSource := func() {
-		require.True(t, getShardRoute(t, keyspace, "-80", "primary"))
+		require.True(t, getShardRoute(t, keyspace, "-80", "replica"))
 	}
 
 	shardReadsRouteToTarget := func() {
-		require.True(t, getShardRoute(t, keyspace, "-40", "primary"))
+		require.True(t, getShardRoute(t, keyspace, "-40", "replica"))
 	}
 
 	shardWritesRouteToSource := func() {
@@ -486,27 +486,48 @@ func splitShard(t *testing.T, keyspace, workflowName, sourceShards, targetShards
 	shardWritesRouteToSource()
 
 	rs.SwitchReads()
+	shardReadsRouteToTarget()
+	shardWritesRouteToSource()
 
 	rs.ReverseReads()
+	shardReadsRouteToSource()
+	shardWritesRouteToSource()
 
 	rs.SwitchReadsAndWrites()
+	shardReadsRouteToTarget()
+	shardWritesRouteToTarget()
 
 	rs.ReverseReadsAndWrites()
+	shardReadsRouteToSource()
+	shardWritesRouteToSource()
 
 	rs.SwitchReadsAndWrites()
+	shardReadsRouteToTarget()
+	shardWritesRouteToTarget()
 
 	rs.ReverseReads()
+	shardReadsRouteToSource()
+	shardWritesRouteToTarget()
 
 	rs.ReverseWrites()
+	shardReadsRouteToSource()
+	shardWritesRouteToSource()
 
 	rs.SwitchReadsAndWrites()
+	shardReadsRouteToTarget()
+	shardWritesRouteToTarget()
 
 	rs.ReverseWrites()
+	shardReadsRouteToTarget()
+	shardWritesRouteToSource()
 
 	rs.ReverseReads()
+	shardReadsRouteToSource()
+	shardWritesRouteToSource()
 
 	rs.SwitchReadsAndWrites()
-	require.True(t, getShardRoute(t, keyspace, "-40", "primary"))
+	shardReadsRouteToTarget()
+	shardWritesRouteToTarget()
 
 	rs.Complete()
 }

--- a/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
+++ b/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
@@ -457,15 +457,33 @@ func splitShard(t *testing.T, keyspace, workflowName, sourceShards, targetShards
 	}
 	vdiff(t, keyspace, workflowName, "zone1", false, true, nil)
 
+	shardReadsRouteToSource := func() {
+		require.True(t, getShardRoute(t, keyspace, "-80", "primary"))
+	}
+
+	shardReadsRouteToTarget := func() {
+		require.True(t, getShardRoute(t, keyspace, "-40", "primary"))
+	}
+
+	shardWritesRouteToSource := func() {
+		require.True(t, getShardRoute(t, keyspace, "-80", "primary"))
+	}
+
+	shardWritesRouteToTarget := func() {
+		require.True(t, getShardRoute(t, keyspace, "-40", "primary"))
+	}
+
 	rs.SwitchReadsAndWrites()
 	waitForLowLag(t, keyspace, workflowName+"_reverse")
 	vdiff(t, keyspace, workflowName+"_reverse", "zone1", true, false, nil)
-	require.True(t, getShardRoute(t, keyspace, "-40", "primary"))
+	shardReadsRouteToTarget()
+	shardWritesRouteToTarget()
 
 	rs.ReverseReadsAndWrites()
 	waitForLowLag(t, keyspace, workflowName)
 	vdiff(t, keyspace, workflowName, "zone1", false, true, nil)
-	require.False(t, getShardRoute(t, keyspace, "-40", "primary"))
+	shardReadsRouteToSource()
+	shardWritesRouteToSource()
 
 	rs.SwitchReads()
 

--- a/go/test/endtoend/vreplication/wrappers_test.go
+++ b/go/test/endtoend/vreplication/wrappers_test.go
@@ -33,6 +33,8 @@ type iWorkflow interface {
 	SwitchReads()
 	SwitchWrites()
 	SwitchReadsAndWrites()
+	ReverseReads()
+	ReverseWrites()
 	ReverseReadsAndWrites()
 	Cancel()
 	Complete()
@@ -156,13 +158,26 @@ func (vmt *VtctlMoveTables) exec(action string) {
 	require.NoError(vmt.vc.t, err)
 }
 func (vmt *VtctlMoveTables) SwitchReads() {
-	// TODO implement me
-	panic("implement me")
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionSwitchTraffic, "replica,rdonly", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
 }
 
 func (vmt *VtctlMoveTables) SwitchWrites() {
-	// TODO implement me
-	panic("implement me")
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionSwitchTraffic, "primary", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
+}
+func (vmt *VtctlMoveTables) ReverseReads() {
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionReverseTraffic, "replica,rdonly", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
+}
+
+func (vmt *VtctlMoveTables) ReverseWrites() {
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionReverseTraffic, "primary", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
 }
 
 func (vmt *VtctlMoveTables) Cancel() {
@@ -259,6 +274,18 @@ func (v VtctldMoveTables) SwitchWrites() {
 	v.exec(args...)
 }
 
+func (v VtctldMoveTables) ReverseReads() {
+	args := []string{"ReverseTraffic", "--tablet-types=rdonly,replica"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
+}
+
+func (v VtctldMoveTables) ReverseWrites() {
+	args := []string{"ReverseTraffic", "--tablet-types=primary"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
+}
+
 func (v VtctldMoveTables) Cancel() {
 	v.exec("Cancel")
 }
@@ -321,6 +348,16 @@ func newReshard(vc *VitessCluster, rs *reshardWorkflow, flavor workflowFlavor) i
 
 type VtctlReshard struct {
 	*reshardWorkflow
+}
+
+func (vrs *VtctlReshard) ReverseReads() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (vrs *VtctlReshard) ReverseWrites() {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (vrs *VtctlReshard) Flavor() string {
@@ -449,13 +486,31 @@ func (v VtctldReshard) Show() {
 }
 
 func (v VtctldReshard) SwitchReads() {
-	// TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=rdonly,replica")
+	v.exec(args...)
 }
 
 func (v VtctldReshard) SwitchWrites() {
-	// TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=primary")
+	v.exec(args...)
+}
+
+func (v VtctldReshard) ReverseReads() {
+	args := []string{"ReverseTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=rdonly,replica")
+	v.exec(args...)
+}
+
+func (v VtctldReshard) ReverseWrites() {
+	args := []string{"ReverseTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=primary")
+	v.exec(args...)
 }
 
 func (v VtctldReshard) Cancel() {


### PR DESCRIPTION

## Description

There is a regression from `vtctl` to `vtctld` where, if only read traffic has been switched for a VReplication Workflow, attempting to reverse this switch errors out. If write traffic has also been switched it works fine. Reported here: https://github.com/vitessio/vitess/issues/16918.

The root cause is that, for a workflow which has been (partially) switched the code deduces the state from the reverse workflow, which is not created unless writes are switched.

Due to paucity of time, aiming to get this into the v21 release we start with a hackier interim fix in this PR.

This will be followed by a refactored implementation from: https://github.com/vitessio/vitess/pull/16920 which has some significant backports and can bake in v22.

This has been present from day 0, so we backport to all supported versions: patches for the older releases are expected in the next couple weeks.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/16918

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
