### PR TITLE
Optimize `sqlutils.ToSqlite3Dialect` for queries + DML/DDLs

### DIFF
--- a/go/vt/external/golib/sqlutils/sqlite_dialect.go
+++ b/go/vt/external/golib/sqlutils/sqlite_dialect.go
@@ -122,10 +122,10 @@ func ToSqlite3Insert(statement string) string {
 
 // ToSqlite3Dialect converts a statement to sqlite3 dialect. The statement
 // is checked in this order:
-//    1. If an insert/replace, convert with ToSqlite3Insert.
-//    2. If a create table, convert with IsCreateTable.
-//    3. If an alter table, convert with IsAlterTable.
-//    4. As fallback, return the statement with sqlite3GeneralConversions applied.
+//  1. If an insert/replace, convert with ToSqlite3Insert.
+//  2. If a create table, convert with IsCreateTable.
+//  3. If an alter table, convert with IsAlterTable.
+//  4. As fallback, return the statement with sqlite3GeneralConversions applied.
 func ToSqlite3Dialect(statement string) (translated string) {
 	if IsInsert(statement) {
 		return ToSqlite3Insert(statement)

--- a/go/vt/external/golib/sqlutils/sqlite_dialect.go
+++ b/go/vt/external/golib/sqlutils/sqlite_dialect.go
@@ -144,19 +144,16 @@ func ToSqlite3Insert(statement string) string {
 //  7. As fallback, return the statement with sqlite3GeneralConversions applied.
 func ToSqlite3Dialect(statement string, potentiallyDMLOrDDL bool) (translated string) {
 	if potentiallyDMLOrDDL {
-		if IsInsert(statement) {
+		switch {
+		case IsInsert(statement):
 			return ToSqlite3Insert(statement)
-		}
-		if IsCreateIndex(statement) {
+		case IsCreateIndex(statement):
 			return ToSqlite3CreateIndex(statement)
-		}
-		if IsDropIndex(statement) {
+		case IsDropIndex(statement):
 			return ToSqlite3DropIndex(statement)
-		}
-		if IsCreateTable(statement) {
+		case IsCreateTable(statement):
 			return ToSqlite3CreateTable(statement)
-		}
-		if IsAlterTable(statement) {
+		case IsAlterTable(statement):
 			return ToSqlite3CreateTable(statement)
 		}
 	}

--- a/go/vt/external/golib/sqlutils/sqlite_dialect.go
+++ b/go/vt/external/golib/sqlutils/sqlite_dialect.go
@@ -135,25 +135,30 @@ func ToSqlite3Insert(statement string) string {
 
 // ToSqlite3Dialect converts a statement to sqlite3 dialect. The statement
 // is checked in this order:
-//  1. If an insert/replace, convert with ToSqlite3Insert.
-//  2. If a create table, convert with IsCreateTable.
-//  3. If an alter table, convert with IsAlterTable.
-//  4. As fallback, return the statement with sqlite3GeneralConversions applied.
-func ToSqlite3Dialect(statement string) (translated string) {
-	if IsInsert(statement) {
-		return ToSqlite3Insert(statement)
-	}
-	if IsCreateIndex(statement) {
-		return ToSqlite3CreateIndex(statement)
-	}
-	if IsDropIndex(statement) {
-		return ToSqlite3DropIndex(statement)
-	}
-	if IsCreateTable(statement) {
-		return ToSqlite3CreateTable(statement)
-	}
-	if IsAlterTable(statement) {
-		return ToSqlite3CreateTable(statement)
+//  1. If a query, return the statement with sqlite3GeneralConversions applied.
+//  2. If an insert/replace, convert with ToSqlite3Insert.
+//  3. If a create index, convert with IsCreateIndex.
+//  4. If an drop table, convert with IsDropIndex.
+//  5. If a create table, convert with IsCreateTable.
+//  6. If an alter table, convert with IsAlterTable.
+//  7. As fallback, return the statement with sqlite3GeneralConversions applied.
+func ToSqlite3Dialect(statement string, potentiallyDMLOrDDL bool) (translated string) {
+	if potentiallyDMLOrDDL {
+		if IsInsert(statement) {
+			return ToSqlite3Insert(statement)
+		}
+		if IsCreateIndex(statement) {
+			return ToSqlite3CreateIndex(statement)
+		}
+		if IsDropIndex(statement) {
+			return ToSqlite3DropIndex(statement)
+		}
+		if IsCreateTable(statement) {
+			return ToSqlite3CreateTable(statement)
+		}
+		if IsAlterTable(statement) {
+			return ToSqlite3CreateTable(statement)
+		}
 	}
 	return applyConversions(statement, sqlite3GeneralConversions)
 }

--- a/go/vt/external/golib/sqlutils/sqlite_dialect.go
+++ b/go/vt/external/golib/sqlutils/sqlite_dialect.go
@@ -78,8 +78,13 @@ var sqlite3GeneralConversions = []regexpMap{
 	rmap(`(?i)\bconcat[(][\s]*([^,)]+)[\s]*,[\s]*([^,)]+)[\s]*,[\s]*([^,)]+)[\s]*[)]`, `($1 || $2 || $3)`),
 
 	rmap(`(?i) rlike `, ` like `),
+}
 
+var sqlite3CreateIndexConversions = []regexpMap{
 	rmap(`(?i)create index([\s\S]+)[(][\s]*[0-9]+[\s]*[)]([\s\S]+)`, `create index ${1}${2}`),
+}
+
+var sqlite3DropIndexConversions = []regexpMap{
 	rmap(`(?i)drop index ([\S]+) on ([\S]+)`, `drop index if exists $1`),
 }
 
@@ -115,6 +120,14 @@ func ToSqlite3CreateTable(statement string) string {
 	return applyConversions(statement, sqlite3CreateTableConversions)
 }
 
+func ToSqlite3CreateIndex(statement string) string {
+	return applyConversions(statement, sqlite3CreateIndexConversions)
+}
+
+func ToSqlite3DropIndex(statement string) string {
+	return applyConversions(statement, sqlite3DropIndexConversions)
+}
+
 func ToSqlite3Insert(statement string) string {
 	statement = applyConversions(statement, sqlite3GeneralConversions)
 	return applyConversions(statement, sqlite3InsertConversions)
@@ -129,6 +142,12 @@ func ToSqlite3Insert(statement string) string {
 func ToSqlite3Dialect(statement string) (translated string) {
 	if IsInsert(statement) {
 		return ToSqlite3Insert(statement)
+	}
+	if IsCreateIndex(statement) {
+		return ToSqlite3CreateIndex(statement)
+	}
+	if IsDropIndex(statement) {
+		return ToSqlite3DropIndex(statement)
 	}
 	if IsCreateTable(statement) {
 		return ToSqlite3CreateTable(statement)

--- a/go/vt/external/golib/sqlutils/sqlite_dialect.go
+++ b/go/vt/external/golib/sqlutils/sqlite_dialect.go
@@ -116,19 +116,25 @@ func ToSqlite3CreateTable(statement string) string {
 }
 
 func ToSqlite3Insert(statement string) string {
+	statement = applyConversions(statement, sqlite3GeneralConversions)
 	return applyConversions(statement, sqlite3InsertConversions)
 }
 
+// ToSqlite3Dialect converts a statement to sqlite3 dialect. The statement
+// is checked in this order:
+//    1. If an insert/replace, convert with ToSqlite3Insert.
+//    2. If a create table, convert with IsCreateTable.
+//    3. If an alter table, convert with IsAlterTable.
+//    4. As fallback, return the statement with sqlite3GeneralConversions applied.
 func ToSqlite3Dialect(statement string) (translated string) {
+	if IsInsert(statement) {
+		return ToSqlite3Insert(statement)
+	}
 	if IsCreateTable(statement) {
 		return ToSqlite3CreateTable(statement)
 	}
 	if IsAlterTable(statement) {
 		return ToSqlite3CreateTable(statement)
 	}
-	statement = applyConversions(statement, sqlite3GeneralConversions)
-	if IsInsert(statement) {
-		return ToSqlite3Insert(statement)
-	}
-	return statement
+	return applyConversions(statement, sqlite3GeneralConversions)
 }

--- a/go/vt/external/golib/sqlutils/sqlite_dialect_test.go
+++ b/go/vt/external/golib/sqlutils/sqlite_dialect_test.go
@@ -21,6 +21,7 @@
 package sqlutils
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -310,5 +311,35 @@ func TestToSqlite3Dialect(t *testing.T) {
 			result := ToSqlite3Dialect(test.input)
 			assert.Equal(t, test.expected, result)
 		})
+	}
+}
+
+func buildToSqlite3Dialect_Insert(instances int) string {
+	var rows []string
+	for i := 0; i < instances; i++ {
+		rows = append(rows, `(?, ?, ?, NOW(), NOW(), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())`)
+	}
+
+	return fmt.Sprintf(`INSERT ignore INTO database_instance
+			(alias, hostname, port, last_checked, last_attempted_check, last_check_partial_success, server_id, server_uuid,
+			version, major_version, version_comment, binlog_server, read_only, binlog_format,
+			binlog_row_image, log_bin, log_replica_updates, binary_log_file, binary_log_pos, source_host, source_port, replica_net_timeout, heartbeat_interval,
+			replica_sql_running, replica_io_running, replication_sql_thread_state, replication_io_thread_state, has_replication_filters, supports_oracle_gtid, oracle_gtid, source_uuid, ancestry_uuid, executed_gtid_set, gtid_mode, gtid_purged, gtid_errant, mariadb_gtid, pseudo_gtid,
+			source_log_file, read_source_log_pos, relay_source_log_file, exec_source_log_pos, relay_log_file, relay_log_pos, last_sql_error, last_io_error, replication_lag_seconds, replica_lag_seconds, sql_delay, data_center, region, physical_environment, replication_depth, is_co_primary, has_replication_credentials, allow_tls, semi_sync_enforced, semi_sync_primary_enabled, semi_sync_primary_timeout, semi_sync_primary_wait_for_replica_count, semi_sync_replica_enabled, semi_sync_primary_status, semi_sync_primary_clients, semi_sync_replica_status, last_discovery_latency, last_seen)
+		VALUES
+			%s
+		ON DUPLICATE KEY UPDATE
+			alias=VALUES(alias), hostname=VALUES(hostname), port=VALUES(port), last_checked=VALUES(last_checked), last_attempted_check=VALUES(last_attempted_check), last_check_partial_success=VALUES(last_check_partial_success), server_id=VALUES(server_id), server_uuid=VALUES(server_uuid), version=VALUES(version), major_version=VALUES(major_version), version_comment=VALUES(version_comment), binlog_server=VALUES(binlog_server), read_only=VALUES(read_only), binlog_format=VALUES(binlog_format), binlog_row_image=VALUES(binlog_row_image), log_bin=VALUES(log_bin), log_replica_updates=VALUES(log_replica_updates), binary_log_file=VALUES(binary_log_file), binary_log_pos=VALUES(binary_log_pos), source_host=VALUES(source_host), source_port=VALUES(source_port), replica_net_timeout=VALUES(replica_net_timeout), heartbeat_interval=VALUES(heartbeat_interval), replica_sql_running=VALUES(replica_sql_running), replica_io_running=VALUES(replica_io_running), replication_sql_thread_state=VALUES(replication_sql_thread_state), replication_io_thread_state=VALUES(replication_io_thread_state), has_replication_filters=VALUES(has_replication_filters), supports_oracle_gtid=VALUES(supports_oracle_gtid), oracle_gtid=VALUES(oracle_gtid), source_uuid=VALUES(source_uuid), ancestry_uuid=VALUES(ancestry_uuid), executed_gtid_set=VALUES(executed_gtid_set), gtid_mode=VALUES(gtid_mode), gtid_purged=VALUES(gtid_purged), gtid_errant=VALUES(gtid_errant), mariadb_gtid=VALUES(mariadb_gtid), pseudo_gtid=VALUES(pseudo_gtid), source_log_file=VALUES(source_log_file), read_source_log_pos=VALUES(read_source_log_pos), relay_source_log_file=VALUES(relay_source_log_file), exec_source_log_pos=VALUES(exec_source_log_pos), relay_log_file=VALUES(relay_log_file), relay_log_pos=VALUES(relay_log_pos), last_sql_error=VALUES(last_sql_error), last_io_error=VALUES(last_io_error), replication_lag_seconds=VALUES(replication_lag_seconds), replica_lag_seconds=VALUES(replica_lag_seconds), sql_delay=VALUES(sql_delay), data_center=VALUES(data_center), region=VALUES(region), physical_environment=VALUES(physical_environment), replication_depth=VALUES(replication_depth), is_co_primary=VALUES(is_co_primary), has_replication_credentials=VALUES(has_replication_credentials), allow_tls=VALUES(allow_tls),
+			semi_sync_enforced=VALUES(semi_sync_enforced), semi_sync_primary_enabled=VALUES(semi_sync_primary_enabled), semi_sync_primary_timeout=VALUES(semi_sync_primary_timeout), semi_sync_primary_wait_for_replica_count=VALUES(semi_sync_primary_wait_for_replica_count), semi_sync_replica_enabled=VALUES(semi_sync_replica_enabled), semi_sync_primary_status=VALUES(semi_sync_primary_status), semi_sync_primary_clients=VALUES(semi_sync_primary_clients), semi_sync_replica_status=VALUES(semi_sync_replica_status),
+			last_discovery_latency=VALUES(last_discovery_latency), last_seen=VALUES(last_seen)
+       `, strings.Join(rows, "\n\t\t\t\t"))
+}
+
+func BenchmarkToSqlite3Dialect_Insert1000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		statement := buildToSqlite3Dialect_Insert(1000)
+		b.StartTimer()
+		ToSqlite3Dialect(statement)
 	}
 }

--- a/go/vt/vtorc/db/db.go
+++ b/go/vt/vtorc/db/db.go
@@ -58,7 +58,11 @@ func OpenVTOrc() (db *sql.DB, err error) {
 }
 
 func translateStatement(statement string) string {
-	return sqlutils.ToSqlite3Dialect(statement)
+	return sqlutils.ToSqlite3Dialect(statement, true /* potentiallyDMLOrDDL */)
+}
+
+func translateQueryStatement(statement string) string {
+	return sqlutils.ToSqlite3Dialect(statement, false /* potentiallyDMLOrDDL */)
 }
 
 // registerVTOrcDeployment updates the vtorc_db_deployments table upon successful deployment
@@ -151,7 +155,7 @@ func ExecVTOrc(query string, args ...any) (sql.Result, error) {
 
 // QueryVTOrcRowsMap
 func QueryVTOrcRowsMap(query string, onRow func(sqlutils.RowMap) error) error {
-	query = translateStatement(query)
+	query = translateQueryStatement(query)
 	db, err := OpenVTOrc()
 	if err != nil {
 		return err
@@ -162,7 +166,7 @@ func QueryVTOrcRowsMap(query string, onRow func(sqlutils.RowMap) error) error {
 
 // QueryVTOrc
 func QueryVTOrc(query string, argsArray []any, onRow func(sqlutils.RowMap) error) error {
-	query = translateStatement(query)
+	query = translateQueryStatement(query)
 	db, err := OpenVTOrc()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

This PR adds some slight optimisations to `sqlutils.ToSqlite3Dialect`, a function we've noticed to take up a significant amount of CPU time in `vtorc` when it watches many instances, primarily due to large insert queries needing to be parsed by `regexp` filters

Profile SVG _(need to enlarge)_:
![profile001](https://github.com/user-attachments/assets/60a719c2-ef26-4011-a18f-1797cf9c980e)

All this change does is assumes inserts happen more frequently than alter/create. Moving inserts to be checked sooner and separating read queries causes them to have to go through [fewer regex matches](https://github.com/vitessio/vitess/blob/main/go/vt/external/golib/sqlutils/sqlite_dialect.go) _(still a lot 🙈)_. The expense of queries that are not insert, alter or create is unchanged.

On Slack's `vtorc` instances this gave us about a 15-20% reduction in user-CPU used by `vtorc` vs the previous avg

In the benchmark I added in the PR the difference is more like 8-9% for big inserts and 18-19% for reads

#### Before
```bash
goos: darwin
goarch: amd64
pkg: vitess.io/vitess/go/vt/external/golib/sqlutils
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkToSqlite3Dialect_Insert1000
BenchmarkToSqlite3Dialect_Insert1000-16    	       1	1870643229 ns/op
BenchmarkToSqlite3Dialect_Select
BenchmarkToSqlite3Dialect_Select-16        	    3541	    330667 ns/op
PASS
ok  	vitess.io/vitess/go/vt/external/golib/sqlutils	4.660s
```

#### After
```bash
goos: darwin
goarch: amd64
pkg: vitess.io/vitess/go/vt/external/golib/sqlutils
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkToSqlite3Dialect_Insert1000
BenchmarkToSqlite3Dialect_Insert1000-16    	       1	1711349181 ns/op
BenchmarkToSqlite3Dialect_Select
BenchmarkToSqlite3Dialect_Select-16        	    4436	    270223 ns/op
PASS
ok  	vitess.io/vitess/go/vt/external/golib/sqlutils	4.528s
```

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/17114

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
