### PR TITLE
Only run sidecardb change detection on serving primary tablets

### DIFF
--- a/go/test/endtoend/vreplication/sidecardb_test.go
+++ b/go/test/endtoend/vreplication/sidecardb_test.go
@@ -91,7 +91,7 @@ func TestSidecarDB(t *testing.T) {
 
 		prs(t, keyspace, shard)
 		currentPrimary = tablet101
-		expectedChanges100 += numChanges
+		expectedChanges101 += numChanges
 		validateSidecarDBTables(t, tablet100, sidecarDBTables)
 		validateSidecarDBTables(t, tablet101, sidecarDBTables)
 		require.Equal(t, expectedChanges100, getNumExecutedDDLQueries(t, tablet100Port))
@@ -100,7 +100,7 @@ func TestSidecarDB(t *testing.T) {
 
 	t.Run("modify schema, prs, and self heal on new primary", func(t *testing.T) {
 		numChanges := modifySidecarDBSchema(t, vc, currentPrimary, ddls1)
-		expectedChanges101 += numChanges
+		expectedChanges100 += numChanges
 		prs(t, keyspace, shard)
 		// nolint
 		currentPrimary = tablet100

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -42,6 +42,7 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
@@ -94,6 +95,19 @@ func TestOpenAndReload(t *testing.T) {
 	mustMatch(t, want, se.GetSchema())
 	assert.Equal(t, int64(0), se.tableFileSizeGauge.Counts()["msg"])
 	assert.Equal(t, int64(0), se.tableAllocatedSizeGauge.Counts()["msg"])
+
+	t.Run("EnsureConnectionAndDB", func(t *testing.T) {
+		// Verify that none of the following configurations run any schema change detection queries -
+		// 1. REPLICA serving
+		// 2. REPLICA non-serving
+		// 3. PRIMARY serving
+		err := se.EnsureConnectionAndDB(topodatapb.TabletType_REPLICA, true)
+		require.NoError(t, err)
+		err = se.EnsureConnectionAndDB(topodatapb.TabletType_PRIMARY, false)
+		require.NoError(t, err)
+		err = se.EnsureConnectionAndDB(topodatapb.TabletType_REPLICA, false)
+		require.NoError(t, err)
+	})
 
 	// Advance time some more.
 	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
@@ -626,8 +640,10 @@ func newEngine(reloadTime time.Duration, idleTimeout time.Duration, schemaMaxAge
 	cfg.OlapReadPool.IdleTimeout = idleTimeout
 	cfg.TxPool.IdleTimeout = idleTimeout
 	cfg.SchemaVersionMaxAgeSeconds = schemaMaxAgeSeconds
+	dbConfigs := newDBConfigs(db)
+	cfg.DB = dbConfigs
 	se := NewEngine(tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "SchemaTest"))
-	se.InitDBConfig(newDBConfigs(db).DbaWithDB())
+	se.InitDBConfig(dbConfigs.DbaWithDB())
 	return se
 }
 

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -140,7 +140,7 @@ type stateManager struct {
 
 type (
 	schemaEngine interface {
-		EnsureConnectionAndDB(topodatapb.TabletType) error
+		EnsureConnectionAndDB(topodatapb.TabletType, bool) error
 		Open() error
 		MakeNonPrimary()
 		MakePrimary(bool)
@@ -447,7 +447,7 @@ func (sm *stateManager) verifyTargetLocked(ctx context.Context, target *querypb.
 func (sm *stateManager) servePrimary() error {
 	sm.watcher.Close()
 
-	if err := sm.connect(topodatapb.TabletType_PRIMARY); err != nil {
+	if err := sm.connect(topodatapb.TabletType_PRIMARY, true); err != nil {
 		return err
 	}
 
@@ -476,7 +476,7 @@ func (sm *stateManager) unservePrimary() error {
 
 	sm.watcher.Close()
 
-	if err := sm.connect(topodatapb.TabletType_PRIMARY); err != nil {
+	if err := sm.connect(topodatapb.TabletType_PRIMARY, false); err != nil {
 		return err
 	}
 
@@ -500,7 +500,7 @@ func (sm *stateManager) serveNonPrimary(wantTabletType topodatapb.TabletType) er
 	sm.se.MakeNonPrimary()
 	sm.hs.MakeNonPrimary()
 
-	if err := sm.connect(wantTabletType); err != nil {
+	if err := sm.connect(wantTabletType, true); err != nil {
 		return err
 	}
 
@@ -518,7 +518,7 @@ func (sm *stateManager) unserveNonPrimary(wantTabletType topodatapb.TabletType) 
 	sm.se.MakeNonPrimary()
 	sm.hs.MakeNonPrimary()
 
-	if err := sm.connect(wantTabletType); err != nil {
+	if err := sm.connect(wantTabletType, false); err != nil {
 		return err
 	}
 
@@ -528,8 +528,8 @@ func (sm *stateManager) unserveNonPrimary(wantTabletType topodatapb.TabletType) 
 	return nil
 }
 
-func (sm *stateManager) connect(tabletType topodatapb.TabletType) error {
-	if err := sm.se.EnsureConnectionAndDB(tabletType); err != nil {
+func (sm *stateManager) connect(tabletType topodatapb.TabletType, serving bool) error {
+	if err := sm.se.EnsureConnectionAndDB(tabletType, serving); err != nil {
 		return err
 	}
 	if err := sm.se.Open(); err != nil {

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -809,7 +809,7 @@ type testSchemaEngine struct {
 	failMySQL bool
 }
 
-func (te *testSchemaEngine) EnsureConnectionAndDB(tabletType topodatapb.TabletType) error {
+func (te *testSchemaEngine) EnsureConnectionAndDB(topodatapb.TabletType, bool) error {
 	if te.failMySQL {
 		te.failMySQL = false
 		return errors.New("intentional error")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
We noticed that the sidecardb logic to detect schema changes in vitess internal tables is running on both the transitions of going to primary serving and primary non-serving. We think it would be a good idea to only do this when a primary is transitioning to serving state. A couple of reasons for it - 
1. `DemotePrimary` is already quite a heavy operation that sometimes times out, so we shouldn't do more work on this call.
2. If a primary tablet already applied the DDL changes when it went into serving state, then there should be no DDLs pending to be applied when it demoting itself. The check for finding the schema diff is therefore wasted effort at that point.
3. In `EmergencyReparentShard`, we demote the primary in parallel with stopping replication on replicas. This means that if even if there were to happen a DDL, the query could just theoretically block on semi-sync (it is a race), and that would fail `DemotePrimary` too.

This PR makes the change of passing in the desired serving state that we are transitioning to and makes the sidecardb code only run for serving primary transitions.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/17060

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
