### PR TITLE
VReplication: Qualify and SQL escape tables in created AutoIncrement VSchema definitions

### DIFF
--- a/go/vt/vtctl/workflow/materializer.go
+++ b/go/vt/vtctl/workflow/materializer.go
@@ -400,8 +400,7 @@ func (mz *materializer) deploySchema() error {
 								if err != nil {
 									return err
 								}
-								seqTableName := fmt.Sprintf(autoSequenceTableFormat, tableName)
-								seqTableName, err = sqlescape.EnsureEscaped(seqTableName)
+								seqTableName, err := sqlescape.EnsureEscaped(fmt.Sprintf(autoSequenceTableFormat, tableName))
 								if err != nil {
 									return err
 								}

--- a/go/vt/vtctl/workflow/materializer.go
+++ b/go/vt/vtctl/workflow/materializer.go
@@ -396,7 +396,11 @@ func (mz *materializer) deploySchema() error {
 							table := targetVSchema.Tables[ts.TargetTable]
 							// Don't override or redo anything that already exists.
 							if table != nil && table.AutoIncrement == nil {
-								seqTableName := fmt.Sprintf(autoSequenceTableFormat, ts.TargetTable)
+								seqTableName, _ := sqlescape.EnsureEscaped(fmt.Sprintf(autoSequenceTableFormat, ts.TargetTable))
+								if mz.ms.WorkflowOptions.GlobalKeyspace != "" {
+									seqTableKeyspace, _ := sqlescape.EnsureEscaped(mz.ms.WorkflowOptions.GlobalKeyspace)
+									seqTableName = fmt.Sprintf("%s.%s", seqTableKeyspace, seqTableName)
+								}
 								// Create a Vitess AutoIncrement definition -- which uses a sequence -- to
 								// replace the MySQL auto_increment definition that we removed.
 								table.AutoIncrement = &vschemapb.AutoIncrement{

--- a/go/vt/vtctl/workflow/materializer_env_test.go
+++ b/go/vt/vtctl/workflow/materializer_env_test.go
@@ -121,7 +121,7 @@ func newTestMaterializerEnv(t *testing.T, ctx context.Context, ms *vtctldatapb.M
 		tableName := ts.TargetTable
 		table, err := venv.Parser().TableFromStatement(ts.SourceExpression)
 		if err == nil {
-			tableName = table.Name.String()
+			tableName = sqlparser.String(table.Name)
 		}
 		var (
 			cols   []string

--- a/go/vt/vtctl/workflow/materializer_test.go
+++ b/go/vt/vtctl/workflow/materializer_test.go
@@ -613,12 +613,12 @@ func TestMoveTablesDDLFlag(t *testing.T) {
 // 2. REMOVE the tables' MySQL auto_increment clauses
 // 3. REPLACE the table's MySQL auto_increment clauses with Vitess sequences
 func TestShardedAutoIncHandling(t *testing.T) {
-	tableName := "t1"
+	tableName := "`t-1`"
 	tableDDL := fmt.Sprintf("create table %s (id int not null auto_increment primary key, c1 varchar(10))", tableName)
-	validateEmptyTableQuery := fmt.Sprintf("select 1 from `%s` limit 1", tableName)
+	validateEmptyTableQuery := fmt.Sprintf("select 1 from %s limit 1", tableName)
 	ms := &vtctldatapb.MaterializeSettings{
 		Workflow:       "workflow",
-		SourceKeyspace: "sourceks",
+		SourceKeyspace: "source-ks",
 		TargetKeyspace: "targetks",
 		TableSettings: []*vtctldatapb.TableMaterializeSettings{{
 			TargetTable:      tableName,
@@ -863,7 +863,7 @@ func TestShardedAutoIncHandling(t *testing.T) {
 						},
 						AutoIncrement: &vschemapb.AutoIncrement{ // AutoIncrement definition added
 							Column:   "id",
-							Sequence: fmt.Sprintf("`%s`.`%s`", ms.SourceKeyspace, fmt.Sprintf(autoSequenceTableFormat, tableName)),
+							Sequence: fmt.Sprintf("`%s`.`%s`", ms.SourceKeyspace, fmt.Sprintf(autoSequenceTableFormat, strings.ReplaceAll(tableName, "`", ""))),
 						},
 					},
 				},

--- a/go/vt/vtctl/workflow/materializer_test.go
+++ b/go/vt/vtctl/workflow/materializer_test.go
@@ -863,7 +863,7 @@ func TestShardedAutoIncHandling(t *testing.T) {
 						},
 						AutoIncrement: &vschemapb.AutoIncrement{ // AutoIncrement definition added
 							Column:   "id",
-							Sequence: fmt.Sprintf(autoSequenceTableFormat, tableName),
+							Sequence: fmt.Sprintf("`%s`.`%s`", ms.SourceKeyspace, fmt.Sprintf(autoSequenceTableFormat, tableName)),
 						},
 					},
 				},
@@ -931,7 +931,7 @@ func TestShardedAutoIncHandling(t *testing.T) {
 				if tc.wantTargetVSchema != nil {
 					targetVSchema, err := env.ws.ts.GetVSchema(ctx, ms.TargetKeyspace)
 					require.NoError(t, err)
-					require.True(t, proto.Equal(targetVSchema, tc.wantTargetVSchema))
+					require.True(t, proto.Equal(targetVSchema, tc.wantTargetVSchema), "got: %v, want: %v", targetVSchema, tc.wantTargetVSchema)
 				}
 			}
 		})

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -235,7 +235,7 @@ func stripAutoIncrement(ddl string, parser *sqlparser.Parser, replace func(colum
 				node.Type.Options.Autoincrement = false
 				if replace != nil {
 					if err := replace(sqlparser.String(node.Name)); err != nil {
-						return false, vterrors.Wrapf(err, "failed to replace auto_increment column %s in %q", sqlparser.String(node.Name), ddl)
+						return false, vterrors.Wrapf(err, "failed to replace auto_increment column %q in %q", sqlparser.String(node.Name), ddl)
 					}
 
 				}


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/vitessio/vitess/pull/16860 that addresses a couple of potential edge cases when we automatically replace the auto increment handling:
  1. The sequence table name in the VSchema AutoIncrement definition needs to be SQL escaped as it contains e.g. dashes
  2. The sequence table name is not unique across the Vitess cluster

This PR addresses those respectively by 1) ensuring that the sequence table name is always properly SQL escaped 2) qualifying the sequence table with the keyspace and ensuring that the keyspace name is also properly SQL escaped.

I think that we should backport this to v21 as it heads off potential bugs related to keyspaces and table names that must be SQL escaped along with potential bugs related to the non-qualified generated sequence names NOT being unique across all keyspaces in the Vitess cluster.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/17173
 
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required