### PR TITLE
Relax vexplain test for upcoming changes

### DIFF
--- a/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
+++ b/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
@@ -53,7 +53,9 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 }
 
 func TestVtGateVExplain(t *testing.T) {
-	t.Skip("v22 changes the output of vexplain queries because of binary bind vars which breaks this test.")
+	if utils.BinaryIsAtLeastAtVersion(22, "vtgate") {
+		t.Skip("v22 changes the output of vexplain queries because of binary bind vars which breaks this test.")
+	}
 	conn, closer := start(t)
 	defer closer()
 

--- a/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
+++ b/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
@@ -53,6 +53,7 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 }
 
 func TestVtGateVExplain(t *testing.T) {
+	t.Skip("v22 changes the output of vexplain queries because of binary bind vars which breaks this test.")
 	conn, closer := start(t)
 	defer closer()
 


### PR DESCRIPTION
The fix in https://github.com/vitessio/vitess/pull/16988 makes a change here that's not really a breaking change, but it does break the test as the test matches the exact string output which changes here due to a binary value.

## Related Issue(s)

Needed for https://github.com/vitessio/vitess/pull/16988 which is a fix for https://github.com/vitessio/vitess/issues/16989. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
