### PR TITLE
fix: flaky test on twopc transaction

### DIFF
--- a/go/test/endtoend/transaction/twopc/main_test.go
+++ b/go/test/endtoend/transaction/twopc/main_test.go
@@ -227,23 +227,20 @@ func getStatement(stmt string) string {
 }
 
 func runVStream(t *testing.T, ctx context.Context, ch chan *binlogdatapb.VEvent, vtgateConn *vtgateconn.VTGateConn) {
-	vgtid := &binlogdatapb.VGtid{
-		ShardGtids: []*binlogdatapb.ShardGtid{
-			{Keyspace: keyspaceName, Shard: "-40", Gtid: "current"},
-			{Keyspace: keyspaceName, Shard: "40-80", Gtid: "current"},
-			{Keyspace: keyspaceName, Shard: "80-", Gtid: "current"},
-		}}
-	filter := &binlogdatapb.Filter{
-		Rules: []*binlogdatapb.Rule{{
-			Match: "/.*/",
-		}},
+	shards := []string{"-40", "40-80", "80-"}
+	shardGtids := make([]*binlogdatapb.ShardGtid, 0, len(shards))
+	var seen = make(map[string]bool, len(shards))
+	var wg sync.WaitGroup
+	for _, shard := range shards {
+		shardGtids = append(shardGtids, &binlogdatapb.ShardGtid{Keyspace: keyspaceName, Shard: shard, Gtid: "current"})
+		seen[shard] = false
+		wg.Add(1)
 	}
+	vgtid := &binlogdatapb.VGtid{ShardGtids: shardGtids}
+	filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{{Match: "/.*/"}}}
+
 	vReader, err := vtgateConn.VStream(ctx, topodatapb.TabletType_PRIMARY, vgtid, filter, nil)
 	require.NoError(t, err)
-
-	// Use a channel to signal that the first VGTID event has been processed
-	firstEventProcessed := make(chan struct{})
-	var once sync.Once
 
 	go func() {
 		for {
@@ -254,9 +251,12 @@ func runVStream(t *testing.T, ctx context.Context, ch chan *binlogdatapb.VEvent,
 			require.NoError(t, err)
 
 			for _, ev := range evs {
-				// Signal the first event has been processed using sync.Once
+				// Mark VGTID event from each shard seen.
 				if ev.Type == binlogdatapb.VEventType_VGTID {
-					once.Do(func() { close(firstEventProcessed) })
+					if !seen[ev.Shard] {
+						seen[ev.Shard] = true
+						wg.Done()
+					}
 				}
 				if ev.Type == binlogdatapb.VEventType_ROW || ev.Type == binlogdatapb.VEventType_FIELD {
 					ch <- ev
@@ -265,8 +265,8 @@ func runVStream(t *testing.T, ctx context.Context, ch chan *binlogdatapb.VEvent,
 		}
 	}()
 
-	// Wait for the first event to be processed
-	<-firstEventProcessed
+	// Wait for VGTID event from all shards
+	wg.Wait()
 }
 
 func retrieveTransitions(t *testing.T, ch chan *binlogdatapb.VEvent, tableMap map[string][]*querypb.Field, dtMap map[string]string) map[string][]string {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the flaky test issue with twopc transactions test.
It now waits for vstream from all the shards before proceeding with the test case.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
