### PR TITLE
VReplication: Restore previous minimal e2e test behavior

### DIFF
--- a/go/test/endtoend/vreplication/movetables_mirrortraffic_test.go
+++ b/go/test/endtoend/vreplication/movetables_mirrortraffic_test.go
@@ -25,6 +25,14 @@ import (
 
 func testMoveTablesMirrorTraffic(t *testing.T, flavor workflowFlavor) {
 	setSidecarDBName("_vt")
+	ogReplicas := defaultReplicas
+	ogRdOnly := defaultRdonly
+	defer func() {
+		defaultReplicas = ogReplicas
+		defaultRdonly = ogRdOnly
+	}()
+	defaultRdonly = 0
+	defaultReplicas = 0
 	vc = setupMinimalCluster(t)
 	defer vc.TearDown()
 

--- a/go/test/endtoend/vreplication/partial_movetables_test.go
+++ b/go/test/endtoend/vreplication/partial_movetables_test.go
@@ -83,10 +83,13 @@ func testCancel(t *testing.T) {
 
 func testPartialMoveTablesBasic(t *testing.T, flavor workflowFlavor) {
 	setSidecarDBName("_vt")
+	origDefaultReplicas := defaultReplicas
 	origDefaultRdonly := defaultRdonly
 	defer func() {
+		defaultReplicas = origDefaultReplicas
 		defaultRdonly = origDefaultRdonly
 	}()
+	defaultReplicas = 0
 	defaultRdonly = 0
 	origExtraVTGateArgs := extraVTGateArgs
 	// We need to enable shard routing for partial movetables routing.

--- a/go/test/endtoend/vreplication/vdiff_online_ddl_test.go
+++ b/go/test/endtoend/vreplication/vdiff_online_ddl_test.go
@@ -23,13 +23,12 @@ func TestOnlineDDLVDiff(t *testing.T) {
 	setSidecarDBName("_vt")
 	originalRdonly := defaultRdonly
 	originalReplicas := defaultReplicas
-	defaultRdonly = 0
-	defaultReplicas = 0
 	defer func() {
 		defaultRdonly = originalRdonly
 		defaultReplicas = originalReplicas
 	}()
-
+	defaultRdonly = 0
+	defaultReplicas = 0
 	vc = setupMinimalCluster(t)
 	defer vc.TearDown()
 	keyspace := "product"

--- a/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
+++ b/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
@@ -46,10 +46,13 @@ import (
 func TestVtctldclientCLI(t *testing.T) {
 	setSidecarDBName("_vt")
 	var err error
+	origDefaultReplicas := defaultReplicas
 	origDefaultRdonly := defaultRdonly
 	defer func() {
+		defaultReplicas = origDefaultReplicas
 		defaultRdonly = origDefaultRdonly
 	}()
+	defaultReplicas = 1
 	defaultRdonly = 0
 	vc = setupMinimalCluster(t)
 	vttablet.InitVReplicationConfigDefaults()


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/pull/16920 we changed the behavior of the minimal cluster setup so that it went from using a hardcoded value of 0 for the `replica` and `rdonly` tablet counts, to instead using the default globals for that (`defaultReplicas`, `defaultRdonly`): https://github.com/vitessio/vitess/pull/16920/files#diff-127f033346a57c5e68aaa42072891ad18fca2bd1463eb16cd16a23f74b136576R942

When working on that PR I noticed that the buffering test started failing every time and the cause was that it now had replicas (and rdonly tablets) and they could not keep up with the load being generated against the primary. So (v)replication could not catch up in time and the `vdiff` did not finish before the 30s timeout. I addressed that in the PR here: https://github.com/vitessio/vitess/pull/16920/commits/a629cbbd62d6026ffe8a623dc1489215530fb775

What I didn't notice was that this minimal cluster behavior change also caused the `TestPartialMoveTablesBasic` test to become flaky (not failing every time, but ~ 50% as I watched the last test run on that PR and the subsequent backport PRs). The failures were caused by the same basic problem, we now had replication in place and the replicas could not catch up with the primary fast enough for the `vdiff` to complete before the 30s timeout we use in the tests. 

In this PR we explicitly ensure that the test behavior for users of the `setupMinimalCluster(t)` remains the same after the change noted from #16920 (the exception is `TestVtctldclientCLI` in which we explicitly *want* to have a replica tablet in each shard to test traffic switching). We should backport this to v21 as #16920 was backported to v21.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
