### PR TITLE
add S3 minimum part size defined by the user

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -679,6 +679,9 @@ spec:
                           maxLength: 256
                           pattern: ^[^\r\n]*$
                           type: string
+                        minPartSize:
+                          format: int64
+                          type: integer
                         region:
                           minLength: 1
                           type: string
@@ -1995,6 +1998,9 @@ spec:
                                 maxLength: 256
                                 pattern: ^[^\r\n]*$
                                 type: string
+                              minPartSize:
+                                format: int64
+                                type: integer
                               region:
                                 minLength: 1
                                 type: string
@@ -3510,6 +3516,14 @@ spec:
                               mysql80Compatible:
                                 type: string
                             type: object
+                          mysqldExporter:
+                            type: string
+                          vtbackup:
+                            type: string
+                          vtorc:
+                            type: string
+                          vttablet:
+                            type: string
                         type: object
                       name:
                         maxLength: 63
@@ -5241,6 +5255,9 @@ spec:
                             maxLength: 256
                             pattern: ^[^\r\n]*$
                             type: string
+                          minPartSize:
+                            format: int64
+                            type: integer
                           region:
                             minLength: 1
                             type: string
@@ -6688,6 +6705,9 @@ spec:
                             maxLength: 256
                             pattern: ^[^\r\n]*$
                             type: string
+                          minPartSize:
+                            format: int64
+                            type: integer
                           region:
                             minLength: 1
                             type: string

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.66.3
 	github.com/aws/smithy-go v1.22.0
 	github.com/bndr/gotabulate v1.1.2
+	github.com/dustin/go-humanize v1.0.1
 	github.com/gammazero/deque v0.2.1
 	github.com/google/safehtml v0.1.0
 	github.com/hashicorp/go-version v1.7.0
@@ -153,7 +154,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4 // indirect
 	github.com/ebitengine/purego v0.8.1 // indirect
 	github.com/envoyproxy/go-control-plane v0.13.1 // indirect

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -195,6 +195,7 @@ Flags:
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --restart_before_backup                                       Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.
       --s3_backup_aws_endpoint string                               endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_minimum_partsize int                          Minimum part size to use (default 5242880)
       --s3_backup_aws_region string                                 AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                   AWS request retries. (default -1)
       --s3_backup_force_path_style                                  force the s3 path style.

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -195,7 +195,7 @@ Flags:
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --restart_before_backup                                       Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.
       --s3_backup_aws_endpoint string                               endpoint of the S3 backend (region must be provided).
-      --s3_backup_aws_minimum_partsize int                          Minimum part size to use (default 5242880)
+      --s3_backup_aws_min_partsize int                              Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                 AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                   AWS request retries. (default -1)
       --s3_backup_force_path_style                                  force the s3 path style.

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -110,6 +110,7 @@ Flags:
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_minimum_partsize int                               Minimum part size to use (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -110,7 +110,7 @@ Flags:
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
-      --s3_backup_aws_minimum_partsize int                               Minimum part size to use (default 5242880)
+      --s3_backup_aws_min_partsize int                                   Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -312,6 +312,7 @@ Flags:
       --restore_from_backup_ts string                                    (init restore parameter) if set, restore the latest backup taken at or before this timestamp. Example: '2021-04-29.133050'
       --retain_online_ddl_tables duration                                How long should vttablet keep an old migrated table before purging it (default 24h0m0s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_minimum_partsize int                               Minimum part size to use (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -312,7 +312,7 @@ Flags:
       --restore_from_backup_ts string                                    (init restore parameter) if set, restore the latest backup taken at or before this timestamp. Example: '2021-04-29.133050'
       --retain_online_ddl_tables duration                                How long should vttablet keep an old migrated table before purging it (default 24h0m0s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
-      --s3_backup_aws_minimum_partsize int                               Minimum part size to use (default 5242880)
+      --s3_backup_aws_min_partsize int                                   Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -243,7 +243,7 @@ func calculateUploadPartSize(filesize int64) (partSizeBytes int64, err error) {
 	}
 
 	if minPartSize != 0 && partSizeBytes < minPartSize {
-		if minPartSize > 1024*1024*1024*5 || minPartSize < 1024*1024*5 { // 5GiB and 5MiB respectively
+		if minPartSize > MaxPartSize || minPartSize < manager.MinUploadPartSize { // 5GiB and 5MiB respectively
 			return 0, fmt.Errorf("%w, currently set to %s",
 				ErrPartSize, humanize.IBytes(uint64(minPartSize)),
 			)

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -228,7 +228,7 @@ func (bh *S3BackupHandle) handleAddFile(ctx context.Context, filename string, pa
 	}()
 }
 
-// this is a helper to calculate the part size, taking into consideration the minimum part size
+// calculateUploadPartSize is a helper to calculate the part size, taking into consideration the minimum part size
 // passed in by an operator.
 func calculateUploadPartSize(filesize int64) (partSizeBytes int64, err error) {
 	// Calculate s3 upload part size using the source filesize

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -58,6 +58,11 @@ import (
 	"vitess.io/vitess/go/vt/servenv"
 )
 
+const (
+	sseCustomerPrefix = "sse_c:"
+	MaxPartSize       = 1024 * 1024 * 1024 * 5 // 5GiB - limited by AWS https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+)
+
 var (
 	// AWS API region
 	region string
@@ -89,7 +94,7 @@ var (
 	delimiter = "/"
 
 	// minimum part size
-	minimumPartSize int64
+	minPartSize int64
 
 	ErrPartSize = errors.New("minimum S3 part size must be between 5MiB and 5GiB")
 )
@@ -104,7 +109,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&tlsSkipVerifyCert, "s3_backup_tls_skip_verify_cert", false, "skip the 'certificate is valid' check for SSL connections.")
 	fs.StringVar(&requiredLogLevel, "s3_backup_log_level", "LogOff", "determine the S3 loglevel to use from LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors.")
 	fs.StringVar(&sse, "s3_backup_server_side_encryption", "", "server-side encryption algorithm (e.g., AES256, aws:kms, sse_c:/path/to/key/file).")
-	fs.Int64Var(&minimumPartSize, "s3_backup_aws_minimum_partsize", 1024*1024*5, "Minimum part size to use")
+	fs.Int64Var(&minPartSize, "s3_backup_aws_min_partsize", manager.MinUploadPartSize, "Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size.")
 }
 
 func init() {
@@ -117,8 +122,6 @@ func init() {
 type logNameToLogLevel map[string]aws.ClientLogMode
 
 var logNameMap logNameToLogLevel
-
-const sseCustomerPrefix = "sse_c:"
 
 type endpointResolver struct {
 	r        s3.EndpointResolverV2
@@ -239,13 +242,13 @@ func calculateUploadPartSize(filesize int64) (partSizeBytes int64, err error) {
 		}
 	}
 
-	if minimumPartSize != 0 && partSizeBytes < minimumPartSize {
-		if minimumPartSize > 1024*1024*1024*5 || minimumPartSize < 1024*1024*5 { // 5GiB and 5MiB respectively
+	if minPartSize != 0 && partSizeBytes < minPartSize {
+		if minPartSize > 1024*1024*1024*5 || minPartSize < 1024*1024*5 { // 5GiB and 5MiB respectively
 			return 0, fmt.Errorf("%w, currently set to %s",
-				ErrPartSize, humanize.IBytes(uint64(minimumPartSize)),
+				ErrPartSize, humanize.IBytes(uint64(minPartSize)),
 			)
 		}
-		partSizeBytes = int64(minimumPartSize)
+		partSizeBytes = int64(minPartSize)
 	}
 
 	return

--- a/go/vt/mysqlctl/s3backupstorage/s3_mock.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_mock.go
@@ -162,7 +162,11 @@ func FailFirstWrite(s3bh *S3BackupHandle, ctx context.Context, filename string, 
 		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
 	}
 
-	partSizeBytes := calculateUploadPartSize(filesize)
+	partSizeBytes, err := calculateUploadPartSize(filesize)
+	if err != nil {
+		return nil, err
+	}
+
 	reader, writer := io.Pipe()
 	r := io.Reader(reader)
 
@@ -181,7 +185,11 @@ func FailAllWrites(s3bh *S3BackupHandle, ctx context.Context, filename string, f
 		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
 	}
 
-	partSizeBytes := calculateUploadPartSize(filesize)
+	partSizeBytes, err := calculateUploadPartSize(filesize)
+	if err != nil {
+		return nil, err
+	}
+
 	reader, writer := io.Pipe()
 	r := &failReadPipeReader{PipeReader: reader}
 

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -328,3 +328,68 @@ func TestWithParams(t *testing.T) {
 	assert.NotNil(t, s3.transport.DialContext)
 	assert.NotNil(t, s3.transport.Proxy)
 }
+
+func TestGetPartSize(t *testing.T) {
+	originalMinimum := minimumPartSize
+	defer func() { minimumPartSize = originalMinimum }()
+
+	tests := []struct {
+		name            string
+		filesize        int64
+		minimumPartSize int64
+		want            int64
+		err             error
+	}{
+		{
+			name:            "minimum - 10 MiB",
+			filesize:        1024 * 1024 * 10, // 10 MiB
+			minimumPartSize: 1024 * 1024 * 5,  // 5 MiB
+			want:            1024 * 1024 * 5,  // 5 MiB,
+			err:             nil,
+		},
+		{
+			name:            "below minimum - 10 MiB",
+			filesize:        1024 * 1024 * 10, // 10 MiB
+			minimumPartSize: 1024 * 1024 * 8,  // 8 MiB
+			want:            1024 * 1024 * 8,  // 8 MiB,
+			err:             nil,
+		},
+		{
+			name:            "above minimum - 1 TiB",
+			filesize:        1024 * 1024 * 1024 * 1024, // 1 TiB
+			minimumPartSize: 1024 * 1024 * 5,           // 5 MiB
+			want:            109951163,                 // ~104 MiB
+			err:             nil,
+		},
+		{
+			name:            "below minimum - 1 TiB",
+			filesize:        1024 * 1024 * 1024 * 1024, // 1 TiB
+			minimumPartSize: 1024 * 1024 * 200,         // 200 MiB
+			want:            1024 * 1024 * 200,         // 200 MiB
+			err:             nil,
+		},
+		{
+			name:            "below S3 limits - 5 MiB",
+			filesize:        1024 * 1024 * 3, // 3 MiB
+			minimumPartSize: 1024 * 1024 * 4, // 4 MiB
+			want:            1024 * 1024 * 5, // 5 MiB - should always return the minimum
+			err:             nil,
+		},
+		{
+			name:            "above S3 limits - 5 GiB",
+			filesize:        1024 * 1024 * 1024 * 1024, // 1 TiB
+			minimumPartSize: 1024 * 1024 * 1024 * 6,    // 6 GiB
+			want:            0,
+			err:             ErrPartSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minimumPartSize = tt.minimumPartSize
+			partSize, err := getPartSize(tt.filesize)
+			require.ErrorIs(t, err, tt.err)
+			require.Equal(t, tt.want, partSize)
+		})
+	}
+}

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -329,9 +329,9 @@ func TestWithParams(t *testing.T) {
 	assert.NotNil(t, s3.transport.Proxy)
 }
 
-func TestGetPartSize(t *testing.T) {
-	originalMinimum := minimumPartSize
-	defer func() { minimumPartSize = originalMinimum }()
+func TestCalculateUploadPartSize(t *testing.T) {
+	originalMinimum := minPartSize
+	defer func() { minPartSize = originalMinimum }()
 
 	tests := []struct {
 		name            string
@@ -386,8 +386,8 @@ func TestGetPartSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			minimumPartSize = tt.minimumPartSize
-			partSize, err := getPartSize(tt.filesize)
+			minPartSize = tt.minimumPartSize
+			partSize, err := calculateUploadPartSize(tt.filesize)
 			require.ErrorIs(t, err, tt.err)
 			require.Equal(t, tt.want, partSize)
 		})


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This adds a new parameter to allow the operator to specify a minimum part size for the S3 uploads.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

  - Fixes: #17175
  - Operator: https://github.com/planetscale/vitess-operator/pull/645

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
