### PR TITLE
VDiff: Also generate default new UUID in VtctldServer VDiffCreate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,7 +77,7 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/vt/vttablet/*tmclient* @ajm188 @GuptaManan100 @rohit-nayak-ps @shlomi-noach
 /go/vt/vttablet/vexec @mattlord @rohit-nayak-ps @shlomi-noach
 /go/vt/wrangler @deepthi @mattlord @rohit-nayak-ps
-/go/vt/workflow @mattlord @rohit-nayak-ps
+/go/vt/vtctl/workflow @mattlord @rohit-nayak-ps
 /proto/ @deepthi @harshit-gangal
 /proto/vtadmin.proto @ajm188 @notfelineit @mattlord
 /proto/vtctldata.proto @ajm188 @notfelineit @mattlord


### PR DESCRIPTION
## Description

The vtctld client performed various input validations and handling for the [vdiff create command](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_vdiff/vtctldclient_vdiff_create/) here: https://github.com/vitessio/vitess/blob/e881b9f36d9adb497cd6bd8304bb3e2fa6fd69b9/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go#L95

People are, however, starting to use the `VtctldServer` RPCs directly rather than using `vtctldclient`. So specifically for the `VDiffCreate` RPC, we should do some of the defaults handling there. In this case we should generate a new UUID there if none was provided in the request. That's exactly what this PR does.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/17001

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required