### PR TITLE
[Direct PR] [release-18.0] Remove sql changes from `schemacopy`

### DIFF
--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -454,6 +454,18 @@ func TestSchemaDiff(t *testing.T) {
 			expectDeps:       1,
 			conflictingDiffs: 2,
 		},
+		{
+			name: "two identical tables, one with explicit charset, one without",
+			fromQueries: []string{
+				"create table t1 (id int primary key, foo varchar(64) character set utf8mb3 collate utf8mb3_bin)",
+			},
+			toQueries: []string{
+				"create table t1 (id int primary key, foo varchar(64) collate utf8mb3_bin)",
+			},
+			// This isn't strictly correct. We have a diff even though there shouldn't be one.
+			expectDiffs: 1,
+			entityOrder: []string{"t1"},
+		},
 
 		// FKs
 		{

--- a/go/vt/sidecardb/schema/schematracker/schemacopy.sql
+++ b/go/vt/sidecardb/schema/schematracker/schemacopy.sql
@@ -16,13 +16,13 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS schemacopy
 (
-    `table_schema`          varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
-    `table_name`            varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
-    `column_name`           varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci  NOT NULL,
-    `ordinal_position`      bigint unsigned                                               NOT NULL,
-    `character_set_name`    varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci  DEFAULT NULL,
-    `collation_name`        varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci  DEFAULT NULL,
-    `data_type`             varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
-    `column_key`            varchar(3)  CHARACTER SET utf8mb3 COLLATE utf8mb3_bin         NOT NULL,
+    `table_schema`       varchar(64)     NOT NULL,
+    `table_name`         varchar(64)     NOT NULL,
+    `column_name`        varchar(64)     NOT NULL,
+    `ordinal_position`   bigint unsigned NOT NULL,
+    `character_set_name` varchar(32) DEFAULT NULL,
+    `collation_name`     varchar(32) DEFAULT NULL,
+    `data_type`          varchar(64)     NOT NULL,
+    `column_key`         varchar(3)      NOT NULL,
     PRIMARY KEY (`table_schema`, `table_name`, `ordinal_position`)
-) ENGINE = InnoDB, CHARACTER SET = utf8mb3
+) ENGINE = InnoDB


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR is fixing an issue we saw while running v18 in production. With the changes to the SQL made in #15859, we are seeing that ever iteration of syncSideCarDB is finding a schema diff and running it - 
```
Applying DDL for table schemacopy:
ALTER TABLE `schemacopy` MODIFY COLUMN `table_schema` varchar(64) COLLATE utf8mb3_bin NOT NULL, MODIFY COLUMN `table_name` varchar(64) COLLATE utf8mb3_bin NOT NULL, MODIFY COLUMN `column_name` varchar(64) NOT NULL, MODIFY COLUMN `character_set_name` varchar(32), MODIFY COLUMN `collation_name` varchar(32), MODIFY COLUMN `data_type` varchar(64) COLLATE utf8mb3_bin NOT NULL, MODIFY COLUMN `column_key` varchar(3) COLLATE utf8mb3_bin NOT NULL, ALGORITHM = COPY
```

This is because the schema diff code doesn't handle collations and charsets correctly. I've added a test for that assertion too. Moreover, in the PR #15859, we already changed how we read the data from `schemacopy` so it doesn't look like the SQL changes there are required. They are being reverted in this PR.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
