### PR TITLE
Fix panic in vttablet when closing topo server twice

### DIFF
--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -143,7 +143,6 @@ func run(cmd *cobra.Command, args []string) error {
 
 	qsc, err := createTabletServer(ctx, env, config, ts, tabletAlias, srvTopoCounts)
 	if err != nil {
-		ts.Close()
 		return err
 	}
 
@@ -172,7 +171,6 @@ func run(cmd *cobra.Command, args []string) error {
 		VDiffEngine:         vdiff.NewEngine(ts, tablet, env.CollationEnv(), env.Parser()),
 	}
 	if err := tm.Start(tablet, config); err != nil {
-		ts.Close()
 		return fmt.Errorf("failed to parse --tablet-path or initialize DB credentials: %w", err)
 	}
 	servenv.OnClose(func() {

--- a/go/cmd/vttablet/cli/cli_test.go
+++ b/go/cmd/vttablet/cli/cli_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+)
+
+// TestRunFailsToStartTabletManager tests the code path in 'run' where we fail to start the TabletManager
+// this is done by starting vttablet without a cnf file but requesting it to restore from backup.
+// When starting, the TabletManager checks if it needs to restore, in tm.handleRestore but this step will
+// fail if we do not provide a cnf file and if the flag --restore_from_backup is provided.
+func TestRunFailsToStartTabletManager(t *testing.T) {
+	tabletPath = "cell-1"
+	ts, factory := memorytopo.NewServerAndFactory(context.Background(), "cell")
+	topo.RegisterFactory("test", factory)
+
+	args := append([]string{}, os.Args...)
+	t.Cleanup(func() {
+		ts.Close()
+		tabletPath = ""
+		os.Args = append([]string{}, args...)
+	})
+
+	os.Args = []string{"vttablet",
+		"--topo_implementation", "test", "--topo_global_server_address", "localhost", "--topo_global_root", "cell",
+		"--db_host", "localhost", "--db_port", "3306",
+		"--tablet-path", "cell-1", "--init_keyspace", "ks", "--init_shard", "0", "--init_tablet_type", "replica",
+		"--restore_from_backup",
+	}
+
+	err := Main.Execute()
+	require.ErrorContains(t, err, "you cannot enable --restore_from_backup without a my.cnf file")
+}

--- a/go/cmd/vttablet/cli/cli_test.go
+++ b/go/cmd/vttablet/cli/cli_test.go
@@ -49,6 +49,10 @@ func TestRunFailsToStartTabletManager(t *testing.T) {
 		"--restore_from_backup",
 	}
 
-	err := Main.Execute()
+	// Creating and canceling the context so that pending tasks in tm_init gets canceled before we close the topo server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := Main.ExecuteContext(ctx)
 	require.ErrorContains(t, err, "you cannot enable --restore_from_backup without a my.cnf file")
 }

--- a/go/cmd/vttablet/cli/cli_test.go
+++ b/go/cmd/vttablet/cli/cli_test.go
@@ -32,7 +32,6 @@ import (
 // When starting, the TabletManager checks if it needs to restore, in tm.handleRestore but this step will
 // fail if we do not provide a cnf file and if the flag --restore_from_backup is provided.
 func TestRunFailsToStartTabletManager(t *testing.T) {
-	tabletPath = "cell-1"
 	ts, factory := memorytopo.NewServerAndFactory(context.Background(), "cell")
 	topo.RegisterFactory("test", factory)
 

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -343,8 +343,10 @@ func GetAliasByCell(ctx context.Context, ts *Server, cell string) string {
 // Close will close all connections to underlying topo Server.
 // It will nil all member variables, so any further access will panic.
 func (ts *Server) Close() {
-	ts.globalCell.Close()
-	if ts.globalReadOnlyCell != ts.globalCell {
+	if ts.globalCell != nil {
+		ts.globalCell.Close()
+	}
+	if ts.globalReadOnlyCell != nil && ts.globalReadOnlyCell != ts.globalCell {
 		ts.globalReadOnlyCell.Close()
 	}
 	ts.globalCell = nil


### PR DESCRIPTION
## Description

As described in https://github.com/vitessio/vitess/issues/17093 we were closing the topo server in vttablet twice: in a defer function, and right before returning an error. This PR fixes the issue.

Using the same reproduction as the one detailed in the issue, we get:
```
$  kubectl logs example-vttablet-zone1-2469782763-bfadd780
W1028 20:22:32.006847       1 log.go:39] Failed to read in config : Config File "vtconfig" Not Found in "[/]". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files.
I1028 20:22:32.014869       1 servenv_unix.go:57] Version: 22.0.0-SNAPSHOT (Git revision 4550640e0882ad71d79bde47e78f7e2123522145 branch 'fix-double-close-of-topo-server-in-tablet') built on Mon Oct 28 19:58:23 UTC 2024 by vitess@buildkitsandbox using go1.23.2 linux/amd64
E1028 20:22:32.016878       1 syslogger.go:171] can't connect to syslog: Unix syslog delivery error
I1028 20:22:32.065152       1 streamlog.go:206] Streaming logs from TabletServer at /debug/querylog.
I1028 20:22:32.065451       1 streamlog.go:206] Streaming logs from TxLog at /debug/txlog.
I1028 20:22:32.080117       1 cli.go:205] Loaded config file  successfully:
consolidator: enable
consolidatorStreamQuerySize: 2097152
consolidatorStreamTotalSize: 134217728
...
```

As mentioned in the issue, this bug is present on `release-21.0` and causes a crash (though it only happens if vttablet was not going to start anyway) so I am adding the `Backport to: release-21.0` label to this PR.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/17093

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
