### PR TITLE
[Direct PR][release-21.0] Add RPC changes segment in the summary doc

### DIFF
--- a/changelog/21.0/21.0.0/summary.md
+++ b/changelog/21.0/21.0.0/summary.md
@@ -9,6 +9,7 @@
         - [Deprecated VTTablet Flags](#vttablet-flags)
         - [Deletion of deprecated metrics](#metric-deletion)
         - [Deprecated Metrics](#deprecations-metrics)
+    - **[RPC Changes](#rpc-changes)**
     - **[Traffic Mirroring](#traffic-mirroring)**
     - **[Atomic Distributed Transaction Support](#atomic-transaction)**
     - **[New VTGate Shutdown Behavior](#new-vtgate-shutdown-behavior)**
@@ -76,6 +77,12 @@ The following metrics are now deprecated and will be deleted in a future release
 | `vttablet` | `QueryCacheEvictions` | `QueryEnginePlanCacheEvictions` |
 | `vttablet` |   `QueryCacheHits`    |   `QueryEnginePlanCacheHits`    |
 | `vttablet` |  `QueryCacheMisses`   |  `QueryEnginePlanCacheMisses`   |
+
+### <a id="rpc-changes"/>RPC Changes</a>
+
+These are the RPC changes made in this release - 
+1. `ReadReparentJournalInfo` RPC has been added in TabletManagerClient interface, that is going to be used in EmergencyReparentShard for better errant GTID detection.
+2. `PrimaryStatus` RPC in TabletManagerClient interface has been updated to also return the server UUID of the primary. This is going to be used in the vttablets so that they can do their own errant GTID detection in `SetReplicationSource`.
 
 ### <a id="traffic-mirroring"/>Traffic Mirroring</a>
 


### PR DESCRIPTION
## Description

We think it's a good idea to also include a segment that just talks about the changes made to RPC calls in the release. This will help users see at a glance what RPCs have changed across different versions.

Diff of all services/proto changes b/w v20 and v21: https://gist.github.com/rohit-nayak-ps/ff70493906f84094e66f92262f9be842


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
