### PR TITLE
List join predicates used in `GetVExplainKeys`

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/keys.go
+++ b/go/vt/vtgate/planbuilder/operators/keys.go
@@ -44,7 +44,6 @@ type (
 		StatementType   string          `json:"statementType"`
 		TableName       []string        `json:"tableName,omitempty"`
 		GroupingColumns []Column        `json:"groupingColumns,omitempty"`
-		JoinColumns     []ColumnUse     `json:"joinColumns,omitempty"`
 		FilterColumns   []ColumnUse     `json:"filterColumns,omitempty"`
 		SelectColumns   []Column        `json:"selectColumns,omitempty"`
 		JoinPredicates  []JoinPredicate `json:"joinPredicates,omitempty"`
@@ -246,7 +245,6 @@ func GetVExplainKeys(ctx *plancontext.PlanningContext, stmt sqlparser.Statement)
 	return VExplainKeys{
 		SelectColumns:   getUniqueColNames(ctx, selectColumns),
 		GroupingColumns: getUniqueColNames(ctx, groupingColumns),
-		JoinColumns:     getUniqueColUsages(ctx, joinColumns),
 		FilterColumns:   getUniqueColUsages(ctx, filterColumns),
 		StatementType:   sqlparser.ASTToStatementType(stmt).String(),
 		JoinPredicates:  getUniqueJoinPredicates(ctx, jps),

--- a/go/vt/vtgate/planbuilder/operators/keys_test.go
+++ b/go/vt/vtgate/planbuilder/operators/keys_test.go
@@ -35,10 +35,6 @@ func TestMarshalUnmarshal(t *testing.T) {
 			{Table: "orders", Name: "category"},
 			{Table: "users", Name: "department"},
 		},
-		JoinColumns: []ColumnUse{
-			{Column: Column{Table: "users", Name: "id"}, Uses: sqlparser.EqualOp},
-			{Column: Column{Table: "orders", Name: "user_id"}, Uses: sqlparser.EqualOp},
-		},
 		FilterColumns: []ColumnUse{
 			{Column: Column{Table: "users", Name: "age"}, Uses: sqlparser.GreaterThanOp},
 			{Column: Column{Table: "orders", Name: "total"}, Uses: sqlparser.LessThanOp},

--- a/go/vt/vtgate/planbuilder/operators/keys_test.go
+++ b/go/vt/vtgate/planbuilder/operators/keys_test.go
@@ -49,6 +49,9 @@ func TestMarshalUnmarshal(t *testing.T) {
 			{Table: "users", Name: "email"},
 			{Table: "orders", Name: "amount"},
 		},
+		JoinPredicates: []JoinPredicate{
+			{LHS: Column{Table: "users", Name: "id"}, RHS: Column{Table: "orders", Name: "user_id"}, Uses: sqlparser.EqualOp},
+		},
 	}
 
 	jsonData, err := json.Marshal(original)

--- a/go/vt/vtgate/testdata/executor_vexplain.json
+++ b/go/vt/vtgate/testdata/executor_vexplain.json
@@ -33,7 +33,7 @@
 				"user_extra.noLimit ="
 			],
 			"joinPredicates": [
-				"user_extra.user_id = `user`.id"
+				"`user`.id = user_extra.user_id"
 			]
 		}
 	},

--- a/go/vt/vtgate/testdata/executor_vexplain.json
+++ b/go/vt/vtgate/testdata/executor_vexplain.json
@@ -1,129 +1,129 @@
 [
-	{
-		"query": "select count(*), col2 from music group by col2",
-		"expected": {
-			"statementType": "SELECT",
-			"groupingColumns": [
-				"music.col2"
-			],
-			"selectColumns": [
-				"music.col2"
-			]
-		}
-	},
-	{
-		"query": "select * from user u join user_extra ue on u.id = ue.user_id where u.col1 \u003e 100 and ue.noLimit = 'foo'",
-		"expected": {
-			"statementType": "SELECT",
-			"filterColumns": [
-				"`user`.col1 gt",
-				"user_extra.noLimit ="
-			],
-			"joinPredicates": [
-				"`user`.id = user_extra.user_id"
-			]
-		}
-	},
-	{
-		"query": "select * from user_extra ue, user u where ue.noLimit = 'foo' and u.col1 \u003e 100 and ue.user_id = u.id",
-		"expected": {
-			"statementType": "SELECT",
-			"filterColumns": [
-				"`user`.col1 gt",
-				"user_extra.noLimit ="
-			],
-			"joinPredicates": [
-				"`user`.id = user_extra.user_id"
-			]
-		}
-	},
-	{
-		"query": "select u.foo, ue.bar, count(*) from user u join user_extra ue on u.id = ue.user_id where u.name = 'John Doe' group by 1, 2",
-		"expected": {
-			"statementType": "SELECT",
-			"groupingColumns": [
-				"`user`.foo",
-				"user_extra.bar"
-			],
-			"filterColumns": [
-				"`user`.`name` ="
-			],
-			"selectColumns": [
-				"`user`.foo",
-				"user_extra.bar"
-			],
-			"joinPredicates": [
-				"`user`.id = user_extra.user_id"
-			]
-		}
-	},
-	{
-		"query": "select * from (select * from user) as derived where derived.amount \u003e 1000",
-		"expected": {
-			"statementType": "SELECT"
-		}
-	},
-	{
-		"query": "select name, sum(amount) from user group by name",
-		"expected": {
-			"statementType": "SELECT",
-			"groupingColumns": [
-				"`user`.`name`"
-			],
-			"selectColumns": [
-				"`user`.`name`",
-				"`user`.amount"
-			]
-		}
-	},
-	{
-		"query": "select name from user where age \u003e 30",
-		"expected": {
-			"statementType": "SELECT",
-			"filterColumns": [
-				"`user`.age gt"
-			],
-			"selectColumns": [
-				"`user`.`name`"
-			]
-		}
-	},
-	{
-		"query": "select * from user where name = 'apa' union select * from user_extra where name = 'monkey'",
-		"expected": {
-			"statementType": "SELECT",
-			"filterColumns": [
-				"`user`.`name` =",
-				"user_extra.`name` ="
-			]
-		}
-	},
-	{
-		"query": "update user set name = 'Jane Doe' where id = 1",
-		"expected": {
-			"statementType": "UPDATE",
-			"filterColumns": [
-				"`user`.id ="
-			]
-		}
-	},
-	{
-		"query": "delete from user where order_date \u003c '2023-01-01'",
-		"expected": {
-			"statementType": "DELETE",
-			"filterColumns": [
-				"`user`.order_date lt"
-			]
-		}
-	},
-	{
-		"query": "select * from user where name between 'A' and 'C'",
-		"expected": {
-			"statementType": "SELECT",
-			"filterColumns": [
-				"`user`.`name` ge",
-				"`user`.`name` le"
-			]
-		}
-	}
+  {
+    "query": "select count(*), col2 from music group by col2",
+    "expected": {
+      "statementType": "SELECT",
+      "groupingColumns": [
+        "music.col2"
+      ],
+      "selectColumns": [
+        "music.col2"
+      ]
+    }
+  },
+  {
+    "query": "select * from user u join user_extra ue on u.id = ue.user_id where u.col1 \u003e 100 and ue.noLimit = 'foo'",
+    "expected": {
+      "statementType": "SELECT",
+      "filterColumns": [
+        "`user`.col1 gt",
+        "user_extra.noLimit ="
+      ],
+      "joinPredicates": [
+        "`user`.id = user_extra.user_id"
+      ]
+    }
+  },
+  {
+    "query": "select * from user_extra ue, user u where ue.noLimit = 'foo' and u.col1 \u003e 100 and ue.user_id = u.id",
+    "expected": {
+      "statementType": "SELECT",
+      "filterColumns": [
+        "`user`.col1 gt",
+        "user_extra.noLimit ="
+      ],
+      "joinPredicates": [
+        "`user`.id = user_extra.user_id"
+      ]
+    }
+  },
+  {
+    "query": "select u.foo, ue.bar, count(*) from user u join user_extra ue on u.id = ue.user_id where u.name = 'John Doe' group by 1, 2",
+    "expected": {
+      "statementType": "SELECT",
+      "groupingColumns": [
+        "`user`.foo",
+        "user_extra.bar"
+      ],
+      "filterColumns": [
+        "`user`.`name` ="
+      ],
+      "selectColumns": [
+        "`user`.foo",
+        "user_extra.bar"
+      ],
+      "joinPredicates": [
+        "`user`.id = user_extra.user_id"
+      ]
+    }
+  },
+  {
+    "query": "select * from (select * from user) as derived where derived.amount \u003e 1000",
+    "expected": {
+      "statementType": "SELECT"
+    }
+  },
+  {
+    "query": "select name, sum(amount) from user group by name",
+    "expected": {
+      "statementType": "SELECT",
+      "groupingColumns": [
+        "`user`.`name`"
+      ],
+      "selectColumns": [
+        "`user`.`name`",
+        "`user`.amount"
+      ]
+    }
+  },
+  {
+    "query": "select name from user where age \u003e 30",
+    "expected": {
+      "statementType": "SELECT",
+      "filterColumns": [
+        "`user`.age gt"
+      ],
+      "selectColumns": [
+        "`user`.`name`"
+      ]
+    }
+  },
+  {
+    "query": "select * from user where name = 'apa' union select * from user_extra where name = 'monkey'",
+    "expected": {
+      "statementType": "SELECT",
+      "filterColumns": [
+        "`user`.`name` =",
+        "user_extra.`name` ="
+      ]
+    }
+  },
+  {
+    "query": "update user set name = 'Jane Doe' where id = 1",
+    "expected": {
+      "statementType": "UPDATE",
+      "filterColumns": [
+        "`user`.id ="
+      ]
+    }
+  },
+  {
+    "query": "delete from user where order_date \u003c '2023-01-01'",
+    "expected": {
+      "statementType": "DELETE",
+      "filterColumns": [
+        "`user`.order_date lt"
+      ]
+    }
+  },
+  {
+    "query": "select * from user where name between 'A' and 'C'",
+    "expected": {
+      "statementType": "SELECT",
+      "filterColumns": [
+        "`user`.`name` ge",
+        "`user`.`name` le"
+      ]
+    }
+  }
 ]

--- a/go/vt/vtgate/testdata/executor_vexplain.json
+++ b/go/vt/vtgate/testdata/executor_vexplain.json
@@ -15,13 +15,12 @@
 		"query": "select * from user u join user_extra ue on u.id = ue.user_id where u.col1 \u003e 100 and ue.noLimit = 'foo'",
 		"expected": {
 			"statementType": "SELECT",
-			"joinColumns": [
-				"`user`.id =",
-				"user_extra.user_id ="
-			],
 			"filterColumns": [
 				"`user`.col1 gt",
 				"user_extra.noLimit ="
+			],
+			"joinPredicates": [
+				"`user`.id = user_extra.user_id"
 			]
 		}
 	},
@@ -29,13 +28,12 @@
 		"query": "select * from user_extra ue, user u where ue.noLimit = 'foo' and u.col1 \u003e 100 and ue.user_id = u.id",
 		"expected": {
 			"statementType": "SELECT",
-			"joinColumns": [
-				"`user`.id =",
-				"user_extra.user_id ="
-			],
 			"filterColumns": [
 				"`user`.col1 gt",
 				"user_extra.noLimit ="
+			],
+			"joinPredicates": [
+				"user_extra.user_id = `user`.id"
 			]
 		}
 	},
@@ -47,16 +45,15 @@
 				"`user`.foo",
 				"user_extra.bar"
 			],
-			"joinColumns": [
-				"`user`.id =",
-				"user_extra.user_id ="
-			],
 			"filterColumns": [
 				"`user`.`name` ="
 			],
 			"selectColumns": [
 				"`user`.foo",
 				"user_extra.bar"
+			],
+			"joinPredicates": [
+				"`user`.id = user_extra.user_id"
 			]
 		}
 	},


### PR DESCRIPTION
## Description

This PR enhances `GetVExplainKeys` to also list the join predicates that were used in the given query. This enable us to achieve https://github.com/vitessio/vt/pull/43 in `vt keys` and `vt benchstat`. Example output and usage were detailed in https://github.com/vitessio/vt/pull/43.
