### PR TITLE
Bugfix for Panic on Joined Queries with Non-Authoritative Tables in Vitess 19.0

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -1070,6 +1070,31 @@
     }
   },
   {
+    "comment": "Ambiguous column is not a problem when we can merge and push down",
+    "query": "select foobar from user join music on user.id = music.user_id order by foobar",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select foobar from user join music on user.id = music.user_id order by foobar",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select foobar, weight_string(foobar) from `user`, music where 1 != 1",
+        "OrderBy": "(0|1) ASC",
+        "Query": "select foobar, weight_string(foobar) from `user`, music where `user`.id = music.user_id order by foobar asc",
+        "ResultColumns": 1,
+        "Table": "`user`, music"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "index hints, make sure they are not stripped.",
     "query": "select user.col from user use index(a)",
     "plan": {

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -1401,6 +1401,7 @@ func fakeSchemaInfo() *FakeSI {
 	si := &FakeSI{
 		Tables: map[string]*vindexes.Table{
 			"t":  {Name: sqlparser.NewIdentifierCS("t"), Keyspace: unsharded},
+			"t3": {Name: sqlparser.NewIdentifierCS("t3"), Keyspace: unsharded},
 			"t1": {Name: sqlparser.NewIdentifierCS("t1"), Columns: cols1, ColumnListAuthoritative: true, Keyspace: ks2},
 			"t2": {Name: sqlparser.NewIdentifierCS("t2"), Columns: cols2, ColumnListAuthoritative: true, Keyspace: ks3},
 		},

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -668,7 +668,15 @@ func (r *earlyRewriter) fillInQualifiers(cursor *sqlparser.CopyOnWriteCursor) {
 	if !found {
 		panic("uh oh")
 	}
-	tbl := r.tables.Tables[ts.TableOffset()]
+	offset := ts.TableOffset()
+	if offset < 0 {
+		// this is a column that is not coming from a table - it's an alias introduced in a SELECT expression
+		// Example: select (1+1) as foo from bar order by foo
+		// we don't want to add a qualifier to foo here
+		cursor.Replace(sqlparser.NewColName(col.Name.String()))
+		return
+	}
+	tbl := r.tables.Tables[offset]
 	tblName, err := tbl.Name()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Description
This PR addresses an uncaught index out of range panic encountered in Vitess 19.0 during the semantic analysis of certain join queries with non-authoritative tables in the vschema. Specifically, queries with a join on non-authoritative tables that should be merged due to sharding keys trigger a runtime panic if they order by one of these unknown columns.

## Related Issue(s)
Fixes #17104

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
