### PR TITLE
fix: Infinite logs in case of non-existent stream logs

### DIFF
--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -863,8 +863,8 @@ ORDER BY
 
 					if stream.Id > streamLog.StreamId {
 						s.Logger().Warningf("Found stream log for nonexistent stream: %+v", streamLog)
-						// This can happen on manual/failed workflow cleanup so keep going.
-						continue
+						// This can happen on manual/failed workflow cleanup so move to the next log.
+						break
 					}
 
 					// stream.Id == streamLog.StreamId

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -1812,7 +1812,9 @@ func createReadVReplicationWorkflowFunc(t *testing.T, workflowType binlogdatapb.
 	}
 }
 
-func TestGetWorkflowsSingleStream(t *testing.T) {
+// Test checks that we don't include logs from non-existent streams in the result.
+// Ensures that we just skip the logs from non-existent streams and include the rest.
+func TestGetWorkflowsStreamLogs(t *testing.T) {
 	ctx := context.Background()
 
 	sourceKeyspace := "source_keyspace"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
In `GetWorkflows()` we use the following algo while collecting logs for a workflow.
We first sort all the streams of each shard by `streamID` in ASC order. Now, we call `fetchStreamLogs` for each workflow. Inside `fetchStreamLogs`, we fetch the streamLogs from each tablet. Now, we run a `for` loop across all the tablets we got from `results` (from query for fetching logs and results sorted by `streamID` in ASC order). Now, as we have already sorted the `shardStreams` by `streamID` and logs are also ordered by `streamID`, so we use a variable `streamIdx` which starts from 0. Now, we run a `for` loop across stream log results from that particular tablet (we got from the outer loop). In this loop, we update `streamIdx` in this code block:
```go
for streamIdx < len(streams) {
	stream := streams[streamIdx]
	if stream.Id < streamLog.StreamId {
		streamIdx++
		continue
	}

	if stream.Id > streamLog.StreamId {
		s.Logger().Warningf("Found stream log for nonexistent stream: %+v", streamLog)
		// This can happen on manual/failed workflow cleanup so keep going.
		continue
	}

	// stream.Id == streamLog.StreamId
	stream.Logs = append(stream.Logs, streamLog)
	break
}
```
So, basically if we increase the `streamIdx` (i.e. `streamIdx++` ) , the next `streamID` will be greater than the last one because we already sorted the streams of each shard. We can consider that `continue` in this loop means that we are finding the stream that matches the particular `streamLog.StreamID`, and break means jumping to next log. But, in the following condition:
```go
if stream.Id > streamLog.StreamId {
      s.Logger().Warningf("Found stream log for nonexistent stream: %+v", streamLog)
      // This can happen on manual/failed workflow cleanup so keep going.
      continue
}
```
Instead of jumping to the next log, we are continuing the search for matching `stream.Id` even when we know it's not possible to find it, because even if we increase the `streamIdx`, `stream.Id` will increase as the results are already sorted. This results in an infinite loop. Instead we should break the for loop and jump to the next log.

Failing Case: If the streamIDs are: 1, 2, 4, 6 and logs have streamIDs in this order: 1, 1, 1, 3, 3, 3, 4. Now, inside the loop when we are at log with streamID 3, right now we will be stuck. And, if we increase the `streamIdx` it won't be right, as we would already be at `stream.Id = 4` and  this will skip the logs for stream 4 and stream 6. But, if we break, we'll be accessing the next log, which would be the correct approach.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- Fixes #16195
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
