### PR TITLE
Add missing changelog for PR #16852

### DIFF
--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -23,6 +23,7 @@
     - **[Experimental MySQL 8.4 support](#experimental-mysql-84)**
     - **[Current Errant GTIDs Count Metric](#errant-gtid-metric)**
     - **[vtctldclient ChangeTabletTags](#vtctldclient-changetablettags)**
+    - **[Support for specifying expected primary in reparents](#reparents-expectedPrimary)
 
 
 ## <a id="major-changes"/>Major Changes</a>
@@ -234,3 +235,7 @@ This metric shows the current count of the errant GTIDs in the tablets.
 ### <a id="vtctldclient-changetablettags"/>`vtctldclient ChangeTabletTags` command
 
 The `vtctldclient` command `ChangeTabletTags` was added to allow the tags of a tablet to be changed dynamically.
+
+### <a id="reparents-expectedPrimary"/>Support specifying expected primary in reparents
+
+The `EmergencyReparentShard` and `PlannedReparentShard` commands and RPCs now support specifying a primary we expect to still be the current primary in order for a reparent operation to be processed. This allows reparents to be conditional on a specific state being true.

--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -23,7 +23,7 @@
     - **[Experimental MySQL 8.4 support](#experimental-mysql-84)**
     - **[Current Errant GTIDs Count Metric](#errant-gtid-metric)**
     - **[vtctldclient ChangeTabletTags](#vtctldclient-changetablettags)**
-    - **[Support for specifying expected primary in reparents](#reparents-expectedPrimary)
+    - **[Support for specifying expected primary in reparents](#reparents-expectedPrimary)**
 
 
 ## <a id="major-changes"/>Major Changes</a>

--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -23,7 +23,7 @@
     - **[Experimental MySQL 8.4 support](#experimental-mysql-84)**
     - **[Current Errant GTIDs Count Metric](#errant-gtid-metric)**
     - **[vtctldclient ChangeTabletTags](#vtctldclient-changetablettags)**
-    - **[Support for specifying expected primary in reparents](#reparents-expectedPrimary)**
+    - **[Support for specifying expected primary in reparents](#reparents-expectedprimary)**
 
 
 ## <a id="major-changes"/>Major Changes</a>
@@ -236,6 +236,6 @@ This metric shows the current count of the errant GTIDs in the tablets.
 
 The `vtctldclient` command `ChangeTabletTags` was added to allow the tags of a tablet to be changed dynamically.
 
-### <a id="reparents-expectedPrimary"/>Support specifying expected primary in reparents
+### <a id="reparents-expectedprimary"/>Support specifying expected primary in reparents
 
 The `EmergencyReparentShard` and `PlannedReparentShard` commands and RPCs now support specifying a primary we expect to still be the current primary in order for a reparent operation to be processed. This allows reparents to be conditional on a specific state being true.


### PR DESCRIPTION
## Description

This PR adds a missing v21 changelog for https://github.com/vitessio/vitess/pull/16852

cc @rohit-nayak-ps 

## Related Issue(s)

https://github.com/vitessio/vitess/pull/16852

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
