### PR TITLE
`Applyschema` uses `ExecuteMultiFetchAsDba`

### DIFF
--- a/go/vt/schemamanager/local_controller.go
+++ b/go/vt/schemamanager/local_controller.go
@@ -208,8 +208,10 @@ func (controller *LocalController) writeToLogDir(ctx context.Context, result *Ex
 	rowsReturned := uint64(0)
 	rowsAffected := uint64(0)
 	for _, queryResult := range result.SuccessShards {
-		rowsReturned += uint64(len(queryResult.Result.Rows))
-		rowsAffected += queryResult.Result.RowsAffected
+		for _, result := range queryResult.Results {
+			rowsReturned += uint64(len(result.Rows))
+			rowsAffected += result.RowsAffected
+		}
 	}
 	logFile.WriteString(fmt.Sprintf("-- Rows returned: %d\n", rowsReturned))
 	logFile.WriteString(fmt.Sprintf("-- Rows affected: %d\n", rowsAffected))

--- a/go/vt/schemamanager/local_controller_test.go
+++ b/go/vt/schemamanager/local_controller_test.go
@@ -138,8 +138,8 @@ func TestLocalControllerSchemaChange(t *testing.T) {
 	result := &ExecuteResult{
 		Sqls: []string{"create table test_table (id int)"},
 		SuccessShards: []ShardResult{{
-			Shard:  "0",
-			Result: &querypb.QueryResult{},
+			Shard:   "0",
+			Results: []*querypb.QueryResult{{}},
 		}},
 	}
 	logPath := path.Join(controller.logDir, controller.sqlFilename)

--- a/go/vt/schemamanager/schemamanager.go
+++ b/go/vt/schemamanager/schemamanager.go
@@ -85,8 +85,8 @@ type ShardWithError struct {
 
 // ShardResult contains sql execute information on a particular shard
 type ShardResult struct {
-	Shard  string
-	Result *querypb.QueryResult
+	Shard   string
+	Results []*querypb.QueryResult
 	// Position is a replication position that is guaranteed to be after the
 	// schema change was applied. It can be used to wait for replicas to receive
 	// the schema change via replication.

--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -293,6 +293,13 @@ func (client *fakeTabletManagerClient) ExecuteFetchAsDba(ctx context.Context, ta
 	return client.TabletManagerClient.ExecuteFetchAsDba(ctx, tablet, usePool, req)
 }
 
+func (client *fakeTabletManagerClient) ExecuteMultiFetchAsDba(ctx context.Context, tablet *topodatapb.Tablet, usePool bool, req *tabletmanagerdatapb.ExecuteMultiFetchAsDbaRequest) ([]*querypb.QueryResult, error) {
+	if client.EnableExecuteFetchAsDbaError {
+		return nil, fmt.Errorf("ExecuteMultiFetchAsDba occur an unknown error")
+	}
+	return client.TabletManagerClient.ExecuteMultiFetchAsDba(ctx, tablet, usePool, req)
+}
+
 // newFakeTopo returns a topo with:
 // - a keyspace named 'test_keyspace'.
 // - 3 shards named '1', '2', '3'.

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -303,7 +303,9 @@ func (s *VtctldServer) ApplySchema(ctx context.Context, req *vtctldatapb.ApplySc
 	}
 
 	for _, shard := range execResult.SuccessShards {
-		resp.RowsAffectedByShard[shard.Shard] = shard.Result.RowsAffected
+		for _, result := range shard.Results {
+			resp.RowsAffectedByShard[shard.Shard] += result.RowsAffected
+		}
 	}
 
 	return resp, err


### PR DESCRIPTION
## Description

See context in https://github.com/vitessio/vitess/issues/15505

In this PR `ApplySchema` uses `ExecuteMultiFetchAsDba()` instead of `ExecuteFetchAsDba()`. This is scheduled for `v22`. In `v23` we will be able to clean up `ExecuteFetchAsDba()` as `ApplySchema` is the last use of `ExecuteFetchAsDba()` that is still allowed to pass multiple statements.

**Note:** hardly any tests changed, because the point is that the behavior is unchanged and that all the tests continue as expected when we switch from `ExecuteFetchAsDba()` to `ExecuteMultiFetchAsDba()`.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15505

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
