### PR TITLE
Update `operator.yaml`

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -3510,6 +3510,14 @@ spec:
                               mysql80Compatible:
                                 type: string
                             type: object
+                          mysqldExporter:
+                            type: string
+                          vtbackup:
+                            type: string
+                          vtorc:
+                            type: string
+                          vttablet:
+                            type: string
                         type: object
                       name:
                         maxLength: 63
@@ -3841,6 +3849,10 @@ spec:
                                               type: object
                                             mysqldExporter:
                                               properties:
+                                                extraFlags:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
                                                 resources:
                                                   properties:
                                                     claims:
@@ -3874,8 +3886,6 @@ spec:
                                                         x-kubernetes-int-or-string: true
                                                       type: object
                                                   type: object
-                                              required:
-                                                - resources
                                               type: object
                                             name:
                                               default: ""
@@ -4282,6 +4292,10 @@ spec:
                                             type: object
                                           mysqldExporter:
                                             properties:
+                                              extraFlags:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
                                               resources:
                                                 properties:
                                                   claims:
@@ -4315,8 +4329,6 @@ spec:
                                                       x-kubernetes-int-or-string: true
                                                     type: object
                                                 type: object
-                                            required:
-                                              - resources
                                             type: object
                                           name:
                                             default: ""
@@ -5655,6 +5667,10 @@ spec:
                                         type: object
                                       mysqldExporter:
                                         properties:
+                                          extraFlags:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
                                           resources:
                                             properties:
                                               claims:
@@ -5688,8 +5704,6 @@ spec:
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                             type: object
-                                        required:
-                                          - resources
                                         type: object
                                       name:
                                         default: ""
@@ -6096,6 +6110,10 @@ spec:
                                       type: object
                                     mysqldExporter:
                                       properties:
+                                        extraFlags:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                         resources:
                                           properties:
                                             claims:
@@ -6129,8 +6147,6 @@ spec:
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                           type: object
-                                      required:
-                                        - resources
                                       type: object
                                     name:
                                       default: ""
@@ -7085,6 +7101,10 @@ spec:
                         type: object
                       mysqldExporter:
                         properties:
+                          extraFlags:
+                            additionalProperties:
+                              type: string
+                            type: object
                           resources:
                             properties:
                               claims:
@@ -7118,8 +7138,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                        required:
-                          - resources
                         type: object
                       name:
                         default: ""


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Pulls latest updates to the `operator.yaml` from upstream. Most of them are related to [adding support of extra flags for mysqld_exporter](https://github.com/planetscale/vitess-operator/pull/629).

## Related Issue(s)

* https://github.com/planetscale/vitess-operator/pull/629

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

* Should only be merged after https://github.com/planetscale/vitess-operator/pull/629 is merged.
