### PR TITLE
Close zookeeper topo connection on disconnect

### DIFF
--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -272,6 +272,8 @@ func (c *ZkConn) withRetry(ctx context.Context, action func(conn *zk.Conn) error
 			c.conn = nil
 		}
 		c.mu.Unlock()
+		log.Infof("zk conn: got ErrConnectionClosed for addr %v: closing", c.addr)
+		conn.Close()
 	}
 	return
 }
@@ -322,13 +324,9 @@ func (c *ZkConn) maybeAddAuth(ctx context.Context) {
 // clears out the connection record.
 func (c *ZkConn) handleSessionEvents(conn *zk.Conn, session <-chan zk.Event) {
 	for event := range session {
-		closeRequired := false
 
 		switch event.State {
-		case zk.StateExpired, zk.StateConnecting:
-			closeRequired = true
-			fallthrough
-		case zk.StateDisconnected:
+		case zk.StateDisconnected, zk.StateExpired, zk.StateConnecting:
 			c.mu.Lock()
 			if c.conn == conn {
 				// The ZkConn still references this
@@ -336,9 +334,7 @@ func (c *ZkConn) handleSessionEvents(conn *zk.Conn, session <-chan zk.Event) {
 				c.conn = nil
 			}
 			c.mu.Unlock()
-			if closeRequired {
-				conn.Close()
-			}
+			conn.Close()
 			log.Infof("zk conn: session for addr %v ended: %v", c.addr, event)
 			return
 		}

--- a/go/vt/topo/zk2topo/zk_conn_test.go
+++ b/go/vt/topo/zk2topo/zk_conn_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zk2topo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/z-division/go-zookeeper/zk"
+
+	"vitess.io/vitess/go/testfiles"
+	"vitess.io/vitess/go/vt/zkctl"
+)
+
+func TestZkConnClosedOnDisconnect(t *testing.T) {
+	zkd, serverAddr := zkctl.StartLocalZk(testfiles.GoVtTopoZk2topoZkID, testfiles.GoVtTopoZk2topoPort)
+	defer zkd.Teardown()
+
+	conn := Connect(serverAddr)
+	defer conn.Close()
+
+	_, _, err := conn.Get(context.Background(), "/")
+	require.NoError(t, err, "Get() failed")
+
+	require.True(t, conn.conn.State().IsConnected(), "Connection not connected")
+
+	oldConn := conn.conn
+
+	// force a disconnect
+	zkd.Shutdown()
+	zkd.Start()
+
+	// do another get to trigger a new connection
+	_, _, err = conn.Get(context.Background(), "/")
+	require.NoError(t, err, "Get() failed")
+
+	// Check that old connection is closed
+	_, _, err = oldConn.Get("/")
+	require.ErrorContains(t, err, "zookeeper is closing")
+
+	require.Equal(t, zk.StateDisconnected, oldConn.State(), "Connection is not in disconnected state")
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes a bug in the zookeeper topo logic that causes it to leak connections/memory during network partitions from zookeeper. As mentioned in the issue, this is due to the zookeeper connection library automatically re-opening connections under the hood, even after a disconnect. To fix this, this PR calls `conn.Close()` whenever there is a disconnect.

This fix has been tested extensively in production in Shopify. A side effect of this fix is that it leads to a query latency regression when topo server is down as mentioned in https://github.com/vitessio/vitess/issues/9147 unless the `srv_topo_cache_ttl` flag is set to a high value. This isn't the case currently because the `SrvKeyspace` watch established [here](https://github.com/vitessio/vitess/blob/9ed8ee2c1bba4c8784296bfae70e356238928a7f/go/vt/topo/zk2topo/watch.go#L30) never terminates because the watch channel returned by the zk client is not invalidated on EOF error auth failure ([source](https://github.com/z-division/go-zookeeper/blob/d4903e321f4d61253059d20da8c864c712b7e5f0/zk/conn.go#L576-L577)), and the `zk.Conn` is never closed (that was the bug). So the watch continues to use an old channel from a leaked `zk.Conn` and vitess just assumes the watch is healthy and returns the cached value [here](https://github.com/vitessio/vitess/blob/9ed8ee2c1bba4c8784296bfae70e356238928a7f/go/vt/srvtopo/watch.go#L125-L127)

We should likely backport this up to v18 since it can lead to OOMkills and place additional load on zookeeper.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes https://github.com/vitessio/vitess/issues/17076

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
