### PR TITLE
Improve efficiency of `vtorc` topo calls 

### DIFF
--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -99,6 +99,7 @@ Flags:
       --topo_global_root string                                     the path of the global topology data in the global topology server
       --topo_global_server_address string                           the address of the global topology server
       --topo_implementation string                                  the topology implementation to use
+      --topo_read_concurrency int                                   Concurrency of topo reads. (default 32)
       --topo_zk_auth_file string                                    auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                               zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                 maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -57,6 +57,7 @@ func init() {
 	servenv.OnParseFor("vtcombo", registerFlags)
 	servenv.OnParseFor("vtctld", registerFlags)
 	servenv.OnParseFor("vtgate", registerFlags)
+	servenv.OnParseFor("vtorc", registerFlags)
 }
 
 // KeyspaceInfo is a meta struct that contains metadata to give the

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -28,20 +28,20 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/constants/sidecar"
-	"vitess.io/vitess/go/protoutil"
-	"vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/vterrors"
+	"golang.org/x/sync/errgroup"
 
+	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/event"
+	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/topo/events"
 	"vitess.io/vitess/go/vt/topo/topoproto"
-
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 const (
@@ -614,6 +614,71 @@ func (ts *Server) FindAllTabletAliasesInShardByCell(ctx context.Context, keyspac
 	}
 	sort.Sort(topoproto.TabletAliasList(result))
 	return result, err
+}
+
+// GetTabletsByShard returns the tablets in the given shard using all cells.
+// It can return ErrPartialResult if it couldn't read all the cells, or all
+// the individual tablets, in which case the result is valid, but partial.
+func (ts *Server) GetTabletsByShard(ctx context.Context, keyspace, shard string) ([]*TabletInfo, error) {
+	return ts.GetTabletsByShardCell(ctx, keyspace, shard, nil)
+}
+
+// GetTabletsByShardCell returns the tablets in the given shard. It can return
+// ErrPartialResult if it couldn't read all the cells, or all the individual
+// tablets, in which case the result is valid, but partial.
+func (ts *Server) GetTabletsByShardCell(ctx context.Context, keyspace, shard string, cells []string) ([]*TabletInfo, error) {
+	span, ctx := trace.NewSpan(ctx, "topo.GetTabletsByShardCell")
+	span.Annotate("keyspace", keyspace)
+	span.Annotate("shard", shard)
+	span.Annotate("num_cells", len(cells))
+	defer span.Finish()
+	ctx = trace.NewContext(ctx, span)
+	var err error
+
+	if len(cells) == 0 {
+		cells, err = ts.GetCellInfoNames(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if len(cells) == 0 { // Nothing to do
+			return nil, nil
+		}
+	}
+
+	// divide the concurrency limit by the number of cells. if there are more
+	// cells than the limit, default to concurrency of 1.
+	cellConcurrency := 1
+	if len(cells) < DefaultConcurrency {
+		cellConcurrency = DefaultConcurrency / len(cells)
+	}
+
+	mu := sync.Mutex{}
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(DefaultConcurrency)
+
+	tablets := make([]*TabletInfo, 0, len(cells)*3)
+	for _, cell := range cells {
+		eg.Go(func() error {
+			t, err := ts.GetTabletsByCell(ctx, cell, &GetTabletsByCellOptions{
+				Concurrency: cellConcurrency,
+				Keyspace:    keyspace,
+				Shard:       shard,
+			})
+			if err != nil {
+				return vterrors.Wrap(err, fmt.Sprintf("GetTabletsByCell for %v failed.", cell))
+			}
+			mu.Lock()
+			tablets = append(tablets, t...)
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		log.Warningf("GetTabletsByShardCell(%v,%v): got partial result: %v", keyspace, shard, err)
+		return tablets, NewError(PartialResult, shard)
+	}
+
+	return tablets, nil
 }
 
 // GetTabletMapForShard returns the tablets for a shard. It can return

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -654,12 +654,16 @@ func (ts *Server) GetTabletsByShardCell(ctx context.Context, keyspace, shard str
 	eg.SetLimit(DefaultConcurrency)
 
 	tablets := make([]*TabletInfo, 0, len(cells))
-	options := &GetTabletsByCellOptions{
-		Concurrency: cellConcurrency,
-		KeyspaceShard: &KeyspaceShard{
+	var kss *KeyspaceShard
+	if keyspace != "" {
+		kss = &KeyspaceShard{
 			Keyspace: keyspace,
 			Shard:    shard,
-		},
+		}
+	}
+	options := &GetTabletsByCellOptions{
+		Concurrency:   cellConcurrency,
+		KeyspaceShard: kss,
 	}
 	for _, cell := range cells {
 		eg.Go(func() error {
@@ -677,7 +681,6 @@ func (ts *Server) GetTabletsByShardCell(ctx context.Context, keyspace, shard str
 		log.Warningf("GetTabletsByShardCell(%v,%v): got partial result: %v", keyspace, shard, err)
 		return tablets, NewError(PartialResult, shard)
 	}
-
 	return tablets, nil
 }
 

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -668,8 +668,8 @@ func (ts *Server) GetTabletsByShardCell(ctx context.Context, keyspace, shard str
 				return vterrors.Wrapf(err, "GetTabletsByCell for %v failed.", cell)
 			}
 			mu.Lock()
+			defer mu.Unlock()
 			tablets = append(tablets, t...)
-			mu.Unlock()
 			return nil
 		})
 	}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -17,11 +17,9 @@ limitations under the License.
 package topo
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"path"
-	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -289,9 +287,6 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string, opt *G
 		}
 		tablets = append(tablets, &TabletInfo{Tablet: tablet, version: listResults[n].Version})
 	}
-	slices.SortFunc(tablets, func(i, j *TabletInfo) int {
-		return cmp.Compare(i.Alias.Uid, j.Alias.Uid)
-	})
 	return tablets, nil
 }
 

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -237,7 +237,7 @@ type GetTabletsByCellOptions struct {
 	// Concurrency controls the maximum number of concurrent calls to GetTablet.
 	Concurrency int
 	// KeyspaceShard is the optional keyspace/shard that tablets must match.
-	// An empty shard value will watch all shards.
+	// An empty shard value will match all shards in the keyspace.
 	KeyspaceShard *KeyspaceShard
 }
 

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -278,7 +278,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string, opt *G
 			return nil, err
 		}
 		if opt != nil && opt.KeyspaceShard != nil {
-			if opt.KeyspaceShard.Keyspace != tablet.Keyspace {
+			if opt.KeyspaceShard.Keyspace != "" && opt.KeyspaceShard.Keyspace != tablet.Keyspace {
 				continue
 			}
 			if opt.KeyspaceShard.Shard != "" && opt.KeyspaceShard.Shard != tablet.Shard {

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -208,8 +208,8 @@ func TestServerGetTabletsByCell(t *testing.T) {
 					Shard:    shard,
 				},
 			},
-			opt:                &topo.GetTabletsByCellOptions{Concurrency: 8},
-			listError:          topo.NewError(topo.ResourceExhausted, ""),
+			opt:       &topo.GetTabletsByCellOptions{Concurrency: 8},
+			listError: topo.NewError(topo.ResourceExhausted, ""),
 		},
 		{
 			name: "filtered by keyspace and shard",

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -41,8 +41,7 @@ func TestServerGetTabletsByCell(t *testing.T) {
 	tests := []struct {
 		name               string
 		createShardTablets int
-		expectedTablets    int
-		expectedShards     []string
+		expectedTablets    []*topodatapb.Tablet
 		opt                *topo.GetTabletsByCellOptions
 		listError          error
 		keyspaceShards     map[string][]string
@@ -50,59 +49,203 @@ func TestServerGetTabletsByCell(t *testing.T) {
 		{
 			name: "negative concurrency",
 			keyspaceShards: map[string][]string{
-				keyspace: []string{shard},
+				keyspace: {shard},
 			},
 			createShardTablets: 1,
-			expectedTablets:    1,
-			expectedShards:     []string{shard},
+			expectedTablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(1),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(1),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+			},
 			// Ensure this doesn't panic.
 			opt: &topo.GetTabletsByCellOptions{Concurrency: -1},
 		},
 		{
 			name: "single",
 			keyspaceShards: map[string][]string{
-				keyspace: []string{shard},
+				keyspace: {shard},
 			},
 			createShardTablets: 1,
-			expectedTablets:    1,
-			expectedShards:     []string{shard},
+			expectedTablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(1),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(1),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+			},
 			// Make sure the defaults apply as expected.
 			opt: nil,
 		},
 		{
 			name: "multiple",
 			keyspaceShards: map[string][]string{
-				keyspace: []string{shard},
+				keyspace: {shard},
 			},
 			// Should work with more than 1 tablet
-			createShardTablets: 32,
-			expectedTablets:    32,
-			expectedShards:     []string{shard},
-			opt:                &topo.GetTabletsByCellOptions{Concurrency: 8},
+			createShardTablets: 4,
+			expectedTablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(1),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(1),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(2),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(2),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(3),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(3),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(4),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(4),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+			},
+			opt: &topo.GetTabletsByCellOptions{Concurrency: 8},
 		},
 		{
 			name: "multiple with list error",
 			keyspaceShards: map[string][]string{
-				keyspace: []string{shard},
+				keyspace: {shard},
 			},
 			// Should work with more than 1 tablet when List returns an error
-			createShardTablets: 32,
-			expectedTablets:    32,
-			expectedShards:     []string{shard},
+			createShardTablets: 4,
+			expectedTablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(1),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(1),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(2),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(2),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(3),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(3),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(4),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(4),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+			},
 			opt:                &topo.GetTabletsByCellOptions{Concurrency: 8},
 			listError:          topo.NewError(topo.ResourceExhausted, ""),
 		},
 		{
 			name: "filtered by keyspace and shard",
 			keyspaceShards: map[string][]string{
-				keyspace:   []string{shard},
-				"filtered": []string{"-"},
+				keyspace:   {shard},
+				"filtered": {"-"},
 			},
 			// Should create 2 tablets in 2 different shards (4 total)
 			// but only a single shard is returned
 			createShardTablets: 2,
-			expectedTablets:    2,
-			expectedShards:     []string{shard},
+			expectedTablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(1),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(1),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(2),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(2),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+			},
 			opt: &topo.GetTabletsByCellOptions{
 				Concurrency: 1,
 				KeyspaceShard: &topo.KeyspaceShard{
@@ -114,7 +257,7 @@ func TestServerGetTabletsByCell(t *testing.T) {
 		{
 			name: "filtered by keyspace and no shard",
 			keyspaceShards: map[string][]string{
-				keyspace: []string{
+				keyspace: {
 					shard,
 					shard + "2",
 				},
@@ -123,8 +266,56 @@ func TestServerGetTabletsByCell(t *testing.T) {
 			// in the same keyspace and both shards are returned due to
 			// empty shard
 			createShardTablets: 2,
-			expectedTablets:    4,
-			expectedShards:     []string{shard, shard + "2"},
+			expectedTablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(1),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(1),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(2),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(2),
+					},
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(3),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(3),
+					},
+					Keyspace: keyspace,
+					Shard:    shard + "2",
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: cell,
+						Uid:  uint32(4),
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"vt": int32(4),
+					},
+					Keyspace: keyspace,
+					Shard:    shard + "2",
+				},
+			},
 			opt: &topo.GetTabletsByCellOptions{
 				Concurrency: 1,
 				KeyspaceShard: &topo.KeyspaceShard{
@@ -155,7 +346,7 @@ func TestServerGetTabletsByCell(t *testing.T) {
 				}
 			}
 
-			tablets := make([]*topo.TabletInfo, tt.expectedTablets)
+			tablets := make([]*topo.TabletInfo, 0)
 
 			var uid uint32 = 1
 			for k, shards := range tt.keyspaceShards {
@@ -174,7 +365,7 @@ func TestServerGetTabletsByCell(t *testing.T) {
 							Shard:    s,
 						}
 						tInfo := &topo.TabletInfo{Tablet: tablet}
-						tablets[i] = tInfo
+						tablets = append(tablets, tInfo)
 						require.NoError(t, ts.CreateTablet(ctx, tablet))
 						uid++
 					}
@@ -185,11 +376,12 @@ func TestServerGetTabletsByCell(t *testing.T) {
 			// tablet matches what we expect.
 			out, err := ts.GetTabletsByCell(ctx, cell, tt.opt)
 			require.NoError(t, err)
-			require.Len(t, out, tt.expectedTablets)
-
-			for _, tablet := range out {
-				require.Equal(t, keyspace, tablet.Keyspace)
-				require.Contains(t, tt.expectedShards, tablet.Shard)
+			require.Len(t, out, len(tt.expectedTablets))
+			for i, tablet := range out {
+				expected := tt.expectedTablets[i]
+				require.Equal(t, expected.Alias.String(), tablet.Alias.String())
+				require.Equal(t, expected.Keyspace, tablet.Keyspace)
+				require.Equal(t, expected.Shard, tablet.Shard)
 			}
 		})
 	}

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -346,8 +346,6 @@ func TestServerGetTabletsByCell(t *testing.T) {
 				}
 			}
 
-			tablets := make([]*topo.TabletInfo, 0)
-
 			var uid uint32 = 1
 			for k, shards := range tt.keyspaceShards {
 				for _, s := range shards {
@@ -364,8 +362,6 @@ func TestServerGetTabletsByCell(t *testing.T) {
 							Keyspace: k,
 							Shard:    s,
 						}
-						tInfo := &topo.TabletInfo{Tablet: tablet}
-						tablets = append(tablets, tInfo)
 						require.NoError(t, ts.CreateTablet(ctx, tablet))
 						uid++
 					}
@@ -377,6 +373,7 @@ func TestServerGetTabletsByCell(t *testing.T) {
 			out, err := ts.GetTabletsByCell(ctx, cell, tt.opt)
 			require.NoError(t, err)
 			require.Len(t, out, len(tt.expectedTablets))
+
 			for i, tablet := range out {
 				expected := tt.expectedTablets[i]
 				require.Equal(t, expected.Alias.String(), tablet.Alias.String())

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package topo_test
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -373,6 +375,10 @@ func TestServerGetTabletsByCell(t *testing.T) {
 			out, err := ts.GetTabletsByCell(ctx, cell, tt.opt)
 			require.NoError(t, err)
 			require.Len(t, out, len(tt.expectedTablets))
+
+			slices.SortFunc(out, func(i, j *topo.TabletInfo) int {
+				return cmp.Compare(i.Alias.Uid, j.Alias.Uid)
+			})
 
 			for i, tablet := range out {
 				expected := tt.expectedTablets[i]

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -377,7 +377,7 @@ func TestServerGetTabletsByCell(t *testing.T) {
 			slices.SortFunc(out, func(i, j *topo.TabletInfo) int {
 				return cmp.Compare(i.Alias.Uid, j.Alias.Uid)
 			})
-			slices.SortFunc(tt.expectedTablets, func(i, j *topo.TabletInfo) int {
+			slices.SortFunc(tt.expectedTablets, func(i, j *topodatapb.Tablet) int {
 				return cmp.Compare(i.Alias.Uid, j.Alias.Uid)
 			})
 

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -377,6 +377,9 @@ func TestServerGetTabletsByCell(t *testing.T) {
 			slices.SortFunc(out, func(i, j *topo.TabletInfo) int {
 				return cmp.Compare(i.Alias.Uid, j.Alias.Uid)
 			})
+			slices.SortFunc(tt.expectedTablets, func(i, j *topo.TabletInfo) int {
+				return cmp.Compare(i.Alias.Uid, j.Alias.Uid)
+			})
 
 			for i, tablet := range out {
 				expected := tt.expectedTablets[i]

--- a/go/vt/topo/tablet_test.go
+++ b/go/vt/topo/tablet_test.go
@@ -85,8 +85,10 @@ func TestServerGetTabletsByCell(t *testing.T) {
 			createShardTablets: 2,
 			opt: &topo.GetTabletsByCellOptions{
 				Concurrency: 1,
-				Keyspace:    keyspace,
-				Shard:       shard,
+				KeyspaceShard: &topo.KeyspaceShard{
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
 			},
 		},
 	}

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -35,7 +35,6 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
-	"vitess.io/vitess/go/vt/topotools"
 	"vitess.io/vitess/go/vt/vtorc/config"
 	"vitess.io/vitess/go/vt/vtorc/db"
 	"vitess.io/vitess/go/vt/vtorc/inst"
@@ -156,7 +155,7 @@ func refreshTabletsUsing(loader func(tabletAlias string), forceRefresh bool) {
 }
 
 func refreshTabletsInCell(ctx context.Context, cell string, loader func(tabletAlias string), forceRefresh bool) {
-	tablets, err := topotools.GetTabletMapForCell(ctx, ts, cell)
+	tablets, err := ts.GetTabletsByCell(ctx, cell, &topo.GetTabletsByCellOptions{Concurrency: topo.DefaultConcurrency})
 	if err != nil {
 		log.Errorf("Error fetching topo info for cell %v: %v", cell, err)
 		return
@@ -188,7 +187,7 @@ func refreshTabletInfoOfShard(ctx context.Context, keyspace, shard string) {
 }
 
 func refreshTabletsInKeyspaceShard(ctx context.Context, keyspace, shard string, loader func(tabletAlias string), forceRefresh bool, tabletsToIgnore []string) {
-	tablets, err := ts.GetTabletMapForShard(ctx, keyspace, shard)
+	tablets, err := ts.GetTabletsByShard(ctx, keyspace, shard)
 	if err != nil {
 		log.Errorf("Error fetching tablets for keyspace/shard %v/%v: %v", keyspace, shard, err)
 		return
@@ -198,7 +197,7 @@ func refreshTabletsInKeyspaceShard(ctx context.Context, keyspace, shard string, 
 	refreshTablets(tablets, query, args, loader, forceRefresh, tabletsToIgnore)
 }
 
-func refreshTablets(tablets map[string]*topo.TabletInfo, query string, args []any, loader func(tabletAlias string), forceRefresh bool, tabletsToIgnore []string) {
+func refreshTablets(tablets []*topo.TabletInfo, query string, args []any, loader func(tabletAlias string), forceRefresh bool, tabletsToIgnore []string) {
 	// Discover new tablets.
 	latestInstances := make(map[string]bool)
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Description

This PR adds [a similar optimization to this PR](https://github.com/vitessio/vitess/pull/14693) to `vtorc` by moving to using `ts.GetTabletsByCell(...)` and the new `ts.GetTabletsByShard(...)` methods to fetch tablets. These methods respect the concurrency limit flag for the topo and seem to be more efficient overall

Support for filtering by keyspace/shard was added to `ts.GetTabletsByCell(...)` which is called by `ts.GetTabletsByShard(...)`

[Related to this discussion](https://github.com/vitessio/vitess/issues/16761), we're unfortunately forced to fetch "all" records from the cell just to filter them out by keyspace/shard using `x != y`. In our production when fetching topo records for a single shard, < 0.5% of the topo records fetched are actually used - but that's nothing new

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/17073

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
