### PR TITLE
Backups: Relax commit order preservation during restore

### DIFF
--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -244,3 +244,14 @@ func ReadMycnf(mycnf *Mycnf, waitTime time.Duration) (*Mycnf, error) {
 
 	return mycnf, nil
 }
+
+// SetServerParam can be used *after* ReadMycnf() is called to
+// customize the base configuration in the file with additional
+// settings that are applicable to a specific scenario such as
+// doing a backup restore.
+// This is NOT concurrent safe with, together with ReadMycnf() or
+// alone.
+func (cnf *Mycnf) SetServerParam(key, val string) {
+	key = normKey([]byte(key))
+	cnf.mycnfMap[key] = val
+}


### PR DESCRIPTION
## Description

Testing potential restore performance improvements, starting with setting [`replica_preserve_commit_order=OFF`](https://dev.mysql.com/doc/refman/8.4/en/replication-options-replica.html#sysvar_replica_preserve_commit_order)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required