### PR TITLE
test: Improve Error Reporting for Cluster Failures in End-to-End Tests

### DIFF
--- a/go/test/endtoend/cluster/command.go
+++ b/go/test/endtoend/cluster/command.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type processInfo struct {
+	proc   *exec.Cmd
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+}
+
+func newCommand(name string, arg ...string) *processInfo {
+	pi := &processInfo{
+		proc: exec.Command(name, arg...),
+	}
+	pi.proc.Stdout = &pi.stdout
+	pi.proc.Stderr = &pi.stderr
+	return pi
+}
+
+func (pi *processInfo) addArgs(arg ...string) {
+	pi.proc.Args = append(pi.proc.Args, arg...)
+}
+
+func (pi *processInfo) getArgs() []string {
+	return pi.proc.Args
+}
+
+func (pi *processInfo) addEnv(arg ...string) {
+	pi.proc.Env = append(pi.proc.Env, arg...)
+}
+
+func (pi *processInfo) failed(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := "failed to run %v: \n%w"
+	if out := pi.stdout.String(); out != "" {
+		message += fmt.Sprintf("\nstdout: %s", out)
+	}
+	if out := pi.stderr.String(); out != "" {
+		message += fmt.Sprintf("\nstderr: %s", out)
+	}
+
+	return fmt.Errorf(message, pi.proc.Args, err)
+}
+
+func (pi *processInfo) start() error {
+	err := pi.proc.Start()
+	return pi.failed(err)
+}
+
+func (pi *processInfo) wait() error {
+	err := pi.proc.Wait()
+	return pi.failed(err)
+}
+
+func (pi *processInfo) process() *os.Process {
+	return pi.proc.Process
+}
+
+func (pi *processInfo) run() error {
+	err := pi.proc.Run()
+	return pi.failed(err)
+}

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -132,7 +132,7 @@ func (mysqlctl *MysqlctlProcess) startProcess(init bool) (*processInfo, error) {
 			extraMyCNF := path.Join(sslPath, "ssl.cnf")
 			fout, err := os.Create(extraMyCNF)
 			if err != nil {
-				log.Error(err)
+				log.Error(err.Error())
 				return nil, err
 			}
 

--- a/go/test/endtoend/cluster/mysqlctld_process.go
+++ b/go/test/endtoend/cluster/mysqlctld_process.go
@@ -93,7 +93,7 @@ func (mysqlctld *MysqlctldProcess) Start() error {
 
 	err := os.MkdirAll(mysqlctld.LogDirectory, 0755)
 	if err != nil {
-		log.Errorf("Failed to create directory for mysqlctld logs: %v", err)
+		log.Errorf("Failed to create directory for mysqlctld logs: %v", err.Error())
 		return err
 	}
 

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -137,15 +137,15 @@ func (topo *TopoProcess) SetupEtcd() (err error) {
 			if ferr == nil {
 				log.Errorf("%s error log contents:\n%s", topo.Binary, string(errBytes))
 			} else {
-				log.Errorf("Failed to read the %s error log file %q: %v", topo.Binary, topo.ErrorLog, ferr)
+				log.Errorf("Failed to read the %s error log file %q: %v", topo.Binary, topo.ErrorLog, ferr.Error())
 			}
-			return fmt.Errorf("process '%s' exited prematurely (err: %s)", topo.Binary, err)
+			return fmt.Errorf("process '%s' exited prematurely (err: %w)", topo.Binary, err)
 		default:
 			time.Sleep(300 * time.Millisecond)
 		}
 	}
 
-	return fmt.Errorf("process '%s' timed out after 60s (err: %s)", topo.Binary, <-topo.exit)
+	return fmt.Errorf("process '%s' timed out after 60s (err: %w)", topo.Binary, <-topo.exit)
 }
 
 // SetupZookeeper spawns a new zookeeper topo service and initializes it with the defaults.
@@ -199,12 +199,12 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 
 	err = os.MkdirAll(topo.LogDirectory, os.ModePerm)
 	if err != nil {
-		log.Errorf("Failed to create directory for consul logs: %v", err)
+		log.Errorf("Failed to create directory for consul logs: %v", err.Error())
 		return
 	}
 	err = os.MkdirAll(topo.DataDirectory, os.ModePerm)
 	if err != nil {
-		log.Errorf("Failed to create directory for consul data: %v", err)
+		log.Errorf("Failed to create directory for consul data: %v", err.Error())
 		return
 	}
 
@@ -213,7 +213,7 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 	logFile := path.Join(topo.LogDirectory, "/consul.log")
 	_, err = os.Create(logFile)
 	if err != nil {
-		log.Errorf("Failed to create file for consul logs: %v", err)
+		log.Errorf("Failed to create file for consul logs: %v", err.Error())
 		return
 	}
 
@@ -357,10 +357,10 @@ func (topo *TopoProcess) IsHealthy() bool {
 
 func (topo *TopoProcess) removeTopoDirectories(Cell string) {
 	if err := topo.ManageTopoDir("rmdir", "/vitess/global"); err != nil {
-		log.Errorf("Failed to remove global topo directory: %v", err)
+		log.Errorf("Failed to remove global topo directory: %v", err.Error())
 	}
 	if err := topo.ManageTopoDir("rmdir", "/vitess/"+Cell); err != nil {
-		log.Errorf("Failed to remove local topo directory: %v", err)
+		log.Errorf("Failed to remove local topo directory: %v", err.Error())
 	}
 }
 

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -70,7 +70,7 @@ func (vtctl *VtctlProcess) CreateKeyspace(keyspace, sidecarDBName, durabilityPol
 	}
 	output, err := vtctl.ExecuteCommandWithOutput(args...)
 	if err != nil {
-		log.Errorf("CreateKeyspace returned err: %s, output: %s", err, output)
+		log.Errorf("CreateKeyspace returned err: %s, output: %s", err.Error(), output)
 	}
 	return err
 }

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -75,7 +75,7 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 
 	err = os.MkdirAll(vtctld.LogDir, 0755)
 	if err != nil {
-		log.Errorf("cannot create log directory for vtctld: %v", err)
+		log.Errorf("cannot create log directory for vtctld: %v", err.Error())
 		return err
 	}
 
@@ -106,7 +106,7 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 			if ferr == nil {
 				log.Errorf("vtctld error log contents:\n%s", string(errBytes))
 			} else {
-				log.Errorf("Failed to read the vtctld error log file %q: %v", vtctld.ErrorLog, ferr)
+				log.Errorf("Failed to read the vtctld error log file %q: %v", vtctld.ErrorLog, ferr.Error())
 			}
 			return fmt.Errorf("process '%s' exited prematurely (err: %s)", vtctld.Name, err)
 		default:

--- a/go/test/endtoend/cluster/vtctldclient_process.go
+++ b/go/test/endtoend/cluster/vtctldclient_process.go
@@ -239,7 +239,7 @@ func (vtctldclient *VtctldClientProcess) CreateKeyspace(keyspaceName string, sid
 		output, err = vtctldclient.ExecuteCommandWithOutput("CreateKeyspace", keyspaceName, "--sidecar-db-name", sidecarDBName)
 	}
 	if err != nil {
-		log.Errorf("CreateKeyspace returned err: %s, output: %s", err, output)
+		log.Errorf("CreateKeyspace returned err: %s, output: %s", err.Error(), output)
 	}
 	return err
 }

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -152,7 +152,7 @@ func (vtgate *VtgateProcess) Setup() error {
 			if ferr == nil {
 				log.Errorf("vtgate error log contents:\n%s", string(errBytes))
 			} else {
-				log.Errorf("Failed to read the vtgate error log file %q: %v", vtgate.ErrorLog, ferr)
+				log.Errorf("Failed to read the vtgate error log file %q: %v", vtgate.ErrorLog, ferr.Error())
 			}
 			return fmt.Errorf("process '%s' exited prematurely (err: %s)", vtgate.Name, err)
 		default:

--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -78,12 +78,12 @@ func (orc *VTOrcProcess) Setup() (err error) {
 	timeNow := time.Now().UnixNano()
 	err = os.MkdirAll(orc.LogDir, 0755)
 	if err != nil {
-		log.Errorf("cannot create log directory for vtorc: %v", err)
+		log.Errorf("cannot create log directory for vtorc: %v", err.Error())
 		return err
 	}
 	configFile, err := os.Create(path.Join(orc.LogDir, fmt.Sprintf("orc-config-%d.json", timeNow)))
 	if err != nil {
-		log.Errorf("cannot create config file for vtorc: %v", err)
+		log.Errorf("cannot create config file for vtorc: %v", err.Error())
 		return err
 	}
 	orc.ConfigPath = configFile.Name()

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -307,7 +307,7 @@ func (vttablet *VttabletProcess) WaitForTabletStatusesForTimeout(expectedStatuse
 			if ferr == nil {
 				log.Errorf("vttablet error log contents:\n%s", string(errBytes))
 			} else {
-				log.Errorf("Failed to read the vttablet error log file %q: %v", vttablet.ErrorLog, ferr)
+				log.Errorf("Failed to read the vttablet error log file %q: %v", vttablet.ErrorLog, ferr.Error())
 			}
 			return fmt.Errorf("process '%s' exited prematurely (err: %s)", vttablet.Name, err)
 		default:

--- a/go/test/endtoend/cluster/vttablet_process_unix.go
+++ b/go/test/endtoend/cluster/vttablet_process_unix.go
@@ -22,5 +22,5 @@ import "syscall"
 
 // ToggleProfiling enables or disables the configured CPU profiler on this vttablet
 func (vttablet *VttabletProcess) ToggleProfiling() error {
-	return vttablet.proc.Process.Signal(syscall.SIGUSR1)
+	return vttablet.proc.process().Signal(syscall.SIGUSR1)
 }

--- a/go/test/endtoend/vtgate/queries/derived/main_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/main_test.go
@@ -54,6 +54,7 @@ func TestMain(m *testing.M) {
 		// Start topo server
 		err := clusterInstance.StartTopo()
 		if err != nil {
+			fmt.Printf("Error starting topo server: %v\n", err.Error())
 			return 1
 		}
 
@@ -65,6 +66,7 @@ func TestMain(m *testing.M) {
 		}
 		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 0, false)
 		if err != nil {
+			fmt.Printf("Error starting keyspace: %v\n", err.Error())
 			return 1
 		}
 
@@ -72,6 +74,7 @@ func TestMain(m *testing.M) {
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {
+			fmt.Printf("Error starting vtgate server: %v\n", err.Error())
 			return 1
 		}
 
@@ -83,7 +86,7 @@ func TestMain(m *testing.M) {
 		// create mysql instance and connection parameters
 		conn, closer, err := utils.NewMySQL(clusterInstance, keyspaceName, schemaSQL)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Printf("Error starting mysql server: %v\n", err.Error())
 			return 1
 		}
 		defer closer()


### PR DESCRIPTION
## Description
When running end-to-end tests, diagnosing failures during cluster startup can be challenging due to limited error details. This PR enhances error reporting by modifying how process information is captured and logged, allowing for clearer insights into failures.

These changes aim to reduce the difficulty in identifying the root cause of cluster startup issues, thereby improving debugging efficiency and test reliability.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required