### PR TITLE
VReplication fix Flaky e2e test TestMoveTablesBuffering

### DIFF
--- a/go/test/endtoend/vreplication/movetables_buffering_test.go
+++ b/go/test/endtoend/vreplication/movetables_buffering_test.go
@@ -39,7 +39,7 @@ func TestMoveTablesBuffering(t *testing.T) {
 
 	catchup(t, targetTab1, workflowName, "MoveTables")
 	catchup(t, targetTab2, workflowName, "MoveTables")
-	vdiffSideBySide(t, ksWorkflow, "")
+	vdiff(t, targetKs, workflowName, "", false, true, nil)
 	waitForLowLag(t, "customer", workflowName)
 	for i := 0; i < 10; i++ {
 		tstWorkflowSwitchReadsAndWrites(t)


### PR DESCRIPTION

## Description

For some reason running vdiff using both vtctlclient and vtctldclient immediately one after the another seems to cause the following vdiff to fail randomly. Tried doing it in the CLI and we are able to do this. Not sure whether there is some timing related issue, but it is pretty consistent also locally. For now just run in vtctldclient to avoid flakiness.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
