### PR TITLE
Use proper zstd decoder pool for binlog event compression handling

### DIFF
--- a/go/mysql/binlog_event_compression.go
+++ b/go/mysql/binlog_event_compression.go
@@ -364,7 +364,7 @@ func (dp *decoderPool) Get(reader io.Reader) (*zstd.Decoder, error) {
 	} else {
 		d, err := zstd.NewReader(nil, zstd.WithDecoderMaxMemory(zstdInMemoryDecompressorMaxSize))
 		if err != nil { // Should only happen e.g. due to ENOMEM
-			return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "failed to create stateful stream decoder")
+			return nil, vterrors.Wrap(err, "failed to create stateful stream decoder")
 		}
 		decoder = d
 	}

--- a/go/mysql/binlog_event_compression_test.go
+++ b/go/mysql/binlog_event_compression_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mysql
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecoderPool(t *testing.T) {
+	type args struct {
+		r io.Reader
+	}
+	tests := []struct {
+		name    string
+		reader  io.Reader
+		wantErr bool
+	}{
+		{
+			name:   "happy path",
+			reader: bytes.NewReader([]byte{0x68, 0x61, 0x70, 0x70, 0x79}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoder, err := statefulDecoderPool.Get(tt.reader)
+			require.NoError(t, err)
+			require.NotNil(t, decoder)
+			require.IsType(t, &zstd.Decoder{}, decoder)
+			statefulDecoderPool.Put(decoder)
+			decoder2, err := statefulDecoderPool.Get(tt.reader)
+			require.NoError(t, err)
+			require.NotNil(t, decoder2)
+			require.IsType(t, &zstd.Decoder{}, decoder)
+			statefulDecoderPool.Put(decoder)
+			require.True(t, (decoder2 == decoder))
+			statefulDecoderPool.Put(decoder2)
+			decoder3, err := statefulDecoderPool.Get(tt.reader)
+			require.NoError(t, err)
+			require.IsType(t, &zstd.Decoder{}, decoder)
+			statefulDecoderPool.Put(decoder)
+			require.True(t, (decoder3 == decoder2))
+		})
+	}
+}

--- a/go/mysql/binlog_event_compression_test.go
+++ b/go/mysql/binlog_event_compression_test.go
@@ -44,7 +44,7 @@ func TestDecoderPool(t *testing.T) {
 			// It's not guaranteed that we get the same decoder back from the pool
 			// that we just put in, so we use a loop and ensure that it worked at
 			// least one of the times. Without doing this the test would be flaky.
-			used := false
+			poolingUsed := false
 
 			for i := 0; i < 20; i++ {
 				decoder, err := statefulDecoderPool.Get(tt.reader)
@@ -56,9 +56,9 @@ func TestDecoderPool(t *testing.T) {
 				decoder2, err := statefulDecoderPool.Get(tt.reader)
 				require.NoError(t, err)
 				require.NotNil(t, decoder2)
-				require.IsType(t, &zstd.Decoder{}, decoder)
+				require.IsType(t, &zstd.Decoder{}, decoder2)
 				if decoder2 == decoder {
-					used = true
+					poolingUsed = true
 				}
 				statefulDecoderPool.Put(decoder2)
 
@@ -67,12 +67,12 @@ func TestDecoderPool(t *testing.T) {
 				require.NotNil(t, &zstd.Decoder{}, decoder3)
 				require.IsType(t, &zstd.Decoder{}, decoder3)
 				if decoder3 == decoder || decoder3 == decoder2 {
-					used = true
+					poolingUsed = true
 				}
-				statefulDecoderPool.Put(decoder)
+				statefulDecoderPool.Put(decoder3)
 			}
 
-			require.True(t, used)
+			require.True(t, poolingUsed)
 		})
 	}
 }


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/vitessio/vitess/pull/16328. There we added usage of `sync.Pool`, however when putting the object back in the pool we used the wrong pool. Instead of using [the `statelessDocoderPool`](https://github.com/vitessio/vitess/blob/03b93a1e3b4cb2300c533832cc43e30b24d36106/go/mysql/binlog_event_compression.go#L84-L109) we were using another `sync.Pool` instance that also existed in the package: [`readersPool`](https://github.com/planetscale/vitess/blob/4522a0ad8930f3556627ec1ebbe69103f3b0fc01/go/mysql/conn.go#L247).

This caused the  `statelessDocoderPool` to NOT be used, but worse than that it could cause a panic when the `readersPool` was used here IF [`--mysql-server-pool-conn-read-buffers`](https://github.com/vitessio/vitess/blob/03b93a1e3b4cb2300c533832cc43e30b24d36106/go/vt/vtgate/plugin_mysql_server.go#L102) was set (defaults to false): https://github.com/planetscale/vitess/blob/4522a0ad8930f3556627ec1ebbe69103f3b0fc01/go/mysql/conn.go#L290-L292

We should backport this to v21 as that's the first release that contains https://github.com/vitessio/vitess/pull/16328.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/17044

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required