### PR TITLE
bugfix: Handle CTEs with columns named in the CTE def

### DIFF
--- a/go/test/endtoend/vtgate/vitess_tester/cte/queries.test
+++ b/go/test/endtoend/vtgate/vitess_tester/cte/queries.test
@@ -30,6 +30,15 @@ WITH RECURSIVE numbers AS (SELECT 1 AS n
 SELECT *
 FROM numbers;
 
+# Simple recursive CTE using literal values, column named in the CTE def
+WITH RECURSIVE numbers(n) AS (SELECT 1
+                              UNION ALL
+                              SELECT n + 1
+                              FROM numbers
+                              WHERE n < 5)
+SELECT *
+FROM numbers;
+
 # Recursive CTE joined with a normal table
 WITH RECURSIVE emp_cte AS (SELECT id, name, manager_id
                            FROM employees

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -242,7 +242,7 @@ func (qb *queryBuilder) unionWith(other *queryBuilder, distinct bool) {
 	}
 }
 
-func (qb *queryBuilder) recursiveCteWith(other *queryBuilder, name, alias string, distinct bool) {
+func (qb *queryBuilder) recursiveCteWith(other *queryBuilder, name, alias string, distinct bool, columns sqlparser.Columns) {
 	cteUnion := &sqlparser.Union{
 		Left:     qb.stmt.(sqlparser.SelectStatement),
 		Right:    other.stmt.(sqlparser.SelectStatement),
@@ -254,7 +254,7 @@ func (qb *queryBuilder) recursiveCteWith(other *queryBuilder, name, alias string
 			Recursive: true,
 			CTEs: []*sqlparser.CommonTableExpr{{
 				ID:       sqlparser.NewIdentifierCS(name),
-				Columns:  nil,
+				Columns:  columns,
 				Subquery: cteUnion,
 			}},
 		},
@@ -726,7 +726,7 @@ func buildRecursiveCTE(op *RecurseCTE, qb *queryBuilder) {
 		panic(err)
 	}
 
-	qb.recursiveCteWith(qbR, op.Def.Name, infoFor.GetAliasedTableExpr().As.String(), op.Distinct)
+	qb.recursiveCteWith(qbR, op.Def.Name, infoFor.GetAliasedTableExpr().As.String(), op.Distinct, op.Def.Columns)
 }
 
 func mergeHaving(h1, h2 *sqlparser.Where) *sqlparser.Where {

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -2260,8 +2260,8 @@
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "with recursive cte as (select 1 from dual where 1 != 1 union all select n + 1 from cte where 1 != 1) select n from cte where 1 != 1",
-        "Query": "with recursive cte as (select 1 from dual union all select n + 1 from cte where n < 5) select n from cte",
+        "FieldQuery": "with recursive cte(n) as (select 1 from dual where 1 != 1 union all select n + 1 from cte where 1 != 1) select n from cte where 1 != 1",
+        "Query": "with recursive cte(n) as (select 1 from dual union all select n + 1 from cte where n < 5) select n from cte",
         "Table": "dual"
       },
       "TablesUsed": [


### PR DESCRIPTION
## Description
This PR addresses an issue where the Vitess planner was incorrectly handling recursive Common Table Expressions (CTEs) when column names were defined in the CTE declaration but not in the SELECT clause. Specifically, vtgate was stripping out the column names before passing the query to MySQL, resulting in query failures.

The fix ensures that column names defined in the CTE declaration are preserved, allowing recursive CTE queries to execute correctly in both Vitess and MySQL.

## Related Issue(s)
Fixes #17177

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required