### PR TITLE
bugfix: treat EXPLAIN like SELECT

### DIFF
--- a/go/vt/vttablet/endtoend/queries_test.go
+++ b/go/vt/vttablet/endtoend/queries_test.go
@@ -122,6 +122,20 @@ var TestQueryCases = []framework.Testable{
 		RowsReturned: 1,
 	},
 	&framework.TestCase{
+		Name:  "explain with bindvars",
+		Query: "explain select :__vtudvp as `@p` from dual",
+		BindVars: map[string]*querypb.BindVariable{
+			"__vtudvp": sqltypes.Int64BindVariable(1),
+		},
+		Result: [][]string{
+			{"1", "SIMPLE", "", "", "", "", "", "", "", "", "", "No tables used"},
+		},
+		Rewritten: []string{
+			"explain select 1 as `@p` from dual",
+		},
+		RowsReturned: 1,
+	},
+	&framework.TestCase{
 		Name:  "limit",
 		Query: "select /* limit */ eid, id from vitess_a limit :a",
 		BindVars: map[string]*querypb.BindVariable{

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -231,7 +231,12 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 	case *sqlparser.Show:
 		plan, err = analyzeShow(stmt, dbName)
 	case *sqlparser.Analyze, sqlparser.Explain:
-		plan = &Plan{PlanID: PlanOtherRead}
+		// Analyze and Explain are treated as read-only queries.
+		// We send down a string, and get a table result back.
+		plan = &Plan{
+			PlanID:    PlanSelect,
+			FullQuery: GenerateFullQuery(stmt),
+		}
 	case *sqlparser.OtherAdmin:
 		plan = &Plan{PlanID: PlanOtherAdmin}
 	case *sqlparser.Savepoint:

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -763,14 +763,15 @@ options:PassthroughDMLs
 # analyze
 "analyze table a"
 {
-  "PlanID": "OtherRead",
+  "PlanID": "Select",
   "TableName": "",
   "Permissions": [
-      {
-        "TableName": "a",
-        "Role": 1
-      }
-  ]
+    {
+      "TableName": "a",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "analyze table a"
 }
 
 # show
@@ -783,15 +784,17 @@ options:PassthroughDMLs
 # describe
 "describe a"
 {
-  "PlanID": "OtherRead",
-  "TableName": ""
+  "PlanID": "Select",
+  "TableName": "",
+  "FullQuery": "explain a"
 }
 
 # explain
 "explain a"
 {
-  "PlanID": "OtherRead",
-  "TableName": ""
+  "PlanID": "Select",
+  "TableName": "",
+  "FullQuery": "explain a"
 }
 
 # repair


### PR DESCRIPTION
## Description
This PR fixes an issue in the tablet server where bind variables (bindvars) were not correctly handled in EXPLAIN queries. Queries such as:

```sql
EXPLAIN SELECT @p
``` 

were being sent with placeholders (e.g., `:__udvp`) still present, leading to a syntax error on MySQL, since our bindvar syntax is not compatible with MySQL’s native syntax.

## Related Issue(s)
Fixes #17053

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
