### PR TITLE
VReplication: Fixes for generated column handling

### DIFF
--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/throttler"
@@ -40,8 +42,6 @@ import (
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
 
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
-
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -48,7 +48,7 @@ var (
 	customerTypes        = []string{"'individual'", "'soho'", "'enterprise'"}
 	initialProductSchema = fmt.Sprintf(`
 create table product(pid int, description varbinary(128), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key(pid), key(date1,date2)) CHARSET=utf8mb4;
-create table customer(cid int auto_increment, name varchar(128) collate utf8mb4_bin, meta json default null, industryCategory varchar(100) generated always as (json_extract(meta, '$.industry')) virtual,
+create table customer(cid int auto_increment, name varchar(128) collate utf8mb4_bin, meta json default null, industryCategory varchar(100) generated always as (json_extract(meta, _utf8mb4'$.industry')) virtual,
   typ enum(%s), sport set('football','cricket','baseball'), ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00',
 	date2 datetime not null default '2021-00-01 00:00:00', dec80 decimal(8,0), blb blob, primary key(cid,typ), key(name)) CHARSET=utf8mb4;
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -48,8 +48,8 @@ var (
 	customerTypes        = []string{"'individual'", "'soho'", "'enterprise'"}
 	initialProductSchema = fmt.Sprintf(`
 create table product(pid int, description varbinary(128), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key(pid), key(date1,date2)) CHARSET=utf8mb4;
-create table customer(cid int auto_increment, name varchar(128) collate utf8mb4_bin, meta json default null, typ enum(%s), sport set('football','cricket','baseball'),
-	ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00', 
+create table customer(cid int auto_increment, name varchar(128) collate utf8mb4_bin, meta json default null, industryCategory varchar(100) GENERATED ALWAYS AS (json_extract(meta, '$.industry')) VIRTUAL,
+  typ enum(%s), sport set('football','cricket','baseball'), ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00', 
 	date2 datetime not null default '2021-00-01 00:00:00', dec80 decimal(8,0), blb blob, primary key(cid,typ), key(name)) CHARSET=utf8mb4;
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table merchant(mname varchar(128), category varchar(128), primary key(mname), key(category)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -48,8 +48,8 @@ var (
 	customerTypes        = []string{"'individual'", "'soho'", "'enterprise'"}
 	initialProductSchema = fmt.Sprintf(`
 create table product(pid int, description varbinary(128), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key(pid), key(date1,date2)) CHARSET=utf8mb4;
-create table customer(cid int auto_increment, name varchar(128) collate utf8mb4_bin, meta json default null, industryCategory varchar(100) GENERATED ALWAYS AS (json_extract(meta, '$.industry')) VIRTUAL,
-  typ enum(%s), sport set('football','cricket','baseball'), ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00', 
+create table customer(cid int auto_increment, name varchar(128) collate utf8mb4_bin, meta json default null, industryCategory varchar(100) generated always as (json_extract(meta, '$.industry')) virtual,
+  typ enum(%s), sport set('football','cricket','baseball'), ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00',
 	date2 datetime not null default '2021-00-01 00:00:00', dec80 decimal(8,0), blb blob, primary key(cid,typ), key(name)) CHARSET=utf8mb4;
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table merchant(mname varchar(128), category varchar(128), primary key(mname), key(category)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -1,7 +1,7 @@
-insert into customer(cid, name, typ, sport, meta) values(1, 'Jøhn "❤️" Rizzolo',1,'football,baseball','{}');
+insert into customer(cid, name, typ, sport, meta) values(1, 'Jøhn "❤️" Rizzolo',1,'football,baseball','{"industry":"IT SaaS","company":"PlanetScale"}');
 insert into customer(cid, name, typ, sport, meta) values(2, 'Paül','soho','cricket',convert(x'7b7d' using utf8mb4));
 -- We use a high cid value here to test the target sequence initialization.
-insert into customer(cid, name, typ, sport, blb) values(999999, 'ringo','enterprise','','blob data');
+insert into customer(cid, name, typ, sport, blb, meta) values(999999, 'ringo','enterprise','','blob data', '{"industry":"Music"}');
 insert into merchant(mname, category) values('Monoprice', 'eléctronics');
 insert into merchant(mname, category) values('newegg', 'elec†ronics');
 insert into product(pid, description) values(1, 'keyböard ⌨️');

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -591,8 +591,10 @@ func testVStreamCellFlag(t *testing.T) {
 // We also reuse the setup of this test to validate that the "vstream * from" vtgate query functionality is functional
 func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	cells := []string{"zone1", "zone2"}
-	defer mainClusterConfig.enableGTIDCompression()
-	defer setAllVTTabletExperimentalFlags()
+	resetCompression := mainClusterConfig.enableGTIDCompression()
+	defer resetCompression()
+	resetExperimentalFlags := setAllVTTabletExperimentalFlags()
+	defer resetExperimentalFlags()
 	vc = NewVitessCluster(t, &clusterOptions{cells: cells})
 	defer vc.TearDown()
 

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -587,8 +587,10 @@ func testVStreamCellFlag(t *testing.T) {
 	}
 }
 
-// TestCellAliasVreplicationWorkflow tests replication from a cell with an alias to test the tablet picker's alias functionality
-// We also reuse the setup of this test to validate that the "vstream * from" vtgate query functionality is functional
+// TestCellAliasVreplicationWorkflow tests replication from a cell with an alias to test
+// the tablet picker's alias functionality.
+// We also reuse the setup of this test to validate that the "vstream * from" vtgate
+// query functionality is functional.
 func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	cells := []string{"zone1", "zone2"}
 	resetCompression := mainClusterConfig.enableGTIDCompression()
@@ -720,12 +722,12 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 		vtgateConn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
 		defer vtgateConn.Close()
 		// Confirm that the 0 scale decimal field, dec80, is replicated correctly
-		dec80Replicated := false
 		execVtgateQuery(t, vtgateConn, sourceKs, "update customer set dec80 = 0")
 		execVtgateQuery(t, vtgateConn, sourceKs, "update customer set blb = \"new blob data\" where cid=3")
 		execVtgateQuery(t, vtgateConn, sourceKs, "update json_tbl set j1 = null, j2 = 'null', j3 = '\"null\"'")
 		execVtgateQuery(t, vtgateConn, sourceKs, "insert into json_tbl(id, j1, j2, j3) values (7, null, 'null', '\"null\"')")
 		waitForNoWorkflowLag(t, vc, targetKs, workflow)
+		dec80Replicated := false
 		for _, tablet := range []*cluster.VttabletProcess{customerTab1, customerTab2} {
 			// Query the tablet's mysqld directly as the targets will have denied table entries.
 			dbc, err := tablet.TabletConn(targetKs, true)

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -80,10 +80,11 @@ type colExpr struct {
 	// references contains all the column names referenced in the expression.
 	references map[string]bool
 
-	isGrouped  bool
-	isPK       bool
-	dataType   string
-	columnType string
+	isGrouped   bool
+	isPK        bool
+	isGenerated bool
+	dataType    string
+	columnType  string
 }
 
 // operation is the opcode for the colExpr.
@@ -694,7 +695,7 @@ func (tpb *tablePlanBuilder) generateInsertPart(buf *sqlparser.TrackedBuffer) *s
 	}
 	separator := ""
 	for _, cexpr := range tpb.colExprs {
-		if tpb.isColumnGenerated(cexpr.colName) {
+		if cexpr.isGenerated {
 			continue
 		}
 		buf.Myprintf("%s%v", separator, cexpr.colName)
@@ -708,7 +709,7 @@ func (tpb *tablePlanBuilder) generateValuesPart(buf *sqlparser.TrackedBuffer, bv
 	bvf.mode = bvAfter
 	separator := "("
 	for _, cexpr := range tpb.colExprs {
-		if tpb.isColumnGenerated(cexpr.colName) {
+		if cexpr.isGenerated {
 			continue
 		}
 		buf.Myprintf("%s", separator)
@@ -745,7 +746,7 @@ func (tpb *tablePlanBuilder) generateSelectPart(buf *sqlparser.TrackedBuffer, bv
 	buf.WriteString(" select ")
 	separator := ""
 	for _, cexpr := range tpb.colExprs {
-		if tpb.isColumnGenerated(cexpr.colName) {
+		if cexpr.isGenerated {
 			continue
 		}
 		buf.Myprintf("%s", separator)
@@ -781,7 +782,7 @@ func (tpb *tablePlanBuilder) generateOnDupPart(buf *sqlparser.TrackedBuffer) *sq
 		if cexpr.isGrouped || cexpr.isPK {
 			continue
 		}
-		if tpb.isColumnGenerated(cexpr.colName) {
+		if cexpr.isGenerated {
 			continue
 		}
 		buf.Myprintf("%s%v=", separator, cexpr.colName)
@@ -812,10 +813,7 @@ func (tpb *tablePlanBuilder) generateUpdateStatement() *sqlparser.ParsedQuery {
 		if cexpr.isPK {
 			tpb.pkIndices[i] = true
 		}
-		if cexpr.isGrouped || cexpr.isPK {
-			continue
-		}
-		if tpb.isColumnGenerated(cexpr.colName) {
+		if cexpr.isGrouped || cexpr.isPK || cexpr.isGenerated {
 			continue
 		}
 		buf.Myprintf("%s%v=", separator, cexpr.colName)
@@ -959,15 +957,6 @@ func (tpb *tablePlanBuilder) generatePKConstraint(buf *sqlparser.TrackedBuffer, 
 		buf.WriteString(charSetCollations[i].collation)
 	}
 	buf.WriteString(")")
-}
-
-func (tpb *tablePlanBuilder) isColumnGenerated(col sqlparser.IdentifierCI) bool {
-	for _, colInfo := range tpb.colInfos {
-		if col.EqualString(colInfo.Name) && colInfo.IsGenerated {
-			return true
-		}
-	}
-	return false
 }
 
 // bindvarFormatter is a dual mode formatter. Its behavior

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -360,7 +360,7 @@ func (tpb *tablePlanBuilder) generate() *TablePlan {
 	fieldsToSkip := make(map[string]bool)
 	for _, colInfo := range tpb.colInfos {
 		if colInfo.IsGenerated {
-			fieldsToSkip[colInfo.Name] = true
+			fieldsToSkip[strings.ToLower(colInfo.Name)] = true
 		}
 	}
 	return &TablePlan{

--- a/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
@@ -142,6 +142,11 @@ type TestQuery struct {
 type TestRowChange struct {
 	before []string
 	after  []string
+
+	// If you need to customize the image you can use the raw types.
+	beforeRaw      *query.Row
+	afterRaw       *query.Row
+	dataColumnsRaw *binlogdatapb.RowChange_Bitmap
 }
 
 // TestRowEventSpec is used for defining a custom row event.
@@ -161,7 +166,12 @@ func (s *TestRowEventSpec) String() string {
 	if len(s.changes) > 0 {
 		for _, c := range s.changes {
 			rowChange := binlogdatapb.RowChange{}
-			if len(c.before) > 0 {
+			if c.dataColumnsRaw != nil {
+				rowChange.DataColumns = c.dataColumnsRaw
+			}
+			if c.beforeRaw != nil {
+				rowChange.Before = c.beforeRaw
+			} else if len(c.before) > 0 {
 				rowChange.Before = &query.Row{}
 				for _, val := range c.before {
 					if val == sqltypes.NullStr {
@@ -171,7 +181,9 @@ func (s *TestRowEventSpec) String() string {
 					rowChange.Before.Values = append(rowChange.Before.Values, []byte(val)...)
 				}
 			}
-			if len(c.after) > 0 {
+			if c.afterRaw != nil {
+				rowChange.After = c.afterRaw
+			} else if len(c.after) > 0 {
 				rowChange.After = &query.Row{}
 				for i, val := range c.after {
 					if val == sqltypes.NullStr {
@@ -354,6 +366,7 @@ func (ts *TestSpec) getBindVarsForUpdate(stmt sqlparser.Statement) (string, map[
 	require.True(ts.t, ok, "field event for table %s not found", table)
 	index := int64(0)
 	state := ts.getCurrentState(table)
+	require.NotNil(ts.t, state)
 	for i, col := range fe.cols {
 		bv[col.name] = string(state.Values[index : index+state.Lengths[i]])
 		index += state.Lengths[i]


### PR DESCRIPTION
## Description

We were using the lowercase column name when building the map of columns to ignore in the copy phase — where we copy the filtered rows from a SELECT statement on the source — but then using the case we got back from MySQL when checking the map. h/t to @aluque01 for doing all of the hard work around this in the issue.

Without the code fix, the tests such as `TestBasicV2Workflows` fail with:
```
=== NAME  TestBasicV2Workflows
    resharding_workflows_v2_test.go:175: Executing workflow command: vtctldclient MoveTables --workflow wf1 --target-keyspace customer Create --source-keyspace product --tables customer,loadtest,vdiff_order,reftable,_vt_PURGE_4f9194b43b2011eb8a0104ed332e05c2_20221210194431 --defer-secondary-keys --cells zone1 --action_timeout=10m
    helper_test.go:409:
        	Error Trace:	/Users/matt/git/vitess/go/test/endtoend/vreplication/helper_test.go:409
        	            				/Users/matt/git/vitess/go/test/endtoend/vreplication/resharding_workflows_v2_test.go:103
        	            				/Users/matt/git/vitess/go/test/endtoend/vreplication/resharding_workflows_v2_test.go:684
        	            				/Users/matt/git/vitess/go/test/endtoend/vreplication/resharding_workflows_v2_test.go:449
        	Error:      	workflow state not reached
        	Test:       	TestBasicV2Workflows
        	Messages:   	Workflow "customer.wf1" did not fully reach the expected state of "Running" before the timeout of 1m30s; last seen output: {
        	            		"Workflow": "wf1",
  ...
        	            						"State": "Error",
        	            						"DBName": "vt_customer",
        	            						"TransactionTimestamp": 0,
        	            						"TimeUpdated": 1730224772,
        	            						"TimeHeartbeat": 0,
        	            						"TimeThrottled": 0,
        	            						"ComponentThrottled": "",
        	            						"Message": "terminal error: task error: failed inserting rows: Column 'typ' cannot be null (errno 1048) (sqlstate 23000) during query: insert into customer(cid,`name`,meta,typ,sport,ts,bits,date1,date2,dec80,blb) values (2,_binary'Paül',JSON_OBJECT(),null,'soho','cricket','2024-10-29 17:59:13',b'00000011','0000-00-00 00:00:00','2021-00-01 00:00:00',null)",
```

The test changes added for that issue, then highlighted another issue with how we handled generated columns. Specifically when using the [`binlog_row_image=noblob` MySQL setting](https://dev.mysql.com/doc/refman/en/replication-options-binary-log.html#sysvar_binlog_row_image) (we added experimental support for that in https://github.com/vitessio/vitess/pull/12905). The problem was that we were removing the generated column from the table's list of columns entirely in the replication plan. This then threw off the indexes used in the bitmap contained in the non-FULL binlog images which denote which columns/fields have data in the event. Without the code fixes for this issue, the tests such as [`TestCellAliasVreplicationWorkflow` which use `binlog_row_image=noblob`](https://github.com/vitessio/vitess/blob/main/go/test/endtoend/vreplication/vreplication_test.go#L592-L603) would fail when doing the vdiff after sharding tables in the product keyspace (examples [here](https://github.com/vitessio/vitess/actions/runs/11579964903/job/32239708429)):
```
2024-10-29T19:20:47.7378764Z 				"MismatchedRowsSample": [
2024-10-29T19:20:47.7379162Z 					{
2024-10-29T19:20:47.7379549Z 						"Source": {
2024-10-29T19:20:47.7379917Z 							"Row": {
2024-10-29T19:20:47.7380352Z 								"`name`": "ringo",
2024-10-29T19:20:47.7380776Z 								"bits": "\u0003",
2024-10-29T19:20:47.7381197Z 								"blb": "blob data",
2024-10-29T19:20:47.7381594Z 								"cid": "999999",
2024-10-29T19:20:47.7382139Z 								"date1": "0000-00-00 00:00:00",
2024-10-29T19:20:47.7382654Z 								"date2": "2021-00-01 00:00:00",
2024-10-29T19:20:47.7383043Z 								"dec80": "0",
2024-10-29T19:20:47.7383562Z 								"industryCategory": "\"Music\"",
2024-10-29T19:20:47.7384076Z 								"meta": "{\"industry\": \"Music\"}",
2024-10-29T19:20:47.7384539Z 								"sport": "",
2024-10-29T19:20:47.7385059Z 								"ts": "2024-10-29 19:04:26",
2024-10-29T19:20:47.7385536Z 								"typ": "enterprise"
2024-10-29T19:20:47.7385914Z 							}
2024-10-29T19:20:47.7386301Z 						},
2024-10-29T19:20:47.7386622Z 						"Target": {
2024-10-29T19:20:47.7387047Z 							"Row": {
2024-10-29T19:20:47.7387543Z 								"`name`": "ringo",
2024-10-29T19:20:47.7387948Z 								"bits": "\u0003",
2024-10-29T19:20:47.7388406Z 								"blb": "",
2024-10-29T19:20:47.7388783Z 								"cid": "999999",
2024-10-29T19:20:47.7389263Z 								"date1": "0000-00-00 00:00:00",
2024-10-29T19:20:47.7389793Z 								"date2": "2021-00-01 00:00:00",
2024-10-29T19:20:47.7390299Z 								"dec80": "0",
2024-10-29T19:20:47.7390750Z 								"industryCategory": "\"Music\"",
2024-10-29T19:20:47.7391317Z 								"meta": "{\"industry\": \"Music\"}",
2024-10-29T19:20:47.7391916Z 								"sport": "",
2024-10-29T19:20:47.7392330Z 								"ts": "2024-10-29 19:04:26",
2024-10-29T19:20:47.7392845Z 								"typ": "enterprise"
2024-10-29T19:20:47.7393229Z 							}
2024-10-29T19:20:47.7393530Z 						}
2024-10-29T19:20:47.7393853Z 					}
2024-10-29T19:20:47.7394156Z 				]
2024-10-29T19:20:47.7394438Z 			}
```

This was because, in this specific case, we incorrectly thought that the binlog event that was generated [here where only the `dec0` column was updated in all existing rows](https://github.com/vitessio/vitess/blob/0beb273786bcdd5a6a297c7dc372d72a0261b527/go/test/endtoend/vreplication/vreplication_test.go#L722), thus resulting in MySQL eliding the `blb` blob column from the ROW images in the binlog event (as it did not change), but VReplication incorrectly thinking it was there and thus assigning a `NULL` value (there was in fact no value in the event for it) to it in the resulting `UPDATE` statement generated.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/16992

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required