### PR TITLE
Skip `TestRunFailsToStartTabletManager` for now

### DIFF
--- a/go/cmd/vttablet/cli/cli_test.go
+++ b/go/cmd/vttablet/cli/cli_test.go
@@ -32,6 +32,9 @@ import (
 // When starting, the TabletManager checks if it needs to restore, in tm.handleRestore but this step will
 // fail if we do not provide a cnf file and if the flag --restore_from_backup is provided.
 func TestRunFailsToStartTabletManager(t *testing.T) {
+	// Skipping the test for now, the test is unveiling some race conditions in the code.
+	// While working on a fix, this test will be skipped.
+	t.Skip()
 	ts, factory := memorytopo.NewServerAndFactory(context.Background(), "cell")
 	topo.RegisterFactory("test", factory)
 

--- a/go/cmd/vttablet/cli/cli_test.go
+++ b/go/cmd/vttablet/cli/cli_test.go
@@ -33,7 +33,7 @@ import (
 // fail if we do not provide a cnf file and if the flag --restore_from_backup is provided.
 func TestRunFailsToStartTabletManager(t *testing.T) {
 	// Skipping the test for now, the test is unveiling some race conditions in the code.
-	// While working on a fix, this test will be skipped.
+	// While working on a fix, this test will be skipped: https://github.com/vitessio/vitess/pull/17165
 	t.Skip()
 	ts, factory := memorytopo.NewServerAndFactory(context.Background(), "cell")
 	topo.RegisterFactory("test", factory)


### PR DESCRIPTION
## Description
Temporarily skipping `TestRunFailsToStartTabletManager` while I work on a longer term fix in https://github.com/vitessio/vitess/pull/17165.

This test fails often on CI as it triggers a set of race conditions in vttablet. Here are some of the stack traces:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x11ca08a]


goroutine 58 [running]:
vitess.io/vitess/go/vt/topo.(*Lock).lock(0xc00098c420, {0x2dc5d08, 0xc0006b2030}, 0xc0005332c0, {0x2dbdbe0, 0xc0004a6030}, {0x0?, 0x10?, 0xc000086d40?})
/home/runner/work/vitess/vitess/go/vt/topo/locks.go:187 +0x4ca
vitess.io/vitess/go/vt/topo.(*Server).internalLock(0xc0005332c0, {0x2dc5d40, 0xc00069c4b0}, {0x2dbdbe0, 0xc0004a6030}, {0x26f3105, 0xf}, {0x0, 0x0, 0x0})
/home/runner/work/vitess/vitess/go/vt/topo/locks.go:233 +0x26f
vitess.io/vitess/go/vt/topo.(*Server).LockKeyspace(0xc0005332c0, {0x2dc5d40, 0xc00069c4b0}, {0x26db470, 0x2}, {0x26f3105, 0xf}, {0x0, 0x0, 0x0})
/home/runner/work/vitess/vitess/go/vt/topo/keyspace_lock.go:47 +0xd6
vitess.io/vitess/go/vt/topotools.RebuildKeyspace({0x2dc5d40, 0xc00069c4b0}, {0x2dd75c0, 0xc000749f00}, 0xc0005332c0, {0x26db470, 0x2}, {0xc000749f70, 0x1, 0x1}, ...)
/home/runner/work/vitess/vitess/go/vt/topotools/rebuild_keyspace.go:34 +0xc5
vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).rebuildKeyspace(0xc0003fe1e0, {0x2dc5d40, 0xc00069c4b0}, 0xc000197eb0?, {0x26db470, 0x2}, 0x3b9aca00)
/home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/tm_init.go:650 +0x22e
created by vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).createKeyspaceShard in goroutine 39
/home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/tm_init.go:581 +0x590
```

```
2024-11-03T22:10:32.0591213Z ==================
2024-11-03T22:10:32.0591453Z WARNING: DATA RACE
2024-11-03T22:10:32.0591728Z Read at 0x00c000898000 by goroutine 62:
2024-11-03T22:10:32.0592161Z   vitess.io/vitess/go/vt/topo.(*Server).GetCellInfo()
2024-11-03T22:10:32.0592797Z       /home/runner/work/vitess/vitess/go/vt/topo/cell_info.go:62 +0x65
2024-11-03T22:10:32.0593348Z   vitess.io/vitess/go/vt/topo.(*Server).ConnForCell()
2024-11-03T22:10:32.0594006Z       /home/runner/work/vitess/vitess/go/vt/topo/server.go:275 +0x228
2024-11-03T22:10:32.0594586Z   vitess.io/vitess/go/vt/topo.(*Server).UpdateSrvKeyspace()
2024-11-03T22:10:32.0595255Z       /home/runner/work/vitess/vitess/go/vt/topo/srv_keyspace.go:630 +0x93
2024-11-03T22:10:32.0595900Z   vitess.io/vitess/go/vt/topotools.RebuildKeyspaceLocked.func1()
2024-11-03T22:10:32.0596679Z       /home/runner/work/vitess/vitess/go/vt/topotools/rebuild_keyspace.go:151 +0x132
2024-11-03T22:10:32.0597386Z   vitess.io/vitess/go/vt/topotools.RebuildKeyspaceLocked.gowrap1()
2024-11-03T22:10:32.0598175Z       /home/runner/work/vitess/vitess/go/vt/topotools/rebuild_keyspace.go:154 +0x61
2024-11-03T22:10:32.0598611Z 
2024-11-03T22:10:32.0598772Z Previous write at 0x00c000898000 by goroutine 40:
2024-11-03T22:10:32.0599211Z   vitess.io/vitess/go/vt/topo.(*Server).Close()
2024-11-03T22:10:32.0599995Z       /home/runner/work/vitess/vitess/go/vt/topo/server.go:352 +0x137
2024-11-03T22:10:32.0600567Z   vitess.io/vitess/go/cmd/vttablet/cli.run.deferwrap1()
2024-11-03T22:10:32.0601228Z       /home/runner/work/vitess/vitess/go/cmd/vttablet/cli/cli.go:118 +0x33
2024-11-03T22:10:32.0601725Z   runtime.deferreturn()
2024-11-03T22:10:32.0602228Z       /opt/hostedtoolcache/go/1.23.2/x64/src/runtime/panic.go:605 +0x5d
2024-11-03T22:10:32.0602734Z   github.com/spf13/cobra.(*Command).execute()
2024-11-03T22:10:32.0603378Z       /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0x10f3
2024-11-03T22:10:32.0603940Z   github.com/spf13/cobra.(*Command).ExecuteC()
2024-11-03T22:10:32.0604586Z       /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x655
2024-11-03T22:10:32.0605134Z   github.com/spf13/cobra.(*Command).Execute()
2024-11-03T22:10:32.0605778Z       /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x5a9
2024-11-03T22:10:32.0606373Z   github.com/spf13/cobra.(*Command).ExecuteContext()
2024-11-03T22:10:32.0607041Z       /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034 +0x5a4
2024-11-03T22:10:32.0607913Z   vitess.io/vitess/go/cmd/vttablet/cli.TestRunFailsToStartTabletManager()
2024-11-03T22:10:32.0608706Z       /home/runner/work/vitess/vitess/go/cmd/vttablet/cli/cli_test.go:56 +0x52d
2024-11-03T22:10:32.0609214Z   testing.tRunner()
2024-11-03T22:10:32.0609716Z       /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1690 +0x226
2024-11-03T22:10:32.0610206Z   testing.(*T).Run.gowrap1()
2024-11-03T22:10:32.0610726Z       /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1743 +0x44
2024-11-03T22:10:32.0611088Z 
2024-11-03T22:10:32.0611209Z Goroutine 62 (running) created at:
2024-11-03T22:10:32.0611657Z   vitess.io/vitess/go/vt/topotools.RebuildKeyspaceLocked()
2024-11-03T22:10:32.0612398Z       /home/runner/work/vitess/vitess/go/vt/topotools/rebuild_keyspace.go:149 +0x884
2024-11-03T22:10:32.0613036Z   vitess.io/vitess/go/vt/topotools.RebuildKeyspace()
2024-11-03T22:10:32.0613740Z       /home/runner/work/vitess/vitess/go/vt/topotools/rebuild_keyspace.go:40 +0x286
2024-11-03T22:10:32.0614521Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).rebuildKeyspace()
2024-11-03T22:10:32.0615406Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/tm_init.go:650 +0x3c4
2024-11-03T22:10:32.0616280Z   vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).createKeyspaceShard.gowrap2()
2024-11-03T22:10:32.0617211Z       /home/runner/work/vitess/vitess/go/vt/vttablet/tabletmanager/tm_init.go:581 +0x8f
2024-11-03T22:10:32.0617662Z 
2024-11-03T22:10:32.0617786Z Goroutine 40 (running) created at:
2024-11-03T22:10:32.0618107Z   testing.(*T).Run()
2024-11-03T22:10:32.0618611Z       /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1743 +0x825
2024-11-03T22:10:32.0619096Z   testing.runTests.func1()
2024-11-03T22:10:32.0619620Z       /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:2168 +0x85
2024-11-03T22:10:32.0620079Z   testing.tRunner()
2024-11-03T22:10:32.0620573Z       /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:1690 +0x226
2024-11-03T22:10:32.0621043Z   testing.runTests()
2024-11-03T22:10:32.0621534Z       /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:2166 +0x8be
2024-11-03T22:10:32.0622169Z   testing.(*M).Run()
2024-11-03T22:10:32.0622659Z       /opt/hostedtoolcache/go/1.23.2/x64/src/testing/testing.go:2034 +0xf17
2024-11-03T22:10:32.0623102Z   main.main()
2024-11-03T22:10:32.0623394Z       _testmain.go:45 +0x164
2024-11-03T22:10:32.0623663Z ==================
```