### PR TITLE
Fix flakiness in `TestDisruptions` for two pc testing

### DIFF
--- a/go/test/endtoend/cluster/vtctldclient_process.go
+++ b/go/test/endtoend/cluster/vtctldclient_process.go
@@ -195,7 +195,9 @@ func (vtctldclient *VtctldClientProcess) PlannedReparentShard(Keyspace string, S
 	output, err := vtctldclient.ExecuteCommandWithOutput(
 		"PlannedReparentShard",
 		fmt.Sprintf("%s/%s", Keyspace, Shard),
-		"--new-primary", alias)
+		"--new-primary", alias,
+		"--wait-replicas-timeout", "30s",
+	)
 	if err != nil {
 		log.Errorf("error in PlannedReparentShard output %s, err %s", output, err.Error())
 	}

--- a/go/test/endtoend/transaction/twopc/utils/utils.go
+++ b/go/test/endtoend/transaction/twopc/utils/utils.go
@@ -221,6 +221,10 @@ func AddShards(t *testing.T, clusterInstance *cluster.LocalProcessCluster, keysp
 		shard, err := clusterInstance.AddShard(keyspaceName, shardName, 3, false, nil)
 		require.NoError(t, err)
 		clusterInstance.Keyspaces[0].Shards = append(clusterInstance.Keyspaces[0].Shards, *shard)
+		for _, vttablet := range shard.Vttablets {
+			err = vttablet.VttabletProcess.WaitForTabletStatuses([]string{"SERVING"})
+			require.NoError(t, err)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This test fixes some flakiness observed in the `TestDisruptions` for two pc testing. There are 2 fixes in this PR - 
1. When we start a new shard, we weren't waiting for the primary tablet to be serving. This sometimes led to vreplication not finding a serving primary tablet to create vreplication streams at. This fails resharding workflow sometimes. The fix is to just wait for a serving tablet.
2. PlannedReparentShard sometimes was timing out because it took some time for the outstanding writes from being killed. Increasing the timeout made this less of an issue.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
