### PR TITLE
Fix flaky test `TestShardSync`

### DIFF
--- a/go/vt/vttablet/tabletmanager/shard_sync_test.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync_test.go
@@ -45,7 +45,7 @@ const (
 )
 
 func TestShardSync(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	ts := memorytopo.NewServer(ctx, "cell1")
 	statsTabletTypeCount.ResetAll()
@@ -68,19 +68,19 @@ func TestShardSync(t *testing.T) {
 	// wait for syncing to work correctly
 	// this should also have updated the shard record since it is a more recent operation
 	// We check here that the shard record and the tablet record are in sync
-	err = checkShardRecordWithTimeout(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+	err = checkShardRecord(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime)
 	require.NoError(t, err)
 
 	// Shard sync loop runs asynchronously and starts a watch on the shard.
 	// We wait for the shard watch to start, otherwise the test is flaky
 	// because the update of the record can happen before the watch is started.
-	waitForShardWatchToStart(ctx, t, tm, originalTime, ti, 10*time.Second)
+	waitForShardWatchToStart(ctx, t, tm, originalTime, ti)
 
 	// even if try to update the shard record with the old timestamp, it should be reverted again
 	updatePrimaryInfoInShardRecord(ctx, t, tm, nil, originalTime)
 
 	// this should have also updated the shard record because of the timestamp.
-	err = checkShardRecordWithTimeout(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+	err = checkShardRecord(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime)
 	require.NoError(t, err)
 
 	// updating the shard record with the latest time should trigger an update in the tablet
@@ -88,28 +88,29 @@ func TestShardSync(t *testing.T) {
 	updatePrimaryInfoInShardRecord(ctx, t, tm, nil, newTime)
 
 	// this should not have updated.
-	err = checkShardRecordWithTimeout(ctx, t, ts, nil, protoutil.TimeToProto(newTime), 1*time.Second)
+	err = checkShardRecord(ctx, t, ts, nil, protoutil.TimeToProto(newTime))
 	require.NoError(t, err)
 
 	// verify that the tablet record has been updated
-	checkTabletRecordWithTimeout(ctx, t, ts, tm.tabletAlias, topodata.TabletType_REPLICA, nil, 1*time.Second)
+	checkTabletRecordWithTimeout(ctx, t, ts, tm.tabletAlias, topodata.TabletType_REPLICA, nil)
 }
 
 // waitForShardWatchToStart waits for shard watch to have started.
-func waitForShardWatchToStart(ctx context.Context, t *testing.T, tm *TabletManager, originalTime time.Time, ti *topo.TabletInfo, timeToWait time.Duration) {
+func waitForShardWatchToStart(ctx context.Context, t *testing.T, tm *TabletManager, originalTime time.Time, ti *topo.TabletInfo) {
 	// We wait for shard watch to start by
 	// updating the record and waiting to see
 	// the shard record is updated back by the tablet manager.
-	timeOut := time.After(timeToWait)
 	idx := 1
 	for {
 		select {
-		case <-timeOut:
-			t.Fatalf("timed out: waiting for shard watch to start")
+		case <-ctx.Done():
+			require.FailNow(t, "timed out: waiting for shard watch to start")
 		default:
 			updatePrimaryInfoInShardRecord(ctx, t, tm, nil, originalTime.Add(-1*time.Duration(idx)*time.Second))
 			idx = idx + 1
-			err := checkShardRecordWithTimeout(ctx, t, tm.TopoServer, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+			checkCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			err := checkShardRecord(checkCtx, t, tm.TopoServer, ti.Alias, ti.PrimaryTermStartTime)
+			cancel()
 			if err == nil {
 				return
 			}
@@ -117,11 +118,10 @@ func waitForShardWatchToStart(ctx context.Context, t *testing.T, tm *TabletManag
 	}
 }
 
-func checkShardRecordWithTimeout(ctx context.Context, t *testing.T, ts *topo.Server, tabletAlias *topodata.TabletAlias, expectedStartTime *vttime.Time, timeToWait time.Duration) error {
-	timeOut := time.After(timeToWait)
+func checkShardRecord(ctx context.Context, t *testing.T, ts *topo.Server, tabletAlias *topodata.TabletAlias, expectedStartTime *vttime.Time) error {
 	for {
 		select {
-		case <-timeOut:
+		case <-ctx.Done():
 			return errors.New("timed out: waiting for shard record to update")
 		default:
 			si, err := ts.GetShard(ctx, keyspace, shard)
@@ -134,12 +134,11 @@ func checkShardRecordWithTimeout(ctx context.Context, t *testing.T, ts *topo.Ser
 	}
 }
 
-func checkTabletRecordWithTimeout(ctx context.Context, t *testing.T, ts *topo.Server, tabletAlias *topodata.TabletAlias, tabletType topodata.TabletType, expectedStartTime *vttime.Time, timeToWait time.Duration) {
-	timeOut := time.After(timeToWait)
+func checkTabletRecordWithTimeout(ctx context.Context, t *testing.T, ts *topo.Server, tabletAlias *topodata.TabletAlias, tabletType topodata.TabletType, expectedStartTime *vttime.Time) {
 	for {
 		select {
-		case <-timeOut:
-			t.Fatalf("timed out: waiting for tablet record to update")
+		case <-ctx.Done():
+			require.FailNow(t, "timed out: waiting for tablet record to update")
 		default:
 			ti, err := ts.GetTablet(ctx, tabletAlias)
 			require.NoError(t, err)

--- a/go/vt/vttablet/tabletmanager/shard_sync_test.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync_test.go
@@ -18,6 +18,7 @@ package tabletmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -67,36 +68,66 @@ func TestShardSync(t *testing.T) {
 	// wait for syncing to work correctly
 	// this should also have updated the shard record since it is a more recent operation
 	// We check here that the shard record and the tablet record are in sync
-	checkShardRecordWithTimeout(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+	err = checkShardRecordWithTimeout(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+	require.NoError(t, err)
+
+	// Shard sync loop runs asynchronously and starts a watch on the shard.
+	// We wait for the shard watch to start, otherwise the test is flaky
+	// because the update of the record can happen before the watch is started.
+	waitForShardWatchToStart(ctx, t, tm, originalTime, ti, 10*time.Second)
 
 	// even if try to update the shard record with the old timestamp, it should be reverted again
 	updatePrimaryInfoInShardRecord(ctx, t, tm, nil, originalTime)
 
 	// this should have also updated the shard record because of the timestamp.
-	checkShardRecordWithTimeout(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+	err = checkShardRecordWithTimeout(ctx, t, ts, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+	require.NoError(t, err)
 
 	// updating the shard record with the latest time should trigger an update in the tablet
 	newTime := time.Now()
 	updatePrimaryInfoInShardRecord(ctx, t, tm, nil, newTime)
 
 	// this should not have updated.
-	checkShardRecordWithTimeout(ctx, t, ts, nil, protoutil.TimeToProto(newTime), 1*time.Second)
+	err = checkShardRecordWithTimeout(ctx, t, ts, nil, protoutil.TimeToProto(newTime), 1*time.Second)
+	require.NoError(t, err)
 
 	// verify that the tablet record has been updated
 	checkTabletRecordWithTimeout(ctx, t, ts, tm.tabletAlias, topodata.TabletType_REPLICA, nil, 1*time.Second)
 }
 
-func checkShardRecordWithTimeout(ctx context.Context, t *testing.T, ts *topo.Server, tabletAlias *topodata.TabletAlias, expectedStartTime *vttime.Time, timeToWait time.Duration) {
+// waitForShardWatchToStart waits for shard watch to have started.
+func waitForShardWatchToStart(ctx context.Context, t *testing.T, tm *TabletManager, originalTime time.Time, ti *topo.TabletInfo, timeToWait time.Duration) {
+	// We wait for shard watch to start by
+	// updating the record and waiting to see
+	// the shard record is updated back by the tablet manager.
+	timeOut := time.After(timeToWait)
+	idx := 1
+	for {
+		select {
+		case <-timeOut:
+			t.Fatalf("timed out: waiting for shard watch to start")
+		default:
+			updatePrimaryInfoInShardRecord(ctx, t, tm, nil, originalTime.Add(-1*time.Duration(idx)*time.Second))
+			idx = idx + 1
+			err := checkShardRecordWithTimeout(ctx, t, tm.TopoServer, ti.Alias, ti.PrimaryTermStartTime, 1*time.Second)
+			if err == nil {
+				return
+			}
+		}
+	}
+}
+
+func checkShardRecordWithTimeout(ctx context.Context, t *testing.T, ts *topo.Server, tabletAlias *topodata.TabletAlias, expectedStartTime *vttime.Time, timeToWait time.Duration) error {
 	timeOut := time.After(timeToWait)
 	for {
 		select {
 		case <-timeOut:
-			t.Fatalf("timed out: waiting for shard record to update")
+			return errors.New("timed out: waiting for shard record to update")
 		default:
 			si, err := ts.GetShard(ctx, keyspace, shard)
 			require.NoError(t, err)
 			if reflect.DeepEqual(tabletAlias, si.PrimaryAlias) && reflect.DeepEqual(expectedStartTime, si.PrimaryTermStartTime) {
-				return
+				return nil
 			}
 			time.Sleep(100 * time.Millisecond)
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the flakiness in the test `TestShardSync`.
It was noticed that the test was flaky. The problem was that when the tablet is promoted to a primary type, it starts shard sync, but it happens asynchronously. In the meantime we also update the shard record in the topo server. If the shard record is updated before the shard watch for the record has started, the tablet doesn't run a shard sync loop for 30 seconds, and that fails the test.

This PR fixes the test by adding an explicit wait for the shard watch to have started. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
