### PR TITLE
Flakes: Setup new fake server if it has gone away

### DIFF
--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -34,11 +34,10 @@ import (
 
 const clientCertUsername = "Client Cert"
 
-// The listener's accept loop actually only ends on a connection
+// The listener's Accept() loop actually only ends on a connection
 // error, which will occur when trying to connect after the listener
 // has been closed. So this function closes the listener and then
-// calls Connect to trigger the error which ends that conneciton
-// request handler goroutine.
+// calls Connect to trigger the error which ends that work.
 var cleanupListener = func(ctx context.Context, l *Listener, params *ConnParams) {
 	l.Close()
 	_, _ = Connect(ctx, params)

--- a/go/mysql/auth_server_static_test.go
+++ b/go/mysql/auth_server_static_test.go
@@ -137,6 +137,7 @@ func TestStaticConfigHUP(t *testing.T) {
 }
 
 func TestStaticConfigHUPWithRotation(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	tmpFile, err := os.CreateTemp("", "mysql_auth_server_static_file.json")
 	require.NoError(t, err, "couldn't create temp file: %v", err)
 	defer os.Remove(tmpFile.Name())

--- a/go/mysql/auth_server_static_test.go
+++ b/go/mysql/auth_server_static_test.go
@@ -37,6 +37,7 @@ func (a *AuthServerStatic) getEntries() map[string][]*AuthServerStaticEntry {
 }
 
 func TestJsonConfigParser(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	// works with legacy format
 	config := make(map[string][]*AuthServerStaticEntry)
 	jsonConfig := "{\"mysql_user\":{\"Password\":\"123\", \"UserData\":\"dummy\"}, \"mysql_user_2\": {\"Password\": \"123\", \"UserData\": \"mysql_user_2\"}}"
@@ -69,6 +70,7 @@ func TestJsonConfigParser(t *testing.T) {
 }
 
 func TestValidateHashGetter(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	jsonConfig := `{"mysql_user": [{"Password": "password", "UserData": "user.name", "Groups": ["user_group"]}]}`
 
 	auth := NewAuthServerStatic("", jsonConfig, 0)
@@ -92,6 +94,7 @@ func TestValidateHashGetter(t *testing.T) {
 }
 
 func TestHostMatcher(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	ip := net.ParseIP("192.168.0.1")
 	addr := &net.TCPAddr{IP: ip, Port: 9999}
 	match := MatchSourceHost(net.Addr(addr), "")
@@ -195,6 +198,7 @@ func hupTestWithRotation(t *testing.T, aStatic *AuthServerStatic, tmpFile *os.Fi
 }
 
 func TestStaticPasswords(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	jsonConfig := `
 {
 	"user01": [{ "Password": "user01" }],

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -61,12 +61,7 @@ func TestClearTextClientAuth(t *testing.T) {
 		SslMode: vttls.Disabled,
 	}
 	go l.Accept()
-	defer func() {
-		l.Close()
-		// The accept loop actually only ends on a connection error, which will
-		// occur when trying to connect after the listener has been closed.
-		_, _ = Connect(ctx, params)
-	}()
+	defer cleanupListener(ctx, l, params)
 
 	// Connection should fail, as server requires SSL for clear text auth.
 	_, err = Connect(ctx, params)
@@ -140,12 +135,7 @@ func TestSSLConnection(t *testing.T) {
 	}
 	l.TLSConfig.Store(serverConfig)
 	go l.Accept()
-	defer func() {
-		l.Close()
-		// The accept loop actually only ends on a connection error, which will
-		// occur when trying to connect after the listener has been closed.
-		_, _ = Connect(ctx, params)
-	}()
+	defer cleanupListener(ctx, l, params)
 
 	t.Run("Basics", func(t *testing.T) {
 		testSSLConnectionBasics(t, ctx, params)

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -37,6 +37,7 @@ import (
 // This file tests the handshake scenarios between our client and our server.
 
 func TestClearTextClientAuth(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
 	th := &testHandler{}
 
 	authServer := NewAuthServerStaticWithAuthMethodDescription("", "", 0, MysqlClearPassword)
@@ -51,10 +52,6 @@ func TestClearTextClientAuth(t *testing.T) {
 	defer l.Close()
 	host := l.Addr().(*net.TCPAddr).IP.String()
 	port := l.Addr().(*net.TCPAddr).Port
-	go func() {
-		l.Accept()
-	}()
-
 	// Setup the right parameters.
 	params := &ConnParams{
 		Host:    host,
@@ -63,9 +60,15 @@ func TestClearTextClientAuth(t *testing.T) {
 		Pass:    "password1",
 		SslMode: vttls.Disabled,
 	}
+	go l.Accept()
+	defer func() {
+		l.Close()
+		// The accept loop actually only ends on a connection error, which will
+		// occur when trying to connect after the listener has been closed.
+		_, _ = Connect(ctx, params)
+	}()
 
 	// Connection should fail, as server requires SSL for clear text auth.
-	ctx := context.Background()
 	_, err = Connect(ctx, params)
 	if err == nil || !strings.Contains(err.Error(), "Cannot use clear text authentication over non-SSL connections") {
 		t.Fatalf("unexpected connection error: %v", err)
@@ -92,6 +95,7 @@ func TestClearTextClientAuth(t *testing.T) {
 // TestSSLConnection creates a server with TLS support, a client that
 // also has SSL support, and connects them.
 func TestSSLConnection(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
 	th := &testHandler{}
 
 	authServer := NewAuthServerStaticWithAuthMethodDescription("", "", 0, MysqlClearPassword)
@@ -103,7 +107,6 @@ func TestSSLConnection(t *testing.T) {
 	// Create the listener, so we can get its host.
 	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false, false, 0, 0)
 	require.NoError(t, err, "NewListener failed: %v", err)
-	defer l.Close()
 	host := l.Addr().(*net.TCPAddr).IP.String()
 	port := l.Addr().(*net.TCPAddr).Port
 
@@ -122,12 +125,6 @@ func TestSSLConnection(t *testing.T) {
 		"",
 		tls.VersionTLS12)
 	require.NoError(t, err, "TLSServerConfig failed: %v", err)
-
-	l.TLSConfig.Store(serverConfig)
-	go func() {
-		l.Accept()
-	}()
-
 	// Setup the right parameters.
 	params := &ConnParams{
 		Host:  host,
@@ -141,20 +138,27 @@ func TestSSLConnection(t *testing.T) {
 		SslKey:     path.Join(root, "client-key.pem"),
 		ServerName: "server.example.com",
 	}
+	l.TLSConfig.Store(serverConfig)
+	go l.Accept()
+	defer func() {
+		l.Close()
+		// The accept loop actually only ends on a connection error, which will
+		// occur when trying to connect after the listener has been closed.
+		_, _ = Connect(ctx, params)
+	}()
 
 	t.Run("Basics", func(t *testing.T) {
-		testSSLConnectionBasics(t, params)
+		testSSLConnectionBasics(t, ctx, params)
 	})
 
 	// Make sure clear text auth works over SSL.
 	t.Run("ClearText", func(t *testing.T) {
-		testSSLConnectionClearText(t, params)
+		testSSLConnectionClearText(t, ctx, params)
 	})
 }
 
-func testSSLConnectionClearText(t *testing.T, params *ConnParams) {
+func testSSLConnectionClearText(t *testing.T, ctx context.Context, params *ConnParams) {
 	// Create a client connection, connect.
-	ctx := context.Background()
 	conn, err := Connect(ctx, params)
 	require.NoError(t, err, "Connect failed: %v", err)
 
@@ -170,9 +174,8 @@ func testSSLConnectionClearText(t *testing.T, params *ConnParams) {
 	conn.writeComQuit()
 }
 
-func testSSLConnectionBasics(t *testing.T, params *ConnParams) {
+func testSSLConnectionBasics(t *testing.T, ctx context.Context, params *ConnParams) {
 	// Create a client connection, connect.
-	ctx := context.Background()
 	conn, err := Connect(ctx, params)
 	require.NoError(t, err, "Connect failed: %v", err)
 

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestComBinlogDump(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	listener, sConn, cConn := createSocketPair(t)
 	defer func() {
 		listener.Close()

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/test/utils"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
@@ -72,6 +73,7 @@ func TestComBinlogDump(t *testing.T) {
 }
 
 func TestComBinlogDumpGTID(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	listener, sConn, cConn := createSocketPair(t)
 	defer func() {
 		listener.Close()
@@ -161,6 +163,7 @@ func TestComBinlogDumpGTID(t *testing.T) {
 }
 
 func TestSendSemiSyncAck(t *testing.T) {
+	_ = utils.LeakCheckContext(t)
 	listener, sConn, cConn := createSocketPair(t)
 	defer func() {
 		listener.Close()

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/utils"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 


### PR DESCRIPTION
## Description

We've had some flakiness in the `go/mysql` package's unit tests, but in particular with `TestTLSRequired`:
```
--- FAIL: TestTLSRequired (3.03s)
    server_test.go:1001: 
        	Error Trace:	go/mysql/server_test.go:1001
        	Error:      	"cannot send HandshakeResponse41: write tcp 127.0.0.1:33754->127.0.0.1:27379: write: connection reset by peer\nWrite(packet) failed\nconn 3 (errno 2013) (sqlstate HY000)" does not contain "remote error: tls: bad certificate"
        	Test:       	TestTLSRequired
```

That test is unique in the package in that it calls `Connect` multiple times. So we address that in this PR by adding handling for when the listener goes away for any reason.

In working on this, I also realized that these unit tests are all leaking goroutines. Which not only impacts the other tests in this package when they are run together, but impacts all tests that are run after it. So I added leak checker usage and plugged those leaks as well.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required