### PR TITLE
VTAdmin: Support for multiple DataTable accessing same URL

### DIFF
--- a/web/vtadmin/src/components/dataTable/DataTable.tsx
+++ b/web/vtadmin/src/components/dataTable/DataTable.tsx
@@ -47,7 +47,7 @@ export const DataTable = <T extends object>({
     pageSize = DEFAULT_PAGE_SIZE,
     renderRows,
     title,
-    pageKey = "",
+    pageKey = '',
 }: Props<T>) => {
     const { pathname } = useLocation();
     const urlQuery = useURLQuery();

--- a/web/vtadmin/src/components/dataTable/DataTable.tsx
+++ b/web/vtadmin/src/components/dataTable/DataTable.tsx
@@ -31,6 +31,10 @@ interface Props<T> {
     pageSize?: number;
     renderRows: (rows: T[]) => JSX.Element[];
     title?: string;
+    // Pass a unique `pageKey` for each DataTable, in case multiple
+    // DataTables access the same URL. This will be used to
+    // access page number from the URL.
+    pageKey?: string;
 }
 
 // Generally, page sizes of ~100 rows are fine in terms of performance,
@@ -43,12 +47,15 @@ export const DataTable = <T extends object>({
     pageSize = DEFAULT_PAGE_SIZE,
     renderRows,
     title,
+    pageKey = "",
 }: Props<T>) => {
     const { pathname } = useLocation();
     const urlQuery = useURLQuery();
 
+    const pageQueryKey = `${pageKey}page`;
+
     const totalPages = Math.ceil(data.length / pageSize);
-    const { page } = useURLPagination({ totalPages });
+    const { page } = useURLPagination({ totalPages, pageQueryKey });
 
     const startIndex = (page - 1) * pageSize;
     const endIndex = startIndex + pageSize;
@@ -59,7 +66,7 @@ export const DataTable = <T extends object>({
 
     const formatPageLink = (p: number) => ({
         pathname,
-        search: stringify({ ...urlQuery.query, page: p === 1 ? undefined : p }),
+        search: stringify({ ...urlQuery.query, [pageQueryKey]: p === 1 ? undefined : p }),
     });
 
     return (

--- a/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
@@ -276,6 +276,7 @@ export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: 
                 renderRows={renderSummaryRows}
                 pageSize={1}
                 title="Summary"
+                pageKey='summary'
             />
             <span id="workflowStreams"></span>
             <DataTable
@@ -284,6 +285,7 @@ export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: 
                 renderRows={renderStreamRows}
                 pageSize={10}
                 title="Streams"
+                pageKey='streams'
             />
             {tableCopyStates && (
                 <DataTable
@@ -292,6 +294,7 @@ export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: 
                     renderRows={renderTableCopyStateRows}
                     pageSize={1000}
                     title="Table Copy State"
+                    pageKey='tableCopyState'
                 />
             )}
             <h3 className="mt-8 mb-4">Recent Logs</h3>
@@ -304,6 +307,7 @@ export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: 
                             renderRows={renderLogRows}
                             pageSize={10}
                             title={stream.key!}
+                            pageKey={`${formatAlias(stream.tablet)}${stream.id}`}
                         />
                     </div>
                 ))

--- a/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
@@ -276,7 +276,7 @@ export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: 
                 renderRows={renderSummaryRows}
                 pageSize={1}
                 title="Summary"
-                pageKey='summary'
+                pageKey="summary"
             />
             <span id="workflowStreams"></span>
             <DataTable
@@ -285,7 +285,7 @@ export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: 
                 renderRows={renderStreamRows}
                 pageSize={10}
                 title="Streams"
-                pageKey='streams'
+                pageKey="streams"
             />
             {tableCopyStates && (
                 <DataTable
@@ -294,7 +294,7 @@ export const WorkflowDetails = ({ clusterID, keyspace, name, refetchInterval }: 
                     renderRows={renderTableCopyStateRows}
                     pageSize={1000}
                     title="Table Copy State"
-                    pageKey='tableCopyState'
+                    pageKey="tableCopyState"
                 />
             )}
             <h3 className="mt-8 mb-4">Recent Logs</h3>

--- a/web/vtadmin/src/components/routes/workflow/WorkflowVDiff.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowVDiff.tsx
@@ -83,7 +83,7 @@ export const WorkflowVDiff = ({ clusterID, keyspace, name }: Props) => {
 
     const isStatusEmpty =
         !lastVDiffStatus ||
-        (Object.keys(lastVDiffStatus.shard_report).length === 1 &&
+        (Object.keys(lastVDiffStatus.shard_report).length > 0 &&
             !lastVDiffStatus.shard_report[Object.keys(lastVDiffStatus.shard_report)[0]].state);
 
     const renderRows = (rows: typeof shardReports) => {

--- a/web/vtadmin/src/hooks/useURLPagination.ts
+++ b/web/vtadmin/src/hooks/useURLPagination.ts
@@ -20,6 +20,7 @@ import { useURLQuery } from './useURLQuery';
 
 export interface PaginationOpts {
     totalPages: number;
+    pageQueryKey?: string;
 }
 
 export interface PaginationParams {
@@ -35,7 +36,7 @@ const FIRST_PAGE = 1;
  * 	- use pagination in some way
  * 	- encode pagination state in the URL (e.g., /some/route?page=123)
  */
-export const useURLPagination = ({ totalPages }: PaginationOpts): PaginationParams => {
+export const useURLPagination = ({ totalPages, pageQueryKey = "page" }: PaginationOpts): PaginationParams => {
     const history = useHistory();
     const location = useLocation();
     const { query, replaceQuery } = useURLQuery({ parseNumbers: true });
@@ -43,7 +44,7 @@ export const useURLPagination = ({ totalPages }: PaginationOpts): PaginationPara
     // A slight nuance here -- if `page` is not in the URL at all, then we can assume
     // it's the first page. This makes for slightly nicer URLs for the first/default page:
     // "/foo" instead of "/foo?page=1". No redirect required.
-    const page = !('page' in query) || query.page === null ? FIRST_PAGE : query.page;
+    const page = !(pageQueryKey in query) || query[pageQueryKey] === null ? FIRST_PAGE : query[pageQueryKey];
 
     useEffect(() => {
         // If the value in the URL *is* defined but is negative, non-numeric,
@@ -53,9 +54,9 @@ export const useURLPagination = ({ totalPages }: PaginationOpts): PaginationPara
 
         if (isPageTooBig || isPageTooSmall || typeof page !== 'number') {
             // Replace history so the invalid value is not persisted in browser history
-            replaceQuery({ page: FIRST_PAGE });
+            replaceQuery({ [pageQueryKey]: FIRST_PAGE });
         }
-    }, [page, totalPages, history, location.pathname, query, replaceQuery]);
+    }, [page, pageQueryKey, totalPages, history, location.pathname, query, replaceQuery]);
 
     return {
         page,

--- a/web/vtadmin/src/hooks/useURLPagination.ts
+++ b/web/vtadmin/src/hooks/useURLPagination.ts
@@ -36,7 +36,7 @@ const FIRST_PAGE = 1;
  * 	- use pagination in some way
  * 	- encode pagination state in the URL (e.g., /some/route?page=123)
  */
-export const useURLPagination = ({ totalPages, pageQueryKey = "page" }: PaginationOpts): PaginationParams => {
+export const useURLPagination = ({ totalPages, pageQueryKey = 'page' }: PaginationOpts): PaginationParams => {
     const history = useHistory();
     const location = useLocation();
     const { query, replaceQuery } = useURLQuery({ parseNumbers: true });


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
`DataTable`(s) on workflow details tab have broken pagination. Every `DataTable` accessed the same query parameter from URL i.e. `page` to set and retrieve the current page number of `DataTable`. It was implemented in such a way that only a single `DataTable` should access the URL parameters at a time. 

This PR fixes this issue by customising the URL parameter used by each `DataTable`. While using multiple `DataTable` in a component, pass on an optional unique prop `pageKey` if we expect multiple `DataTable` using the same URL. Each `DataTable` will use a query parameter for fetching/modifying the page number based on it's own unique passed prop `pageKey`.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #11690
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
