### PR TITLE
vstreamclient: framework for robust + simple usage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@ go.sum @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui @timvaillanco
 /go/test/endtoend/schemadiff @shlomi-noach @mattlord
 /go/test/endtoend/transaction @harshit-gangal @systay @frouioui
 /go/test/endtoend/*throttler* @shlomi-noach @mattlord @timvaillancourt
+/go/test/endtoend/vstreamclient @derekperkins
 /go/test/endtoend/vtgate @harshit-gangal @systay @frouioui
 /go/test/endtoend/vtorc @mattlord @shlomi-noach @timvaillancourt
 /go/tools/ @frouioui @systay
@@ -65,6 +66,7 @@ go.sum @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui @timvaillanco
 /go/vt/vtgate/*vstream* @rohit-nayak-ps @mattlord @shlomi-noach @beingnoble03
 /go/vt/vtgate/evalengine @dbussink @systay
 /go/vt/vtorc @mattlord @shlomi-noach @timvaillancourt
+/go/vt/vstreamclient @derekperkins
 /go/vt/vttablet/*conn* @harshit-gangal @systay
 /go/vt/vttablet/endtoend @harshit-gangal @mattlord @rohit-nayak-ps @systay
 /go/vt/vttablet/grpc* @rohit-nayak-ps @shlomi-noach @harshit-gangal @timvaillancourt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@ go.sum @mattlord @frouioui @timvaillancourt
 /go/test/endtoend/schemadiff @mattlord
 /go/test/endtoend/transaction @frouioui
 /go/test/endtoend/*throttler* @mattlord @timvaillancourt
+/go/test/endtoend/vstreamclient @derekperkins
 /go/test/endtoend/vtgate @frouioui @arthurschreiber
 /go/test/endtoend/vtorc @mattlord @timvaillancourt
 /go/tools/ @frouioui
@@ -65,6 +66,7 @@ go.sum @mattlord @frouioui @timvaillancourt
 /go/vt/vtgate/*vstream* @mattlord
 /go/vt/vtgate/evalengine @arthurschreiber
 /go/vt/vtorc @mattlord @timvaillancourt @mhamza15
+/go/vt/vstreamclient @derekperkins
 /go/vt/vttablet/*conn* @arthurschreiber
 /go/vt/vttablet/endtoend @mattlord @arthurschreiber
 /go/vt/vttablet/grpc* @mattlord @timvaillancourt

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/vstreamclient"
 )
@@ -202,7 +201,7 @@ func TestVStreamClientTransactionBoundaries(t *testing.T) {
 func TestVStreamClientHandlesDDL(t *testing.T) {
 	te := newTestEnv(t)
 
-	var got []*Customer
+	gotCh := make(chan *Customer, 1)
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
 		Table:           "customer",
@@ -211,7 +210,10 @@ func TestVStreamClientHandlesDDL(t *testing.T) {
 		DataType:        &Customer{},
 		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
 			for _, row := range rows {
-				got = append(got, row.Data.(*Customer))
+				select {
+				case gotCh <- row.Data.(*Customer):
+				default:
+				}
 			}
 			return nil
 		},
@@ -224,10 +226,12 @@ func TestVStreamClientHandlesDDL(t *testing.T) {
 	te.exec(t, "alter table customer.customer add column ddl_note varchar(64) null", nil)
 	te.exec(t, "insert into customer.customer(id, email, ddl_note) values (1401, 'ddl@domain.com', 'ok')", nil)
 
-	assert.Eventually(t, func() bool {
-		return len(got) == 1
-	}, 3*time.Second, 100*time.Millisecond)
-	assert.Equal(t, []*Customer{{ID: 1401, Email: "ddl@domain.com"}}, got)
+	select {
+	case got := <-gotCh:
+		assert.Equal(t, &Customer{ID: 1401, Email: "ddl@domain.com"}, got)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for row after DDL")
+	}
 
 	cancelRun()
 	err := <-runErrCh
@@ -241,7 +245,7 @@ func TestVStreamClientHandlesDDL(t *testing.T) {
 func TestVStreamClientReuseBatchSlice(t *testing.T) {
 	te := newTestEnv(t)
 
-	var batchPointers []string
+	batchPointers := make(chan string, 2)
 	newClient := func(t *testing.T) *vstreamclient.VStreamClient {
 		t.Helper()
 		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
@@ -252,9 +256,13 @@ func TestVStreamClientReuseBatchSlice(t *testing.T) {
 			ReuseBatchSlice: true,
 			DataType:        &Customer{},
 			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-				batchPointers = append(batchPointers, "")
+				pointer := ""
 				if len(rows) > 0 {
-					batchPointers[len(batchPointers)-1] = fmt.Sprintf("%p", &rows[0])
+					pointer = fmt.Sprintf("%p", &rows[0])
+				}
+				select {
+				case batchPointers <- pointer:
+				default:
 				}
 				return nil
 			},
@@ -265,14 +273,20 @@ func TestVStreamClientReuseBatchSlice(t *testing.T) {
 	vstreamClient := newClient(t)
 	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
 	defer cancelRun()
-	assert.Eventually(t, func() bool {
-		return len(batchPointers) >= 1
-	}, 3*time.Second, 50*time.Millisecond)
+	var firstPointer string
+	select {
+	case firstPointer = <-batchPointers:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first batch flush")
+	}
 
 	te.exec(t, "insert into customer.customer(id, email) values (1963, 'reuse-c@domain.com'), (1964, 'reuse-d@domain.com')", nil)
-	assert.Eventually(t, func() bool {
-		return len(batchPointers) >= 2
-	}, 3*time.Second, 50*time.Millisecond)
+	var secondPointer string
+	select {
+	case secondPointer = <-batchPointers:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for second batch flush")
+	}
 
 	cancelRun()
 	err := <-runErrCh
@@ -280,6 +294,5 @@ func TestVStreamClientReuseBatchSlice(t *testing.T) {
 		t.Fatalf("failed to run vstreamclient: %v", err)
 	}
 
-	require.Len(t, batchPointers, 2)
-	assert.Equal(t, batchPointers[0], batchPointers[1])
+	assert.Equal(t, firstPointer, secondPointer)
 }

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -1,0 +1,285 @@
+package vstreamclient
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+// TestVStreamClient verifies the core insert, update, and delete stream flow,
+// which is important because it exercises the basic end-to-end contract users rely on.
+func TestVStreamClient(t *testing.T) {
+	te := newTestEnv(t)
+
+	flushCount := 0
+	gotCustomers := make([]*Customer, 0)
+	tables := []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 1 and 9",
+		MaxRowsPerFlush: 7,
+		DataType:        &Customer{},
+		FlushFn: func(ctx context.Context, rows []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
+			flushCount++
+
+			t.Logf("upserting %d customers\n", len(rows))
+			for i, row := range rows {
+				switch {
+				case row.RowChange.After == nil:
+					customer := row.Data.(*Customer)
+					customer.DeletedAt = time.Now()
+					gotCustomers = append(gotCustomers, customer)
+					t.Logf("deleting customer %d: %v\n", i, row)
+				case row.RowChange.Before == nil:
+					gotCustomers = append(gotCustomers, row.Data.(*Customer))
+					t.Logf("inserting customer %d: %v\n", i, row)
+				case row.RowChange.Before != nil:
+					gotCustomers = append(gotCustomers, row.Data.(*Customer))
+					t.Logf("updating customer %d: %v\n", i, row)
+				}
+			}
+			return nil
+		},
+	}}
+	newClient := func(t *testing.T) *vstreamclient.VStreamClient {
+		t.Helper()
+		return te.newDefaultClient(t, "bob", tables)
+	}
+
+	t.Run("inserting rows", func(t *testing.T) {
+		wantCustomers := []*Customer{{ID: 1, Email: "alice@domain.com"}, {ID: 2, Email: "bob@domain.com"}, {ID: 3, Email: "charlie@domain.com"}, {ID: 4, Email: "dan@domain.com"}, {ID: 5, Email: "eve@domain.com"}}
+		for _, customer := range wantCustomers {
+			te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(customer.ID, customer.Email))
+		}
+		te.runUntilTimeout(t, newClient(t), 2*time.Second)
+		assert.Positive(t, flushCount)
+		assert.ElementsMatch(t, gotCustomers, wantCustomers)
+	})
+
+	t.Run("updating rows", func(t *testing.T) {
+		gotCustomers = nil
+		updateCustomers := []*Customer{{ID: 1, Email: "alice_new@domain.com"}, {ID: 5, Email: "eve_new@domain.com"}}
+		for _, customer := range updateCustomers {
+			te.exec(t, "update customer.customer set email=:email where id=:id", customerBindVars(customer.ID, customer.Email))
+		}
+		te.runUntilTimeout(t, newClient(t), 2*time.Second)
+		assert.ElementsMatch(t, gotCustomers, updateCustomers)
+	})
+
+	t.Run("deleting rows", func(t *testing.T) {
+		gotCustomers = nil
+		deleteCustomerIDs := []int{1, 5}
+		for _, id := range deleteCustomerIDs {
+			te.exec(t, "delete from customer.customer where id=:id", idBindVar(int64(id)))
+		}
+		te.runUntilTimeout(t, newClient(t), 2*time.Second)
+		assert.Len(t, gotCustomers, len(deleteCustomerIDs))
+		for _, gotCustomer := range gotCustomers {
+			assert.NotEmpty(t, gotCustomer.DeletedAt)
+		}
+	})
+}
+
+// TestVStreamClientFlushChunking verifies large batches are split according to
+// MaxRowsPerFlush, which is important for bounded memory and downstream writes.
+func TestVStreamClientFlushChunking(t *testing.T) {
+	te := newTestEnv(t)
+
+	var chunkSizes []int
+	var got []*Customer
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 400 and 499",
+		MaxRowsPerFlush: 2,
+		DataType:        &Customer{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			chunkSizes = append(chunkSizes, len(rows))
+			for _, row := range rows {
+				got = append(got, row.Data.(*Customer))
+			}
+			return nil
+		},
+	}})
+
+	te.exec(t, "insert into customer.customer(id, email) values (401, 'chunk-1@domain.com'), (402, 'chunk-2@domain.com'), (403, 'chunk-3@domain.com'), (404, 'chunk-4@domain.com'), (405, 'chunk-5@domain.com')", nil)
+	te.runUntilTimeout(t, vstreamClient, 2*time.Second)
+
+	assert.Equal(t, []int{2, 2, 1}, chunkSizes)
+	assert.ElementsMatch(t, []*Customer{{ID: 401, Email: "chunk-1@domain.com"}, {ID: 402, Email: "chunk-2@domain.com"}, {ID: 403, Email: "chunk-3@domain.com"}, {ID: 404, Email: "chunk-4@domain.com"}, {ID: 405, Email: "chunk-5@domain.com"}}, got)
+}
+
+// TestVStreamClientFlushesOnHeartbeat verifies heartbeat timing flushes buffered
+// rows even when the batch size is not reached, which prevents data from stalling.
+func TestVStreamClientFlushesOnHeartbeat(t *testing.T) {
+	te := newTestEnv(t)
+
+	flushes := make(chan []*Customer, 2)
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 500 and 599",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			batch := make([]*Customer, 0, len(rows))
+			for _, row := range rows {
+				batch = append(batch, row.Data.(*Customer))
+			}
+			flushes <- batch
+			return nil
+		},
+	}}, vstreamclient.WithMinFlushDuration(1500*time.Millisecond))
+
+	te.exec(t, "insert into customer.customer(id, email) values (501, 'heartbeat-initial@domain.com')", nil)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	defer cancelRun()
+
+	firstFlush := <-flushes
+	assert.Equal(t, []*Customer{{ID: 501, Email: "heartbeat-initial@domain.com"}}, firstFlush)
+
+	te.exec(t, "insert into customer.customer(id, email) values (502, 'heartbeat-late@domain.com')", nil)
+	insertedAt := time.Now()
+
+	secondFlush := <-flushes
+	assert.Equal(t, []*Customer{{ID: 502, Email: "heartbeat-late@domain.com"}}, secondFlush)
+	assert.Greater(t, time.Since(insertedAt), time.Second)
+
+	cancelRun()
+	err := <-runErrCh
+	if err != nil && runCtx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+}
+
+// TestVStreamClientTransactionBoundaries verifies rows from one transaction are
+// flushed together after COMMIT, which preserves transactional consistency.
+func TestVStreamClientTransactionBoundaries(t *testing.T) {
+	te := newTestEnv(t)
+
+	flushes := make(chan []*Customer, 1)
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 1300 and 1399",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			batch := make([]*Customer, 0, len(rows))
+			for _, row := range rows {
+				batch = append(batch, row.Data.(*Customer))
+			}
+			flushes <- batch
+			return nil
+		},
+	}})
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 3*time.Second)
+	defer cancelRun()
+
+	te.exec(t, "begin", nil)
+	te.exec(t, "insert into customer.customer(id, email) values (1301, 'tx-a@domain.com'), (1302, 'tx-b@domain.com')", nil)
+	te.exec(t, "commit", nil)
+
+	batch := <-flushes
+	assert.ElementsMatch(t, []*Customer{{ID: 1301, Email: "tx-a@domain.com"}, {ID: 1302, Email: "tx-b@domain.com"}}, batch)
+
+	cancelRun()
+	err := <-runErrCh
+	if err != nil && runCtx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+}
+
+// TestVStreamClientHandlesDDL verifies schema changes do not stop the stream
+// from continuing to deliver matching rows in the normal tolerant mode.
+func TestVStreamClientHandlesDDL(t *testing.T) {
+	te := newTestEnv(t)
+
+	var got []*Customer
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 1400 and 1499",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				got = append(got, row.Data.(*Customer))
+			}
+			return nil
+		},
+	}})
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	defer cancelRun()
+	time.Sleep(200 * time.Millisecond)
+
+	te.exec(t, "alter table customer.customer add column ddl_note varchar(64) null", nil)
+	te.exec(t, "insert into customer.customer(id, email, ddl_note) values (1401, 'ddl@domain.com', 'ok')", nil)
+
+	assert.Eventually(t, func() bool {
+		return len(got) == 1
+	}, 3*time.Second, 100*time.Millisecond)
+	assert.Equal(t, []*Customer{{ID: 1401, Email: "ddl@domain.com"}}, got)
+
+	cancelRun()
+	err := <-runErrCh
+	if err != nil && runCtx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+}
+
+// TestVStreamClientReuseBatchSlice verifies the opt-in batch reuse mode actually
+// reuses batch backing storage, which matters for allocation-sensitive consumers.
+func TestVStreamClientReuseBatchSlice(t *testing.T) {
+	te := newTestEnv(t)
+
+	var batchPointers []string
+	newClient := func(t *testing.T) *vstreamclient.VStreamClient {
+		t.Helper()
+		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1960 and 1969",
+			MaxRowsPerFlush: 2,
+			ReuseBatchSlice: true,
+			DataType:        &Customer{},
+			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+				batchPointers = append(batchPointers, "")
+				if len(rows) > 0 {
+					batchPointers[len(batchPointers)-1] = fmt.Sprintf("%p", &rows[0])
+				}
+				return nil
+			},
+		}})
+	}
+
+	te.exec(t, "insert into customer.customer(id, email) values (1961, 'reuse-a@domain.com'), (1962, 'reuse-b@domain.com')", nil)
+	vstreamClient := newClient(t)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	defer cancelRun()
+	assert.Eventually(t, func() bool {
+		return len(batchPointers) >= 1
+	}, 3*time.Second, 50*time.Millisecond)
+
+	te.exec(t, "insert into customer.customer(id, email) values (1963, 'reuse-c@domain.com'), (1964, 'reuse-d@domain.com')", nil)
+	assert.Eventually(t, func() bool {
+		return len(batchPointers) >= 2
+	}, 3*time.Second, 50*time.Millisecond)
+
+	cancelRun()
+	err := <-runErrCh
+	if err != nil && runCtx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+
+	require.Len(t, batchPointers, 2)
+	assert.Equal(t, batchPointers[0], batchPointers[1])
+}

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -160,21 +160,22 @@ func TestVStreamClientFlushesOnHeartbeat(t *testing.T) {
 	heartbeatSinceLastRow := false
 
 	flushes := make(chan flush, 2)
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 500 and 599",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn: func(_ context.Context, rows []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
-			batch := make([]*Customer, 0, len(rows))
-			for _, row := range rows {
-				batch = append(batch, row.Data.(*Customer))
-			}
-			flushes <- flush{customers: batch, reason: meta.FlushReason, heartbeatSinceLastRow: heartbeatSinceLastRow}
-			return nil
-		},
-	}},
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 500 and 599",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn: func(_ context.Context, rows []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
+				batch := make([]*Customer, 0, len(rows))
+				for _, row := range rows {
+					batch = append(batch, row.Data.(*Customer))
+				}
+				flushes <- flush{customers: batch, reason: meta.FlushReason, heartbeatSinceLastRow: heartbeatSinceLastRow}
+				return nil
+			},
+		}},
 		vstreamclient.WithMinFlushDuration(5*time.Second),
 		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
 			heartbeatSinceLastRow = false

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -19,6 +19,7 @@ package vstreamclient
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ func TestVStreamClient(t *testing.T) {
 	te := newTestEnv(t)
 
 	flushCount := 0
+	var rowsFlushed atomic.Int64
 	gotCustomers := make([]*Customer, 0)
 	tables := []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
@@ -42,6 +44,7 @@ func TestVStreamClient(t *testing.T) {
 		DataType:        &Customer{},
 		FlushFn: func(ctx context.Context, rows []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
 			flushCount++
+			defer rowsFlushed.Add(int64(len(rows)))
 
 			t.Logf("upserting %d customers\n", len(rows))
 			for i, row := range rows {
@@ -72,28 +75,30 @@ func TestVStreamClient(t *testing.T) {
 		for _, customer := range wantCustomers {
 			te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(customer.ID, customer.Email))
 		}
-		te.runUntilTimeout(t, newClient(t), 2*time.Second)
+		te.runUntilCopyCompleted(t, newClient(t), "bob")
 		assert.Positive(t, flushCount)
 		assert.ElementsMatch(t, gotCustomers, wantCustomers)
 	})
 
 	t.Run("updating rows", func(t *testing.T) {
 		gotCustomers = nil
+		base := rowsFlushed.Load()
 		updateCustomers := []*Customer{{ID: 1, Email: "alice_new@domain.com"}, {ID: 5, Email: "eve_new@domain.com"}}
 		for _, customer := range updateCustomers {
 			te.exec(t, "update customer.customer set email=:email where id=:id", customerBindVars(customer.ID, customer.Email))
 		}
-		te.runUntilTimeout(t, newClient(t), 2*time.Second)
+		te.runUntil(t, newClient(t), func() bool { return rowsFlushed.Load() >= base+2 })
 		assert.ElementsMatch(t, gotCustomers, updateCustomers)
 	})
 
 	t.Run("deleting rows", func(t *testing.T) {
 		gotCustomers = nil
+		base := rowsFlushed.Load()
 		deleteCustomerIDs := []int{1, 5}
 		for _, id := range deleteCustomerIDs {
 			te.exec(t, "delete from customer.customer where id=:id", idBindVar(int64(id)))
 		}
-		te.runUntilTimeout(t, newClient(t), 2*time.Second)
+		te.runUntil(t, newClient(t), func() bool { return rowsFlushed.Load() >= base+2 })
 		assert.Len(t, gotCustomers, len(deleteCustomerIDs))
 		for _, gotCustomer := range gotCustomers {
 			assert.NotEmpty(t, gotCustomer.DeletedAt)
@@ -124,9 +129,16 @@ func TestVStreamClientFlushChunking(t *testing.T) {
 	}})
 
 	te.exec(t, "insert into customer.customer(id, email) values (401, 'chunk-1@domain.com'), (402, 'chunk-2@domain.com'), (403, 'chunk-3@domain.com'), (404, 'chunk-4@domain.com'), (405, 'chunk-5@domain.com')", nil)
-	te.runUntilTimeout(t, vstreamClient, 2*time.Second)
+	te.runUntilCopyCompleted(t, vstreamClient, t.Name())
 
-	assert.Equal(t, []int{2, 2, 1}, chunkSizes)
+	// the exact chunk shape depends on how many rows were still buffered at each flush boundary,
+	// so only pin the chunking contract: no chunk exceeds MaxRowsPerFlush and no row is dropped
+	totalRows := 0
+	for _, size := range chunkSizes {
+		assert.LessOrEqual(t, size, 2)
+		totalRows += size
+	}
+	assert.Equal(t, 5, totalRows)
 	assert.ElementsMatch(t, []*Customer{{ID: 401, Email: "chunk-1@domain.com"}, {ID: 402, Email: "chunk-2@domain.com"}, {ID: 403, Email: "chunk-3@domain.com"}, {ID: 404, Email: "chunk-4@domain.com"}, {ID: 405, Email: "chunk-5@domain.com"}}, got)
 }
 
@@ -153,18 +165,19 @@ func TestVStreamClientFlushesOnHeartbeat(t *testing.T) {
 	}}, vstreamclient.WithMinFlushDuration(1500*time.Millisecond))
 
 	te.exec(t, "insert into customer.customer(id, email) values (501, 'heartbeat-initial@domain.com')", nil)
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	firstFlush := recvOrFail(t, flushes, "first flush")
 	assert.Equal(t, []*Customer{{ID: 501, Email: "heartbeat-initial@domain.com"}}, firstFlush)
 
+	// with no further writes after this insert, only a heartbeat (or min-duration) boundary can
+	// flush the buffered row; asserting on elapsed wall-clock time here is inherently flaky on
+	// loaded CI runners, so only the delivery itself is pinned
 	te.exec(t, "insert into customer.customer(id, email) values (502, 'heartbeat-late@domain.com')", nil)
-	insertedAt := time.Now()
 
 	secondFlush := recvOrFail(t, flushes, "second flush")
 	assert.Equal(t, []*Customer{{ID: 502, Email: "heartbeat-late@domain.com"}}, secondFlush)
-	assert.Greater(t, time.Since(insertedAt), time.Second)
 
 	cancelRun()
 	err := <-runErrCh
@@ -195,7 +208,7 @@ func TestVStreamClientTransactionBoundaries(t *testing.T) {
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 3*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, "begin", nil)
@@ -216,6 +229,11 @@ func TestVStreamClientTransactionBoundaries(t *testing.T) {
 // from continuing to deliver matching rows in the normal tolerant mode.
 func TestVStreamClientHandlesDDL(t *testing.T) {
 	te := newTestEnv(t)
+	t.Cleanup(func() {
+		// without this drop, the leftover column breaks the strict-mode schema drift test in
+		// any later test ordering, making the suite order-dependent
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column ddl_note", nil)
+	})
 
 	gotCh := make(chan *Customer, 1)
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
@@ -235,19 +253,18 @@ func TestVStreamClientHandlesDDL(t *testing.T) {
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
-	time.Sleep(200 * time.Millisecond)
+
+	// wait for the stream to be up (copy phase checkpointed) before issuing DDL, instead of
+	// guessing readiness with a sleep
+	assert.Eventually(t, te.copyCompleted(t.Name()), 30*time.Second, 50*time.Millisecond)
 
 	te.exec(t, "alter table customer.customer add column ddl_note varchar(64) null", nil)
 	te.exec(t, "insert into customer.customer(id, email, ddl_note) values (1401, 'ddl@domain.com', 'ok')", nil)
 
-	select {
-	case got := <-gotCh:
-		assert.Equal(t, &Customer{ID: 1401, Email: "ddl@domain.com"}, got)
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for row after DDL")
-	}
+	got := recvOrFail(t, gotCh, "row after DDL")
+	assert.Equal(t, &Customer{ID: 1401, Email: "ddl@domain.com"}, got)
 
 	cancelRun()
 	err := <-runErrCh

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -156,13 +156,13 @@ func TestVStreamClientFlushesOnHeartbeat(t *testing.T) {
 	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
 	defer cancelRun()
 
-	firstFlush := <-flushes
+	firstFlush := recvOrFail(t, flushes, "first flush")
 	assert.Equal(t, []*Customer{{ID: 501, Email: "heartbeat-initial@domain.com"}}, firstFlush)
 
 	te.exec(t, "insert into customer.customer(id, email) values (502, 'heartbeat-late@domain.com')", nil)
 	insertedAt := time.Now()
 
-	secondFlush := <-flushes
+	secondFlush := recvOrFail(t, flushes, "second flush")
 	assert.Equal(t, []*Customer{{ID: 502, Email: "heartbeat-late@domain.com"}}, secondFlush)
 	assert.Greater(t, time.Since(insertedAt), time.Second)
 
@@ -202,7 +202,7 @@ func TestVStreamClientTransactionBoundaries(t *testing.T) {
 	te.exec(t, "insert into customer.customer(id, email) values (1301, 'tx-a@domain.com'), (1302, 'tx-b@domain.com')", nil)
 	te.exec(t, "commit", nil)
 
-	batch := <-flushes
+	batch := recvOrFail(t, flushes, "transaction flush")
 	assert.ElementsMatch(t, []*Customer{{ID: 1301, Email: "tx-a@domain.com"}, {ID: 1302, Email: "tx-b@domain.com"}}, batch)
 
 	cancelRun()

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -18,7 +18,6 @@ package vstreamclient
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -273,59 +272,7 @@ func TestVStreamClientHandlesDDL(t *testing.T) {
 	}
 }
 
-// TestVStreamClientReuseBatchSlice verifies the opt-in batch reuse mode actually
-// reuses batch backing storage, which matters for allocation-sensitive consumers.
-func TestVStreamClientReuseBatchSlice(t *testing.T) {
-	te := newTestEnv(t)
-
-	batchPointers := make(chan string, 2)
-	newClient := func(t *testing.T) *vstreamclient.VStreamClient {
-		t.Helper()
-		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-			Keyspace:        "customer",
-			Table:           "customer",
-			Query:           "select * from customer where id between 1960 and 1969",
-			MaxRowsPerFlush: 2,
-			ReuseBatchSlice: true,
-			DataType:        &Customer{},
-			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-				pointer := ""
-				if len(rows) > 0 {
-					pointer = fmt.Sprintf("%p", &rows[0])
-				}
-				select {
-				case batchPointers <- pointer:
-				default:
-				}
-				return nil
-			},
-		}})
-	}
-
-	te.exec(t, "insert into customer.customer(id, email) values (1961, 'reuse-a@domain.com'), (1962, 'reuse-b@domain.com')", nil)
-	vstreamClient := newClient(t)
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
-	defer cancelRun()
-	var firstPointer string
-	select {
-	case firstPointer = <-batchPointers:
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for first batch flush")
-	}
-
-	te.exec(t, "insert into customer.customer(id, email) values (1963, 'reuse-c@domain.com'), (1964, 'reuse-d@domain.com')", nil)
-	var secondPointer string
-	select {
-	case secondPointer = <-batchPointers:
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for second batch flush")
-	}
-
-	cancelRun()
-	err := <-runErrCh
-	if err != nil && runCtx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
-	}
-
-	assert.Equal(t, firstPointer, secondPointer)
-}
+// The batch-reuse contract of ReuseBatchSlice is pinned deterministically by the unit test
+// TestResetBatch_ReuseBatchSlice in the vstreamclient package. An e2e version comparing batch
+// addresses across flushes can false-pass: without reuse, the previous batch is garbage by the
+// time the next one is allocated, so the allocator may legitimately return the same address.

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/vstreamclient"
 )
@@ -181,7 +182,7 @@ func TestVStreamClientFlushesOnHeartbeat(t *testing.T) {
 	cancelRun()
 	err := <-runErrCh
 	if err != nil && runCtx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+		require.NoError(t, err, "failed to run vstreamclient")
 	}
 }
 
@@ -220,7 +221,7 @@ func TestVStreamClientTransactionBoundaries(t *testing.T) {
 	cancelRun()
 	err := <-runErrCh
 	if err != nil && runCtx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+		require.NoError(t, err, "failed to run vstreamclient")
 	}
 }
 
@@ -268,7 +269,7 @@ func TestVStreamClientHandlesDDL(t *testing.T) {
 	cancelRun()
 	err := <-runErrCh
 	if err != nil && runCtx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+		require.NoError(t, err, "failed to run vstreamclient")
 	}
 }
 

--- a/go/test/endtoend/vstreamclient/core_test.go
+++ b/go/test/endtoend/vstreamclient/core_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	"vitess.io/vitess/go/vt/vstreamclient"
 )
 
@@ -147,37 +149,60 @@ func TestVStreamClientFlushChunking(t *testing.T) {
 func TestVStreamClientFlushesOnHeartbeat(t *testing.T) {
 	te := newTestEnv(t)
 
-	flushes := make(chan []*Customer, 2)
+	type flush struct {
+		customers             []*Customer
+		reason                vstreamclient.FlushReason
+		heartbeatSinceLastRow bool
+	}
+
+	// the hooks and FlushFn all run on the Run goroutine, so this needs no synchronization;
+	// the test goroutine only observes it through the flushes channel payloads
+	heartbeatSinceLastRow := false
+
+	flushes := make(chan flush, 2)
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
 		Table:           "customer",
 		Query:           "select * from customer where id between 500 and 599",
 		MaxRowsPerFlush: 10,
 		DataType:        &Customer{},
-		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
 			batch := make([]*Customer, 0, len(rows))
 			for _, row := range rows {
 				batch = append(batch, row.Data.(*Customer))
 			}
-			flushes <- batch
+			flushes <- flush{customers: batch, reason: meta.FlushReason, heartbeatSinceLastRow: heartbeatSinceLastRow}
 			return nil
 		},
-	}}, vstreamclient.WithMinFlushDuration(1500*time.Millisecond))
+	}},
+		vstreamclient.WithMinFlushDuration(5*time.Second),
+		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+			heartbeatSinceLastRow = false
+			return nil
+		}, binlogdatapb.VEventType_ROW),
+		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+			heartbeatSinceLastRow = true
+			return nil
+		}, binlogdatapb.VEventType_HEARTBEAT),
+	)
 
 	te.exec(t, "insert into customer.customer(id, email) values (501, 'heartbeat-initial@domain.com')", nil)
 	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	firstFlush := recvOrFail(t, flushes, "first flush")
-	assert.Equal(t, []*Customer{{ID: 501, Email: "heartbeat-initial@domain.com"}}, firstFlush)
+	assert.Equal(t, []*Customer{{ID: 501, Email: "heartbeat-initial@domain.com"}}, firstFlush.customers)
+	assert.Equal(t, vstreamclient.FlushReasonCopyCompleted, firstFlush.reason)
 
-	// with no further writes after this insert, only a heartbeat (or min-duration) boundary can
-	// flush the buffered row; asserting on elapsed wall-clock time here is inherently flaky on
-	// loaded CI runners, so only the delivery itself is pinned
+	// with no further writes after this insert, the buffered row can only be delivered by a
+	// heartbeat boundary once minFlushDuration elapses: the row's own COMMIT arrives well
+	// inside the 5s window, so it cannot be the flush boundary
 	te.exec(t, "insert into customer.customer(id, email) values (502, 'heartbeat-late@domain.com')", nil)
 
 	secondFlush := recvOrFail(t, flushes, "second flush")
-	assert.Equal(t, []*Customer{{ID: 502, Email: "heartbeat-late@domain.com"}}, secondFlush)
+	assert.Equal(t, []*Customer{{ID: 502, Email: "heartbeat-late@domain.com"}}, secondFlush.customers)
+	assert.Equal(t, vstreamclient.FlushReasonMinDuration, secondFlush.reason)
+	assert.True(t, secondFlush.heartbeatSinceLastRow, "the flush boundary should have been a heartbeat, not the row's own commit")
 
 	cancelRun()
 	err := <-runErrCh
@@ -186,19 +211,34 @@ func TestVStreamClientFlushesOnHeartbeat(t *testing.T) {
 	}
 }
 
-// TestVStreamClientTransactionBoundaries verifies rows from one transaction are
-// flushed together after COMMIT, which preserves transactional consistency.
+// TestVStreamClientTransactionBoundaries verifies rows from one transaction are flushed
+// together after COMMIT — even with TransactionChunkSize enabled, which makes VTGate deliver the
+// transaction's rows in separate chunks — which preserves transactional consistency. The
+// deterministic mid-transaction heartbeat interleavings are pinned by the package unit test
+// TestHandleEvents_HeartbeatMidTransactionDefersFlush.
 func TestVStreamClientTransactionBoundaries(t *testing.T) {
 	te := newTestEnv(t)
 
-	flushes := make(chan []*Customer, 1)
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 1300 and 1399",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+	newClient := func(flushFn vstreamclient.FlushFunc, opts ...vstreamclient.Option) *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1300 and 1399",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         flushFn,
+		}}, opts...)
+	}
+
+	// complete the copy phase first, so the chunked transaction below arrives through streaming
+	te.runUntilCopyCompleted(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), t.Name())
+
+	flushes := make(chan []*Customer, 4)
+	var flushCalls atomic.Int32
+	var heartbeats atomic.Int32
+	client := newClient(
+		func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			flushCalls.Add(1)
 			batch := make([]*Customer, 0, len(rows))
 			for _, row := range rows {
 				batch = append(batch, row.Data.(*Customer))
@@ -206,17 +246,33 @@ func TestVStreamClientTransactionBoundaries(t *testing.T) {
 			flushes <- batch
 			return nil
 		},
-	}})
+		// TransactionChunkSize makes VTGate deliver the transaction's rows in separate chunks,
+		// exercising the path where a flush boundary could otherwise split the transaction
+		vstreamclient.WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, TransactionChunkSize: 1}),
+		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+			heartbeats.Add(1)
+			return nil
+		}, binlogdatapb.VEventType_HEARTBEAT),
+	)
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, "begin", nil)
 	te.exec(t, "insert into customer.customer(id, email) values (1301, 'tx-a@domain.com'), (1302, 'tx-b@domain.com')", nil)
+
+	// hold the transaction open across several heartbeats: the stream is demonstrably live,
+	// and nothing may be flushed before the transaction commits
+	heartbeatBase := heartbeats.Load()
+	require.Eventually(t, func() bool { return heartbeats.Load() >= heartbeatBase+2 }, 30*time.Second, 50*time.Millisecond)
+	assert.Zero(t, flushCalls.Load(), "no rows may be delivered before COMMIT")
+
 	te.exec(t, "commit", nil)
 
+	// both chunked rows must arrive in a single flush at the commit boundary
 	batch := recvOrFail(t, flushes, "transaction flush")
 	assert.ElementsMatch(t, []*Customer{{ID: 1301, Email: "tx-a@domain.com"}, {ID: 1302, Email: "tx-b@domain.com"}}, batch)
+	assert.Equal(t, int32(1), flushCalls.Load(), "the transaction's rows must not be split across flushes")
 
 	cancelRun()
 	err := <-runErrCh

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamclient
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vstreamclient"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+// Customer is the concrete type that will be built from the stream.
+type Customer struct {
+	ID        int64     `vstream:"id"`
+	Email     string    `vstream:"email"`
+	DeletedAt time.Time `vstream:"-"`
+}
+
+type Order struct {
+	ID         int64  `vstream:"id"`
+	CustomerID int64  `vstream:"customer_id"`
+	Note       string `vstream:"note"`
+}
+
+type testEnv struct {
+	ctx     context.Context
+	conn    *vtgateconn.VTGateConn
+	session *vtgateconn.VTGateSession
+	qCtx    context.Context
+}
+
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+
+	ctx := context.Background()
+	conn, err := cluster.DialVTGate(ctx, t.Name(), vtgateGrpcAddress, "test_user", "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		conn.Close()
+	})
+
+	return &testEnv{
+		ctx:     ctx,
+		conn:    conn,
+		session: conn.Session("", nil),
+		qCtx:    t.Context(),
+	}
+}
+
+func (te *testEnv) newDefaultClient(t *testing.T, name string, tables []vstreamclient.TableConfig, opts ...vstreamclient.Option) *vstreamclient.VStreamClient {
+	t.Helper()
+
+	defaultOpts := []vstreamclient.Option{
+		vstreamclient.WithMinFlushDuration(500 * time.Millisecond),
+		vstreamclient.WithHeartbeatSeconds(1),
+		vstreamclient.WithStateTable("commerce", "vstreams"),
+	}
+
+	client, err := vstreamclient.New(te.ctx, name, te.conn, tables, append(defaultOpts, opts...)...)
+	require.NoError(t, err)
+	return client
+}
+
+func (te *testEnv) exec(t *testing.T, query string, bindVariables map[string]*querypb.BindVariable) {
+	t.Helper()
+
+	_, err := te.session.Execute(te.qCtx, query, bindVariables, false)
+	require.NoError(t, err)
+}
+
+func (te *testEnv) execBackground(t *testing.T, query string, bindVariables map[string]*querypb.BindVariable) {
+	t.Helper()
+
+	_, err := te.session.Execute(context.Background(), query, bindVariables, false)
+	require.NoError(t, err)
+}
+
+func (te *testEnv) runUntilTimeout(t *testing.T, client *vstreamclient.VStreamClient, timeout time.Duration) {
+	t.Helper()
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), timeout)
+	defer cancelRun()
+
+	err := client.Run(runCtx)
+	if err != nil && !isExpectedRunStop(err, runCtx) {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+}
+
+func (te *testEnv) runAsync(client *vstreamclient.VStreamClient, timeout time.Duration) (context.Context, context.CancelFunc, chan error) {
+	runCtx, cancelRun := context.WithTimeout(context.Background(), timeout)
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- client.Run(runCtx)
+	}()
+	return runCtx, cancelRun, runErrCh
+}
+
+func isExpectedRunStop(err error, runCtx context.Context) bool {
+	if err == nil {
+		return true
+	}
+	if runCtx != nil && runCtx.Err() != nil {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "code = DeadlineExceeded") ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "code = Canceled") ||
+		strings.Contains(msg, "error code: CANCEL")
+}
+
+func customerBindVars(id int64, email string) map[string]*querypb.BindVariable {
+	return map[string]*querypb.BindVariable{
+		"id":    {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(id, 10))},
+		"email": {Type: querypb.Type_VARCHAR, Value: []byte(email)},
+	}
+}
+
+func idBindVar(id int64) map[string]*querypb.BindVariable {
+	return map[string]*querypb.BindVariable{
+		"id": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(id, 10))},
+	}
+}
+
+func queryLatestVGtid(t *testing.T, ctx context.Context, session *vtgateconn.VTGateSession, name string) *binlogdatapb.VGtid {
+	t.Helper()
+
+	result, err := session.Execute(ctx, "select latest_vgtid from commerce.vstreams where name = :name", map[string]*querypb.BindVariable{
+		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+
+	bytes, err := result.Rows[0][0].ToBytes()
+	require.NoError(t, err)
+
+	vgtid := &binlogdatapb.VGtid{}
+	err = protojson.Unmarshal(bytes, vgtid)
+	require.NoError(t, err)
+	return vgtid
+}

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -99,6 +99,21 @@ func (te *testEnv) execBackground(t *testing.T, query string, bindVariables map[
 	require.NoError(t, err)
 }
 
+func (te *testEnv) execBackgroundAllowMissingColumn(t *testing.T, query string, bindVariables map[string]*querypb.BindVariable) {
+	t.Helper()
+
+	_, err := te.session.Execute(context.Background(), query, bindVariables, false)
+	if err == nil {
+		return
+	}
+
+	if strings.Contains(err.Error(), "errno 1091") || strings.Contains(err.Error(), "check that column/key exists") {
+		return
+	}
+
+	require.NoError(t, err)
+}
+
 func (te *testEnv) runUntilTimeout(t *testing.T, client *vstreamclient.VStreamClient, timeout time.Duration) {
 	t.Helper()
 

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -18,8 +18,10 @@ package vstreamclient
 
 import (
 	"context"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -147,6 +149,34 @@ func isExpectedRunStop(err error, runCtx context.Context) bool {
 		strings.Contains(msg, "context deadline exceeded") ||
 		strings.Contains(msg, "code = Canceled") ||
 		strings.Contains(msg, "error code: CANCEL")
+}
+
+// rowCollector accumulates flushed rows behind a mutex. FlushFn runs on the goroutine that calls
+// Run, while tests poll and assert on the collected rows from the test goroutine, so appending to
+// and reading an unsynchronized slice is a data race.
+type rowCollector[T any] struct {
+	mu   sync.Mutex
+	rows []T
+}
+
+func (c *rowCollector[T]) collect(rows []vstreamclient.Row) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, row := range rows {
+		c.rows = append(c.rows, row.Data.(T))
+	}
+}
+
+func (c *rowCollector[T]) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.rows)
+}
+
+func (c *rowCollector[T]) snapshot() []T {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.rows)
 }
 
 func customerBindVars(id int64, email string) map[string]*querypb.BindVariable {

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -96,19 +96,29 @@ func (te *testEnv) exec(t *testing.T, query string, bindVariables map[string]*qu
 	require.NoError(t, err)
 }
 
-// execBackground uses context.Background() on purpose: it is called from t.Cleanup and from
-// FlushFns that must outlive a canceled run context, both of which run after t.Context() is done.
+// backgroundQueryCtx returns a context for queries issued from t.Cleanup or from FlushFns that
+// must outlive a canceled run context. WithoutCancel detaches from the test's cancellation while
+// preserving its values, and the generous timeout keeps a stuck VTGate from hanging the whole
+// package indefinitely.
+func (te *testEnv) backgroundQueryCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(te.qCtx), time.Minute)
+}
+
 func (te *testEnv) execBackground(t *testing.T, query string, bindVariables map[string]*querypb.BindVariable) {
 	t.Helper()
 
-	_, err := te.session.Execute(context.Background(), query, bindVariables, false)
+	ctx, cancel := te.backgroundQueryCtx()
+	defer cancel()
+	_, err := te.session.Execute(ctx, query, bindVariables, false)
 	require.NoError(t, err)
 }
 
 func (te *testEnv) execBackgroundAllowMissingColumn(t *testing.T, query string, bindVariables map[string]*querypb.BindVariable) {
 	t.Helper()
 
-	_, err := te.session.Execute(context.Background(), query, bindVariables, false)
+	ctx, cancel := te.backgroundQueryCtx()
+	defer cancel()
+	_, err := te.session.Execute(ctx, query, bindVariables, false)
 	if err == nil {
 		return
 	}

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -18,6 +18,7 @@ package vstreamclient
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strconv"
 	"strings"
@@ -116,15 +117,65 @@ func (te *testEnv) execBackgroundAllowMissingColumn(t *testing.T, query string, 
 	require.NoError(t, err)
 }
 
-func (te *testEnv) runUntilTimeout(t *testing.T, client *vstreamclient.VStreamClient, timeout time.Duration) {
+// runUntil runs the client until condition reports true, then stops it with GracefulShutdown and
+// waits for Run to exit. GracefulShutdown flushes and checkpoints buffered work at the next safe
+// boundary before Run returns, so anything the condition observed (e.g. rows seen by FlushFn) is
+// durably checkpointed by the time runUntil returns — later clients with the same stream name
+// resume instead of replaying. The deadlines are generous so slow CI runners don't flake; fast
+// runs return as soon as the condition is met instead of burning a fixed wall-clock window.
+func (te *testEnv) runUntil(t *testing.T, client *vstreamclient.VStreamClient, condition func() bool) {
 	t.Helper()
 
-	runCtx, cancelRun := context.WithTimeout(context.Background(), timeout)
+	runCtx, cancelRun := context.WithCancel(context.Background())
 	defer cancelRun()
 
-	err := client.Run(runCtx)
-	if err != nil && !isExpectedRunStop(err, runCtx) {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- client.Run(runCtx)
+	}()
+
+	deadline := time.After(30 * time.Second)
+	for !condition() {
+		select {
+		case err := <-runErrCh:
+			require.NoError(t, err, "vstreamclient exited before the run condition was met")
+			require.FailNow(t, "vstreamclient exited cleanly before the run condition was met")
+		case <-deadline:
+			require.FailNow(t, "timed out waiting for the run condition")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	client.GracefulShutdown(15 * time.Second)
+	err := recvOrFail(t, runErrCh, "vstreamclient Run to exit")
+	if err != nil && !errors.Is(err, context.Canceled) && !isExpectedRunStop(err, runCtx) {
+		require.NoError(t, err, "failed to run vstreamclient")
+	}
+}
+
+// runUntilCopyCompleted runs the client until the stream's copy phase has been flushed and
+// checkpointed. The copy-completed flush writes buffered rows before persisting copy_completed,
+// so once the column reads true, all copy-phase rows have been delivered to FlushFn and the next
+// client with the same stream name will resume from the stored vgtid instead of re-copying.
+func (te *testEnv) runUntilCopyCompleted(t *testing.T, client *vstreamclient.VStreamClient, streamName string) {
+	t.Helper()
+
+	te.runUntil(t, client, te.copyCompleted(streamName))
+}
+
+// copyCompleted returns a condition that reports whether the stream's copy phase has been
+// checkpointed in the state table.
+func (te *testEnv) copyCompleted(streamName string) func() bool {
+	return func() bool {
+		result, err := te.session.Execute(te.qCtx, "select copy_completed from commerce.vstreams where name = :name", map[string]*querypb.BindVariable{
+			"name": {Type: querypb.Type_VARBINARY, Value: []byte(streamName)},
+		}, false)
+		if err != nil || len(result.Rows) == 0 {
+			return false
+		}
+
+		completed, err := result.Rows[0][0].ToBool()
+		return err == nil && completed
 	}
 }
 

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -112,7 +113,8 @@ func (te *testEnv) execBackgroundAllowMissingColumn(t *testing.T, query string, 
 		return
 	}
 
-	if strings.Contains(err.Error(), "errno 1091") || strings.Contains(err.Error(), "check that column/key exists") {
+	var sqlErr *sqlerror.SQLError
+	if errors.As(sqlerror.NewSQLErrorFromError(err), &sqlErr) && sqlErr.Number() == sqlerror.ERCantDropFieldOrKey {
 		return
 	}
 

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -59,7 +59,7 @@ type testEnv struct {
 func newTestEnv(t *testing.T) *testEnv {
 	t.Helper()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn, err := cluster.DialVTGate(ctx, t.Name(), vtgateGrpcAddress, "test_user", "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -95,6 +95,8 @@ func (te *testEnv) exec(t *testing.T, query string, bindVariables map[string]*qu
 	require.NoError(t, err)
 }
 
+// execBackground uses context.Background() on purpose: it is called from t.Cleanup and from
+// FlushFns that must outlive a canceled run context, both of which run after t.Context() is done.
 func (te *testEnv) execBackground(t *testing.T, query string, bindVariables map[string]*querypb.BindVariable) {
 	t.Helper()
 
@@ -126,7 +128,7 @@ func (te *testEnv) execBackgroundAllowMissingColumn(t *testing.T, query string, 
 func (te *testEnv) runUntil(t *testing.T, client *vstreamclient.VStreamClient, condition func() bool) {
 	t.Helper()
 
-	runCtx, cancelRun := context.WithCancel(context.Background())
+	runCtx, cancelRun := context.WithCancel(t.Context())
 	defer cancelRun()
 
 	runErrCh := make(chan error, 1)
@@ -180,7 +182,7 @@ func (te *testEnv) copyCompleted(streamName string) func() bool {
 }
 
 func (te *testEnv) runAsync(client *vstreamclient.VStreamClient, timeout time.Duration) (context.Context, context.CancelFunc, chan error) {
-	runCtx, cancelRun := context.WithTimeout(context.Background(), timeout)
+	runCtx, cancelRun := context.WithTimeout(te.qCtx, timeout)
 	runErrCh := make(chan error, 1)
 	go func() {
 		runErrCh <- client.Run(runCtx)

--- a/go/test/endtoend/vstreamclient/helpers_test.go
+++ b/go/test/endtoend/vstreamclient/helpers_test.go
@@ -151,6 +151,22 @@ func isExpectedRunStop(err error, runCtx context.Context) bool {
 		strings.Contains(msg, "error code: CANCEL")
 }
 
+// recvOrFail receives from ch or fails the test after a generous timeout. A bare channel receive
+// would block forever if the expected flush never happens, hanging the whole package until the go
+// test binary timeout kills it.
+func recvOrFail[T any](t *testing.T, ch <-chan T, what string) T {
+	t.Helper()
+
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "timed out waiting for "+what)
+		var zero T
+		return zero
+	}
+}
+
 // rowCollector accumulates flushed rows behind a mutex. FlushFn runs on the goroutine that calls
 // Run, while tests poll and assert on the collected rows from the test goroutine, so appending to
 // and reading an unsynchronized slice is a data race.

--- a/go/test/endtoend/vstreamclient/hooks_test.go
+++ b/go/test/endtoend/vstreamclient/hooks_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/hooks_test.go
+++ b/go/test/endtoend/vstreamclient/hooks_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/test/endtoend/vstreamclient/hooks_test.go
+++ b/go/test/endtoend/vstreamclient/hooks_test.go
@@ -1,0 +1,109 @@
+package vstreamclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+// TestVStreamClientEventHooks verifies event callbacks receive real FIELD, ROW,
+// and COMMIT events, which is important for observability and custom processing.
+func TestVStreamClientEventHooks(t *testing.T) {
+	te := newTestEnv(t)
+
+	fieldCount := 0
+	rowCount := 0
+	commitCount := 0
+	var rowTableNames []string
+
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 900 and 999",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	}},
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			fieldCount++
+			assert.Equal(t, "customer.customer", ev.FieldEvent.TableName)
+			return nil
+		}, binlogdatapb.VEventType_FIELD),
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			rowCount += len(ev.RowEvent.RowChanges)
+			rowTableNames = append(rowTableNames, ev.RowEvent.TableName)
+			return nil
+		}, binlogdatapb.VEventType_ROW),
+		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+			commitCount++
+			return nil
+		}, binlogdatapb.VEventType_COMMIT),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values (901, 'event-hook@domain.com')", nil)
+	te.runUntilTimeout(t, vstreamClient, 2*time.Second)
+
+	assert.Positive(t, fieldCount)
+	assert.Equal(t, 1, rowCount)
+	assert.Positive(t, commitCount)
+	assert.Contains(t, rowTableNames, "customer.customer")
+}
+
+// TestVStreamClientFlushFnError verifies flush failures are returned from Run,
+// which is important so downstream write errors are never silently ignored.
+func TestVStreamClientFlushFnError(t *testing.T) {
+	te := newTestEnv(t)
+
+	flushErr := errors.New("flush failed")
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 1000 and 1099",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return flushErr },
+	}})
+
+	te.exec(t, "insert into customer.customer(id, email) values (1001, 'flush-error@domain.com')", nil)
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelRun()
+	err := vstreamClient.Run(runCtx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "error flushing table customer")
+	assert.ErrorContains(t, err, flushErr.Error())
+}
+
+// TestVStreamClientEventHookError verifies callback failures abort the stream,
+// which is important when hooks are part of correctness-sensitive workflows.
+func TestVStreamClientEventHookError(t *testing.T) {
+	te := newTestEnv(t)
+
+	hookErr := errors.New("field hook failed")
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 1700 and 1799",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	}},
+		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error { return hookErr }, binlogdatapb.VEventType_FIELD),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values (1701, 'hook-error@domain.com')", nil)
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelRun()
+	err := vstreamClient.Run(runCtx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "user error processing FIELD event")
+	assert.ErrorContains(t, err, hookErr.Error())
+}

--- a/go/test/endtoend/vstreamclient/hooks_test.go
+++ b/go/test/endtoend/vstreamclient/hooks_test.go
@@ -91,7 +91,7 @@ func TestVStreamClientFlushFnError(t *testing.T) {
 	te.exec(t, "insert into customer.customer(id, email) values (1001, 'flush-error@domain.com')", nil)
 
 	// the run self-terminates on the flush error; the deadline is only a generous cap
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancelRun := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancelRun()
 	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)
@@ -120,7 +120,7 @@ func TestVStreamClientEventHookError(t *testing.T) {
 	te.exec(t, "insert into customer.customer(id, email) values (1701, 'hook-error@domain.com')", nil)
 
 	// the run self-terminates on the hook error; the deadline is only a generous cap
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancelRun := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancelRun()
 	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)

--- a/go/test/endtoend/vstreamclient/hooks_test.go
+++ b/go/test/endtoend/vstreamclient/hooks_test.go
@@ -39,14 +39,15 @@ func TestVStreamClientEventHooks(t *testing.T) {
 	commitCount := 0
 	var rowTableNames []string
 
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 900 and 999",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-	}},
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 900 and 999",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		}},
 		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
 			fieldCount++
 			assert.Equal(t, "customer.customer", ev.FieldEvent.TableName)
@@ -64,7 +65,7 @@ func TestVStreamClientEventHooks(t *testing.T) {
 	)
 
 	te.exec(t, "insert into customer.customer(id, email) values (901, 'event-hook@domain.com')", nil)
-	te.runUntilTimeout(t, vstreamClient, 2*time.Second)
+	te.runUntilCopyCompleted(t, vstreamClient, t.Name())
 
 	assert.Positive(t, fieldCount)
 	assert.Equal(t, 1, rowCount)
@@ -89,7 +90,8 @@ func TestVStreamClientFlushFnError(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email) values (1001, 'flush-error@domain.com')", nil)
 
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	// the run self-terminates on the flush error; the deadline is only a generous cap
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelRun()
 	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)
@@ -103,20 +105,22 @@ func TestVStreamClientEventHookError(t *testing.T) {
 	te := newTestEnv(t)
 
 	hookErr := errors.New("field hook failed")
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 1700 and 1799",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-	}},
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1700 and 1799",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		}},
 		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error { return hookErr }, binlogdatapb.VEventType_FIELD),
 	)
 
 	te.exec(t, "insert into customer.customer(id, email) values (1701, 'hook-error@domain.com')", nil)
 
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	// the run self-terminates on the hook error; the deadline is only a generous cap
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelRun()
 	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)

--- a/go/test/endtoend/vstreamclient/hooks_test.go
+++ b/go/test/endtoend/vstreamclient/hooks_test.go
@@ -95,7 +95,7 @@ func TestVStreamClientFlushFnError(t *testing.T) {
 	defer cancelRun()
 	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "error flushing table customer")
+	require.ErrorContains(t, err, "error flushing table customer")
 	assert.ErrorContains(t, err, flushErr.Error())
 }
 
@@ -124,6 +124,6 @@ func TestVStreamClientEventHookError(t *testing.T) {
 	defer cancelRun()
 	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "user error processing FIELD event")
+	require.ErrorContains(t, err, "user error processing FIELD event")
 	assert.ErrorContains(t, err, hookErr.Error())
 }

--- a/go/test/endtoend/vstreamclient/main_test.go
+++ b/go/test/endtoend/vstreamclient/main_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/main_test.go
+++ b/go/test/endtoend/vstreamclient/main_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamclient
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance   *cluster.LocalProcessCluster
+	vtParams          mysql.ConnParams
+	keyspaceName      = "customer"
+	vtgateGrpcAddress string
+	cell              = "zone1"
+	sqlSchema         = `create table customer(
+			id bigint not null auto_increment,
+			email varchar(128),
+			primary key(id)
+		) ENGINE=InnoDB;
+		create table purchases(
+			id bigint not null auto_increment,
+			customer_id bigint not null,
+			note varchar(128),
+			primary key(id)
+		) ENGINE=InnoDB;`
+
+	vSchema = `{
+						"tables": {
+							"customer": {},
+							"purchases": {}
+						}
+					}`
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitcode, err := func() (int, error) {
+		clusterInstance = cluster.NewCluster(cell, "localhost")
+		clusterInstance.VtTabletExtraArgs = []string{"--health_check_interval", "1s", "--shutdown_grace_period", "3s"}
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1, err
+		}
+
+		// Start keyspace
+		customerKeyspace := &cluster.Keyspace{
+			Name:      "customer",
+			SchemaSQL: sqlSchema,
+			VSchema:   vSchema,
+		}
+		err = clusterInstance.StartUnshardedKeyspace(*customerKeyspace, 1, true, cell)
+		if err != nil {
+			return 1, err
+		}
+
+		accountingKeyspace := &cluster.Keyspace{
+			Name:      "accounting",
+			SchemaSQL: sqlSchema,
+			VSchema:   vSchema,
+		}
+		err = clusterInstance.StartUnshardedKeyspace(*accountingKeyspace, 1, true, cell)
+		if err != nil {
+			return 1, err
+		}
+
+		commerceKeyspace := &cluster.Keyspace{
+			Name:      "commerce",
+			SchemaSQL: "",
+			VSchema:   "",
+		}
+		err = clusterInstance.StartUnshardedKeyspace(*commerceKeyspace, 1, true, cell)
+		if err != nil {
+			return 1, err
+		}
+
+		vtgateInstance := clusterInstance.NewVtgateInstance()
+		// Start vtgate
+		err = vtgateInstance.Setup()
+		if err != nil {
+			return 1, err
+		}
+		// ensure it is torn down during cluster TearDown
+		clusterInstance.VtgateProcess = *vtgateInstance
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		vtgateGrpcAddress = fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateGrpcPort)
+		return m.Run(), nil
+	}()
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(exitcode)
+}

--- a/go/test/endtoend/vstreamclient/main_test.go
+++ b/go/test/endtoend/vstreamclient/main_test.go
@@ -22,14 +22,11 @@ import (
 	"os"
 	"testing"
 
-	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 var (
 	clusterInstance   *cluster.LocalProcessCluster
-	vtParams          mysql.ConnParams
-	keyspaceName      = "customer"
 	vtgateGrpcAddress string
 	cell              = "zone1"
 	sqlSchema         = `create table customer(
@@ -57,7 +54,7 @@ func TestMain(m *testing.M) {
 
 	exitcode, err := func() (int, error) {
 		clusterInstance = cluster.NewCluster(cell, "localhost")
-		clusterInstance.VtTabletExtraArgs = []string{"--health_check_interval", "1s", "--shutdown_grace_period", "3s"}
+		clusterInstance.VtTabletExtraArgs = []string{"--health-check-interval", "1s", "--shutdown-grace-period", "3s"}
 		defer clusterInstance.Teardown()
 
 		// Start topo server
@@ -105,10 +102,6 @@ func TestMain(m *testing.M) {
 		}
 		// ensure it is torn down during cluster TearDown
 		clusterInstance.VtgateProcess = *vtgateInstance
-		vtParams = mysql.ConnParams{
-			Host: clusterInstance.Hostname,
-			Port: clusterInstance.VtgateMySQLPort,
-		}
 		vtgateGrpcAddress = fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateGrpcPort)
 		return m.Run(), nil
 	}()

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -1,0 +1,189 @@
+package vstreamclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+// TestVStreamClientResumesFromCheckpoint verifies that persisted stream state is
+// used on a fresh client, so a second run only emits rows written after the
+// first run checkpointed successfully.
+func TestVStreamClientResumesFromCheckpoint(t *testing.T) {
+	te := newTestEnv(t)
+	streamName := t.Name()
+
+	newClient := func(flushFn vstreamclient.FlushFunc) *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, streamName, []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 100 and 199",
+			MaxRowsPerFlush: 2,
+			DataType:        &Customer{},
+			FlushFn:         flushFn,
+		}})
+	}
+
+	insertCustomers := func(customers []*Customer) {
+		for _, customer := range customers {
+			te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(customer.ID, customer.Email))
+		}
+	}
+
+	firstBatch := []*Customer{{ID: 101, Email: "resume-alice@domain.com"}, {ID: 102, Email: "resume-bob@domain.com"}}
+	secondBatch := []*Customer{{ID: 103, Email: "resume-charlie@domain.com"}, {ID: 104, Email: "resume-dan@domain.com"}}
+
+	insertCustomers(firstBatch)
+
+	var firstRunCustomers []*Customer
+	firstClient := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			firstRunCustomers = append(firstRunCustomers, row.Data.(*Customer))
+		}
+		return nil
+	})
+	te.runUntilTimeout(t, firstClient, 2*time.Second)
+	assert.ElementsMatch(t, firstBatch, firstRunCustomers)
+
+	insertCustomers(secondBatch)
+
+	var secondRunCustomers []*Customer
+	secondClient := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			secondRunCustomers = append(secondRunCustomers, row.Data.(*Customer))
+		}
+		return nil
+	})
+	te.runUntilTimeout(t, secondClient, 2*time.Second)
+	assert.ElementsMatch(t, secondBatch, secondRunCustomers)
+}
+
+// TestVStreamClientResumesUpdateDeleteFromCheckpoint verifies checkpoint resume
+// works for mutations after the initial copy, not just for new inserts.
+func TestVStreamClientResumesUpdateDeleteFromCheckpoint(t *testing.T) {
+	te := newTestEnv(t)
+
+	newClient := func(flushFn vstreamclient.FlushFunc) *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 800 and 899",
+			MaxRowsPerFlush: 1,
+			DataType:        &Customer{},
+			FlushFn:         flushFn,
+		}})
+	}
+
+	te.exec(t, "insert into customer.customer(id, email) values (801, 'restart-update@domain.com'), (802, 'restart-delete@domain.com')", nil)
+	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+
+	te.exec(t, "update customer.customer set email = 'restart-update-new@domain.com' where id = 801", nil)
+	te.exec(t, "delete from customer.customer where id = 802", nil)
+
+	type mutation struct {
+		ID      int64
+		Email   string
+		Deleted bool
+	}
+	var got []mutation
+	client := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			customer := row.Data.(*Customer)
+			got = append(got, mutation{ID: customer.ID, Email: customer.Email, Deleted: row.RowChange.After == nil})
+		}
+		return nil
+	})
+	te.runUntilTimeout(t, client, 2*time.Second)
+
+	assert.ElementsMatch(t, []mutation{{ID: 801, Email: "restart-update-new@domain.com", Deleted: false}, {ID: 802, Email: "restart-delete@domain.com", Deleted: true}}, got)
+}
+
+// TestVStreamClientRestartsInterruptedCopy verifies an interrupted copy phase is
+// restarted from the beginning, which protects against partial initial loads.
+func TestVStreamClientRestartsInterruptedCopy(t *testing.T) {
+	te := newTestEnv(t)
+
+	te.exec(t, "insert into customer.customer(id, email) values (1101, 'copy-a@domain.com'), (1102, 'copy-b@domain.com'), (1103, 'copy-c@domain.com')", nil)
+
+	interruptErr := errors.New("interrupt copy before final completion")
+	interruptedClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 1100 and 1199",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	}},
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			if ev.Keyspace != "" {
+				return interruptErr
+			}
+			return nil
+		}, binlogdatapb.VEventType_COPY_COMPLETED),
+	)
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	err := interruptedClient.Run(runCtx)
+	cancelRun()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, interruptErr.Error())
+
+	var got []*Customer
+	restartedClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 1100 and 1199",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				got = append(got, row.Data.(*Customer))
+			}
+			return nil
+		},
+	}})
+
+	te.runUntilTimeout(t, restartedClient, 2*time.Second)
+	assert.ElementsMatch(t, []*Customer{{ID: 1101, Email: "copy-a@domain.com"}, {ID: 1102, Email: "copy-b@domain.com"}, {ID: 1103, Email: "copy-c@domain.com"}}, got)
+}
+
+// TestVStreamClientStartingVGtidOverridesState verifies an explicit starting
+// VGtid wins over stored checkpoint state, which is important for replay control.
+func TestVStreamClientStartingVGtidOverridesState(t *testing.T) {
+	te := newTestEnv(t)
+
+	newClient := func(flushFn vstreamclient.FlushFunc, opts ...vstreamclient.Option) *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1500 and 1599",
+			MaxRowsPerFlush: 1,
+			DataType:        &Customer{},
+			FlushFn:         flushFn,
+		}}, opts...)
+	}
+
+	te.exec(t, "insert into customer.customer(id, email) values (1501, 'override-a@domain.com')", nil)
+	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+	vgtid1 := queryLatestVGtid(t, te.ctx, te.session, t.Name())
+
+	te.exec(t, "insert into customer.customer(id, email) values (1502, 'override-b@domain.com')", nil)
+	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+
+	var replayed []*Customer
+	te.runUntilTimeout(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			replayed = append(replayed, row.Data.(*Customer))
+		}
+		return nil
+	}, vstreamclient.WithStartingVGtid(vgtid1)), 2*time.Second)
+
+	assert.Equal(t, []*Customer{{ID: 1502, Email: "override-b@domain.com"}}, replayed)
+}

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -166,7 +166,7 @@ func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
 		return te.newDefaultClient(t, streamName, []vstreamclient.TableConfig{{
 			Keyspace:        "customer",
 			Table:           "customer",
-			Query:           "select * from customer where id between 1700 and 1799",
+			Query:           "select * from customer where id between 1760 and 1799",
 			MaxRowsPerFlush: 1,
 			DataType:        &Customer{},
 			FlushFn:         flushFn,
@@ -177,7 +177,7 @@ func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
 	// post-copy checkpoint write, not from an interrupted bootstrap copy.
 	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
 
-	want := &Customer{ID: 1701, Email: "checkpoint-replay@domain.com"}
+	want := &Customer{ID: 1761, Email: "checkpoint-replay@domain.com"}
 	te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
 
 	var firstRun []*Customer

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vstreamclient"
 )
 
@@ -152,6 +153,63 @@ func TestVStreamClientRestartsInterruptedCopy(t *testing.T) {
 
 	te.runUntilTimeout(t, restartedClient, 2*time.Second)
 	assert.ElementsMatch(t, []*Customer{{ID: 1101, Email: "copy-a@domain.com"}, {ID: 1102, Email: "copy-b@domain.com"}, {ID: 1103, Email: "copy-c@domain.com"}}, got)
+}
+
+// TestVStreamClientReplaysRowsWhenCheckpointWriteFails verifies the package's
+// at-least-once contract: if FlushFn succeeds but the checkpoint write fails,
+// the same rows are replayed on the next startup.
+func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
+	te := newTestEnv(t)
+	streamName := t.Name()
+
+	newClient := func(flushFn vstreamclient.FlushFunc) *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, streamName, []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1700 and 1799",
+			MaxRowsPerFlush: 1,
+			DataType:        &Customer{},
+			FlushFn:         flushFn,
+		}})
+	}
+
+	// Finish the initial copy first so the replay we observe comes from a failed
+	// post-copy checkpoint write, not from an interrupted bootstrap copy.
+	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+
+	want := &Customer{ID: 1701, Email: "checkpoint-replay@domain.com"}
+	te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
+
+	var firstRun []*Customer
+	failingClient := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			firstRun = append(firstRun, row.Data.(*Customer))
+		}
+
+		te.execBackground(t, "delete from commerce.vstreams where name = :name", map[string]*querypb.BindVariable{
+			"name": {Type: querypb.Type_VARBINARY, Value: []byte(streamName)},
+		})
+
+		return nil
+	})
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	err := failingClient.Run(runCtx)
+	cancelRun()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected number of rows affected")
+	assert.Equal(t, []*Customer{want}, firstRun)
+
+	var replayed []*Customer
+	replayClient := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			replayed = append(replayed, row.Data.(*Customer))
+		}
+		return nil
+	})
+
+	te.runUntilTimeout(t, replayClient, 2*time.Second)
+	assert.Equal(t, []*Customer{want}, replayed)
 }
 
 // TestVStreamClientStartingVGtidOverridesState verifies an explicit starting

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -19,6 +19,7 @@ package vstreamclient
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -66,19 +67,21 @@ func TestVStreamClientResumesFromCheckpoint(t *testing.T) {
 		}
 		return nil
 	})
-	te.runUntilTimeout(t, firstClient, 2*time.Second)
+	te.runUntilCopyCompleted(t, firstClient, streamName)
 	assert.ElementsMatch(t, firstBatch, firstRunCustomers)
 
 	insertCustomers(secondBatch)
 
 	var secondRunCustomers []*Customer
+	var secondRunRows atomic.Int64
 	secondClient := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
 		for _, row := range rows {
 			secondRunCustomers = append(secondRunCustomers, row.Data.(*Customer))
 		}
+		secondRunRows.Add(int64(len(rows)))
 		return nil
 	})
-	te.runUntilTimeout(t, secondClient, 2*time.Second)
+	te.runUntil(t, secondClient, func() bool { return secondRunRows.Load() >= int64(len(secondBatch)) })
 	assert.ElementsMatch(t, secondBatch, secondRunCustomers)
 }
 
@@ -99,7 +102,7 @@ func TestVStreamClientResumesUpdateDeleteFromCheckpoint(t *testing.T) {
 	}
 
 	te.exec(t, "insert into customer.customer(id, email) values (801, 'restart-update@domain.com'), (802, 'restart-delete@domain.com')", nil)
-	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+	te.runUntilCopyCompleted(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), t.Name())
 
 	te.exec(t, "update customer.customer set email = 'restart-update-new@domain.com' where id = 801", nil)
 	te.exec(t, "delete from customer.customer where id = 802", nil)
@@ -110,14 +113,16 @@ func TestVStreamClientResumesUpdateDeleteFromCheckpoint(t *testing.T) {
 		Deleted bool
 	}
 	var got []mutation
+	var mutationsSeen atomic.Int64
 	client := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
 		for _, row := range rows {
 			customer := row.Data.(*Customer)
 			got = append(got, mutation{ID: customer.ID, Email: customer.Email, Deleted: row.RowChange.After == nil})
 		}
+		mutationsSeen.Add(int64(len(rows)))
 		return nil
 	})
-	te.runUntilTimeout(t, client, 2*time.Second)
+	te.runUntil(t, client, func() bool { return mutationsSeen.Load() >= 2 })
 
 	assert.ElementsMatch(t, []mutation{{ID: 801, Email: "restart-update-new@domain.com", Deleted: false}, {ID: 802, Email: "restart-delete@domain.com", Deleted: true}}, got)
 }
@@ -147,7 +152,8 @@ func TestVStreamClientRestartsInterruptedCopy(t *testing.T) {
 		}, binlogdatapb.VEventType_COPY_COMPLETED),
 	)
 
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	// the run self-terminates when the hook error fires; the deadline is only a generous cap
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
 	err := interruptedClient.Run(runCtx)
 	cancelRun()
 	require.Error(t, err)
@@ -168,7 +174,7 @@ func TestVStreamClientRestartsInterruptedCopy(t *testing.T) {
 		},
 	}})
 
-	te.runUntilTimeout(t, restartedClient, 2*time.Second)
+	te.runUntilCopyCompleted(t, restartedClient, t.Name())
 	assert.ElementsMatch(t, []*Customer{{ID: 1101, Email: "copy-a@domain.com"}, {ID: 1102, Email: "copy-b@domain.com"}, {ID: 1103, Email: "copy-c@domain.com"}}, got)
 }
 
@@ -192,7 +198,7 @@ func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
 
 	// Finish the initial copy first so the replay we observe comes from a failed
 	// post-copy checkpoint write, not from an interrupted bootstrap copy.
-	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+	te.runUntilCopyCompleted(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), streamName)
 
 	want := &Customer{ID: 1761, Email: "checkpoint-replay@domain.com"}
 	te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
@@ -210,12 +216,15 @@ func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
 		return nil
 	})
 
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	// the run self-terminates when the checkpoint write fails; the deadline is only a generous cap
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
 	err := failingClient.Run(runCtx)
 	cancelRun()
 	require.ErrorIs(t, err, vstreamclient.ErrFenced)
 	assert.Equal(t, []*Customer{want}, firstRun)
 
+	// the failing FlushFn deleted the state row, so this client bootstraps a fresh copy that
+	// replays the flushed-but-uncheckpointed row
 	var replayed []*Customer
 	replayClient := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
 		for _, row := range rows {
@@ -224,7 +233,7 @@ func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
 		return nil
 	})
 
-	te.runUntilTimeout(t, replayClient, 2*time.Second)
+	te.runUntilCopyCompleted(t, replayClient, streamName)
 	assert.Equal(t, []*Customer{want}, replayed)
 }
 
@@ -245,19 +254,27 @@ func TestVStreamClientStartingVGtidOverridesState(t *testing.T) {
 	}
 
 	te.exec(t, "insert into customer.customer(id, email) values (1501, 'override-a@domain.com')", nil)
-	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+	te.runUntilCopyCompleted(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), t.Name())
 	vgtid1 := queryLatestVGtid(t, te.ctx, te.session, t.Name())
 
+	// this run advances the stored checkpoint past the second insert, so the replay below can
+	// only observe it because the explicit starting VGtid overrides stored state
 	te.exec(t, "insert into customer.customer(id, email) values (1502, 'override-b@domain.com')", nil)
-	te.runUntilTimeout(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+	var advanceRows atomic.Int64
+	te.runUntil(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		advanceRows.Add(int64(len(rows)))
+		return nil
+	}), func() bool { return advanceRows.Load() >= 1 })
 
 	var replayed []*Customer
-	te.runUntilTimeout(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+	var replayedRows atomic.Int64
+	te.runUntil(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
 		for _, row := range rows {
 			replayed = append(replayed, row.Data.(*Customer))
 		}
+		replayedRows.Add(int64(len(rows)))
 		return nil
-	}, vstreamclient.WithStartingVGtid(vgtid1)), 2*time.Second)
+	}, vstreamclient.WithStartingVGtid(vgtid1)), func() bool { return replayedRows.Load() >= 1 })
 
 	assert.Equal(t, []*Customer{{ID: 1502, Email: "override-b@domain.com"}}, replayed)
 }

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -130,14 +130,15 @@ func TestVStreamClientRestartsInterruptedCopy(t *testing.T) {
 	te.exec(t, "insert into customer.customer(id, email) values (1101, 'copy-a@domain.com'), (1102, 'copy-b@domain.com'), (1103, 'copy-c@domain.com')", nil)
 
 	interruptErr := errors.New("interrupt copy before final completion")
-	interruptedClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 1100 and 1199",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-	}},
+	interruptedClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1100 and 1199",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		}},
 		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
 			if ev.Keyspace != "" {
 				return interruptErr
@@ -212,8 +213,7 @@ func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
 	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
 	err := failingClient.Run(runCtx)
 	cancelRun()
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "unexpected number of rows affected")
+	require.ErrorIs(t, err, vstreamclient.ErrFenced)
 	assert.Equal(t, []*Customer{want}, firstRun)
 
 	var replayed []*Customer

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -153,7 +153,7 @@ func TestVStreamClientRestartsInterruptedCopy(t *testing.T) {
 	)
 
 	// the run self-terminates when the hook error fires; the deadline is only a generous cap
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancelRun := context.WithTimeout(t.Context(), 30*time.Second)
 	err := interruptedClient.Run(runCtx)
 	cancelRun()
 	require.Error(t, err)
@@ -217,7 +217,7 @@ func TestVStreamClientReplaysRowsWhenCheckpointWriteFails(t *testing.T) {
 	})
 
 	// the run self-terminates when the checkpoint write fails; the deadline is only a generous cap
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancelRun := context.WithTimeout(t.Context(), 30*time.Second)
 	err := failingClient.Run(runCtx)
 	cancelRun()
 	require.ErrorIs(t, err, vstreamclient.ErrFenced)

--- a/go/test/endtoend/vstreamclient/resume_test.go
+++ b/go/test/endtoend/vstreamclient/resume_test.go
@@ -157,7 +157,7 @@ func TestVStreamClientRestartsInterruptedCopy(t *testing.T) {
 	err := interruptedClient.Run(runCtx)
 	cancelRun()
 	require.Error(t, err)
-	assert.ErrorContains(t, err, interruptErr.Error())
+	require.ErrorContains(t, err, interruptErr.Error())
 
 	var got []*Customer
 	restartedClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -171,11 +171,11 @@ func TestVStreamClientBareTableNamesWithCustomFlags(t *testing.T) {
 }
 
 // TestVStreamClientBareTableNamesAmbiguousAcrossKeyspaces verifies ambiguous bare
-// table names fail fast across keyspaces, which prevents silent misrouting.
+// table names are rejected during construction, which prevents silent misrouting.
 func TestVStreamClientBareTableNamesAmbiguousAcrossKeyspaces(t *testing.T) {
 	te := newTestEnv(t)
 
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
+	_, err := vstreamclient.New(te.ctx, t.Name(), te.conn, []vstreamclient.TableConfig{
 		{
 			Keyspace:        "customer",
 			Table:           "customer",
@@ -193,14 +193,12 @@ func TestVStreamClientBareTableNamesAmbiguousAcrossKeyspaces(t *testing.T) {
 			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
 		},
 	},
+		vstreamclient.WithMinFlushDuration(500*time.Millisecond),
+		vstreamclient.WithHeartbeatSeconds(1),
+		vstreamclient.WithStateTable("commerce", "vstreams"),
 		vstreamclient.WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
 	)
-
-	te.exec(t, "insert into customer.customer(id, email) values (2301, 'ambiguous@domain.com')", nil)
-
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancelRun()
-	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "ambiguous table name: customer")
+	assert.ErrorContains(t, err, "ExcludeKeyspaceFromTableName")
+	assert.ErrorContains(t, err, "customer")
 }

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -1,0 +1,206 @@
+package vstreamclient
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+// TestVStreamClientDisambiguatesSameTableNames verifies that streaming two
+// keyspaces with the same table name routes events to the correct configured
+// table using the qualified keyspace.table names from VTGate.
+func TestVStreamClientDisambiguatesSameTableNames(t *testing.T) {
+	te := newTestEnv(t)
+	var gotFieldEvents []string
+	var gotRowEvents []string
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
+		{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 200 and 399",
+			MaxRowsPerFlush: 2,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		},
+		{
+			Keyspace:        "accounting",
+			Table:           "customer",
+			Query:           "select * from customer where id between 200 and 399",
+			MaxRowsPerFlush: 2,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		},
+	},
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			gotFieldEvents = append(gotFieldEvents, fmt.Sprintf("%s:%s", ev.Keyspace, ev.FieldEvent.TableName))
+			return nil
+		}, binlogdatapb.VEventType_FIELD),
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			gotRowEvents = append(gotRowEvents, fmt.Sprintf("%s:%s", ev.Keyspace, ev.RowEvent.TableName))
+			return nil
+		}, binlogdatapb.VEventType_ROW),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", map[string]*querypb.BindVariable{
+		"id":    {Type: querypb.Type_UINT64, Value: []byte("201")},
+		"email": {Type: querypb.Type_VARCHAR, Value: []byte("multi-customer@domain.com")},
+	})
+	te.exec(t, "insert into accounting.customer(id, email) values(:id, :email)", map[string]*querypb.BindVariable{
+		"id":    {Type: querypb.Type_UINT64, Value: []byte("301")},
+		"email": {Type: querypb.Type_VARCHAR, Value: []byte("multi-accounting@domain.com")},
+	})
+
+	te.runUntilTimeout(t, vstreamClient, 5*time.Second)
+
+	assert.Contains(t, gotFieldEvents, "customer:customer.customer")
+	assert.Contains(t, gotFieldEvents, "accounting:accounting.customer")
+	assert.Contains(t, gotRowEvents, "customer:customer.customer")
+	assert.Contains(t, gotRowEvents, "accounting:accounting.customer")
+}
+
+// TestVStreamClientStreamsMultipleTablesInOneKeyspace verifies one client can
+// stream multiple tables in the same keyspace through normal Run-time flushes,
+// without depending on shutdown-time flushing.
+func TestVStreamClientStreamsMultipleTablesInOneKeyspace(t *testing.T) {
+	te := newTestEnv(t)
+
+	var gotCustomers []*Customer
+	var gotOrders []*Order
+	var fieldTables []string
+	var rowTables []string
+	rowTableSeen := make(chan string, 4)
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
+		{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1800 and 1899",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+				for _, row := range rows {
+					gotCustomers = append(gotCustomers, row.Data.(*Customer))
+				}
+				return nil
+			},
+		},
+		{
+			Keyspace:        "customer",
+			Table:           "purchases",
+			Query:           "select * from `purchases` where id between 1800 and 1899",
+			MaxRowsPerFlush: 10,
+			DataType:        &Order{},
+			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+				for _, row := range rows {
+					gotOrders = append(gotOrders, row.Data.(*Order))
+				}
+				return nil
+			},
+		},
+	},
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			fieldTables = append(fieldTables, ev.FieldEvent.TableName)
+			return nil
+		}, binlogdatapb.VEventType_FIELD),
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			rowTables = append(rowTables, ev.RowEvent.TableName)
+			select {
+			case rowTableSeen <- ev.RowEvent.TableName:
+			default:
+			}
+			return nil
+		}, binlogdatapb.VEventType_ROW),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values (1801, 'multi-table@domain.com')", nil)
+	te.exec(t, "insert into customer.purchases(id, customer_id, note) values (1801, 1801, 'first-order')", nil)
+	te.runUntilTimeout(t, vstreamClient, 5*time.Second)
+
+	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, fieldTables)
+	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)
+	assert.Equal(t, []*Customer{{ID: 1801, Email: "multi-table@domain.com"}}, gotCustomers)
+	assert.Equal(t, []*Order{{ID: 1801, CustomerID: 1801, Note: "first-order"}}, gotOrders)
+}
+
+// TestVStreamClientBareTableNamesWithCustomFlags verifies bare table-name events
+// still resolve correctly when callers explicitly opt out of keyspace prefixes.
+func TestVStreamClientBareTableNamesWithCustomFlags(t *testing.T) {
+	te := newTestEnv(t)
+
+	var fieldTables []string
+	var rowTables []string
+	var got []*Customer
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 2200 and 2299",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				got = append(got, row.Data.(*Customer))
+			}
+			return nil
+		},
+	}},
+		vstreamclient.WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			fieldTables = append(fieldTables, ev.FieldEvent.TableName)
+			return nil
+		}, binlogdatapb.VEventType_FIELD),
+		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+			rowTables = append(rowTables, ev.RowEvent.TableName)
+			return nil
+		}, binlogdatapb.VEventType_ROW),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values (2201, 'bare-table@domain.com')", nil)
+	te.runUntilTimeout(t, vstreamClient, 2*time.Second)
+
+	assert.Contains(t, fieldTables, "customer")
+	assert.Contains(t, rowTables, "customer")
+	assert.Equal(t, []*Customer{{ID: 2201, Email: "bare-table@domain.com"}}, got)
+}
+
+// TestVStreamClientBareTableNamesAmbiguousAcrossKeyspaces verifies ambiguous bare
+// table names fail fast across keyspaces, which prevents silent misrouting.
+func TestVStreamClientBareTableNamesAmbiguousAcrossKeyspaces(t *testing.T) {
+	te := newTestEnv(t)
+
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
+		{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 2300 and 2499",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		},
+		{
+			Keyspace:        "accounting",
+			Table:           "customer",
+			Query:           "select * from customer where id between 2300 and 2499",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		},
+	},
+		vstreamclient.WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values (2301, 'ambiguous@domain.com')", nil)
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelRun()
+	err := vstreamClient.Run(runCtx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "ambiguous table name: customer")
+}

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -38,24 +38,25 @@ func TestVStreamClientDisambiguatesSameTableNames(t *testing.T) {
 	te := newTestEnv(t)
 	var gotFieldEvents []string
 	var gotRowEvents []string
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
-		{
-			Keyspace:        "customer",
-			Table:           "customer",
-			Query:           "select * from customer where id between 200 and 399",
-			MaxRowsPerFlush: 2,
-			DataType:        &Customer{},
-			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 200 and 399",
+				MaxRowsPerFlush: 2,
+				DataType:        &Customer{},
+				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+			},
+			{
+				Keyspace:        "accounting",
+				Table:           "customer",
+				Query:           "select * from customer where id between 200 and 399",
+				MaxRowsPerFlush: 2,
+				DataType:        &Customer{},
+				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+			},
 		},
-		{
-			Keyspace:        "accounting",
-			Table:           "customer",
-			Query:           "select * from customer where id between 200 and 399",
-			MaxRowsPerFlush: 2,
-			DataType:        &Customer{},
-			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-		},
-	},
 		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
 			gotFieldEvents = append(gotFieldEvents, fmt.Sprintf("%s:%s", ev.Keyspace, ev.FieldEvent.TableName))
 			return nil
@@ -75,7 +76,7 @@ func TestVStreamClientDisambiguatesSameTableNames(t *testing.T) {
 		"email": {Type: querypb.Type_VARCHAR, Value: []byte("multi-accounting@domain.com")},
 	})
 
-	te.runUntilTimeout(t, vstreamClient, 5*time.Second)
+	te.runUntilCopyCompleted(t, vstreamClient, t.Name())
 
 	assert.Contains(t, gotFieldEvents, "customer:customer.customer")
 	assert.Contains(t, gotFieldEvents, "accounting:accounting.customer")
@@ -94,34 +95,35 @@ func TestVStreamClientStreamsMultipleTablesInOneKeyspace(t *testing.T) {
 	var fieldTables []string
 	var rowTables []string
 	rowTableSeen := make(chan string, 4)
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
-		{
-			Keyspace:        "customer",
-			Table:           "customer",
-			Query:           "select * from customer where id between 1800 and 1899",
-			MaxRowsPerFlush: 10,
-			DataType:        &Customer{},
-			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-				for _, row := range rows {
-					gotCustomers = append(gotCustomers, row.Data.(*Customer))
-				}
-				return nil
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1800 and 1899",
+				MaxRowsPerFlush: 10,
+				DataType:        &Customer{},
+				FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					for _, row := range rows {
+						gotCustomers = append(gotCustomers, row.Data.(*Customer))
+					}
+					return nil
+				},
+			},
+			{
+				Keyspace:        "customer",
+				Table:           "purchases",
+				Query:           "select * from `purchases` where id between 1800 and 1899",
+				MaxRowsPerFlush: 10,
+				DataType:        &Order{},
+				FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					for _, row := range rows {
+						gotOrders = append(gotOrders, row.Data.(*Order))
+					}
+					return nil
+				},
 			},
 		},
-		{
-			Keyspace:        "customer",
-			Table:           "purchases",
-			Query:           "select * from `purchases` where id between 1800 and 1899",
-			MaxRowsPerFlush: 10,
-			DataType:        &Order{},
-			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-				for _, row := range rows {
-					gotOrders = append(gotOrders, row.Data.(*Order))
-				}
-				return nil
-			},
-		},
-	},
 		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
 			fieldTables = append(fieldTables, ev.FieldEvent.TableName)
 			return nil
@@ -138,7 +140,7 @@ func TestVStreamClientStreamsMultipleTablesInOneKeyspace(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email) values (1801, 'multi-table@domain.com')", nil)
 	te.exec(t, "insert into customer.purchases(id, customer_id, note) values (1801, 1801, 'first-order')", nil)
-	te.runUntilTimeout(t, vstreamClient, 5*time.Second)
+	te.runUntilCopyCompleted(t, vstreamClient, t.Name())
 
 	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, fieldTables)
 	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)
@@ -154,19 +156,20 @@ func TestVStreamClientBareTableNamesWithCustomFlags(t *testing.T) {
 	var fieldTables []string
 	var rowTables []string
 	var got []*Customer
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 2200 and 2299",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-			for _, row := range rows {
-				got = append(got, row.Data.(*Customer))
-			}
-			return nil
-		},
-	}},
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 2200 and 2299",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+				for _, row := range rows {
+					got = append(got, row.Data.(*Customer))
+				}
+				return nil
+			},
+		}},
 		vstreamclient.WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
 		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
 			fieldTables = append(fieldTables, ev.FieldEvent.TableName)
@@ -179,7 +182,7 @@ func TestVStreamClientBareTableNamesWithCustomFlags(t *testing.T) {
 	)
 
 	te.exec(t, "insert into customer.customer(id, email) values (2201, 'bare-table@domain.com')", nil)
-	te.runUntilTimeout(t, vstreamClient, 2*time.Second)
+	te.runUntilCopyCompleted(t, vstreamClient, t.Name())
 
 	assert.Contains(t, fieldTables, "customer")
 	assert.Contains(t, rowTables, "customer")
@@ -191,24 +194,25 @@ func TestVStreamClientBareTableNamesWithCustomFlags(t *testing.T) {
 func TestVStreamClientBareTableNamesAmbiguousAcrossKeyspaces(t *testing.T) {
 	te := newTestEnv(t)
 
-	_, err := vstreamclient.New(te.ctx, t.Name(), te.conn, []vstreamclient.TableConfig{
-		{
-			Keyspace:        "customer",
-			Table:           "customer",
-			Query:           "select * from customer where id between 2300 and 2499",
-			MaxRowsPerFlush: 10,
-			DataType:        &Customer{},
-			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	_, err := vstreamclient.New(
+		te.ctx, t.Name(), te.conn, []vstreamclient.TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 2300 and 2499",
+				MaxRowsPerFlush: 10,
+				DataType:        &Customer{},
+				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+			},
+			{
+				Keyspace:        "accounting",
+				Table:           "customer",
+				Query:           "select * from customer where id between 2300 and 2499",
+				MaxRowsPerFlush: 10,
+				DataType:        &Customer{},
+				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+			},
 		},
-		{
-			Keyspace:        "accounting",
-			Table:           "customer",
-			Query:           "select * from customer where id between 2300 and 2499",
-			MaxRowsPerFlush: 10,
-			DataType:        &Customer{},
-			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-		},
-	},
 		vstreamclient.WithMinFlushDuration(500*time.Millisecond),
 		vstreamclient.WithHeartbeatSeconds(1),
 		vstreamclient.WithStateTable("commerce", "vstreams"),

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -94,7 +94,6 @@ func TestVStreamClientStreamsMultipleTablesInOneKeyspace(t *testing.T) {
 	var gotOrders []*Order
 	var fieldTables []string
 	var rowTables []string
-	rowTableSeen := make(chan string, 4)
 	vstreamClient := te.newDefaultClient(
 		t, t.Name(), []vstreamclient.TableConfig{
 			{
@@ -130,10 +129,6 @@ func TestVStreamClientStreamsMultipleTablesInOneKeyspace(t *testing.T) {
 		}, binlogdatapb.VEventType_FIELD),
 		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
 			rowTables = append(rowTables, ev.RowEvent.TableName)
-			select {
-			case rowTableSeen <- ev.RowEvent.TableName:
-			default:
-			}
 			return nil
 		}, binlogdatapb.VEventType_ROW),
 	)

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -38,6 +38,8 @@ func TestVStreamClientDisambiguatesSameTableNames(t *testing.T) {
 	te := newTestEnv(t)
 	var gotFieldEvents []string
 	var gotRowEvents []string
+	customerRows := &rowCollector[*Customer]{}
+	accountingRows := &rowCollector[*Customer]{}
 	vstreamClient := te.newDefaultClient(
 		t, t.Name(), []vstreamclient.TableConfig{
 			{
@@ -46,7 +48,10 @@ func TestVStreamClientDisambiguatesSameTableNames(t *testing.T) {
 				Query:           "select * from customer where id between 200 and 399",
 				MaxRowsPerFlush: 2,
 				DataType:        &Customer{},
-				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+				FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					customerRows.collect(rows)
+					return nil
+				},
 			},
 			{
 				Keyspace:        "accounting",
@@ -54,7 +59,10 @@ func TestVStreamClientDisambiguatesSameTableNames(t *testing.T) {
 				Query:           "select * from customer where id between 200 and 399",
 				MaxRowsPerFlush: 2,
 				DataType:        &Customer{},
-				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+				FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					accountingRows.collect(rows)
+					return nil
+				},
 			},
 		},
 		vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
@@ -82,6 +90,11 @@ func TestVStreamClientDisambiguatesSameTableNames(t *testing.T) {
 	assert.Contains(t, gotFieldEvents, "accounting:accounting.customer")
 	assert.Contains(t, gotRowEvents, "customer:customer.customer")
 	assert.Contains(t, gotRowEvents, "accounting:accounting.customer")
+
+	// each row must reach only its own keyspace's FlushFn; misrouting between the two
+	// same-named tables would swap or duplicate these
+	assert.Equal(t, []*Customer{{ID: 201, Email: "multi-customer@domain.com"}}, customerRows.snapshot())
+	assert.Equal(t, []*Customer{{ID: 301, Email: "multi-accounting@domain.com"}}, accountingRows.snapshot())
 }
 
 // TestVStreamClientStreamsMultipleTablesInOneKeyspace verifies one client can

--- a/go/test/endtoend/vstreamclient/routing_test.go
+++ b/go/test/endtoend/vstreamclient/routing_test.go
@@ -227,6 +227,6 @@ func TestVStreamClientBareTableNamesAmbiguousAcrossKeyspaces(t *testing.T) {
 		vstreamclient.WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
 	)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "ExcludeKeyspaceFromTableName")
+	require.ErrorContains(t, err, "ExcludeKeyspaceFromTableName")
 	assert.ErrorContains(t, err, "customer")
 }

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -110,7 +110,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
 	te := newTestEnv(t)
 	te.exec(t, "alter table customer.customer add column projected_col varchar(128) null", nil)
 	t.Cleanup(func() {
-		te.execBackground(t, "alter table customer.customer drop column if exists projected_col", nil)
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column projected_col", nil)
 	})
 
 	var got []*customerWithProjectedString
@@ -150,8 +150,8 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
 	te := newTestEnv(t)
 	te.exec(t, "alter table customer.customer add column projected_col varchar(128) null", nil)
 	t.Cleanup(func() {
-		te.execBackground(t, "alter table customer.customer drop column if exists projected_col", nil)
-		te.execBackground(t, "alter table customer.customer drop column if exists projected_col_renamed", nil)
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column projected_col", nil)
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column projected_col_renamed", nil)
 	})
 
 	var got []*customerWithProjectedString
@@ -191,7 +191,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 	te := newTestEnv(t)
 	te.exec(t, "alter table customer.customer add column projected_payload text null", nil)
 	t.Cleanup(func() {
-		te.execBackground(t, "alter table customer.customer drop column if exists projected_payload", nil)
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column projected_payload", nil)
 	})
 
 	var got []*customerWithProjectedPayload
@@ -218,6 +218,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 	}, 3*time.Second, 50*time.Millisecond)
 	assert.Equal(t, []*customerWithProjectedPayload{{ID: 3501, Payload: &customerPayload{Source: "before-type"}}}, got)
 
+	te.exec(t, "update customer.customer set projected_payload = null where id = 3501", nil)
 	te.exec(t, "alter table customer.customer modify column projected_payload bigint null", nil)
 	te.exec(t, "insert into customer.customer(id, email, projected_payload) values (3502, 'projected-after-type@domain.com', 123)", nil)
 
@@ -232,7 +233,8 @@ func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {
 	te := newTestEnv(t)
 	te.exec(t, "alter table customer.customer add column remap_a varchar(128) null, add column remap_b varchar(128) null", nil)
 	t.Cleanup(func() {
-		te.execBackground(t, "alter table customer.customer drop column if exists remap_a, drop column if exists remap_b", nil)
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column remap_a", nil)
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column remap_b", nil)
 	})
 
 	var got []*customerWithRemapColumns

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -1,0 +1,90 @@
+package vstreamclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+type customerPayload struct {
+	Source string `json:"source"`
+}
+
+type customerWithPayload struct {
+	ID      int64            `vstream:"id"`
+	Email   string           `vstream:"email"`
+	Payload *customerPayload `vstream:"payload,json"`
+}
+
+// TestVStreamClientSchemaDriftFailsWithUnknownFields verifies strict configs
+// fail after schema drift, which is important for consumers that require exact mappings.
+func TestVStreamClientSchemaDriftFailsWithUnknownFields(t *testing.T) {
+	te := newTestEnv(t)
+	t.Cleanup(func() {
+		te.execBackground(t, "alter table customer.customer drop column strict_extra", nil)
+	})
+
+	newClient := func() *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:             "customer",
+			Table:                "customer",
+			Query:                "select * from customer where id between 2500 and 2599",
+			MaxRowsPerFlush:      10,
+			ErrorOnUnknownFields: true,
+			DataType:             &Customer{},
+			FlushFn:              func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		}})
+	}
+
+	te.exec(t, "insert into customer.customer(id, email) values (2501, 'strict-before@domain.com')", nil)
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	err := newClient().Run(runCtx)
+	cancelRun()
+	if err != nil && runCtx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+
+	te.exec(t, "alter table customer.customer add column strict_extra varchar(64) null", nil)
+	te.exec(t, "insert into customer.customer(id, email, strict_extra) values (2502, 'strict-after@domain.com', 'extra')", nil)
+
+	runCtx, cancelRun = context.WithTimeout(context.Background(), 2*time.Second)
+	err = newClient().Run(runCtx)
+	cancelRun()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not found in provided data type")
+}
+
+// TestVStreamClientJSONDecodeFailure verifies a live streamed row fails when a
+// field tagged with ,json contains invalid JSON, which is important because the
+// stream should stop rather than silently checkpoint bad data.
+func TestVStreamClientJSONDecodeFailure(t *testing.T) {
+	te := newTestEnv(t)
+	t.Cleanup(func() {
+		te.execBackground(t, "alter table customer.customer drop column payload", nil)
+	})
+
+	te.exec(t, "alter table customer.customer add column payload text null", nil)
+	te.exec(t, "insert into customer.customer(id, email, payload) values (2701, 'bad-json@domain.com', 'not-json')", nil)
+
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select id, email, payload from customer where id between 2700 and 2799",
+		MaxRowsPerFlush: 10,
+		DataType:        &customerWithPayload{},
+		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	}})
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelRun()
+
+	err := vstreamClient.Run(runCtx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "error unmarshalling JSON for field payload")
+}

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -21,6 +21,23 @@ type customerWithPayload struct {
 	Payload *customerPayload `vstream:"payload,json"`
 }
 
+type customerWithProjectedString struct {
+	ID        int64  `vstream:"id"`
+	Projected string `vstream:"projected_col"`
+}
+
+type customerWithProjectedPayload struct {
+	ID      int64            `vstream:"id"`
+	Payload *customerPayload `vstream:"projected_payload,json"`
+}
+
+type customerWithRemapColumns struct {
+	ID     int64  `vstream:"id"`
+	Email  string `vstream:"email"`
+	RemapA string `vstream:"remap_a"`
+	RemapB string `vstream:"remap_b"`
+}
+
 // TestVStreamClientSchemaDriftFailsWithUnknownFields verifies strict configs
 // fail after schema drift, which is important for consumers that require exact mappings.
 func TestVStreamClientSchemaDriftFailsWithUnknownFields(t *testing.T) {
@@ -87,4 +104,173 @@ func TestVStreamClientJSONDecodeFailure(t *testing.T) {
 	err := vstreamClient.Run(runCtx)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "error unmarshalling JSON for field payload")
+}
+
+func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
+	te := newTestEnv(t)
+	te.exec(t, "alter table customer.customer add column projected_col varchar(128) null", nil)
+	t.Cleanup(func() {
+		te.execBackground(t, "alter table customer.customer drop column if exists projected_col", nil)
+	})
+
+	var got []*customerWithProjectedString
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select id, projected_col from customer where id between 3300 and 3399",
+		MaxRowsPerFlush: 1,
+		DataType:        &customerWithProjectedString{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				got = append(got, row.Data.(*customerWithProjectedString))
+			}
+			return nil
+		},
+	}})
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	defer cancelRun()
+
+	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3301, 'projected-before-drop@domain.com', 'before-drop')", nil)
+	assert.Eventually(t, func() bool {
+		return len(got) == 1
+	}, 3*time.Second, 50*time.Millisecond)
+	assert.Equal(t, []*customerWithProjectedString{{ID: 3301, Projected: "before-drop"}}, got)
+
+	te.exec(t, "alter table customer.customer drop column projected_col", nil)
+	te.exec(t, "insert into customer.customer(id, email) values (3302, 'projected-after-drop@domain.com')", nil)
+
+	err := <-runErrCh
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "projected_col")
+	_ = runCtx
+}
+
+func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
+	te := newTestEnv(t)
+	te.exec(t, "alter table customer.customer add column projected_col varchar(128) null", nil)
+	t.Cleanup(func() {
+		te.execBackground(t, "alter table customer.customer drop column if exists projected_col", nil)
+		te.execBackground(t, "alter table customer.customer drop column if exists projected_col_renamed", nil)
+	})
+
+	var got []*customerWithProjectedString
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select id, projected_col from customer where id between 3400 and 3499",
+		MaxRowsPerFlush: 1,
+		DataType:        &customerWithProjectedString{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				got = append(got, row.Data.(*customerWithProjectedString))
+			}
+			return nil
+		},
+	}})
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	defer cancelRun()
+
+	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3401, 'projected-before-rename@domain.com', 'before-rename')", nil)
+	assert.Eventually(t, func() bool {
+		return len(got) == 1
+	}, 3*time.Second, 50*time.Millisecond)
+	assert.Equal(t, []*customerWithProjectedString{{ID: 3401, Projected: "before-rename"}}, got)
+
+	te.exec(t, "alter table customer.customer change column projected_col projected_col_renamed varchar(128) null", nil)
+	te.exec(t, "insert into customer.customer(id, email, projected_col_renamed) values (3402, 'projected-after-rename@domain.com', 'after-rename')", nil)
+
+	err := <-runErrCh
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "projected_col")
+	_ = runCtx
+}
+
+func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.T) {
+	te := newTestEnv(t)
+	te.exec(t, "alter table customer.customer add column projected_payload text null", nil)
+	t.Cleanup(func() {
+		te.execBackground(t, "alter table customer.customer drop column if exists projected_payload", nil)
+	})
+
+	var got []*customerWithProjectedPayload
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select id, projected_payload from customer where id between 3500 and 3599",
+		MaxRowsPerFlush: 1,
+		DataType:        &customerWithProjectedPayload{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				got = append(got, row.Data.(*customerWithProjectedPayload))
+			}
+			return nil
+		},
+	}})
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	defer cancelRun()
+
+	te.exec(t, `insert into customer.customer(id, email, projected_payload) values (3501, 'projected-before-type@domain.com', '{"source":"before-type"}')`, nil)
+	assert.Eventually(t, func() bool {
+		return len(got) == 1
+	}, 3*time.Second, 50*time.Millisecond)
+	assert.Equal(t, []*customerWithProjectedPayload{{ID: 3501, Payload: &customerPayload{Source: "before-type"}}}, got)
+
+	te.exec(t, "alter table customer.customer modify column projected_payload bigint null", nil)
+	te.exec(t, "insert into customer.customer(id, email, projected_payload) values (3502, 'projected-after-type@domain.com', 123)", nil)
+
+	err := <-runErrCh
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "projected_payload")
+	assert.ErrorContains(t, err, "error unmarshalling JSON")
+	_ = runCtx
+}
+
+func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {
+	te := newTestEnv(t)
+	te.exec(t, "alter table customer.customer add column remap_a varchar(128) null, add column remap_b varchar(128) null", nil)
+	t.Cleanup(func() {
+		te.execBackground(t, "alter table customer.customer drop column if exists remap_a, drop column if exists remap_b", nil)
+	})
+
+	var got []*customerWithRemapColumns
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 3600 and 3699",
+		MaxRowsPerFlush: 1,
+		DataType:        &customerWithRemapColumns{},
+		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				got = append(got, row.Data.(*customerWithRemapColumns))
+			}
+			return nil
+		},
+	}})
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	defer cancelRun()
+
+	te.exec(t, "insert into customer.customer(id, email, remap_a, remap_b) values (3601, 'remap-before@domain.com', 'A1', 'B1')", nil)
+	assert.Eventually(t, func() bool {
+		return len(got) == 1
+	}, 3*time.Second, 50*time.Millisecond)
+
+	te.exec(t, "alter table customer.customer modify column remap_b varchar(128) null after id, modify column remap_a varchar(128) null after remap_b", nil)
+	te.exec(t, "insert into customer.customer(id, email, remap_a, remap_b) values (3602, 'remap-after@domain.com', 'A2', 'B2')", nil)
+	assert.Eventually(t, func() bool {
+		return len(got) == 2
+	}, 3*time.Second, 50*time.Millisecond)
+	assert.Equal(t, []*customerWithRemapColumns{
+		{ID: 3601, Email: "remap-before@domain.com", RemapA: "A1", RemapB: "B1"},
+		{ID: 3602, Email: "remap-after@domain.com", RemapA: "A2", RemapB: "B2"},
+	}, got)
+
+	cancelRun()
+	err := <-runErrCh
+	if err != nil && runCtx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
 }

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -83,7 +83,7 @@ func TestVStreamClientSchemaDriftFailsWithUnknownFields(t *testing.T) {
 	te.exec(t, "insert into customer.customer(id, email, strict_extra) values (2502, 'strict-after@domain.com', 'extra')", nil)
 
 	// the run self-terminates on the strict schema mismatch; the deadline is only a generous cap
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancelRun := context.WithTimeout(t.Context(), 30*time.Second)
 	err := newClient().Run(runCtx)
 	cancelRun()
 	require.Error(t, err)
@@ -112,7 +112,7 @@ func TestVStreamClientJSONDecodeFailure(t *testing.T) {
 	}})
 
 	// the run self-terminates on the JSON decode failure; the deadline is only a generous cap
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancelRun := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancelRun()
 
 	err := vstreamClient.Run(runCtx)

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -140,7 +140,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
+	_, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3301, 'projected-before-drop@domain.com', 'before-drop')", nil)
@@ -155,7 +155,6 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
 	err := <-runErrCh
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "projected_col")
-	_ = runCtx
 }
 
 func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
@@ -179,7 +178,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
+	_, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3401, 'projected-before-rename@domain.com', 'before-rename')", nil)
@@ -194,7 +193,6 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
 	err := <-runErrCh
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "projected_col")
-	_ = runCtx
 }
 
 func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.T) {
@@ -217,7 +215,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
+	_, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, `insert into customer.customer(id, email, projected_payload) values (3501, 'projected-before-type@domain.com', '{"source":"before-type"}')`, nil)
@@ -234,7 +232,6 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "projected_payload")
 	assert.ErrorContains(t, err, "error unmarshalling JSON")
-	_ = runCtx
 }
 
 func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -59,7 +59,8 @@ type customerWithRemapColumns struct {
 func TestVStreamClientSchemaDriftFailsWithUnknownFields(t *testing.T) {
 	te := newTestEnv(t)
 	t.Cleanup(func() {
-		te.execBackground(t, "alter table customer.customer drop column strict_extra", nil)
+		// tolerate a missing column so an early test failure isn't masked by the cleanup
+		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column strict_extra", nil)
 	})
 
 	newClient := func() *vstreamclient.VStreamClient {
@@ -76,18 +77,14 @@ func TestVStreamClientSchemaDriftFailsWithUnknownFields(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email) values (2501, 'strict-before@domain.com')", nil)
 
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
-	err := newClient().Run(runCtx)
-	cancelRun()
-	if err != nil && runCtx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
-	}
+	te.runUntilCopyCompleted(t, newClient(), t.Name())
 
 	te.exec(t, "alter table customer.customer add column strict_extra varchar(64) null", nil)
 	te.exec(t, "insert into customer.customer(id, email, strict_extra) values (2502, 'strict-after@domain.com', 'extra')", nil)
 
-	runCtx, cancelRun = context.WithTimeout(context.Background(), 2*time.Second)
-	err = newClient().Run(runCtx)
+	// the run self-terminates on the strict schema mismatch; the deadline is only a generous cap
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
+	err := newClient().Run(runCtx)
 	cancelRun()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not found in provided data type")
@@ -114,7 +111,8 @@ func TestVStreamClientJSONDecodeFailure(t *testing.T) {
 		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
 	}})
 
-	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Second)
+	// the run self-terminates on the JSON decode failure; the deadline is only a generous cap
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelRun()
 
 	err := vstreamClient.Run(runCtx)
@@ -142,13 +140,13 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3301, 'projected-before-drop@domain.com', 'before-drop')", nil)
 	assert.Eventually(t, func() bool {
 		return got.count() == 1
-	}, 3*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 	assert.Equal(t, []*customerWithProjectedString{{ID: 3301, Projected: "before-drop"}}, got.snapshot())
 
 	te.exec(t, "alter table customer.customer drop column projected_col", nil)
@@ -181,13 +179,13 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3401, 'projected-before-rename@domain.com', 'before-rename')", nil)
 	assert.Eventually(t, func() bool {
 		return got.count() == 1
-	}, 3*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 	assert.Equal(t, []*customerWithProjectedString{{ID: 3401, Projected: "before-rename"}}, got.snapshot())
 
 	te.exec(t, "alter table customer.customer change column projected_col projected_col_renamed varchar(128) null", nil)
@@ -219,13 +217,13 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, `insert into customer.customer(id, email, projected_payload) values (3501, 'projected-before-type@domain.com', '{"source":"before-type"}')`, nil)
 	assert.Eventually(t, func() bool {
 		return got.count() == 1
-	}, 3*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 	assert.Equal(t, []*customerWithProjectedPayload{{ID: 3501, Payload: &customerPayload{Source: "before-type"}}}, got.snapshot())
 
 	te.exec(t, "update customer.customer set projected_payload = null where id = 3501", nil)
@@ -260,19 +258,19 @@ func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {
 		},
 	}})
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 4*time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
 
 	te.exec(t, "insert into customer.customer(id, email, remap_a, remap_b) values (3601, 'remap-before@domain.com', 'A1', 'B1')", nil)
 	assert.Eventually(t, func() bool {
 		return got.count() == 1
-	}, 3*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 
 	te.exec(t, "alter table customer.customer modify column remap_b varchar(128) null after id, modify column remap_a varchar(128) null after remap_b", nil)
 	te.exec(t, "insert into customer.customer(id, email, remap_a, remap_b) values (3602, 'remap-after@domain.com', 'A2', 'B2')", nil)
 	assert.Eventually(t, func() bool {
 		return got.count() == 2
-	}, 3*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 	assert.Equal(t, []*customerWithRemapColumns{
 		{ID: 3601, Email: "remap-before@domain.com", RemapA: "A1", RemapB: "B1"},
 		{ID: 3602, Email: "remap-after@domain.com", RemapA: "A2", RemapB: "B2"},

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -129,7 +129,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
 		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column projected_col", nil)
 	})
 
-	var got []*customerWithProjectedString
+	got := &rowCollector[*customerWithProjectedString]{}
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
 		Table:           "customer",
@@ -137,9 +137,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
 		MaxRowsPerFlush: 1,
 		DataType:        &customerWithProjectedString{},
 		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-			for _, row := range rows {
-				got = append(got, row.Data.(*customerWithProjectedString))
-			}
+			got.collect(rows)
 			return nil
 		},
 	}})
@@ -149,9 +147,9 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnDropped(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3301, 'projected-before-drop@domain.com', 'before-drop')", nil)
 	assert.Eventually(t, func() bool {
-		return len(got) == 1
+		return got.count() == 1
 	}, 3*time.Second, 50*time.Millisecond)
-	assert.Equal(t, []*customerWithProjectedString{{ID: 3301, Projected: "before-drop"}}, got)
+	assert.Equal(t, []*customerWithProjectedString{{ID: 3301, Projected: "before-drop"}}, got.snapshot())
 
 	te.exec(t, "alter table customer.customer drop column projected_col", nil)
 	te.exec(t, "insert into customer.customer(id, email) values (3302, 'projected-after-drop@domain.com')", nil)
@@ -170,7 +168,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
 		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column projected_col_renamed", nil)
 	})
 
-	var got []*customerWithProjectedString
+	got := &rowCollector[*customerWithProjectedString]{}
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
 		Table:           "customer",
@@ -178,9 +176,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
 		MaxRowsPerFlush: 1,
 		DataType:        &customerWithProjectedString{},
 		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-			for _, row := range rows {
-				got = append(got, row.Data.(*customerWithProjectedString))
-			}
+			got.collect(rows)
 			return nil
 		},
 	}})
@@ -190,9 +186,9 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnRenamed(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email, projected_col) values (3401, 'projected-before-rename@domain.com', 'before-rename')", nil)
 	assert.Eventually(t, func() bool {
-		return len(got) == 1
+		return got.count() == 1
 	}, 3*time.Second, 50*time.Millisecond)
-	assert.Equal(t, []*customerWithProjectedString{{ID: 3401, Projected: "before-rename"}}, got)
+	assert.Equal(t, []*customerWithProjectedString{{ID: 3401, Projected: "before-rename"}}, got.snapshot())
 
 	te.exec(t, "alter table customer.customer change column projected_col projected_col_renamed varchar(128) null", nil)
 	te.exec(t, "insert into customer.customer(id, email, projected_col_renamed) values (3402, 'projected-after-rename@domain.com', 'after-rename')", nil)
@@ -210,7 +206,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column projected_payload", nil)
 	})
 
-	var got []*customerWithProjectedPayload
+	got := &rowCollector[*customerWithProjectedPayload]{}
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
 		Table:           "customer",
@@ -218,9 +214,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 		MaxRowsPerFlush: 1,
 		DataType:        &customerWithProjectedPayload{},
 		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-			for _, row := range rows {
-				got = append(got, row.Data.(*customerWithProjectedPayload))
-			}
+			got.collect(rows)
 			return nil
 		},
 	}})
@@ -230,9 +224,9 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 
 	te.exec(t, `insert into customer.customer(id, email, projected_payload) values (3501, 'projected-before-type@domain.com', '{"source":"before-type"}')`, nil)
 	assert.Eventually(t, func() bool {
-		return len(got) == 1
+		return got.count() == 1
 	}, 3*time.Second, 50*time.Millisecond)
-	assert.Equal(t, []*customerWithProjectedPayload{{ID: 3501, Payload: &customerPayload{Source: "before-type"}}}, got)
+	assert.Equal(t, []*customerWithProjectedPayload{{ID: 3501, Payload: &customerPayload{Source: "before-type"}}}, got.snapshot())
 
 	te.exec(t, "update customer.customer set projected_payload = null where id = 3501", nil)
 	te.exec(t, "alter table customer.customer modify column projected_payload bigint null", nil)
@@ -253,7 +247,7 @@ func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {
 		te.execBackgroundAllowMissingColumn(t, "alter table customer.customer drop column remap_b", nil)
 	})
 
-	var got []*customerWithRemapColumns
+	got := &rowCollector[*customerWithRemapColumns]{}
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
 		Table:           "customer",
@@ -261,9 +255,7 @@ func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {
 		MaxRowsPerFlush: 1,
 		DataType:        &customerWithRemapColumns{},
 		FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-			for _, row := range rows {
-				got = append(got, row.Data.(*customerWithRemapColumns))
-			}
+			got.collect(rows)
 			return nil
 		},
 	}})
@@ -273,18 +265,18 @@ func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email, remap_a, remap_b) values (3601, 'remap-before@domain.com', 'A1', 'B1')", nil)
 	assert.Eventually(t, func() bool {
-		return len(got) == 1
+		return got.count() == 1
 	}, 3*time.Second, 50*time.Millisecond)
 
 	te.exec(t, "alter table customer.customer modify column remap_b varchar(128) null after id, modify column remap_a varchar(128) null after remap_b", nil)
 	te.exec(t, "insert into customer.customer(id, email, remap_a, remap_b) values (3602, 'remap-after@domain.com', 'A2', 'B2')", nil)
 	assert.Eventually(t, func() bool {
-		return len(got) == 2
+		return got.count() == 2
 	}, 3*time.Second, 50*time.Millisecond)
 	assert.Equal(t, []*customerWithRemapColumns{
 		{ID: 3601, Email: "remap-before@domain.com", RemapA: "A1", RemapB: "B1"},
 		{ID: 3602, Email: "remap-after@domain.com", RemapA: "A2", RemapB: "B2"},
-	}, got)
+	}, got.snapshot())
 
 	cancelRun()
 	err := <-runErrCh

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -279,6 +279,6 @@ func TestVStreamClientRemapsFieldsAfterDDL(t *testing.T) {
 	cancelRun()
 	err := <-runErrCh
 	if err != nil && runCtx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+		require.NoError(t, err, "failed to run vstreamclient")
 	}
 }

--- a/go/test/endtoend/vstreamclient/schema_test.go
+++ b/go/test/endtoend/vstreamclient/schema_test.go
@@ -230,7 +230,7 @@ func TestVStreamClientSchemaDriftFailsWhenProjectedColumnTypeChanges(t *testing.
 
 	err := <-runErrCh
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "projected_payload")
+	require.ErrorContains(t, err, "projected_payload")
 	assert.ErrorContains(t, err, "error unmarshalling JSON")
 }
 

--- a/go/test/endtoend/vstreamclient/sharded_test.go
+++ b/go/test/endtoend/vstreamclient/sharded_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/sharded_test.go
+++ b/go/test/endtoend/vstreamclient/sharded_test.go
@@ -110,9 +110,8 @@ func TestVStreamClientStreamsAndResumesFromShardedSource(t *testing.T) {
 	assert.ElementsMatch(t, firstBatch, firstRun)
 
 	vgtid := queryLatestVGtid(t, te.ctx, te.session, streamName)
-	if assert.Len(t, vgtid.ShardGtids, 2) {
-		assert.ElementsMatch(t, []string{"-80", "80-"}, []string{vgtid.ShardGtids[0].Shard, vgtid.ShardGtids[1].Shard})
-	}
+	require.Len(t, vgtid.ShardGtids, 2)
+	assert.ElementsMatch(t, []string{"-80", "80-"}, []string{vgtid.ShardGtids[0].Shard, vgtid.ShardGtids[1].Shard})
 
 	secondBatch := []*Customer{{ID: 4103, Email: "sharded-c@domain.com"}}
 	for _, customer := range secondBatch {

--- a/go/test/endtoend/vstreamclient/sharded_test.go
+++ b/go/test/endtoend/vstreamclient/sharded_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/test/endtoend/vstreamclient/sharded_test.go
+++ b/go/test/endtoend/vstreamclient/sharded_test.go
@@ -1,0 +1,109 @@
+package vstreamclient
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+var (
+	startShardedKeyspaceOnce sync.Once
+	startShardedKeyspaceErr  error
+)
+
+const shardedVSchema = `{
+  "sharded": true,
+  "vindexes": {
+    "hash": {
+      "type": "hash"
+    }
+  },
+  "tables": {
+    "customer": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ]
+    },
+    "purchases": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        }
+      ]
+    }
+  }
+}`
+
+func ensureShardedCustomerKeyspace(t *testing.T) {
+	t.Helper()
+
+	startShardedKeyspaceOnce.Do(func() {
+		startShardedKeyspaceErr = clusterInstance.StartKeyspace(cluster.Keyspace{
+			Name:      "sharded_customer",
+			SchemaSQL: sqlSchema,
+			VSchema:   shardedVSchema,
+		}, []string{"-80", "80-"}, 1, true, cell)
+	})
+	require.NoError(t, startShardedKeyspaceErr)
+}
+
+func TestVStreamClientStreamsAndResumesFromShardedSource(t *testing.T) {
+	ensureShardedCustomerKeyspace(t)
+	te := newTestEnv(t)
+	streamName := t.Name()
+
+	newClient := func(flushFn vstreamclient.FlushFunc) *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, streamName, []vstreamclient.TableConfig{{
+			Keyspace:        "sharded_customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 4100 and 4199",
+			MaxRowsPerFlush: 1,
+			DataType:        &Customer{},
+			FlushFn:         flushFn,
+		}})
+	}
+
+	firstBatch := []*Customer{{ID: 4101, Email: "sharded-a@domain.com"}, {ID: 4102, Email: "sharded-b@domain.com"}}
+	for _, customer := range firstBatch {
+		te.exec(t, "insert into sharded_customer.customer(id, email) values(:id, :email)", customerBindVars(customer.ID, customer.Email))
+	}
+
+	var firstRun []*Customer
+	te.runUntilTimeout(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			firstRun = append(firstRun, row.Data.(*Customer))
+		}
+		return nil
+	}), 3*time.Second)
+	assert.ElementsMatch(t, firstBatch, firstRun)
+
+	vgtid := queryLatestVGtid(t, te.ctx, te.session, streamName)
+	if assert.Len(t, vgtid.ShardGtids, 2) {
+		assert.ElementsMatch(t, []string{"-80", "80-"}, []string{vgtid.ShardGtids[0].Shard, vgtid.ShardGtids[1].Shard})
+	}
+
+	secondBatch := []*Customer{{ID: 4103, Email: "sharded-c@domain.com"}}
+	for _, customer := range secondBatch {
+		te.exec(t, "insert into sharded_customer.customer(id, email) values(:id, :email)", customerBindVars(customer.ID, customer.Email))
+	}
+
+	var secondRun []*Customer
+	te.runUntilTimeout(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			secondRun = append(secondRun, row.Data.(*Customer))
+		}
+		return nil
+	}), 3*time.Second)
+	assert.ElementsMatch(t, secondBatch, secondRun)
+}

--- a/go/test/endtoend/vstreamclient/sharded_test.go
+++ b/go/test/endtoend/vstreamclient/sharded_test.go
@@ -54,6 +54,11 @@ func ensureShardedCustomerKeyspace(t *testing.T) {
 			SchemaSQL: sqlSchema,
 			VSchema:   shardedVSchema,
 		}, []string{"-80", "80-"}, 1, true, cell)
+		if startShardedKeyspaceErr != nil {
+			return
+		}
+
+		startShardedKeyspaceErr = clusterInstance.WaitForTabletsToHealthyInVtgate()
 	})
 	require.NoError(t, startShardedKeyspaceErr)
 }

--- a/go/test/endtoend/vstreamclient/sharded_test.go
+++ b/go/test/endtoend/vstreamclient/sharded_test.go
@@ -19,8 +19,8 @@ package vstreamclient
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,12 +101,12 @@ func TestVStreamClientStreamsAndResumesFromShardedSource(t *testing.T) {
 	}
 
 	var firstRun []*Customer
-	te.runUntilTimeout(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+	te.runUntilCopyCompleted(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
 		for _, row := range rows {
 			firstRun = append(firstRun, row.Data.(*Customer))
 		}
 		return nil
-	}), 3*time.Second)
+	}), streamName)
 	assert.ElementsMatch(t, firstBatch, firstRun)
 
 	vgtid := queryLatestVGtid(t, te.ctx, te.session, streamName)
@@ -119,11 +119,13 @@ func TestVStreamClientStreamsAndResumesFromShardedSource(t *testing.T) {
 	}
 
 	var secondRun []*Customer
-	te.runUntilTimeout(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+	var secondRunRows atomic.Int64
+	te.runUntil(t, newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
 		for _, row := range rows {
 			secondRun = append(secondRun, row.Data.(*Customer))
 		}
+		secondRunRows.Add(int64(len(rows)))
 		return nil
-	}), 3*time.Second)
+	}), func() bool { return secondRunRows.Load() >= int64(len(secondBatch)) })
 	assert.ElementsMatch(t, secondBatch, secondRun)
 }

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -1,0 +1,212 @@
+package vstreamclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+// TestVStreamClientGracefulShutdownChanStopsActiveRun verifies a configured
+// shutdown channel can trigger GracefulShutdown without a manual call.
+func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
+	te := newTestEnv(t)
+
+	rowSeen := make(chan struct{}, 1)
+	shutdownCh := make(chan struct{})
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 2600 and 2699",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	}},
+		vstreamclient.WithMinFlushDuration(10*time.Second),
+		vstreamclient.WithHeartbeatSeconds(5),
+		vstreamclient.WithGracefulShutdownChan(shutdownCh, 6*time.Second),
+		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+			select {
+			case rowSeen <- struct{}{}:
+			default:
+			}
+			return nil
+		}, binlogdatapb.VEventType_ROW),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values (2601, 'graceful-chan@domain.com')", nil)
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 5*time.Second)
+	select {
+	case <-rowSeen:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for row event")
+	}
+	close(shutdownCh)
+
+	err := <-runErrCh
+	if !isExpectedRunStop(err, runCtx) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+	cancelRun()
+	err = vstreamClient.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "client is closed")
+	_ = runCtx
+}
+
+// TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush verifies shutdown
+// completes on the next safe flush boundary even when that flush was already
+// going to happen because MaxRowsPerFlush was reached.
+func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
+	te := newTestEnv(t)
+
+	rowSeen := make(chan struct{}, 1)
+	shutdownCh := make(chan struct{})
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 2650 and 2699",
+		MaxRowsPerFlush: 1,
+		DataType:        &Customer{},
+		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+	}},
+		vstreamclient.WithMinFlushDuration(10*time.Second),
+		vstreamclient.WithHeartbeatSeconds(5),
+		vstreamclient.WithGracefulShutdownChan(shutdownCh, 5*time.Second),
+		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+			select {
+			case rowSeen <- struct{}{}:
+			default:
+			}
+			return nil
+		}, binlogdatapb.VEventType_ROW),
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values (2651, 'threshold-shutdown@domain.com')", nil)
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, time.Second)
+	defer cancelRun()
+	select {
+	case <-rowSeen:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for row event")
+	}
+	close(shutdownCh)
+
+	err := <-runErrCh
+	assert.NotErrorIs(t, runCtx.Err(), context.DeadlineExceeded)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+}
+
+// TestVStreamClientIgnoresNoOpTransactions verifies unrelated writes do not
+// trigger flushes for a filtered stream, which avoids noisy false-positive work.
+func TestVStreamClientIgnoresNoOpTransactions(t *testing.T) {
+	te := newTestEnv(t)
+
+	flushCount := 0
+	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		Query:           "select * from customer where id between 2900 and 2999",
+		MaxRowsPerFlush: 10,
+		DataType:        &Customer{},
+		FlushFn: func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+			flushCount++
+			return nil
+		},
+	}})
+
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 2*time.Second)
+	defer cancelRun()
+
+	te.exec(t, "insert into accounting.customer(id, email) values (2901, 'unrelated@domain.com')", nil)
+
+	assert.Never(t, func() bool {
+		return flushCount > 0
+	}, 1500*time.Millisecond, 100*time.Millisecond)
+
+	cancelRun()
+	err := <-runErrCh
+	if err != nil && runCtx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+	assert.Zero(t, flushCount)
+}
+
+// TestVStreamClientGracefulShutdownClosesMultiTableClient verifies
+// GracefulShutdown can stop a multi-table stream after both tables have started
+// emitting rows, and that the client is closed afterward.
+func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
+	te := newTestEnv(t)
+
+	var rowTables []string
+	rowTableSeen := make(chan string, 4)
+	newClient := func() *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1950 and 1959",
+				MaxRowsPerFlush: 100,
+				DataType:        &Customer{},
+				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+			},
+			{
+				Keyspace:        "customer",
+				Table:           "purchases",
+				Query:           "select * from purchases where id between 1950 and 1959",
+				MaxRowsPerFlush: 100,
+				DataType:        &Order{},
+				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+			},
+		},
+			vstreamclient.WithMinFlushDuration(10*time.Second),
+			vstreamclient.WithHeartbeatSeconds(5),
+			vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
+				rowTables = append(rowTables, ev.RowEvent.TableName)
+				select {
+				case rowTableSeen <- ev.RowEvent.TableName:
+				default:
+				}
+				return nil
+			}, binlogdatapb.VEventType_ROW),
+		)
+	}
+
+	te.exec(t, "insert into customer.customer(id, email) values (1950, 'close-prime@domain.com')", nil)
+	te.exec(t, "insert into customer.purchases(id, customer_id, note) values (1950, 1950, 'close-prime-order')", nil)
+
+	vstreamClient := newClient()
+	_, cancelRun, runErrCh := te.runAsync(vstreamClient, 5*time.Second)
+	seen := map[string]bool{}
+	deadline := time.After(3 * time.Second)
+	for !(seen["customer.customer"] && seen["customer.purchases"]) {
+		select {
+		case tableName := <-rowTableSeen:
+			seen[tableName] = true
+		case <-deadline:
+			t.Fatal("timed out waiting for both prime row event tables")
+		}
+	}
+
+	vstreamClient.GracefulShutdown(6 * time.Second)
+	cancelRun()
+	err := <-runErrCh
+	if !isExpectedRunStop(err, nil) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+
+	err = vstreamClient.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "client is closed")
+	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)
+}

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -3,6 +3,7 @@ package vstreamclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -209,4 +210,210 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
 	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)
+}
+
+func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
+	testCases := []struct {
+		name       string
+		streamName string
+		id         int64
+		run        func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer)
+	}{
+		{
+			name:       "before safe boundary replays",
+			streamName: "shutdown_before_boundary",
+			id:         3001,
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+				var client *vstreamclient.VStreamClient
+				flushCount := 0
+				client = newClient(10, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					flushCount += len(rows)
+					return nil
+				},
+					vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+						client.GracefulShutdown(100 * time.Millisecond)
+						return nil
+					}, binlogdatapb.VEventType_ROW),
+				)
+
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				defer cancelRun()
+				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
+
+				err := <-runErrCh
+				require.Error(t, err)
+				assert.ErrorIs(t, err, context.Canceled)
+				assert.Zero(t, flushCount)
+
+				var replayed []*Customer
+				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					for _, row := range rows {
+						replayed = append(replayed, row.Data.(*Customer))
+					}
+					return nil
+				}), 2*time.Second)
+				assert.Equal(t, []*Customer{want}, replayed)
+				_ = runCtx
+			},
+		},
+		{
+			name:       "after safe boundary does not replay",
+			streamName: "shutdown_after_boundary",
+			id:         3002,
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+				flushSeen := make(chan struct{}, 1)
+				var active []*Customer
+				client := newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					for _, row := range rows {
+						active = append(active, row.Data.(*Customer))
+					}
+					select {
+					case flushSeen <- struct{}{}:
+					default:
+					}
+					return nil
+				})
+
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				defer cancelRun()
+				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
+
+				select {
+				case <-flushSeen:
+				case <-time.After(3 * time.Second):
+					t.Fatal("timed out waiting for flush")
+				}
+				go client.GracefulShutdown(2 * time.Second)
+
+				err := <-runErrCh
+				if err != nil && !errors.Is(err, context.Canceled) && !isExpectedRunStop(err, runCtx) {
+					t.Fatalf("failed to run vstreamclient: %v", err)
+				}
+				assert.Equal(t, []*Customer{want}, active)
+
+				var replayed []*Customer
+				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					for _, row := range rows {
+						replayed = append(replayed, row.Data.(*Customer))
+					}
+					return nil
+				}), 2*time.Second)
+				assert.Empty(t, replayed)
+			},
+		},
+		{
+			name:       "during slow flush does not replay",
+			streamName: "shutdown_slow_flush",
+			id:         3003,
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+				flushStarted := make(chan struct{}, 1)
+				var client *vstreamclient.VStreamClient
+				var active []*Customer
+				client = newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					select {
+					case flushStarted <- struct{}{}:
+					default:
+					}
+					time.Sleep(300 * time.Millisecond)
+					for _, row := range rows {
+						active = append(active, row.Data.(*Customer))
+					}
+					return nil
+				},
+					vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+						go client.GracefulShutdown(2 * time.Second)
+						time.Sleep(50 * time.Millisecond)
+						return nil
+					}, binlogdatapb.VEventType_ROW),
+				)
+
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				defer cancelRun()
+				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
+
+				select {
+				case <-flushStarted:
+				case <-time.After(3 * time.Second):
+					t.Fatal("timed out waiting for slow flush")
+				}
+
+				err := <-runErrCh
+				if err != nil && !errors.Is(err, context.Canceled) && !isExpectedRunStop(err, runCtx) {
+					t.Fatalf("failed to run vstreamclient: %v", err)
+				}
+				assert.Equal(t, []*Customer{want}, active)
+
+				var replayed []*Customer
+				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					for _, row := range rows {
+						replayed = append(replayed, row.Data.(*Customer))
+					}
+					return nil
+				}), 2*time.Second)
+				assert.Empty(t, replayed)
+			},
+		},
+		{
+			name:       "wait zero replays",
+			streamName: "shutdown_wait_zero",
+			id:         3004,
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+				var client *vstreamclient.VStreamClient
+				flushCount := 0
+				client = newClient(10, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					flushCount += len(rows)
+					return nil
+				},
+					vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+						client.GracefulShutdown(0)
+						return nil
+					}, binlogdatapb.VEventType_ROW),
+				)
+
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				defer cancelRun()
+				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
+
+				err := <-runErrCh
+				require.Error(t, err)
+				assert.ErrorIs(t, err, context.Canceled)
+				assert.Zero(t, flushCount)
+
+				var replayed []*Customer
+				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					for _, row := range rows {
+						replayed = append(replayed, row.Data.(*Customer))
+					}
+					return nil
+				}), 2*time.Second)
+				assert.Equal(t, []*Customer{want}, replayed)
+				_ = runCtx
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			te := newTestEnv(t)
+			want := &Customer{ID: tc.id, Email: tc.streamName + "@domain.com"}
+			query := fmt.Sprintf("select * from customer where id between %d and %d", tc.id, tc.id)
+
+			newClient := func(maxRows int, flushFn vstreamclient.FlushFunc, opts ...vstreamclient.Option) *vstreamclient.VStreamClient {
+				return te.newDefaultClient(t, tc.streamName, []vstreamclient.TableConfig{{
+					Keyspace:        "customer",
+					Table:           "customer",
+					Query:           query,
+					MaxRowsPerFlush: maxRows,
+					DataType:        &Customer{},
+					FlushFn:         flushFn,
+				}}, append([]vstreamclient.Option{
+					vstreamclient.WithMinFlushDuration(10 * time.Second),
+					vstreamclient.WithHeartbeatSeconds(1),
+				}, opts...)...)
+			}
+
+			te.runUntilTimeout(t, newClient(1, func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
+			tc.run(t, te, newClient, want)
+		})
+	}
 }

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -113,7 +114,7 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 func TestVStreamClientIgnoresNoOpTransactions(t *testing.T) {
 	te := newTestEnv(t)
 
-	flushCount := 0
+	var flushCount atomic.Int32
 	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
 		Keyspace:        "customer",
 		Table:           "customer",
@@ -121,7 +122,7 @@ func TestVStreamClientIgnoresNoOpTransactions(t *testing.T) {
 		MaxRowsPerFlush: 10,
 		DataType:        &Customer{},
 		FlushFn: func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-			flushCount++
+			flushCount.Add(1)
 			return nil
 		},
 	}})
@@ -132,7 +133,7 @@ func TestVStreamClientIgnoresNoOpTransactions(t *testing.T) {
 	te.exec(t, "insert into accounting.customer(id, email) values (2901, 'unrelated@domain.com')", nil)
 
 	assert.Never(t, func() bool {
-		return flushCount > 0
+		return flushCount.Load() > 0
 	}, 1500*time.Millisecond, 100*time.Millisecond)
 
 	cancelRun()
@@ -140,7 +141,7 @@ func TestVStreamClientIgnoresNoOpTransactions(t *testing.T) {
 	if err != nil && runCtx.Err() == nil {
 		t.Fatalf("failed to run vstreamclient: %v", err)
 	}
-	assert.Zero(t, flushCount)
+	assert.Zero(t, flushCount.Load())
 }
 
 // TestVStreamClientGracefulShutdownClosesMultiTableClient verifies

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -119,39 +119,52 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 	}
 }
 
-// TestVStreamClientIgnoresNoOpTransactions verifies unrelated writes do not
-// trigger flushes for a filtered stream, which avoids noisy false-positive work.
+// TestVStreamClientIgnoresNoOpTransactions verifies transactions in the streamed keyspace whose
+// rows are all filtered out (here: a write to a table the stream doesn't match) still stream
+// BEGIN/VGTID/COMMIT events but never invoke FlushFn. The sentinel row is written after the no-op
+// transaction, so binlog order guarantees that once the sentinel arrives, any phantom delivery
+// from the no-op transaction would already have been observed.
 func TestVStreamClientIgnoresNoOpTransactions(t *testing.T) {
 	te := newTestEnv(t)
 
-	var flushCount atomic.Int32
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 2900 and 2999",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn: func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-			flushCount.Add(1)
-			return nil
-		},
-	}})
-
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 2*time.Second)
-	defer cancelRun()
-
-	te.exec(t, "insert into accounting.customer(id, email) values (2901, 'unrelated@domain.com')", nil)
-
-	assert.Never(t, func() bool {
-		return flushCount.Load() > 0
-	}, 1500*time.Millisecond, 100*time.Millisecond)
-
-	cancelRun()
-	err := <-runErrCh
-	if err != nil && runCtx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+	newClient := func(flushFn vstreamclient.FlushFunc) *vstreamclient.VStreamClient {
+		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 2900 and 2999",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         flushFn,
+		}})
 	}
-	assert.Zero(t, flushCount.Load())
+
+	// complete the copy phase first, so the writes below arrive through streaming
+	te.runUntilCopyCompleted(t, newClient(func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), t.Name())
+
+	var got []*Customer
+	var flushCalls atomic.Int32
+	var sentinelSeen atomic.Bool
+	sentinel := &Customer{ID: 2902, Email: "noop-sentinel@domain.com"}
+	client := newClient(func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		flushCalls.Add(1)
+		for _, row := range rows {
+			customer := row.Data.(*Customer)
+			got = append(got, customer)
+			if customer.ID == sentinel.ID {
+				sentinelSeen.Store(true)
+			}
+		}
+		return nil
+	})
+
+	// a no-op transaction for this stream: same keyspace, but a table the filter doesn't match
+	te.exec(t, "insert into customer.purchases(id, customer_id, note) values (2901, 2901, 'noop-tx')", nil)
+	te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(sentinel.ID, sentinel.Email))
+
+	te.runUntil(t, client, sentinelSeen.Load)
+
+	assert.Equal(t, []*Customer{sentinel}, got)
+	assert.Equal(t, int32(1), flushCalls.Load())
 }
 
 // TestVStreamClientGracefulShutdownClosesMultiTableClient verifies

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -67,7 +67,7 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 
 	err := <-runErrCh
 	if !isExpectedRunStop(err, runCtx) && !errors.Is(err, context.Canceled) {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+		require.NoError(t, err, "failed to run vstreamclient")
 	}
 	cancelRun()
 	err = vstreamClient.Run(context.Background())
@@ -115,7 +115,7 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 	err := <-runErrCh
 	assert.NotErrorIs(t, runCtx.Err(), context.DeadlineExceeded)
 	if err != nil && !errors.Is(err, context.Canceled) {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+		require.NoError(t, err, "failed to run vstreamclient")
 	}
 }
 
@@ -220,7 +220,7 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 		case tableName := <-rowTableSeen:
 			seen[tableName] = true
 		case <-deadline:
-			t.Fatal("timed out waiting for both prime row event tables")
+			require.FailNow(t, "timed out waiting for both prime row event tables")
 		}
 	}
 
@@ -228,7 +228,7 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 	cancelRun()
 	err := <-runErrCh
 	if !isExpectedRunStop(err, nil) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("failed to run vstreamclient: %v", err)
+		require.NoError(t, err, "failed to run vstreamclient")
 	}
 
 	err = vstreamClient.Run(context.Background())
@@ -332,7 +332,7 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 
 				err := <-runErrCh
 				if err != nil && !errors.Is(err, context.Canceled) && !isExpectedRunStop(err, runCtx) {
-					t.Fatalf("failed to run vstreamclient: %v", err)
+					require.NoError(t, err, "failed to run vstreamclient")
 				}
 				assert.Equal(t, []*Customer{want}, active)
 
@@ -377,7 +377,7 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 
 				err := <-runErrCh
 				if err != nil && !errors.Is(err, context.Canceled) && !isExpectedRunStop(err, runCtx) {
-					t.Fatalf("failed to run vstreamclient: %v", err)
+					require.NoError(t, err, "failed to run vstreamclient")
 				}
 				assert.Equal(t, []*Customer{want}, active)
 

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -73,7 +73,6 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 	err = vstreamClient.Run(t.Context())
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
-	_ = runCtx
 }
 
 // TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush verifies shutdown
@@ -291,7 +290,7 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 					}, binlogdatapb.VEventType_ROW),
 				)
 
-				runCtx, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
+				_, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
 				defer cancelRun()
 				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
 
@@ -302,7 +301,6 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 
 				replayed := replayAfterShutdown(t, te, newClient, sentinel)
 				assert.Equal(t, []*Customer{want, sentinel}, replayed)
-				_ = runCtx
 			},
 		},
 		{
@@ -403,7 +401,7 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 					}, binlogdatapb.VEventType_ROW),
 				)
 
-				runCtx, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
+				_, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
 				defer cancelRun()
 				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
 
@@ -414,7 +412,6 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 
 				replayed := replayAfterShutdown(t, te, newClient, sentinel)
 				assert.Equal(t, []*Customer{want, sentinel}, replayed)
-				_ = runCtx
 			},
 		},
 	}

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -38,14 +38,15 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 
 	rowSeen := make(chan struct{}, 1)
 	shutdownCh := make(chan struct{})
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 2600 and 2699",
-		MaxRowsPerFlush: 10,
-		DataType:        &Customer{},
-		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-	}},
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 2600 and 2699",
+			MaxRowsPerFlush: 10,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		}},
 		vstreamclient.WithMinFlushDuration(10*time.Second),
 		vstreamclient.WithHeartbeatSeconds(5),
 		vstreamclient.WithGracefulShutdownChan(shutdownCh, 6*time.Second),
@@ -60,12 +61,8 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email) values (2601, 'graceful-chan@domain.com')", nil)
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 5*time.Second)
-	select {
-	case <-rowSeen:
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for row event")
-	}
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
+	recvOrFail(t, rowSeen, "row event")
 	close(shutdownCh)
 
 	err := <-runErrCh
@@ -87,14 +84,15 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 
 	rowSeen := make(chan struct{}, 1)
 	shutdownCh := make(chan struct{})
-	vstreamClient := te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		Query:           "select * from customer where id between 2650 and 2699",
-		MaxRowsPerFlush: 1,
-		DataType:        &Customer{},
-		FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-	}},
+	vstreamClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 2650 and 2699",
+			MaxRowsPerFlush: 1,
+			DataType:        &Customer{},
+			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		}},
 		vstreamclient.WithMinFlushDuration(10*time.Second),
 		vstreamclient.WithHeartbeatSeconds(5),
 		vstreamclient.WithGracefulShutdownChan(shutdownCh, 5*time.Second),
@@ -109,13 +107,9 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 
 	te.exec(t, "insert into customer.customer(id, email) values (2651, 'threshold-shutdown@domain.com')", nil)
 
-	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, time.Second)
+	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
-	select {
-	case <-rowSeen:
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for row event")
-	}
+	recvOrFail(t, rowSeen, "row event")
 	close(shutdownCh)
 
 	err := <-runErrCh
@@ -169,24 +163,25 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 	var rowTables []string
 	rowTableSeen := make(chan string, 4)
 	newClient := func() *vstreamclient.VStreamClient {
-		return te.newDefaultClient(t, t.Name(), []vstreamclient.TableConfig{
-			{
-				Keyspace:        "customer",
-				Table:           "customer",
-				Query:           "select * from customer where id between 1950 and 1959",
-				MaxRowsPerFlush: 100,
-				DataType:        &Customer{},
-				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+		return te.newDefaultClient(
+			t, t.Name(), []vstreamclient.TableConfig{
+				{
+					Keyspace:        "customer",
+					Table:           "customer",
+					Query:           "select * from customer where id between 1950 and 1959",
+					MaxRowsPerFlush: 100,
+					DataType:        &Customer{},
+					FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+				},
+				{
+					Keyspace:        "customer",
+					Table:           "purchases",
+					Query:           "select * from purchases where id between 1950 and 1959",
+					MaxRowsPerFlush: 100,
+					DataType:        &Order{},
+					FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+				},
 			},
-			{
-				Keyspace:        "customer",
-				Table:           "purchases",
-				Query:           "select * from purchases where id between 1950 and 1959",
-				MaxRowsPerFlush: 100,
-				DataType:        &Order{},
-				FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
-			},
-		},
 			vstreamclient.WithMinFlushDuration(10*time.Second),
 			vstreamclient.WithHeartbeatSeconds(5),
 			vstreamclient.WithEventFunc(func(_ context.Context, ev *binlogdatapb.VEvent) error {
@@ -204,9 +199,9 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 	te.exec(t, "insert into customer.purchases(id, customer_id, note) values (1950, 1950, 'close-prime-order')", nil)
 
 	vstreamClient := newClient()
-	_, cancelRun, runErrCh := te.runAsync(vstreamClient, 5*time.Second)
+	_, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	seen := map[string]bool{}
-	deadline := time.After(3 * time.Second)
+	deadline := time.After(30 * time.Second)
 	for !(seen["customer.customer"] && seen["customer.purchases"]) {
 		select {
 		case tableName := <-rowTableSeen:
@@ -229,31 +224,61 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)
 }
 
+// replayAfterShutdown inserts a sentinel row and runs a fresh client until the sentinel arrives.
+// Binlog order guarantees the tested row would be delivered before the sentinel, so once the
+// sentinel shows up, whether the tested row replayed is already decided — no timing window needed
+// for the negative cases.
+func replayAfterShutdown(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, sentinel *Customer) []*Customer {
+	t.Helper()
+
+	te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(sentinel.ID, sentinel.Email))
+
+	var replayed []*Customer
+	var sentinelSeen atomic.Bool
+	client := newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+		for _, row := range rows {
+			customer := row.Data.(*Customer)
+			replayed = append(replayed, customer)
+			if customer.ID == sentinel.ID {
+				sentinelSeen.Store(true)
+			}
+		}
+		return nil
+	})
+
+	te.runUntil(t, client, sentinelSeen.Load)
+	return replayed
+}
+
 func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 	testCases := []struct {
 		name       string
 		streamName string
 		id         int64
-		run        func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer)
+		run        func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want, sentinel *Customer)
 	}{
 		{
 			name:       "before safe boundary replays",
 			streamName: "shutdown_before_boundary",
 			id:         3001,
-			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want, sentinel *Customer) {
 				var client *vstreamclient.VStreamClient
 				flushCount := 0
-				client = newClient(10, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-					flushCount += len(rows)
-					return nil
-				},
+				client = newClient(
+					10, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+						flushCount += len(rows)
+						return nil
+					},
 					vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
+						// the hook runs on the event loop, so this GracefulShutdown call blocks
+						// event processing until the wait expires; the cancel therefore always
+						// lands before the transaction's COMMIT can trigger a flush
 						client.GracefulShutdown(100 * time.Millisecond)
 						return nil
 					}, binlogdatapb.VEventType_ROW),
 				)
 
-				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
 				defer cancelRun()
 				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
 
@@ -262,22 +287,16 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 				assert.ErrorIs(t, err, context.Canceled)
 				assert.Zero(t, flushCount)
 
-				var replayed []*Customer
-				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-					for _, row := range rows {
-						replayed = append(replayed, row.Data.(*Customer))
-					}
-					return nil
-				}), 2*time.Second)
-				assert.Equal(t, []*Customer{want}, replayed)
+				replayed := replayAfterShutdown(t, te, newClient, sentinel)
+				assert.Equal(t, []*Customer{want, sentinel}, replayed)
 				_ = runCtx
 			},
 		},
 		{
 			name:       "after safe boundary does not replay",
 			streamName: "shutdown_after_boundary",
-			id:         3002,
-			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+			id:         3011,
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want, sentinel *Customer) {
 				flushSeen := make(chan struct{}, 1)
 				var active []*Customer
 				client := newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
@@ -291,16 +310,12 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 					return nil
 				})
 
-				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
 				defer cancelRun()
 				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
 
-				select {
-				case <-flushSeen:
-				case <-time.After(3 * time.Second):
-					t.Fatal("timed out waiting for flush")
-				}
-				go client.GracefulShutdown(2 * time.Second)
+				recvOrFail(t, flushSeen, "flush")
+				go client.GracefulShutdown(15 * time.Second)
 
 				err := <-runErrCh
 				if err != nil && !errors.Is(err, context.Canceled) && !isExpectedRunStop(err, runCtx) {
@@ -308,22 +323,17 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 				}
 				assert.Equal(t, []*Customer{want}, active)
 
-				var replayed []*Customer
-				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-					for _, row := range rows {
-						replayed = append(replayed, row.Data.(*Customer))
-					}
-					return nil
-				}), 2*time.Second)
-				assert.Empty(t, replayed)
+				replayed := replayAfterShutdown(t, te, newClient, sentinel)
+				assert.Equal(t, []*Customer{sentinel}, replayed)
 			},
 		},
 		{
 			name:       "during slow flush does not replay",
 			streamName: "shutdown_slow_flush",
-			id:         3003,
-			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+			id:         3021,
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want, sentinel *Customer) {
 				flushStarted := make(chan struct{}, 1)
+				flushGate := make(chan struct{})
 				var client *vstreamclient.VStreamClient
 				var active []*Customer
 				client = newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
@@ -331,28 +341,26 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 					case flushStarted <- struct{}{}:
 					default:
 					}
-					time.Sleep(300 * time.Millisecond)
+					// block the flush until the test has issued GracefulShutdown, so the
+					// shutdown request lands while this flush is still in progress
+					<-flushGate
 					for _, row := range rows {
 						active = append(active, row.Data.(*Customer))
 					}
 					return nil
-				},
-					vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
-						go client.GracefulShutdown(2 * time.Second)
-						time.Sleep(50 * time.Millisecond)
-						return nil
-					}, binlogdatapb.VEventType_ROW),
-				)
+				})
 
-				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
 				defer cancelRun()
 				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
 
-				select {
-				case <-flushStarted:
-				case <-time.After(3 * time.Second):
-					t.Fatal("timed out waiting for slow flush")
-				}
+				recvOrFail(t, flushStarted, "slow flush start")
+				go client.GracefulShutdown(15 * time.Second)
+				// give the GracefulShutdown goroutine time to record the shutdown request before
+				// the flush resumes; if it ever lost this race, the case would degrade to
+				// "after safe boundary", which expects the same outcome
+				time.Sleep(500 * time.Millisecond)
+				close(flushGate)
 
 				err := <-runErrCh
 				if err != nil && !errors.Is(err, context.Canceled) && !isExpectedRunStop(err, runCtx) {
@@ -360,34 +368,29 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 				}
 				assert.Equal(t, []*Customer{want}, active)
 
-				var replayed []*Customer
-				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-					for _, row := range rows {
-						replayed = append(replayed, row.Data.(*Customer))
-					}
-					return nil
-				}), 2*time.Second)
-				assert.Empty(t, replayed)
+				replayed := replayAfterShutdown(t, te, newClient, sentinel)
+				assert.Equal(t, []*Customer{sentinel}, replayed)
 			},
 		},
 		{
 			name:       "wait zero replays",
 			streamName: "shutdown_wait_zero",
-			id:         3004,
-			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want *Customer) {
+			id:         3031,
+			run: func(t *testing.T, te *testEnv, newClient func(int, vstreamclient.FlushFunc, ...vstreamclient.Option) *vstreamclient.VStreamClient, want, sentinel *Customer) {
 				var client *vstreamclient.VStreamClient
 				flushCount := 0
-				client = newClient(10, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-					flushCount += len(rows)
-					return nil
-				},
+				client = newClient(
+					10, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+						flushCount += len(rows)
+						return nil
+					},
 					vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
 						client.GracefulShutdown(0)
 						return nil
 					}, binlogdatapb.VEventType_ROW),
 				)
 
-				runCtx, cancelRun, runErrCh := te.runAsync(client, 5*time.Second)
+				runCtx, cancelRun, runErrCh := te.runAsync(client, 30*time.Second)
 				defer cancelRun()
 				te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(want.ID, want.Email))
 
@@ -396,14 +399,8 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 				assert.ErrorIs(t, err, context.Canceled)
 				assert.Zero(t, flushCount)
 
-				var replayed []*Customer
-				te.runUntilTimeout(t, newClient(1, func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
-					for _, row := range rows {
-						replayed = append(replayed, row.Data.(*Customer))
-					}
-					return nil
-				}), 2*time.Second)
-				assert.Equal(t, []*Customer{want}, replayed)
+				replayed := replayAfterShutdown(t, te, newClient, sentinel)
+				assert.Equal(t, []*Customer{want, sentinel}, replayed)
 				_ = runCtx
 			},
 		},
@@ -413,7 +410,8 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			te := newTestEnv(t)
 			want := &Customer{ID: tc.id, Email: tc.streamName + "@domain.com"}
-			query := fmt.Sprintf("select * from customer where id between %d and %d", tc.id, tc.id)
+			sentinel := &Customer{ID: tc.id + 1, Email: tc.streamName + "-sentinel@domain.com"}
+			query := fmt.Sprintf("select * from customer where id between %d and %d", tc.id, tc.id+1)
 
 			newClient := func(maxRows int, flushFn vstreamclient.FlushFunc, opts ...vstreamclient.Option) *vstreamclient.VStreamClient {
 				return te.newDefaultClient(t, tc.streamName, []vstreamclient.TableConfig{{
@@ -429,8 +427,8 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 				}, opts...)...)
 			}
 
-			te.runUntilTimeout(t, newClient(1, func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), 2*time.Second)
-			tc.run(t, te, newClient, want)
+			te.runUntilCopyCompleted(t, newClient(1, func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil }), tc.streamName)
+			tc.run(t, te, newClient, want, sentinel)
 		})
 	}
 }

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -49,7 +49,7 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 		}},
 		vstreamclient.WithMinFlushDuration(10*time.Second),
 		vstreamclient.WithHeartbeatSeconds(5),
-		vstreamclient.WithGracefulShutdownChan(shutdownCh, 6*time.Second),
+		vstreamclient.WithGracefulShutdownChan(shutdownCh, 15*time.Second),
 		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
 			select {
 			case rowSeen <- struct{}{}:
@@ -62,14 +62,17 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 	te.exec(t, "insert into customer.customer(id, email) values (2601, 'graceful-chan@domain.com')", nil)
 
 	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
+	defer cancelRun()
 	recvOrFail(t, rowSeen, "row event")
 	close(shutdownCh)
 
-	err := <-runErrCh
-	if !isExpectedRunStop(err, runCtx) && !errors.Is(err, context.Canceled) {
-		require.NoError(t, err, "failed to run vstreamclient")
-	}
-	cancelRun()
+	err := recvOrFail(t, runErrCh, "run exit after shutdown channel closed")
+
+	// the configured channel must be what stopped the run: a clean graceful exit before the
+	// outer run deadline. If the channel were ignored, Run would only end via the deadline.
+	require.NoError(t, runCtx.Err(), "run context expired before the shutdown channel stopped the run")
+	require.NoError(t, err)
+
 	err = vstreamClient.Run(t.Context())
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
@@ -83,6 +86,7 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 
 	rowSeen := make(chan struct{}, 1)
 	shutdownCh := make(chan struct{})
+	var flushReasons []vstreamclient.FlushReason
 	vstreamClient := te.newDefaultClient(
 		t, t.Name(), []vstreamclient.TableConfig{{
 			Keyspace:        "customer",
@@ -90,11 +94,14 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 			Query:           "select * from customer where id between 2650 and 2699",
 			MaxRowsPerFlush: 1,
 			DataType:        &Customer{},
-			FlushFn:         func(_ context.Context, _ []vstreamclient.Row, _ vstreamclient.FlushMeta) error { return nil },
+			FlushFn: func(_ context.Context, _ []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
+				flushReasons = append(flushReasons, meta.FlushReason)
+				return nil
+			},
 		}},
 		vstreamclient.WithMinFlushDuration(10*time.Second),
 		vstreamclient.WithHeartbeatSeconds(5),
-		vstreamclient.WithGracefulShutdownChan(shutdownCh, 5*time.Second),
+		vstreamclient.WithGracefulShutdownChan(shutdownCh, 15*time.Second),
 		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
 			select {
 			case rowSeen <- struct{}{}:
@@ -111,11 +118,13 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 	recvOrFail(t, rowSeen, "row event")
 	close(shutdownCh)
 
-	err := <-runErrCh
-	assert.NotErrorIs(t, runCtx.Err(), context.DeadlineExceeded)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		require.NoError(t, err, "failed to run vstreamclient")
-	}
+	err := recvOrFail(t, runErrCh, "run exit after shutdown channel closed")
+	require.NoError(t, runCtx.Err(), "run context expired before the shutdown channel stopped the run")
+	require.NoError(t, err)
+
+	// the buffered row hit MaxRowsPerFlush=1, so the shutdown must have completed on a
+	// threshold-triggered flush, not only on the shutdown-forced one
+	assert.Contains(t, flushReasons, vstreamclient.FlushReasonMaxRowsPerFlush)
 }
 
 // TestVStreamClientIgnoresNoOpTransactions verifies transactions in the streamed keyspace whose
@@ -212,6 +221,7 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 
 	vstreamClient := newClient()
 	_, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
+	defer cancelRun()
 	seen := map[string]bool{}
 	deadline := time.After(30 * time.Second)
 	for !(seen["customer.customer"] && seen["customer.purchases"]) {
@@ -223,12 +233,15 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 		}
 	}
 
-	vstreamClient.GracefulShutdown(6 * time.Second)
-	cancelRun()
-	err := <-runErrCh
-	if !isExpectedRunStop(err, nil) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		require.NoError(t, err, "failed to run vstreamclient")
-	}
+	// no fallback cancellation here: GracefulShutdown alone must end the run, otherwise a
+	// no-op shutdown implementation could pass on the strength of the cancel
+	vstreamClient.GracefulShutdown(15 * time.Second)
+	err := recvOrFail(t, runErrCh, "run exit after graceful shutdown")
+	require.NoError(t, err)
+
+	// the shutdown flush must have durably checkpointed the stream
+	vgtid := queryLatestVGtid(t, te.ctx, te.session, t.Name())
+	require.NotEmpty(t, vgtid.ShardGtids)
 
 	err = vstreamClient.Run(t.Context())
 	require.Error(t, err)
@@ -367,10 +380,9 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 
 				recvOrFail(t, flushStarted, "slow flush start")
 				go client.GracefulShutdown(15 * time.Second)
-				// give the GracefulShutdown goroutine time to record the shutdown request before
-				// the flush resumes; if it ever lost this race, the case would degrade to
-				// "after safe boundary", which expects the same outcome
-				time.Sleep(500 * time.Millisecond)
+				// wait for the shutdown request to be registered before releasing the flush, so
+				// this case deterministically proves shutdown-during-flush semantics
+				require.Eventually(t, client.ShutdownRequested, 30*time.Second, 10*time.Millisecond)
 				close(flushGate)
 
 				err := <-runErrCh

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -70,7 +70,7 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 		require.NoError(t, err, "failed to run vstreamclient")
 	}
 	cancelRun()
-	err = vstreamClient.Run(context.Background())
+	err = vstreamClient.Run(t.Context())
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
 	_ = runCtx
@@ -231,7 +231,7 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 		require.NoError(t, err, "failed to run vstreamclient")
 	}
 
-	err = vstreamClient.Run(context.Background())
+	err = vstreamClient.Run(t.Context())
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
 	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	"vitess.io/vitess/go/vt/vstreamclient"
@@ -85,8 +87,10 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 	te := newTestEnv(t)
 
 	shutdownCh := make(chan struct{})
-	flushStarted := make(chan vstreamclient.FlushReason, 4)
+	flushStarted := make(chan vstreamclient.FlushMeta, 4)
 	flushGate := make(chan struct{})
+	releaseFlush := sync.OnceFunc(func() { close(flushGate) })
+	t.Cleanup(releaseFlush)
 	var flushCalls atomic.Int32
 	vstreamClient := te.newDefaultClient(
 		t, t.Name(), []vstreamclient.TableConfig{{
@@ -97,7 +101,7 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 			DataType:        &Customer{},
 			FlushFn: func(_ context.Context, _ []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
 				flushCalls.Add(1)
-				flushStarted <- meta.FlushReason
+				flushStarted <- meta
 				<-flushGate
 				return nil
 			},
@@ -114,13 +118,13 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 
 	// the buffered row hits MaxRowsPerFlush=1, so the first flush is threshold-triggered;
 	// hold it open on the gate
-	reason := recvOrFail(t, flushStarted, "threshold flush start")
-	require.Equal(t, vstreamclient.FlushReasonMaxRowsPerFlush, reason)
+	meta := recvOrFail(t, flushStarted, "threshold flush start")
+	require.Equal(t, vstreamclient.FlushReasonMaxRowsPerFlush, meta.FlushReason)
 
 	// request the shutdown while that flush is provably still in progress, then release it
 	close(shutdownCh)
 	require.Eventually(t, vstreamClient.ShutdownRequested, 30*time.Second, 10*time.Millisecond)
-	close(flushGate)
+	releaseFlush()
 
 	err := recvOrFail(t, runErrCh, "run exit after shutdown channel closed")
 	require.NoError(t, runCtx.Err(), "run context expired before the shutdown channel stopped the run")
@@ -128,6 +132,7 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 
 	// the shutdown completed on that very threshold flush: no later flush boundary was needed
 	assert.Equal(t, int32(1), flushCalls.Load())
+	assert.True(t, proto.Equal(meta.LatestVGtid, queryLatestVGtid(t, te.ctx, te.session, t.Name())))
 }
 
 // TestVStreamClientIgnoresNoOpTransactions verifies transactions in the streamed keyspace whose
@@ -253,7 +258,7 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 
 	err = vstreamClient.Run(t.Context())
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "client is closed")
+	require.ErrorContains(t, err, "client is closed")
 	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)
 
 	// restart with a sentinel row: the shutdown checkpoint must cover the priming rows, so a
@@ -362,7 +367,7 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 
 				err := <-runErrCh
 				require.Error(t, err)
-				assert.ErrorIs(t, err, context.Canceled)
+				require.ErrorIs(t, err, context.Canceled)
 				assert.Zero(t, flushCount)
 
 				replayed := replayAfterShutdown(t, te, newClient, sentinel)
@@ -472,7 +477,7 @@ func TestVStreamClientGracefulShutdownReplayMatrix(t *testing.T) {
 
 				err := <-runErrCh
 				require.Error(t, err)
-				assert.ErrorIs(t, err, context.Canceled)
+				require.ErrorIs(t, err, context.Canceled)
 				assert.Zero(t, flushCount)
 
 				replayed := replayAfterShutdown(t, te, newClient, sentinel)

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -84,9 +84,10 @@ func TestVStreamClientGracefulShutdownChanStopsActiveRun(t *testing.T) {
 func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 	te := newTestEnv(t)
 
-	rowSeen := make(chan struct{}, 1)
 	shutdownCh := make(chan struct{})
-	var flushReasons []vstreamclient.FlushReason
+	flushStarted := make(chan vstreamclient.FlushReason, 4)
+	flushGate := make(chan struct{})
+	var flushCalls atomic.Int32
 	vstreamClient := te.newDefaultClient(
 		t, t.Name(), []vstreamclient.TableConfig{{
 			Keyspace:        "customer",
@@ -95,36 +96,38 @@ func TestVStreamClientGracefulShutdownChanStopsOnThresholdFlush(t *testing.T) {
 			MaxRowsPerFlush: 1,
 			DataType:        &Customer{},
 			FlushFn: func(_ context.Context, _ []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
-				flushReasons = append(flushReasons, meta.FlushReason)
+				flushCalls.Add(1)
+				flushStarted <- meta.FlushReason
+				<-flushGate
 				return nil
 			},
 		}},
 		vstreamclient.WithMinFlushDuration(10*time.Second),
 		vstreamclient.WithHeartbeatSeconds(5),
 		vstreamclient.WithGracefulShutdownChan(shutdownCh, 15*time.Second),
-		vstreamclient.WithEventFunc(func(_ context.Context, _ *binlogdatapb.VEvent) error {
-			select {
-			case rowSeen <- struct{}{}:
-			default:
-			}
-			return nil
-		}, binlogdatapb.VEventType_ROW),
 	)
 
 	te.exec(t, "insert into customer.customer(id, email) values (2651, 'threshold-shutdown@domain.com')", nil)
 
 	runCtx, cancelRun, runErrCh := te.runAsync(vstreamClient, 30*time.Second)
 	defer cancelRun()
-	recvOrFail(t, rowSeen, "row event")
+
+	// the buffered row hits MaxRowsPerFlush=1, so the first flush is threshold-triggered;
+	// hold it open on the gate
+	reason := recvOrFail(t, flushStarted, "threshold flush start")
+	require.Equal(t, vstreamclient.FlushReasonMaxRowsPerFlush, reason)
+
+	// request the shutdown while that flush is provably still in progress, then release it
 	close(shutdownCh)
+	require.Eventually(t, vstreamClient.ShutdownRequested, 30*time.Second, 10*time.Millisecond)
+	close(flushGate)
 
 	err := recvOrFail(t, runErrCh, "run exit after shutdown channel closed")
 	require.NoError(t, runCtx.Err(), "run context expired before the shutdown channel stopped the run")
 	require.NoError(t, err)
 
-	// the buffered row hit MaxRowsPerFlush=1, so the shutdown must have completed on a
-	// threshold-triggered flush, not only on the shutdown-forced one
-	assert.Contains(t, flushReasons, vstreamclient.FlushReasonMaxRowsPerFlush)
+	// the shutdown completed on that very threshold flush: no later flush boundary was needed
+	assert.Equal(t, int32(1), flushCalls.Load())
 }
 
 // TestVStreamClientIgnoresNoOpTransactions verifies transactions in the streamed keyspace whose
@@ -247,6 +250,51 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
 	assert.ElementsMatch(t, []string{"customer.customer", "customer.purchases"}, rowTables)
+
+	// restart with a sentinel row: the shutdown checkpoint must cover the priming rows, so a
+	// fresh client may only ever see the sentinel. A replayed priming row here would mean the
+	// graceful shutdown did not durably advance the checkpoint.
+	sentinel := &Customer{ID: 1951, Email: "close-sentinel@domain.com"}
+	restartCustomers := &rowCollector[*Customer]{}
+	restartOrders := &rowCollector[*Order]{}
+	var sentinelSeen atomic.Bool
+	restartClient := te.newDefaultClient(
+		t, t.Name(), []vstreamclient.TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1950 and 1959",
+				MaxRowsPerFlush: 100,
+				DataType:        &Customer{},
+				FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					restartCustomers.collect(rows)
+					for _, row := range rows {
+						if row.Data.(*Customer).ID == sentinel.ID {
+							sentinelSeen.Store(true)
+						}
+					}
+					return nil
+				},
+			},
+			{
+				Keyspace:        "customer",
+				Table:           "purchases",
+				Query:           "select * from purchases where id between 1950 and 1959",
+				MaxRowsPerFlush: 100,
+				DataType:        &Order{},
+				FlushFn: func(_ context.Context, rows []vstreamclient.Row, _ vstreamclient.FlushMeta) error {
+					restartOrders.collect(rows)
+					return nil
+				},
+			},
+		},
+	)
+
+	te.exec(t, "insert into customer.customer(id, email) values(:id, :email)", customerBindVars(sentinel.ID, sentinel.Email))
+	te.runUntil(t, restartClient, sentinelSeen.Load)
+
+	assert.Equal(t, []*Customer{sentinel}, restartCustomers.snapshot())
+	assert.Empty(t, restartOrders.snapshot())
 }
 
 // replayAfterShutdown inserts a sentinel row and runs a fresh client until the sentinel arrives.

--- a/go/test/endtoend/vstreamclient/shutdown_test.go
+++ b/go/test/endtoend/vstreamclient/shutdown_test.go
@@ -236,6 +236,11 @@ func TestVStreamClientGracefulShutdownClosesMultiTableClient(t *testing.T) {
 		}
 	}
 
+	// wait for the copy phase to be checkpointed before shutting down: a shutdown mid-copy
+	// correctly restarts the copy on the next client (at-least-once), which would make the
+	// no-replay assertion below meaningless
+	require.Eventually(t, te.copyCompleted(t.Name()), 30*time.Second, 50*time.Millisecond)
+
 	// no fallback cancellation here: GracefulShutdown alone must end the run, otherwise a
 	// no-op shutdown implementation could pass on the strength of the cancel
 	vstreamClient.GracefulShutdown(15 * time.Second)

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -1,0 +1,838 @@
+# vstreamclient
+
+<!-- TOC -->
+* [vstreamclient](#vstreamclient)
+  * [Goals](#goals)
+  * [Non-Goals](#non-goals)
+  * [What It Does](#what-it-does)
+  * [How It Works](#how-it-works)
+    * [1. Configure tables](#1-configure-tables)
+    * [2. Configure state](#2-configure-state)
+    * [3. Run the stream](#3-run-the-stream)
+    * [4. Flush buffered rows](#4-flush-buffered-rows)
+    * [5. Persist checkpoints](#5-persist-checkpoints)
+  * [Quick Start](#quick-start)
+  * [Important Types](#important-types)
+    * [`TableConfig`](#tableconfig)
+    * [`Row`](#row)
+    * [`FlushMeta`](#flushmeta)
+  * [Struct Mapping](#struct-mapping)
+  * [Custom Scanning](#custom-scanning)
+  * [Common Usage Patterns](#common-usage-patterns)
+    * [Single-table consumer](#single-table-consumer)
+    * [Multi-table consumer](#multi-table-consumer)
+    * [BigQuery via GCS](#bigquery-via-gcs)
+    * [Same table name across keyspaces](#same-table-name-across-keyspaces)
+    * [Event hooks](#event-hooks)
+    * [Starting from a specific VGtid](#starting-from-a-specific-vgtid)
+  * [Things To Watch Out For](#things-to-watch-out-for)
+    * [`Run()` cannot be reused](#run-cannot-be-reused)
+    * [Use `GracefulShutdown()` to stop safely](#use-gracefulshutdown-to-stop-safely)
+    * [`FlushFn` errors stop the stream](#flushfn-errors-stop-the-stream)
+    * [Event hook errors also stop the stream](#event-hook-errors-also-stop-the-stream)
+    * [State table must be unsharded](#state-table-must-be-unsharded)
+    * [Table configuration is part of state](#table-configuration-is-part-of-state)
+    * [Copy interruption restarts from the beginning](#copy-interruption-restarts-from-the-beginning)
+    * [`MaxRowsPerFlush` is not an exact upstream batch size](#maxrowsperflush-is-not-an-exact-upstream-batch-size)
+    * [Schema drift can be strict or tolerant](#schema-drift-can-be-strict-or-tolerant)
+    * [`binlog_row_image` changes what row data is present](#binlog_row_image-changes-what-row-data-is-present)
+    * [`ReuseBatchSlice` changes ownership expectations](#reusebatchslice-changes-ownership-expectations)
+    * [Bare table names are opt-in and can be dangerous](#bare-table-names-are-opt-in-and-can-be-dangerous)
+  * [Recommended Patterns](#recommended-patterns)
+  * [Limitations And Current Scope](#limitations-and-current-scope)
+  * [Testing And Examples](#testing-and-examples)
+  * [When To Use This Package](#when-to-use-this-package)
+<!-- TOC -->
+
+`vstreamclient` is a reference implementation for consuming Vitess VStream from Go.
+
+It is meant to make VStream easier to use safely for common CDC-style workloads, especially when you want to turn
+VStream events back into typed Go structs and send them somewhere else: a data warehouse, object storage, a search
+index, a cache warmer, or a custom sink.
+
+This package is intentionally semi-opinionated. It handles a number of correctness details for you, but it is still just
+a client library. It does not require special Vitess internals, and it is not the only way to use VStream.
+
+## Goals
+
+These goals come from the original RFC for the package:
+
+- provide a simple, production-ready way to consume VStream without deep VStream expertise
+- translate VStream row events back into Go structs
+- serve as a starting point for custom VStream consumers and connectors
+- document important edge cases, gotchas, and recommended patterns
+
+## Non-Goals
+
+- it is not required in order to use VStream
+- it is not tied to any specific warehouse, sink, or export target
+- it does not require special server-side privileges or Vitess internals
+- it is not a full CDC platform like Debezium, Kafka Connect, or Flink
+
+## What It Does
+
+At a high level, `vstreamclient`:
+
+- creates a VStream with one or more table filters
+- maps `FIELD` and `ROW` events into typed Go values
+- buffers rows until a safe flush boundary
+- calls your `FlushFn` with typed rows and metadata
+- stores checkpoint state in a Vitess table that you own
+- resumes from the last successful checkpoint on restart
+
+The package is designed to be a practical base for building your own sink, not to decide where data goes after it leaves
+Vitess.
+
+**Overall Event Flow**
+
+```mermaid
+flowchart TD
+    A@{ shape: processes, label: "Table Configs" } --> B[VTGate VStream]
+    B --> S{Does stream exist<br/>in state table?}
+    S -->|Yes| T[Start from last VGtid]
+    S -->|No| U[Create state record<br/>and start copy phase]
+    T --> C[vstreamclient Run loop]
+    U --> C
+    C --> D[**Process Events**<br/>FIELD: cache schema<br/>ROW: buffer rows<br/>VGTID: checkpoint<br/><br>COMMIT: flush<br>DDL: flush<br>HEARTBEAT: flush<br/><br>BEGIN: ignore<br/>JOURNAL: ignore<br>VERSION: ignore<br>LASTPK: ignore<br>SAVEPOINT: ignore]
+
+    subgraph HOOKS[Optional EventFunc hooks]
+        H[Run before built-in handling]
+        I{Hook returned error?}
+        H --> I
+    end
+	D --> H
+
+    I -->|Yes| J[Run returns error]
+    I -->|No| C
+
+    C --> K[**GracefulShutdown**]
+    K --> L[Wait for flush boundary or timeout]
+
+    J --> Z[Program exit / restart]
+    L --> Z
+
+    classDef source fill:#e8f1ff,stroke:#4a78c2,color:#16355f;
+    classDef event fill:#eef7ea,stroke:#5a8f4b,color:#1f4d1a;
+    classDef decision fill:#fff4db,stroke:#c28a2c,color:#6b4a00;
+    classDef stop fill:#fdeaea,stroke:#c24a4a,color:#6b1f1f;
+    classDef clean fill:#eef7ea,stroke:#5a8f4b,color:#1f4d1a;
+    class A,B source;
+    class S decision;
+    class T,U clean;
+    class D,H event;
+    class I decision;
+    class J,Z stop;
+    class K,L clean;
+    style HOOKS stroke-dasharray: 5 5
+    style HOOKS fill:#e8f1ff,stroke:#4a78c2,color:#16355f
+```
+
+**Detailed Row Event Flow**
+
+```mermaid
+flowchart TD
+    A[ROW event arrives] --> B[Lookup table by keyspace.table name]
+    B --> C[Decode row into configured Go type]
+    C --> D[Append row to that table's in-memory batch]
+    D --> E{***Flush conditions met?***<br/>- Safe event boundary<br/>- MinDuration elapsed<br/>- MaxRowsPerFlush reached<br/>- GracefulShutdown waiting}
+    E -->|Yes| G[FlushFn]
+    E -->|No| F[Keep buffering rows]
+    G --> H[Downstream sink<br/>warehouse / GCS / object storage / custom target]
+    H --> I{FlushFn succeeded?}
+    I -->|No| J[Run returns error<br/>restart resumes from last checkpoint]
+    I -->|Yes| K[Persist latest VGtid in state table]
+    F --> A
+    K --> A
+    J --> M[Program exit / restart]
+
+    classDef event fill:#eef7ea,stroke:#5a8f4b,color:#1f4d1a;
+    classDef buffer fill:#e8f1ff,stroke:#4a78c2,color:#16355f;
+    classDef decision fill:#fff4db,stroke:#c28a2c,color:#6b4a00;
+    classDef sink fill:#f1ecff,stroke:#7b61c2,color:#35205f;
+    classDef stop fill:#fdeaea,stroke:#c24a4a,color:#6b1f1f;
+
+    class A,B,C,D,F event;
+    class E,I decision;
+    class G,K buffer;
+    class H sink;
+    class J,M stop;
+```
+
+## How It Works
+
+### 1. Configure tables
+
+You provide one or more `TableConfig` values. Each one tells the client:
+
+- which keyspace and table to stream
+- which query to use for copy/filtering
+- which Go type rows should be decoded into
+- which function should handle flushed rows
+
+If `Query` is empty, the default is:
+
+```sql
+select * from `<table>`
+```
+
+### 2. Configure state
+
+You must provide a state table with `WithStateTable(...)`.
+
+The state table:
+
+- must live in an unsharded keyspace
+- is created automatically if needed
+- stores:
+    - stream name
+    - latest VGtid
+    - stored table configuration
+    - whether the initial copy phase completed
+
+### 3. Run the stream
+
+`Run(ctx)` reads events until the context is canceled, the remote stream ends, or an error occurs.
+Each `VStreamClient` is single-use: after any `Run(...)` call returns, create a new client for the next attempt.
+
+`Run(ctx)` returns an error when:
+
+- `Run()` is called on a client that was already used by a previous `Run(...)` attempt
+- the VStream transport fails or ends unexpectedly
+- the context is canceled or times out while the stream is still active
+- an event hook returns an error
+- table lookup or row decoding fails
+- `FlushFn` returns an error
+- updating checkpoint state in the state table fails
+
+The client processes:
+
+- `FIELD` events to learn schema
+- `ROW` events to decode data
+- `VGTID` events to track checkpoint position
+- `COMMIT`, `DDL`, and `HEARTBEAT` events as safe flush boundaries
+
+If you register hooks with `WithEventFunc(...)`, they run inside this same event loop before the built-in handling for
+that event type. That means:
+
+- a `FIELD` hook runs before schema metadata is cached for that table
+- a `ROW` hook runs before the row is decoded and added to a batch
+- a `VGTID` hook runs before the candidate checkpoint is updated
+- a `COMMIT`, `DDL`, or `HEARTBEAT` hook runs before the built-in flush logic for that event
+
+Because hooks run inline in the main loop, they should stay lightweight. Slow hooks directly delay stream progress,
+batch flushing, and checkpoint advancement.
+
+### 4. Flush buffered rows
+
+Rows are buffered per table and flushed via your `FlushFn`.
+
+Flushes happen when:
+
+- `minFlushDuration` has elapsed and a safe boundary is reached
+- a table reaches `MaxRowsPerFlush`
+- `GracefulShutdown(...)` waits for the next safe boundary during shutdown
+
+### 5. Persist checkpoints
+
+After a successful flush, the client stores the latest VGtid. If your `FlushFn` returns an error, the checkpoint is not
+advanced.
+
+That means restart behavior is tied to successful flushes, not just received events.
+
+## Quick Start
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"time"
+
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+	"vitess.io/vitess/go/vt/vstreamclient"
+)
+
+type Customer struct {
+	ID    int64  `vstream:"id"`
+	Email string `vstream:"email"`
+}
+
+func run(ctx context.Context, conn *vtgateconn.VTGateConn) error {
+	client, err := vstreamclient.New(ctx, "customer-sync", conn, []vstreamclient.TableConfig{{
+		Keyspace: "customer",
+		Table:    "customer",
+		DataType: &Customer{},
+		FlushFn: func(ctx context.Context, rows []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
+			for _, row := range rows {
+				customer := row.Data.(*Customer)
+				_ = customer
+			}
+			return nil
+		},
+	}},
+		vstreamclient.WithStateTable("commerce", "vstreams"),
+		vstreamclient.WithMinFlushDuration(5*time.Second),
+		vstreamclient.WithHeartbeatSeconds(1),
+		vstreamclient.WithGracefulShutdownSignals(10*time.Second, os.Interrupt, syscall.SIGTERM),
+	)
+	if err != nil {
+		return err
+	}
+
+	return client.Run(ctx)
+}
+```
+
+## Important Types
+
+### `TableConfig`
+
+Important fields:
+
+- `Keyspace`, `Table`: identify the table being streamed
+- `Query`: the VStream rule filter used for copy and row selection
+- `DataType`: the Go type rows should decode into
+- `FlushFn`: called with buffered rows
+- `MaxRowsPerFlush`: limits batch size and can force flushing
+- `ReuseBatchSlice`: reuses the batch slice backing array across flushes
+- `ErrorOnUnknownFields`: fails if stream fields do not map to your struct
+
+> [!NOTE]
+> `MaxRowsPerFlush` and `WithMinFlushDuration(...)` are workload-tuning knobs, not just convenience settings.
+>
+> `MaxRowsPerFlush` means up to that many rows can stay buffered in memory until a flush runs, so make sure the process 
+> has enough memory for the table shape and batch size you choose. It can also help to align this number with the 
+> destination system. For example, if you are loading into an OLAP database, you may want batches that produce files 
+> near the destination's preferred size for load performance.
+>
+> A larger `WithMinFlushDuration(...)` trades freshness for the throughput gains of larger batches. A smaller 
+> `WithMinFlushDuration(...)` reduces the blast radius of a failure, because a flush error means the stream restarts 
+> from the last checkpoint.
+
+### `Row`
+
+Each flushed row includes:
+
+- the raw `RowEvent`
+- the specific `RowChange`
+- the decoded `Data`
+
+For insert/update/delete handling, inspect `RowChange`:
+
+- insert: `Before == nil`
+- delete: `After == nil`
+- update: both are present
+
+Delete rows still include decoded `Data`, built from the `Before` image.
+
+### `FlushMeta`
+
+Each flush also includes metadata:
+
+- `Keyspace`
+- `Table`
+- per-table stats
+- stream-wide stats
+- latest VGtid at the flush boundary
+- `FlushReason`, which tells you whether the flush ran because of forced copy completion, min duration, max rows, or graceful shutdown
+
+## Struct Mapping
+
+By default, rows are decoded into structs using reflection.
+
+Field matching uses this order:
+
+1. `vstream` tag
+2. `db` tag
+3. `json` tag
+4. Go field name
+
+Example:
+
+```go
+type Customer struct {
+	ID       int64   `vstream:"id"`
+	Email    string  `db:"email"`
+	Nickname *string `json:"nickname"`
+}
+```
+
+Additional mapping behavior:
+
+- `vstream:"-"` ignores a field
+- pointer fields are supported for nullable columns
+- `vstream:"field_name,json"` enables JSON decoding into that field
+
+Example:
+
+```go
+type Payload struct {
+	Source string `json:"source"`
+}
+
+type EventRow struct {
+	ID      int64    `vstream:"id"`
+	Payload *Payload `vstream:"payload,json"`
+}
+```
+
+## Custom Scanning
+
+If reflection is not enough, implement `VStreamScanner`:
+
+```go
+type Customer struct {
+	ID    int64
+	Email string
+}
+
+func (c *Customer) VStreamScan(fields []*querypb.Field, row []sqltypes.Value, rowEvent *binlogdatapb.RowEvent, rowChange *binlogdatapb.RowChange) error {
+	// custom decoding here
+	return nil
+}
+```
+
+If `DataType` implements `VStreamScanner`, that logic is used instead of reflection.
+
+For more complex rows, `VStreamScan` lets you handle custom parsing, nullable fields,
+and event-specific behavior in one place.
+
+Example:
+
+```go
+type OrderStatus string
+
+const (
+	OrderStatusPending OrderStatus = "pending"
+	OrderStatusPaid    OrderStatus = "paid"
+)
+
+type OrderMetadata struct {
+	Source string `json:"source"`
+	Note   string `json:"note"`
+}
+
+type Order struct {
+	ID         int64
+	CustomerID int64
+	Status     OrderStatus
+	Metadata   *OrderMetadata
+	Deleted    bool
+}
+
+func (o *Order) VStreamScan(fields []*querypb.Field, row []sqltypes.Value, _ *binlogdatapb.RowEvent, rowChange *binlogdatapb.RowChange) error {
+	for i, field := range fields {
+		value := row[i]
+
+		switch field.Name {
+		case "id":
+			id, err := value.ToInt64()
+			if err != nil {
+				return fmt.Errorf("scan id: %w", err)
+			}
+			o.ID = id
+
+		case "customer_id":
+			customerID, err := value.ToInt64()
+			if err != nil {
+				return fmt.Errorf("scan customer_id: %w", err)
+			}
+			o.CustomerID = customerID
+
+		case "status":
+			o.Status = OrderStatus(value.ToString())
+
+		case "metadata":
+			if value.IsNull() {
+				o.Metadata = nil
+				continue
+			}
+
+			b, err := value.ToBytes()
+ 			if err != nil {
+ 				return fmt.Errorf("scan metadata: %w", err)
+ 			}
+
+			metadata := &OrderMetadata{}
+			if err := json.Unmarshal(b, metadata); err != nil {
+				return fmt.Errorf("scan metadata: %w", err)
+			}
+			o.Metadata = metadata
+		}
+	}
+
+	// delete events use the Before image, so this is a convenient place to tag them.
+	o.Deleted = rowChange.After == nil
+	return nil
+}
+```
+
+This approach is useful when:
+
+- column names need custom mapping logic
+- values need validation or conversion into enums or domain types
+- JSON/blob columns need bespoke decoding
+- delete events need special handling beyond the default struct mapping
+
+## Common Usage Patterns
+
+### Single-table consumer
+
+Use one `TableConfig` with a typed `FlushFn`. This is the simplest CDC pipeline shape.
+
+### Multi-table consumer
+
+You can stream multiple tables in one client by passing multiple `TableConfig` entries. Each table keeps its own buffer
+and stats, but checkpointing is coordinated at the stream level.
+
+### BigQuery via GCS
+
+One common pattern is:
+
+- convert each flushed row into newline-delimited JSON
+- write the batch to GCS
+- start a BigQuery load job from that object
+
+Example:
+
+```go
+type Customer struct {
+	ID    int64  `json:"id"`
+	Email string `json:"email"`
+}
+
+
+func makeBigQueryFlushFn(gcsClient *storage.Client, bqClient *bigquery.Client, bucketName string) vstreamclient.FlushFunc {
+	return func(ctx context.Context, rows []vstreamclient.Row, meta vstreamclient.FlushMeta) error {
+		objectName := fmt.Sprintf(
+			"vstream/%s/%s/%s/%d.jsonl",
+			meta.Keyspace,
+			meta.Table,
+			meta.LatestVGtid.ShardGtids[0].Gtid,
+			time.Now().UnixNano(),
+		)
+
+		bucket := gcsClient.Bucket(bucketName)
+		writer := bucket.Object(objectName).NewWriter(ctx)
+		writer.ContentType = "application/x-ndjson"
+
+		encoder := json.NewEncoder(writer)
+		for _, row := range rows {
+			customer := row.Data.(*Customer)
+			payload := map[string]any{
+				"id":         customer.ID,
+				"email":      customer.Email,
+				"deleted":    row.RowChange.After == nil,
+				"keyspace":   meta.Keyspace,
+				"table":      meta.Table,
+				"vgtid":      meta.LatestVGtid.String(),
+				"flushed_at": time.Now().UTC().Format(time.RFC3339Nano),
+			}
+
+			if err := encoder.Encode(payload); err != nil {
+				_ = writer.Close()
+				return fmt.Errorf("encode json row: %w", err)
+			}
+		}
+
+		if err := writer.Close(); err != nil {
+			return fmt.Errorf("upload batch to gcs: %w", err)
+		}
+
+		gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/%s", bucketName, objectName))
+		gcsRef.SourceFormat = bigquery.JSON
+
+		loader := bqClient.Dataset("analytics").Table("customers_raw").LoaderFrom(gcsRef)
+		loader.WriteDisposition = bigquery.WriteAppend
+
+		job, err := loader.Run(ctx)
+		if err != nil {
+			return fmt.Errorf("start bigquery load job: %w", err)
+		}
+
+		// This waits synchronously so the flush is only considered successful after
+		// BigQuery accepts the load. You do not have to wait here; many pipelines
+		// increase throughput by enqueueing the job and waiting elsewhere.
+		status, err := job.Wait(ctx)
+		if err != nil {
+			return fmt.Errorf("wait for bigquery load job: %w", err)
+		}
+		if err := status.Err(); err != nil {
+			return fmt.Errorf("bigquery load job failed: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func newCustomerSink(ctx context.Context, conn *vtgateconn.VTGateConn, gcsClient *storage.Client, bqClient *bigquery.Client, bucketName string) (*vstreamclient.VStreamClient, error) {
+	tableConfig := vstreamclient.TableConfig{
+		Keyspace:        "customer",
+		Table:           "customer",
+		MaxRowsPerFlush: 1000,
+		DataType:        &Customer{},
+		FlushFn:         makeBigQueryFlushFn(gcsClient, bqClient, bucketName),
+	}
+
+	return vstreamclient.New(ctx, "customer-bigquery-sync", conn, []vstreamclient.TableConfig{tableConfig},
+		vstreamclient.WithStateTable("commerce", "vstreams"),
+		// A longer flush window trades freshness for fewer load jobs. That can be a
+		// good fit for BigQuery because load jobs have a daily quota.
+		vstreamclient.WithMinFlushDuration(5*time.Minute),
+		vstreamclient.WithHeartbeatSeconds(1),
+	)
+}
+```
+
+Things to keep in mind with this pattern:
+
+- if `FlushFn` returns an error, the checkpoint is not advanced and the same rows will be replayed
+- the load path should therefore be idempotent, or at least deduplicatable downstream
+- waiting synchronously gives simpler correctness semantics, but lower throughput
+- a longer `WithMinFlushDuration(...)` reduces load-job frequency, which helps with BigQuery's per-day load-job quota, but it also makes the data less real-time
+- uploading to GCS and handing load-job execution to a worker queue often scales better
+
+### Same table name across keyspaces
+
+This package supports same-named tables across keyspaces.
+
+By default, it keeps keyspace-qualified table names from VTGate:
+
+- `customer.customer`
+- `accounting.customer`
+
+That is the default for a reason: it avoids ambiguity.
+
+### Event hooks
+
+Use `WithEventFunc(...)` to intercept specific event types before normal handling.
+
+Hooks run synchronously in the main `Run()` loop, one event at a time. They are best suited for:
+
+- metrics and logging
+- tracing or debugging event order
+- lightweight validation or guardrails
+- small pieces of event-specific side logic
+
+They are usually a poor fit for:
+
+- long-running network calls
+- heavy transformation work
+- expensive synchronous writes to external systems
+- anything that should happen after a flush boundary instead of before it
+
+Example uses:
+
+- logging `FIELD` or `DDL` events
+- metrics
+- debugging event order
+- aborting on a specific event
+
+If an event hook returns an error, `Run()` stops immediately and the default handling for that event does not run.
+For example, if a `ROW` hook returns an error, that row is not decoded or buffered, and if a `COMMIT` hook returns an
+error, the normal flush path for that commit does not run.
+
+### Starting from a specific VGtid
+
+Use `WithStartingVGtid(...)` to override any stored checkpoint and begin from a caller-supplied position.
+
+This is useful for:
+
+- replay
+- recovery
+- controlled backfills
+
+## Things To Watch Out For
+
+### `Run()` cannot be reused
+
+Do not call `Run()` on the same client instance more than once.
+
+Whether `Run(...)` exits because of `GracefulShutdown(...)`, context cancellation, a transport error, or any other
+stream failure, create a new client before trying again.
+
+### Use `GracefulShutdown()` to stop safely
+
+`GracefulShutdown(wait)` asks an active `Run()` call to stop after the next safe flush boundary. If no safe boundary
+arrives before `wait` expires, the client stops and buffered rows are replayed on the next startup.
+
+Recommended pattern:
+
+If you already want to shut down on OS signals, the client can manage that goroutine for you:
+
+```go
+client, err := vstreamclient.New(ctx, "customer-sync", conn, tables,
+	vstreamclient.WithStateTable("commerce", "vstreams"),
+	vstreamclient.WithGracefulShutdownSignals(10*time.Second, os.Interrupt, syscall.SIGTERM),
+)
+if err != nil {
+	return err
+}
+
+return client.Run(ctx)
+```
+
+This pattern is convenient when your application already shuts down on OS signals. In general, keep the `Run(...)`
+context separate from the shutdown signal source so the stream can finish its graceful shutdown path instead
+of being canceled immediately.
+
+### `FlushFn` errors stop the stream
+
+If `FlushFn` returns an error:
+
+- `Run()` returns that error
+- checkpoint state is not advanced
+- the next run resumes from the last successful flush
+
+This is important for correctness, but it means your flush logic should be explicit about retry behavior.
+
+### Event hook errors also stop the stream
+
+`WithEventFunc(...)` is not fire-and-forget. Returning an error aborts the stream before normal processing for that
+event.
+
+### State table must be unsharded
+
+`WithStateTable(...)` requires an unsharded keyspace. This package intentionally stores its state in a user-owned Vitess
+table rather than in `_vt`.
+
+### Table configuration is part of state
+
+The client stores a simplified version of your table config in the state table and validates it on restart.
+
+That means changing things like:
+
+- keyspace
+- table
+- query
+
+for an existing stream name will fail fast instead of silently drifting.
+
+### Copy interruption restarts from the beginning
+
+If the initial copy phase starts but does not reach the final aggregate `COPY_COMPLETED`, the next startup restarts the
+copy phase from the beginning.
+
+This is intentional. Resuming from a partial copy is unsafe.
+
+### `MaxRowsPerFlush` is not an exact upstream batch size
+
+`MaxRowsPerFlush` is a client-side buffering and chunking control. It does not tell Vitess to send exactly that many
+rows at a time.
+
+During the copy phase in particular, Vitess batches rows primarily by packet byte size, not by a fixed row count. That
+means an incoming packet can push the in-memory batch past your configured `MaxRowsPerFlush` before `vstreamclient`
+reaches the next flush decision point.
+
+In practice, this means:
+
+- do not expect source-side copy batches to arrive in exact `MaxRowsPerFlush` increments
+- do not assume the first flush trigger happens at exactly row `N`
+- do expect `vstreamclient` to cap individual `FlushFn` calls to chunks of at most `MaxRowsPerFlush` rows once a flush runs
+
+So `MaxRowsPerFlush` is best treated as an upper bound for downstream flush chunking and a heuristic for when the client
+should flush, not as an exact statement about how many rows Vitess will deliver per packet or per copy-phase batch.
+
+### Schema drift can be strict or tolerant
+
+By default, the package is tolerant enough for many schema changes.
+
+If you set `ErrorOnUnknownFields: true`, the stream fails when a streamed field does not map to your struct. That is
+useful for strict consumers, but it means schema changes must be coordinated carefully.
+
+### `binlog_row_image` changes what row data is present
+
+For row events coming from MySQL binlog replication, `binlog_row_image` affects how complete the row images are.
+
+| `binlog_row_image` | What to expect | Tradeoff |
+| --- | --- | --- |
+| `FULL` | You can generally expect the row image to be fully populated. | Easiest to reason about, but uses more binlog bandwidth and more memory in the stream consumer. |
+| `NOBLOB` | Large blob/text-style fields may be omitted from row images. | Reduces memory and event size, but if your sink assumes those fields are always present, you can accidentally write `NULL` or otherwise clear data you expected to keep. |
+| `MINIMAL` | Only the fields needed for the row event may be present. | Smallest row images, but you should not assume you received a full record. If you need to flesh out missing data, a common pattern is to fetch the extra metadata inside `FlushFn` using the primary key from the event. |
+
+If your downstream system expects each flushed row to be a complete current record, `FULL` is the safest default.
+If you optimize for lower memory or network usage with `NOBLOB` or `MINIMAL`, make sure your `FlushFn` treats missing
+fields as "not provided by the binlog image" rather than "the value should be cleared."
+
+### `ReuseBatchSlice` changes ownership expectations
+
+If `ReuseBatchSlice` is `true`, the backing array for the batch may be reused on later flushes.
+
+That reduces allocations, but it means:
+
+- you must copy anything you want to keep after `FlushFn` returns
+- you should not retain the batch slice itself for later use
+
+### Bare table names are opt-in and can be dangerous
+
+If you explicitly set:
+
+```go
+WithFlags(&vtgatepb.VStreamFlags{
+	HeartbeatInterval:           1,
+	ExcludeKeyspaceFromTableName: true,
+})
+```
+
+then VTGate emits bare table names instead of `keyspace.table`.
+
+That is only safe when table names are unique across the streamed keyspaces. If multiple keyspaces stream the same table
+name, the client will fail with an ambiguity error rather than guess.
+
+## Recommended Patterns
+
+- use one stable stream name per consumer pipeline
+- store state in a dedicated unsharded keyspace/table
+- keep `Query` as narrow as you reasonably can
+- use typed structs rather than manual row decoding when possible
+- copy data inside `FlushFn` if you use `ReuseBatchSlice`
+- treat `FlushFn` as the durability boundary for your downstream system
+- use event hooks for logging and metrics, not heavy business logic
+
+## Limitations And Current Scope
+
+This package intentionally does not try to solve everything.
+
+Current limitations and design choices include:
+
+- state is stored in Vitess, not an external coordinator
+- checkpointing is stream-level, not per-table
+- no built-in retry or backoff framework for flush failures
+- no built-in destination connector implementations
+- no special handling for resharding beyond what normal VStream already provides
+- `FlushInTx` exists in `TableConfig`, but a SQL transaction is not currently exposed to `FlushFn`
+
+## Testing And Examples
+
+The best examples today are in the tests:
+
+- package-level tests in `go/vt/vstreamclient/`
+- end-to-end coverage in `go/test/endtoend/vstreamclient/`
+
+Those tests cover:
+
+- inserts, updates, and deletes
+- checkpoint resume behavior
+- copy interruption handling
+- same table names across keyspaces
+- multiple tables in one stream
+- heartbeat flushing
+- strict schema drift failures
+- custom table-name flags
+
+## When To Use This Package
+
+Use `vstreamclient` when:
+
+- you want a Go-native way to consume VStream
+- you want typed row decoding
+- you need a reference implementation that already handles common edge cases
+- you are building a custom CDC/export pipeline and do not want a full external CDC stack
+
+It may not be the right fit when:
+
+- you need a full managed CDC ecosystem with connectors, schemas, and queues built in
+- you want a cross-language platform instead of a Go library
+- you need a completely unopinionated raw VStream consumer

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -239,6 +239,10 @@ advanced.
 
 That means restart behavior is tied to successful flushes, not just received events.
 
+The delivery contract at this boundary is at-least-once, not exactly-once. `FlushFn` runs before checkpoint
+persistence, so if your sink write succeeds but the checkpoint write fails, those same rows can be replayed on the next
+startup.
+
 ## Quick Start
 
 ```go
@@ -591,6 +595,7 @@ func newCustomerSink(ctx context.Context, conn *vtgateconn.VTGateConn, gcsClient
 
 Things to keep in mind with this pattern:
 
+- `vstreamclient` is at-least-once at the flush/checkpoint boundary, so replay is possible after sink success
 - if `FlushFn` returns an error, the checkpoint is not advanced and the same rows will be replayed
 - the load path should therefore be idempotent, or at least deduplicatable downstream
 - waiting synchronously gives simpler correctness semantics, but lower throughput
@@ -688,6 +693,9 @@ If `FlushFn` returns an error:
 - `Run()` returns that error
 - checkpoint state is not advanced
 - the next run resumes from the last successful flush
+
+Even if `FlushFn` succeeds, a later checkpoint write can still fail. In that case the same flushed rows may be replayed
+on restart, so downstream consumers should be idempotent or able to deduplicate.
 
 This is important for correctness, but it means your flush logic should be explicit about retry behavior.
 

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -364,6 +364,8 @@ Additional mapping behavior:
 - `vstream:"-"` ignores a field
 - pointer fields are supported for nullable columns
 - `vstream:"field_name,json"` enables JSON decoding into that field
+- default struct decoding requires full row images and non-partial JSON values
+- if Vitess sets `RowChange.DataColumns` or `RowChange.JsonPartialValues`, `Run()` fails fast unless your `DataType` implements `VStreamScanner`
 
 Example:
 
@@ -474,6 +476,7 @@ This approach is useful when:
 - column names need custom mapping logic
 - values need validation or conversion into enums or domain types
 - JSON/blob columns need bespoke decoding
+- partial row images or partial JSON updates need bitmap-aware handling
 - delete events need special handling beyond the default struct mapping
 
 ## Common Usage Patterns
@@ -755,6 +758,15 @@ For row events coming from MySQL binlog replication, `binlog_row_image` affects 
 If your downstream system expects each flushed row to be a complete current record, `FULL` is the safest default.
 If you optimize for lower memory or network usage with `NOBLOB` or `MINIMAL`, make sure your `FlushFn` treats missing
 fields as "not provided by the binlog image" rather than "the value should be cleared."
+
+For the default reflection-based decoder, `vstreamclient` now fails fast when Vitess explicitly marks a row as partial:
+
+- `RowChange.DataColumns != nil`
+- `RowChange.JsonPartialValues != nil`
+
+That behavior is intentional. Without bitmap-aware decoding, omitted columns can be misread as real `NULL` or empty
+values. If you need to consume partial row images or partial JSON updates, implement `VStreamScanner` and handle the
+bitmaps directly from `rowChange`.
 
 ### `ReuseBatchSlice` changes ownership expectations
 

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -837,7 +837,7 @@ Current limitations and design choices include:
 - no built-in retry or backoff framework for flush failures
 - no built-in destination connector implementations
 - no special handling for resharding beyond what normal VStream already provides
-- `FlushInTx` exists in `TableConfig`, but a SQL transaction is not currently exposed to `FlushFn`
+- no SQL transaction is exposed to `FlushFn`; transactional sink behavior is the consumer's responsibility
 
 ## Testing And Examples
 

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -188,6 +188,8 @@ The state table:
     - latest VGtid
     - stored table configuration
     - whether the initial copy phase completed
+    - the owner token of the most recent client instance, used to fence out older clients running
+      with the same stream name
 
 ### 3. Run the stream
 
@@ -708,6 +710,19 @@ event.
 
 `WithStateTable(...)` requires an unsharded keyspace. This package intentionally stores its state in a user-owned Vitess
 table rather than in `_vt`.
+
+### Run only one client per stream name
+
+Two clients running with the same stream name would interleave checkpoint writes, so the checkpoint could move
+backwards and cause large replays. To prevent that, `New(...)` claims ownership of the state row with a unique owner
+token, and every checkpoint write requires the token to still match.
+
+The newest client wins: when a new client starts (for example during a rolling deploy), the previous client's next
+checkpoint write fails and its `Run(...)` returns an error wrapping `ErrFenced`, which you can match with `errors.Is`.
+Rows the fenced client flushed after the newer client read its starting checkpoint may be replayed by the newer
+client — the usual at-least-once contract applies.
+
+If you want multiple concurrent consumers, use a distinct stream name for each.
 
 ### Table configuration is part of state
 

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -484,7 +484,7 @@ This approach is useful when:
 - column names need custom mapping logic
 - values need validation or conversion into enums or domain types
 - JSON/blob columns need bespoke decoding
-- partial row images or partial JSON updates need bitmap-aware handling
+- partial after-images or partial JSON updates need bitmap-aware handling
 - delete events need special handling beyond the default struct mapping
 
 ## Common Usage Patterns
@@ -664,6 +664,10 @@ error, the normal flush path for that commit does not run.
 
 Use `WithStartingVGtid(...)` to override any stored checkpoint and begin from a caller-supplied position.
 
+Every configured source shard must have exactly one concrete, parseable GTID, using the serving partition for the
+configured tablet type (REPLICA by default). Empty positions, `current`, foreign shards, and `TablePKs` copy cursors
+are rejected before any state row is changed. To start a fresh copy, omit this option.
+
 This is useful for:
 
 - replay
@@ -683,6 +687,14 @@ stream failure, create a new client before trying again.
 
 `GracefulShutdown(wait)` asks an active `Run()` call to stop after the next safe flush boundary. If no safe boundary
 arrives before `wait` expires, the client stops and buffered rows are replayed on the next startup.
+
+Liveness failures (`ErrHeartbeatTimeout` and `ErrStartupTimeout`) cancel the stream immediately without waiting for
+the graceful shutdown window. Any work after the last successful checkpoint is replayed on restart.
+
+The liveness window is `HeartbeatInterval × DefaultHeartbeatTimeoutMultiplier`: by default, one-second heartbeats
+and a multiplier of ten allow ten seconds of silence. Set the package default before constructing clients if your
+environment needs a different tolerance. `WithHeartbeatSeconds(...)` overrides the heartbeat interval supplied by
+`WithFlags(...)` in either option order; it does not override other flags.
 
 Recommended pattern:
 
@@ -727,16 +739,28 @@ event.
 `WithStateTable(...)` requires an unsharded keyspace. This package intentionally stores its state in a user-owned Vitess
 table rather than in `_vt`.
 
+The keyspace must report `sharded=false` in `SHOW VSCHEMA KEYSPACES`; if that metadata cannot be read, construction
+fails. The state keyspace does not need replicas just because the source stream uses REPLICA tablets.
+
+Every `New(...)` call executes `CREATE TABLE IF NOT EXISTS` for the state table, including when it already exists.
+The consumer's account must be permitted to execute that DDL as well as read and write checkpoints. Automatic
+creation is currently mandatory; provisioning the table separately does not suppress the startup DDL.
+
 ### Run only one client per stream name
 
 Two clients running with the same stream name would interleave checkpoint writes, so the checkpoint could move
-backwards and cause large replays. To prevent that, `New(...)` claims ownership of the state row with a unique owner
-token, and every checkpoint write requires the token to still match.
+backwards and cause large replays. To prevent that, `Run(...)` claims ownership of the state row with a unique owner
+token after opening its VStream, and every checkpoint write requires the token to still match. `New(...)` prepares
+the takeover without claiming the row, so an abandoned constructor or failed stream setup does not fence a running
+consumer.
 
 The newest client wins: when a new client starts (for example during a rolling deploy), the previous client's next
 checkpoint write fails and its `Run(...)` returns an error wrapping `ErrFenced`, which you can match with `errors.Is`.
-Rows the fenced client flushed after the newer client read its starting checkpoint may be replayed by the newer
-client — the usual at-least-once contract applies.
+Ownership is checked when writing the checkpoint, after `FlushFn` returns. Until that check, both processes can
+write to the sink concurrently. `WithMinFlushDuration(...)` is not a hard upper bound on this overlap: a long
+transaction or slow flush can extend it. An older row image can arrive after a newer one, so idempotency alone
+does not guarantee correct ordering. Serialize consumer handoffs externally, or use sink-enforced fencing or
+source-version checks that reject stale writes. State-row fencing protects the checkpoint, not the sink.
 
 If you want multiple concurrent consumers, use a distinct stream name for each.
 
@@ -791,8 +815,8 @@ For row events coming from MySQL binlog replication, `binlog_row_image` affects 
 | `binlog_row_image` | What to expect | Tradeoff |
 | --- | --- | --- |
 | `FULL` | You can generally expect the row image to be fully populated. | Easiest to reason about, but uses more binlog bandwidth and more memory in the stream consumer. |
-| `NOBLOB` | Large blob/text-style fields may be omitted from row images. | Reduces memory and event size, but if your sink assumes those fields are always present, you can accidentally write `NULL` or otherwise clear data you expected to keep. |
-| `MINIMAL` | Only the fields needed for the row event may be present. | Smallest row images, but you should not assume you received a full record. If you need to flesh out missing data, a common pattern is to fetch the extra metadata inside `FlushFn` using the primary key from the event. |
+| `NOBLOB` | Large blob/text-style fields may be omitted from row images. | Unsupported: omitted delete values cannot be distinguished from SQL `NULL`. |
+| `MINIMAL` | Only the fields needed for the row event may be present. | Unsupported: neither a scanner nor a later query can reconstruct omitted delete values reliably. |
 
 This client requires `FULL`. `New(...)` probes `@@global.binlog_row_image` on every source shard and fails unless it
 reports `FULL`; an unverifiable shard also fails, since it could silently be running `NOBLOB`. The check can be

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -608,7 +608,21 @@ Things to keep in mind with this pattern:
 
 ### Same table name across keyspaces
 
-This package supports same-named tables across keyspaces.
+This package supports same-named tables across keyspaces, with one important restriction: when
+streaming more than one keyspace, every keyspace must be configured with the **identical set of
+(table, query) pairs**. A single vstream filter is forwarded to every keyspace in the stream, so a
+configuration like `{ks1.foo, ks2.bar}` would apply both rules in both keyspaces — the copy phase
+can fail on tables that don't exist there, and same-named foreign tables would stream unwanted
+rows. `New(...)` rejects heterogeneous configurations; use a separate client per keyspace instead.
+
+For example, this is supported because both keyspaces use the same table and query:
+
+```go
+[]vstreamclient.TableConfig{
+    {Keyspace: "customer", Table: "customer", Query: "select * from customer", ...},
+    {Keyspace: "accounting", Table: "customer", Query: "select * from customer", ...},
+}
+```
 
 By default, it keeps keyspace-qualified table names from VTGate:
 

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -93,7 +93,7 @@ flowchart TD
     S -->|No| U[Create state record<br/>and start copy phase]
     T --> C[vstreamclient Run loop]
     U --> C
-    C --> D[**Process Events**<br/>FIELD: cache schema<br/>ROW: buffer rows<br/>VGTID: checkpoint<br/><br>COMMIT: flush<br>DDL: flush<br>HEARTBEAT: flush if not in a transaction<br/><br>BEGIN: track transaction<br/>ROLLBACK: end transaction<br/>JOURNAL: ignore<br>VERSION: ignore<br>LASTPK: ignore<br>SAVEPOINT: ignore]
+    C --> D[**Process Events**<br/>FIELD: cache schema<br/>ROW: buffer rows<br/>VGTID: checkpoint<br/><br>COMMIT: flush<br>DDL: flush<br>HEARTBEAT: flush if not in a transaction<br/><br>BEGIN: track transaction<br/>ROLLBACK: end transaction and flush<br/>JOURNAL: ignore<br>VERSION: ignore<br>LASTPK: ignore<br>SAVEPOINT: ignore]
 
     subgraph HOOKS[Optional EventFunc hooks]
         H[Run before built-in handling]
@@ -750,9 +750,10 @@ creation is currently mandatory; provisioning the table separately does not supp
 
 Two clients running with the same stream name would interleave checkpoint writes, so the checkpoint could move
 backwards and cause large replays. To prevent that, `Run(...)` claims ownership of the state row with a unique owner
-token after opening its VStream, and every checkpoint write requires the token to still match. `New(...)` prepares
-the takeover without claiming the row, so an abandoned constructor or failed stream setup does not fence a running
-consumer.
+token after receiving the first successful VStream response, and every checkpoint write requires the token to
+still match. `New(...)` prepares the takeover without claiming the row, so an abandoned constructor, failed stream
+setup, or failure/timeout on the first receive does not fence a running consumer. The first batch is processed
+after the ownership claim succeeds.
 
 The newest client wins: when a new client starts (for example during a rolling deploy), the previous client's next
 checkpoint write fails and its `Run(...)` returns an error wrapping `ErrFenced`, which you can match with `errors.Is`.
@@ -818,8 +819,9 @@ For row events coming from MySQL binlog replication, `binlog_row_image` affects 
 | `NOBLOB` | Large blob/text-style fields may be omitted from row images. | Unsupported: omitted delete values cannot be distinguished from SQL `NULL`. |
 | `MINIMAL` | Only the fields needed for the row event may be present. | Unsupported: neither a scanner nor a later query can reconstruct omitted delete values reliably. |
 
-This client requires `FULL`. `New(...)` probes `@@global.binlog_row_image` on every source shard and fails unless it
-reports `FULL`; an unverifiable shard also fails, since it could silently be running `NOBLOB`. The check can be
+This client requires `FULL`. On every source shard, `New(...)` probes `@@global.binlog_row_image` on the primary
+and on the configured stream tablet type, and fails unless both report `FULL`. An unverifiable target also fails,
+since it could silently be running `NOBLOB`. The check can be
 bypassed with `WithSkipRowImageCheck()` when the probe cannot run (e.g. restricted permissions), but only do that if
 you have verified `FULL` out of band.
 
@@ -828,9 +830,11 @@ for before-images: under `NOBLOB` or `MINIMAL`, an omitted delete value is indis
 for both the default decoder and custom `VStreamScanner` implementations, so nullable fields get silently corrupted.
 There is no way to "handle it in `FlushFn`" — the information is simply not on the wire.
 
-Note the probe can only verify the *current* value on each shard. Replaying from an old position (stored state or an
-explicit starting VGtid) can deliver events written while a different row image was active, and writer sessions can
-override the global value. `FULL` must have been in effect for the entire retained replay range you intend to consume.
+The probes sample one tablet per target and only verify its *current* global value. Every tablet that may serve the
+stream must use `FULL`, including its replication applier sessions: replicas can omit delete values when re-logging
+events. Replaying from an old position (stored state or an explicit starting VGtid) can deliver events written while
+a different row image was active, and writer or replication sessions can retain or override the global value.
+`FULL` must have been in effect for the entire retained replay range you intend to consume.
 
 For after-images, the default reflection-based decoder fails fast when Vitess explicitly marks a row as partial:
 

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -780,18 +780,29 @@ For row events coming from MySQL binlog replication, `binlog_row_image` affects 
 | `NOBLOB` | Large blob/text-style fields may be omitted from row images. | Reduces memory and event size, but if your sink assumes those fields are always present, you can accidentally write `NULL` or otherwise clear data you expected to keep. |
 | `MINIMAL` | Only the fields needed for the row event may be present. | Smallest row images, but you should not assume you received a full record. If you need to flesh out missing data, a common pattern is to fetch the extra metadata inside `FlushFn` using the primary key from the event. |
 
-If your downstream system expects each flushed row to be a complete current record, `FULL` is the safest default.
-If you optimize for lower memory or network usage with `NOBLOB` or `MINIMAL`, make sure your `FlushFn` treats missing
-fields as "not provided by the binlog image" rather than "the value should be cleared."
+This client requires `FULL`. `New(...)` probes `@@global.binlog_row_image` on every source shard and fails unless it
+reports `FULL`; an unverifiable shard also fails, since it could silently be running `NOBLOB`. The check can be
+bypassed with `WithSkipRowImageCheck()` when the probe cannot run (e.g. restricted permissions), but only do that if
+you have verified `FULL` out of band.
 
-For the default reflection-based decoder, `vstreamclient` now fails fast when Vitess explicitly marks a row as partial:
+The hard requirement exists because delete events carry only a before-image, and the protocol has no presence bitmap
+for before-images: under `NOBLOB` or `MINIMAL`, an omitted delete value is indistinguishable from a real SQL `NULL`
+for both the default decoder and custom `VStreamScanner` implementations, so nullable fields get silently corrupted.
+There is no way to "handle it in `FlushFn`" — the information is simply not on the wire.
+
+Note the probe can only verify the *current* value on each shard. Replaying from an old position (stored state or an
+explicit starting VGtid) can deliver events written while a different row image was active, and writer sessions can
+override the global value. `FULL` must have been in effect for the entire retained replay range you intend to consume.
+
+For after-images, the default reflection-based decoder fails fast when Vitess explicitly marks a row as partial:
 
 - `RowChange.DataColumns != nil`
 - `RowChange.JsonPartialValues != nil`
 
 That behavior is intentional. Without bitmap-aware decoding, omitted columns can be misread as real `NULL` or empty
-values. If you need to consume partial row images or partial JSON updates, implement `VStreamScanner` and handle the
-bitmaps directly from `rowChange`.
+values. If you need to consume partial after-images or partial JSON updates, implement `VStreamScanner` and handle the
+bitmaps directly from `rowChange` — but note this only helps for after-images, which carry bitmaps; delete
+before-images do not.
 
 ### `ReuseBatchSlice` changes ownership expectations
 

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -93,7 +93,7 @@ flowchart TD
     S -->|No| U[Create state record<br/>and start copy phase]
     T --> C[vstreamclient Run loop]
     U --> C
-    C --> D[**Process Events**<br/>FIELD: cache schema<br/>ROW: buffer rows<br/>VGTID: checkpoint<br/><br>COMMIT: flush<br>DDL: flush<br>HEARTBEAT: flush<br/><br>BEGIN: ignore<br/>JOURNAL: ignore<br>VERSION: ignore<br>LASTPK: ignore<br>SAVEPOINT: ignore]
+    C --> D[**Process Events**<br/>FIELD: cache schema<br/>ROW: buffer rows<br/>VGTID: checkpoint<br/><br>COMMIT: flush<br>DDL: flush<br>HEARTBEAT: flush if not in a transaction<br/><br>BEGIN: track transaction<br/>ROLLBACK: end transaction<br/>JOURNAL: ignore<br>VERSION: ignore<br>LASTPK: ignore<br>SAVEPOINT: ignore]
 
     subgraph HOOKS[Optional EventFunc hooks]
         H[Run before built-in handling]
@@ -211,7 +211,9 @@ The client processes:
 - `FIELD` events to learn schema
 - `ROW` events to decode data
 - `VGTID` events to track checkpoint position
-- `COMMIT`, `DDL`, and `HEARTBEAT` events as safe flush boundaries
+- `COMMIT`, `OTHER`, and `DDL` events as safe flush boundaries, plus `HEARTBEAT` events when the
+  stream is not inside a transaction (with `TransactionChunkSize`, a heartbeat can arrive between
+  a transaction's chunks, and flushing there would split the transaction)
 
 If you register hooks with `WithEventFunc(...)`, they run inside this same event loop before the built-in handling for
 that event type. That means:

--- a/go/vt/vstreamclient/README.md
+++ b/go/vt/vstreamclient/README.md
@@ -695,6 +695,7 @@ The liveness window is `HeartbeatInterval × DefaultHeartbeatTimeoutMultiplier`:
 and a multiplier of ten allow ten seconds of silence. Set the package default before constructing clients if your
 environment needs a different tolerance. `WithHeartbeatSeconds(...)` overrides the heartbeat interval supplied by
 `WithFlags(...)` in either option order; it does not override other flags.
+`New(...)` rejects configurations whose interval times multiplier cannot fit in a positive `time.Duration`.
 
 Recommended pattern:
 

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -1,0 +1,84 @@
+package vstreamclient
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"vitess.io/vitess/go/sqltypes"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+// VStreamScanner allows for custom scan implementations
+type VStreamScanner interface {
+	VStreamScan(fields []*querypb.Field, row []sqltypes.Value, rowEvent *binlogdatapb.RowEvent, rowChange *binlogdatapb.RowChange) error
+}
+
+// copyRowToStruct builds a customer from a row event
+// TODO: this is very rudimentary mapping that only works for top-level fields
+func copyRowToStruct(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value) error {
+	for fieldName, m := range shard.fieldMap {
+		structField := reflect.Indirect(vPtr).FieldByIndex(m.structIndex)
+
+		switch m.kind {
+		case reflect.Bool:
+			rowVal, err := row[m.rowIndex].ToBool()
+			if err != nil {
+				return fmt.Errorf("error converting row value to bool for field %s: %w", fieldName, err)
+			}
+			structField.SetBool(rowVal)
+
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			rowVal, err := row[m.rowIndex].ToInt64()
+			if err != nil {
+				return fmt.Errorf("error converting row value to int64 for field %s: %w", fieldName, err)
+			}
+			structField.SetInt(rowVal)
+
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			rowVal, err := row[m.rowIndex].ToUint64()
+			if err != nil {
+				return fmt.Errorf("error converting row value to uint64 for field %s: %w", fieldName, err)
+			}
+			structField.SetUint(rowVal)
+
+		case reflect.Float32, reflect.Float64:
+			rowVal, err := row[m.rowIndex].ToFloat64()
+			if err != nil {
+				return fmt.Errorf("error converting row value to float64 for field %s: %w", fieldName, err)
+			}
+			structField.SetFloat(rowVal)
+
+		case reflect.String:
+			rowVal := row[m.rowIndex].ToString()
+			structField.SetString(rowVal)
+
+		case reflect.Struct:
+			switch m.structType.(type) {
+			case time.Time, *time.Time:
+				rowVal, err := row[m.rowIndex].ToTime()
+				if err != nil {
+					return fmt.Errorf("error converting row value to time.Time for field %s: %w", fieldName, err)
+				}
+				structField.Set(reflect.ValueOf(rowVal))
+			}
+
+		case reflect.Pointer,
+			reflect.Slice,
+			reflect.Array,
+			reflect.Invalid,
+			reflect.Uintptr,
+			reflect.Complex64,
+			reflect.Complex128,
+			reflect.Chan,
+			reflect.Func,
+			reflect.Interface,
+			reflect.Map,
+			reflect.UnsafePointer:
+			return fmt.Errorf("vstreamclient: unsupported field type: %s", m.kind.String())
+		}
+	}
+
+	return nil
+}

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -1,6 +1,9 @@
 package vstreamclient
 
 import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -16,9 +19,24 @@ type VStreamScanner interface {
 	VStreamScan(fields []*querypb.Field, row []sqltypes.Value, rowEvent *binlogdatapb.RowEvent, rowChange *binlogdatapb.RowChange) error
 }
 
-// copyRowToStruct builds a struct from a row event
-// TODO: this is very rudimentary mapping that only works for top-level fields
+var (
+	timeType              = reflect.TypeFor[time.Time]()
+	sqlScannerType        = reflect.TypeFor[sql.Scanner]()
+	textUnmarshalerType   = reflect.TypeFor[encoding.TextUnmarshaler]()
+	byteSliceElemKind     = reflect.Uint8
+	defaultDecodeLocation = time.UTC
+)
+
+// copyRowToStruct builds a struct from a row event.
 func copyRowToStruct(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value) error {
+	return copyRowToStructInLocation(shard, row, vPtr, defaultDecodeLocation)
+}
+
+func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value, loc *time.Location) error {
+	if loc == nil {
+		loc = defaultDecodeLocation
+	}
+
 	for fieldName, m := range shard.fieldMap {
 		structField := reflect.Indirect(vPtr).FieldByIndex(m.structIndex)
 
@@ -44,10 +62,22 @@ func copyRowToStruct(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value
 			if err != nil {
 				return fmt.Errorf("vstreamclient: error converting row value to bytes for field %s: %w", fieldName, err)
 			}
+			if isByteSliceType(structField.Type()) {
+				setByteSliceValue(structField, rowVal)
+				continue
+			}
 
 			if err = json.Unmarshal(rowVal, structField.Addr().Interface()); err != nil {
 				return fmt.Errorf("vstreamclient: error unmarshalling JSON for field %s: %w", fieldName, err)
 			}
+			continue
+		}
+
+		handled, err := tryScanSpecialField(structField, row[m.rowIndex], loc)
+		if err != nil {
+			return fmt.Errorf("vstreamclient: error converting row value for field %s: %w", fieldName, err)
+		}
+		if handled {
 			continue
 		}
 
@@ -110,11 +140,11 @@ func copyRowToStruct(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value
 
 		case reflect.Struct:
 			switch m.structType {
-			case reflect.TypeFor[time.Time]():
+			case timeType:
 				if row[m.rowIndex].IsNull() {
 					return fmt.Errorf("vstreamclient: error converting row value to time.Time for field %s: NULL into non-pointer field", fieldName)
 				}
-				rowVal, err := row[m.rowIndex].ToTime(time.UTC) // TODO: make timezone configurable
+				rowVal, err := row[m.rowIndex].ToTime(loc)
 				if err != nil {
 					return fmt.Errorf("vstreamclient: error converting row value to time.Time for field %s: %w", fieldName, err)
 				}
@@ -124,8 +154,20 @@ func copyRowToStruct(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value
 				return fmt.Errorf("vstreamclient: unsupported struct field type for field %s: %s", fieldName, m.structType.String())
 			}
 
+		case reflect.Slice:
+			if !isByteSliceType(m.structType) {
+				return fmt.Errorf("vstreamclient: unsupported field type: %s", m.kind.String())
+			}
+			if row[m.rowIndex].IsNull() {
+				return fmt.Errorf("vstreamclient: error converting row value to bytes for field %s: NULL into non-pointer field", fieldName)
+			}
+			rowVal, err := row[m.rowIndex].ToBytes()
+			if err != nil {
+				return fmt.Errorf("vstreamclient: error converting row value to bytes for field %s: %w", fieldName, err)
+			}
+			setByteSliceValue(structField, rowVal)
+
 		case reflect.Pointer,
-			reflect.Slice,
 			reflect.Array,
 			reflect.Invalid,
 			reflect.Uintptr,
@@ -141,4 +183,81 @@ func copyRowToStruct(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value
 	}
 
 	return nil
+}
+
+func tryScanSpecialField(structField reflect.Value, rowValue sqltypes.Value, loc *time.Location) (bool, error) {
+	if structField.Type() == timeType {
+		return false, nil
+	}
+
+	if structField.CanAddr() {
+		if structField.Addr().Type().Implements(sqlScannerType) {
+			scanner := structField.Addr().Interface().(sql.Scanner)
+			driverValue, err := sqlValueToDriverValue(rowValue, loc)
+			if err != nil {
+				return true, err
+			}
+			return true, scanner.Scan(driverValue)
+		}
+
+		if structField.Addr().Type().Implements(textUnmarshalerType) {
+			if rowValue.IsNull() {
+				return false, nil
+			}
+			rowBytes, err := rowValue.ToBytes()
+			if err != nil {
+				return true, err
+			}
+			unmarshaler := structField.Addr().Interface().(encoding.TextUnmarshaler)
+			return true, unmarshaler.UnmarshalText(rowBytes)
+		}
+	}
+
+	return false, nil
+}
+
+func sqlValueToDriverValue(rowValue sqltypes.Value, loc *time.Location) (driver.Value, error) {
+	if rowValue.IsNull() {
+		return nil, nil
+	}
+
+	if loc == nil {
+		loc = defaultDecodeLocation
+	}
+
+	switch rowValue.Type() {
+	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int24, sqltypes.Int32, sqltypes.Int64:
+		return rowValue.ToInt64()
+
+	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32:
+		rowVal, err := rowValue.ToUint64()
+		if err != nil {
+			return nil, err
+		}
+		return int64(rowVal), nil
+
+	case sqltypes.Float32, sqltypes.Float64:
+		return rowValue.ToFloat64()
+
+	case sqltypes.Decimal:
+		return rowValue.ToString(), nil
+
+	case sqltypes.Date, sqltypes.Datetime, sqltypes.Timestamp:
+		return rowValue.ToTime(loc)
+	}
+
+	if rowVal, err := rowValue.ToBool(); err == nil {
+		return rowVal, nil
+	}
+
+	return rowValue.ToBytes()
+}
+
+func isByteSliceType(t reflect.Type) bool {
+	return t.Kind() == reflect.Slice && t.Elem().Kind() == byteSliceElemKind
+}
+
+func setByteSliceValue(structField reflect.Value, rowVal []byte) {
+	cloned := append([]byte(nil), rowVal...)
+	structField.Set(reflect.ValueOf(cloned).Convert(structField.Type()))
 }

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -1,6 +1,7 @@
 package vstreamclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -15,53 +16,112 @@ type VStreamScanner interface {
 	VStreamScan(fields []*querypb.Field, row []sqltypes.Value, rowEvent *binlogdatapb.RowEvent, rowChange *binlogdatapb.RowChange) error
 }
 
-// copyRowToStruct builds a customer from a row event
+// copyRowToStruct builds a struct from a row event
 // TODO: this is very rudimentary mapping that only works for top-level fields
 func copyRowToStruct(shard shardConfig, row []sqltypes.Value, vPtr reflect.Value) error {
 	for fieldName, m := range shard.fieldMap {
 		structField := reflect.Indirect(vPtr).FieldByIndex(m.structIndex)
 
+		// Handle pointer fields by allocating as needed.
+		// NULL values are left as nil pointers.
+		if m.isPointer {
+			if row[m.rowIndex].IsNull() {
+				structField.SetZero()
+				continue
+			}
+			if structField.IsNil() {
+				structField.Set(reflect.New(m.structType))
+			}
+			structField = structField.Elem()
+		}
+
+		if m.jsonDecode {
+			if row[m.rowIndex].IsNull() {
+				return fmt.Errorf("vstreamclient: error unmarshalling JSON for field %s: NULL into non-pointer field", fieldName)
+			}
+
+			rowVal, err := row[m.rowIndex].ToBytes()
+			if err != nil {
+				return fmt.Errorf("vstreamclient: error converting row value to bytes for field %s: %w", fieldName, err)
+			}
+
+			if err = json.Unmarshal(rowVal, structField.Addr().Interface()); err != nil {
+				return fmt.Errorf("vstreamclient: error unmarshalling JSON for field %s: %w", fieldName, err)
+			}
+			continue
+		}
+
 		switch m.kind {
 		case reflect.Bool:
+			if row[m.rowIndex].IsNull() {
+				return fmt.Errorf("vstreamclient: error converting row value to bool for field %s: NULL into non-pointer field", fieldName)
+			}
 			rowVal, err := row[m.rowIndex].ToBool()
 			if err != nil {
-				return fmt.Errorf("error converting row value to bool for field %s: %w", fieldName, err)
+				return fmt.Errorf("vstreamclient: error converting row value to bool for field %s: %w", fieldName, err)
 			}
 			structField.SetBool(rowVal)
 
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if row[m.rowIndex].IsNull() {
+				return fmt.Errorf("vstreamclient: error converting row value to int64 for field %s: NULL into non-pointer field", fieldName)
+			}
 			rowVal, err := row[m.rowIndex].ToInt64()
 			if err != nil {
-				return fmt.Errorf("error converting row value to int64 for field %s: %w", fieldName, err)
+				return fmt.Errorf("vstreamclient: error converting row value to int64 for field %s: %w", fieldName, err)
+			}
+			if structField.OverflowInt(rowVal) {
+				return fmt.Errorf("vstreamclient: error converting row value to int64 for field %s: %d overflows destination type %s", fieldName, rowVal, structField.Type())
 			}
 			structField.SetInt(rowVal)
 
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if row[m.rowIndex].IsNull() {
+				return fmt.Errorf("vstreamclient: error converting row value to uint64 for field %s: NULL into non-pointer field", fieldName)
+			}
 			rowVal, err := row[m.rowIndex].ToUint64()
 			if err != nil {
-				return fmt.Errorf("error converting row value to uint64 for field %s: %w", fieldName, err)
+				return fmt.Errorf("vstreamclient: error converting row value to uint64 for field %s: %w", fieldName, err)
+			}
+			if structField.OverflowUint(rowVal) {
+				return fmt.Errorf("vstreamclient: error converting row value to uint64 for field %s: %d overflows destination type %s", fieldName, rowVal, structField.Type())
 			}
 			structField.SetUint(rowVal)
 
 		case reflect.Float32, reflect.Float64:
+			if row[m.rowIndex].IsNull() {
+				return fmt.Errorf("vstreamclient: error converting row value to float64 for field %s: NULL into non-pointer field", fieldName)
+			}
 			rowVal, err := row[m.rowIndex].ToFloat64()
 			if err != nil {
-				return fmt.Errorf("error converting row value to float64 for field %s: %w", fieldName, err)
+				return fmt.Errorf("vstreamclient: error converting row value to float64 for field %s: %w", fieldName, err)
+			}
+			if structField.OverflowFloat(rowVal) {
+				return fmt.Errorf("vstreamclient: error converting row value to float64 for field %s: %v overflows destination type %s", fieldName, rowVal, structField.Type())
 			}
 			structField.SetFloat(rowVal)
 
 		case reflect.String:
+			if row[m.rowIndex].IsNull() {
+				return fmt.Errorf("vstreamclient: error converting row value to string for field %s: NULL into non-pointer field", fieldName)
+			}
 			rowVal := row[m.rowIndex].ToString()
 			structField.SetString(rowVal)
 
 		case reflect.Struct:
-			switch m.structType.(type) {
-			case time.Time, *time.Time:
-				rowVal, err := row[m.rowIndex].ToTime()
+			switch m.structType {
+			case reflect.TypeFor[time.Time]():
+				if row[m.rowIndex].IsNull() {
+					return fmt.Errorf("vstreamclient: error converting row value to time.Time for field %s: NULL into non-pointer field", fieldName)
+				}
+				rowVal, err := row[m.rowIndex].ToTime(time.UTC) // TODO: make timezone configurable
 				if err != nil {
-					return fmt.Errorf("error converting row value to time.Time for field %s: %w", fieldName, err)
+					return fmt.Errorf("vstreamclient: error converting row value to time.Time for field %s: %w", fieldName, err)
 				}
 				structField.Set(reflect.ValueOf(rowVal))
+
+			default:
+				return fmt.Errorf("vstreamclient: unsupported struct field type for field %s: %s", fieldName, m.structType.String())
 			}
 
 		case reflect.Pointer,

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (
@@ -6,6 +22,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"time"
 
@@ -233,6 +250,16 @@ func sqlValueToDriverValue(rowValue sqltypes.Value, loc *time.Location) (driver.
 		rowVal, err := rowValue.ToUint64()
 		if err != nil {
 			return nil, err
+		}
+		return int64(rowVal), nil
+
+	case sqltypes.Uint64:
+		rowVal, err := rowValue.ToUint64()
+		if err != nil {
+			return nil, err
+		}
+		if rowVal > math.MaxInt64 {
+			return rowValue.ToString(), nil
 		}
 		return int64(rowVal), nil
 

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -248,7 +248,7 @@ func sqlValueToDriverValue(rowValue sqltypes.Value, loc *time.Location) (driver.
 	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int24, sqltypes.Int32, sqltypes.Int64:
 		return rowValue.ToInt64()
 
-	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32:
+	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Year:
 		rowVal, err := rowValue.ToUint64()
 		if err != nil {
 			return nil, err
@@ -275,10 +275,8 @@ func sqlValueToDriverValue(rowValue sqltypes.Value, loc *time.Location) (driver.
 		return rowValue.ToTime(loc)
 	}
 
-	if rowVal, err := rowValue.ToBool(); err == nil {
-		return rowVal, nil
-	}
-
+	// every integral type is handled above, so anything else (text, blobs, json, bit, enum,
+	// set, time, ...) is passed through as bytes for the scanner to interpret
 	return rowValue.ToBytes()
 }
 

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -29,6 +29,8 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 // VStreamScanner allows for custom scan implementations
@@ -72,7 +74,7 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 
 		if m.jsonDecode {
 			if row[m.rowIndex].IsNull() {
-				return fmt.Errorf("vstreamclient: error unmarshalling JSON for field %s: NULL into non-pointer field", fieldName)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error unmarshalling JSON for field %s: NULL into non-pointer field", fieldName)
 			}
 
 			rowVal, err := row[m.rowIndex].ToBytes()
@@ -101,7 +103,7 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 		switch m.kind {
 		case reflect.Bool:
 			if row[m.rowIndex].IsNull() {
-				return fmt.Errorf("vstreamclient: error converting row value to bool for field %s: NULL into non-pointer field", fieldName)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to bool for field %s: NULL into non-pointer field", fieldName)
 			}
 			rowVal, err := row[m.rowIndex].ToBool()
 			if err != nil {
@@ -111,46 +113,46 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			if row[m.rowIndex].IsNull() {
-				return fmt.Errorf("vstreamclient: error converting row value to int64 for field %s: NULL into non-pointer field", fieldName)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to int64 for field %s: NULL into non-pointer field", fieldName)
 			}
 			rowVal, err := row[m.rowIndex].ToInt64()
 			if err != nil {
 				return fmt.Errorf("vstreamclient: error converting row value to int64 for field %s: %w", fieldName, err)
 			}
 			if structField.OverflowInt(rowVal) {
-				return fmt.Errorf("vstreamclient: error converting row value to int64 for field %s: %d overflows destination type %s", fieldName, rowVal, structField.Type())
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to int64 for field %s: %d overflows destination type %s", fieldName, rowVal, structField.Type())
 			}
 			structField.SetInt(rowVal)
 
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 			if row[m.rowIndex].IsNull() {
-				return fmt.Errorf("vstreamclient: error converting row value to uint64 for field %s: NULL into non-pointer field", fieldName)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to uint64 for field %s: NULL into non-pointer field", fieldName)
 			}
 			rowVal, err := row[m.rowIndex].ToUint64()
 			if err != nil {
 				return fmt.Errorf("vstreamclient: error converting row value to uint64 for field %s: %w", fieldName, err)
 			}
 			if structField.OverflowUint(rowVal) {
-				return fmt.Errorf("vstreamclient: error converting row value to uint64 for field %s: %d overflows destination type %s", fieldName, rowVal, structField.Type())
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to uint64 for field %s: %d overflows destination type %s", fieldName, rowVal, structField.Type())
 			}
 			structField.SetUint(rowVal)
 
 		case reflect.Float32, reflect.Float64:
 			if row[m.rowIndex].IsNull() {
-				return fmt.Errorf("vstreamclient: error converting row value to float64 for field %s: NULL into non-pointer field", fieldName)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to float64 for field %s: NULL into non-pointer field", fieldName)
 			}
 			rowVal, err := row[m.rowIndex].ToFloat64()
 			if err != nil {
 				return fmt.Errorf("vstreamclient: error converting row value to float64 for field %s: %w", fieldName, err)
 			}
 			if structField.OverflowFloat(rowVal) {
-				return fmt.Errorf("vstreamclient: error converting row value to float64 for field %s: %v overflows destination type %s", fieldName, rowVal, structField.Type())
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to float64 for field %s: %v overflows destination type %s", fieldName, rowVal, structField.Type())
 			}
 			structField.SetFloat(rowVal)
 
 		case reflect.String:
 			if row[m.rowIndex].IsNull() {
-				return fmt.Errorf("vstreamclient: error converting row value to string for field %s: NULL into non-pointer field", fieldName)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to string for field %s: NULL into non-pointer field", fieldName)
 			}
 			rowVal := row[m.rowIndex].ToString()
 			structField.SetString(rowVal)
@@ -159,7 +161,7 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 			switch m.structType {
 			case timeType:
 				if row[m.rowIndex].IsNull() {
-					return fmt.Errorf("vstreamclient: error converting row value to time.Time for field %s: NULL into non-pointer field", fieldName)
+					return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to time.Time for field %s: NULL into non-pointer field", fieldName)
 				}
 				rowVal, err := row[m.rowIndex].ToTime(loc)
 				if err != nil {
@@ -168,15 +170,15 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 				structField.Set(reflect.ValueOf(rowVal))
 
 			default:
-				return fmt.Errorf("vstreamclient: unsupported struct field type for field %s: %s", fieldName, m.structType.String())
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: unsupported struct field type for field %s: %s", fieldName, m.structType.String())
 			}
 
 		case reflect.Slice:
 			if !isByteSliceType(m.structType) {
-				return fmt.Errorf("vstreamclient: unsupported field type: %s", m.kind.String())
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: unsupported field type: %s", m.kind.String())
 			}
 			if row[m.rowIndex].IsNull() {
-				return fmt.Errorf("vstreamclient: error converting row value to bytes for field %s: NULL into non-pointer field", fieldName)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: error converting row value to bytes for field %s: NULL into non-pointer field", fieldName)
 			}
 			rowVal, err := row[m.rowIndex].ToBytes()
 			if err != nil {
@@ -195,7 +197,7 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 			reflect.Interface,
 			reflect.Map,
 			reflect.UnsafePointer:
-			return fmt.Errorf("vstreamclient: unsupported field type: %s", m.kind.String())
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: unsupported field type: %s", m.kind.String())
 		}
 	}
 

--- a/go/vt/vstreamclient/convert.go
+++ b/go/vt/vstreamclient/convert.go
@@ -56,7 +56,8 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 		loc = defaultDecodeLocation
 	}
 
-	for fieldName, m := range shard.fieldMap {
+	for _, m := range shard.fieldMappings {
+		fieldName := m.name
 		structField := reflect.Indirect(vPtr).FieldByIndex(m.structIndex)
 
 		// Handle pointer fields by allocating as needed.
@@ -92,7 +93,7 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 			continue
 		}
 
-		handled, err := tryScanSpecialField(structField, row[m.rowIndex], loc)
+		handled, err := tryScanSpecialField(m, structField, row[m.rowIndex], loc)
 		if err != nil {
 			return fmt.Errorf("vstreamclient: error converting row value for field %s: %w", fieldName, err)
 		}
@@ -204,13 +205,16 @@ func copyRowToStructInLocation(shard shardConfig, row []sqltypes.Value, vPtr ref
 	return nil
 }
 
-func tryScanSpecialField(structField reflect.Value, rowValue sqltypes.Value, loc *time.Location) (bool, error) {
-	if structField.Type() == timeType {
+// The interface checks here depend only on the struct field's type, so they are
+// resolved once in reflectMapStructFields rather than per row. structField.Addr
+// is taken only when a cached verdict says the interface is actually satisfied.
+func tryScanSpecialField(m fieldMapping, structField reflect.Value, rowValue sqltypes.Value, loc *time.Location) (bool, error) {
+	if m.isTime {
 		return false, nil
 	}
 
 	if structField.CanAddr() {
-		if structField.Addr().Type().Implements(sqlScannerType) {
+		if m.implementsSQLScanner {
 			scanner := structField.Addr().Interface().(sql.Scanner)
 			driverValue, err := sqlValueToDriverValue(rowValue, loc)
 			if err != nil {
@@ -219,7 +223,7 @@ func tryScanSpecialField(structField reflect.Value, rowValue sqltypes.Value, loc
 			return true, scanner.Scan(driverValue)
 		}
 
-		if structField.Addr().Type().Implements(textUnmarshalerType) {
+		if m.implementsTextUnmarshaler {
 			if rowValue.IsNull() {
 				return false, nil
 			}

--- a/go/vt/vstreamclient/convert_benchmark_test.go
+++ b/go/vt/vstreamclient/convert_benchmark_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamclient
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+// benchWideRow mirrors a typical CDC destination struct: mostly integers, a
+// couple of timestamps, and no fields implementing sql.Scanner or
+// encoding.TextUnmarshaler. That last part is the common case, and it is the
+// case that previously paid two reflect.Type.Implements calls per field per row.
+type benchWideRow struct {
+	ProjectPullID        int64     `vstream:"project_pull_id"`
+	WorkspaceID          int64     `vstream:"workspace_id"`
+	ProjectID            int64     `vstream:"project_id"`
+	PullID               int64     `vstream:"pull_id"`
+	RankingID            int64     `vstream:"ranking_id"`
+	Requested            int64     `vstream:"requested"`
+	KeywordID            int64     `vstream:"keyword_id"`
+	RankingLastUpdatedAt int64     `vstream:"ranking_last_updated_at"`
+	LastInsertedAt       int64     `vstream:"last_inserted_at"`
+	InsertedCount        int32     `vstream:"inserted_count"`
+	CreatedAt            time.Time `vstream:"created_at"`
+}
+
+func benchWideFields() []*querypb.Field {
+	return []*querypb.Field{
+		{Name: "project_pull_id", Type: querypb.Type_INT64},
+		{Name: "workspace_id", Type: querypb.Type_INT64},
+		{Name: "project_id", Type: querypb.Type_INT64},
+		{Name: "pull_id", Type: querypb.Type_INT64},
+		{Name: "ranking_id", Type: querypb.Type_INT64},
+		{Name: "requested", Type: querypb.Type_INT64},
+		{Name: "keyword_id", Type: querypb.Type_INT64},
+		{Name: "ranking_last_updated_at", Type: querypb.Type_INT64},
+		{Name: "last_inserted_at", Type: querypb.Type_INT64},
+		{Name: "inserted_count", Type: querypb.Type_INT32},
+		{Name: "created_at", Type: querypb.Type_TIMESTAMP},
+	}
+}
+
+func benchWideValues() []sqltypes.Value {
+	return []sqltypes.Value{
+		sqltypes.NewInt64(101),
+		sqltypes.NewInt64(102),
+		sqltypes.NewInt64(103),
+		sqltypes.NewInt64(104),
+		sqltypes.NewInt64(105),
+		sqltypes.NewInt64(1753972645),
+		sqltypes.NewInt64(106),
+		sqltypes.NewInt64(107),
+		sqltypes.NewInt64(108),
+		sqltypes.NewInt32(109),
+		sqltypes.NewTimestamp("2026-07-02 03:04:05"),
+	}
+}
+
+func BenchmarkCopyRowToStruct(b *testing.B) {
+	fields := benchWideFields()
+	table := &TableConfig{DataType: &benchWideRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMappings, err := table.reflectMapFields(fields)
+	require.NoError(b, err)
+
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
+	row := benchWideValues()
+	dest := reflect.New(table.underlyingType)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if copyErr := copyRowToStruct(shard, row, dest); copyErr != nil {
+			b.Fatal(copyErr)
+		}
+	}
+}

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -2,6 +2,8 @@ package vstreamclient
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -75,6 +77,39 @@ type testSmallFloatRow struct {
 	Value float32 `vstream:"value"`
 }
 
+type testBytesAndRawJSONRow struct {
+	Payload    []byte           `vstream:"payload"`
+	RawPayload json.RawMessage  `vstream:"raw_payload,json"`
+	OptRaw     *json.RawMessage `vstream:"opt_raw,json"`
+}
+
+type TestEmbeddedFieldsExported struct {
+	ID int64 `vstream:"id"`
+}
+
+type testNestedFields struct {
+	Name string `vstream:"name"`
+}
+
+type testNestedMappedRow struct {
+	TestEmbeddedFieldsExported
+	Meta testNestedFields
+}
+
+type testTextWrapper string
+
+type testWrapperRow struct {
+	Name   sql.NullString  `vstream:"name"`
+	Count  sql.NullInt64   `vstream:"count"`
+	SeenAt sql.NullTime    `vstream:"seen_at"`
+	Level  testTextWrapper `vstream:"level"`
+}
+
+func (w *testTextWrapper) UnmarshalText(text []byte) error {
+	*w = testTextWrapper("wrapped:" + string(text))
+	return nil
+}
+
 func (r *testScannerRow) VStreamScan(_ []*querypb.Field, row []sqltypes.Value, _ *binlogdatapb.RowEvent, _ *binlogdatapb.RowChange) error {
 	v, err := row[0].ToInt64()
 	if err != nil {
@@ -121,6 +156,38 @@ func TestCopyRowToStruct_TimeAndPointers(t *testing.T) {
 	assert.Nil(t, out.Opt)
 	if assert.NotNil(t, out.OptT) {
 		assert.False(t, out.OptT.IsZero())
+	}
+}
+
+func TestHandleRowEvent_TimeUsesConfiguredLocation(t *testing.T) {
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "ts", Type: querypb.Type_TIMESTAMP},
+	}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRow{}, timeLocation: loc}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		After: sqltypes.RowToProto3([]sqltypes.Value{
+			sqltypes.NewInt64(1),
+			sqltypes.NewTimestamp("2026-02-10 11:12:13"),
+		}),
+	}}}
+
+	err = table.handleRowEvent(ev, &VStreamStats{})
+	assert.NoError(t, err)
+	if assert.Len(t, table.currentBatch, 1) {
+		out, ok := table.currentBatch[0].Data.(*testRow)
+		if assert.True(t, ok) {
+			assert.Equal(t, time.Date(2026, 2, 10, 11, 12, 13, 0, loc), out.TS)
+			assert.Equal(t, loc, out.TS.Location())
+		}
 	}
 }
 
@@ -224,6 +291,103 @@ func TestCopyRowToStruct_JSONFieldNullIntoNonPointerErrors(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "error unmarshalling JSON for field payload")
 	assert.ErrorContains(t, err, "NULL into non-pointer field")
+}
+
+func TestCopyRowToStruct_ByteAndRawJSONFields(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "payload", Type: querypb.Type_VARBINARY},
+		{Name: "raw_payload", Type: querypb.Type_JSON},
+		{Name: "opt_raw", Type: querypb.Type_JSON},
+	}
+
+	table := &TableConfig{DataType: &testBytesAndRawJSONRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	rawPayload, err := sqltypes.NewJSON(`{"name":"alpha","count":2}`)
+	assert.NoError(t, err)
+	row := []sqltypes.Value{
+		sqltypes.NewVarBinary("payload-bytes"),
+		rawPayload,
+		sqltypes.NULL,
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.NoError(t, err)
+
+	out := v.Interface().(*testBytesAndRawJSONRow)
+	assert.Equal(t, []byte("payload-bytes"), out.Payload)
+	assert.JSONEq(t, `{"name":"alpha","count":2}`, string(out.RawPayload))
+	assert.Nil(t, out.OptRaw)
+}
+
+func TestCopyRowToStruct_NestedAndEmbeddedFields(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "name", Type: querypb.Type_VARCHAR},
+	}
+
+	table := &TableConfig{DataType: &testNestedMappedRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+	assert.Contains(t, fieldMap, "id")
+	assert.Contains(t, fieldMap, "name")
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{
+		sqltypes.NewInt64(7),
+		sqltypes.NewVarChar("alpha"),
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.NoError(t, err)
+
+	out := v.Interface().(*testNestedMappedRow)
+	assert.Equal(t, int64(7), out.ID)
+	assert.Equal(t, "alpha", out.Meta.Name)
+}
+
+func TestCopyRowToStruct_ScannerAndTextUnmarshalerFields(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "name", Type: querypb.Type_VARCHAR},
+		{Name: "count", Type: querypb.Type_INT64},
+		{Name: "seen_at", Type: querypb.Type_TIMESTAMP},
+		{Name: "level", Type: querypb.Type_VARCHAR},
+	}
+
+	table := &TableConfig{DataType: &testWrapperRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{
+		sqltypes.NewVarChar("alpha"),
+		sqltypes.NewInt64(42),
+		sqltypes.NewTimestamp("2026-02-10 11:12:13"),
+		sqltypes.NewVarChar("gold"),
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.NoError(t, err)
+
+	out := v.Interface().(*testWrapperRow)
+	assert.True(t, out.Name.Valid)
+	assert.Equal(t, "alpha", out.Name.String)
+	assert.True(t, out.Count.Valid)
+	assert.Equal(t, int64(42), out.Count.Int64)
+	assert.True(t, out.SeenAt.Valid)
+	assert.Equal(t, time.Date(2026, 2, 10, 11, 12, 13, 0, time.UTC), out.SeenAt.Time)
+	assert.Equal(t, testTextWrapper("wrapped:gold"), out.Level)
 }
 
 func TestCopyRowToStruct_UnsupportedStructFieldErrors(t *testing.T) {

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -485,6 +485,37 @@ func TestValidateTableConfig(t *testing.T) {
 		)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "provided tables do not match stored tables")
+		assert.ErrorContains(t, err, "table ks.t query changed")
+		assert.ErrorContains(t, err, "provided \"select * from t\"")
+		assert.ErrorContains(t, err, "stored \"select id from t\"")
+	})
+
+	t.Run("missing stored table is reported", func(t *testing.T) {
+		err := validateTableConfig(
+			map[string]*TableConfig{
+				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
+				"t2": {Keyspace: "ks", Table: "t2", Query: "select * from t2"},
+			},
+			map[string]*TableConfig{
+				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
+			},
+		)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "table ks.t2 is new in provided config")
+	})
+
+	t.Run("missing provided table is reported", func(t *testing.T) {
+		err := validateTableConfig(
+			map[string]*TableConfig{
+				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
+			},
+			map[string]*TableConfig{
+				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
+				"t2": {Keyspace: "ks", Table: "t2", Query: "select * from t2"},
+			},
+		)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "table ks.t2 is missing from provided config")
 	})
 }
 

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -789,6 +790,47 @@ func TestHandleRowEvent_UsesTypedScanner(t *testing.T) {
 	if assert.Len(t, table.currentBatch, 1) {
 		row := table.currentBatch[0]
 		scanned, ok := row.Data.(*testScannerRow)
+		if assert.True(t, ok) {
+			assert.Equal(t, int64(7), scanned.ID)
+		}
+	}
+}
+
+func TestInitTables_ValueDataTypeStillUsesPointerScanner(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{{
+		Keyspace: "ks",
+		Table:    "t",
+		DataType: testScannerRow{},
+		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
+	}})
+	require.NoError(t, err)
+
+	table := v.tables[qualifiedTableName("ks", "t")]
+	require.NotNil(t, table)
+	assert.True(t, table.implementsScanner)
+
+	err = table.handleFieldEvent(&binlogdatapb.FieldEvent{
+		Shard:  "0",
+		Fields: []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}},
+	})
+	require.NoError(t, err)
+
+	err = table.handleRowEvent(&binlogdatapb.RowEvent{
+		TableName: "t",
+		Shard:     "0",
+		RowChanges: []*binlogdatapb.RowChange{{
+			After: &querypb.Row{Lengths: []int64{1}, Values: []byte("7")},
+		}},
+	}, &VStreamStats{})
+	require.NoError(t, err)
+
+	if assert.Len(t, table.currentBatch, 1) {
+		scanned, ok := table.currentBatch[0].Data.(*testScannerRow)
 		if assert.True(t, ok) {
 			assert.Equal(t, int64(7), scanned.ID)
 		}

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -624,6 +624,59 @@ func TestHandleRowEvent_ScannerFailureDoesNotBufferRow(t *testing.T) {
 	assert.Len(t, table.currentBatch, 0)
 }
 
+func TestHandleRowEvent_PartialRowImageFailsForDefaultDecoder(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}, {Name: "email", Type: querypb.Type_VARCHAR}}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		After:       sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(7)}),
+		DataColumns: &binlogdatapb.RowChange_Bitmap{Count: 2, Cols: []byte{0x01}},
+	}}}
+
+	stats := &VStreamStats{}
+	err = table.handleRowEvent(ev, stats)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "partial row images are unsupported")
+	assert.Len(t, table.currentBatch, 0)
+}
+
+func TestHandleRowEvent_PartialJSONFailsForDefaultDecoder(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "payload", Type: querypb.Type_JSON},
+		{Name: "opt_payload", Type: querypb.Type_JSON},
+	}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testJSONRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		After: sqltypes.RowToProto3([]sqltypes.Value{
+			sqltypes.NewInt64(1),
+			sqltypes.TestValue(sqltypes.Expression, "JSON_SET(payload, '$.name', 'beta')"),
+			sqltypes.NULL,
+		}),
+		DataColumns:       &binlogdatapb.RowChange_Bitmap{Count: 3, Cols: []byte{0x03}},
+		JsonPartialValues: &binlogdatapb.RowChange_Bitmap{Count: 3, Cols: []byte{0x02}},
+	}}}
+
+	stats := &VStreamStats{}
+	err = table.handleRowEvent(ev, stats)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "partial JSON updates are unsupported")
+	assert.Len(t, table.currentBatch, 0)
+}
+
 func TestWithFlags_RejectsZeroHeartbeatInterval(t *testing.T) {
 	v := &VStreamClient{}
 	err := WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 0})(v)

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -1,0 +1,632 @@
+package vstreamclient
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/sqltypes"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+)
+
+type testRow struct {
+	ID   int64      `vstream:"id"`
+	TS   time.Time  `vstream:"ts"`
+	Opt  *int64     `vstream:"opt"`
+	OptT *time.Time `vstream:"opt_ts"`
+}
+
+type testRowSmall struct {
+	ID int64 `vstream:"id"`
+}
+
+type testScannerRow struct {
+	ID int64
+}
+
+type testFailingScannerRow struct{}
+
+type testJSONPayload struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type testJSONRow struct {
+	ID         int64            `vstream:"id"`
+	Payload    testJSONPayload  `vstream:"payload,json"`
+	OptPayload *testJSONPayload `vstream:"opt_payload,json"`
+}
+
+type testFallbackTagRow struct {
+	DBName     string `db:"db_name,omitempty"`
+	JSONName   string `json:"json_name,omitempty"`
+	OptionName string `vstream:" option_name , JSON "`
+}
+
+type testNullableJSONRow struct {
+	ID      int64            `vstream:"id"`
+	Opt     *int64           `vstream:"opt"`
+	Payload *testJSONPayload `vstream:"payload,json"`
+}
+
+type testCustomStructField struct {
+	Value string
+}
+
+type testStructFieldRow struct {
+	ID      int64                 `vstream:"id"`
+	Wrapped testCustomStructField `vstream:"wrapped"`
+}
+
+type testSmallIntRow struct {
+	Value int8 `vstream:"value"`
+}
+
+type testSmallUintRow struct {
+	Value uint8 `vstream:"value"`
+}
+
+type testSmallFloatRow struct {
+	Value float32 `vstream:"value"`
+}
+
+func (r *testScannerRow) VStreamScan(_ []*querypb.Field, row []sqltypes.Value, _ *binlogdatapb.RowEvent, _ *binlogdatapb.RowChange) error {
+	v, err := row[0].ToInt64()
+	if err != nil {
+		return err
+	}
+	r.ID = v
+	return nil
+}
+
+func (r *testFailingScannerRow) VStreamScan(_ []*querypb.Field, _ []sqltypes.Value, _ *binlogdatapb.RowEvent, _ *binlogdatapb.RowChange) error {
+	return assert.AnError
+}
+
+func TestCopyRowToStruct_TimeAndPointers(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "ts", Type: querypb.Type_TIMESTAMP},
+		{Name: "opt", Type: querypb.Type_INT64},
+		{Name: "opt_ts", Type: querypb.Type_TIMESTAMP},
+	}
+
+	table := &TableConfig{DataType: &testRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+
+	row := []sqltypes.Value{
+		sqltypes.NewInt64(1),
+		sqltypes.NewTimestamp("2026-02-10 11:12:13"),
+		sqltypes.NULL,
+		sqltypes.NewTimestamp("2026-02-10 11:12:14"),
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.NoError(t, err)
+
+	out := v.Interface().(*testRow)
+	assert.Equal(t, int64(1), out.ID)
+	assert.False(t, out.TS.IsZero())
+	assert.Nil(t, out.Opt)
+	if assert.NotNil(t, out.OptT) {
+		assert.False(t, out.OptT.IsZero())
+	}
+}
+
+func TestCopyRowToStruct_NullIntoNonPointerErrors(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{DataType: &testRowSmall{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{sqltypes.NULL}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "NULL into non-pointer field")
+}
+
+func TestCopyRowToStruct_JSONFields(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "payload", Type: querypb.Type_JSON},
+		{Name: "opt_payload", Type: querypb.Type_JSON},
+	}
+
+	table := &TableConfig{DataType: &testJSONRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{
+		sqltypes.NewInt64(1),
+		sqltypes.NewVarBinary(`{"name":"alpha","count":2}`),
+		sqltypes.NULL,
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.NoError(t, err)
+
+	out := v.Interface().(*testJSONRow)
+	assert.Equal(t, int64(1), out.ID)
+	assert.Equal(t, "alpha", out.Payload.Name)
+	assert.Equal(t, 2, out.Payload.Count)
+	assert.Nil(t, out.OptPayload)
+}
+
+func TestCopyRowToStruct_JSONFieldInvalidErrors(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "payload", Type: querypb.Type_JSON},
+		{Name: "opt_payload", Type: querypb.Type_JSON},
+	}
+
+	table := &TableConfig{DataType: &testJSONRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{
+		sqltypes.NewInt64(1),
+		sqltypes.NewVarBinary(`{"name":"alpha"`),
+		sqltypes.NULL,
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "error unmarshalling JSON for field payload")
+}
+
+func TestCopyRowToStruct_JSONFieldNullIntoNonPointerErrors(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "payload", Type: querypb.Type_JSON},
+		{Name: "opt_payload", Type: querypb.Type_JSON},
+	}
+
+	table := &TableConfig{DataType: &testJSONRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{
+		sqltypes.NewInt64(1),
+		sqltypes.NULL,
+		sqltypes.NULL,
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "error unmarshalling JSON for field payload")
+	assert.ErrorContains(t, err, "NULL into non-pointer field")
+}
+
+func TestCopyRowToStruct_UnsupportedStructFieldErrors(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}, {Name: "wrapped", Type: querypb.Type_VARCHAR}}
+
+	table := &TableConfig{DataType: &testStructFieldRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewVarChar("value")}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported struct field type")
+	assert.ErrorContains(t, err, "wrapped")
+}
+
+func TestCopyRowToStruct_IntOverflowErrors(t *testing.T) {
+	fields := []*querypb.Field{{Name: "value", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{DataType: &testSmallIntRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{sqltypes.NewInt64(128)}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "overflows destination type")
+	assert.ErrorContains(t, err, "value")
+}
+
+func TestCopyRowToStruct_UintOverflowErrors(t *testing.T) {
+	fields := []*querypb.Field{{Name: "value", Type: querypb.Type_UINT64}}
+
+	table := &TableConfig{DataType: &testSmallUintRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{sqltypes.NewUint64(256)}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "overflows destination type")
+	assert.ErrorContains(t, err, "value")
+}
+
+func TestCopyRowToStruct_FloatOverflowErrors(t *testing.T) {
+	fields := []*querypb.Field{{Name: "value", Type: querypb.Type_FLOAT64}}
+
+	table := &TableConfig{DataType: &testSmallFloatRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{sqltypes.NewFloat64(1e40)}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "overflows destination type")
+	assert.ErrorContains(t, err, "value")
+}
+
+func TestReflectMapFields_ErrorOnUnknownFields(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}, {Name: "extra", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{DataType: &testRowSmall{}, ErrorOnUnknownFields: true}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	_, err := table.reflectMapFields(fields)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "field extra")
+}
+
+func TestReflectMapFields_FallbackTagsStripOptions(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "db_name", Type: querypb.Type_VARCHAR},
+		{Name: "json_name", Type: querypb.Type_VARCHAR},
+		{Name: "option_name", Type: querypb.Type_VARCHAR},
+	}
+
+	table := &TableConfig{DataType: &testFallbackTagRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	_, ok := fieldMap["db_name"]
+	assert.True(t, ok)
+	_, ok = fieldMap["json_name"]
+	assert.True(t, ok)
+	m, ok := fieldMap["option_name"]
+	if assert.True(t, ok) {
+		assert.True(t, m.jsonDecode)
+	}
+}
+
+func TestInitTables_RequiresFlushFn(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{{
+		Keyspace: "ks",
+		Table:    "t",
+		DataType: &testRowSmall{},
+	}})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "has no flush function")
+}
+
+func TestInitTables_SetsDefaults(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{{
+		Keyspace: "ks",
+		Table:    "t",
+		DataType: &testRowSmall{},
+		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
+	}})
+	assert.NoError(t, err)
+
+	table := v.tables[qualifiedTableName("ks", "t")]
+	if assert.NotNil(t, table) {
+		assert.Equal(t, "select * from `t`", table.Query)
+		assert.Equal(t, DefaultMaxRowsPerFlush, table.MaxRowsPerFlush)
+		assert.Len(t, table.currentBatch, 0)
+		assert.Equal(t, DefaultMaxRowsPerFlush, cap(table.currentBatch))
+	}
+}
+
+func TestInitTables_RejectsDuplicateTables(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks1": {"0"}, "ks2": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{
+		{Keyspace: "ks1", Table: "t", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+		{Keyspace: "ks2", Table: "t", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, v.tables, qualifiedTableName("ks1", "t"))
+	assert.Contains(t, v.tables, qualifiedTableName("ks2", "t"))
+}
+
+func TestInitTables_RejectsConflictingQueriesForSameTableAcrossKeyspaces(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks1": {"0"}, "ks2": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{
+		{Keyspace: "ks1", Table: "t", Query: "select * from t where id < 10", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+		{Keyspace: "ks2", Table: "t", Query: "select * from t where id >= 10", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "same table name across keyspaces must use identical queries")
+}
+
+func TestInitTables_RejectsUnknownKeyspace(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{{
+		Keyspace: "missing",
+		Table:    "t",
+		DataType: &testRowSmall{},
+		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
+	}})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "keyspace missing not found")
+}
+
+func TestInitTables_RejectsNonStructDataType(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{{
+		Keyspace: "ks",
+		Table:    "t",
+		DataType: new(int64),
+		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
+	}})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "must be a struct")
+}
+
+func TestInitTables_RejectsTypedNilDataType(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	var row *testRowSmall
+	err := v.initTables([]TableConfig{{
+		Keyspace: "ks",
+		Table:    "t",
+		DataType: row,
+		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
+	}})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "has no data type")
+}
+
+func TestInitTables_RejectsNegativeMaxRowsPerFlush(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: -1,
+		DataType:        &testRowSmall{},
+		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+	}})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "max rows per flush must be positive")
+}
+
+func TestValidateTableConfig(t *testing.T) {
+	t.Run("matching config passes", func(t *testing.T) {
+		err := validateTableConfig(
+			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
+			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("different config fails", func(t *testing.T) {
+		err := validateTableConfig(
+			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
+			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select id from t"}},
+		)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "provided tables do not match stored tables")
+	})
+}
+
+func TestHandleRowEvent_DeleteUsesBeforeRowData(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		Before: &querypb.Row{Lengths: []int64{1}, Values: []byte("1")},
+		After:  nil,
+	}}}
+
+	stats := &VStreamStats{}
+	err = table.handleRowEvent(ev, stats)
+	assert.NoError(t, err)
+	if assert.Len(t, table.currentBatch, 1) {
+		row, ok := table.currentBatch[0].Data.(*testRowSmall)
+		if assert.True(t, ok) {
+			assert.Equal(t, int64(1), row.ID)
+		}
+	}
+}
+
+func TestHandleRowEvent_InsertScansNullableFields(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "id", Type: querypb.Type_INT64},
+		{Name: "opt", Type: querypb.Type_INT64},
+		{Name: "payload", Type: querypb.Type_JSON},
+	}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testNullableJSONRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{
+		TableName: "ks.t",
+		Shard:     "0",
+		RowChanges: []*binlogdatapb.RowChange{{
+			After: sqltypes.RowToProto3([]sqltypes.Value{
+				sqltypes.NewInt64(7),
+				sqltypes.NULL,
+				sqltypes.NewVarBinary(`{"name":"beta","count":4}`),
+			}),
+		}},
+	}
+
+	stats := &VStreamStats{}
+	err = table.handleRowEvent(ev, stats)
+	assert.NoError(t, err)
+	if assert.Len(t, table.currentBatch, 1) {
+		row, ok := table.currentBatch[0].Data.(*testNullableJSONRow)
+		if assert.True(t, ok) {
+			assert.Equal(t, int64(7), row.ID)
+			assert.Nil(t, row.Opt)
+			if assert.NotNil(t, row.Payload) {
+				assert.Equal(t, "beta", row.Payload.Name)
+				assert.Equal(t, 4, row.Payload.Count)
+			}
+		}
+	}
+}
+
+func TestHandleRowEvent_UsesTypedScanner(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testScannerRow{}}
+	table.implementsScanner = true
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	table.shards = map[string]shardConfig{"0": {fieldMap: nil, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		Before: nil,
+		After:  &querypb.Row{Lengths: []int64{1}, Values: []byte("7")},
+	}}}
+
+	stats := &VStreamStats{}
+	err := table.handleRowEvent(ev, stats)
+	assert.NoError(t, err)
+	if assert.Len(t, table.currentBatch, 1) {
+		row := table.currentBatch[0]
+		scanned, ok := row.Data.(*testScannerRow)
+		if assert.True(t, ok) {
+			assert.Equal(t, int64(7), scanned.ID)
+		}
+	}
+}
+
+func TestHandleRowEvent_DecodeFailureDoesNotBufferRow(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	assert.NoError(t, err)
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		After: &querypb.Row{Lengths: []int64{3}, Values: []byte("bad")},
+	}}}
+
+	stats := &VStreamStats{}
+	err = table.handleRowEvent(ev, stats)
+	assert.Error(t, err)
+	assert.Len(t, table.currentBatch, 0)
+}
+
+func TestHandleRowEvent_ScannerFailureDoesNotBufferRow(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testFailingScannerRow{}}
+	table.implementsScanner = true
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	table.shards = map[string]shardConfig{"0": {fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		After: &querypb.Row{Lengths: []int64{1}, Values: []byte("7")},
+	}}}
+
+	stats := &VStreamStats{}
+	err := table.handleRowEvent(ev, stats)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "client scan failed")
+	assert.Len(t, table.currentBatch, 0)
+}
+
+func TestWithFlags_RejectsZeroHeartbeatInterval(t *testing.T) {
+	v := &VStreamClient{}
+	err := WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 0})(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "HeartbeatInterval")
+}

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -152,7 +152,7 @@ func TestCopyRowToStruct_TimeAndPointers(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 
@@ -165,15 +165,14 @@ func TestCopyRowToStruct_TimeAndPointers(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	out := v.Interface().(*testRow)
 	assert.Equal(t, int64(1), out.ID)
 	assert.False(t, out.TS.IsZero())
 	assert.Nil(t, out.Opt)
-	if assert.NotNil(t, out.OptT) {
-		assert.False(t, out.OptT.IsZero())
-	}
+	require.NotNil(t, out.OptT)
+	assert.False(t, out.OptT.IsZero())
 }
 
 func TestHandleRowEvent_TimeUsesConfiguredLocation(t *testing.T) {
@@ -186,7 +185,7 @@ func TestHandleRowEvent_TimeUsesConfiguredLocation(t *testing.T) {
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRow{}, timeLocation: loc}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
 	table.resetBatch()
 
@@ -198,14 +197,12 @@ func TestHandleRowEvent_TimeUsesConfiguredLocation(t *testing.T) {
 	}}}
 
 	err = table.handleRowEvent(ev, &VStreamStats{})
-	assert.NoError(t, err)
-	if assert.Len(t, table.currentBatch, 1) {
-		out, ok := table.currentBatch[0].Data.(*testRow)
-		if assert.True(t, ok) {
-			assert.Equal(t, time.Date(2026, 2, 10, 11, 12, 13, 0, loc), out.TS)
-			assert.Equal(t, loc, out.TS.Location())
-		}
-	}
+	require.NoError(t, err)
+	require.Len(t, table.currentBatch, 1)
+	out, ok := table.currentBatch[0].Data.(*testRow)
+	require.True(t, ok)
+	assert.Equal(t, time.Date(2026, 2, 10, 11, 12, 13, 0, loc), out.TS)
+	assert.Equal(t, loc, out.TS.Location())
 }
 
 func TestCopyRowToStruct_NullIntoNonPointerErrors(t *testing.T) {
@@ -215,7 +212,7 @@ func TestCopyRowToStruct_NullIntoNonPointerErrors(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{sqltypes.NULL}
@@ -237,7 +234,7 @@ func TestCopyRowToStruct_JSONFields(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{
@@ -248,7 +245,7 @@ func TestCopyRowToStruct_JSONFields(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	out := v.Interface().(*testJSONRow)
 	assert.Equal(t, int64(1), out.ID)
@@ -268,7 +265,7 @@ func TestCopyRowToStruct_JSONFieldInvalidErrors(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{
@@ -294,7 +291,7 @@ func TestCopyRowToStruct_JSONFieldNullIntoNonPointerErrors(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{
@@ -321,11 +318,11 @@ func TestCopyRowToStruct_ByteAndRawJSONFields(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	rawPayload, err := sqltypes.NewJSON(`{"name":"alpha","count":2}`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	row := []sqltypes.Value{
 		sqltypes.NewVarBinary("payload-bytes"),
 		rawPayload,
@@ -334,7 +331,7 @@ func TestCopyRowToStruct_ByteAndRawJSONFields(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	out := v.Interface().(*testBytesAndRawJSONRow)
 	assert.Equal(t, []byte("payload-bytes"), out.Payload)
@@ -352,7 +349,7 @@ func TestCopyRowToStruct_NestedAndEmbeddedFields(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, fieldMap, "id")
 	assert.Contains(t, fieldMap, "name")
 
@@ -364,7 +361,7 @@ func TestCopyRowToStruct_NestedAndEmbeddedFields(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	out := v.Interface().(*testNestedMappedRow)
 	assert.Equal(t, int64(7), out.ID)
@@ -383,7 +380,7 @@ func TestCopyRowToStruct_ScannerAndTextUnmarshalerFields(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{
@@ -395,7 +392,7 @@ func TestCopyRowToStruct_ScannerAndTextUnmarshalerFields(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	out := v.Interface().(*testWrapperRow)
 	assert.True(t, out.Name.Valid)
@@ -414,7 +411,7 @@ func TestCopyRowToStruct_UnsupportedStructFieldErrors(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewVarChar("value")}
@@ -433,7 +430,7 @@ func TestCopyRowToStruct_IntOverflowErrors(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewInt64(128)}
@@ -452,7 +449,7 @@ func TestCopyRowToStruct_UintOverflowErrors(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewUint64(256)}
@@ -471,7 +468,7 @@ func TestCopyRowToStruct_FloatOverflowErrors(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	shard := shardConfig{fieldMap: fieldMap, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewFloat64(1e40)}
@@ -505,16 +502,15 @@ func TestReflectMapFields_FallbackTagsStripOptions(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, ok := fieldMap["db_name"]
 	assert.True(t, ok)
 	_, ok = fieldMap["json_name"]
 	assert.True(t, ok)
 	m, ok := fieldMap["option_name"]
-	if assert.True(t, ok) {
-		assert.True(t, m.jsonDecode)
-	}
+	require.True(t, ok)
+	assert.True(t, m.jsonDecode)
 }
 
 func TestInitTables_RequiresFlushFn(t *testing.T) {
@@ -544,15 +540,14 @@ func TestInitTables_SetsDefaults(t *testing.T) {
 		DataType: &testRowSmall{},
 		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
 	}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	table := v.tables[qualifiedTableName("ks", "t")]
-	if assert.NotNil(t, table) {
-		assert.Equal(t, "select * from `t`", table.Query)
-		assert.Equal(t, DefaultMaxRowsPerFlush, table.MaxRowsPerFlush)
-		assert.Len(t, table.currentBatch, 0)
-		assert.Equal(t, DefaultMaxRowsPerFlush, cap(table.currentBatch))
-	}
+	require.NotNil(t, table)
+	assert.Equal(t, "select * from `t`", table.Query)
+	assert.Equal(t, DefaultMaxRowsPerFlush, table.MaxRowsPerFlush)
+	assert.Len(t, table.currentBatch, 0)
+	assert.Equal(t, DefaultMaxRowsPerFlush, cap(table.currentBatch))
 }
 
 func TestInitTables_RejectsDuplicateTables(t *testing.T) {
@@ -565,7 +560,7 @@ func TestInitTables_RejectsDuplicateTables(t *testing.T) {
 		{Keyspace: "ks1", Table: "t", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
 		{Keyspace: "ks2", Table: "t", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, v.tables, qualifiedTableName("ks1", "t"))
 	assert.Contains(t, v.tables, qualifiedTableName("ks2", "t"))
 }
@@ -656,7 +651,7 @@ func TestValidateTableConfig(t *testing.T) {
 			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
 			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("different config fails", func(t *testing.T) {
@@ -706,7 +701,7 @@ func TestHandleRowEvent_DeleteUsesBeforeRowData(t *testing.T) {
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
 	table.resetBatch()
@@ -718,13 +713,11 @@ func TestHandleRowEvent_DeleteUsesBeforeRowData(t *testing.T) {
 
 	stats := &VStreamStats{}
 	err = table.handleRowEvent(ev, stats)
-	assert.NoError(t, err)
-	if assert.Len(t, table.currentBatch, 1) {
-		row, ok := table.currentBatch[0].Data.(*testRowSmall)
-		if assert.True(t, ok) {
-			assert.Equal(t, int64(1), row.ID)
-		}
-	}
+	require.NoError(t, err)
+	require.Len(t, table.currentBatch, 1)
+	row, ok := table.currentBatch[0].Data.(*testRowSmall)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), row.ID)
 }
 
 func TestHandleRowEvent_InsertScansNullableFields(t *testing.T) {
@@ -737,7 +730,7 @@ func TestHandleRowEvent_InsertScansNullableFields(t *testing.T) {
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testNullableJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
 	table.resetBatch()
 
@@ -755,18 +748,15 @@ func TestHandleRowEvent_InsertScansNullableFields(t *testing.T) {
 
 	stats := &VStreamStats{}
 	err = table.handleRowEvent(ev, stats)
-	assert.NoError(t, err)
-	if assert.Len(t, table.currentBatch, 1) {
-		row, ok := table.currentBatch[0].Data.(*testNullableJSONRow)
-		if assert.True(t, ok) {
-			assert.Equal(t, int64(7), row.ID)
-			assert.Nil(t, row.Opt)
-			if assert.NotNil(t, row.Payload) {
-				assert.Equal(t, "beta", row.Payload.Name)
-				assert.Equal(t, 4, row.Payload.Count)
-			}
-		}
-	}
+	require.NoError(t, err)
+	require.Len(t, table.currentBatch, 1)
+	row, ok := table.currentBatch[0].Data.(*testNullableJSONRow)
+	require.True(t, ok)
+	assert.Equal(t, int64(7), row.ID)
+	assert.Nil(t, row.Opt)
+	require.NotNil(t, row.Payload)
+	assert.Equal(t, "beta", row.Payload.Name)
+	assert.Equal(t, 4, row.Payload.Count)
 }
 
 func TestHandleRowEvent_UsesTypedScanner(t *testing.T) {
@@ -786,14 +776,12 @@ func TestHandleRowEvent_UsesTypedScanner(t *testing.T) {
 
 	stats := &VStreamStats{}
 	err := table.handleRowEvent(ev, stats)
-	assert.NoError(t, err)
-	if assert.Len(t, table.currentBatch, 1) {
-		row := table.currentBatch[0]
-		scanned, ok := row.Data.(*testScannerRow)
-		if assert.True(t, ok) {
-			assert.Equal(t, int64(7), scanned.ID)
-		}
-	}
+	require.NoError(t, err)
+	require.Len(t, table.currentBatch, 1)
+	row := table.currentBatch[0]
+	scanned, ok := row.Data.(*testScannerRow)
+	require.True(t, ok)
+	assert.Equal(t, int64(7), scanned.ID)
 }
 
 func TestInitTables_ValueDataTypeStillUsesPointerScanner(t *testing.T) {
@@ -829,12 +817,10 @@ func TestInitTables_ValueDataTypeStillUsesPointerScanner(t *testing.T) {
 	}, &VStreamStats{})
 	require.NoError(t, err)
 
-	if assert.Len(t, table.currentBatch, 1) {
-		scanned, ok := table.currentBatch[0].Data.(*testScannerRow)
-		if assert.True(t, ok) {
-			assert.Equal(t, int64(7), scanned.ID)
-		}
-	}
+	require.Len(t, table.currentBatch, 1)
+	scanned, ok := table.currentBatch[0].Data.(*testScannerRow)
+	require.True(t, ok)
+	assert.Equal(t, int64(7), scanned.ID)
 }
 
 func TestHandleRowEvent_DecodeFailureDoesNotBufferRow(t *testing.T) {
@@ -843,7 +829,7 @@ func TestHandleRowEvent_DecodeFailureDoesNotBufferRow(t *testing.T) {
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
 	table.resetBatch()
 
@@ -883,7 +869,7 @@ func TestHandleRowEvent_PartialRowImageFailsForDefaultDecoder(t *testing.T) {
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
 	table.resetBatch()
 
@@ -909,7 +895,7 @@ func TestHandleRowEvent_PartialJSONFailsForDefaultDecoder(t *testing.T) {
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 	fieldMap, err := table.reflectMapFields(fields)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
 	table.resetBatch()
 

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -692,6 +692,34 @@ func TestInitTables_AllowsSameTableAcrossKeyspaces(t *testing.T) {
 	assert.Contains(t, v.tables, qualifiedTableName("ks2", "t"))
 }
 
+func TestInitTables_RejectsSlashPrefixedTableNames(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks1": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{
+		{Keyspace: "ks1", Table: "/evil.*", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+	})
+	require.ErrorContains(t, err, "interpreted as regular expressions")
+}
+
+func TestInitTables_RejectsInvalidDefaultMaxRowsPerFlush(t *testing.T) {
+	original := DefaultMaxRowsPerFlush
+	t.Cleanup(func() { DefaultMaxRowsPerFlush = original })
+	DefaultMaxRowsPerFlush = 0
+
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks1": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{
+		{Keyspace: "ks1", Table: "t", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+	})
+	require.ErrorContains(t, err, "max rows per flush must be positive")
+}
+
 func TestInitTables_RejectsDuplicateTables(t *testing.T) {
 	v := &VStreamClient{
 		shardsByKeyspace: map[string][]string{"ks1": {"0"}},

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -19,8 +19,11 @@ package vstreamclient
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
+	"math"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -402,6 +405,71 @@ func TestCopyRowToStruct_ScannerAndTextUnmarshalerFields(t *testing.T) {
 	assert.True(t, out.SeenAt.Valid)
 	assert.Equal(t, time.Date(2026, 2, 10, 11, 12, 13, 0, time.UTC), out.SeenAt.Time)
 	assert.Equal(t, testTextWrapper("wrapped:gold"), out.Level)
+}
+
+func TestCopyRowToStruct_NullThroughScannerFields(t *testing.T) {
+	fields := []*querypb.Field{
+		{Name: "name", Type: querypb.Type_VARCHAR},
+		{Name: "count", Type: querypb.Type_INT64},
+		{Name: "seen_at", Type: querypb.Type_TIMESTAMP},
+		{Name: "level", Type: querypb.Type_VARCHAR},
+	}
+
+	table := &TableConfig{DataType: &testWrapperRow{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+	fieldMap, err := table.reflectMapFields(fields)
+	require.NoError(t, err)
+
+	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	row := []sqltypes.Value{
+		sqltypes.NULL,
+		sqltypes.NULL,
+		sqltypes.NULL,
+		sqltypes.NewVarChar("gold"),
+	}
+
+	v := reflect.New(table.underlyingType)
+	err = copyRowToStruct(shard, row, v)
+	require.NoError(t, err)
+
+	// NULLs reach sql.Scanner fields as nil driver values, so they scan as invalid
+	out := v.Interface().(*testWrapperRow)
+	assert.False(t, out.Name.Valid)
+	assert.False(t, out.Count.Valid)
+	assert.False(t, out.SeenAt.Valid)
+	assert.Equal(t, testTextWrapper("wrapped:gold"), out.Level)
+}
+
+func TestSQLValueToDriverValue_Branches(t *testing.T) {
+	denver, err := time.LoadLocation("America/Denver")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		value sqltypes.Value
+		want  driver.Value
+	}{
+		{name: "null", value: sqltypes.NULL, want: nil},
+		{name: "signed int", value: sqltypes.NewInt64(-42), want: int64(-42)},
+		{name: "small unsigned as int64", value: sqltypes.MakeTrusted(sqltypes.Uint32, []byte("42")), want: int64(42)},
+		{name: "uint64 within int64 range", value: sqltypes.NewUint64(42), want: int64(42)},
+		{name: "uint64 above int64 range as string", value: sqltypes.NewUint64(math.MaxUint64), want: strconv.FormatUint(math.MaxUint64, 10)},
+		{name: "float", value: sqltypes.NewFloat64(1.5), want: 1.5},
+		{name: "decimal keeps exact text", value: sqltypes.NewDecimal("12.34"), want: "12.34"},
+		{name: "date in location", value: sqltypes.MakeTrusted(sqltypes.Date, []byte("2024-01-02")), want: time.Date(2024, 1, 2, 0, 0, 0, 0, denver)},
+		{name: "datetime in location", value: sqltypes.MakeTrusted(sqltypes.Datetime, []byte("2024-01-02 03:04:05")), want: time.Date(2024, 1, 2, 3, 4, 5, 0, denver)},
+		{name: "integral zero-or-one bool fallback", value: sqltypes.MakeTrusted(sqltypes.Year, []byte("1")), want: true},
+		{name: "text bytes fallback", value: sqltypes.NewVarChar("hello"), want: []byte("hello")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sqlValueToDriverValue(tt.value, denver)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestCopyRowToStruct_UnsupportedStructFieldErrors(t *testing.T) {

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -407,6 +407,65 @@ func TestCopyRowToStruct_ScannerAndTextUnmarshalerFields(t *testing.T) {
 	assert.Equal(t, testTextWrapper("wrapped:gold"), out.Level)
 }
 
+func TestHandleRowEvent_UpdateUsesAfterRowData(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	require.NoError(t, err)
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
+		Before: sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(1)}),
+		After:  sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(2)}),
+	}}}
+
+	vstreamStats := &VStreamStats{}
+	err = table.handleRowEvent(ev, vstreamStats)
+	require.NoError(t, err)
+
+	require.Len(t, table.currentBatch, 1)
+	out, ok := table.currentBatch[0].Data.(*testRowSmall)
+	require.True(t, ok)
+	assert.Equal(t, int64(2), out.ID)
+	assert.Equal(t, 1, table.stats.RowUpdateCount)
+	assert.Equal(t, 1, vstreamStats.RowUpdateCount)
+}
+
+func TestHandleRowEvent_CountsStatsPerChangeType(t *testing.T) {
+	fields := []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}}
+
+	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	fieldMap, err := table.reflectMapFields(fields)
+	require.NoError(t, err)
+	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.resetBatch()
+
+	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{
+		{After: sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(1)})}, // insert
+		{
+			Before: sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(1)}), // update
+			After:  sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(2)}),
+		},
+		{Before: sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(2)})}, // delete
+	}}
+
+	vstreamStats := &VStreamStats{}
+	err = table.handleRowEvent(ev, vstreamStats)
+	require.NoError(t, err)
+
+	require.Len(t, table.currentBatch, 3)
+	assert.Equal(t, 1, table.stats.RowInsertCount)
+	assert.Equal(t, 1, table.stats.RowUpdateCount)
+	assert.Equal(t, 1, table.stats.RowDeleteCount)
+	assert.Equal(t, 1, vstreamStats.RowInsertCount)
+	assert.Equal(t, 1, vstreamStats.RowUpdateCount)
+	assert.Equal(t, 1, vstreamStats.RowDeleteCount)
+}
+
 func TestCopyRowToStruct_NullThroughScannerFields(t *testing.T) {
 	fields := []*querypb.Field{
 		{Name: "name", Type: querypb.Type_VARCHAR},

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -819,7 +819,7 @@ func TestValidateTableConfig(t *testing.T) {
 	t.Run("matching config passes", func(t *testing.T) {
 		err := validateTableConfig(
 			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
-			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
+			map[string]dbTableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
 		)
 		require.NoError(t, err)
 	})
@@ -827,7 +827,7 @@ func TestValidateTableConfig(t *testing.T) {
 	t.Run("different config fails", func(t *testing.T) {
 		err := validateTableConfig(
 			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
-			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select id from t"}},
+			map[string]dbTableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select id from t"}},
 		)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "provided tables do not match stored tables")
@@ -842,7 +842,7 @@ func TestValidateTableConfig(t *testing.T) {
 				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
 				"t2": {Keyspace: "ks", Table: "t2", Query: "select * from t2"},
 			},
-			map[string]*TableConfig{
+			map[string]dbTableConfig{
 				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
 			},
 		)
@@ -855,7 +855,7 @@ func TestValidateTableConfig(t *testing.T) {
 			map[string]*TableConfig{
 				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
 			},
-			map[string]*TableConfig{
+			map[string]dbTableConfig{
 				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
 				"t2": {Keyspace: "ks", Table: "t2", Query: "select * from t2"},
 			},

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -518,7 +518,8 @@ func TestSQLValueToDriverValue_Branches(t *testing.T) {
 		{name: "decimal keeps exact text", value: sqltypes.NewDecimal("12.34"), want: "12.34"},
 		{name: "date in location", value: sqltypes.MakeTrusted(sqltypes.Date, []byte("2024-01-02")), want: time.Date(2024, 1, 2, 0, 0, 0, 0, denver)},
 		{name: "datetime in location", value: sqltypes.MakeTrusted(sqltypes.Datetime, []byte("2024-01-02 03:04:05")), want: time.Date(2024, 1, 2, 3, 4, 5, 0, denver)},
-		{name: "integral zero-or-one bool fallback", value: sqltypes.MakeTrusted(sqltypes.Year, []byte("1")), want: true},
+		{name: "year as int64", value: sqltypes.MakeTrusted(sqltypes.Year, []byte("2024")), want: int64(2024)},
+		{name: "year one stays numeric", value: sqltypes.MakeTrusted(sqltypes.Year, []byte("1")), want: int64(1)},
 		{name: "text bytes fallback", value: sqltypes.NewVarChar("hello"), want: []byte("hello")},
 	}
 

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -550,7 +550,7 @@ func TestInitTables_SetsDefaults(t *testing.T) {
 	assert.Equal(t, DefaultMaxRowsPerFlush, cap(table.currentBatch))
 }
 
-func TestInitTables_RejectsDuplicateTables(t *testing.T) {
+func TestInitTables_AllowsSameTableAcrossKeyspaces(t *testing.T) {
 	v := &VStreamClient{
 		shardsByKeyspace: map[string][]string{"ks1": {"0"}, "ks2": {"0"}},
 		tables:           make(map[string]*TableConfig),
@@ -563,6 +563,20 @@ func TestInitTables_RejectsDuplicateTables(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, v.tables, qualifiedTableName("ks1", "t"))
 	assert.Contains(t, v.tables, qualifiedTableName("ks2", "t"))
+}
+
+func TestInitTables_RejectsDuplicateTables(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks1": {"0"}},
+		tables:           make(map[string]*TableConfig),
+	}
+
+	err := v.initTables([]TableConfig{
+		{Keyspace: "ks1", Table: "t", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+		{Keyspace: "ks1", Table: "t", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "duplicate table ks1.t")
 }
 
 func TestInitTables_RejectsConflictingQueriesForSameTableAcrossKeyspaces(t *testing.T) {

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -33,7 +33,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
 type testRow struct {
@@ -1083,11 +1082,4 @@ func TestHandleRowEvent_PartialJSONFailsForDefaultDecoder(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "partial JSON updates are unsupported")
 	assert.Empty(t, table.currentBatch)
-}
-
-func TestWithFlags_RejectsZeroHeartbeatInterval(t *testing.T) {
-	v := &VStreamClient{}
-	err := WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 0})(v)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "HeartbeatInterval")
 }

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -222,7 +222,7 @@ func TestCopyRowToStruct_NullIntoNonPointerErrors(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "NULL into non-pointer field")
 }
 
@@ -279,7 +279,7 @@ func TestCopyRowToStruct_JSONFieldInvalidErrors(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "error unmarshalling JSON for field payload")
 }
 
@@ -305,8 +305,8 @@ func TestCopyRowToStruct_JSONFieldNullIntoNonPointerErrors(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "error unmarshalling JSON for field payload")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "error unmarshalling JSON for field payload")
 	assert.ErrorContains(t, err, "NULL into non-pointer field")
 }
 
@@ -546,8 +546,8 @@ func TestCopyRowToStruct_UnsupportedStructFieldErrors(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "unsupported struct field type")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unsupported struct field type")
 	assert.ErrorContains(t, err, "wrapped")
 }
 
@@ -565,8 +565,8 @@ func TestCopyRowToStruct_IntOverflowErrors(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "overflows destination type")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "overflows destination type")
 	assert.ErrorContains(t, err, "value")
 }
 
@@ -584,8 +584,8 @@ func TestCopyRowToStruct_UintOverflowErrors(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "overflows destination type")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "overflows destination type")
 	assert.ErrorContains(t, err, "value")
 }
 
@@ -603,8 +603,8 @@ func TestCopyRowToStruct_FloatOverflowErrors(t *testing.T) {
 
 	v := reflect.New(table.underlyingType)
 	err = copyRowToStruct(shard, row, v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "overflows destination type")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "overflows destination type")
 	assert.ErrorContains(t, err, "value")
 }
 
@@ -615,7 +615,7 @@ func TestReflectMapFields_ErrorOnUnknownFields(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 	_, err := table.reflectMapFields(fields)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "field extra")
 }
 
@@ -652,7 +652,7 @@ func TestInitTables_RequiresFlushFn(t *testing.T) {
 		Table:    "t",
 		DataType: &testRowSmall{},
 	}})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "has no flush function")
 }
 
@@ -674,7 +674,7 @@ func TestInitTables_SetsDefaults(t *testing.T) {
 	require.NotNil(t, table)
 	assert.Equal(t, "select * from `t`", table.Query)
 	assert.Equal(t, DefaultMaxRowsPerFlush, table.MaxRowsPerFlush)
-	assert.Len(t, table.currentBatch, 0)
+	assert.Empty(t, table.currentBatch)
 	assert.Equal(t, DefaultMaxRowsPerFlush, cap(table.currentBatch))
 }
 
@@ -745,7 +745,7 @@ func TestInitTables_RejectsConflictingQueriesForSameTableAcrossKeyspaces(t *test
 		{Keyspace: "ks1", Table: "t", Query: "select * from t where id < 10", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
 		{Keyspace: "ks2", Table: "t", Query: "select * from t where id >= 10", DataType: &testRowSmall{}, FlushFn: func(context.Context, []Row, FlushMeta) error { return nil }},
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "same table name across keyspaces must use identical queries")
 }
 
@@ -761,7 +761,7 @@ func TestInitTables_RejectsUnknownKeyspace(t *testing.T) {
 		DataType: &testRowSmall{},
 		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
 	}})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "keyspace missing not found")
 }
 
@@ -777,7 +777,7 @@ func TestInitTables_RejectsNonStructDataType(t *testing.T) {
 		DataType: new(int64),
 		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
 	}})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "must be a struct")
 }
 
@@ -794,7 +794,7 @@ func TestInitTables_RejectsTypedNilDataType(t *testing.T) {
 		DataType: row,
 		FlushFn:  func(context.Context, []Row, FlushMeta) error { return nil },
 	}})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "has no data type")
 }
 
@@ -811,7 +811,7 @@ func TestInitTables_RejectsNegativeMaxRowsPerFlush(t *testing.T) {
 		DataType:        &testRowSmall{},
 		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
 	}})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "max rows per flush must be positive")
 }
 
@@ -829,10 +829,9 @@ func TestValidateTableConfig(t *testing.T) {
 			map[string]*TableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select * from t"}},
 			map[string]dbTableConfig{"t": {Keyspace: "ks", Table: "t", Query: "select id from t"}},
 		)
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "provided tables do not match stored tables")
-		assert.ErrorContains(t, err, "table ks.t query changed")
-		assert.ErrorContains(t, err, "provided \"select * from t\"")
+		require.ErrorContains(t, err, "provided tables do not match stored tables")
+		require.ErrorContains(t, err, "table ks.t query changed")
+		require.ErrorContains(t, err, "provided \"select * from t\"")
 		assert.ErrorContains(t, err, "stored \"select id from t\"")
 	})
 
@@ -846,7 +845,7 @@ func TestValidateTableConfig(t *testing.T) {
 				"t1": {Keyspace: "ks", Table: "t1", Query: "select * from t1"},
 			},
 		)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.ErrorContains(t, err, "table ks.t2 is new in provided config")
 	})
 
@@ -860,7 +859,7 @@ func TestValidateTableConfig(t *testing.T) {
 				"t2": {Keyspace: "ks", Table: "t2", Query: "select * from t2"},
 			},
 		)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.ErrorContains(t, err, "table ks.t2 is missing from provided config")
 	})
 }
@@ -1009,8 +1008,8 @@ func TestHandleRowEvent_DecodeFailureDoesNotBufferRow(t *testing.T) {
 
 	stats := &VStreamStats{}
 	err = table.handleRowEvent(ev, stats)
-	assert.Error(t, err)
-	assert.Len(t, table.currentBatch, 0)
+	require.Error(t, err)
+	assert.Empty(t, table.currentBatch)
 }
 
 func TestHandleRowEvent_ScannerFailureDoesNotBufferRow(t *testing.T) {
@@ -1028,9 +1027,9 @@ func TestHandleRowEvent_ScannerFailureDoesNotBufferRow(t *testing.T) {
 
 	stats := &VStreamStats{}
 	err := table.handleRowEvent(ev, stats)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "client scan failed")
-	assert.Len(t, table.currentBatch, 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "client scan failed")
+	assert.Empty(t, table.currentBatch)
 }
 
 func TestHandleRowEvent_PartialRowImageFailsForDefaultDecoder(t *testing.T) {
@@ -1050,9 +1049,9 @@ func TestHandleRowEvent_PartialRowImageFailsForDefaultDecoder(t *testing.T) {
 
 	stats := &VStreamStats{}
 	err = table.handleRowEvent(ev, stats)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "partial row images are unsupported")
-	assert.Len(t, table.currentBatch, 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "partial row images are unsupported")
+	assert.Empty(t, table.currentBatch)
 }
 
 func TestHandleRowEvent_PartialJSONFailsForDefaultDecoder(t *testing.T) {
@@ -1081,14 +1080,14 @@ func TestHandleRowEvent_PartialJSONFailsForDefaultDecoder(t *testing.T) {
 
 	stats := &VStreamStats{}
 	err = table.handleRowEvent(ev, stats)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "partial JSON updates are unsupported")
-	assert.Len(t, table.currentBatch, 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "partial JSON updates are unsupported")
+	assert.Empty(t, table.currentBatch)
 }
 
 func TestWithFlags_RejectsZeroHeartbeatInterval(t *testing.T) {
 	v := &VStreamClient{}
 	err := WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 0})(v)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "HeartbeatInterval")
 }

--- a/go/vt/vstreamclient/convert_test.go
+++ b/go/vt/vstreamclient/convert_test.go
@@ -153,10 +153,10 @@ func TestCopyRowToStruct_TimeAndPointers(t *testing.T) {
 	table := &TableConfig{DataType: &testRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 
 	row := []sqltypes.Value{
 		sqltypes.NewInt64(1),
@@ -186,9 +186,9 @@ func TestHandleRowEvent_TimeUsesConfiguredLocation(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRow{}, timeLocation: loc}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
@@ -213,10 +213,10 @@ func TestCopyRowToStruct_NullIntoNonPointerErrors(t *testing.T) {
 	table := &TableConfig{DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{sqltypes.NULL}
 
 	v := reflect.New(table.underlyingType)
@@ -235,10 +235,10 @@ func TestCopyRowToStruct_JSONFields(t *testing.T) {
 	table := &TableConfig{DataType: &testJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{
 		sqltypes.NewInt64(1),
 		sqltypes.NewVarBinary(`{"name":"alpha","count":2}`),
@@ -266,10 +266,10 @@ func TestCopyRowToStruct_JSONFieldInvalidErrors(t *testing.T) {
 	table := &TableConfig{DataType: &testJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{
 		sqltypes.NewInt64(1),
 		sqltypes.NewVarBinary(`{"name":"alpha"`),
@@ -292,10 +292,10 @@ func TestCopyRowToStruct_JSONFieldNullIntoNonPointerErrors(t *testing.T) {
 	table := &TableConfig{DataType: &testJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{
 		sqltypes.NewInt64(1),
 		sqltypes.NULL,
@@ -319,10 +319,10 @@ func TestCopyRowToStruct_ByteAndRawJSONFields(t *testing.T) {
 	table := &TableConfig{DataType: &testBytesAndRawJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	rawPayload, err := sqltypes.NewJSON(`{"name":"alpha","count":2}`)
 	require.NoError(t, err)
 	row := []sqltypes.Value{
@@ -350,12 +350,12 @@ func TestCopyRowToStruct_NestedAndEmbeddedFields(t *testing.T) {
 	table := &TableConfig{DataType: &testNestedMappedRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	assert.Contains(t, fieldMap, "id")
-	assert.Contains(t, fieldMap, "name")
+	assert.True(t, hasFieldMapping(fieldMappings, "id"))
+	assert.True(t, hasFieldMapping(fieldMappings, "name"))
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{
 		sqltypes.NewInt64(7),
 		sqltypes.NewVarChar("alpha"),
@@ -381,10 +381,10 @@ func TestCopyRowToStruct_ScannerAndTextUnmarshalerFields(t *testing.T) {
 	table := &TableConfig{DataType: &testWrapperRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{
 		sqltypes.NewVarChar("alpha"),
 		sqltypes.NewInt64(42),
@@ -411,9 +411,9 @@ func TestHandleRowEvent_UpdateUsesAfterRowData(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
@@ -438,9 +438,9 @@ func TestHandleRowEvent_CountsStatsPerChangeType(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{
@@ -476,10 +476,10 @@ func TestCopyRowToStruct_NullThroughScannerFields(t *testing.T) {
 	table := &TableConfig{DataType: &testWrapperRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{
 		sqltypes.NULL,
 		sqltypes.NULL,
@@ -537,10 +537,10 @@ func TestCopyRowToStruct_UnsupportedStructFieldErrors(t *testing.T) {
 	table := &TableConfig{DataType: &testStructFieldRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewVarChar("value")}
 
 	v := reflect.New(table.underlyingType)
@@ -556,10 +556,10 @@ func TestCopyRowToStruct_IntOverflowErrors(t *testing.T) {
 	table := &TableConfig{DataType: &testSmallIntRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewInt64(128)}
 
 	v := reflect.New(table.underlyingType)
@@ -575,10 +575,10 @@ func TestCopyRowToStruct_UintOverflowErrors(t *testing.T) {
 	table := &TableConfig{DataType: &testSmallUintRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewUint64(256)}
 
 	v := reflect.New(table.underlyingType)
@@ -594,10 +594,10 @@ func TestCopyRowToStruct_FloatOverflowErrors(t *testing.T) {
 	table := &TableConfig{DataType: &testSmallFloatRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	shard := shardConfig{fieldMap: fieldMap, fields: fields}
+	shard := shardConfig{fieldMappings: fieldMappings, fields: fields}
 	row := []sqltypes.Value{sqltypes.NewFloat64(1e40)}
 
 	v := reflect.New(table.underlyingType)
@@ -628,16 +628,28 @@ func TestReflectMapFields_FallbackTagsStripOptions(t *testing.T) {
 	table := &TableConfig{DataType: &testFallbackTagRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	_, ok := fieldMap["db_name"]
-	assert.True(t, ok)
-	_, ok = fieldMap["json_name"]
-	assert.True(t, ok)
-	m, ok := fieldMap["option_name"]
+	assert.True(t, hasFieldMapping(fieldMappings, "db_name"))
+	assert.True(t, hasFieldMapping(fieldMappings, "json_name"))
+	m, ok := findFieldMapping(fieldMappings, "option_name")
 	require.True(t, ok)
 	assert.True(t, m.jsonDecode)
+}
+
+func findFieldMapping(mappings []fieldMapping, name string) (fieldMapping, bool) {
+	for _, mapping := range mappings {
+		if mapping.name == name {
+			return mapping, true
+		}
+	}
+	return fieldMapping{}, false
+}
+
+func hasFieldMapping(mappings []fieldMapping, name string) bool {
+	_, ok := findFieldMapping(mappings, name)
+	return ok
 }
 
 func TestInitTables_RequiresFlushFn(t *testing.T) {
@@ -868,10 +880,10 @@ func TestHandleRowEvent_DeleteUsesBeforeRowData(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
 
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
@@ -897,9 +909,9 @@ func TestHandleRowEvent_InsertScansNullableFields(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testNullableJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{
@@ -934,7 +946,7 @@ func TestHandleRowEvent_UsesTypedScanner(t *testing.T) {
 	table.implementsScanner = true
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
-	table.shards = map[string]shardConfig{"0": {fieldMap: nil, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: nil, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
@@ -996,9 +1008,9 @@ func TestHandleRowEvent_DecodeFailureDoesNotBufferRow(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
@@ -1036,9 +1048,9 @@ func TestHandleRowEvent_PartialRowImageFailsForDefaultDecoder(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testRowSmall{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{
@@ -1062,9 +1074,9 @@ func TestHandleRowEvent_PartialJSONFailsForDefaultDecoder(t *testing.T) {
 
 	table := &TableConfig{Keyspace: "ks", Table: "t", DataType: &testJSONRow{}}
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
-	fieldMap, err := table.reflectMapFields(fields)
+	fieldMappings, err := table.reflectMapFields(fields)
 	require.NoError(t, err)
-	table.shards = map[string]shardConfig{"0": {fieldMap: fieldMap, fields: fields}}
+	table.shards = map[string]shardConfig{"0": {fieldMappings: fieldMappings, fields: fields}}
 	table.resetBatch()
 
 	ev := &binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{{

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -1,0 +1,115 @@
+package vstreamclient
+
+import (
+	"fmt"
+	"time"
+
+	"vitess.io/vitess/go/sqlescape"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+)
+
+var (
+	// DefaultMinFlushDuration is the default minimum duration between flushes, used if not explicitly
+	// set using WithMinFlushDuration. This can be safely modified if needed before calling New.
+	DefaultMinFlushDuration = 5 * time.Second
+
+	// DefaultMaxRowsPerFlush is the default number of rows to buffer per table, used if not explicitly
+	// set in the table configuration. This same number is also used to chunk rows when calling flush.
+	// This can be safely modified if needed before calling New.
+	DefaultMaxRowsPerFlush = 1000
+)
+
+// Option is a function that can be used to configure a VStreamClient
+type Option func(v *VStreamClient) error
+
+// WithMinFlushDuration sets the minimum duration between flushes. This is useful for ensuring that data
+// isn't flushed too often, which can be inefficient. The default is 30 seconds.
+func WithMinFlushDuration(d time.Duration) Option {
+	return func(v *VStreamClient) error {
+		if d <= 0 {
+			return fmt.Errorf("vstreamclient: minimum flush duration must be positive, got %s", d.String())
+		}
+
+		v.minFlushDuration = d
+		return nil
+	}
+}
+
+func WithHeartbeatSeconds(seconds int) Option {
+	return func(v *VStreamClient) error {
+		if seconds <= 0 {
+			return fmt.Errorf("vstreamclient: heartbeat seconds must be positive, got %d", seconds)
+		}
+
+		v.heartbeatSeconds = seconds
+		return nil
+	}
+}
+
+func WithStateTable(keyspace, table string) Option {
+	return func(v *VStreamClient) error {
+		shards, ok := v.shardsByKeyspace[keyspace]
+		if !ok {
+			return fmt.Errorf("vstreamclient: keyspace %s not found", keyspace)
+		}
+
+		// this could allow for shard pinning, but we can support that if it becomes useful
+		if len(shards) > 1 {
+			return fmt.Errorf("vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
+		}
+
+		v.vgtidStateKeyspace = sqlescape.EscapeID(keyspace)
+		v.vgtidStateTable = sqlescape.EscapeID(table)
+		return nil
+	}
+}
+
+// DefaultFlags returns a default set of flags for a VStreamClient, safe to use in most cases, but can be customized
+func DefaultFlags() *vtgatepb.VStreamFlags {
+	return &vtgatepb.VStreamFlags{
+		HeartbeatInterval: 1,
+	}
+}
+
+// WithFlags lets you manually control all the flag options, instead of using helper functions
+func WithFlags(flags *vtgatepb.VStreamFlags) Option {
+	return func(v *VStreamClient) error {
+		v.flags = flags
+		return nil
+	}
+}
+
+// WithEventFunc provides for custom event handling functions for specific event types. Only one function
+// can be registered per event type, and it is called before the default event handling function. Returning
+// an error from the custom function will exit the stream before the default function is called.
+func WithEventFunc(fn EventFunc, eventTypes ...binlogdatapb.VEventType) Option {
+	return func(v *VStreamClient) error {
+		if len(eventTypes) == 0 {
+			return fmt.Errorf("vstreamclient: no event types provided")
+		}
+
+		if v.eventFuncs == nil {
+			v.eventFuncs = make(map[binlogdatapb.VEventType]EventFunc)
+		}
+
+		for _, eventType := range eventTypes {
+			if _, ok := v.eventFuncs[eventType]; ok {
+				return fmt.Errorf("vstreamclient: event type %s already has a function", eventType.String())
+			}
+
+			v.eventFuncs[eventType] = fn
+		}
+
+		return nil
+	}
+}
+
+// WithStartingVGtid sets the starting VGtid for the VStreamClient. This is useful for resuming a stream from a
+// specific point, vs what might be stored in the state table.
+func WithStartingVGtid(vgtid *binlogdatapb.VGtid) Option {
+	return func(v *VStreamClient) error {
+		v.latestVgtid = vgtid
+		return nil
+	}
+}

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -136,6 +136,10 @@ func WithGracefulShutdownSignals(wait time.Duration, signals ...os.Signal) Optio
 
 func WithStateTable(keyspace, table string) Option {
 	return func(v *VStreamClient) error {
+		if table == "" {
+			return errors.New("vstreamclient: state table name is required")
+		}
+
 		shards, ok := v.shardsByKeyspace[keyspace]
 		if !ok {
 			return fmt.Errorf("vstreamclient: keyspace %s not found", keyspace)

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -60,6 +60,17 @@ func WithHeartbeatSeconds(seconds int) Option {
 	}
 }
 
+func WithTimeLocation(loc *time.Location) Option {
+	return func(v *VStreamClient) error {
+		if loc == nil {
+			return errors.New("vstreamclient: time location cannot be nil")
+		}
+
+		v.cfg.timeLocation = loc
+		return nil
+	}
+}
+
 // WithTabletType overrides the tablet type used when opening the VStream.
 // The default is REPLICA.
 func WithTabletType(tabletType topodatapb.TabletType) Option {

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -40,7 +40,7 @@ func WithMinFlushDuration(d time.Duration) Option {
 			return fmt.Errorf("vstreamclient: minimum flush duration must be positive, got %s", d.String())
 		}
 
-		v.minFlushDuration = d
+		v.cfg.minFlushDuration = d
 		return nil
 	}
 }
@@ -55,7 +55,7 @@ func WithHeartbeatSeconds(seconds int) Option {
 			return fmt.Errorf("vstreamclient: heartbeat seconds must be %d or less, got %d", uint64(math.MaxUint32), seconds)
 		}
 
-		v.heartbeatSeconds = seconds
+		v.cfg.heartbeatSeconds = seconds
 		return nil
 	}
 }
@@ -68,7 +68,7 @@ func WithTabletType(tabletType topodatapb.TabletType) Option {
 			return errors.New("vstreamclient: tablet type cannot be UNKNOWN")
 		}
 
-		v.tabletType = tabletType
+		v.cfg.tabletType = tabletType
 		return nil
 	}
 }
@@ -84,8 +84,8 @@ func WithGracefulShutdownChan(ch <-chan struct{}, wait time.Duration) Option {
 			return fmt.Errorf("vstreamclient: graceful shutdown wait must be positive, got %s", wait)
 		}
 
-		v.gracefulShutdownChan = ch
-		v.gracefulShutdownWaitDur = wait
+		v.cfg.gracefulShutdownChan = ch
+		v.cfg.gracefulShutdownWaitDur = wait
 		return nil
 	}
 }
@@ -101,8 +101,8 @@ func WithGracefulShutdownSignals(wait time.Duration, signals ...os.Signal) Optio
 			return fmt.Errorf("vstreamclient: graceful shutdown wait must be positive, got %s", wait)
 		}
 
-		v.gracefulShutdownSignals = append([]os.Signal(nil), signals...)
-		v.gracefulShutdownWaitDur = wait
+		v.cfg.gracefulShutdownSignals = append([]os.Signal(nil), signals...)
+		v.cfg.gracefulShutdownWaitDur = wait
 		return nil
 	}
 }
@@ -119,8 +119,8 @@ func WithStateTable(keyspace, table string) Option {
 			return fmt.Errorf("vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
 		}
 
-		v.vgtidStateKeyspace = sqlescape.EscapeID(keyspace)
-		v.vgtidStateTable = sqlescape.EscapeID(table)
+		v.cfg.vgtidStateKeyspace = sqlescape.EscapeID(keyspace)
+		v.cfg.vgtidStateTable = sqlescape.EscapeID(table)
 		return nil
 	}
 }
@@ -143,7 +143,7 @@ func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 		if flags.HeartbeatInterval == 0 {
 			return errors.New("vstreamclient: HeartbeatInterval must be positive")
 		}
-		v.flags = flags
+		v.cfg.flags = flags
 		return nil
 	}
 }
@@ -161,16 +161,16 @@ func WithEventFunc(fn EventFunc, eventTypes ...binlogdatapb.VEventType) Option {
 			return errors.New("vstreamclient: event func cannot be nil")
 		}
 
-		if v.eventFuncs == nil {
-			v.eventFuncs = make(map[binlogdatapb.VEventType]EventFunc)
+		if v.cfg.eventFuncs == nil {
+			v.cfg.eventFuncs = make(map[binlogdatapb.VEventType]EventFunc)
 		}
 
 		for _, eventType := range eventTypes {
-			if _, ok := v.eventFuncs[eventType]; ok {
+			if _, ok := v.cfg.eventFuncs[eventType]; ok {
 				return fmt.Errorf("vstreamclient: event type %s already has a function", eventType.String())
 			}
 
-			v.eventFuncs[eventType] = fn
+			v.cfg.eventFuncs[eventType] = fn
 		}
 
 		return nil

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -1,23 +1,32 @@
 package vstreamclient
 
 import (
+	"errors"
 	"fmt"
+	"math"
+	"os"
 	"time"
 
 	"vitess.io/vitess/go/sqlescape"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
 var (
 	// DefaultMinFlushDuration is the default minimum duration between flushes, used if not explicitly
 	// set using WithMinFlushDuration. This can be safely modified if needed before calling New.
-	DefaultMinFlushDuration = 5 * time.Second
+	DefaultMinFlushDuration = 30 * time.Second
 
 	// DefaultMaxRowsPerFlush is the default number of rows to buffer per table, used if not explicitly
 	// set in the table configuration. This same number is also used to chunk rows when calling flush.
 	// This can be safely modified if needed before calling New.
 	DefaultMaxRowsPerFlush = 1000
+
+	// DefaultGracefulShutdownWaitDur is the default duration to wait for the stream to gracefully shutdown after
+	// receiving a shutdown signal, used if not explicitly set using WithGracefulShutdownChan or
+	// WithGracefulShutdownSignals. This can be safely modified if needed before calling New.
+	DefaultGracefulShutdownWaitDur = 5 * time.Second
 )
 
 // Option is a function that can be used to configure a VStreamClient
@@ -42,7 +51,58 @@ func WithHeartbeatSeconds(seconds int) Option {
 			return fmt.Errorf("vstreamclient: heartbeat seconds must be positive, got %d", seconds)
 		}
 
+		if uint64(seconds) > math.MaxUint32 {
+			return fmt.Errorf("vstreamclient: heartbeat seconds must be %d or less, got %d", uint64(math.MaxUint32), seconds)
+		}
+
 		v.heartbeatSeconds = seconds
+		return nil
+	}
+}
+
+// WithTabletType overrides the tablet type used when opening the VStream.
+// The default is REPLICA.
+func WithTabletType(tabletType topodatapb.TabletType) Option {
+	return func(v *VStreamClient) error {
+		if tabletType == topodatapb.TabletType_UNKNOWN {
+			return errors.New("vstreamclient: tablet type cannot be UNKNOWN")
+		}
+
+		v.tabletType = tabletType
+		return nil
+	}
+}
+
+// WithGracefulShutdownChan triggers GracefulShutdown when the provided channel is closed.
+// A common pattern is to pass a channel derived from signal.Notify or signal.NotifyContext.
+func WithGracefulShutdownChan(ch <-chan struct{}, wait time.Duration) Option {
+	return func(v *VStreamClient) error {
+		if ch == nil {
+			return errors.New("vstreamclient: graceful shutdown channel is required")
+		}
+		if wait <= 0 {
+			return fmt.Errorf("vstreamclient: graceful shutdown wait must be positive, got %s", wait)
+		}
+
+		v.gracefulShutdownChan = ch
+		v.gracefulShutdownWaitDur = wait
+		return nil
+	}
+}
+
+// WithGracefulShutdownSignals triggers GracefulShutdown when one of the provided
+// OS signals is received. A common pattern is to pass os.Interrupt and syscall.SIGTERM.
+func WithGracefulShutdownSignals(wait time.Duration, signals ...os.Signal) Option {
+	return func(v *VStreamClient) error {
+		if len(signals) == 0 {
+			return errors.New("vstreamclient: graceful shutdown signals are required")
+		}
+		if wait <= 0 {
+			return fmt.Errorf("vstreamclient: graceful shutdown wait must be positive, got %s", wait)
+		}
+
+		v.gracefulShutdownSignals = append([]os.Signal(nil), signals...)
+		v.gracefulShutdownWaitDur = wait
 		return nil
 	}
 }
@@ -69,12 +129,20 @@ func WithStateTable(keyspace, table string) Option {
 func DefaultFlags() *vtgatepb.VStreamFlags {
 	return &vtgatepb.VStreamFlags{
 		HeartbeatInterval: 1,
+		// Keep keyspace in TableName so multiple-keyspace streams disambiguate tables.
+		ExcludeKeyspaceFromTableName: false,
 	}
 }
 
 // WithFlags lets you manually control all the flag options, instead of using helper functions
 func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 	return func(v *VStreamClient) error {
+		if flags == nil {
+			return errors.New("vstreamclient: flags cannot be nil")
+		}
+		if flags.HeartbeatInterval == 0 {
+			return errors.New("vstreamclient: HeartbeatInterval must be positive")
+		}
 		v.flags = flags
 		return nil
 	}
@@ -86,7 +154,11 @@ func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 func WithEventFunc(fn EventFunc, eventTypes ...binlogdatapb.VEventType) Option {
 	return func(v *VStreamClient) error {
 		if len(eventTypes) == 0 {
-			return fmt.Errorf("vstreamclient: no event types provided")
+			return errors.New("vstreamclient: no event types provided")
+		}
+
+		if fn == nil {
+			return errors.New("vstreamclient: event func cannot be nil")
 		}
 
 		if v.eventFuncs == nil {

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"vitess.io/vitess/go/sqlescape"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -184,7 +186,12 @@ func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 		if flags.HeartbeatInterval == 0 {
 			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: HeartbeatInterval must be positive")
 		}
-		v.cfg.flags = flags
+		if flags.StreamKeyspaceHeartbeats {
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: StreamKeyspaceHeartbeats is not supported: it streams internal sidecar heartbeat table events that have no TableConfig")
+		}
+
+		// clone so later caller mutations can't change stream behavior or bypass the validation above
+		v.cfg.flags = proto.Clone(flags).(*vtgatepb.VStreamFlags)
 		return nil
 	}
 }

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -43,6 +43,16 @@ var (
 	// receiving a shutdown signal, used if not explicitly set using WithGracefulShutdownChan or
 	// WithGracefulShutdownSignals. This can be safely modified if needed before calling New.
 	DefaultGracefulShutdownWaitDur = 5 * time.Second
+
+	// DefaultStartupTimeout is how long the client waits for the first event after Run starts before it
+	// shuts itself down with ErrStartupTimeout. This can be safely modified if needed before calling New.
+	DefaultStartupTimeout = 5 * time.Minute
+
+	// DefaultHeartbeatTimeoutMultiplier controls the liveness window as a multiple of the heartbeat
+	// interval: once the first event has been received, if no event (including heartbeats) is received
+	// for that window, the client shuts itself down with ErrHeartbeatTimeout. This can be safely
+	// modified if needed before calling New.
+	DefaultHeartbeatTimeoutMultiplier = 2
 )
 
 // Option is a function that can be used to configure a VStreamClient

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -158,9 +158,20 @@ func WithStateTable(keyspace, table string) Option {
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s not found", keyspace)
 		}
 
-		// this could allow for shard pinning, but we can support that if it becomes useful
-		if len(shards) > 1 {
+		// unsharded keyspaces always have exactly one shard named "0". A sharded keyspace can
+		// currently have a single shard (named "-") and can gain shards through resharding, so
+		// checking the shard count alone is not enough.
+		if len(shards) != 1 || shards[0] != "0" {
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
+		}
+
+		// checkpoint writes are themselves transactions: if the state keyspace is also a source
+		// keyspace, every checkpoint advances the stream position and schedules another
+		// checkpoint, creating a self-sustaining write loop on an otherwise idle stream
+		for _, tbl := range v.tables {
+			if tbl.Keyspace == keyspace {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state keyspace %s is also a streamed source keyspace; store checkpoints in a keyspace that is not being streamed", keyspace)
+			}
 		}
 
 		v.cfg.vgtidStateKeyspace = sqlescape.EscapeID(keyspace)

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -48,7 +48,10 @@ var (
 	DefaultGracefulShutdownWaitDur = 5 * time.Second
 
 	// DefaultStartupTimeout is how long the client waits for the first event after Run starts before it
-	// shuts itself down with ErrStartupTimeout. This can be safely modified if needed before calling New.
+	// shuts itself down with ErrStartupTimeout. The effective timeout is never shorter than the
+	// heartbeat liveness window (heartbeat interval times DefaultHeartbeatTimeoutMultiplier), since an
+	// idle stream may not deliver its first event until the first heartbeat. This can be safely
+	// modified if needed before calling New.
 	DefaultStartupTimeout = 5 * time.Minute
 
 	// DefaultHeartbeatTimeoutMultiplier controls the liveness window as a multiple of the heartbeat

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -19,6 +19,7 @@ package vstreamclient
 import (
 	"math"
 	"os"
+	"strings"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -227,9 +228,27 @@ func WithEventFunc(fn EventFunc, eventTypes ...binlogdatapb.VEventType) Option {
 
 // WithStartingVGtid sets the starting VGtid for the VStreamClient. This is useful for resuming a stream from a
 // specific point, vs what might be stored in the state table.
+//
+// The position is persisted with copy_completed=true and becomes the durable restart point, so every
+// shard gtid must be a concrete position: symbolic positions like "current" are resolved afresh by
+// VTGate on every run, which would silently skip rows delivered between a crash and the restart.
 func WithStartingVGtid(vgtid *binlogdatapb.VGtid) Option {
 	return func(v *VStreamClient) error {
-		v.latestVgtid = vgtid
+		if vgtid == nil || len(vgtid.ShardGtids) == 0 {
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid must include at least one shard gtid")
+		}
+
+		for _, shardGtid := range vgtid.ShardGtids {
+			if shardGtid == nil || shardGtid.Keyspace == "" || shardGtid.Shard == "" {
+				return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: every starting shard gtid must name a keyspace and shard")
+			}
+			if shardGtid.Gtid == "" || strings.EqualFold(shardGtid.Gtid, "current") {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting gtid for %s/%s must be a concrete position, got %q: symbolic or empty positions cannot be persisted as a restart point", shardGtid.Keyspace, shardGtid.Shard, shardGtid.Gtid)
+			}
+		}
+
+		// clone so later caller mutations can't change or race with client state
+		v.latestVgtid = proto.Clone(vgtid).(*binlogdatapb.VGtid)
 		return nil
 	}
 }

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -17,8 +17,6 @@ limitations under the License.
 package vstreamclient
 
 import (
-	"errors"
-	"fmt"
 	"math"
 	"os"
 	"time"
@@ -27,6 +25,8 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 var (
@@ -63,7 +63,7 @@ type Option func(v *VStreamClient) error
 func WithMinFlushDuration(d time.Duration) Option {
 	return func(v *VStreamClient) error {
 		if d <= 0 {
-			return fmt.Errorf("vstreamclient: minimum flush duration must be positive, got %s", d.String())
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: minimum flush duration must be positive, got %s", d.String())
 		}
 
 		v.cfg.minFlushDuration = d
@@ -74,11 +74,11 @@ func WithMinFlushDuration(d time.Duration) Option {
 func WithHeartbeatSeconds(seconds int) Option {
 	return func(v *VStreamClient) error {
 		if seconds <= 0 {
-			return fmt.Errorf("vstreamclient: heartbeat seconds must be positive, got %d", seconds)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: heartbeat seconds must be positive, got %d", seconds)
 		}
 
 		if uint64(seconds) > math.MaxUint32 {
-			return fmt.Errorf("vstreamclient: heartbeat seconds must be %d or less, got %d", uint64(math.MaxUint32), seconds)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: heartbeat seconds must be %d or less, got %d", uint64(math.MaxUint32), seconds)
 		}
 
 		v.cfg.heartbeatSeconds = seconds
@@ -89,7 +89,7 @@ func WithHeartbeatSeconds(seconds int) Option {
 func WithTimeLocation(loc *time.Location) Option {
 	return func(v *VStreamClient) error {
 		if loc == nil {
-			return errors.New("vstreamclient: time location cannot be nil")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: time location cannot be nil")
 		}
 
 		v.cfg.timeLocation = loc
@@ -102,7 +102,7 @@ func WithTimeLocation(loc *time.Location) Option {
 func WithTabletType(tabletType topodatapb.TabletType) Option {
 	return func(v *VStreamClient) error {
 		if tabletType == topodatapb.TabletType_UNKNOWN {
-			return errors.New("vstreamclient: tablet type cannot be UNKNOWN")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: tablet type cannot be UNKNOWN")
 		}
 
 		v.cfg.tabletType = tabletType
@@ -115,10 +115,10 @@ func WithTabletType(tabletType topodatapb.TabletType) Option {
 func WithGracefulShutdownChan(ch <-chan struct{}, wait time.Duration) Option {
 	return func(v *VStreamClient) error {
 		if ch == nil {
-			return errors.New("vstreamclient: graceful shutdown channel is required")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: graceful shutdown channel is required")
 		}
 		if wait <= 0 {
-			return fmt.Errorf("vstreamclient: graceful shutdown wait must be positive, got %s", wait)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: graceful shutdown wait must be positive, got %s", wait)
 		}
 
 		v.cfg.gracefulShutdownChan = ch
@@ -132,10 +132,10 @@ func WithGracefulShutdownChan(ch <-chan struct{}, wait time.Duration) Option {
 func WithGracefulShutdownSignals(wait time.Duration, signals ...os.Signal) Option {
 	return func(v *VStreamClient) error {
 		if len(signals) == 0 {
-			return errors.New("vstreamclient: graceful shutdown signals are required")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: graceful shutdown signals are required")
 		}
 		if wait <= 0 {
-			return fmt.Errorf("vstreamclient: graceful shutdown wait must be positive, got %s", wait)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: graceful shutdown wait must be positive, got %s", wait)
 		}
 
 		v.cfg.gracefulShutdownSignals = append([]os.Signal(nil), signals...)
@@ -147,17 +147,17 @@ func WithGracefulShutdownSignals(wait time.Duration, signals ...os.Signal) Optio
 func WithStateTable(keyspace, table string) Option {
 	return func(v *VStreamClient) error {
 		if table == "" {
-			return errors.New("vstreamclient: state table name is required")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state table name is required")
 		}
 
 		shards, ok := v.shardsByKeyspace[keyspace]
 		if !ok {
-			return fmt.Errorf("vstreamclient: keyspace %s not found", keyspace)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s not found", keyspace)
 		}
 
 		// this could allow for shard pinning, but we can support that if it becomes useful
 		if len(shards) > 1 {
-			return fmt.Errorf("vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
 		}
 
 		v.cfg.vgtidStateKeyspace = sqlescape.EscapeID(keyspace)
@@ -179,10 +179,10 @@ func DefaultFlags() *vtgatepb.VStreamFlags {
 func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 	return func(v *VStreamClient) error {
 		if flags == nil {
-			return errors.New("vstreamclient: flags cannot be nil")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: flags cannot be nil")
 		}
 		if flags.HeartbeatInterval == 0 {
-			return errors.New("vstreamclient: HeartbeatInterval must be positive")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: HeartbeatInterval must be positive")
 		}
 		v.cfg.flags = flags
 		return nil
@@ -195,11 +195,11 @@ func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 func WithEventFunc(fn EventFunc, eventTypes ...binlogdatapb.VEventType) Option {
 	return func(v *VStreamClient) error {
 		if len(eventTypes) == 0 {
-			return errors.New("vstreamclient: no event types provided")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: no event types provided")
 		}
 
 		if fn == nil {
-			return errors.New("vstreamclient: event func cannot be nil")
+			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: event func cannot be nil")
 		}
 
 		if v.cfg.eventFuncs == nil {
@@ -208,7 +208,7 @@ func WithEventFunc(fn EventFunc, eventTypes ...binlogdatapb.VEventType) Option {
 
 		for _, eventType := range eventTypes {
 			if _, ok := v.cfg.eventFuncs[eventType]; ok {
-				return fmt.Errorf("vstreamclient: event type %s already has a function", eventType.String())
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: event type %s already has a function", eventType.String())
 			}
 
 			v.cfg.eventFuncs[eventType] = fn

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -216,9 +216,6 @@ func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 		if flags == nil {
 			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: flags cannot be nil")
 		}
-		if flags.HeartbeatInterval == 0 {
-			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: HeartbeatInterval must be positive")
-		}
 		if flags.StreamKeyspaceHeartbeats {
 			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: StreamKeyspaceHeartbeats is not supported: it streams internal sidecar heartbeat table events that have no TableConfig")
 		}

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -60,7 +60,7 @@ var (
 	// interval: once the first event has been received, if no event (including heartbeats) is received
 	// for that window, the client shuts itself down with ErrHeartbeatTimeout. This can be safely
 	// modified if needed before calling New.
-	DefaultHeartbeatTimeoutMultiplier = 2
+	DefaultHeartbeatTimeoutMultiplier = 10
 )
 
 // Option is a function that can be used to configure a VStreamClient
@@ -79,6 +79,8 @@ func WithMinFlushDuration(d time.Duration) Option {
 	}
 }
 
+// WithHeartbeatSeconds sets the heartbeat interval in seconds. It overrides the
+// HeartbeatInterval in WithFlags regardless of the order the options are supplied.
 func WithHeartbeatSeconds(seconds int) Option {
 	return func(v *VStreamClient) error {
 		if seconds <= 0 {
@@ -158,36 +160,33 @@ func WithStateTable(keyspace, table string) Option {
 			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state table name is required")
 		}
 
-		shards, ok := v.shardsByKeyspace[keyspace]
-		if !ok {
-			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s not found", keyspace)
-		}
-
-		// the vschema sharded property is the authoritative check: a sharded keyspace can have
-		// any single shard today (even one named "0") and gain shards through resharding
-		if sharded, ok := v.shardedByKeyspace[keyspace]; ok && sharded {
-			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
-		}
-
-		// shard-name heuristic as a backstop for clusters where the vschema cannot be read:
-		// unsharded keyspaces always have exactly one shard named "0"
-		if len(shards) != 1 || shards[0] != "0" {
-			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
-		}
-
-		// checkpoint writes are themselves transactions: if the state keyspace is also a source
-		// keyspace, every checkpoint advances the stream position and schedules another
-		// checkpoint, creating a self-sustaining write loop on an otherwise idle stream
-		for _, tbl := range v.tables {
-			if tbl.Keyspace == keyspace {
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state keyspace %s is also a streamed source keyspace; store checkpoints in a keyspace that is not being streamed", keyspace)
-			}
-		}
-
 		v.cfg.vgtidStateKeyspace = sqlescape.EscapeID(keyspace)
 		v.cfg.vgtidStateTable = sqlescape.EscapeID(table)
 		return nil
 	}
+}
+
+func (v *VStreamClient) validateStateTable() error {
+	if v.cfg.vgtidStateKeyspace == "" || v.cfg.vgtidStateTable == "" {
+		return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state table not configured (use WithStateTable)")
+	}
+	keyspace, err := sqlescape.UnescapeID(v.cfg.vgtidStateKeyspace)
+	if err != nil {
+		return vterrors.Wrap(err, "vstreamclient: invalid state keyspace")
+	}
+	sharded, ok := v.shardedByKeyspace[keyspace]
+	if !ok {
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s not found in vschema", keyspace)
+	}
+	if sharded {
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
+	}
+	for _, table := range v.tables {
+		if table.Keyspace == keyspace {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state keyspace %s is also a streamed source keyspace; store checkpoints in a keyspace that is not being streamed", keyspace)
+		}
+	}
+	return nil
 }
 
 // WithSkipRowImageCheck disables the verification that every source shard uses
@@ -210,7 +209,8 @@ func DefaultFlags() *vtgatepb.VStreamFlags {
 	}
 }
 
-// WithFlags lets you manually control all the flag options, instead of using helper functions
+// WithFlags configures the VStream flags. WithHeartbeatSeconds overrides its
+// HeartbeatInterval regardless of option order; other flags are preserved.
 func WithFlags(flags *vtgatepb.VStreamFlags) Option {
 	return func(v *VStreamClient) error {
 		if flags == nil {
@@ -273,15 +273,13 @@ func WithStartingVGtid(vgtid *binlogdatapb.VGtid) Option {
 			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid must include at least one shard gtid")
 		}
 
-		configuredKeyspaces := make(map[string]bool, len(v.tables))
-		for _, table := range v.tables {
-			configuredKeyspaces[table.Keyspace] = true
-		}
-
 		seen := make(map[string]bool, len(vgtid.ShardGtids))
 		for _, shardGtid := range vgtid.ShardGtids {
 			if shardGtid == nil || shardGtid.Keyspace == "" || shardGtid.Shard == "" {
 				return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: every starting shard gtid must name a keyspace and shard")
+			}
+			if len(shardGtid.TablePKs) != 0 {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting gtid for %s/%s contains TablePKs; copy cursors are not supported", shardGtid.Keyspace, shardGtid.Shard)
 			}
 			if shardGtid.Gtid == "" || strings.EqualFold(shardGtid.Gtid, "current") {
 				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting gtid for %s/%s must be a concrete position, got %q: symbolic or empty positions cannot be persisted as a restart point", shardGtid.Keyspace, shardGtid.Shard, shardGtid.Gtid)
@@ -289,13 +287,6 @@ func WithStartingVGtid(vgtid *binlogdatapb.VGtid) Option {
 			if _, err := replication.DecodePosition(shardGtid.Gtid); err != nil {
 				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting gtid for %s/%s is not a parseable position: %v", shardGtid.Keyspace, shardGtid.Shard, err)
 			}
-			if !configuredKeyspaces[shardGtid.Keyspace] {
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names keyspace %s, which is not a configured source keyspace", shardGtid.Keyspace)
-			}
-			if !slices.Contains(v.shardsByKeyspace[shardGtid.Keyspace], shardGtid.Shard) {
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names shard %s/%s, which does not exist in the cluster", shardGtid.Keyspace, shardGtid.Shard)
-			}
-
 			key := shardGtid.Keyspace + "/" + shardGtid.Shard
 			if seen[key] {
 				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names shard %s more than once", key)
@@ -303,18 +294,36 @@ func WithStartingVGtid(vgtid *binlogdatapb.VGtid) Option {
 			seen[key] = true
 		}
 
-		// VTGate only opens streams for the listed shards, so a partial position would silently
-		// never consume the omitted shards
-		for keyspace := range configuredKeyspaces {
-			for _, shard := range v.shardsByKeyspace[keyspace] {
-				if !seen[keyspace+"/"+shard] {
-					return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid does not cover shard %s/%s; every shard of every configured source keyspace needs a position", keyspace, shard)
-				}
-			}
-		}
-
 		// clone so later caller mutations can't change or race with client state
 		v.latestVgtid = proto.Clone(vgtid).(*binlogdatapb.VGtid)
 		return nil
 	}
+}
+
+func (v *VStreamClient) validateStartingVGtid() error {
+	if v.latestVgtid == nil {
+		return nil
+	}
+	configuredKeyspaces := make(map[string]bool, len(v.tables))
+	for _, table := range v.tables {
+		configuredKeyspaces[table.Keyspace] = true
+	}
+	seen := make(map[string]bool, len(v.latestVgtid.ShardGtids))
+	for _, shardGtid := range v.latestVgtid.ShardGtids {
+		if !configuredKeyspaces[shardGtid.Keyspace] {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names keyspace %s, which is not a configured source keyspace", shardGtid.Keyspace)
+		}
+		if !slices.Contains(v.shardsByKeyspace[shardGtid.Keyspace], shardGtid.Shard) {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names shard %s/%s, which does not exist in the cluster", shardGtid.Keyspace, shardGtid.Shard)
+		}
+		seen[shardGtid.Keyspace+"/"+shardGtid.Shard] = true
+	}
+	for keyspace := range configuredKeyspaces {
+		for _, shard := range v.shardsByKeyspace[keyspace] {
+			if !seen[keyspace+"/"+shard] {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid does not cover shard %s/%s; every shard of every configured source keyspace needs a position", keyspace, shard)
+			}
+		}
+	}
+	return nil
 }

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -19,11 +19,13 @@ package vstreamclient
 import (
 	"math"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
 	"google.golang.org/protobuf/proto"
 
+	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqlescape"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -243,21 +245,55 @@ func WithEventFunc(fn EventFunc, eventTypes ...binlogdatapb.VEventType) Option {
 // WithStartingVGtid sets the starting VGtid for the VStreamClient. This is useful for resuming a stream from a
 // specific point, vs what might be stored in the state table.
 //
-// The position is persisted with copy_completed=true and becomes the durable restart point, so every
-// shard gtid must be a concrete position: symbolic positions like "current" are resolved afresh by
-// VTGate on every run, which would silently skip rows delivered between a crash and the restart.
+// The position is persisted with copy_completed=true and becomes the durable restart point, so it
+// is validated strictly: every shard gtid must be a parseable, concrete position (symbolic
+// positions like "current" are resolved afresh by VTGate on every run, which would silently skip
+// rows delivered between a crash and the restart), must belong to a configured source keyspace,
+// and together they must cover every shard of every configured source keyspace, since VTGate only
+// opens streams for the listed shards.
 func WithStartingVGtid(vgtid *binlogdatapb.VGtid) Option {
 	return func(v *VStreamClient) error {
 		if vgtid == nil || len(vgtid.ShardGtids) == 0 {
 			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid must include at least one shard gtid")
 		}
 
+		configuredKeyspaces := make(map[string]bool, len(v.tables))
+		for _, table := range v.tables {
+			configuredKeyspaces[table.Keyspace] = true
+		}
+
+		seen := make(map[string]bool, len(vgtid.ShardGtids))
 		for _, shardGtid := range vgtid.ShardGtids {
 			if shardGtid == nil || shardGtid.Keyspace == "" || shardGtid.Shard == "" {
 				return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: every starting shard gtid must name a keyspace and shard")
 			}
 			if shardGtid.Gtid == "" || strings.EqualFold(shardGtid.Gtid, "current") {
 				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting gtid for %s/%s must be a concrete position, got %q: symbolic or empty positions cannot be persisted as a restart point", shardGtid.Keyspace, shardGtid.Shard, shardGtid.Gtid)
+			}
+			if _, err := replication.DecodePosition(shardGtid.Gtid); err != nil {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting gtid for %s/%s is not a parseable position: %v", shardGtid.Keyspace, shardGtid.Shard, err)
+			}
+			if !configuredKeyspaces[shardGtid.Keyspace] {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names keyspace %s, which is not a configured source keyspace", shardGtid.Keyspace)
+			}
+			if !slices.Contains(v.shardsByKeyspace[shardGtid.Keyspace], shardGtid.Shard) {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names shard %s/%s, which does not exist in the cluster", shardGtid.Keyspace, shardGtid.Shard)
+			}
+
+			key := shardGtid.Keyspace + "/" + shardGtid.Shard
+			if seen[key] {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid names shard %s more than once", key)
+			}
+			seen[key] = true
+		}
+
+		// VTGate only opens streams for the listed shards, so a partial position would silently
+		// never consume the omitted shards
+		for keyspace := range configuredKeyspaces {
+			for _, shard := range v.shardsByKeyspace[keyspace] {
+				if !seen[keyspace+"/"+shard] {
+					return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: starting vgtid does not cover shard %s/%s; every shard of every configured source keyspace needs a position", keyspace, shard)
+				}
 			}
 		}
 

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -163,9 +163,14 @@ func WithStateTable(keyspace, table string) Option {
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s not found", keyspace)
 		}
 
-		// unsharded keyspaces always have exactly one shard named "0". A sharded keyspace can
-		// currently have a single shard (named "-") and can gain shards through resharding, so
-		// checking the shard count alone is not enough.
+		// the vschema sharded property is the authoritative check: a sharded keyspace can have
+		// any single shard today (even one named "0") and gain shards through resharding
+		if sharded, ok := v.shardedByKeyspace[keyspace]; ok && sharded {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
+		}
+
+		// shard-name heuristic as a backstop for clusters where the vschema cannot be read:
+		// unsharded keyspaces always have exactly one shard named "0"
 		if len(shards) != 1 || shards[0] != "0" {
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s is sharded, only unsharded keyspaces are supported", keyspace)
 		}

--- a/go/vt/vstreamclient/options.go
+++ b/go/vt/vstreamclient/options.go
@@ -185,6 +185,17 @@ func WithStateTable(keyspace, table string) Option {
 	}
 }
 
+// WithSkipRowImageCheck disables the verification that every source shard uses
+// binlog_row_image=FULL. Use this only when the probe cannot run (e.g. restricted permissions)
+// and you have verified FULL out of band: with NOBLOB or MINIMAL row images, omitted delete
+// before-image values are indistinguishable from SQL NULL and silently corrupt nullable fields.
+func WithSkipRowImageCheck() Option {
+	return func(v *VStreamClient) error {
+		v.cfg.skipRowImageCheck = true
+		return nil
+	}
+}
+
 // DefaultFlags returns a default set of flags for a VStreamClient, safe to use in most cases, but can be customized
 func DefaultFlags() *vtgatepb.VStreamFlags {
 	return &vtgatepb.VStreamFlags{

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
@@ -42,6 +43,53 @@ func TestWithFlags_RejectsStreamKeyspaceHeartbeats(t *testing.T) {
 
 	err := WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, StreamKeyspaceHeartbeats: true})(v)
 	require.ErrorContains(t, err, "StreamKeyspaceHeartbeats is not supported")
+}
+
+func TestWithStartingVGtid_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		vgtid   *binlogdatapb.VGtid
+		wantErr string
+	}{
+		{name: "nil", vgtid: nil, wantErr: "at least one shard gtid"},
+		{name: "empty", vgtid: &binlogdatapb.VGtid{}, wantErr: "at least one shard gtid"},
+		{
+			name:    "missing keyspace",
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Shard: "0", Gtid: "MySQL56/1"}}},
+			wantErr: "must name a keyspace and shard",
+		},
+		{
+			name:    "empty gtid",
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0"}}},
+			wantErr: "must be a concrete position",
+		},
+		{
+			name:    "symbolic current",
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "current"}}},
+			wantErr: "must be a concrete position",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := WithStartingVGtid(tt.vgtid)(&VStreamClient{})
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestWithStartingVGtid_ClonesInput(t *testing.T) {
+	v := &VStreamClient{}
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	}
+
+	err := WithStartingVGtid(vgtid)(v)
+	require.NoError(t, err)
+	require.NotSame(t, vgtid, v.latestVgtid)
+
+	vgtid.ShardGtids[0].Gtid = "mutated"
+	assert.Equal(t, "MySQL56/1", v.latestVgtid.ShardGtids[0].Gtid)
 }
 
 func TestWithStateTable_RequiresTableName(t *testing.T) {

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithStateTable_RequiresTableName(t *testing.T) {
+	v := &VStreamClient{shardsByKeyspace: map[string][]string{"ks": {"0"}}}
+
+	err := WithStateTable("ks", "")(v)
+	require.ErrorContains(t, err, "state table name is required")
+}
+
+func TestWithStateTable_RejectsUnknownKeyspace(t *testing.T) {
+	v := &VStreamClient{shardsByKeyspace: map[string][]string{"ks": {"0"}}}
+
+	err := WithStateTable("missing", "state")(v)
+	require.ErrorContains(t, err, "keyspace missing not found")
+}
+
+func TestWithStateTable_RejectsShardedKeyspace(t *testing.T) {
+	v := &VStreamClient{shardsByKeyspace: map[string][]string{"sharded": {"-80", "80-"}}}
+
+	err := WithStateTable("sharded", "state")(v)
+	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
+}
+
+func TestWithStateTable_EscapesIdentifiers(t *testing.T) {
+	v := &VStreamClient{shardsByKeyspace: map[string][]string{"ks": {"0"}}}
+
+	err := WithStateTable("ks", "state")(v)
+	require.NoError(t, err)
+
+	// the identifiers are stored pre-escaped, since every state query interpolates them
+	assert.Equal(t, "`ks`", v.cfg.vgtidStateKeyspace)
+	assert.Equal(t, "`state`", v.cfg.vgtidStateTable)
+}

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -21,7 +21,28 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
+
+func TestWithFlags_ClonesInput(t *testing.T) {
+	v := &VStreamClient{}
+	flags := &vtgatepb.VStreamFlags{HeartbeatInterval: 1}
+
+	err := WithFlags(flags)(v)
+	require.NoError(t, err)
+
+	// mutating the caller-owned struct after validation must not affect the client
+	flags.HeartbeatInterval = 0
+	assert.EqualValues(t, 1, v.cfg.flags.HeartbeatInterval)
+}
+
+func TestWithFlags_RejectsStreamKeyspaceHeartbeats(t *testing.T) {
+	v := &VStreamClient{}
+
+	err := WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, StreamKeyspaceHeartbeats: true})(v)
+	require.ErrorContains(t, err, "StreamKeyspaceHeartbeats is not supported")
+}
 
 func TestWithStateTable_RequiresTableName(t *testing.T) {
 	v := &VStreamClient{shardsByKeyspace: map[string][]string{"ks": {"0"}}}

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -113,6 +113,27 @@ func TestWithStateTable_RejectsShardedKeyspace(t *testing.T) {
 	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
 }
 
+func TestWithStateTable_RejectsSingleShardShardedKeyspace(t *testing.T) {
+	// a sharded keyspace with one shard is named "-", not "0"; the shard count alone
+	// cannot distinguish it from an unsharded keyspace
+	v := &VStreamClient{shardsByKeyspace: map[string][]string{"sharded": {"-"}}}
+
+	err := WithStateTable("sharded", "state")(v)
+	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
+}
+
+func TestWithStateTable_RejectsStreamedSourceKeyspace(t *testing.T) {
+	v := &VStreamClient{
+		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		tables: map[string]*TableConfig{
+			"ks.t": {Keyspace: "ks", Table: "t"},
+		},
+	}
+
+	err := WithStateTable("ks", "state")(v)
+	require.ErrorContains(t, err, "also a streamed source keyspace")
+}
+
 func TestWithStateTable_EscapesIdentifiers(t *testing.T) {
 	v := &VStreamClient{shardsByKeyspace: map[string][]string{"ks": {"0"}}}
 

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -45,6 +45,27 @@ func TestWithFlags_RejectsStreamKeyspaceHeartbeats(t *testing.T) {
 	require.ErrorContains(t, err, "StreamKeyspaceHeartbeats is not supported")
 }
 
+// testConcretePosition is a parseable MySQL56 position for starting-vgtid tests.
+const testConcretePosition = "MySQL56/16b1039f-22b6-11ed-b765-0a43f95f28a3:1-5"
+
+// newStartingVGtidClient returns a client configured with two source shards (ks/-80, ks/80-),
+// which the starting vgtid must fully cover.
+func newStartingVGtidClient() *VStreamClient {
+	return &VStreamClient{
+		tables: map[string]*TableConfig{
+			"ks.t": {Keyspace: "ks", Table: "t"},
+		},
+		shardsByKeyspace: map[string][]string{
+			"ks":    {"-80", "80-"},
+			"other": {"0"},
+		},
+	}
+}
+
+func startingShardGtid(shard string) *binlogdatapb.ShardGtid {
+	return &binlogdatapb.ShardGtid{Keyspace: "ks", Shard: shard, Gtid: testConcretePosition}
+}
+
 func TestWithStartingVGtid_Validation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -55,33 +76,60 @@ func TestWithStartingVGtid_Validation(t *testing.T) {
 		{name: "empty", vgtid: &binlogdatapb.VGtid{}, wantErr: "at least one shard gtid"},
 		{
 			name:    "missing keyspace",
-			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Shard: "0", Gtid: "MySQL56/1"}}},
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Shard: "-80", Gtid: testConcretePosition}}},
 			wantErr: "must name a keyspace and shard",
 		},
 		{
 			name:    "empty gtid",
-			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0"}}},
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "-80"}}},
 			wantErr: "must be a concrete position",
 		},
 		{
 			name:    "symbolic current",
-			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "current"}}},
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "-80", Gtid: "current"}}},
 			wantErr: "must be a concrete position",
+		},
+		{
+			name:    "unparseable position",
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "-80", Gtid: "garbage"}}},
+			wantErr: "not a parseable position",
+		},
+		{
+			name:    "foreign keyspace",
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "other", Shard: "0", Gtid: testConcretePosition}}},
+			wantErr: "not a configured source keyspace",
+		},
+		{
+			name:    "unknown shard",
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{startingShardGtid("-40")}},
+			wantErr: "does not exist in the cluster",
+		},
+		{
+			name: "duplicate shard",
+			vgtid: &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{
+				startingShardGtid("-80"), startingShardGtid("-80"),
+			}},
+			wantErr: "more than once",
+		},
+		{
+			name:    "missing shard coverage",
+			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{startingShardGtid("-80")}},
+			wantErr: "does not cover shard ks/80-",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := WithStartingVGtid(tt.vgtid)(&VStreamClient{})
+			err := WithStartingVGtid(tt.vgtid)(newStartingVGtidClient())
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }
 
 func TestWithStartingVGtid_ClonesInput(t *testing.T) {
-	v := &VStreamClient{}
+	v := newStartingVGtidClient()
 	vgtid := &binlogdatapb.VGtid{
-		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+		ShardGtids: []*binlogdatapb.ShardGtid{startingShardGtid("-80"), startingShardGtid("80-")},
 	}
 
 	err := WithStartingVGtid(vgtid)(v)
@@ -89,7 +137,7 @@ func TestWithStartingVGtid_ClonesInput(t *testing.T) {
 	require.NotSame(t, vgtid, v.latestVgtid)
 
 	vgtid.ShardGtids[0].Gtid = "mutated"
-	assert.Equal(t, "MySQL56/1", v.latestVgtid.ShardGtids[0].Gtid)
+	assert.Equal(t, testConcretePosition, v.latestVgtid.ShardGtids[0].Gtid)
 }
 
 func TestWithStateTable_RequiresTableName(t *testing.T) {

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -45,6 +45,44 @@ func TestWithFlags_RejectsStreamKeyspaceHeartbeats(t *testing.T) {
 	require.ErrorContains(t, err, "StreamKeyspaceHeartbeats is not supported")
 }
 
+func TestNew_ValidatesEffectiveHeartbeatInterval(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		opts    []Option
+		wantErr bool
+	}{
+		{
+			name: "flags before heartbeat override",
+			opts: []Option{WithFlags(&vtgatepb.VStreamFlags{TransactionChunkSize: 123}), WithHeartbeatSeconds(5)},
+		},
+		{
+			name: "heartbeat override before flags",
+			opts: []Option{WithHeartbeatSeconds(5), WithFlags(&vtgatepb.VStreamFlags{TransactionChunkSize: 123})},
+		},
+		{
+			name:    "zero heartbeat without override",
+			opts:    []Option{WithFlags(&vtgatepb.VStreamFlags{TransactionChunkSize: 123})},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := newConstructorTestConn(t)
+			table := newStateTestTableConfig()
+			table.Keyspace = "customer"
+			opts := append([]Option{WithStateTable("commerce", "vstreams")}, tt.opts...)
+			v, err := New(t.Context(), "stream", conn, []TableConfig{table}, opts...)
+			if tt.wantErr {
+				require.ErrorContains(t, err, "HeartbeatInterval must be positive")
+				assert.Nil(t, v)
+				return
+			}
+			require.NoError(t, err)
+			assert.EqualValues(t, 5, v.cfg.flags.HeartbeatInterval)
+			assert.EqualValues(t, 123, v.cfg.flags.TransactionChunkSize)
+		})
+	}
+}
+
 // testConcretePosition is a parseable MySQL56 position for starting-vgtid tests.
 const testConcretePosition = "MySQL56/16b1039f-22b6-11ed-b765-0a43f95f28a3:1-5"
 

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vstreamclient
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,8 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 func TestWithFlags_ClonesInput(t *testing.T) {
@@ -79,6 +82,47 @@ func TestNew_ValidatesEffectiveHeartbeatInterval(t *testing.T) {
 			require.NoError(t, err)
 			assert.EqualValues(t, 5, v.cfg.flags.HeartbeatInterval)
 			assert.EqualValues(t, 123, v.cfg.flags.TransactionChunkSize)
+		})
+	}
+}
+
+func TestNew_RejectsHeartbeatLivenessOverflow(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		interval   uint32
+		multiplier int
+		override   int
+		wantErr    bool
+	}{
+		{name: "multiplier ten boundary", interval: 922337203, multiplier: 10},
+		{name: "above multiplier ten boundary", interval: 922337204, multiplier: 10, wantErr: true},
+		{name: "positive wrapped product", interval: math.MaxUint32, multiplier: 10, wantErr: true},
+		{name: "dedicated heartbeat overflow", interval: 1, multiplier: 10, override: 1000000000, wantErr: true},
+		{name: "valid dedicated override", interval: math.MaxUint32, multiplier: 10, override: 5},
+		{name: "uint32 maximum fits multiplier two", interval: math.MaxUint32, multiplier: 2},
+		{name: "uint32 maximum exceeds multiplier three", interval: math.MaxUint32, multiplier: 3, wantErr: true},
+		{name: "custom multiplier boundary", interval: 9223372, multiplier: 1000},
+		{name: "above custom multiplier boundary", interval: 9223373, multiplier: 1000, wantErr: true},
+		{name: "maximum multiplier", interval: 10, multiplier: math.MaxInt, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			originalMultiplier := DefaultHeartbeatTimeoutMultiplier
+			DefaultHeartbeatTimeoutMultiplier = tt.multiplier
+			t.Cleanup(func() { DefaultHeartbeatTimeoutMultiplier = originalMultiplier })
+			conn, impl := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
+			opts := []Option{WithStateTable("stateks", "state"), WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: tt.interval})}
+			if tt.override > 0 {
+				opts = append(opts, WithHeartbeatSeconds(tt.override))
+			}
+
+			_, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()}, opts...)
+			if tt.wantErr {
+				require.ErrorContains(t, err, "heartbeat liveness window exceeds maximum duration")
+				assert.Equal(t, vtrpcpb.Code_FAILED_PRECONDITION, vterrors.Code(err))
+				assert.Empty(t, impl.queries)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -170,6 +170,18 @@ func TestWithStateTable_RejectsSingleShardShardedKeyspace(t *testing.T) {
 	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
 }
 
+func TestWithStateTable_RejectsVSchemaShardedKeyspace(t *testing.T) {
+	// the vschema property is authoritative: a sharded keyspace whose single shard happens to
+	// be named "0" passes the shard-name heuristic but must still be rejected
+	v := &VStreamClient{
+		shardsByKeyspace:  map[string][]string{"sharded": {"0"}},
+		shardedByKeyspace: map[string]bool{"sharded": true},
+	}
+
+	err := WithStateTable("sharded", "state")(v)
+	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
+}
+
 func TestWithStateTable_RejectsStreamedSourceKeyspace(t *testing.T) {
 	v := &VStreamClient{
 		shardsByKeyspace: map[string][]string{"ks": {"0"}},

--- a/go/vt/vstreamclient/options_test.go
+++ b/go/vt/vstreamclient/options_test.go
@@ -95,6 +95,14 @@ func TestWithStartingVGtid_Validation(t *testing.T) {
 			wantErr: "not a parseable position",
 		},
 		{
+			name: "copy cursor",
+			vgtid: &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{
+				{Keyspace: "ks", Shard: "-80", Gtid: testConcretePosition, TablePKs: []*binlogdatapb.TableLastPK{{TableName: "t"}}},
+				startingShardGtid("80-"),
+			}},
+			wantErr: "copy cursors are not supported",
+		},
+		{
 			name:    "foreign keyspace",
 			vgtid:   &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "other", Shard: "0", Gtid: testConcretePosition}}},
 			wantErr: "not a configured source keyspace",
@@ -120,7 +128,11 @@ func TestWithStartingVGtid_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := WithStartingVGtid(tt.vgtid)(newStartingVGtidClient())
+			v := newStartingVGtidClient()
+			err := WithStartingVGtid(tt.vgtid)(v)
+			if err == nil {
+				err = v.validateStartingVGtid()
+			}
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
@@ -150,23 +162,26 @@ func TestWithStateTable_RequiresTableName(t *testing.T) {
 func TestWithStateTable_RejectsUnknownKeyspace(t *testing.T) {
 	v := &VStreamClient{shardsByKeyspace: map[string][]string{"ks": {"0"}}}
 
-	err := WithStateTable("missing", "state")(v)
+	require.NoError(t, WithStateTable("missing", "state")(v))
+	err := v.validateStateTable()
 	require.ErrorContains(t, err, "keyspace missing not found")
 }
 
 func TestWithStateTable_RejectsShardedKeyspace(t *testing.T) {
-	v := &VStreamClient{shardsByKeyspace: map[string][]string{"sharded": {"-80", "80-"}}}
+	v := &VStreamClient{shardsByKeyspace: map[string][]string{"sharded": {"-80", "80-"}}, shardedByKeyspace: map[string]bool{"sharded": true}}
 
-	err := WithStateTable("sharded", "state")(v)
+	require.NoError(t, WithStateTable("sharded", "state")(v))
+	err := v.validateStateTable()
 	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
 }
 
 func TestWithStateTable_RejectsSingleShardShardedKeyspace(t *testing.T) {
 	// a sharded keyspace with one shard is named "-", not "0"; the shard count alone
 	// cannot distinguish it from an unsharded keyspace
-	v := &VStreamClient{shardsByKeyspace: map[string][]string{"sharded": {"-"}}}
+	v := &VStreamClient{shardsByKeyspace: map[string][]string{"sharded": {"-"}}, shardedByKeyspace: map[string]bool{"sharded": true}}
 
-	err := WithStateTable("sharded", "state")(v)
+	require.NoError(t, WithStateTable("sharded", "state")(v))
+	err := v.validateStateTable()
 	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
 }
 
@@ -178,19 +193,22 @@ func TestWithStateTable_RejectsVSchemaShardedKeyspace(t *testing.T) {
 		shardedByKeyspace: map[string]bool{"sharded": true},
 	}
 
-	err := WithStateTable("sharded", "state")(v)
+	require.NoError(t, WithStateTable("sharded", "state")(v))
+	err := v.validateStateTable()
 	require.ErrorContains(t, err, "only unsharded keyspaces are supported")
 }
 
 func TestWithStateTable_RejectsStreamedSourceKeyspace(t *testing.T) {
 	v := &VStreamClient{
-		shardsByKeyspace: map[string][]string{"ks": {"0"}},
+		shardsByKeyspace:  map[string][]string{"ks": {"0"}},
+		shardedByKeyspace: map[string]bool{"ks": false},
 		tables: map[string]*TableConfig{
 			"ks.t": {Keyspace: "ks", Table: "t"},
 		},
 	}
 
-	err := WithStateTable("ks", "state")(v)
+	require.NoError(t, WithStateTable("ks", "state")(v))
+	err := v.validateStateTable()
 	require.ErrorContains(t, err, "also a streamed source keyspace")
 }
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -1,0 +1,302 @@
+package vstreamclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+// EventFunc is an optional callback function that can be registered for individual event types
+type EventFunc func(ctx context.Context, event *binlogdatapb.VEvent) error
+
+// FlushFunc is called per batch of rows, which could be any number of rows, but will be limited by the
+// MaxRowsPerFlush setting. The rows are always a slice of the data type for the table, which is configured
+// per table. You can use type assertion to convert the rows to the correct type, and then process them as needed.
+//
+//	func(ctx context.Context, rows any, meta FlushMeta) error {
+//		 typedRows := rows.([]*DataType)
+//		 // do something with the rows
+//		 return nil
+//	}
+//
+// Returning an error will stop the stream, and the last vgtid will not be stored. The stream will need to be
+// restarted from the last successful flushed vgtid.
+type FlushFunc func(ctx context.Context, rows []Row, meta FlushMeta) error
+
+// Row is the data structure that will be passed to the FlushFunc. It contains the row event, the row change,
+// and the scanned data itself. The data will be the type registered for the table, unless it is a delete event, in
+// which case it will be nil.
+type Row struct {
+	RowEvent  *binlogdatapb.RowEvent
+	RowChange *binlogdatapb.RowChange
+	Data      any // will be populated as the data type registered for the table, unless it is a delete event
+}
+
+// FlushMeta is the metadata that is passed to the FlushFunc. It's not necessary, but might be useful
+// for logging, debugging, etc.
+type FlushMeta struct {
+	Keyspace string
+	Table    string
+
+	TableStats   TableStats
+	VStreamStats VStreamStats
+
+	LatestVGtid *binlogdatapb.VGtid
+}
+
+// Run starts the vstream, processing events from the stream until it ends or an error occurs.
+func (v *VStreamClient) Run(ctx context.Context) error {
+	// make a cancelable context, so the heartbeat monitor can cancel the stream if necessary
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go v.monitorHeartbeat(ctx, cancel)
+
+	// ********************************************************************************************************
+	// Event Processing
+	//
+	// this is the main loop that processes events from the stream. It will continue until the stream ends or an
+	// error occurs. The context is checked before processing each event.
+	// ********************************************************************************************************
+	for {
+		// events come in batches, depending on how busy the keyspace is. This is where the network communication
+		// happens, so it's the most likely place for errors to occur.
+		events, err := v.reader.Recv()
+		switch {
+		case err == nil: // no error, continue processing below
+
+		case errors.Is(err, io.EOF):
+			fmt.Println("vstreamclient: stream ended")
+			return nil
+
+		default:
+			return fmt.Errorf("vstreamclient: remote error: %w", err)
+		}
+
+		for _, ev := range events {
+			// check for context errors before processing the next event, since any processing will likely be wasted
+			err = ctx.Err()
+			if err != nil {
+				return fmt.Errorf("vstreamclient: context error: %w", err)
+			}
+
+			// keep track of the last event time for heartbeat monitoring. We're purposefully not using the event
+			// timestamp, since that would cause cancellation if the stream was copying, delayed, or lagging.
+			v.lastEventReceivedAtUnix.Store(time.Now().Unix())
+
+			// call the user-defined event function, if it exists
+			fn, ok := v.eventFuncs[ev.Type]
+			if ok {
+				err = fn(ctx, ev)
+				if err != nil {
+					return fmt.Errorf("vstreamclient: user error processing %s event: %w", ev.Type.String(), err)
+				}
+			}
+
+			// handle individual events based on their type
+			switch ev.Type {
+			// field events are sent first, and contain schema information for any tables that are being streamed,
+			// so we cache the fields for each table as they come in
+			case binlogdatapb.VEventType_FIELD:
+				var table *TableConfig
+				table, ok = v.tables[ev.FieldEvent.TableName]
+				if !ok {
+					return errors.New("vstreamclient: unexpected table name: " + ev.FieldEvent.TableName)
+				}
+
+				err = table.handleFieldEvent(ev.FieldEvent)
+				if err != nil {
+					return err
+				}
+
+			// row events are the actual data changes, and we'll process them based on the table name
+			case binlogdatapb.VEventType_ROW:
+				var table *TableConfig
+				table, ok = v.tables[ev.RowEvent.TableName]
+				if !ok {
+					return errors.New("vstreamclient: unexpected table name: " + ev.FieldEvent.TableName)
+				}
+
+				err = table.handleRowEvent(ev.RowEvent, &v.stats)
+				if err != nil {
+					return err
+				}
+
+			// vgtid events are sent periodically, and we'll store the latest vgtid for checkpointing. We may get
+			// this mid-transaction, so we don't flush here, so we don't propagate a partial transaction that may
+			// be rolled back.
+			case binlogdatapb.VEventType_VGTID:
+				v.latestVgtid = ev.Vgtid
+
+			// commit and other events are safe to flush on, since they indicate the end of a transaction.
+			// Otherwise, there's not much to do with these events.
+			case binlogdatapb.VEventType_COMMIT, binlogdatapb.VEventType_OTHER:
+				// only flush when we have an event that guarantees we're not flushing mid-transaction
+				err = v.flush(ctx)
+				if err != nil {
+					return err
+				}
+
+			// DDL events are schema changes, and we might want to handle them differently than data events.
+			// They are safe to flush on, since they indicate the end of a transaction. If you want to
+			// transparently adjust the destination schema based on DDL events, you would do that here.
+			case binlogdatapb.VEventType_DDL:
+				err = v.flush(ctx)
+				if err != nil {
+					return err
+				}
+
+			case binlogdatapb.VEventType_COPY_COMPLETED:
+				// TODO: don't flush until the copy is completed? do some sort of cleanup if we haven't received this?
+
+				err = setCopyCompleted(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable)
+				if err != nil {
+					return err
+				}
+
+			// heartbeat events are sent periodically, if the source keyspace is idle and there are no other events.
+			// It's possible that there is still buffered data that hadn't exceeded the min duration or max rows
+			// thresholds the last time flush was called. Most of the time, that won't be the case, but flush will
+			// check for that and only run if necessary.
+			case binlogdatapb.VEventType_HEARTBEAT:
+				err = v.flush(ctx)
+				if err != nil {
+					return err
+				}
+
+			// even if there are no changes to the tables being streamed, we'll still get a begin, vgtid, and commit
+			// event for each transaction. The other two are used for checkpoints, but nothing to do here.
+			case binlogdatapb.VEventType_BEGIN:
+
+			// journal events are sent on resharding. Unless you are manually targeting shards, vstream should
+			// transparently handle resharding for you, so you shouldn't need to do anything with these events.
+			// You might want to log them for debugging purposes, or to alert on resharding events in case
+			// something goes wrong. After resharding, if the pre-reshard vgtid is no longer valid, you may need
+			// to restart the stream from the beginning.
+			case binlogdatapb.VEventType_JOURNAL:
+
+			// there aren't strong cases for handling these events, but you might want to log them for debugging
+			case binlogdatapb.VEventType_VERSION, binlogdatapb.VEventType_LASTPK, binlogdatapb.VEventType_SAVEPOINT:
+			}
+		}
+	}
+}
+
+// ********************************************************************************************************
+// Heartbeat Monitoring
+//
+// the heartbeat ticker will be used to ensure that we haven't been disconnected from the stream. This starts
+// a goroutine that will cancel the context if we haven't received an event in twice the heartbeat duration.
+// ********************************************************************************************************
+func (v *VStreamClient) monitorHeartbeat(ctx context.Context, cancel context.CancelFunc) {
+	heartbeatDur := time.Duration(v.flags.HeartbeatInterval) * time.Second
+	heartbeat := time.NewTicker(heartbeatDur)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case tm := <-heartbeat.C:
+			// if we haven't received an event yet, we'll skip the heartbeat check
+			if v.lastEventReceivedAtUnix.Load() == 0 {
+				continue
+			}
+
+			// if we haven't received an event in twice the heartbeat duration, we'll cancel the context, since
+			// we're likely disconnected, and exit the goroutine
+			if tm.Sub(time.Unix(v.lastEventReceivedAtUnix.Load(), 0)) > heartbeatDur*2 {
+				cancel()
+				return
+			}
+
+		case <-ctx.Done():
+			// this cancel is probably unnecessary, since the context is already done, but it's good practice
+			cancel()
+			return
+		}
+	}
+}
+
+// ********************************************************************************************************
+// Flush Data + Store Vgtid
+//
+// as we process events, we'll periodically need to check point the last vgtid and store the customers in the
+// database. You can control the frequency of this flush by adjusting the minFlushDuration and maxRowsPerFlush.
+// This is only called when we have an event that guarantees we're not flushing mid-transaction.
+// ********************************************************************************************************
+//
+// we might consider exporting Flush, but we'd need to have a mutex or something to block the stream from
+// processing, and technically we'd need to let it run until a commit event happens.
+func (v *VStreamClient) flush(ctx context.Context) error {
+	// if the lastFlushedVgtid is the same as the latestVgtid, we don't need to do anything
+	if proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
+		return nil
+	}
+
+	// if we have exceeded the minFlushDuration, we'll force a flush, regardless how many rows each table has
+	shouldFlush := time.Since(v.stats.LastFlushedAt) > v.minFlushDuration
+
+	// if we haven't exceeded the min flush duration, we'll check if any of the tables have exceeded their
+	// max rows to flush. If any of them have, we will force a flush. Every table needs to be flushed at
+	// the same time, since the last vgtid covers all tables.
+	if !shouldFlush {
+		for _, table := range v.tables {
+			if len(table.currentBatch) >= table.MaxRowsPerFlush {
+				shouldFlush = true
+				break
+			}
+		}
+	}
+
+	if !shouldFlush {
+		return nil
+	}
+
+	// TODO: maybe start a transaction here, and pass it to the flush function
+
+	for _, table := range v.tables {
+		// flush the rows to the database, chunked using the max batch size
+		for chunk := range slices.Chunk(table.currentBatch, table.MaxRowsPerFlush) {
+			err := table.FlushFn(ctx, chunk, FlushMeta{
+				Keyspace: table.Keyspace,
+				Table:    table.Table,
+
+				TableStats:   table.stats,
+				VStreamStats: v.stats,
+
+				LatestVGtid: v.latestVgtid,
+			})
+			if err != nil {
+				return fmt.Errorf("vstreamclient: error flushing table %s: %w", table.Table, err)
+			}
+
+			// update the stats for the table and the vstream
+			table.stats.FlushCount++
+			table.stats.FlushedRowCount += len(chunk)
+			table.stats.LastFlushedAt = time.Now()
+
+			v.stats.TableFlushCount++
+			v.stats.FlushedRowCount += len(chunk)
+		}
+
+		table.resetBatch()
+	}
+
+	// always store the latest vgtid, even if there are no customers to store
+	err := updateLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.latestVgtid)
+	if err != nil {
+		return err
+	}
+
+	v.stats.FlushCount++
+	v.stats.LastFlushedAt = time.Now()
+	v.lastFlushedVgtid = v.latestVgtid
+
+	return nil
+}

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -93,14 +93,14 @@ func (r FlushReason) String() string {
 //   - FlushFn returns an error
 //   - checkpoint state updates fail
 func (v *VStreamClient) Run(ctx context.Context) error {
-	if v.isClosing.Load() {
+	// make a cancelable context for GracefulShutdown to use, so it can signal the Run loop to exit
+	ctx, cancelRunCtxFn := context.WithCancel(ctx)
+	if !v.beginRun(cancelRunCtxFn) {
+		cancelRunCtxFn()
 		return errors.New("vstreamclient: client is closed; create a new client for each Run attempt")
 	}
-	defer v.isClosing.Store(true)
-
-	// make a cancelable context for GracefulShutdown to use, so it can signal the Run loop to exit
-	ctx, v.cancelRunCtxFn = context.WithCancel(ctx)
-	defer v.cancelRunCtxFn()
+	defer cancelRunCtxFn()
+	defer v.endRun()
 
 	// initialize the streamer
 	var err error
@@ -162,11 +162,13 @@ func (v *VStreamClient) shouldExitRun(ctx context.Context) (bool, error) {
 	// returning an error, whereas if the context is canceled, we want to return the context error. They'll often both
 	// happen around the same time, in which case the select would choose pseudo-randomly between the two.
 
+	gracefulShutdownFlushChan := v.getGracefulShutdownFlushChan()
+
 	select {
 	// if we enter this case, that means the last flush completed during the shutdown process, and closed
 	// the channel, so we can exit immediately without processing any more events. This is the happy
 	// path for graceful shutdown, since we were able to flush all buffered data
-	case <-v.gracefulShutdownFlushChan:
+	case <-gracefulShutdownFlushChan:
 		return true, nil
 
 	default:
@@ -432,11 +434,7 @@ func (v *VStreamClient) flush(ctx context.Context, force bool) error {
 	// if the lastFlushedVgtid is the same as the latestVgtid and there is no buffered data,
 	// we don't need to do anything.
 	if !force && !hasBufferedRows && proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
-		if v.isClosing.Load() {
-			v.gracefulShutdownFlushOnce.Do(func() {
-				close(v.gracefulShutdownFlushChan)
-			})
-		}
+		v.signalGracefulShutdownFlushed()
 		return nil
 	}
 
@@ -492,11 +490,7 @@ func (v *VStreamClient) flush(ctx context.Context, force bool) error {
 
 	// if we're in the middle of a graceful shutdown, and we've successfully flushed all the remaining data,
 	// we can close the channel to let the Run loop know it can exit
-	if v.isClosing.Load() {
-		v.gracefulShutdownFlushOnce.Do(func() {
-			close(v.gracefulShutdownFlushChan)
-		})
-	}
+	v.signalGracefulShutdownFlushed()
 
 	return nil
 }
@@ -534,7 +528,7 @@ func (v *VStreamClient) shouldFlush(hasBufferedRows, force bool) (bool, FlushRea
 
 	// even if we haven't hit either of minDuration or maxRows, if we're actively closing
 	// down, go ahead and force the flush.
-	if v.isClosing.Load() {
+	if v.isShutdownRequested() {
 		return true, FlushReasonGracefulShutdown
 	}
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -108,7 +108,7 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 
 	// initialize the streamer
 	var err error
-	v.reader, err = v.conn.VStream(ctx, v.tabletType, v.latestVgtid, v.filter, v.flags)
+	v.reader, err = v.cfg.conn.VStream(ctx, v.cfg.tabletType, v.latestVgtid, v.cfg.filter, v.cfg.flags)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
 	}
@@ -212,7 +212,7 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		}
 
 		// call the user-defined event function if it exists
-		fn, ok := v.eventFuncs[ev.Type]
+		fn, ok := v.cfg.eventFuncs[ev.Type]
 		if ok {
 			err = fn(ctx, ev)
 			if err != nil {
@@ -328,23 +328,23 @@ func isFinalCopyCompletedEvent(ev *binlogdatapb.VEvent) bool {
 // is canceled or times out.
 // ********************************************************************************************************
 func (v *VStreamClient) listenForGracefulShutdown(ctx context.Context) {
-	if v.gracefulShutdownChan == nil && len(v.gracefulShutdownSignals) == 0 {
+	if v.cfg.gracefulShutdownChan == nil && len(v.cfg.gracefulShutdownSignals) == 0 {
 		return
 	}
 
 	var signalChan chan os.Signal
-	if len(v.gracefulShutdownSignals) > 0 {
+	if len(v.cfg.gracefulShutdownSignals) > 0 {
 		signalChan = make(chan os.Signal, 1)
-		signal.Notify(signalChan, v.gracefulShutdownSignals...)
+		signal.Notify(signalChan, v.cfg.gracefulShutdownSignals...)
 		defer signal.Stop(signalChan)
 	}
 
 	select {
-	case <-v.gracefulShutdownChan:
-		v.GracefulShutdown(v.gracefulShutdownWaitDur)
+	case <-v.cfg.gracefulShutdownChan:
+		v.GracefulShutdown(v.cfg.gracefulShutdownWaitDur)
 
 	case <-signalChan:
-		v.GracefulShutdown(v.gracefulShutdownWaitDur)
+		v.GracefulShutdown(v.cfg.gracefulShutdownWaitDur)
 
 	case <-ctx.Done():
 	}
@@ -361,7 +361,7 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 	const startupTimeout = 5 * time.Minute
 	const timeoutMultiplier = 2
 
-	heartbeatDur := time.Duration(v.flags.HeartbeatInterval) * time.Second
+	heartbeatDur := time.Duration(v.cfg.flags.HeartbeatInterval) * time.Second
 	heartbeat := time.NewTicker(heartbeatDur)
 	defer heartbeat.Stop()
 
@@ -396,7 +396,7 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 			// if we haven't received an event in twice the heartbeat duration, we'll cancel the context, since
 			// we're likely disconnected, and exit the goroutine
 			if tm.Sub(time.Unix(0, lastEventProcessedAtUnixNano)) > heartbeatDur*timeoutMultiplier {
-				v.GracefulShutdown(v.gracefulShutdownWaitDur)
+				v.GracefulShutdown(v.cfg.gracefulShutdownWaitDur)
 				return
 			}
 
@@ -483,7 +483,7 @@ func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
 	}
 
 	// always store the latest vgtid, even if there are no rows to store
-	err := updateLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.latestVgtid, isCopyCompleted)
+	err := updateLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.latestVgtid, isCopyCompleted)
 	if err != nil {
 		return err
 	}
@@ -515,7 +515,7 @@ func (v *VStreamClient) shouldFlush(hasBufferedRows, isCopyCompleted bool) (bool
 	}
 
 	// if we have exceeded the minFlushDuration, we'll force a flush, regardless how many rows each table has
-	if time.Since(v.stats.LastFlushedAt) > v.minFlushDuration {
+	if time.Since(v.stats.LastFlushedAt) > v.cfg.minFlushDuration {
 		return true, FlushReasonMinDuration
 	}
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -58,7 +58,7 @@ type FlushReason int8
 
 const (
 	FlushReasonNone             FlushReason = 1
-	FlushReasonForced           FlushReason = 2
+	FlushReasonCopyCompleted    FlushReason = 2
 	FlushReasonMinDuration      FlushReason = 3
 	FlushReasonMaxRowsPerFlush  FlushReason = 4
 	FlushReasonGracefulShutdown FlushReason = 5
@@ -68,7 +68,7 @@ func (r FlushReason) String() string {
 	switch r {
 	case FlushReasonNone:
 		return "none"
-	case FlushReasonForced:
+	case FlushReasonCopyCompleted:
 		return "forced"
 	case FlushReasonMinDuration:
 		return "minDuration"
@@ -281,11 +281,6 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 				if err != nil {
 					return err
 				}
-
-				err = setCopyCompleted(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable)
-				if err != nil {
-					return err
-				}
 			}
 
 		// heartbeat events are sent periodically if the source keyspace is idle and there are no other events.
@@ -420,11 +415,13 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 // as we process events, we'll periodically need to checkpoint the last vgtid and persist the buffered data to
 // storage. You can control the frequency of this flush by adjusting the minFlushDuration and maxRowsPerFlush.
 // This is only called when we have an event that guarantees we're not flushing mid-transaction.
-// ********************************************************************************************************
 //
-// we might consider exporting Flush, but we'd need to have a mutex or something to block the stream from
-// processing, and technically we'd need to let it run until a commit event happens.
-func (v *VStreamClient) flush(ctx context.Context, force bool) error {
+// The isCopyCompleted flag is used to indicate that we've received the final COPY_COMPLETED event, which means
+// we should flush all remaining data, even if it doesn't meet the usual thresholds for flushing. This ensures
+// that all copied data is flushed and checkpointed before we mark the stream as fully copied. It also sets
+// copy_completed to true in the state table.
+// ********************************************************************************************************
+func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("vstreamclient: context error before flush: %w", err)
 	}
@@ -433,12 +430,12 @@ func (v *VStreamClient) flush(ctx context.Context, force bool) error {
 
 	// if the lastFlushedVgtid is the same as the latestVgtid and there is no buffered data,
 	// we don't need to do anything.
-	if !force && !hasBufferedRows && proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
+	if !isCopyCompleted && !hasBufferedRows && proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
 		v.signalGracefulShutdownFlushed()
 		return nil
 	}
 
-	shouldFlush, flushReason := v.shouldFlush(hasBufferedRows, force)
+	shouldFlush, flushReason := v.shouldFlush(hasBufferedRows, isCopyCompleted)
 	if !shouldFlush {
 		return nil
 	}
@@ -479,7 +476,7 @@ func (v *VStreamClient) flush(ctx context.Context, force bool) error {
 	}
 
 	// always store the latest vgtid, even if there are no rows to store
-	err := updateLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.latestVgtid)
+	err := updateLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.latestVgtid, isCopyCompleted)
 	if err != nil {
 		return err
 	}
@@ -505,9 +502,9 @@ func (v *VStreamClient) hasBufferedRows() bool {
 	return false
 }
 
-func (v *VStreamClient) shouldFlush(hasBufferedRows, force bool) (bool, FlushReason) {
-	if force {
-		return true, FlushReasonForced
+func (v *VStreamClient) shouldFlush(hasBufferedRows, isCopyCompleted bool) (bool, FlushReason) {
+	if isCopyCompleted {
+		return true, FlushReasonCopyCompleted
 	}
 
 	// if we have exceeded the minFlushDuration, we'll force a flush, regardless how many rows each table has

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"slices"
 	"time"
 
@@ -31,12 +33,12 @@ type EventFunc func(ctx context.Context, event *binlogdatapb.VEvent) error
 type FlushFunc func(ctx context.Context, rows []Row, meta FlushMeta) error
 
 // Row is the data structure that will be passed to the FlushFunc. It contains the row event, the row change,
-// and the scanned data itself. The data will be the type registered for the table, unless it is a delete event, in
-// which case it will be nil.
+// and the scanned data itself. The data will be the type registered for the table; for delete events, it will be
+// populated from the "before" image of the row.
 type Row struct {
 	RowEvent  *binlogdatapb.RowEvent
 	RowChange *binlogdatapb.RowChange
-	Data      any // will be populated as the data type registered for the table, unless it is a delete event
+	Data      any // populated as the data type registered for the table; for delete events, built from the "before" image
 }
 
 // FlushMeta is the metadata that is passed to the FlushFunc. It's not necessary, but might be useful
@@ -49,15 +51,70 @@ type FlushMeta struct {
 	VStreamStats VStreamStats
 
 	LatestVGtid *binlogdatapb.VGtid
+	FlushReason FlushReason
 }
 
-// Run starts the vstream, processing events from the stream until it ends or an error occurs.
-func (v *VStreamClient) Run(ctx context.Context) error {
-	// make a cancelable context, so the heartbeat monitor can cancel the stream if necessary
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+type FlushReason int8
 
-	go v.monitorHeartbeat(ctx, cancel)
+const (
+	FlushReasonNone             FlushReason = 1
+	FlushReasonForced           FlushReason = 2
+	FlushReasonMinDuration      FlushReason = 3
+	FlushReasonMaxRowsPerFlush  FlushReason = 4
+	FlushReasonGracefulShutdown FlushReason = 5
+)
+
+func (r FlushReason) String() string {
+	switch r {
+	case FlushReasonNone:
+		return "none"
+	case FlushReasonForced:
+		return "forced"
+	case FlushReasonMinDuration:
+		return "minDuration"
+	case FlushReasonMaxRowsPerFlush:
+		return "maxRows"
+	case FlushReasonGracefulShutdown:
+		return "gracefulShutdown"
+	default:
+		panic(fmt.Sprintf("unknown FlushReason: %d", r))
+	}
+}
+
+// Run starts the VStream and processes events until the stream ends or an error occurs.
+// A VStreamClient is single-use: after any Run call returns, create a new client for the next attempt.
+//
+// Run returns an error in these cases:
+//   - Run is called on a client that was already used by a previous Run attempt
+//   - the underlying VStream recv loop fails
+//   - the context is canceled or times out while Run is still active
+//   - a registered event hook returns an error
+//   - row decoding or table lookup fails
+//   - FlushFn returns an error
+//   - checkpoint state updates fail
+func (v *VStreamClient) Run(ctx context.Context) error {
+	if v.isClosing.Load() {
+		return errors.New("vstreamclient: client is closed; create a new client for each Run attempt")
+	}
+	defer v.isClosing.Store(true)
+
+	// make a cancelable context for GracefulShutdown to use, so it can signal the Run loop to exit
+	ctx, v.cancelRunCtxFn = context.WithCancel(ctx)
+	defer v.cancelRunCtxFn()
+
+	// initialize the streamer
+	var err error
+	v.reader, err = v.conn.VStream(ctx, v.tabletType, v.latestVgtid, v.filter, v.flags)
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
+	}
+
+	go v.listenForGracefulShutdown(ctx)
+
+	go v.monitorHeartbeat(ctx)
+
+	// to prevent an immediate flush, we initialize LastFlushedAt here, even if it wasn't technically flushed
+	v.stats.LastFlushedAt = time.Now()
 
 	// ********************************************************************************************************
 	// Event Processing
@@ -68,124 +125,227 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 	for {
 		// events come in batches, depending on how busy the keyspace is. This is where the network communication
 		// happens, so it's the most likely place for errors to occur.
-		events, err := v.reader.Recv()
+		var events []*binlogdatapb.VEvent
+		events, err = v.reader.Recv()
 		switch {
 		case err == nil: // no error, continue processing below
 
 		case errors.Is(err, io.EOF):
-			fmt.Println("vstreamclient: stream ended")
 			return nil
 
 		default:
 			return fmt.Errorf("vstreamclient: remote error: %w", err)
 		}
 
-		for _, ev := range events {
-			// check for context errors before processing the next event, since any processing will likely be wasted
-			err = ctx.Err()
+		err = v.handleEvents(ctx, events)
+		if err != nil {
+			return err
+		}
+
+		// this is also checked inside of handleEvents, but in case the flush function takes a long time, we'll check
+		// here as well to make sure we can exit in a timely manner during shutdown or if the context is canceled
+		// while processing events.
+		var shouldExit bool
+		shouldExit, err = v.shouldExitRun(ctx)
+		if err != nil {
+			return err
+		}
+		if shouldExit {
+			return nil
+		}
+	}
+}
+
+func (v *VStreamClient) shouldExitRun(ctx context.Context) (bool, error) {
+	// the select cases are executed separately, because if both the graceful shutdown flush channel is closed and
+	// the context is canceled, we want to check the graceful shutdown first. That means we can exit without
+	// returning an error, whereas if the context is canceled, we want to return the context error. They'll often both
+	// happen around the same time, in which case the select would choose pseudo-randomly between the two.
+
+	select {
+	// if we enter this case, that means the last flush completed during the shutdown process, and closed
+	// the channel, so we can exit immediately without processing any more events. This is the happy
+	// path for graceful shutdown, since we were able to flush all buffered data
+	case <-v.gracefulShutdownFlushChan:
+		return true, nil
+
+	default:
+	}
+
+	select {
+	// since any processing will likely be wasted, return early if the context is already done
+	case <-ctx.Done():
+		return true, ctx.Err()
+
+	default:
+	}
+
+	return false, nil
+}
+
+func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb.VEvent) error {
+	// if event processing / flushing takes longer than the heartbeat timeout, the heartbeat monitor might trigger
+	// and cancel the context, since no events are processed during that time. This technically leaves a tiny race
+	// condition between defer running and the next Recv happening in the Run() loop, but trying to make that
+	// perfect would add a lot of complexity, and the window is very small.
+	v.isProcessingEvents.Store(true)
+	defer func() {
+		// keep track of the last event time for heartbeat monitoring. We're purposefully not using the event
+		// timestamp, since that would cause cancellation if the stream was copying, delayed, or lagging.
+		v.lastEventProcessedAtUnixNano.Store(time.Now().UnixNano())
+		v.isProcessingEvents.Store(false)
+	}()
+
+	for _, ev := range events {
+		shouldExit, err := v.shouldExitRun(ctx)
+		if err != nil {
+			return err
+		}
+		if shouldExit {
+			return nil
+		}
+
+		// call the user-defined event function if it exists
+		fn, ok := v.eventFuncs[ev.Type]
+		if ok {
+			err = fn(ctx, ev)
 			if err != nil {
-				return fmt.Errorf("vstreamclient: context error: %w", err)
+				return fmt.Errorf("vstreamclient: user error processing %s event: %w", ev.Type.String(), err)
+			}
+		}
+
+		// handle individual events based on their type
+		switch ev.Type {
+		// field events are sent first and contain schema information for any tables that are being streamed,
+		// so we cache the fields for each table as they come in
+		case binlogdatapb.VEventType_FIELD:
+			var table *TableConfig
+			table, err = v.lookupTable(ev.FieldEvent.TableName)
+			if err != nil {
+				return err
 			}
 
-			// keep track of the last event time for heartbeat monitoring. We're purposefully not using the event
-			// timestamp, since that would cause cancellation if the stream was copying, delayed, or lagging.
-			v.lastEventReceivedAtUnix.Store(time.Now().Unix())
-
-			// call the user-defined event function, if it exists
-			fn, ok := v.eventFuncs[ev.Type]
-			if ok {
-				err = fn(ctx, ev)
-				if err != nil {
-					return fmt.Errorf("vstreamclient: user error processing %s event: %w", ev.Type.String(), err)
-				}
+			err = table.handleFieldEvent(ev.FieldEvent)
+			if err != nil {
+				return err
 			}
 
-			// handle individual events based on their type
-			switch ev.Type {
-			// field events are sent first, and contain schema information for any tables that are being streamed,
-			// so we cache the fields for each table as they come in
-			case binlogdatapb.VEventType_FIELD:
-				var table *TableConfig
-				table, ok = v.tables[ev.FieldEvent.TableName]
-				if !ok {
-					return errors.New("vstreamclient: unexpected table name: " + ev.FieldEvent.TableName)
-				}
+		// row events are the actual data changes, and we'll process them based on the table name
+		case binlogdatapb.VEventType_ROW:
+			var table *TableConfig
+			table, err = v.lookupTable(ev.RowEvent.TableName)
+			if err != nil {
+				return err
+			}
 
-				err = table.handleFieldEvent(ev.FieldEvent)
+			err = table.handleRowEvent(ev.RowEvent, &v.stats)
+			if err != nil {
+				return err
+			}
+
+		// vgtid events are sent periodically, and we'll store the latest vgtid for checkpointing. We may get
+		// this mid-transaction, so we don't flush here, so we don't propagate a partial transaction that may
+		// be rolled back.
+		case binlogdatapb.VEventType_VGTID:
+			v.latestVgtid = ev.Vgtid
+
+		// commit and other events are safe to flush on, since they indicate the end of a transaction.
+		// Otherwise, there's not much to do with these events.
+		case binlogdatapb.VEventType_COMMIT, binlogdatapb.VEventType_OTHER:
+			// only flush when we have an event that guarantees we're not flushing mid-transaction
+			err = v.flush(ctx, false)
+			if err != nil {
+				return err
+			}
+
+		// DDL events are schema changes, and we might want to handle them differently than data events.
+		// They are safe to flush on, since they indicate the end of a transaction. If you want to
+		// transparently adjust the destination schema based on DDL events, you would do that here.
+		case binlogdatapb.VEventType_DDL:
+			err = v.flush(ctx, false)
+			if err != nil {
+				return err
+			}
+
+		// COPY_COMPLETED events come through once per keyspace/shard, and an additional fully completed event
+		// as noted in go/vt/vtgate/endtoend/vstream_test.go:951.
+		// "The arrival order of COPY_COMPLETED events with keyspace/shard is not constant.
+		// On the other hand, the last event should always be a fully COPY_COMPLETED event."
+		case binlogdatapb.VEventType_COPY_COMPLETED:
+			if isFinalCopyCompletedEvent(ev) {
+				// The final copy boundary must checkpoint any buffered copy rows before
+				// we persist copy_completed, or a crash can drop them permanently.
+				err = v.flush(ctx, true)
 				if err != nil {
 					return err
 				}
-
-			// row events are the actual data changes, and we'll process them based on the table name
-			case binlogdatapb.VEventType_ROW:
-				var table *TableConfig
-				table, ok = v.tables[ev.RowEvent.TableName]
-				if !ok {
-					return errors.New("vstreamclient: unexpected table name: " + ev.FieldEvent.TableName)
-				}
-
-				err = table.handleRowEvent(ev.RowEvent, &v.stats)
-				if err != nil {
-					return err
-				}
-
-			// vgtid events are sent periodically, and we'll store the latest vgtid for checkpointing. We may get
-			// this mid-transaction, so we don't flush here, so we don't propagate a partial transaction that may
-			// be rolled back.
-			case binlogdatapb.VEventType_VGTID:
-				v.latestVgtid = ev.Vgtid
-
-			// commit and other events are safe to flush on, since they indicate the end of a transaction.
-			// Otherwise, there's not much to do with these events.
-			case binlogdatapb.VEventType_COMMIT, binlogdatapb.VEventType_OTHER:
-				// only flush when we have an event that guarantees we're not flushing mid-transaction
-				err = v.flush(ctx)
-				if err != nil {
-					return err
-				}
-
-			// DDL events are schema changes, and we might want to handle them differently than data events.
-			// They are safe to flush on, since they indicate the end of a transaction. If you want to
-			// transparently adjust the destination schema based on DDL events, you would do that here.
-			case binlogdatapb.VEventType_DDL:
-				err = v.flush(ctx)
-				if err != nil {
-					return err
-				}
-
-			case binlogdatapb.VEventType_COPY_COMPLETED:
-				// TODO: don't flush until the copy is completed? do some sort of cleanup if we haven't received this?
 
 				err = setCopyCompleted(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable)
 				if err != nil {
 					return err
 				}
-
-			// heartbeat events are sent periodically, if the source keyspace is idle and there are no other events.
-			// It's possible that there is still buffered data that hadn't exceeded the min duration or max rows
-			// thresholds the last time flush was called. Most of the time, that won't be the case, but flush will
-			// check for that and only run if necessary.
-			case binlogdatapb.VEventType_HEARTBEAT:
-				err = v.flush(ctx)
-				if err != nil {
-					return err
-				}
-
-			// even if there are no changes to the tables being streamed, we'll still get a begin, vgtid, and commit
-			// event for each transaction. The other two are used for checkpoints, but nothing to do here.
-			case binlogdatapb.VEventType_BEGIN:
-
-			// journal events are sent on resharding. Unless you are manually targeting shards, vstream should
-			// transparently handle resharding for you, so you shouldn't need to do anything with these events.
-			// You might want to log them for debugging purposes, or to alert on resharding events in case
-			// something goes wrong. After resharding, if the pre-reshard vgtid is no longer valid, you may need
-			// to restart the stream from the beginning.
-			case binlogdatapb.VEventType_JOURNAL:
-
-			// there aren't strong cases for handling these events, but you might want to log them for debugging
-			case binlogdatapb.VEventType_VERSION, binlogdatapb.VEventType_LASTPK, binlogdatapb.VEventType_SAVEPOINT:
 			}
+
+		// heartbeat events are sent periodically if the source keyspace is idle and there are no other events.
+		// It's possible that there is still buffered data that hadn't exceeded the min duration or max rows
+		// thresholds the last time flush was called. Most of the time, that won't be the case, but flush will
+		// check for that and only run if necessary.
+		case binlogdatapb.VEventType_HEARTBEAT:
+			err = v.flush(ctx, false)
+			if err != nil {
+				return err
+			}
+
+		// even if there are no changes to the tables being streamed, we'll still get a begin, vgtid, and commit
+		// event for each transaction. The other two are used for checkpoints, but nothing to do here.
+		case binlogdatapb.VEventType_BEGIN:
+
+		// journal events are sent on resharding. Unless you are manually targeting shards, vstream should
+		// transparently handle resharding for you, so you shouldn't need to do anything with these events.
+		// You might want to log them for debugging purposes or to alert on resharding events in case
+		// something goes wrong. After resharding, if the pre-reshard vgtid is no longer valid, you may need
+		// to restart the stream from the beginning.
+		case binlogdatapb.VEventType_JOURNAL:
+
+		// there aren't strong cases for handling these events, but you might want to log them for debugging
+		case binlogdatapb.VEventType_VERSION, binlogdatapb.VEventType_LASTPK, binlogdatapb.VEventType_SAVEPOINT:
 		}
+	}
+
+	return nil
+}
+
+func isFinalCopyCompletedEvent(ev *binlogdatapb.VEvent) bool {
+	return ev.Type == binlogdatapb.VEventType_COPY_COMPLETED && ev.Keyspace == "" && ev.Shard == ""
+}
+
+// ********************************************************************************************************
+// Graceful Shutdown
+//
+// listenForGracefulShutdown waits for either a configured shutdown channel or configured OS signals,
+// then initiates a graceful shutdown of the VStreamClient. It returns early if the provided context
+// is canceled or times out.
+// ********************************************************************************************************
+func (v *VStreamClient) listenForGracefulShutdown(ctx context.Context) {
+	if v.gracefulShutdownChan == nil && len(v.gracefulShutdownSignals) == 0 {
+		return
+	}
+
+	var signalChan chan os.Signal
+	if len(v.gracefulShutdownSignals) > 0 {
+		signalChan = make(chan os.Signal, 1)
+		signal.Notify(signalChan, v.gracefulShutdownSignals...)
+		defer signal.Stop(signalChan)
+	}
+
+	select {
+	case <-v.gracefulShutdownChan:
+		v.GracefulShutdown(v.gracefulShutdownWaitDur)
+
+	case <-signalChan:
+		v.GracefulShutdown(v.gracefulShutdownWaitDur)
+
+	case <-ctx.Done():
 	}
 }
 
@@ -195,7 +355,13 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 // the heartbeat ticker will be used to ensure that we haven't been disconnected from the stream. This starts
 // a goroutine that will cancel the context if we haven't received an event in twice the heartbeat duration.
 // ********************************************************************************************************
-func (v *VStreamClient) monitorHeartbeat(ctx context.Context, cancel context.CancelFunc) {
+func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
+	// Start heartbeat liveness tracking when Run begins so startup stalls are treated the same
+	// as post-start disconnects.
+	v.lastEventProcessedAtUnixNano.Store(time.Now().UnixNano())
+
+	const timeoutMultiplier = 2
+
 	heartbeatDur := time.Duration(v.flags.HeartbeatInterval) * time.Second
 	heartbeat := time.NewTicker(heartbeatDur)
 	defer heartbeat.Stop()
@@ -203,21 +369,22 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context, cancel context.Can
 	for {
 		select {
 		case tm := <-heartbeat.C:
-			// if we haven't received an event yet, we'll skip the heartbeat check
-			if v.lastEventReceivedAtUnix.Load() == 0 {
+			// if we're currently processing events, we should skip the heartbeat check, since it's likely that we're
+			// just busy and haven't had a chance to receive the latest event yet. This is especially important for
+			// long-running flushes since they can take longer than the heartbeat duration, and we don't want to
+			// accidentally cancel the context during a flush.
+			if v.isProcessingEvents.Load() {
 				continue
 			}
 
 			// if we haven't received an event in twice the heartbeat duration, we'll cancel the context, since
 			// we're likely disconnected, and exit the goroutine
-			if tm.Sub(time.Unix(v.lastEventReceivedAtUnix.Load(), 0)) > heartbeatDur*2 {
-				cancel()
+			if tm.Sub(time.Unix(0, v.lastEventProcessedAtUnixNano.Load())) > heartbeatDur*timeoutMultiplier {
+				v.GracefulShutdown(v.gracefulShutdownWaitDur)
 				return
 			}
 
 		case <-ctx.Done():
-			// this cancel is probably unnecessary, since the context is already done, but it's good practice
-			cancel()
 			return
 		}
 	}
@@ -226,34 +393,32 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context, cancel context.Can
 // ********************************************************************************************************
 // Flush Data + Store Vgtid
 //
-// as we process events, we'll periodically need to check point the last vgtid and store the customers in the
-// database. You can control the frequency of this flush by adjusting the minFlushDuration and maxRowsPerFlush.
+// as we process events, we'll periodically need to checkpoint the last vgtid and persist the buffered data to
+// storage. You can control the frequency of this flush by adjusting the minFlushDuration and maxRowsPerFlush.
 // This is only called when we have an event that guarantees we're not flushing mid-transaction.
 // ********************************************************************************************************
 //
 // we might consider exporting Flush, but we'd need to have a mutex or something to block the stream from
 // processing, and technically we'd need to let it run until a commit event happens.
-func (v *VStreamClient) flush(ctx context.Context) error {
-	// if the lastFlushedVgtid is the same as the latestVgtid, we don't need to do anything
-	if proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
+func (v *VStreamClient) flush(ctx context.Context, force bool) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("vstreamclient: context error before flush: %w", err)
+	}
+
+	hasBufferedRows := v.hasBufferedRows()
+
+	// if the lastFlushedVgtid is the same as the latestVgtid and there is no buffered data,
+	// we don't need to do anything.
+	if !force && !hasBufferedRows && proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
+		if v.isClosing.Load() {
+			v.gracefulShutdownFlushOnce.Do(func() {
+				close(v.gracefulShutdownFlushChan)
+			})
+		}
 		return nil
 	}
 
-	// if we have exceeded the minFlushDuration, we'll force a flush, regardless how many rows each table has
-	shouldFlush := time.Since(v.stats.LastFlushedAt) > v.minFlushDuration
-
-	// if we haven't exceeded the min flush duration, we'll check if any of the tables have exceeded their
-	// max rows to flush. If any of them have, we will force a flush. Every table needs to be flushed at
-	// the same time, since the last vgtid covers all tables.
-	if !shouldFlush {
-		for _, table := range v.tables {
-			if len(table.currentBatch) >= table.MaxRowsPerFlush {
-				shouldFlush = true
-				break
-			}
-		}
-	}
-
+	shouldFlush, flushReason := v.shouldFlush(hasBufferedRows, force)
 	if !shouldFlush {
 		return nil
 	}
@@ -263,6 +428,10 @@ func (v *VStreamClient) flush(ctx context.Context) error {
 	for _, table := range v.tables {
 		// flush the rows to the database, chunked using the max batch size
 		for chunk := range slices.Chunk(table.currentBatch, table.MaxRowsPerFlush) {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("vstreamclient: context error during flush: %w", err)
+			}
+
 			err := table.FlushFn(ctx, chunk, FlushMeta{
 				Keyspace: table.Keyspace,
 				Table:    table.Table,
@@ -271,6 +440,7 @@ func (v *VStreamClient) flush(ctx context.Context) error {
 				VStreamStats: v.stats,
 
 				LatestVGtid: v.latestVgtid,
+				FlushReason: flushReason,
 			})
 			if err != nil {
 				return fmt.Errorf("vstreamclient: error flushing table %s: %w", table.Table, err)
@@ -288,7 +458,7 @@ func (v *VStreamClient) flush(ctx context.Context) error {
 		table.resetBatch()
 	}
 
-	// always store the latest vgtid, even if there are no customers to store
+	// always store the latest vgtid, even if there are no rows to store
 	err := updateLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.latestVgtid)
 	if err != nil {
 		return err
@@ -298,5 +468,53 @@ func (v *VStreamClient) flush(ctx context.Context) error {
 	v.stats.LastFlushedAt = time.Now()
 	v.lastFlushedVgtid = v.latestVgtid
 
+	// if we're in the middle of a graceful shutdown, and we've successfully flushed all the remaining data,
+	// we can close the channel to let the Run loop know it can exit
+	if v.isClosing.Load() {
+		v.gracefulShutdownFlushOnce.Do(func() {
+			close(v.gracefulShutdownFlushChan)
+		})
+	}
+
 	return nil
+}
+
+func (v *VStreamClient) hasBufferedRows() bool {
+	for _, table := range v.tables {
+		if len(table.currentBatch) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (v *VStreamClient) shouldFlush(hasBufferedRows, force bool) (bool, FlushReason) {
+	if force {
+		return true, FlushReasonForced
+	}
+
+	// if we have exceeded the minFlushDuration, we'll force a flush, regardless how many rows each table has
+	if time.Since(v.stats.LastFlushedAt) > v.minFlushDuration {
+		return true, FlushReasonMinDuration
+	}
+
+	// if we haven't exceeded the min flush duration, we'll check if any of the tables have exceeded their
+	// max rows to flush. If any of them have, we will force a flush. Every table needs to be flushed at
+	// the same time, since the last vgtid covers all tables.
+	if hasBufferedRows {
+		for _, table := range v.tables {
+			if len(table.currentBatch) >= table.MaxRowsPerFlush {
+				return true, FlushReasonMaxRowsPerFlush
+			}
+		}
+	}
+
+	// even if we haven't hit either of minDuration or maxRows, if we're actively closing
+	// down, go ahead and force the flush.
+	if v.isClosing.Load() {
+		return true, FlushReasonGracefulShutdown
+	}
+
+	return false, FlushReasonNone
 }

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -30,6 +30,10 @@ type EventFunc func(ctx context.Context, event *binlogdatapb.VEvent) error
 //
 // Returning an error will stop the stream, and the last vgtid will not be stored. The stream will need to be
 // restarted from the last successful flushed vgtid.
+//
+// Delivery is at-least-once at the flush/checkpoint boundary: if FlushFn succeeds but the checkpoint write fails,
+// the same rows may be delivered again on the next startup. Downstream sinks should therefore be idempotent or
+// explicitly deduplicatable.
 type FlushFunc func(ctx context.Context, rows []Row, meta FlushMeta) error
 
 // Row is the data structure that will be passed to the FlushFunc. It contains the row event, the row change,
@@ -415,6 +419,9 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 // as we process events, we'll periodically need to checkpoint the last vgtid and persist the buffered data to
 // storage. You can control the frequency of this flush by adjusting the minFlushDuration and maxRowsPerFlush.
 // This is only called when we have an event that guarantees we're not flushing mid-transaction.
+//
+// The durability boundary is at-least-once, not exactly-once: FlushFn runs before checkpoint persistence, so any
+// failure after a successful flush can replay that same data on restart.
 //
 // The isCopyCompleted flag is used to indicate that we've received the final COPY_COMPLETED event, which means
 // we should flush all remaining data, even if it doesn't meet the usual thresholds for flushing. This ensures

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -131,7 +131,7 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 		case err == nil: // no error, continue processing below
 
 		case errors.Is(err, io.EOF):
-			return nil
+			return fmt.Errorf("vstreamclient: remote error: %w", io.ErrUnexpectedEOF)
 
 		default:
 			return fmt.Errorf("vstreamclient: remote error: %w", err)

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -19,12 +19,15 @@ import (
 type EventFunc func(ctx context.Context, event *binlogdatapb.VEvent) error
 
 // FlushFunc is called per batch of rows, which could be any number of rows, but will be limited by the
-// MaxRowsPerFlush setting. The rows are always a slice of the data type for the table, which is configured
-// per table. You can use type assertion to convert the rows to the correct type, and then process them as needed.
+// MaxRowsPerFlush setting. The rows are passed as a slice of `Row` structs. For each `Row`, the `Data` field
+// will hold the specific data type configured for the table. You can use type assertion on `Row.Data` to
+// convert it to the correct type, and then process it as needed.
 //
-//	func(ctx context.Context, rows any, meta FlushMeta) error {
-//		 typedRows := rows.([]*DataType)
-//		 // do something with the rows
+//	func(ctx context.Context, rows []Row, meta FlushMeta) error {
+//		 for _, row := range rows {
+//			 typedRow := row.Data.(*DataType)
+//			 // do something with the row
+//		 }
 //		 return nil
 //	}
 //
@@ -403,7 +406,8 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 		case <-startupTimerChan:
 			// this is a sanity check to shutdown the client if we never receive a single event
 			if v.lastEventProcessedAtUnixNano.Load() == 0 {
-				panic("vstreamclient: vstream never received an event")
+				v.GracefulShutdown(v.cfg.gracefulShutdownWaitDur)
+				return
 			}
 			startupTimerChan = nil
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -125,14 +125,14 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 	defer cancelRunCtxFn()
 	defer v.endRun()
 
+	go v.listenForGracefulShutdown(ctx)
+
 	// initialize the streamer
 	var err error
 	v.reader, err = v.cfg.conn.VStream(ctx, v.cfg.tabletType, v.latestVgtid, v.cfg.filter, v.cfg.flags)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
 	}
-
-	go v.listenForGracefulShutdown(ctx)
 
 	go v.monitorHeartbeat(ctx)
 
@@ -421,7 +421,7 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 
 		case <-startupTimerChan:
 			// this is a sanity check to shutdown the client if we never receive a single event
-			if v.lastEventProcessedAtUnixNano.Load() == 0 {
+			if v.lastEventProcessedAtUnixNano.Load() == 0 && !v.isProcessingEvents.Load() {
 				v.GracefulShutdown(v.cfg.gracefulShutdownWaitDur)
 				return
 			}

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -463,7 +463,7 @@ func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
 				TableStats:   table.stats,
 				VStreamStats: v.stats,
 
-				LatestVGtid: v.latestVgtid,
+				LatestVGtid: cloneVGtid(v.latestVgtid),
 				FlushReason: flushReason,
 			})
 			if err != nil {
@@ -497,6 +497,14 @@ func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
 	v.signalGracefulShutdownFlushed()
 
 	return nil
+}
+
+func cloneVGtid(vgtid *binlogdatapb.VGtid) *binlogdatapb.VGtid {
+	if vgtid == nil {
+		return nil
+	}
+
+	return proto.Clone(vgtid).(*binlogdatapb.VGtid)
 }
 
 func (v *VStreamClient) hasBufferedRows() bool {

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (
@@ -487,9 +503,13 @@ func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
 	}
 
 	// always store the latest vgtid, even if there are no rows to store
-	err := updateLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.latestVgtid, isCopyCompleted)
-	if err != nil {
-		return err
+	// but skip the update if the vgtid hasn't changed and we're not setting copy_completed,
+	// because MySQL will return RowsAffected=0 for an UPDATE that doesn't change any columns
+	if isCopyCompleted || !proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
+		err := updateLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.latestVgtid, isCopyCompleted)
+		if err != nil {
+			return err
+		}
 	}
 
 	v.stats.FlushCount++

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -352,23 +352,38 @@ func (v *VStreamClient) listenForGracefulShutdown(ctx context.Context) {
 // ********************************************************************************************************
 // Heartbeat Monitoring
 //
-// the heartbeat ticker will be used to ensure that we haven't been disconnected from the stream. This starts
-// a goroutine that will cancel the context if we haven't received an event in twice the heartbeat duration.
+// the heartbeat ticker is used to ensure that we haven't been disconnected from the stream after the stream has
+// started delivering events. Before the first event arrives, heartbeat liveness checks stay disabled so a slow but
+// healthy startup does not self-cancel.
 // ********************************************************************************************************
 func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
-	// Start heartbeat liveness tracking when Run begins so startup stalls are treated the same
-	// as post-start disconnects.
-	v.lastEventProcessedAtUnixNano.Store(time.Now().UnixNano())
-
+	const startupTimeout = 5 * time.Minute
 	const timeoutMultiplier = 2
 
 	heartbeatDur := time.Duration(v.flags.HeartbeatInterval) * time.Second
 	heartbeat := time.NewTicker(heartbeatDur)
 	defer heartbeat.Stop()
 
+	startupTimer := time.NewTimer(startupTimeout)
+	startupTimerChan := startupTimer.C
+
 	for {
 		select {
 		case tm := <-heartbeat.C:
+			// if we haven't processed any events yet, we should skip the heartbeat check, since it's likely that
+			// we're still starting up and haven't had a chance to receive the first event yet. This is especially
+			// important if the startup is slow, since we don't want to accidentally shut down during startup.
+			lastEventProcessedAtUnixNano := v.lastEventProcessedAtUnixNano.Load()
+			if lastEventProcessedAtUnixNano == 0 {
+				continue
+			}
+
+			// once we receive the first event, we can stop the startup timer and disable the select case
+			if startupTimerChan != nil {
+				startupTimer.Stop()
+				startupTimerChan = nil
+			}
+
 			// if we're currently processing events, we should skip the heartbeat check, since it's likely that we're
 			// just busy and haven't had a chance to receive the latest event yet. This is especially important for
 			// long-running flushes since they can take longer than the heartbeat duration, and we don't want to
@@ -379,10 +394,17 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 
 			// if we haven't received an event in twice the heartbeat duration, we'll cancel the context, since
 			// we're likely disconnected, and exit the goroutine
-			if tm.Sub(time.Unix(0, v.lastEventProcessedAtUnixNano.Load())) > heartbeatDur*timeoutMultiplier {
+			if tm.Sub(time.Unix(0, lastEventProcessedAtUnixNano)) > heartbeatDur*timeoutMultiplier {
 				v.GracefulShutdown(v.gracefulShutdownWaitDur)
 				return
 			}
+
+		case <-startupTimerChan:
+			// this is a sanity check to shutdown the client if we never receive a single event
+			if v.lastEventProcessedAtUnixNano.Load() == 0 {
+				panic("vstreamclient: vstream never received an event")
+			}
+			startupTimerChan = nil
 
 		case <-ctx.Done():
 			return

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -565,7 +565,7 @@ func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
 	// but skip the update if the vgtid hasn't changed and we're not setting copy_completed,
 	// because MySQL will return RowsAffected=0 for an UPDATE that doesn't change any columns
 	if isCopyCompleted || !proto.Equal(v.lastFlushedVgtid, v.latestVgtid) {
-		err := updateLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.latestVgtid, isCopyCompleted)
+		err := updateLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, v.latestVgtid, isCopyCompleted)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -31,17 +31,19 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 var (
 	// ErrHeartbeatTimeout is returned by Run (as the wrapped cause) when the heartbeat monitor stops
 	// the stream because no events, including heartbeats, were received within the liveness window
 	// (the heartbeat interval times DefaultHeartbeatTimeoutMultiplier).
-	ErrHeartbeatTimeout = errors.New("vstreamclient: no events received within the heartbeat liveness window")
+	ErrHeartbeatTimeout = vterrors.New(vtrpcpb.Code_UNAVAILABLE, "vstreamclient: no events received within the heartbeat liveness window")
 
 	// ErrStartupTimeout is returned by Run (as the wrapped cause) when the stream never delivered a
 	// single event within DefaultStartupTimeout after Run started.
-	ErrStartupTimeout = errors.New("vstreamclient: no events received before the startup timeout")
+	ErrStartupTimeout = vterrors.New(vtrpcpb.Code_UNAVAILABLE, "vstreamclient: no events received before the startup timeout")
 )
 
 // EventFunc is an optional callback function that can be registered for individual event types
@@ -137,7 +139,7 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 	ctx, cancelRunCtxFn := context.WithCancelCause(ctx)
 	if !v.beginRun(cancelRunCtxFn) {
 		cancelRunCtxFn(nil)
-		return errors.New("vstreamclient: client is closed; create a new client for each Run attempt")
+		return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: client is closed; create a new client for each Run attempt")
 	}
 	defer cancelRunCtxFn(nil)
 	defer v.endRun()

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -115,7 +115,8 @@ func (r FlushReason) String() string {
 	case FlushReasonGracefulShutdown:
 		return "gracefulShutdown"
 	default:
-		panic(fmt.Sprintf("unknown FlushReason: %d", r))
+		// the zero value and any future values are reachable by consumers, so never panic here
+		return fmt.Sprintf("unknown(%d)", r)
 	}
 }
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -323,6 +323,7 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		// Otherwise, there's not much to do with these events.
 		case binlogdatapb.VEventType_COMMIT, binlogdatapb.VEventType_OTHER:
 			// only flush when we have an event that guarantees we're not flushing mid-transaction
+			v.inTransaction = false
 			err = v.flush(ctx, false)
 			if err != nil {
 				return err
@@ -332,6 +333,7 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		// They are safe to flush on, since they indicate the end of a transaction. If you want to
 		// transparently adjust the destination schema based on DDL events, you would do that here.
 		case binlogdatapb.VEventType_DDL:
+			v.inTransaction = false
 			err = v.flush(ctx, false)
 			if err != nil {
 				return err
@@ -356,6 +358,13 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		// thresholds the last time flush was called. Most of the time, that won't be the case, but flush will
 		// check for that and only run if necessary.
 		case binlogdatapb.VEventType_HEARTBEAT:
+			// a heartbeat is NOT a transaction boundary: with TransactionChunkSize enabled, VTGate
+			// can deliver BEGIN and row chunks in separate batches while its heartbeat ticker runs
+			// independently. Flushing mid-transaction would expose uncommitted rows (which could
+			// still roll back) and duplicate the prefix on replay, so defer to the next boundary.
+			if v.inTransaction {
+				continue
+			}
 			err = v.flush(ctx, false)
 			if err != nil {
 				return err
@@ -364,6 +373,7 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		// even if there are no changes to the tables being streamed, we'll still get a begin, vgtid, and commit
 		// event for each transaction. The other two are used for checkpoints, but nothing to do here.
 		case binlogdatapb.VEventType_BEGIN:
+			v.inTransaction = true
 
 		// journal events are sent on resharding. Unless you are manually targeting shards, vstream should
 		// transparently handle resharding for you, so you shouldn't need to do anything with these events.

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"slices"
@@ -28,7 +29,19 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+var (
+	// ErrHeartbeatTimeout is returned by Run (as the wrapped cause) when the heartbeat monitor stops
+	// the stream because no events, including heartbeats, were received within the liveness window
+	// (the heartbeat interval times DefaultHeartbeatTimeoutMultiplier).
+	ErrHeartbeatTimeout = errors.New("vstreamclient: no events received within the heartbeat liveness window")
+
+	// ErrStartupTimeout is returned by Run (as the wrapped cause) when the stream never delivered a
+	// single event within DefaultStartupTimeout after Run started.
+	ErrStartupTimeout = errors.New("vstreamclient: no events received before the startup timeout")
 )
 
 // EventFunc is an optional callback function that can be registered for individual event types
@@ -111,18 +124,22 @@ func (r FlushReason) String() string {
 //   - Run is called on a client that was already used by a previous Run attempt
 //   - the underlying VStream recv loop fails
 //   - the context is canceled or times out while Run is still active
+//   - the client shuts itself down because no events were received; the returned error
+//     wraps ErrHeartbeatTimeout or ErrStartupTimeout, so callers can match with errors.Is
 //   - a registered event hook returns an error
 //   - row decoding or table lookup fails
 //   - FlushFn returns an error
 //   - checkpoint state updates fail
 func (v *VStreamClient) Run(ctx context.Context) error {
-	// make a cancelable context for GracefulShutdown to use, so it can signal the Run loop to exit
-	ctx, cancelRunCtxFn := context.WithCancel(ctx)
+	// make a cancelable context for GracefulShutdown to use, so it can signal the Run loop to exit.
+	// The cancel cause distinguishes monitor-initiated shutdowns (e.g. ErrHeartbeatTimeout) from
+	// ordinary context cancellation.
+	ctx, cancelRunCtxFn := context.WithCancelCause(ctx)
 	if !v.beginRun(cancelRunCtxFn) {
-		cancelRunCtxFn()
+		cancelRunCtxFn(nil)
 		return errors.New("vstreamclient: client is closed; create a new client for each Run attempt")
 	}
-	defer cancelRunCtxFn()
+	defer cancelRunCtxFn(nil)
 	defer v.endRun()
 
 	go v.listenForGracefulShutdown(ctx)
@@ -157,6 +174,13 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 			return fmt.Errorf("vstreamclient: remote error: %w", io.ErrUnexpectedEOF)
 
 		default:
+			// if the recv failed because our own context was canceled with an explicit cause
+			// (e.g. the heartbeat monitor), surface that cause instead of the generic grpc error
+			if ctx.Err() != nil {
+				if cause := context.Cause(ctx); !errors.Is(cause, ctx.Err()) {
+					return fmt.Errorf("vstreamclient: stream canceled: %w", cause)
+				}
+			}
 			return fmt.Errorf("vstreamclient: remote error: %w", err)
 		}
 
@@ -200,12 +224,27 @@ func (v *VStreamClient) shouldExitRun(ctx context.Context) (bool, error) {
 	select {
 	// since any processing will likely be wasted, return early if the context is already done
 	case <-ctx.Done():
-		return true, ctx.Err()
+		return true, contextErr(ctx)
 
 	default:
 	}
 
 	return false, nil
+}
+
+// contextErr returns the context's cancel cause when it differs from ctx.Err() (e.g. the heartbeat
+// monitor canceled the run), and ctx.Err() otherwise. It returns nil if the context is not done.
+func contextErr(ctx context.Context) error {
+	err := ctx.Err()
+	if err == nil {
+		return nil
+	}
+
+	if cause := context.Cause(ctx); !errors.Is(cause, err) {
+		return cause
+	}
+
+	return err
 }
 
 func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb.VEvent) error {
@@ -377,10 +416,19 @@ func (v *VStreamClient) listenForGracefulShutdown(ctx context.Context) {
 // healthy startup does not self-cancel.
 // ********************************************************************************************************
 func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
-	const startupTimeout = 5 * time.Minute
-	const timeoutMultiplier = 2
+	// guard against zero values so a zero liveness window or startup timeout can never
+	// trigger an immediate shutdown
+	startupTimeout := v.cfg.startupTimeout
+	if startupTimeout <= 0 {
+		startupTimeout = DefaultStartupTimeout
+	}
+	timeoutMultiplier := v.cfg.heartbeatTimeoutMultiplier
+	if timeoutMultiplier <= 0 {
+		timeoutMultiplier = DefaultHeartbeatTimeoutMultiplier
+	}
 
 	heartbeatDur := time.Duration(v.cfg.flags.HeartbeatInterval) * time.Second
+	livenessWindow := heartbeatDur * time.Duration(timeoutMultiplier)
 	heartbeat := time.NewTicker(heartbeatDur)
 	defer heartbeat.Stop()
 
@@ -412,17 +460,28 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 				continue
 			}
 
-			// if we haven't received an event in twice the heartbeat duration, we'll cancel the context, since
+			// if we haven't received an event within the liveness window, we'll cancel the context, since
 			// we're likely disconnected, and exit the goroutine
-			if tm.Sub(time.Unix(0, lastEventProcessedAtUnixNano)) > heartbeatDur*timeoutMultiplier {
-				v.GracefulShutdown(v.cfg.gracefulShutdownWaitDur)
+			if tm.Sub(time.Unix(0, lastEventProcessedAtUnixNano)) > livenessWindow {
+				log.Warn(
+					"vstreamclient: no events received within the liveness window, shutting down the stream",
+					slog.String("name", v.cfg.name),
+					slog.Duration("liveness_window", livenessWindow),
+					slog.Time("last_event_processed_at", time.Unix(0, lastEventProcessedAtUnixNano)),
+				)
+				v.gracefulShutdownWithCause(v.cfg.gracefulShutdownWaitDur, ErrHeartbeatTimeout)
 				return
 			}
 
 		case <-startupTimerChan:
 			// this is a sanity check to shutdown the client if we never receive a single event
 			if v.lastEventProcessedAtUnixNano.Load() == 0 && !v.isProcessingEvents.Load() {
-				v.GracefulShutdown(v.cfg.gracefulShutdownWaitDur)
+				log.Warn(
+					"vstreamclient: no events received since Run started, shutting down the stream",
+					slog.String("name", v.cfg.name),
+					slog.Duration("startup_timeout", startupTimeout),
+				)
+				v.gracefulShutdownWithCause(v.cfg.gracefulShutdownWaitDur, ErrStartupTimeout)
 				return
 			}
 			startupTimerChan = nil
@@ -449,7 +508,7 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 // copy_completed to true in the state table.
 // ********************************************************************************************************
 func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
-	if err := ctx.Err(); err != nil {
+	if err := contextErr(ctx); err != nil {
 		return fmt.Errorf("vstreamclient: context error before flush: %w", err)
 	}
 
@@ -472,7 +531,7 @@ func (v *VStreamClient) flush(ctx context.Context, isCopyCompleted bool) error {
 	for _, table := range v.tables {
 		// flush the rows to the database, chunked using the max batch size
 		for chunk := range slices.Chunk(table.currentBatch, table.MaxRowsPerFlush) {
-			if err := ctx.Err(); err != nil {
+			if err := contextErr(ctx); err != nil {
 				return fmt.Errorf("vstreamclient: context error during flush: %w", err)
 			}
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -147,13 +147,15 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 
 	go v.listenForGracefulShutdown(ctx)
 
+	// start the monitor before opening the stream, so a blocked stream setup is covered by the
+	// startup deadline rather than hanging outside of it
+	go v.monitorHeartbeat(ctx)
+
 	// initialize the streamer
 	reader, err := v.cfg.conn.VStream(ctx, v.cfg.tabletType, v.latestVgtid, v.cfg.filter, v.cfg.flags)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
 	}
-
-	go v.monitorHeartbeat(ctx)
 
 	// to prevent an immediate flush, we initialize LastFlushedAt here, even if it wasn't technically flushed
 	v.stats.LastFlushedAt = time.Now()
@@ -216,9 +218,11 @@ func (v *VStreamClient) shouldExitRun(ctx context.Context) (bool, error) {
 	select {
 	// if we enter this case, that means the last flush completed during the shutdown process, and closed
 	// the channel, so we can exit immediately without processing any more events. This is the happy
-	// path for graceful shutdown, since we were able to flush all buffered data
+	// path for graceful shutdown, since we were able to flush all buffered data. A monitor-initiated
+	// shutdown still surfaces its cause (e.g. ErrHeartbeatTimeout) even though the flush succeeded,
+	// so applications that restart only on errors don't silently stop consuming.
 	case <-gracefulShutdownFlushChan:
-		return true, nil
+		return true, v.getShutdownCause()
 
 	default:
 	}
@@ -380,6 +384,14 @@ func isFinalCopyCompletedEvent(ev *binlogdatapb.VEvent) bool {
 	return ev.Type == binlogdatapb.VEventType_COPY_COMPLETED && ev.Keyspace == "" && ev.Shard == ""
 }
 
+// effectiveStartupTimeout returns the startup timeout floored at the liveness window: an idle
+// stream at a concrete position may not deliver its first event until the first heartbeat, so a
+// startup timeout shorter than the liveness window would cancel a healthy stream whose configured
+// heartbeat simply hasn't fired yet.
+func effectiveStartupTimeout(configured, livenessWindow time.Duration) time.Duration {
+	return max(configured, livenessWindow)
+}
+
 // ********************************************************************************************************
 // Graceful Shutdown
 //
@@ -431,6 +443,7 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 
 	heartbeatDur := time.Duration(v.cfg.flags.HeartbeatInterval) * time.Second
 	livenessWindow := heartbeatDur * time.Duration(timeoutMultiplier)
+	startupTimeout = effectiveStartupTimeout(startupTimeout, livenessWindow)
 	heartbeat := time.NewTicker(heartbeatDur)
 	defer heartbeat.Stop()
 
@@ -461,6 +474,12 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 			if v.isProcessingEvents.Load() {
 				continue
 			}
+
+			// re-read the timestamp after observing that processing is idle: the event goroutine
+			// may have stored a fresh timestamp and cleared the processing flag between our first
+			// load and the check above, and comparing against the stale value could trigger a
+			// false timeout right at the boundary
+			lastEventProcessedAtUnixNano = v.lastEventProcessedAtUnixNano.Load()
 
 			// if we haven't received an event within the liveness window, we'll cancel the context, since
 			// we're likely disconnected, and exit the goroutine
@@ -625,7 +644,7 @@ func (v *VStreamClient) shouldFlush(hasBufferedRows, isCopyCompleted bool) (bool
 
 	// even if we haven't hit either of minDuration or maxRows, if we're actively closing
 	// down, go ahead and force the flush.
-	if v.isShutdownRequested() {
+	if v.ShutdownRequested() {
 		return true, FlushReasonGracefulShutdown
 	}
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -145,8 +145,7 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 	go v.listenForGracefulShutdown(ctx)
 
 	// initialize the streamer
-	var err error
-	v.reader, err = v.cfg.conn.VStream(ctx, v.cfg.tabletType, v.latestVgtid, v.cfg.filter, v.cfg.flags)
+	reader, err := v.cfg.conn.VStream(ctx, v.cfg.tabletType, v.latestVgtid, v.cfg.filter, v.cfg.flags)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
 	}
@@ -166,7 +165,7 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 		// events come in batches, depending on how busy the keyspace is. This is where the network communication
 		// happens, so it's the most likely place for errors to occur.
 		var events []*binlogdatapb.VEvent
-		events, err = v.reader.Recv()
+		events, err = reader.Recv()
 		switch {
 		case err == nil: // no error, continue processing below
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -156,6 +156,13 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 	// initialize the streamer
 	reader, err := v.cfg.conn.VStream(ctx, v.cfg.tabletType, v.latestVgtid, v.cfg.filter, v.cfg.flags)
 	if err != nil {
+		// a blocked stream setup can be canceled by the startup watchdog; surface its cause
+		// (e.g. ErrStartupTimeout) instead of the generic transport error, like the Recv path
+		if ctx.Err() != nil {
+			if cause := context.Cause(ctx); !errors.Is(cause, ctx.Err()) {
+				return fmt.Errorf("vstreamclient: stream canceled: %w", cause)
+			}
+		}
 		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
 	}
 

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -272,16 +272,16 @@ func contextErr(ctx context.Context) error {
 }
 
 func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb.VEvent) error {
-	// if event processing / flushing takes longer than the heartbeat timeout, the heartbeat monitor might trigger
-	// and cancel the context, since no events are processed during that time. This technically leaves a tiny race
-	// condition between defer running and the next Recv happening in the Run() loop, but trying to make that
-	// perfect would add a lot of complexity, and the window is very small.
-	v.isProcessingEvents.Store(true)
+	v.eventMu.Lock()
+	v.isProcessingEvents = true
+	v.eventMu.Unlock()
 	defer func() {
 		// keep track of the last event time for heartbeat monitoring. We're purposefully not using the event
 		// timestamp, since that would cause cancellation if the stream was copying, delayed, or lagging.
-		v.lastEventProcessedAtUnixNano.Store(time.Now().UnixNano())
-		v.isProcessingEvents.Store(false)
+		v.eventMu.Lock()
+		v.lastEventProcessedAtUnixNano = time.Now().UnixNano()
+		v.isProcessingEvents = false
+		v.eventMu.Unlock()
 	}()
 
 	for _, ev := range events {
@@ -475,7 +475,7 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 	}
 	timeoutMultiplier := v.cfg.heartbeatTimeoutMultiplier
 	if timeoutMultiplier <= 0 {
-		timeoutMultiplier = 2
+		timeoutMultiplier = 10
 	}
 
 	heartbeatDur := time.Duration(v.cfg.flags.HeartbeatInterval) * time.Second
@@ -485,67 +485,30 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 	defer heartbeat.Stop()
 
 	startupTimer := time.NewTimer(startupTimeout)
+	defer startupTimer.Stop()
 	startupTimerChan := startupTimer.C
 
 	for {
 		select {
 		case tm := <-heartbeat.C:
-			// if we haven't processed any events yet, we should skip the heartbeat check, since it's likely that
-			// we're still starting up and haven't had a chance to receive the first event yet. This is especially
-			// important if the startup is slow, since we don't want to accidentally shut down during startup.
-			lastEventProcessedAtUnixNano := v.lastEventProcessedAtUnixNano.Load()
-			if lastEventProcessedAtUnixNano == 0 {
-				continue
-			}
-
-			// once we receive the first event, we can stop the startup timer and disable the select case
-			if startupTimerChan != nil {
-				startupTimer.Stop()
-				startupTimerChan = nil
-			}
-
-			// if we're currently processing events, we should skip the heartbeat check, since it's likely that we're
-			// just busy and haven't had a chance to receive the latest event yet. This is especially important for
-			// long-running flushes since they can take longer than the heartbeat duration, and we don't want to
-			// accidentally cancel the context during a flush.
-			if v.isProcessingEvents.Load() {
-				continue
-			}
-
-			// require a stable snapshot: the timestamp must be unchanged across the idle
-			// observation above. handleEvents stores the timestamp before clearing the
-			// processing flag, so if the value moved, a batch completed while we were sampling
-			// and its fresh timestamp resets the window; skip this tick instead of comparing
-			// against a value that was mid-update.
-			if v.lastEventProcessedAtUnixNano.Load() != lastEventProcessedAtUnixNano {
-				continue
-			}
-
-			// if we haven't received an event within the liveness window, we'll cancel the context, since
-			// we're likely disconnected, and exit the goroutine
-			if tm.Sub(time.Unix(0, lastEventProcessedAtUnixNano)) > livenessWindow {
+			if err := v.cancelIfIdle(tm, livenessWindow, false); err != nil {
 				log.Warn(
 					"vstreamclient: no events received within the liveness window, shutting down the stream",
 					slog.String("name", v.cfg.name),
 					slog.Duration("liveness_window", livenessWindow),
-					slog.Time("last_event_processed_at", time.Unix(0, lastEventProcessedAtUnixNano)),
+					slog.Any("error", err),
 				)
-				v.gracefulShutdownWithCause(v.cfg.gracefulShutdownWaitDur, ErrHeartbeatTimeout)
 				return
 			}
 
 		case <-startupTimerChan:
-			// this is a sanity check to shutdown the client if we never receive a single event.
-			// The processing flag is checked before the timestamp: handleEvents stores the
-			// timestamp before clearing the flag, so once we observe idle, the timestamp read
-			// is guaranteed to see any batch that just finished.
-			if !v.isProcessingEvents.Load() && v.lastEventProcessedAtUnixNano.Load() == 0 {
+			if err := v.cancelIfIdle(time.Now(), livenessWindow, true); err != nil {
 				log.Warn(
 					"vstreamclient: no events received since Run started, shutting down the stream",
 					slog.String("name", v.cfg.name),
 					slog.Duration("startup_timeout", startupTimeout),
+					slog.Any("error", err),
 				)
-				v.gracefulShutdownWithCause(v.cfg.gracefulShutdownWaitDur, ErrStartupTimeout)
 				return
 			}
 			startupTimerChan = nil
@@ -554,6 +517,36 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 			return
 		}
 	}
+}
+
+func (v *VStreamClient) cancelIfIdle(now time.Time, livenessWindow time.Duration, startup bool) error {
+	v.eventMu.Lock()
+	defer v.eventMu.Unlock()
+	if v.isProcessingEvents {
+		return nil
+	}
+
+	cause := ErrHeartbeatTimeout
+	if startup {
+		if v.lastEventProcessedAtUnixNano != 0 {
+			return nil
+		}
+		cause = ErrStartupTimeout
+	} else if v.lastEventProcessedAtUnixNano == 0 || now.Sub(time.Unix(0, v.lastEventProcessedAtUnixNano)) <= livenessWindow {
+		return nil
+	}
+
+	v.lifecycle.mu.Lock()
+	if !v.lifecycle.runActive || v.lifecycle.cancelRunCtxFn == nil {
+		v.lifecycle.mu.Unlock()
+		return nil
+	}
+	v.lifecycle.shutdownRequested = true
+	v.lifecycle.shutdownCause = cause
+	cancelRunCtxFn := v.lifecycle.cancelRunCtxFn
+	v.lifecycle.mu.Unlock()
+	cancelRunCtxFn(cause)
+	return cause
 }
 
 // ********************************************************************************************************

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -129,6 +129,8 @@ func (r FlushReason) String() string {
 //   - the context is canceled or times out while Run is still active
 //   - the client shuts itself down because no events were received; the returned error
 //     wraps ErrHeartbeatTimeout or ErrStartupTimeout, so callers can match with errors.Is
+//   - taking ownership of the state row fails because another client with the same stream
+//     name claimed it since New read state; the returned error wraps ErrFenced
 //   - a registered event hook returns an error
 //   - row decoding or table lookup fails
 //   - FlushFn returns an error
@@ -155,6 +157,15 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 	reader, err := v.cfg.conn.VStream(ctx, v.cfg.tabletType, v.latestVgtid, v.cfg.filter, v.cfg.flags)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
+	}
+
+	// take ownership of the state row only once the stream is established, so an abandoned
+	// constructor or a failed stream setup never fences the incumbent consumer. The takeover
+	// fails with an error wrapping ErrFenced if another client claimed the stream since New
+	// read its state.
+	err = v.takeStateOwnership(ctx)
+	if err != nil {
+		return err
 	}
 
 	// to prevent an immediate flush, we initialize LastFlushedAt here, even if it wasn't technically flushed

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -510,11 +510,14 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 				continue
 			}
 
-			// re-read the timestamp after observing that processing is idle: the event goroutine
-			// may have stored a fresh timestamp and cleared the processing flag between our first
-			// load and the check above, and comparing against the stale value could trigger a
-			// false timeout right at the boundary
-			lastEventProcessedAtUnixNano = v.lastEventProcessedAtUnixNano.Load()
+			// require a stable snapshot: the timestamp must be unchanged across the idle
+			// observation above. handleEvents stores the timestamp before clearing the
+			// processing flag, so if the value moved, a batch completed while we were sampling
+			// and its fresh timestamp resets the window; skip this tick instead of comparing
+			// against a value that was mid-update.
+			if v.lastEventProcessedAtUnixNano.Load() != lastEventProcessedAtUnixNano {
+				continue
+			}
 
 			// if we haven't received an event within the liveness window, we'll cancel the context, since
 			// we're likely disconnected, and exit the goroutine
@@ -530,8 +533,11 @@ func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
 			}
 
 		case <-startupTimerChan:
-			// this is a sanity check to shutdown the client if we never receive a single event
-			if v.lastEventProcessedAtUnixNano.Load() == 0 && !v.isProcessingEvents.Load() {
+			// this is a sanity check to shutdown the client if we never receive a single event.
+			// The processing flag is checked before the timestamp: handleEvents stores the
+			// timestamp before clearing the flag, so once we observe idle, the timestamp read
+			// is guaranteed to see any batch that just finished.
+			if !v.isProcessingEvents.Load() && v.lastEventProcessedAtUnixNano.Load() == 0 {
 				log.Warn(
 					"vstreamclient: no events received since Run started, shutting down the stream",
 					slog.String("name", v.cfg.name),

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -465,15 +465,17 @@ func (v *VStreamClient) listenForGracefulShutdown(ctx context.Context) {
 // healthy startup does not self-cancel.
 // ********************************************************************************************************
 func (v *VStreamClient) monitorHeartbeat(ctx context.Context) {
-	// guard against zero values so a zero liveness window or startup timeout can never
-	// trigger an immediate shutdown
+	// New validates the configured values; these fixed floors only guard directly-constructed
+	// clients (tests) so a zero liveness window or startup timeout can never trigger an
+	// immediate shutdown. They deliberately don't fall back to the mutable package defaults,
+	// which could themselves hold invalid values.
 	startupTimeout := v.cfg.startupTimeout
 	if startupTimeout <= 0 {
-		startupTimeout = DefaultStartupTimeout
+		startupTimeout = 5 * time.Minute
 	}
 	timeoutMultiplier := v.cfg.heartbeatTimeoutMultiplier
 	if timeoutMultiplier <= 0 {
-		timeoutMultiplier = DefaultHeartbeatTimeoutMultiplier
+		timeoutMultiplier = 2
 	}
 
 	heartbeatDur := time.Duration(v.cfg.flags.HeartbeatInterval) * time.Second

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -393,6 +393,13 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		case binlogdatapb.VEventType_BEGIN:
 			v.inTransaction = true
 
+		// rollback also terminates a transaction. Rows from rolled-back transactions are never
+		// delivered (vstream reads the binlog, which only contains committed transactions), so
+		// there is nothing to discard; only the transaction state must be cleared, or every
+		// later heartbeat flush would stay suppressed on an idle stream.
+		case binlogdatapb.VEventType_ROLLBACK:
+			v.inTransaction = false
+
 		// journal events are sent on resharding. Unless you are manually targeting shards, vstream should
 		// transparently handle resharding for you, so you shouldn't need to do anything with these events.
 		// You might want to log them for debugging purposes or to alert on resharding events in case

--- a/go/vt/vstreamclient/run.go
+++ b/go/vt/vstreamclient/run.go
@@ -166,24 +166,13 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 		return fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
 	}
 
-	// take ownership of the state row only once the stream is established, so an abandoned
-	// constructor or a failed stream setup never fences the incumbent consumer. The takeover
-	// fails with an error wrapping ErrFenced if another client claimed the stream since New
-	// read its state.
-	err = v.takeStateOwnership(ctx)
-	if err != nil {
-		return err
-	}
-
-	// to prevent an immediate flush, we initialize LastFlushedAt here, even if it wasn't technically flushed
-	v.stats.LastFlushedAt = time.Now()
-
 	// ********************************************************************************************************
 	// Event Processing
 	//
 	// this is the main loop that processes events from the stream. It will continue until the stream ends or an
 	// error occurs. The context is checked before processing each event.
 	// ********************************************************************************************************
+	claimedOwnership := false
 	for {
 		// events come in batches, depending on how busy the keyspace is. This is where the network communication
 		// happens, so it's the most likely place for errors to occur.
@@ -204,6 +193,15 @@ func (v *VStreamClient) Run(ctx context.Context) error {
 				}
 			}
 			return fmt.Errorf("vstreamclient: remote error: %w", err)
+		}
+
+		if !claimedOwnership {
+			err = v.takeStateOwnership(ctx)
+			if err != nil {
+				return err
+			}
+			v.stats.LastFlushedAt = time.Now()
+			claimedOwnership = true
 		}
 
 		err = v.handleEvents(ctx, events)
@@ -337,9 +335,9 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		case binlogdatapb.VEventType_VGTID:
 			v.latestVgtid = ev.Vgtid
 
-		// commit and other events are safe to flush on, since they indicate the end of a transaction.
+		// commit, other, and rollback events are safe to flush on, since they indicate the end of a transaction.
 		// Otherwise, there's not much to do with these events.
-		case binlogdatapb.VEventType_COMMIT, binlogdatapb.VEventType_OTHER:
+		case binlogdatapb.VEventType_COMMIT, binlogdatapb.VEventType_OTHER, binlogdatapb.VEventType_ROLLBACK:
 			// only flush when we have an event that guarantees we're not flushing mid-transaction
 			v.inTransaction = false
 			err = v.flush(ctx, false)
@@ -392,13 +390,6 @@ func (v *VStreamClient) handleEvents(ctx context.Context, events []*binlogdatapb
 		// event for each transaction. The other two are used for checkpoints, but nothing to do here.
 		case binlogdatapb.VEventType_BEGIN:
 			v.inTransaction = true
-
-		// rollback also terminates a transaction. Rows from rolled-back transactions are never
-		// delivered (vstream reads the binlog, which only contains committed transactions), so
-		// there is nothing to discard; only the transaction state must be cleared, or every
-		// later heartbeat flush would stay suppressed on an idle stream.
-		case binlogdatapb.VEventType_ROLLBACK:
-			v.inTransaction = false
 
 		// journal events are sent on resharding. Unless you are manually targeting shards, vstream should
 		// transparently handle resharding for you, so you shouldn't need to do anything with these events.

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -1,0 +1,192 @@
+package vstreamclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+type dbTableConfig struct {
+	Keyspace string
+	Table    string
+	Query    string
+}
+
+func tablesToDBTableConfig(tables map[string]*TableConfig) map[string]dbTableConfig {
+	m := make(map[string]dbTableConfig, len(tables))
+
+	for k, table := range tables {
+		m[k] = dbTableConfig{
+			Keyspace: table.Keyspace,
+			Table:    table.Table,
+			Query:    table.Query,
+		}
+	}
+
+	return m
+}
+
+func initStateTable(ctx context.Context, session *vtgateconn.VTGateSession, keyspaceName, tableName string) error {
+	query := fmt.Sprintf(`create table if not exists %s.%s (
+  name varbinary(64) not null,
+  latest_vgtid json,
+  table_config json not null,
+  copy_completed bool not null default false,
+  created_at timestamp default current_timestamp,
+  updated_at timestamp default current_timestamp on update current_timestamp,
+  PRIMARY KEY (name)
+)`, keyspaceName, tableName)
+
+	fmt.Println("query: ", query)
+
+	_, err := session.Execute(ctx, query, nil)
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to create state table: %w", err)
+	}
+
+	return nil
+}
+
+func initVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, tables map[string]*TableConfig, shardsByKeyspace map[string][]string) (*binlogdatapb.VGtid, error) {
+	vgtid, err := newVGtid(tables, shardsByKeyspace)
+	if err != nil {
+		return nil, err
+	}
+
+	latestVgtidJSON, err := json.Marshal(vgtid)
+	if err != nil {
+		return nil, fmt.Errorf("vstreamclient: failed to marshal latest vgtid: %w", err)
+	}
+
+	tablesJSON, err := json.Marshal(tablesToDBTableConfig(tables))
+	if err != nil {
+		return nil, fmt.Errorf("vstreamclient: failed to marshal tables: %w", err)
+	}
+
+	query := fmt.Sprintf(`insert into %s.%s (name, latest_vgtid, table_config) values (:name, :latest_vgtid, :table_config)`,
+		keyspaceName, tableName,
+	)
+	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
+		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtidJSON},
+		"table_config": {Type: querypb.Type_JSON, Value: tablesJSON},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
+	}
+
+	return vgtid, nil
+}
+
+func newVGtid(tables map[string]*TableConfig, shardsByKeyspace map[string][]string) (*binlogdatapb.VGtid, error) {
+	bootstrappedKeyspaces := make(map[string]bool)
+	vgtid := &binlogdatapb.VGtid{}
+
+	for _, table := range tables {
+		if bootstrappedKeyspaces[table.Keyspace] {
+			continue
+		}
+
+		// TODO: this currently doesn't support subsetting shards, but we can add that if needed
+		shards, ok := shardsByKeyspace[table.Keyspace]
+		if !ok {
+			return nil, fmt.Errorf("vstreamclient: keyspace %s not found", table.Keyspace)
+		}
+
+		for _, shard := range shards {
+			vgtid.ShardGtids = append(vgtid.ShardGtids, &binlogdatapb.ShardGtid{
+				Keyspace: table.Keyspace,
+				Shard:    shard,
+				Gtid:     "", // start from the beginning, meaning initializing a copy phase
+			})
+		}
+	}
+
+	return vgtid, nil
+}
+
+func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) (*binlogdatapb.VGtid, map[string]*TableConfig, bool, error) {
+	query := fmt.Sprintf(`select latest_vgtid, table_config, copy_completed from %s.%s where name = :name`, keyspaceName, tableName)
+
+	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
+		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+	})
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
+	}
+
+	// if there are no rows, or the value is null, return nil, which will start the stream from the beginning
+	if len(result.Rows) == 0 || result.Rows[0][0].IsNull() {
+		return nil, nil, false, nil
+	}
+
+	// unmarshal the JSON value which should be a valid, initialized VGtid
+	latestVGtidJSON, err := result.Rows[0][0].ToBytes()
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("vstreamclient: failed to convert latest_vgtid to bytes: %w", err)
+	}
+
+	var latestVGtid binlogdatapb.VGtid
+	err = json.Unmarshal(latestVGtidJSON, &latestVGtid)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("vstreamclient: failed to unmarshal latest_vgtid: %w", err)
+	}
+
+	// unmarshal the JSON value which should be the original table config
+	tablesJSON, err := result.Rows[0][1].ToBytes()
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("vstreamclient: failed to convert table_config to bytes: %w", err)
+	}
+
+	var tables map[string]*TableConfig
+	err = json.Unmarshal(tablesJSON, &tables)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("vstreamclient: failed to unmarshal table_config: %w", err)
+	}
+
+	// check if the copy has been completed
+	copyCompleted, err := result.Rows[0][2].ToBool()
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("vstreamclient: failed to convert copy_completed to bool: %w", err)
+	}
+
+	return &latestVGtid, tables, copyCompleted, nil
+}
+
+func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, vgtid *binlogdatapb.VGtid) error {
+	latestVgtid, err := json.Marshal(vgtid)
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to marshal latest_vgtid: %w", err)
+	}
+
+	query := fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid where name = :name`,
+		keyspaceName, tableName,
+	)
+	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
+		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtid},
+		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+	})
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to update latest_vgtid for %s.%s: %w", keyspaceName, tableName, err)
+	}
+
+	return nil
+}
+
+func setCopyCompleted(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) error {
+	query := fmt.Sprintf(`update %s.%s set copy_completed = true where name = :name`,
+		keyspaceName, tableName,
+	)
+	_, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
+		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+	})
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to set copy_completed for %s.%s: %w", keyspaceName, tableName, err)
+	}
+
+	return nil
+}

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -198,16 +198,17 @@ func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name
 	return &latestVGtid, tables, copyCompleted, nil
 }
 
-func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, vgtid *binlogdatapb.VGtid) error {
+func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, vgtid *binlogdatapb.VGtid, setCopyCompleted bool) error {
 	latestVgtid, err := protojson.Marshal(vgtid)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to marshal latest_vgtid: %w", err)
 	}
 
-	query := fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid where name = :name`,
-		keyspaceName, tableName,
-	)
-	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
+	query := fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid where name = :name`, keyspaceName, tableName)
+	if setCopyCompleted {
+		query = fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid, copy_completed = true where name = :name`, keyspaceName, tableName)
+	}
+	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtid},
 		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
 	}, false)
@@ -215,18 +216,8 @@ func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, n
 		return fmt.Errorf("vstreamclient: failed to update latest_vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
-	return nil
-}
-
-func setCopyCompleted(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) error {
-	query := fmt.Sprintf(`update %s.%s set copy_completed = true where name = :name`,
-		keyspaceName, tableName,
-	)
-	_, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
-		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
-	}, false)
-	if err != nil {
-		return fmt.Errorf("vstreamclient: failed to set copy_completed for %s.%s: %w", keyspaceName, tableName, err)
+	if result.RowsAffected != 1 {
+		return fmt.Errorf("vstreamclient: unexpected number of rows affected when setting latest_vgtid for %s.%s: %d", keyspaceName, tableName, result.RowsAffected)
 	}
 
 	return nil

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"google.golang.org/protobuf/encoding/protojson"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
@@ -41,9 +43,7 @@ func initStateTable(ctx context.Context, session *vtgateconn.VTGateSession, keys
   PRIMARY KEY (name)
 )`, keyspaceName, tableName)
 
-	fmt.Println("query: ", query)
-
-	_, err := session.Execute(ctx, query, nil)
+	_, err := session.Execute(ctx, query, nil, false)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to create state table: %w", err)
 	}
@@ -51,35 +51,75 @@ func initStateTable(ctx context.Context, session *vtgateconn.VTGateSession, keys
 	return nil
 }
 
+// initVGtid is used when there is no existing state for the stream, which means we need to create a new vgtid that
+// starts from the beginning of the stream (empty gtid for each shard) and persist that along with the table config.
+// This will kick off a copy phase on the vttablet side, which will read all existing data and then transition to
+// streaming new changes.
 func initVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, tables map[string]*TableConfig, shardsByKeyspace map[string][]string) (*binlogdatapb.VGtid, error) {
 	vgtid, err := newVGtid(tables, shardsByKeyspace)
 	if err != nil {
 		return nil, err
 	}
 
-	latestVgtidJSON, err := json.Marshal(vgtid)
+	latestVgtidJSON, tablesJSON, err := marshalState(vgtid, tables)
 	if err != nil {
-		return nil, fmt.Errorf("vstreamclient: failed to marshal latest vgtid: %w", err)
+		return nil, err
 	}
 
-	tablesJSON, err := json.Marshal(tablesToDBTableConfig(tables))
-	if err != nil {
-		return nil, fmt.Errorf("vstreamclient: failed to marshal tables: %w", err)
-	}
-
-	query := fmt.Sprintf(`insert into %s.%s (name, latest_vgtid, table_config) values (:name, :latest_vgtid, :table_config)`,
+	query := fmt.Sprintf(`insert into %s.%s (name, latest_vgtid, table_config) values (:name, :latest_vgtid, :table_config)
+on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config)`,
 		keyspaceName, tableName,
 	)
 	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
 		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtidJSON},
 		"table_config": {Type: querypb.Type_JSON, Value: tablesJSON},
-	})
+	}, false)
 	if err != nil {
 		return nil, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
 	return vgtid, nil
+}
+
+// initStartingVGtid is used when the caller explicitly provides a starting vgtid, which means we want to persist
+// that vgtid and the table config. Since they provided a vgtid, their intention isn't to start a copy phase, so we set
+// copy_completed to true, which means the stream will start from the provided vgtid and not attempt to do a copy phase,
+// either now or on restart.
+func initStartingVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig) error {
+	latestVgtidJSON, tablesJSON, err := marshalState(vgtid, tables)
+	if err != nil {
+		return err
+	}
+
+	query := fmt.Sprintf(`insert into %s.%s (name, latest_vgtid, table_config, copy_completed) values (:name, :latest_vgtid, :table_config, true)
+on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config), copy_completed = true`,
+		keyspaceName, tableName,
+	)
+	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
+		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtidJSON},
+		"table_config": {Type: querypb.Type_JSON, Value: tablesJSON},
+	}, false)
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to initialize starting vgtid for %s.%s: %w", keyspaceName, tableName, err)
+	}
+
+	return nil
+}
+
+func marshalState(vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig) (latestVgtidJSON []byte, tablesJSON []byte, err error) {
+	latestVgtidJSON, err = protojson.Marshal(vgtid)
+	if err != nil {
+		return nil, nil, fmt.Errorf("vstreamclient: failed to marshal latest vgtid: %w", err)
+	}
+
+	tablesJSON, err = json.Marshal(tablesToDBTableConfig(tables))
+	if err != nil {
+		return nil, nil, fmt.Errorf("vstreamclient: failed to marshal tables: %w", err)
+	}
+
+	return latestVgtidJSON, tablesJSON, nil
 }
 
 func newVGtid(tables map[string]*TableConfig, shardsByKeyspace map[string][]string) (*binlogdatapb.VGtid, error) {
@@ -104,6 +144,7 @@ func newVGtid(tables map[string]*TableConfig, shardsByKeyspace map[string][]stri
 				Gtid:     "", // start from the beginning, meaning initializing a copy phase
 			})
 		}
+		bootstrappedKeyspaces[table.Keyspace] = true
 	}
 
 	return vgtid, nil
@@ -114,7 +155,7 @@ func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name
 
 	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
-	})
+	}, false)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
@@ -131,7 +172,7 @@ func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name
 	}
 
 	var latestVGtid binlogdatapb.VGtid
-	err = json.Unmarshal(latestVGtidJSON, &latestVGtid)
+	err = protojson.Unmarshal(latestVGtidJSON, &latestVGtid)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("vstreamclient: failed to unmarshal latest_vgtid: %w", err)
 	}
@@ -158,7 +199,7 @@ func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name
 }
 
 func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, vgtid *binlogdatapb.VGtid) error {
-	latestVgtid, err := json.Marshal(vgtid)
+	latestVgtid, err := protojson.Marshal(vgtid)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to marshal latest_vgtid: %w", err)
 	}
@@ -169,7 +210,7 @@ func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, n
 	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtid},
 		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to update latest_vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
@@ -183,7 +224,7 @@ func setCopyCompleted(ctx context.Context, session *vtgateconn.VTGateSession, na
 	)
 	_, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to set copy_completed for %s.%s: %w", keyspaceName, tableName, err)
 	}

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -19,6 +19,7 @@ package vstreamclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -27,6 +28,12 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
+
+// ErrFenced is returned (as the wrapped cause) when a checkpoint write affects no rows, meaning the
+// state row was deleted or another client using the same stream name claimed ownership after this
+// client started. The newest client wins; this client must stop so the two don't ping-pong the
+// checkpoint back and forth.
+var ErrFenced = errors.New("vstreamclient: state row missing or claimed by another client")
 
 type dbTableConfig struct {
 	Keyspace string
@@ -54,6 +61,7 @@ func initStateTable(ctx context.Context, session *vtgateconn.VTGateSession, keys
   latest_vgtid json,
   table_config json not null,
   copy_completed bool not null default false,
+  owner_token varbinary(36),
   created_at timestamp default current_timestamp,
   updated_at timestamp default current_timestamp on update current_timestamp,
   PRIMARY KEY (name)
@@ -71,7 +79,7 @@ func initStateTable(ctx context.Context, session *vtgateconn.VTGateSession, keys
 // starts from the beginning of the stream (empty gtid for each shard) and persist that along with the table config.
 // This will kick off a copy phase on the vttablet side, which will read all existing data and then transition to
 // streaming new changes.
-func initVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, tables map[string]*TableConfig, shardsByKeyspace map[string][]string) (*binlogdatapb.VGtid, error) {
+func initVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, tables map[string]*TableConfig, shardsByKeyspace map[string][]string) (*binlogdatapb.VGtid, error) {
 	vgtid, err := newVGtid(tables, shardsByKeyspace)
 	if err != nil {
 		return nil, err
@@ -82,17 +90,19 @@ func initVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, key
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`insert into %s.%s (name, latest_vgtid, table_config) values (:name, :latest_vgtid, :table_config)
-on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config)`,
+	query := fmt.Sprintf(
+		`insert into %s.%s (name, latest_vgtid, table_config, owner_token) values (:name, :latest_vgtid, :table_config, :owner_token)
+on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config), owner_token = values(owner_token)`,
 		keyspaceName, tableName,
 	)
 	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
 		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtidJSON},
 		"table_config": {Type: querypb.Type_JSON, Value: tablesJSON},
+		"owner_token":  {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
 	}, false)
 	if err != nil {
-		return nil, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
+		return nil, fmt.Errorf("vstreamclient: failed to initialize vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
 	return vgtid, nil
@@ -102,20 +112,22 @@ on duplicate key update latest_vgtid = values(latest_vgtid), table_config = valu
 // that vgtid and the table config. Since they provided a vgtid, their intention isn't to start a copy phase, so we set
 // copy_completed to true, which means the stream will start from the provided vgtid and not attempt to do a copy phase,
 // either now or on restart.
-func initStartingVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig) error {
+func initStartingVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig) error {
 	latestVgtidJSON, tablesJSON, err := marshalState(vgtid, tables)
 	if err != nil {
 		return err
 	}
 
-	query := fmt.Sprintf(`insert into %s.%s (name, latest_vgtid, table_config, copy_completed) values (:name, :latest_vgtid, :table_config, true)
-on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config), copy_completed = true`,
+	query := fmt.Sprintf(
+		`insert into %s.%s (name, latest_vgtid, table_config, copy_completed, owner_token) values (:name, :latest_vgtid, :table_config, true, :owner_token)
+on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config), copy_completed = true, owner_token = values(owner_token)`,
 		keyspaceName, tableName,
 	)
 	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
 		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtidJSON},
 		"table_config": {Type: querypb.Type_JSON, Value: tablesJSON},
+		"owner_token":  {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
 	}, false)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to initialize starting vgtid for %s.%s: %w", keyspaceName, tableName, err)
@@ -166,6 +178,24 @@ func newVGtid(tables map[string]*TableConfig, shardsByKeyspace map[string][]stri
 	return vgtid, nil
 }
 
+// claimStateOwnership stamps this client's owner token on the state row, fencing out any other
+// client that is still running with the same stream name: its next checkpoint write will no longer
+// match its own token and will fail with ErrFenced. It is a no-op when the state row doesn't exist
+// yet; the bootstrap insert stores the token instead.
+func claimStateOwnership(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string) error {
+	query := fmt.Sprintf(`update %s.%s set owner_token = :owner_token where name = :name`, keyspaceName, tableName)
+
+	_, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
+		"owner_token": {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
+		"name":        {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+	}, false)
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to claim state ownership for %s.%s: %w", keyspaceName, tableName, err)
+	}
+
+	return nil
+}
+
 func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) (*binlogdatapb.VGtid, map[string]*TableConfig, bool, error) {
 	query := fmt.Sprintf(`select latest_vgtid, table_config, copy_completed from %s.%s where name = :name`, keyspaceName, tableName)
 
@@ -214,26 +244,29 @@ func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name
 	return &latestVGtid, tables, copyCompleted, nil
 }
 
-func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string, vgtid *binlogdatapb.VGtid, setCopyCompleted bool) error {
+func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, setCopyCompleted bool) error {
 	latestVgtid, err := protojson.Marshal(vgtid)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to marshal latest_vgtid: %w", err)
 	}
 
-	query := fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid where name = :name`, keyspaceName, tableName)
+	// the owner_token predicate fences out this client once another client with the same stream
+	// name has claimed ownership: the update then affects no rows and we fail with ErrFenced
+	query := fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid where name = :name and owner_token = :owner_token`, keyspaceName, tableName)
 	if setCopyCompleted {
-		query = fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid, copy_completed = true where name = :name`, keyspaceName, tableName)
+		query = fmt.Sprintf(`update %s.%s set latest_vgtid = :latest_vgtid, copy_completed = true where name = :name and owner_token = :owner_token`, keyspaceName, tableName)
 	}
 	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtid},
 		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"owner_token":  {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
 	}, false)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to update latest_vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
 	if result.RowsAffected != 1 {
-		return fmt.Errorf("vstreamclient: unexpected number of rows affected when setting latest_vgtid for %s.%s: %d", keyspaceName, tableName, result.RowsAffected)
+		return fmt.Errorf("%w: stream %s in %s.%s", ErrFenced, name, keyspaceName, tableName)
 	}
 
 	return nil

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -19,13 +19,14 @@ package vstreamclient
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
 
@@ -33,7 +34,7 @@ import (
 // state row was deleted or another client using the same stream name claimed ownership after this
 // client started. The newest client wins; this client must stop so the two don't ping-pong the
 // checkpoint back and forth.
-var ErrFenced = errors.New("vstreamclient: state row missing or claimed by another client")
+var ErrFenced = vterrors.New(vtrpcpb.Code_ABORTED, "vstreamclient: state row missing or claimed by another client")
 
 type dbTableConfig struct {
 	Keyspace string
@@ -162,7 +163,7 @@ func newVGtid(tables map[string]*TableConfig, shardsByKeyspace map[string][]stri
 		// TODO: this currently doesn't support subsetting shards, but we can add that if needed
 		shards, ok := shardsByKeyspace[table.Keyspace]
 		if !ok {
-			return nil, fmt.Errorf("vstreamclient: keyspace %s not found", table.Keyspace)
+			return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s not found", table.Keyspace)
 		}
 
 		for _, shard := range shards {

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -19,9 +19,12 @@ package vstreamclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"vitess.io/vitess/go/mysql/sqlerror"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -76,65 +79,73 @@ func initStateTable(ctx context.Context, session *vtgateconn.VTGateSession, keys
 	return nil
 }
 
-// initVGtid is used when there is no existing state for the stream, which means we need to create a new vgtid that
-// starts from the beginning of the stream (empty gtid for each shard) and persist that along with the table config.
-// This will kick off a copy phase on the vttablet side, which will read all existing data and then transition to
-// streaming new changes.
-func initVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, tables map[string]*TableConfig, shardsByKeyspace map[string][]string) (*binlogdatapb.VGtid, error) {
-	vgtid, err := newVGtid(tables, shardsByKeyspace)
-	if err != nil {
-		return nil, err
-	}
-
-	latestVgtidJSON, tablesJSON, err := marshalState(vgtid, tables)
-	if err != nil {
-		return nil, err
-	}
-
-	query := fmt.Sprintf(
-		`insert into %s.%s (name, latest_vgtid, table_config, owner_token) values (:name, :latest_vgtid, :table_config, :owner_token)
-on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config), owner_token = values(owner_token)`,
-		keyspaceName, tableName,
-	)
-	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
-		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
-		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtidJSON},
-		"table_config": {Type: querypb.Type_JSON, Value: tablesJSON},
-		"owner_token":  {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
-	}, false)
-	if err != nil {
-		return nil, fmt.Errorf("vstreamclient: failed to initialize vgtid for %s.%s: %w", keyspaceName, tableName, err)
-	}
-
-	return vgtid, nil
-}
-
-// initStartingVGtid is used when the caller explicitly provides a starting vgtid, which means we want to persist
-// that vgtid and the table config. Since they provided a vgtid, their intention isn't to start a copy phase, so we set
-// copy_completed to true, which means the stream will start from the provided vgtid and not attempt to do a copy phase,
-// either now or on restart.
-func initStartingVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig) error {
+// insertStateRow creates the state row for a stream that has none. A plain insert (rather than an
+// upsert) means a concurrent initializer surfaces as a duplicate-key conflict instead of silently
+// stealing ownership back from a newer client.
+func insertStateRow(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig, copyCompleted bool) error {
 	latestVgtidJSON, tablesJSON, err := marshalState(vgtid, tables)
 	if err != nil {
 		return err
 	}
 
 	query := fmt.Sprintf(
-		`insert into %s.%s (name, latest_vgtid, table_config, copy_completed, owner_token) values (:name, :latest_vgtid, :table_config, true, :owner_token)
-on duplicate key update latest_vgtid = values(latest_vgtid), table_config = values(table_config), copy_completed = true, owner_token = values(owner_token)`,
+		`insert into %s.%s (name, latest_vgtid, table_config, copy_completed, owner_token) values (:name, :latest_vgtid, :table_config, :copy_completed, :owner_token)`,
 		keyspaceName, tableName,
 	)
 	_, err = session.Execute(ctx, query, map[string]*querypb.BindVariable{
-		"name":         {Type: querypb.Type_VARBINARY, Value: []byte(name)},
-		"latest_vgtid": {Type: querypb.Type_JSON, Value: latestVgtidJSON},
-		"table_config": {Type: querypb.Type_JSON, Value: tablesJSON},
-		"owner_token":  {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
+		"name":           {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"latest_vgtid":   {Type: querypb.Type_JSON, Value: latestVgtidJSON},
+		"table_config":   {Type: querypb.Type_JSON, Value: tablesJSON},
+		"copy_completed": {Type: querypb.Type_INT64, Value: boolBindValue(copyCompleted)},
+		"owner_token":    {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
 	}, false)
 	if err != nil {
-		return fmt.Errorf("vstreamclient: failed to initialize starting vgtid for %s.%s: %w", keyspaceName, tableName, err)
+		var sqlErr *sqlerror.SQLError
+		if errors.As(sqlerror.NewSQLErrorFromError(err), &sqlErr) && sqlErr.Number() == sqlerror.ERDupEntry {
+			return fmt.Errorf("%w: stream %s in %s.%s was initialized concurrently", ErrFenced, name, keyspaceName, tableName)
+		}
+		return fmt.Errorf("vstreamclient: failed to initialize state for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
 	return nil
+}
+
+// updateStateRow replaces the stored position, table config, and copy flag for an existing state
+// row. The write is predicated on this client's owner token, so a stale initializer that lost
+// ownership after reading state cannot steal it back; it fails with ErrFenced instead.
+func updateStateRow(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig, copyCompleted bool) error {
+	latestVgtidJSON, tablesJSON, err := marshalState(vgtid, tables)
+	if err != nil {
+		return err
+	}
+
+	query := fmt.Sprintf(
+		`update %s.%s set latest_vgtid = :latest_vgtid, table_config = :table_config, copy_completed = :copy_completed where name = :name and owner_token = :owner_token`,
+		keyspaceName, tableName,
+	)
+	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
+		"name":           {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"latest_vgtid":   {Type: querypb.Type_JSON, Value: latestVgtidJSON},
+		"table_config":   {Type: querypb.Type_JSON, Value: tablesJSON},
+		"copy_completed": {Type: querypb.Type_INT64, Value: boolBindValue(copyCompleted)},
+		"owner_token":    {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
+	}, false)
+	if err != nil {
+		return fmt.Errorf("vstreamclient: failed to initialize state for %s.%s: %w", keyspaceName, tableName, err)
+	}
+
+	if result.RowsAffected != 1 {
+		return fmt.Errorf("%w: stream %s in %s.%s", ErrFenced, name, keyspaceName, tableName)
+	}
+
+	return nil
+}
+
+func boolBindValue(b bool) []byte {
+	if b {
+		return []byte("1")
+	}
+	return []byte("0")
 }
 
 func marshalState(vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig) (latestVgtidJSON []byte, tablesJSON []byte, err error) {
@@ -179,14 +190,14 @@ func newVGtid(tables map[string]*TableConfig, shardsByKeyspace map[string][]stri
 	return vgtid, nil
 }
 
-// claimStateOwnership stamps this client's owner token on the state row, fencing out any other
-// client that is still running with the same stream name: its next checkpoint write will no longer
-// match its own token and will fail with ErrFenced. It is a no-op when the state row doesn't exist
-// yet; the bootstrap insert stores the token instead.
+// claimStateOwnership stamps this client's owner token on an existing state row, fencing out any
+// other client that is still running with the same stream name: its next checkpoint write will no
+// longer match its own token and will fail with ErrFenced. This runs only after all validation has
+// passed, so a constructor that fails can never leave the running client fenced.
 func claimStateOwnership(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string) error {
 	query := fmt.Sprintf(`update %s.%s set owner_token = :owner_token where name = :name`, keyspaceName, tableName)
 
-	_, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
+	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"owner_token": {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
 		"name":        {Type: querypb.Type_VARBINARY, Value: []byte(name)},
 	}, false)
@@ -194,55 +205,65 @@ func claimStateOwnership(ctx context.Context, session *vtgateconn.VTGateSession,
 		return fmt.Errorf("vstreamclient: failed to claim state ownership for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
+	if result.RowsAffected != 1 {
+		return fmt.Errorf("%w: stream %s in %s.%s disappeared while claiming ownership", ErrFenced, name, keyspaceName, tableName)
+	}
+
 	return nil
 }
 
-func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) (*binlogdatapb.VGtid, map[string]*TableConfig, bool, error) {
+func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) (vgtid *binlogdatapb.VGtid, tables map[string]dbTableConfig, copyCompleted, rowExists bool, err error) {
 	query := fmt.Sprintf(`select latest_vgtid, table_config, copy_completed from %s.%s where name = :name`, keyspaceName, tableName)
 
 	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
 	}, false)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
+		return nil, nil, false, false, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
-	// if there are no rows, or the value is null, return nil, which will start the stream from the beginning
-	if len(result.Rows) == 0 || result.Rows[0][0].IsNull() {
-		return nil, nil, false, nil
+	if len(result.Rows) == 0 {
+		return nil, nil, false, false, nil
+	}
+
+	// a row with a null vgtid is treated like missing state: the stream restarts from the
+	// beginning, but through the update path since the row exists
+	if result.Rows[0][0].IsNull() {
+		return nil, nil, false, true, nil
 	}
 
 	// unmarshal the JSON value which should be a valid, initialized VGtid
 	latestVGtidJSON, err := result.Rows[0][0].ToBytes()
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("vstreamclient: failed to convert latest_vgtid to bytes: %w", err)
+		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to convert latest_vgtid to bytes: %w", err)
 	}
 
 	var latestVGtid binlogdatapb.VGtid
 	err = protojson.Unmarshal(latestVGtidJSON, &latestVGtid)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("vstreamclient: failed to unmarshal latest_vgtid: %w", err)
+		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to unmarshal latest_vgtid: %w", err)
 	}
 
-	// unmarshal the JSON value which should be the original table config
+	// unmarshal the JSON value which should be the original table config. Unmarshalling into a
+	// map of values (not pointers) means malformed entries like {"ks.t":null} become zero values
+	// that fail table-config validation with a structured error instead of panicking.
 	tablesJSON, err := result.Rows[0][1].ToBytes()
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("vstreamclient: failed to convert table_config to bytes: %w", err)
+		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to convert table_config to bytes: %w", err)
 	}
 
-	var tables map[string]*TableConfig
 	err = json.Unmarshal(tablesJSON, &tables)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("vstreamclient: failed to unmarshal table_config: %w", err)
+		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to unmarshal table_config: %w", err)
 	}
 
 	// check if the copy has been completed
-	copyCompleted, err := result.Rows[0][2].ToBool()
+	copyCompleted, err = result.Rows[0][2].ToBool()
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("vstreamclient: failed to convert copy_completed to bool: %w", err)
+		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to convert copy_completed to bool: %w", err)
 	}
 
-	return &latestVGtid, tables, copyCompleted, nil
+	return &latestVGtid, tables, copyCompleted, true, nil
 }
 
 func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, setCopyCompleted bool) error {

--- a/go/vt/vstreamclient/state.go
+++ b/go/vt/vstreamclient/state.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"vitess.io/vitess/go/mysql/sqlerror"
+	"vitess.io/vitess/go/sqltypes"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -111,24 +112,28 @@ func insertStateRow(ctx context.Context, session *vtgateconn.VTGateSession, name
 }
 
 // updateStateRow replaces the stored position, table config, and copy flag for an existing state
-// row. The write is predicated on this client's owner token, so a stale initializer that lost
-// ownership after reading state cannot steal it back; it fails with ErrFenced instead.
-func updateStateRow(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig, copyCompleted bool) error {
+// row, claiming ownership in the same statement. The write is a compare-and-swap against the owner
+// token observed when state was read, so a stale initializer that lost ownership cannot steal it
+// back; it fails with ErrFenced instead. Rotating the owner token also guarantees the row always
+// changes when the CAS matches, so MySQL's changed-rows semantics can't misreport a no-op update
+// of identical values as a fence.
+func updateStateRow(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, observedOwnerToken sqltypes.Value, vgtid *binlogdatapb.VGtid, tables map[string]*TableConfig, copyCompleted bool) error {
 	latestVgtidJSON, tablesJSON, err := marshalState(vgtid, tables)
 	if err != nil {
 		return err
 	}
 
 	query := fmt.Sprintf(
-		`update %s.%s set latest_vgtid = :latest_vgtid, table_config = :table_config, copy_completed = :copy_completed where name = :name and owner_token = :owner_token`,
+		`update %s.%s set owner_token = :owner_token, latest_vgtid = :latest_vgtid, table_config = :table_config, copy_completed = :copy_completed where name = :name and owner_token <=> :observed_owner_token`,
 		keyspaceName, tableName,
 	)
 	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
-		"name":           {Type: querypb.Type_VARBINARY, Value: []byte(name)},
-		"latest_vgtid":   {Type: querypb.Type_JSON, Value: latestVgtidJSON},
-		"table_config":   {Type: querypb.Type_JSON, Value: tablesJSON},
-		"copy_completed": {Type: querypb.Type_INT64, Value: boolBindValue(copyCompleted)},
-		"owner_token":    {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
+		"name":                 {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"latest_vgtid":         {Type: querypb.Type_JSON, Value: latestVgtidJSON},
+		"table_config":         {Type: querypb.Type_JSON, Value: tablesJSON},
+		"copy_completed":       {Type: querypb.Type_INT64, Value: boolBindValue(copyCompleted)},
+		"owner_token":          {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
+		"observed_owner_token": sqltypes.ValueBindVariable(observedOwnerToken),
 	}, false)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to initialize state for %s.%s: %w", keyspaceName, tableName, err)
@@ -192,56 +197,62 @@ func newVGtid(tables map[string]*TableConfig, shardsByKeyspace map[string][]stri
 
 // claimStateOwnership stamps this client's owner token on an existing state row, fencing out any
 // other client that is still running with the same stream name: its next checkpoint write will no
-// longer match its own token and will fail with ErrFenced. This runs only after all validation has
-// passed, so a constructor that fails can never leave the running client fenced.
-func claimStateOwnership(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string) error {
-	query := fmt.Sprintf(`update %s.%s set owner_token = :owner_token where name = :name`, keyspaceName, tableName)
+// longer match its own token and will fail with ErrFenced. The claim is a compare-and-swap against
+// the owner token observed when state was read, so two racing constructors cannot both believe
+// they own the stream. This runs only after all validation has passed, so a constructor that
+// fails can never leave the running client fenced.
+func claimStateOwnership(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, observedOwnerToken sqltypes.Value) error {
+	query := fmt.Sprintf(`update %s.%s set owner_token = :owner_token where name = :name and owner_token <=> :observed_owner_token`, keyspaceName, tableName)
 
 	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
-		"owner_token": {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
-		"name":        {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"owner_token":          {Type: querypb.Type_VARBINARY, Value: []byte(ownerToken)},
+		"name":                 {Type: querypb.Type_VARBINARY, Value: []byte(name)},
+		"observed_owner_token": sqltypes.ValueBindVariable(observedOwnerToken),
 	}, false)
 	if err != nil {
 		return fmt.Errorf("vstreamclient: failed to claim state ownership for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
 	if result.RowsAffected != 1 {
-		return fmt.Errorf("%w: stream %s in %s.%s disappeared while claiming ownership", ErrFenced, name, keyspaceName, tableName)
+		return fmt.Errorf("%w: stream %s in %s.%s changed owner while claiming ownership", ErrFenced, name, keyspaceName, tableName)
 	}
 
 	return nil
 }
 
-func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) (vgtid *binlogdatapb.VGtid, tables map[string]dbTableConfig, copyCompleted, rowExists bool, err error) {
-	query := fmt.Sprintf(`select latest_vgtid, table_config, copy_completed from %s.%s where name = :name`, keyspaceName, tableName)
+func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName string) (vgtid *binlogdatapb.VGtid, tables map[string]dbTableConfig, copyCompleted, rowExists bool, observedOwnerToken sqltypes.Value, err error) {
+	query := fmt.Sprintf(`select latest_vgtid, table_config, copy_completed, owner_token from %s.%s where name = :name`, keyspaceName, tableName)
 
 	result, err := session.Execute(ctx, query, map[string]*querypb.BindVariable{
 		"name": {Type: querypb.Type_VARBINARY, Value: []byte(name)},
 	}, false)
 	if err != nil {
-		return nil, nil, false, false, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
+		return nil, nil, false, false, sqltypes.NULL, fmt.Errorf("vstreamclient: failed to get latest vgtid for %s.%s: %w", keyspaceName, tableName, err)
 	}
 
 	if len(result.Rows) == 0 {
-		return nil, nil, false, false, nil
+		return nil, nil, false, false, sqltypes.NULL, nil
 	}
+
+	// the observed owner token is the compare half of the later claim/init compare-and-swap
+	observedOwnerToken = result.Rows[0][3]
 
 	// a row with a null vgtid is treated like missing state: the stream restarts from the
 	// beginning, but through the update path since the row exists
 	if result.Rows[0][0].IsNull() {
-		return nil, nil, false, true, nil
+		return nil, nil, false, true, observedOwnerToken, nil
 	}
 
 	// unmarshal the JSON value which should be a valid, initialized VGtid
 	latestVGtidJSON, err := result.Rows[0][0].ToBytes()
 	if err != nil {
-		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to convert latest_vgtid to bytes: %w", err)
+		return nil, nil, false, true, observedOwnerToken, fmt.Errorf("vstreamclient: failed to convert latest_vgtid to bytes: %w", err)
 	}
 
 	var latestVGtid binlogdatapb.VGtid
 	err = protojson.Unmarshal(latestVGtidJSON, &latestVGtid)
 	if err != nil {
-		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to unmarshal latest_vgtid: %w", err)
+		return nil, nil, false, true, observedOwnerToken, fmt.Errorf("vstreamclient: failed to unmarshal latest_vgtid: %w", err)
 	}
 
 	// unmarshal the JSON value which should be the original table config. Unmarshalling into a
@@ -249,21 +260,21 @@ func getLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name
 	// that fail table-config validation with a structured error instead of panicking.
 	tablesJSON, err := result.Rows[0][1].ToBytes()
 	if err != nil {
-		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to convert table_config to bytes: %w", err)
+		return nil, nil, false, true, observedOwnerToken, fmt.Errorf("vstreamclient: failed to convert table_config to bytes: %w", err)
 	}
 
 	err = json.Unmarshal(tablesJSON, &tables)
 	if err != nil {
-		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to unmarshal table_config: %w", err)
+		return nil, nil, false, true, observedOwnerToken, fmt.Errorf("vstreamclient: failed to unmarshal table_config: %w", err)
 	}
 
 	// check if the copy has been completed
 	copyCompleted, err = result.Rows[0][2].ToBool()
 	if err != nil {
-		return nil, nil, false, true, fmt.Errorf("vstreamclient: failed to convert copy_completed to bool: %w", err)
+		return nil, nil, false, true, observedOwnerToken, fmt.Errorf("vstreamclient: failed to convert copy_completed to bool: %w", err)
 	}
 
-	return &latestVGtid, tables, copyCompleted, true, nil
+	return &latestVGtid, tables, copyCompleted, true, observedOwnerToken, nil
 }
 
 func updateLatestVGtid(ctx context.Context, session *vtgateconn.VTGateSession, name, keyspaceName, tableName, ownerToken string, vgtid *binlogdatapb.VGtid, setCopyCompleted bool) error {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +55,30 @@ func newStateTestSession(t *testing.T, responses ...stateExecuteResponse) (*vtga
 	return conn.Session("", nil), impl
 }
 
+func newStateTestConn(t *testing.T, responses ...stateExecuteResponse) (*vtgateconn.VTGateConn, *stateTestVTGateImpl) {
+	t.Helper()
+
+	impl := &stateTestVTGateImpl{responses: responses}
+	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+		return impl, nil
+	}, "")
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+
+	return conn, impl
+}
+
+func stateRowResult(latestVGtid, tableConfig, copyCompleted sqltypes.Value) *sqltypes.Result {
+	return &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "latest_vgtid", Type: querypb.Type_JSON},
+			{Name: "table_config", Type: querypb.Type_JSON},
+			{Name: "copy_completed", Type: querypb.Type_VARCHAR},
+		},
+		Rows: [][]sqltypes.Value{{latestVGtid, tableConfig, copyCompleted}},
+	}
+}
+
 func TestNewVGtid_DeduplicatesKeyspaces(t *testing.T) {
 	tables := map[string]*TableConfig{
 		"t1": {Keyspace: "ks1", Table: "table_a"},
@@ -91,6 +116,67 @@ func TestNewVGtid_MissingKeyspaceErrors(t *testing.T) {
 	assert.ErrorContains(t, err, "keyspace missing not found")
 }
 
+func TestGetLatestVGtid_MalformedStoredJSONErrors(t *testing.T) {
+	session, _ := newStateTestSession(t, stateExecuteResponse{result: stateRowResult(
+		sqltypes.NewVarBinary("not-json"),
+		sqltypes.NewVarBinary(`{"t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+		sqltypes.NewInt64(1),
+	)})
+
+	_, _, _, err := getLatestVGtid(context.Background(), session, "stream", "ks", "state")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to unmarshal latest_vgtid")
+}
+
+func TestGetLatestVGtid_MalformedCopyCompletedErrors(t *testing.T) {
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	session, _ := newStateTestSession(t, stateExecuteResponse{result: stateRowResult(
+		sqltypes.NewVarBinary(string(vgtidJSON)),
+		sqltypes.NewVarBinary(`{"t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+		sqltypes.NewVarBinary("not-a-bool"),
+	)})
+
+	_, _, _, err = getLatestVGtid(context.Background(), session, "stream", "ks", "state")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to convert copy_completed to bool")
+}
+
+func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	conn, _ := newStateTestConn(t,
+		stateExecuteResponse{result: &sqltypes.Result{
+			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+		}},
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
+		stateExecuteResponse{result: stateRowResult(
+			sqltypes.NewVarBinary(string(vgtidJSON)),
+			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t where id < 10"}}`),
+			sqltypes.NewInt64(1),
+		)},
+	)
+
+	_, err = New(context.Background(), "stream", conn, []TableConfig{{
+		Keyspace:        "ks",
+		Table:           "t",
+		Query:           "select * from t where id >= 10",
+		MaxRowsPerFlush: 1,
+		DataType:        &testRowSmall{},
+		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+	}}, WithStateTable("ks", "state"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "provided tables do not match stored tables")
+	assert.ErrorContains(t, err, "query changed")
+}
+
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {
 	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
 
@@ -122,6 +208,38 @@ func TestHandleEvents_FinalCopyCompletedPersistsCheckpointAndCopyCompletedTogeth
 	require.NoError(t, err)
 	require.Len(t, impl.queries, 1)
 	assert.True(t, strings.Contains(impl.queries[0], "latest_vgtid = :latest_vgtid") && strings.Contains(impl.queries[0], "copy_completed = true"))
+	assert.Same(t, vgtid, v.lastFlushedVgtid)
+	expectedVGtidJSON, err := protojson.Marshal(vgtid)
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[0]["latest_vgtid"].Value))
+}
+
+func TestHandleEvents_HeartbeatCheckpointsLatestVGtidWithoutRows(t *testing.T) {
+	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}})
+
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Second,
+		},
+		session: session,
+		tables:  map[string]*TableConfig{},
+		stats:   VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+	}
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/2"}},
+	}
+
+	err := v.handleEvents(context.Background(), []*binlogdatapb.VEvent{
+		{Type: binlogdatapb.VEventType_VGTID, Vgtid: vgtid},
+		{Type: binlogdatapb.VEventType_HEARTBEAT},
+	})
+	require.NoError(t, err)
+	require.Len(t, impl.queries, 1)
+	assert.Contains(t, impl.queries[0], "update ks.state set latest_vgtid = :latest_vgtid")
 	assert.Same(t, vgtid, v.lastFlushedVgtid)
 	expectedVGtidJSON, err := protojson.Marshal(vgtid)
 	require.NoError(t, err)

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -108,12 +108,14 @@ func TestHandleEvents_FinalCopyCompletedPersistsCheckpointAndCopyCompletedTogeth
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
 	}
 	v := &VStreamClient{
-		name:               "stream",
-		session:            session,
-		vgtidStateKeyspace: "ks",
-		vgtidStateTable:    "state",
-		latestVgtid:        vgtid,
-		tables:             map[string]*TableConfig{},
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+		},
+		session:     session,
+		latestVgtid: vgtid,
+		tables:      map[string]*TableConfig{},
 	}
 
 	err := v.handleEvents(context.Background(), []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_COPY_COMPLETED}})

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -2,6 +2,7 @@ package vstreamclient
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
@@ -40,6 +42,10 @@ func (t *stateTestVTGateImpl) Execute(ctx context.Context, session *vtgatepb.Ses
 	response := t.responses[0]
 	t.responses = t.responses[1:]
 	return session, response.result, response.err
+}
+
+func (t *stateTestVTGateImpl) BinlogDumpGTID(context.Context, string, string, topodatapb.TabletType, *topodatapb.TabletAlias, string, uint64, string, uint32) (vtgateconn.BinlogDumpGTIDReader, error) {
+	return nil, fmt.Errorf("unexpected BinlogDumpGTID call")
 }
 
 func newStateTestSession(t *testing.T, responses ...stateExecuteResponse) (*vtgateconn.VTGateSession, *stateTestVTGateImpl) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -1,0 +1,44 @@
+package vstreamclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewVGtid_DeduplicatesKeyspaces(t *testing.T) {
+	tables := map[string]*TableConfig{
+		"t1": {Keyspace: "ks1", Table: "table_a"},
+		"t2": {Keyspace: "ks1", Table: "table_b"},
+		"t3": {Keyspace: "ks2", Table: "table_c"},
+	}
+	shardsByKeyspace := map[string][]string{
+		"ks1": {"-80", "80-"},
+		"ks2": {"0"},
+	}
+
+	vgtid, err := newVGtid(tables, shardsByKeyspace)
+	assert.NoError(t, err)
+	if !assert.NotNil(t, vgtid) {
+		return
+	}
+
+	counts := make(map[string]int)
+	for _, shardGtid := range vgtid.ShardGtids {
+		counts[shardGtid.Keyspace]++
+	}
+
+	assert.Equal(t, 2, counts["ks1"])
+	assert.Equal(t, 1, counts["ks2"])
+	assert.Len(t, vgtid.ShardGtids, 3)
+}
+
+func TestNewVGtid_MissingKeyspaceErrors(t *testing.T) {
+	tables := map[string]*TableConfig{
+		"t1": {Keyspace: "missing", Table: "table_a"},
+	}
+
+	_, err := newVGtid(tables, map[string][]string{"ks1": {"0"}})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "keyspace missing not found")
+}

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -113,10 +113,8 @@ func TestNewVGtid_DeduplicatesKeyspaces(t *testing.T) {
 	}
 
 	vgtid, err := newVGtid(tables, shardsByKeyspace)
-	assert.NoError(t, err)
-	if !assert.NotNil(t, vgtid) {
-		return
-	}
+	require.NoError(t, err)
+	require.NotNil(t, vgtid)
 
 	counts := make(map[string]int)
 	for _, shardGtid := range vgtid.ShardGtids {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -1,10 +1,58 @@
 package vstreamclient
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"vitess.io/vitess/go/sqltypes"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
+
+type stateExecuteResponse struct {
+	result *sqltypes.Result
+	err    error
+}
+
+type stateTestVTGateImpl struct {
+	testVTGateImpl
+	responses []stateExecuteResponse
+	queries   []string
+	bindVars  []map[string]*querypb.BindVariable
+}
+
+func (t *stateTestVTGateImpl) Execute(ctx context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error) {
+	t.queries = append(t.queries, query)
+	t.bindVars = append(t.bindVars, bindVars)
+
+	if len(t.responses) == 0 {
+		return session, &sqltypes.Result{RowsAffected: 1}, nil
+	}
+
+	response := t.responses[0]
+	t.responses = t.responses[1:]
+	return session, response.result, response.err
+}
+
+func newStateTestSession(t *testing.T, responses ...stateExecuteResponse) (*vtgateconn.VTGateSession, *stateTestVTGateImpl) {
+	t.Helper()
+
+	impl := &stateTestVTGateImpl{responses: responses}
+	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+		return impl, nil
+	}, "")
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+
+	return conn.Session("", nil), impl
+}
 
 func TestNewVGtid_DeduplicatesKeyspaces(t *testing.T) {
 	tables := map[string]*TableConfig{
@@ -41,4 +89,49 @@ func TestNewVGtid_MissingKeyspaceErrors(t *testing.T) {
 	_, err := newVGtid(tables, map[string][]string{"ks1": {"0"}})
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "keyspace missing not found")
+}
+
+func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {
+	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
+
+	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", &binlogdatapb.VGtid{}, false)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected number of rows affected")
+	require.Len(t, impl.queries, 1)
+	assert.NotContains(t, impl.queries[0], "copy_completed = true")
+}
+
+func TestHandleEvents_FinalCopyCompletedPersistsCheckpointAndCopyCompletedTogether(t *testing.T) {
+	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}})
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	}
+	v := &VStreamClient{
+		name:               "stream",
+		session:            session,
+		vgtidStateKeyspace: "ks",
+		vgtidStateTable:    "state",
+		latestVgtid:        vgtid,
+		tables:             map[string]*TableConfig{},
+	}
+
+	err := v.handleEvents(context.Background(), []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_COPY_COMPLETED}})
+	require.NoError(t, err)
+	require.Len(t, impl.queries, 1)
+	assert.True(t, strings.Contains(impl.queries[0], "latest_vgtid = :latest_vgtid") && strings.Contains(impl.queries[0], "copy_completed = true"))
+	assert.Same(t, vgtid, v.lastFlushedVgtid)
+	expectedVGtidJSON, err := protojson.Marshal(vgtid)
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[0]["latest_vgtid"].Value))
+}
+
+func TestUpdateLatestVGtid_CopyCompletedMissingStateRowErrors(t *testing.T) {
+	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
+
+	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", &binlogdatapb.VGtid{}, true)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected number of rows affected")
+	require.Len(t, impl.queries, 1)
+	assert.Contains(t, impl.queries[0], "copy_completed = true")
 }

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -18,7 +18,7 @@ package vstreamclient
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -61,7 +61,7 @@ func (t *stateTestVTGateImpl) Execute(ctx context.Context, session *vtgatepb.Ses
 }
 
 func (t *stateTestVTGateImpl) BinlogDumpGTID(context.Context, string, string, topodatapb.TabletType, *topodatapb.TabletAlias, string, uint64, string, uint32) (vtgateconn.BinlogDumpGTIDReader, error) {
-	return nil, fmt.Errorf("unexpected BinlogDumpGTID call")
+	return nil, errors.New("unexpected BinlogDumpGTID call")
 }
 
 func newStateTestSession(t *testing.T, responses ...stateExecuteResponse) (*vtgateconn.VTGateSession, *stateTestVTGateImpl) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -424,6 +424,68 @@ func TestNew_NilTableConfigEntryReportsStructuredError(t *testing.T) {
 	require.ErrorContains(t, err, "provided tables do not match stored tables")
 }
 
+func TestHandleEvents_HeartbeatMidTransactionDefersFlush(t *testing.T) {
+	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}})
+
+	flushed := 0
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: 10,
+		FlushFn: func(_ context.Context, rows []Row, _ FlushMeta) error {
+			flushed += len(rows)
+			return nil
+		},
+		currentBatch: []Row{{Data: "buffered"}},
+	}
+
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Second,
+		},
+		session: session,
+		stats:   VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+		tables:  map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+	}
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/2"}},
+	}
+
+	// with TransactionChunkSize enabled, a heartbeat can arrive between a BEGIN and its COMMIT;
+	// flushing there would expose uncommitted rows and checkpoint a transaction prefix
+	err := v.handleEvents(t.Context(), []*binlogdatapb.VEvent{
+		{Type: binlogdatapb.VEventType_BEGIN},
+		{Type: binlogdatapb.VEventType_VGTID, Vgtid: vgtid},
+		{Type: binlogdatapb.VEventType_HEARTBEAT},
+	})
+	require.NoError(t, err)
+	assert.Zero(t, flushed)
+	assert.Empty(t, impl.queries)
+
+	// the terminating COMMIT flushes the buffered rows and checkpoints
+	err = v.handleEvents(t.Context(), []*binlogdatapb.VEvent{
+		{Type: binlogdatapb.VEventType_COMMIT},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, flushed)
+	require.Len(t, impl.queries, 1)
+
+	// once the transaction has terminated, heartbeats flush again as usual
+	v.latestVgtid = &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/3"}},
+	}
+	v.stats.LastFlushedAt = time.Now().Add(-2 * time.Second)
+	err = v.handleEvents(t.Context(), []*binlogdatapb.VEvent{
+		{Type: binlogdatapb.VEventType_HEARTBEAT},
+	})
+	require.NoError(t, err)
+	assert.Len(t, impl.queries, 2)
+}
+
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {
 	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
 

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -68,7 +68,7 @@ func newStateTestSession(t *testing.T, responses ...stateExecuteResponse) (*vtga
 	t.Helper()
 
 	impl := &stateTestVTGateImpl{responses: responses}
-	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+	conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
 		return impl, nil
 	}, "")
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func newStateTestConn(t *testing.T, responses ...stateExecuteResponse) (*vtgatec
 	t.Helper()
 
 	impl := &stateTestVTGateImpl{responses: responses}
-	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+	conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
 		return impl, nil
 	}, "")
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestGetLatestVGtid_MalformedStoredJSONErrors(t *testing.T) {
 		sqltypes.NewInt64(1),
 	)})
 
-	_, _, _, err := getLatestVGtid(context.Background(), session, "stream", "ks", "state")
+	_, _, _, err := getLatestVGtid(t.Context(), session, "stream", "ks", "state")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to unmarshal latest_vgtid")
 }
@@ -160,7 +160,7 @@ func TestGetLatestVGtid_MalformedCopyCompletedErrors(t *testing.T) {
 		sqltypes.NewVarBinary("not-a-bool"),
 	)})
 
-	_, _, _, err = getLatestVGtid(context.Background(), session, "stream", "ks", "state")
+	_, _, _, err = getLatestVGtid(t.Context(), session, "stream", "ks", "state")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to convert copy_completed to bool")
 }
@@ -186,7 +186,7 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 		)},
 	)
 
-	_, err = New(context.Background(), "stream", conn, []TableConfig{{
+	_, err = New(t.Context(), "stream", conn, []TableConfig{{
 		Keyspace:        "ks",
 		Table:           "t",
 		Query:           "select * from t where id >= 10",
@@ -220,7 +220,7 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 		)},
 	)
 
-	v, err := New(context.Background(), "stream", conn, []TableConfig{{
+	v, err := New(t.Context(), "stream", conn, []TableConfig{{
 		Keyspace:        "ks",
 		Table:           "t",
 		Query:           "select * from t",
@@ -234,7 +234,7 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 	// an idle stream after resume has no buffered rows and an unchanged vgtid, so a flush
 	// (e.g. triggered by a heartbeat after minFlushDuration) must not rewrite the checkpoint:
 	// MySQL reports RowsAffected=0 for a no-op update, which updateLatestVGtid treats as an error
-	err = v.flush(context.Background(), false)
+	err = v.flush(t.Context(), false)
 	require.NoError(t, err)
 	assert.Len(t, impl.queries, queriesAfterNew)
 }
@@ -273,7 +273,7 @@ func TestNew_ExplicitStartingVGtidPersistsWithCopyCompleted(t *testing.T) {
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/42"}},
 	}
 
-	v, err := New(context.Background(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
 		WithStateTable("ks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
@@ -310,7 +310,7 @@ func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/42"}},
 	}
 
-	v, err := New(context.Background(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
 		WithStateTable("ks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
@@ -336,7 +336,7 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 		sqltypes.NewInt64(0),
 	))...)
 
-	v, err := New(context.Background(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
 		WithStateTable("ks", "state"))
 	require.NoError(t, err)
 
@@ -377,7 +377,7 @@ func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 		)},
 	)
 
-	v, err := New(context.Background(), "stream", conn, []TableConfig{{
+	v, err := New(t.Context(), "stream", conn, []TableConfig{{
 		Keyspace:        "ks",
 		Table:           "t",
 		Query:           "select * from t",
@@ -399,7 +399,7 @@ func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 	v.latestVgtid = &binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/2"}},
 	}
-	err = v.flush(context.Background(), false)
+	err = v.flush(t.Context(), false)
 	require.NoError(t, err)
 
 	lastIdx := len(impl.queries) - 1
@@ -410,7 +410,7 @@ func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {
 	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
 
-	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", "token-a", &binlogdatapb.VGtid{}, false)
+	err := updateLatestVGtid(t.Context(), session, "stream", "ks", "state", "token-a", &binlogdatapb.VGtid{}, false)
 	require.ErrorIs(t, err, ErrFenced)
 	require.Len(t, impl.queries, 1)
 	assert.NotContains(t, impl.queries[0], "copy_completed = true")
@@ -435,7 +435,7 @@ func TestHandleEvents_FinalCopyCompletedPersistsCheckpointAndCopyCompletedTogeth
 		tables:      map[string]*TableConfig{},
 	}
 
-	err := v.handleEvents(context.Background(), []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_COPY_COMPLETED}})
+	err := v.handleEvents(t.Context(), []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_COPY_COMPLETED}})
 	require.NoError(t, err)
 	require.Len(t, impl.queries, 1)
 	assert.True(t, strings.Contains(impl.queries[0], "latest_vgtid = :latest_vgtid") && strings.Contains(impl.queries[0], "copy_completed = true"))
@@ -464,7 +464,7 @@ func TestHandleEvents_HeartbeatCheckpointsLatestVGtidWithoutRows(t *testing.T) {
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/2"}},
 	}
 
-	err := v.handleEvents(context.Background(), []*binlogdatapb.VEvent{
+	err := v.handleEvents(t.Context(), []*binlogdatapb.VEvent{
 		{Type: binlogdatapb.VEventType_VGTID, Vgtid: vgtid},
 		{Type: binlogdatapb.VEventType_HEARTBEAT},
 	})
@@ -480,7 +480,7 @@ func TestHandleEvents_HeartbeatCheckpointsLatestVGtidWithoutRows(t *testing.T) {
 func TestUpdateLatestVGtid_CopyCompletedMissingStateRowErrors(t *testing.T) {
 	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
 
-	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", "token-a", &binlogdatapb.VGtid{}, true)
+	err := updateLatestVGtid(t.Context(), session, "stream", "ks", "state", "token-a", &binlogdatapb.VGtid{}, true)
 	require.ErrorIs(t, err, ErrFenced)
 	require.Len(t, impl.queries, 1)
 	assert.Contains(t, impl.queries[0], "copy_completed = true")

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -46,9 +46,27 @@ type stateTestVTGateImpl struct {
 	responses []stateExecuteResponse
 	queries   []string
 	bindVars  []map[string]*querypb.BindVariable
+
+	// rowImage overrides the binlog_row_image probe answer; empty means FULL.
+	// rowImageErr makes the probe fail, exercising the warn-and-continue path.
+	rowImage    string
+	rowImageErr bool
 }
 
 func (t *stateTestVTGateImpl) Execute(ctx context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error) {
+	// answered non-positionally so the per-keyspace row-image probe doesn't disturb the
+	// positional response queues or query-index assertions
+	if strings.Contains(query, "binlog_row_image") {
+		if t.rowImageErr {
+			return session, nil, errors.New("binlog_row_image probe failed")
+		}
+		rowImage := t.rowImage
+		if rowImage == "" {
+			rowImage = "FULL"
+		}
+		return session, sqltypes.MakeTestResult(sqltypes.MakeTestFields("@@global.binlog_row_image", "varchar"), rowImage), nil
+	}
+
 	t.queries = append(t.queries, query)
 	t.bindVars = append(t.bindVars, bindVars)
 
@@ -401,6 +419,24 @@ func TestNew_ClaimsStateOwnershipAfterValidatingState(t *testing.T) {
 	lastIdx := len(impl.queries) - 1
 	assert.Contains(t, impl.queries[lastIdx], "owner_token = :owner_token")
 	assert.Equal(t, claimToken, impl.bindVars[lastIdx]["owner_token"].Value)
+}
+
+func TestNew_RejectsNonFullBinlogRowImage(t *testing.T) {
+	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
+	impl.rowImage = "NOBLOB"
+
+	_, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.ErrorContains(t, err, "requires FULL")
+}
+
+func TestNew_UnqueryableBinlogRowImageWarnsAndContinues(t *testing.T) {
+	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
+	impl.rowImageErr = true
+
+	_, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
 }
 
 func TestNew_NilTableConfigEntryReportsStructuredError(t *testing.T) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -288,8 +289,10 @@ func TestNew_ExplicitStartingVGtidPersistsWithCopyCompleted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
 
-	assert.Same(t, explicit, v.latestVgtid)
-	assert.Same(t, explicit, v.lastFlushedVgtid)
+	// the client stores a clone of the caller-owned vgtid
+	assert.NotSame(t, explicit, v.latestVgtid)
+	assert.True(t, proto.Equal(explicit, v.latestVgtid))
+	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
 }
 
 func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
@@ -319,7 +322,7 @@ func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
 	expectedVGtidJSON, err := protojson.Marshal(explicit)
 	require.NoError(t, err)
 	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
-	assert.Same(t, explicit, v.latestVgtid)
+	assert.True(t, proto.Equal(explicit, v.latestVgtid))
 }
 
 func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -178,6 +178,7 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
 		}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
 		stateExecuteResponse{result: stateRowResult(
 			sqltypes.NewVarBinary(string(vgtidJSON)),
 			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t where id < 10"}}`),
@@ -211,6 +212,7 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
 		}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
 		stateExecuteResponse{result: stateRowResult(
 			sqltypes.NewVarBinary(string(vgtidJSON)),
 			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
@@ -237,14 +239,66 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 	assert.Len(t, impl.queries, queriesAfterNew)
 }
 
+func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	conn, impl := newStateTestConn(
+		t,
+		stateExecuteResponse{result: &sqltypes.Result{
+			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+		}},
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
+		stateExecuteResponse{result: stateRowResult(
+			sqltypes.NewVarBinary(string(vgtidJSON)),
+			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+			sqltypes.NewInt64(1),
+		)},
+	)
+
+	v, err := New(context.Background(), "stream", conn, []TableConfig{{
+		Keyspace:        "ks",
+		Table:           "t",
+		Query:           "select * from t",
+		MaxRowsPerFlush: 1,
+		DataType:        &testRowSmall{},
+		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+	}}, WithStateTable("ks", "state"))
+	require.NoError(t, err)
+
+	// the ownership claim must run after the state table is created and before state is read,
+	// so a concurrent client with the same name is fenced before we decide where to resume
+	require.GreaterOrEqual(t, len(impl.queries), 4)
+	assert.Contains(t, impl.queries[2], "set owner_token = :owner_token")
+	claimToken := impl.bindVars[2]["owner_token"].Value
+	assert.NotEmpty(t, claimToken)
+	assert.Contains(t, impl.queries[3], "select latest_vgtid")
+
+	// checkpoint writes must carry the same token the client claimed with
+	v.latestVgtid = &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/2"}},
+	}
+	err = v.flush(context.Background(), false)
+	require.NoError(t, err)
+
+	lastIdx := len(impl.queries) - 1
+	assert.Contains(t, impl.queries[lastIdx], "owner_token = :owner_token")
+	assert.Equal(t, claimToken, impl.bindVars[lastIdx]["owner_token"].Value)
+}
+
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {
 	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
 
-	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", &binlogdatapb.VGtid{}, false)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "unexpected number of rows affected")
+	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", "token-a", &binlogdatapb.VGtid{}, false)
+	require.ErrorIs(t, err, ErrFenced)
 	require.Len(t, impl.queries, 1)
 	assert.NotContains(t, impl.queries[0], "copy_completed = true")
+	assert.Contains(t, impl.queries[0], "owner_token = :owner_token")
+	assert.Equal(t, []byte("token-a"), impl.bindVars[0]["owner_token"].Value)
 }
 
 func TestHandleEvents_FinalCopyCompletedPersistsCheckpointAndCopyCompletedTogether(t *testing.T) {
@@ -309,9 +363,9 @@ func TestHandleEvents_HeartbeatCheckpointsLatestVGtidWithoutRows(t *testing.T) {
 func TestUpdateLatestVGtid_CopyCompletedMissingStateRowErrors(t *testing.T) {
 	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
 
-	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", &binlogdatapb.VGtid{}, true)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "unexpected number of rows affected")
+	err := updateLatestVGtid(context.Background(), session, "stream", "ks", "state", "token-a", &binlogdatapb.VGtid{}, true)
+	require.ErrorIs(t, err, ErrFenced)
 	require.Len(t, impl.queries, 1)
 	assert.Contains(t, impl.queries[0], "copy_completed = true")
+	assert.Contains(t, impl.queries[0], "owner_token = :owner_token")
 }

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -171,7 +171,8 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	conn, _ := newStateTestConn(t,
+	conn, _ := newStateTestConn(
+		t,
 		stateExecuteResponse{result: &sqltypes.Result{
 			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
 			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
@@ -195,6 +196,45 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "provided tables do not match stored tables")
 	assert.ErrorContains(t, err, "query changed")
+}
+
+func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	conn, impl := newStateTestConn(
+		t,
+		stateExecuteResponse{result: &sqltypes.Result{
+			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+		}},
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
+		stateExecuteResponse{result: stateRowResult(
+			sqltypes.NewVarBinary(string(vgtidJSON)),
+			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+			sqltypes.NewInt64(1),
+		)},
+	)
+
+	v, err := New(context.Background(), "stream", conn, []TableConfig{{
+		Keyspace:        "ks",
+		Table:           "t",
+		Query:           "select * from t",
+		MaxRowsPerFlush: 1,
+		DataType:        &testRowSmall{},
+		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+	}}, WithStateTable("ks", "state"))
+	require.NoError(t, err)
+	queriesAfterNew := len(impl.queries)
+
+	// an idle stream after resume has no buffered rows and an unchanged vgtid, so a flush
+	// (e.g. triggered by a heartbeat after minFlushDuration) must not rewrite the checkpoint:
+	// MySQL reports RowsAffected=0 for a no-op update, which updateLatestVGtid treats as an error
+	err = v.flush(context.Background(), false)
+	require.NoError(t, err)
+	assert.Len(t, impl.queries, queriesAfterNew)
 }
 
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -144,7 +144,7 @@ func TestGetLatestVGtid_MalformedStoredJSONErrors(t *testing.T) {
 		sqltypes.NewInt64(1),
 	)})
 
-	_, _, _, err := getLatestVGtid(t.Context(), session, "stream", "ks", "state")
+	_, _, _, _, err := getLatestVGtid(t.Context(), session, "stream", "ks", "state")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to unmarshal latest_vgtid")
 }
@@ -161,7 +161,7 @@ func TestGetLatestVGtid_MalformedCopyCompletedErrors(t *testing.T) {
 		sqltypes.NewVarBinary("not-a-bool"),
 	)})
 
-	_, _, _, err = getLatestVGtid(t.Context(), session, "stream", "ks", "state")
+	_, _, _, _, err = getLatestVGtid(t.Context(), session, "stream", "ks", "state")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to convert copy_completed to bool")
 }
@@ -172,19 +172,13 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	conn, _ := newStateTestConn(
+	conn, impl := newStateTestConn(
 		t,
-		stateExecuteResponse{result: &sqltypes.Result{
-			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
-			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
-		}},
-		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
-		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
-		stateExecuteResponse{result: stateRowResult(
+		shardsAndStateTableResponses(stateRowResult(
 			sqltypes.NewVarBinary(string(vgtidJSON)),
 			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t where id < 10"}}`),
 			sqltypes.NewInt64(1),
-		)},
+		))...,
 	)
 
 	_, err = New(t.Context(), "stream", conn, []TableConfig{{
@@ -198,6 +192,14 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "provided tables do not match stored tables")
 	assert.ErrorContains(t, err, "query changed")
+
+	// a failed constructor must not have fenced the running client: no insert or update may
+	// have touched the owner token
+	for _, query := range impl.queries {
+		if strings.HasPrefix(query, "update ") || strings.HasPrefix(query, "insert ") {
+			assert.NotContains(t, query, "owner_token")
+		}
+	}
 }
 
 func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
@@ -208,17 +210,11 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 
 	conn, impl := newStateTestConn(
 		t,
-		stateExecuteResponse{result: &sqltypes.Result{
-			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
-			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
-		}},
-		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
-		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
-		stateExecuteResponse{result: stateRowResult(
+		shardsAndStateTableResponses(stateRowResult(
 			sqltypes.NewVarBinary(string(vgtidJSON)),
 			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
 			sqltypes.NewInt64(1),
-		)},
+		))...,
 	)
 
 	v, err := New(t.Context(), "stream", conn, []TableConfig{{
@@ -251,6 +247,9 @@ func newStateTestTableConfig() TableConfig {
 	}
 }
 
+// shardsAndStateTableResponses queues the responses New consumes before any state mutation:
+// SHOW VITESS_SHARDS, the create-table DDL, and the state row select. Later writes (claim,
+// insert, update) fall through to the fake's default RowsAffected=1 response.
 func shardsAndStateTableResponses(stateRow *sqltypes.Result) []stateExecuteResponse {
 	responses := []stateExecuteResponse{
 		{result: &sqltypes.Result{
@@ -258,7 +257,6 @@ func shardsAndStateTableResponses(stateRow *sqltypes.Result) []stateExecuteRespo
 			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
 		}},
 		{result: &sqltypes.Result{RowsAffected: 1}}, // create state table
-		{result: &sqltypes.Result{RowsAffected: 1}}, // claim ownership
 	}
 
 	if stateRow == nil {
@@ -278,16 +276,15 @@ func TestNew_ExplicitStartingVGtidPersistsWithCopyCompleted(t *testing.T) {
 		WithStateTable("stateks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
-	// the caller provided a starting point, so no copy phase should run, now or on restart:
-	// the persisted row must set copy_completed together with the explicit vgtid
-	require.Len(t, impl.queries, 5)
-	assert.Contains(t, impl.queries[4], "insert into `stateks`.`state`")
-	assert.Contains(t, impl.queries[4], "values (:name, :latest_vgtid, :table_config, true, :owner_token)")
-	assert.Contains(t, impl.queries[4], "copy_completed = true")
+	// the caller provided a starting point and no state row exists, so a single insert persists
+	// the explicit vgtid together with copy_completed, and no copy phase runs, now or on restart
+	require.Len(t, impl.queries, 4)
+	assert.Contains(t, impl.queries[3], "insert into `stateks`.`state`")
+	assert.Equal(t, []byte("1"), impl.bindVars[3]["copy_completed"].Value)
 
 	expectedVGtidJSON, err := protojson.Marshal(explicit)
 	require.NoError(t, err)
-	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[3]["latest_vgtid"].Value))
 
 	// the client stores a clone of the caller-owned vgtid
 	assert.NotSame(t, explicit, v.latestVgtid)
@@ -317,8 +314,12 @@ func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
 		WithStateTable("stateks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
+	// the row exists, so the explicit position lands via claim + owner-predicated update
 	require.Len(t, impl.queries, 5)
-	assert.Contains(t, impl.queries[4], "insert into `stateks`.`state`")
+	assert.Contains(t, impl.queries[3], "set owner_token = :owner_token")
+	assert.Contains(t, impl.queries[4], "update `stateks`.`state`")
+	assert.Contains(t, impl.queries[4], "owner_token = :owner_token")
+	assert.Equal(t, []byte("1"), impl.bindVars[4]["copy_completed"].Value)
 	expectedVGtidJSON, err := protojson.Marshal(explicit)
 	require.NoError(t, err)
 	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
@@ -343,9 +344,13 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 		WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 
+	// the row exists, so the fresh copy position lands via claim + owner-predicated update,
+	// and copy_completed is explicitly reset so a crash mid-copy is never mistaken for
+	// completed state
 	require.Len(t, impl.queries, 5)
-	assert.Contains(t, impl.queries[4], "insert into `stateks`.`state`")
-	assert.NotContains(t, impl.queries[4], "copy_completed")
+	assert.Contains(t, impl.queries[3], "set owner_token = :owner_token")
+	assert.Contains(t, impl.queries[4], "update `stateks`.`state`")
+	assert.Equal(t, []byte("0"), impl.bindVars[4]["copy_completed"].Value)
 
 	freshVGtid := &binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: ""}},
@@ -359,7 +364,7 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
 }
 
-func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
+func TestNew_ClaimsStateOwnershipAfterValidatingState(t *testing.T) {
 	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
 	})
@@ -367,36 +372,24 @@ func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 
 	conn, impl := newStateTestConn(
 		t,
-		stateExecuteResponse{result: &sqltypes.Result{
-			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
-			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
-		}},
-		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
-		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
-		stateExecuteResponse{result: stateRowResult(
+		shardsAndStateTableResponses(stateRowResult(
 			sqltypes.NewVarBinary(string(vgtidJSON)),
 			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
 			sqltypes.NewInt64(1),
-		)},
+		))...,
 	)
 
-	v, err := New(t.Context(), "stream", conn, []TableConfig{{
-		Keyspace:        "ks",
-		Table:           "t",
-		Query:           "select * from t",
-		MaxRowsPerFlush: 1,
-		DataType:        &testRowSmall{},
-		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
-	}}, WithStateTable("stateks", "state"))
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 
-	// the ownership claim must run after the state table is created and before state is read,
-	// so a concurrent client with the same name is fenced before we decide where to resume
-	require.GreaterOrEqual(t, len(impl.queries), 4)
-	assert.Contains(t, impl.queries[2], "set owner_token = :owner_token")
-	claimToken := impl.bindVars[2]["owner_token"].Value
+	// the ownership claim must run after state is read and validated, so a constructor that
+	// fails validation can never fence a healthy running client
+	require.Len(t, impl.queries, 4)
+	assert.Contains(t, impl.queries[2], "select latest_vgtid")
+	assert.Contains(t, impl.queries[3], "set owner_token = :owner_token")
+	claimToken := impl.bindVars[3]["owner_token"].Value
 	assert.NotEmpty(t, claimToken)
-	assert.Contains(t, impl.queries[3], "select latest_vgtid")
 
 	// checkpoint writes must carry the same token the client claimed with
 	v.latestVgtid = &binlogdatapb.VGtid{
@@ -408,6 +401,27 @@ func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 	lastIdx := len(impl.queries) - 1
 	assert.Contains(t, impl.queries[lastIdx], "owner_token = :owner_token")
 	assert.Equal(t, claimToken, impl.bindVars[lastIdx]["owner_token"].Value)
+}
+
+func TestNew_NilTableConfigEntryReportsStructuredError(t *testing.T) {
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	// a null entry is valid JSON; it must surface as a state-validation error, not a panic
+	conn, _ := newStateTestConn(
+		t,
+		shardsAndStateTableResponses(stateRowResult(
+			sqltypes.NewVarBinary(string(vgtidJSON)),
+			sqltypes.NewVarBinary(`{"ks.t":null}`),
+			sqltypes.NewInt64(1),
+		))...,
+	)
+
+	_, err = New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.ErrorContains(t, err, "provided tables do not match stored tables")
 }
 
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -239,6 +239,123 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 	assert.Len(t, impl.queries, queriesAfterNew)
 }
 
+func newStateTestTableConfig() TableConfig {
+	return TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		Query:           "select * from t",
+		MaxRowsPerFlush: 1,
+		DataType:        &testRowSmall{},
+		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+	}
+}
+
+func shardsAndStateTableResponses(stateRow *sqltypes.Result) []stateExecuteResponse {
+	responses := []stateExecuteResponse{
+		{result: &sqltypes.Result{
+			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+		}},
+		{result: &sqltypes.Result{RowsAffected: 1}}, // create state table
+		{result: &sqltypes.Result{RowsAffected: 1}}, // claim ownership
+	}
+
+	if stateRow == nil {
+		stateRow = &sqltypes.Result{}
+	}
+	return append(responses, stateExecuteResponse{result: stateRow})
+}
+
+func TestNew_ExplicitStartingVGtidPersistsWithCopyCompleted(t *testing.T) {
+	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
+
+	explicit := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/42"}},
+	}
+
+	v, err := New(context.Background(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("ks", "state"), WithStartingVGtid(explicit))
+	require.NoError(t, err)
+
+	// the caller provided a starting point, so no copy phase should run, now or on restart:
+	// the persisted row must set copy_completed together with the explicit vgtid
+	require.Len(t, impl.queries, 5)
+	assert.Contains(t, impl.queries[4], "insert into `ks`.`state`")
+	assert.Contains(t, impl.queries[4], "values (:name, :latest_vgtid, :table_config, true, :owner_token)")
+	assert.Contains(t, impl.queries[4], "copy_completed = true")
+
+	expectedVGtidJSON, err := protojson.Marshal(explicit)
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
+
+	assert.Same(t, explicit, v.latestVgtid)
+	assert.Same(t, explicit, v.lastFlushedVgtid)
+}
+
+func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
+	storedVGtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	// the stored table config does not match the provided one; an ordinary resume would fail
+	// validation, but an explicit starting vgtid overwrites stored state instead
+	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(stateRowResult(
+		sqltypes.NewVarBinary(string(storedVGtidJSON)),
+		sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t where id < 10"}}`),
+		sqltypes.NewInt64(1),
+	))...)
+
+	explicit := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/42"}},
+	}
+
+	v, err := New(context.Background(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("ks", "state"), WithStartingVGtid(explicit))
+	require.NoError(t, err)
+
+	require.Len(t, impl.queries, 5)
+	assert.Contains(t, impl.queries[4], "insert into `ks`.`state`")
+	expectedVGtidJSON, err := protojson.Marshal(explicit)
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
+	assert.Same(t, explicit, v.latestVgtid)
+}
+
+func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
+	storedVGtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	// stored state exists but copy_completed is false, so the copy must restart from the
+	// beginning instead of resuming from the stored vgtid
+	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(stateRowResult(
+		sqltypes.NewVarBinary(string(storedVGtidJSON)),
+		sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+		sqltypes.NewInt64(0),
+	))...)
+
+	v, err := New(context.Background(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("ks", "state"))
+	require.NoError(t, err)
+
+	require.Len(t, impl.queries, 5)
+	assert.Contains(t, impl.queries[4], "insert into `ks`.`state`")
+	assert.NotContains(t, impl.queries[4], "copy_completed")
+
+	freshVGtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: ""}},
+	}
+	expectedVGtidJSON, err := protojson.Marshal(freshVGtid)
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
+
+	require.Len(t, v.latestVgtid.ShardGtids, 1)
+	assert.Empty(t, v.latestVgtid.ShardGtids[0].Gtid)
+	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
+}
+
 func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -115,8 +115,9 @@ func stateRowResult(latestVGtid, tableConfig, copyCompleted sqltypes.Value) *sql
 			{Name: "latest_vgtid", Type: querypb.Type_JSON},
 			{Name: "table_config", Type: querypb.Type_JSON},
 			{Name: "copy_completed", Type: querypb.Type_VARCHAR},
+			{Name: "owner_token", Type: querypb.Type_VARBINARY},
 		},
-		Rows: [][]sqltypes.Value{{latestVGtid, tableConfig, copyCompleted}},
+		Rows: [][]sqltypes.Value{{latestVGtid, tableConfig, copyCompleted, sqltypes.NewVarBinary("previous-owner")}},
 	}
 }
 
@@ -162,7 +163,7 @@ func TestGetLatestVGtid_MalformedStoredJSONErrors(t *testing.T) {
 		sqltypes.NewInt64(1),
 	)})
 
-	_, _, _, _, err := getLatestVGtid(t.Context(), session, "stream", "ks", "state")
+	_, _, _, _, _, err := getLatestVGtid(t.Context(), session, "stream", "ks", "state")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to unmarshal latest_vgtid")
 }
@@ -179,7 +180,7 @@ func TestGetLatestVGtid_MalformedCopyCompletedErrors(t *testing.T) {
 		sqltypes.NewVarBinary("not-a-bool"),
 	)})
 
-	_, _, _, _, err = getLatestVGtid(t.Context(), session, "stream", "ks", "state")
+	_, _, _, _, _, err = getLatestVGtid(t.Context(), session, "stream", "ks", "state")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to convert copy_completed to bool")
 }
@@ -332,15 +333,17 @@ func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
 		WithStateTable("stateks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
-	// the row exists, so the explicit position lands via claim + owner-predicated update
-	require.Len(t, impl.queries, 5)
+	// the row exists, so the explicit position lands via a single compare-and-swap update that
+	// claims ownership and persists the position atomically
+	require.Len(t, impl.queries, 4)
+	assert.Contains(t, impl.queries[3], "update `stateks`.`state`")
 	assert.Contains(t, impl.queries[3], "set owner_token = :owner_token")
-	assert.Contains(t, impl.queries[4], "update `stateks`.`state`")
-	assert.Contains(t, impl.queries[4], "owner_token = :owner_token")
-	assert.Equal(t, []byte("1"), impl.bindVars[4]["copy_completed"].Value)
+	assert.Contains(t, impl.queries[3], "owner_token <=> :observed_owner_token")
+	assert.Equal(t, []byte("previous-owner"), impl.bindVars[3]["observed_owner_token"].Value)
+	assert.Equal(t, []byte("1"), impl.bindVars[3]["copy_completed"].Value)
 	expectedVGtidJSON, err := protojson.Marshal(explicit)
 	require.NoError(t, err)
-	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[3]["latest_vgtid"].Value))
 	assert.True(t, proto.Equal(explicit, v.latestVgtid))
 }
 
@@ -362,20 +365,21 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 		WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 
-	// the row exists, so the fresh copy position lands via claim + owner-predicated update,
-	// and copy_completed is explicitly reset so a crash mid-copy is never mistaken for
-	// completed state
-	require.Len(t, impl.queries, 5)
+	// the row exists, so the fresh copy position lands via a single compare-and-swap update
+	// that claims ownership atomically, and copy_completed is explicitly reset so a crash
+	// mid-copy is never mistaken for completed state
+	require.Len(t, impl.queries, 4)
+	assert.Contains(t, impl.queries[3], "update `stateks`.`state`")
 	assert.Contains(t, impl.queries[3], "set owner_token = :owner_token")
-	assert.Contains(t, impl.queries[4], "update `stateks`.`state`")
-	assert.Equal(t, []byte("0"), impl.bindVars[4]["copy_completed"].Value)
+	assert.Contains(t, impl.queries[3], "owner_token <=> :observed_owner_token")
+	assert.Equal(t, []byte("0"), impl.bindVars[3]["copy_completed"].Value)
 
 	freshVGtid := &binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: ""}},
 	}
 	expectedVGtidJSON, err := protojson.Marshal(freshVGtid)
 	require.NoError(t, err)
-	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
+	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[3]["latest_vgtid"].Value))
 
 	require.Len(t, v.latestVgtid.ShardGtids, 1)
 	assert.Empty(t, v.latestVgtid.ShardGtids[0].Gtid)

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -176,7 +176,7 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 		t,
 		stateExecuteResponse{result: &sqltypes.Result{
 			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
-			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
 		}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
@@ -194,7 +194,7 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 		MaxRowsPerFlush: 1,
 		DataType:        &testRowSmall{},
 		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
-	}}, WithStateTable("ks", "state"))
+	}}, WithStateTable("stateks", "state"))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "provided tables do not match stored tables")
 	assert.ErrorContains(t, err, "query changed")
@@ -210,7 +210,7 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 		t,
 		stateExecuteResponse{result: &sqltypes.Result{
 			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
-			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
 		}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
@@ -228,7 +228,7 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 		MaxRowsPerFlush: 1,
 		DataType:        &testRowSmall{},
 		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
-	}}, WithStateTable("ks", "state"))
+	}}, WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 	queriesAfterNew := len(impl.queries)
 
@@ -255,7 +255,7 @@ func shardsAndStateTableResponses(stateRow *sqltypes.Result) []stateExecuteRespo
 	responses := []stateExecuteResponse{
 		{result: &sqltypes.Result{
 			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
-			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
 		}},
 		{result: &sqltypes.Result{RowsAffected: 1}}, // create state table
 		{result: &sqltypes.Result{RowsAffected: 1}}, // claim ownership
@@ -275,13 +275,13 @@ func TestNew_ExplicitStartingVGtidPersistsWithCopyCompleted(t *testing.T) {
 	}
 
 	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
-		WithStateTable("ks", "state"), WithStartingVGtid(explicit))
+		WithStateTable("stateks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
 	// the caller provided a starting point, so no copy phase should run, now or on restart:
 	// the persisted row must set copy_completed together with the explicit vgtid
 	require.Len(t, impl.queries, 5)
-	assert.Contains(t, impl.queries[4], "insert into `ks`.`state`")
+	assert.Contains(t, impl.queries[4], "insert into `stateks`.`state`")
 	assert.Contains(t, impl.queries[4], "values (:name, :latest_vgtid, :table_config, true, :owner_token)")
 	assert.Contains(t, impl.queries[4], "copy_completed = true")
 
@@ -314,11 +314,11 @@ func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
 	}
 
 	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
-		WithStateTable("ks", "state"), WithStartingVGtid(explicit))
+		WithStateTable("stateks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
 	require.Len(t, impl.queries, 5)
-	assert.Contains(t, impl.queries[4], "insert into `ks`.`state`")
+	assert.Contains(t, impl.queries[4], "insert into `stateks`.`state`")
 	expectedVGtidJSON, err := protojson.Marshal(explicit)
 	require.NoError(t, err)
 	assert.Equal(t, string(expectedVGtidJSON), string(impl.bindVars[4]["latest_vgtid"].Value))
@@ -340,11 +340,11 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 	))...)
 
 	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
-		WithStateTable("ks", "state"))
+		WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 
 	require.Len(t, impl.queries, 5)
-	assert.Contains(t, impl.queries[4], "insert into `ks`.`state`")
+	assert.Contains(t, impl.queries[4], "insert into `stateks`.`state`")
 	assert.NotContains(t, impl.queries[4], "copy_completed")
 
 	freshVGtid := &binlogdatapb.VGtid{
@@ -369,7 +369,7 @@ func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 		t,
 		stateExecuteResponse{result: &sqltypes.Result{
 			Fields: []*querypb.Field{{Name: "shard", Type: querypb.Type_VARCHAR}},
-			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}},
+			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("ks/0")}, {sqltypes.NewVarBinary("stateks/0")}},
 		}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
 		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}},
@@ -387,7 +387,7 @@ func TestNew_ClaimsStateOwnershipBeforeReadingState(t *testing.T) {
 		MaxRowsPerFlush: 1,
 		DataType:        &testRowSmall{},
 		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
-	}}, WithStateTable("ks", "state"))
+	}}, WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 
 	// the ownership claim must run after the state table is created and before state is read,

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -179,7 +179,7 @@ func TestNewVGtid_MissingKeyspaceErrors(t *testing.T) {
 	}
 
 	_, err := newVGtid(tables, map[string][]string{"ks1": {"0"}})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "keyspace missing not found")
 }
 
@@ -236,8 +236,8 @@ func TestNew_RestartTableConfigMismatchErrors(t *testing.T) {
 		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
 	}}, WithStateTable("stateks", "state"))
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "provided tables do not match stored tables")
-	assert.ErrorContains(t, err, "query changed")
+	require.ErrorContains(t, err, "provided tables do not match stored tables")
+	require.ErrorContains(t, err, "query changed")
 
 	// a failed constructor must not have fenced the running client: no insert or update may
 	// have touched the owner token

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -71,6 +71,16 @@ func (t *stateTestVTGateImpl) VStream(ctx context.Context, _ topodatapb.TabletTy
 }
 
 func (t *stateTestVTGateImpl) Execute(ctx context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error) {
+	// answered non-positionally so the vschema probe doesn't disturb the positional response
+	// queues or query-index assertions; all fake keyspaces report unsharded
+	if query == "SHOW VSCHEMA KEYSPACES" {
+		return session, sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("Keyspace|Sharded|Foreign Key|Comment", "varchar|varchar|varchar|varchar"),
+			"ks|false|unmanaged|",
+			"stateks|false|unmanaged|",
+		), nil
+	}
+
 	// answered non-positionally so the per-keyspace row-image probe doesn't disturb the
 	// positional response queues or query-index assertions
 	if strings.Contains(query, "binlog_row_image") {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -409,6 +409,114 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
 }
 
+func resumableStateRow(t *testing.T) *sqltypes.Result {
+	t.Helper()
+
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	return stateRowResult(
+		sqltypes.NewVarBinary(string(vgtidJSON)),
+		sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+		sqltypes.NewInt64(1),
+	)
+}
+
+func TestTakeStateOwnership_FencedWhenClaimLosesRace(t *testing.T) {
+	// the claim CAS affects zero rows: another client rotated the owner token between this
+	// client's state read and its takeover
+	conn, _ := newStateTestConn(t, append(
+		shardsAndStateTableResponses(resumableStateRow(t)),
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}},
+	)...)
+
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
+
+	err = v.takeStateOwnership(t.Context())
+	require.ErrorIs(t, err, ErrFenced)
+}
+
+func TestTakeStateOwnership_FencedWhenPersistLosesRace(t *testing.T) {
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	// copy-restart path: the CAS persist affects zero rows because the observed owner changed
+	conn, _ := newStateTestConn(t, append(
+		shardsAndStateTableResponses(stateRowResult(
+			sqltypes.NewVarBinary(string(vgtidJSON)),
+			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+			sqltypes.NewInt64(0),
+		)),
+		stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}},
+	)...)
+
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
+
+	err = v.takeStateOwnership(t.Context())
+	require.ErrorIs(t, err, ErrFenced)
+}
+
+func TestTakeStateOwnership_FencedOnConcurrentBootstrapInsert(t *testing.T) {
+	// bootstrap path: a concurrent initializer inserted the row first, so the plain insert
+	// fails with a duplicate key, which maps to ErrFenced
+	conn, _ := newStateTestConn(t, append(
+		shardsAndStateTableResponses(nil),
+		stateExecuteResponse{err: errors.New("Duplicate entry 'stream' for key 'PRIMARY' (errno 1062) (sqlstate 23000)")},
+	)...)
+
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
+
+	err = v.takeStateOwnership(t.Context())
+	require.ErrorIs(t, err, ErrFenced)
+}
+
+func TestTakeStateOwnership_TwoConstructorsOnlyOneWins(t *testing.T) {
+	// two constructors read the same state (and thus the same observed owner token); only the
+	// first compare-and-swap can match, and the loser must fail with ErrFenced
+	impl := &stateTestVTGateImpl{responses: []stateExecuteResponse{
+		// constructor A: shards, create table, state row
+		shardsAndStateTableResponses(resumableStateRow(t))[0],
+		shardsAndStateTableResponses(resumableStateRow(t))[1],
+		shardsAndStateTableResponses(resumableStateRow(t))[2],
+		// constructor B: shards, create table, state row
+		shardsAndStateTableResponses(resumableStateRow(t))[0],
+		shardsAndStateTableResponses(resumableStateRow(t))[1],
+		shardsAndStateTableResponses(resumableStateRow(t))[2],
+		// A's claim CAS matches, B's does not
+		{result: &sqltypes.Result{RowsAffected: 1}},
+		{result: &sqltypes.Result{RowsAffected: 0}},
+	}}
+
+	dial := func() *vtgateconn.VTGateConn {
+		conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
+			return impl, nil
+		}, "")
+		require.NoError(t, err)
+		t.Cleanup(conn.Close)
+		return conn
+	}
+
+	clientA, err := New(t.Context(), "stream", dial(), []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
+	clientB, err := New(t.Context(), "stream", dial(), []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
+
+	require.NoError(t, clientA.takeStateOwnership(t.Context()))
+	require.ErrorIs(t, clientB.takeStateOwnership(t.Context()), ErrFenced)
+}
+
 func TestRun_FailedStreamSetupDoesNotFenceIncumbent(t *testing.T) {
 	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -53,10 +53,17 @@ type stateTestVTGateImpl struct {
 	rowImageErr bool
 
 	// vstreamErr makes VStream fail, exercising Run's failed-stream-setup path.
-	vstreamErr error
+	// vstreamBlocks makes VStream block until the context is canceled, exercising the
+	// startup-watchdog path for a hung stream setup.
+	vstreamErr    error
+	vstreamBlocks bool
 }
 
-func (t *stateTestVTGateImpl) VStream(context.Context, topodatapb.TabletType, *binlogdatapb.VGtid, *binlogdatapb.Filter, *vtgatepb.VStreamFlags) (vtgateconn.VStreamReader, error) {
+func (t *stateTestVTGateImpl) VStream(ctx context.Context, _ topodatapb.TabletType, _ *binlogdatapb.VGtid, _ *binlogdatapb.Filter, _ *vtgatepb.VStreamFlags) (vtgateconn.VStreamReader, error) {
+	if t.vstreamBlocks {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	if t.vstreamErr != nil {
 		return nil, t.vstreamErr
 	}
@@ -548,6 +555,29 @@ func TestRun_FailedStreamSetupDoesNotFenceIncumbent(t *testing.T) {
 			assert.NotContains(t, query, "owner_token")
 		}
 	}
+}
+
+func TestRun_BlockedStreamSetupSurfacesStartupTimeout(t *testing.T) {
+	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(resumableStateRow(t))...)
+	impl.vstreamBlocks = true
+
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
+
+	// shrink the watchdog windows so the test completes quickly; the effective startup timeout
+	// is floored at the liveness window (1s here)
+	v.cfg.startupTimeout = 50 * time.Millisecond
+	v.cfg.heartbeatTimeoutMultiplier = 1
+	v.cfg.gracefulShutdownWaitDur = time.Millisecond
+
+	// the watchdog must cover a hung stream setup, and Run must surface the startup cause
+	// instead of the generic transport error
+	err = v.Run(t.Context())
+	require.ErrorIs(t, err, ErrStartupTimeout)
+
+	// a Run that never established its stream must not have taken ownership
+	require.Len(t, impl.queries, 3)
 }
 
 func TestNew_ClaimsStateOwnershipAfterValidatingState(t *testing.T) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -631,12 +631,23 @@ func TestNew_RejectsNonFullBinlogRowImage(t *testing.T) {
 	require.ErrorContains(t, err, "requires FULL")
 }
 
-func TestNew_UnqueryableBinlogRowImageWarnsAndContinues(t *testing.T) {
+func TestNew_UnqueryableBinlogRowImageFailsClosed(t *testing.T) {
+	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
+	impl.rowImageErr = true
+
+	// an unverifiable shard must fail closed: a shard we cannot probe could be running NOBLOB,
+	// which silently corrupts delete before-images
+	_, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.ErrorContains(t, err, "could not verify binlog_row_image")
+}
+
+func TestNew_SkipRowImageCheckBypassesProbe(t *testing.T) {
 	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
 	impl.rowImageErr = true
 
 	_, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
-		WithStateTable("stateks", "state"))
+		WithStateTable("stateks", "state"), WithSkipRowImageCheck())
 	require.NoError(t, err)
 }
 

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -51,6 +51,16 @@ type stateTestVTGateImpl struct {
 	// rowImageErr makes the probe fail, exercising the warn-and-continue path.
 	rowImage    string
 	rowImageErr bool
+
+	// vstreamErr makes VStream fail, exercising Run's failed-stream-setup path.
+	vstreamErr error
+}
+
+func (t *stateTestVTGateImpl) VStream(context.Context, topodatapb.TabletType, *binlogdatapb.VGtid, *binlogdatapb.Filter, *vtgatepb.VStreamFlags) (vtgateconn.VStreamReader, error) {
+	if t.vstreamErr != nil {
+		return nil, t.vstreamErr
+	}
+	return t.reader, nil
 }
 
 func (t *stateTestVTGateImpl) Execute(ctx context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error) {
@@ -245,14 +255,15 @@ func TestNew_ResumeThenIdleFlushSkipsCheckpointWrite(t *testing.T) {
 		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
 	}}, WithStateTable("stateks", "state"))
 	require.NoError(t, err)
-	queriesAfterNew := len(impl.queries)
+	require.NoError(t, v.takeStateOwnership(t.Context()))
+	queriesAfterTakeover := len(impl.queries)
 
 	// an idle stream after resume has no buffered rows and an unchanged vgtid, so a flush
 	// (e.g. triggered by a heartbeat after minFlushDuration) must not rewrite the checkpoint:
 	// MySQL reports RowsAffected=0 for a no-op update, which updateLatestVGtid treats as an error
 	err = v.flush(t.Context(), false)
 	require.NoError(t, err)
-	assert.Len(t, impl.queries, queriesAfterNew)
+	assert.Len(t, impl.queries, queriesAfterTakeover)
 }
 
 func newStateTestTableConfig() TableConfig {
@@ -295,6 +306,10 @@ func TestNew_ExplicitStartingVGtidPersistsWithCopyCompleted(t *testing.T) {
 		WithStateTable("stateks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
+	// New itself must not write state; the takeover happens on Run
+	require.Len(t, impl.queries, 3)
+	require.NoError(t, v.takeStateOwnership(t.Context()))
+
 	// the caller provided a starting point and no state row exists, so a single insert persists
 	// the explicit vgtid together with copy_completed, and no copy phase runs, now or on restart
 	require.Len(t, impl.queries, 4)
@@ -333,6 +348,10 @@ func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
 		WithStateTable("stateks", "state"), WithStartingVGtid(explicit))
 	require.NoError(t, err)
 
+	// New itself must not write state; the takeover happens on Run
+	require.Len(t, impl.queries, 3)
+	require.NoError(t, v.takeStateOwnership(t.Context()))
+
 	// the row exists, so the explicit position lands via a single compare-and-swap update that
 	// claims ownership and persists the position atomically
 	require.Len(t, impl.queries, 4)
@@ -365,6 +384,10 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 		WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 
+	// New itself must not write state; the takeover happens on Run
+	require.Len(t, impl.queries, 3)
+	require.NoError(t, v.takeStateOwnership(t.Context()))
+
 	// the row exists, so the fresh copy position lands via a single compare-and-swap update
 	// that claims ownership atomically, and copy_completed is explicitly reset so a crash
 	// mid-copy is never mistaken for completed state
@@ -386,6 +409,39 @@ func TestNew_RestartsIncompleteCopyFromScratch(t *testing.T) {
 	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
 }
 
+func TestRun_FailedStreamSetupDoesNotFenceIncumbent(t *testing.T) {
+	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	})
+	require.NoError(t, err)
+
+	conn, impl := newStateTestConn(
+		t,
+		shardsAndStateTableResponses(stateRowResult(
+			sqltypes.NewVarBinary(string(vgtidJSON)),
+			sqltypes.NewVarBinary(`{"ks.t":{"Keyspace":"ks","Table":"t","Query":"select * from t"}}`),
+			sqltypes.NewInt64(1),
+		))...,
+	)
+	impl.vstreamErr = errors.New("vstream unavailable")
+
+	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
+		WithStateTable("stateks", "state"))
+	require.NoError(t, err)
+
+	err = v.Run(t.Context())
+	require.ErrorContains(t, err, "failed to create vstream")
+
+	// a Run that could not establish its stream must not have taken ownership: the incumbent
+	// consumer keeps checkpointing undisturbed
+	require.Len(t, impl.queries, 3)
+	for _, query := range impl.queries {
+		if strings.HasPrefix(query, "update ") || strings.HasPrefix(query, "insert ") {
+			assert.NotContains(t, query, "owner_token")
+		}
+	}
+}
+
 func TestNew_ClaimsStateOwnershipAfterValidatingState(t *testing.T) {
 	vgtidJSON, err := protojson.Marshal(&binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
@@ -405,8 +461,11 @@ func TestNew_ClaimsStateOwnershipAfterValidatingState(t *testing.T) {
 		WithStateTable("stateks", "state"))
 	require.NoError(t, err)
 
-	// the ownership claim must run after state is read and validated, so a constructor that
-	// fails validation can never fence a healthy running client
+	// the ownership claim must run after state is read and validated (and only once Run has
+	// established the stream), so a constructor that fails validation, is abandoned, or cannot
+	// open its stream can never fence a healthy running client
+	require.Len(t, impl.queries, 3)
+	require.NoError(t, v.takeStateOwnership(t.Context()))
 	require.Len(t, impl.queries, 4)
 	assert.Contains(t, impl.queries[2], "select latest_vgtid")
 	assert.Contains(t, impl.queries[3], "set owner_token = :owner_token")

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -723,6 +723,50 @@ func TestHandleEvents_HeartbeatMidTransactionDefersFlush(t *testing.T) {
 	assert.Len(t, impl.queries, 2)
 }
 
+func TestHandleEvents_RollbackTerminatesTransactionState(t *testing.T) {
+	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}})
+
+	flushed := 0
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: 10,
+		FlushFn: func(_ context.Context, rows []Row, _ FlushMeta) error {
+			flushed += len(rows)
+			return nil
+		},
+		currentBatch: []Row{{Data: "buffered"}},
+	}
+
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Second,
+		},
+		session: session,
+		stats:   VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+		tables:  map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+	}
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/2"}},
+	}
+
+	// ROLLBACK must terminate the transaction state; if it didn't, every heartbeat flush after
+	// BEGIN/ROLLBACK would stay suppressed on an idle stream
+	err := v.handleEvents(t.Context(), []*binlogdatapb.VEvent{
+		{Type: binlogdatapb.VEventType_BEGIN},
+		{Type: binlogdatapb.VEventType_ROLLBACK},
+		{Type: binlogdatapb.VEventType_VGTID, Vgtid: vgtid},
+		{Type: binlogdatapb.VEventType_HEARTBEAT},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, flushed)
+	require.Len(t, impl.queries, 1)
+}
+
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {
 	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 0}})
 

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -19,8 +19,10 @@ package vstreamclient
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -57,6 +59,7 @@ type stateTestVTGateImpl struct {
 	// startup-watchdog path for a hung stream setup.
 	vstreamErr    error
 	vstreamBlocks bool
+	recvBlocks    bool
 }
 
 func (t *stateTestVTGateImpl) VStream(ctx context.Context, _ topodatapb.TabletType, _ *binlogdatapb.VGtid, _ *binlogdatapb.Filter, _ *vtgatepb.VStreamFlags) (vtgateconn.VStreamReader, error) {
@@ -66,6 +69,12 @@ func (t *stateTestVTGateImpl) VStream(ctx context.Context, _ topodatapb.TabletTy
 	}
 	if t.vstreamErr != nil {
 		return nil, t.vstreamErr
+	}
+	if t.recvBlocks {
+		return &testVStreamReader{recvFn: func() ([]*binlogdatapb.VEvent, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}}, nil
 	}
 	return t.reader, nil
 }
@@ -567,6 +576,75 @@ func TestRun_FailedStreamSetupDoesNotFenceIncumbent(t *testing.T) {
 	}
 }
 
+func TestRun_FailedFirstReceiveDoesNotFenceIncumbent(t *testing.T) {
+	rejected := errors.New("stream rejected")
+	for _, tt := range []struct {
+		name    string
+		recvErr error
+		wantErr error
+	}{
+		{name: "server rejection", recvErr: rejected, wantErr: rejected},
+		{name: "EOF", recvErr: io.EOF, wantErr: io.ErrUnexpectedEOF},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, impl := newStateTestConn(t, shardsAndStateTableResponses(resumableStateRow(t))...)
+			impl.reader = &testVStreamReader{err: tt.recvErr}
+			v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()}, WithStateTable("stateks", "state"))
+			require.NoError(t, err)
+			queriesBeforeRun := len(impl.queries)
+
+			err = v.Run(t.Context())
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Len(t, impl.queries, queriesBeforeRun)
+			assert.True(t, v.stats.LastFlushedAt.IsZero())
+		})
+	}
+}
+
+func TestRun_FirstReceiveStartupTimeoutDoesNotFenceIncumbent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn, impl := newStateTestConn(t, shardsAndStateTableResponses(resumableStateRow(t))...)
+		impl.recvBlocks = true
+		v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()}, WithStateTable("stateks", "state"))
+		require.NoError(t, err)
+		queriesBeforeRun := len(impl.queries)
+		v.cfg.startupTimeout = 30 * time.Second
+
+		err = v.Run(t.Context())
+		require.ErrorIs(t, err, ErrStartupTimeout)
+		assert.Len(t, impl.queries, queriesBeforeRun)
+		assert.True(t, v.stats.LastFlushedAt.IsZero())
+	})
+}
+
+func TestRun_ClaimsAfterFirstBatchAndProcessesIt(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn, impl := newStateTestConn(t, shardsAndStateTableResponses(resumableStateRow(t))...)
+		processed := errors.New("first batch processed")
+		var v *VStreamClient
+		var firstReceivedAt time.Time
+		var hookCalls int
+		v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()}, WithStateTable("stateks", "state"),
+			WithEventFunc(func(context.Context, *binlogdatapb.VEvent) error {
+				hookCalls++
+				assert.Len(t, impl.queries, 4)
+				assert.False(t, v.stats.LastFlushedAt.Before(firstReceivedAt))
+				return processed
+			}, binlogdatapb.VEventType_HEARTBEAT))
+		require.NoError(t, err)
+		impl.reader = &testVStreamReader{recvFn: func() ([]*binlogdatapb.VEvent, error) {
+			require.Len(t, impl.queries, 3)
+			time.Sleep(2 * time.Second)
+			firstReceivedAt = time.Now()
+			return []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_HEARTBEAT}}, nil
+		}}
+
+		err = v.Run(t.Context())
+		require.ErrorIs(t, err, processed)
+		assert.Equal(t, 1, hookCalls)
+	})
+}
+
 func TestRun_BlockedStreamSetupSurfacesStartupTimeout(t *testing.T) {
 	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(resumableStateRow(t))...)
 	impl.vstreamBlocks = true
@@ -779,13 +857,43 @@ func TestHandleEvents_RollbackTerminatesTransactionState(t *testing.T) {
 	// BEGIN/ROLLBACK would stay suppressed on an idle stream
 	err := v.handleEvents(t.Context(), []*binlogdatapb.VEvent{
 		{Type: binlogdatapb.VEventType_BEGIN},
-		{Type: binlogdatapb.VEventType_ROLLBACK},
 		{Type: binlogdatapb.VEventType_VGTID, Vgtid: vgtid},
+		{Type: binlogdatapb.VEventType_ROLLBACK},
 		{Type: binlogdatapb.VEventType_HEARTBEAT},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, flushed)
 	require.Len(t, impl.queries, 1)
+}
+
+func TestHandleEvents_RollbackFlushesDuringShutdown(t *testing.T) {
+	session, impl := newStateTestSession(t)
+	flushed := 0
+	table := &TableConfig{
+		Keyspace: "ks", Table: "t", MaxRowsPerFlush: 10,
+		FlushFn: func(_ context.Context, rows []Row, meta FlushMeta) error {
+			assert.Equal(t, FlushReasonGracefulShutdown, meta.FlushReason)
+			flushed += len(rows)
+			return nil
+		},
+		currentBatch: []Row{{Data: "previously committed"}},
+	}
+	v := &VStreamClient{
+		cfg:     clientConfig{name: "stream", vgtidStateKeyspace: "ks", vgtidStateTable: "state", minFlushDuration: time.Hour},
+		session: session, stats: VStreamStats{LastFlushedAt: time.Now()},
+		tables:      map[string]*TableConfig{"ks.t": table},
+		latestVgtid: &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: testConcretePosition}}},
+	}
+	setLifecycleState(v, true, true, true, nil)
+
+	err := v.handleEvents(t.Context(), []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_BEGIN}, {Type: binlogdatapb.VEventType_ROLLBACK}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, flushed)
+	assert.Len(t, impl.queries, 1)
+	assert.Empty(t, table.currentBatch)
+	shouldExit, err := v.shouldExitRun(t.Context())
+	require.NoError(t, err)
+	assert.True(t, shouldExit)
 }
 
 func TestUpdateLatestVGtid_MissingStateRowErrors(t *testing.T) {

--- a/go/vt/vstreamclient/state_test.go
+++ b/go/vt/vstreamclient/state_test.go
@@ -306,7 +306,7 @@ func TestNew_ExplicitStartingVGtidPersistsWithCopyCompleted(t *testing.T) {
 	conn, impl := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
 
 	explicit := &binlogdatapb.VGtid{
-		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/42"}},
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: testConcretePosition}},
 	}
 
 	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},
@@ -348,7 +348,7 @@ func TestNew_ExplicitStartingVGtidOverridesStoredState(t *testing.T) {
 	))...)
 
 	explicit := &binlogdatapb.VGtid{
-		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/42"}},
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: testConcretePosition}},
 	}
 
 	v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()},

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -1,0 +1,324 @@
+package vstreamclient
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"time"
+
+	"vitess.io/vitess/go/sqlescape"
+	"vitess.io/vitess/go/sqltypes"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+// TableConfig is the configuration for a table, which is used to configure filtering and scanning of the results
+type TableConfig struct {
+	Keyspace string
+	Table    string
+
+	// if no configured, this is set to "select * from keyspace.table", streaming all the fields. This can be
+	// overridden to select only the fields that are needed, which can reduce memory usage and improve performance,
+	// and also alias the fields to match the struct fields.
+	Query string
+
+	// MaxRowsPerFlush serves two purposes:
+	//  1. it limits the number of rows that are flushed at once, to avoid large transactions. If more than
+	//     this number of rows are processed, they will be flushed in chunks of this size.
+	//  2. if this number is exceeded before reaching the minFlushDuration, it will trigger a flush to avoid
+	//     holding too much memory in the rows slice.
+	MaxRowsPerFlush int
+
+	// if true, will reuse the same slice for each batch, which can reduce memory allocations. It does mean
+	// that the caller must copy the data if they want to keep it, because the slice will be reused.
+	ReuseBatchSlice bool
+
+	// if true, will error and block the stream if there are fields in the result that don't match the struct
+	ErrorOnUnknownFields bool
+
+	// this is the function that will be called to flush the rows to the handler. This is called when the
+	// minFlushDuration has passed, or the maxRowsPerFlush has been exceeded.
+	FlushFn FlushFunc
+
+	// TODO: translate this to *sql.Tx so we can pass it to the flush function
+	FlushInTx bool
+
+	// purposefully not exported, so we don't have to use a mutex to access it. The idea is that the consumer only
+	// needs to access this when they are flushing the rows, so they can copy the data if they want to keep it. If
+	// there is a use case for accessing this outside of the flush function, we can add a getter method.
+	stats TableStats
+
+	// this is the data type for this table, which is used to scan the results. Regardless whether a pointer
+	// or value is supplied, the return value will always be []*DataType.
+	DataType          any
+	underlyingType    reflect.Type
+	implementsScanner bool
+
+	// this stores the current batch of rows for this table, which caches the results until the next flush.
+	currentBatch []Row
+
+	// this is the mapping of fields to the query results, which is used to scan the results. This is done
+	// on a per-shard basis, because while unlikely, it's possible that the same table in different shards
+	// could have different schemas.
+	shards map[string]shardConfig
+}
+
+// TableStats keeps track of the number of rows processed and flushed for a single table
+type TableStats struct {
+	// how many rows have been processed for this table. These are incremented as each row
+	// is processed, regardless of whether it is flushed.
+	RowInsertCount int
+	RowUpdateCount int
+	RowDeleteCount int
+
+	FlushedRowCount int // sum of rows flushed, including all insert/update/delete events
+
+	FlushCount    int       // how many times the flush function was executed for this table. Not incremented for no-ops
+	LastFlushedAt time.Time // only set after a flush successfully completes
+}
+
+// shardConfig is the per-shard configuration for a table, which is used to scan the results
+type shardConfig struct {
+	fieldMap map[string]fieldMapping
+	fields   []*querypb.Field
+}
+
+// fieldMapping caches the mapping of table fields to struct fields, to reduce reflection overhead. This is
+// configured once per shard, and used for all rows in that shard, unless a DDL event changes the schema,
+// in which case the mapping is updated.
+type fieldMapping struct {
+	rowIndex    int
+	structIndex []int
+	structType  any
+	kind        reflect.Kind
+	isPointer   bool
+}
+
+// TODO: there's a consolidation issue to deal with here. Someone could easily add a new table in
+// code after the copy phase completes and redeploy, expecting it to catch up, but it wouldn't
+// by default. To support that, I think we'd have to store a list of tables in state, and if a
+// new table is added, catch it up to the same vgtid, then do a cutover to be in the same stream.
+// That'd be a much better user experience, but a decent amount of added complexity.
+func (v *VStreamClient) initTables(tables []TableConfig) error {
+	if len(v.tables) > 0 {
+		return fmt.Errorf("vstreamclient: %d tables already configured", len(v.tables))
+	}
+
+	if len(tables) == 0 {
+		return fmt.Errorf("vstreamclient: no tables provided")
+	}
+
+	for _, table := range tables {
+		// basic validation
+		if table.DataType == nil {
+			return fmt.Errorf("vstreamclient: table %s.%s has no data type", table.Keyspace, table.Table)
+		}
+
+		if table.Keyspace == "" {
+			return fmt.Errorf("vstreamclient: table %v has no keyspace", table)
+		}
+
+		if table.Table == "" {
+			return fmt.Errorf("vstreamclient: table %v has no table name", table)
+		}
+
+		fmt.Println("shardsByKeyspace", v.shardsByKeyspace)
+		// make sure the keyspace exists in the cluster
+		_, ok := v.shardsByKeyspace[table.Keyspace]
+		if !ok {
+			return fmt.Errorf("vstreamclient: keyspace %s not found in the cluster", table.Keyspace)
+		}
+
+		// the key is the keyspace and table name, separated by a period. We use this because vstream events
+		// use this as the table name, so it's easier for lookup, and it's unique.
+		k := fmt.Sprintf("%s.%s", table.Keyspace, table.Table)
+
+		// if the same table is referenced multiple times in the same stream, only one table will actually
+		// receive events. This prevents users from unknowingly missing events for the second table reference.
+		if _, ok = v.tables[k]; ok {
+			return fmt.Errorf("duplicate table %s in keyspace %s", table.Table, table.Keyspace)
+		}
+
+		// set defaults if not provided
+		if table.Query == "" {
+			table.Query = "select * from " + sqlescape.EscapeID(table.Table)
+		}
+
+		if table.MaxRowsPerFlush == 0 {
+			table.MaxRowsPerFlush = DefaultMaxRowsPerFlush
+		}
+
+		// if the data type implements VStreamScanner, we will use that to scan the results
+		_, table.implementsScanner = table.DataType.(VStreamScanner)
+
+		// regardless whether the user provided a pointer to a struct or a struct, we want to store the
+		// underlying type of the struct, so we can create new instances of it later
+		table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+
+		if table.underlyingType.Kind() != reflect.Struct {
+			return fmt.Errorf("vstreamclient: data type for table %s.%s must be a struct", table.Keyspace, table.Table)
+		}
+
+		table.shards = make(map[string]shardConfig)
+
+		// initialize the slice containing the batch of rows for this table
+		table.resetBatch()
+
+		// store the table in the map
+		v.tables[k] = &table
+	}
+
+	return nil
+}
+
+func validateTableConfig(providedTables, dbTables map[string]*TableConfig) error {
+	providedTablesMap := tablesToDBTableConfig(providedTables)
+	dbTablesMap := tablesToDBTableConfig(dbTables)
+
+	if !maps.Equal(providedTablesMap, dbTablesMap) {
+		// TODO: this could be more user-friendly and show the differences
+		return fmt.Errorf("vstreamclient: provided tables do not match stored tables")
+	}
+
+	return nil
+}
+
+func (table *TableConfig) resetBatch() {
+	if table.ReuseBatchSlice && table.currentBatch != nil {
+		table.currentBatch = slices.Delete(table.currentBatch, 0, len(table.currentBatch))
+	} else {
+		table.currentBatch = make([]Row, 0, table.MaxRowsPerFlush)
+	}
+}
+
+func (table *TableConfig) handleFieldEvent(ev *binlogdatapb.FieldEvent) error {
+	var fieldMap map[string]fieldMapping
+	var err error
+
+	if !table.implementsScanner {
+		fieldMap, err = table.reflectMapFields(ev.Fields)
+		if err != nil {
+			return err
+		}
+	}
+
+	table.shards[ev.Shard] = shardConfig{
+		fieldMap: fieldMap,
+		fields:   ev.Fields,
+	}
+
+	return nil
+}
+
+func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]fieldMapping, error) {
+	fieldMap := make(map[string]fieldMapping, len(fields))
+
+	for i := 0; i < table.underlyingType.NumField(); i++ {
+		structField := table.underlyingType.Field(i)
+		if !structField.IsExported() {
+			continue
+		}
+
+		// get the field name from the vstream, db, json tag, or the field name, in that order
+		mappedFieldName := structField.Tag.Get("vstream")
+		if mappedFieldName == "-" {
+			continue
+		}
+		if mappedFieldName == "" {
+			mappedFieldName = structField.Tag.Get("db")
+		}
+		if mappedFieldName == "" {
+			mappedFieldName = structField.Tag.Get("json")
+		}
+		if mappedFieldName == "" {
+			mappedFieldName = structField.Name
+		}
+
+		var found bool
+		for j, tableField := range fields {
+			if tableField.Name != mappedFieldName {
+				continue
+			}
+
+			found = true
+			fieldMap[mappedFieldName] = fieldMapping{
+				rowIndex:    j,
+				structIndex: structField.Index,
+				kind:        structField.Type.Kind(),
+				isPointer:   structField.Type.Kind() == reflect.Ptr,
+			}
+		}
+		if !found && table.ErrorOnUnknownFields {
+			return nil, fmt.Errorf("vstreamclient: field %s not found in provided data type", mappedFieldName)
+		}
+	}
+
+	// sanity check that we found at least one field
+	if len(fieldMap) == 0 {
+		return nil, fmt.Errorf("vstreamclient: no matching fields found for table %s", table.Table)
+	}
+
+	return fieldMap, nil
+}
+
+func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats *VStreamStats) error {
+	shard, ok := table.shards[ev.Shard]
+	if !ok {
+		return fmt.Errorf("unexpected shard: %s", ev.Shard)
+	}
+
+	table.currentBatch = slices.Grow(table.currentBatch, len(ev.RowChanges))
+
+	for _, rc := range ev.RowChanges {
+		var row []sqltypes.Value
+
+		switch {
+		case rc.After == nil: // delete event
+			// even though a delete event might be represented as a nil row, the consumer will still need to know
+			// which row was deleted, so we'll pass the before row to the consumer, which should contain the primary
+			// key fields, so they can be used however necessary to handle the delete in a downstream system.
+			row = sqltypes.MakeRowTrusted(shard.fields, rc.Before)
+			vstreamStats.RowDeleteCount++
+			table.stats.RowDeleteCount++
+
+		case rc.Before == nil: // insert event
+			row = sqltypes.MakeRowTrusted(shard.fields, rc.After)
+			vstreamStats.RowInsertCount++
+			table.stats.RowInsertCount++
+
+		case rc.Before != nil: // update event
+			row = sqltypes.MakeRowTrusted(shard.fields, rc.After)
+			vstreamStats.RowUpdateCount++
+			table.stats.RowUpdateCount++
+		}
+
+		// create a new struct for the row
+		v := reflect.New(table.underlyingType)
+		table.currentBatch = append(table.currentBatch, Row{
+			RowEvent:  ev,
+			RowChange: rc,
+			Data:      v.Interface(),
+		})
+
+		// use the custom scanner if available
+		if table.implementsScanner {
+			returnVals := v.MethodByName("VStreamScan").Call([]reflect.Value{
+				reflect.ValueOf(shard.fields),
+				reflect.ValueOf(row),
+				reflect.ValueOf(ev),
+				reflect.ValueOf(rc),
+			})
+			if !returnVals[0].IsNil() {
+				return fmt.Errorf("vstreamclient: client scan failed: %w", returnVals[0].Interface().(error))
+			}
+		} else {
+			err := copyRowToStruct(shard, row, v)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -345,6 +345,24 @@ func parseTagName(tag string) string {
 	return strings.TrimSpace(name)
 }
 
+func (table *TableConfig) validateRowChangeForDefaultDecoding(rc *binlogdatapb.RowChange) error {
+	if table.implementsScanner || rc == nil || rc.After == nil {
+		return nil
+	}
+
+	qualifiedName := qualifiedTableName(table.Keyspace, table.Table)
+
+	if rc.JsonPartialValues != nil {
+		return fmt.Errorf("vstreamclient: partial JSON updates are unsupported for default decoding on table %s; implement VStreamScanner to handle RowChange bitmaps explicitly", qualifiedName)
+	}
+
+	if rc.DataColumns != nil {
+		return fmt.Errorf("vstreamclient: partial row images are unsupported for default decoding on table %s; implement VStreamScanner to handle RowChange bitmaps explicitly", qualifiedName)
+	}
+
+	return nil
+}
+
 func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats *VStreamStats) error {
 	shard, ok := table.shards[ev.Shard]
 	if !ok {
@@ -354,6 +372,10 @@ func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats
 	table.currentBatch = slices.Grow(table.currentBatch, len(ev.RowChanges))
 
 	for _, rc := range ev.RowChanges {
+		if err := table.validateRowChangeForDefaultDecoding(rc); err != nil {
+			return err
+		}
+
 		var row []sqltypes.Value
 
 		switch {

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -1,10 +1,12 @@
 package vstreamclient
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"vitess.io/vitess/go/sqlescape"
@@ -18,7 +20,7 @@ type TableConfig struct {
 	Keyspace string
 	Table    string
 
-	// if no configured, this is set to "select * from keyspace.table", streaming all the fields. This can be
+	// if not configured, this is set to "select * from keyspace.table", streaming all the fields. This can be
 	// overridden to select only the fields that are needed, which can reduce memory usage and improve performance,
 	// and also alias the fields to match the struct fields.
 	Query string
@@ -90,9 +92,10 @@ type shardConfig struct {
 type fieldMapping struct {
 	rowIndex    int
 	structIndex []int
-	structType  any
+	structType  reflect.Type
 	kind        reflect.Kind
 	isPointer   bool
+	jsonDecode  bool
 }
 
 // TODO: there's a consolidation issue to deal with here. Someone could easily add a new table in
@@ -106,13 +109,23 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 	}
 
 	if len(tables) == 0 {
-		return fmt.Errorf("vstreamclient: no tables provided")
+		return errors.New("vstreamclient: no tables provided")
 	}
+
+	queriesByTableName := make(map[string]string)
 
 	for _, table := range tables {
 		// basic validation
 		if table.DataType == nil {
 			return fmt.Errorf("vstreamclient: table %s.%s has no data type", table.Keyspace, table.Table)
+		}
+
+		dataTypeValue := reflect.ValueOf(table.DataType)
+		switch dataTypeValue.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+			if dataTypeValue.IsNil() {
+				return fmt.Errorf("vstreamclient: table %s.%s has no data type", table.Keyspace, table.Table)
+			}
 		}
 
 		if table.Keyspace == "" {
@@ -122,22 +135,20 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 		if table.Table == "" {
 			return fmt.Errorf("vstreamclient: table %v has no table name", table)
 		}
+		if table.FlushFn == nil {
+			return fmt.Errorf("vstreamclient: table %s.%s has no flush function", table.Keyspace, table.Table)
+		}
 
-		fmt.Println("shardsByKeyspace", v.shardsByKeyspace)
 		// make sure the keyspace exists in the cluster
 		_, ok := v.shardsByKeyspace[table.Keyspace]
 		if !ok {
 			return fmt.Errorf("vstreamclient: keyspace %s not found in the cluster", table.Keyspace)
 		}
 
-		// the key is the keyspace and table name, separated by a period. We use this because vstream events
-		// use this as the table name, so it's easier for lookup, and it's unique.
-		k := fmt.Sprintf("%s.%s", table.Keyspace, table.Table)
+		k := qualifiedTableName(table.Keyspace, table.Table)
 
-		// if the same table is referenced multiple times in the same stream, only one table will actually
-		// receive events. This prevents users from unknowingly missing events for the second table reference.
 		if _, ok = v.tables[k]; ok {
-			return fmt.Errorf("duplicate table %s in keyspace %s", table.Table, table.Keyspace)
+			return fmt.Errorf("vstreamclient: duplicate table %s", k)
 		}
 
 		// set defaults if not provided
@@ -145,8 +156,18 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 			table.Query = "select * from " + sqlescape.EscapeID(table.Table)
 		}
 
+		// VStream rules match by bare table name, so same-named tables across keyspaces can
+		// end up sharing whichever rule is matched first. Requiring identical queries makes
+		// that overlap harmless instead of silently applying the wrong filter/projection.
+		if existingQuery, ok := queriesByTableName[table.Table]; ok && existingQuery != table.Query {
+			return fmt.Errorf("vstreamclient: same table name across keyspaces must use identical queries: %s", table.Table)
+		}
+		queriesByTableName[table.Table] = table.Query
+
 		if table.MaxRowsPerFlush == 0 {
 			table.MaxRowsPerFlush = DefaultMaxRowsPerFlush
+		} else if table.MaxRowsPerFlush < 0 {
+			return fmt.Errorf("vstreamclient: max rows per flush must be positive for table %s.%s, got %d", table.Keyspace, table.Table, table.MaxRowsPerFlush)
 		}
 
 		// if the data type implements VStreamScanner, we will use that to scan the results
@@ -172,13 +193,40 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 	return nil
 }
 
+func qualifiedTableName(keyspace, table string) string {
+	return keyspace + "." + table
+}
+
+func (v *VStreamClient) lookupTable(tableName string) (*TableConfig, error) {
+	if table, ok := v.tables[tableName]; ok {
+		return table, nil
+	}
+
+	var matched *TableConfig
+	for _, table := range v.tables {
+		if table.Table != tableName {
+			continue
+		}
+		if matched != nil {
+			return nil, fmt.Errorf("vstreamclient: ambiguous table name: %s", tableName)
+		}
+		matched = table
+	}
+
+	if matched == nil {
+		return nil, fmt.Errorf("vstreamclient: unexpected table name: %s", tableName)
+	}
+
+	return matched, nil
+}
+
 func validateTableConfig(providedTables, dbTables map[string]*TableConfig) error {
 	providedTablesMap := tablesToDBTableConfig(providedTables)
 	dbTablesMap := tablesToDBTableConfig(dbTables)
 
 	if !maps.Equal(providedTablesMap, dbTablesMap) {
 		// TODO: this could be more user-friendly and show the differences
-		return fmt.Errorf("vstreamclient: provided tables do not match stored tables")
+		return errors.New("vstreamclient: provided tables do not match stored tables")
 	}
 
 	return nil
@@ -214,43 +262,53 @@ func (table *TableConfig) handleFieldEvent(ev *binlogdatapb.FieldEvent) error {
 func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]fieldMapping, error) {
 	fieldMap := make(map[string]fieldMapping, len(fields))
 
-	for i := 0; i < table.underlyingType.NumField(); i++ {
-		structField := table.underlyingType.Field(i)
+	for structField := range table.underlyingType.Fields() {
 		if !structField.IsExported() {
 			continue
 		}
 
 		// get the field name from the vstream, db, json tag, or the field name, in that order
-		mappedFieldName := structField.Tag.Get("vstream")
+		mappedFieldName, jsonDecode := parseVStreamTag(structField.Tag.Get("vstream"))
 		if mappedFieldName == "-" {
 			continue
 		}
 		if mappedFieldName == "" {
-			mappedFieldName = structField.Tag.Get("db")
+			mappedFieldName = parseTagName(structField.Tag.Get("db"))
 		}
 		if mappedFieldName == "" {
-			mappedFieldName = structField.Tag.Get("json")
+			mappedFieldName = parseTagName(structField.Tag.Get("json"))
 		}
 		if mappedFieldName == "" {
 			mappedFieldName = structField.Name
 		}
 
-		var found bool
 		for j, tableField := range fields {
 			if tableField.Name != mappedFieldName {
 				continue
 			}
 
-			found = true
+			fieldType := structField.Type
+			isPointer := fieldType.Kind() == reflect.Ptr
+			if isPointer {
+				fieldType = fieldType.Elem()
+			}
+
 			fieldMap[mappedFieldName] = fieldMapping{
 				rowIndex:    j,
 				structIndex: structField.Index,
-				kind:        structField.Type.Kind(),
-				isPointer:   structField.Type.Kind() == reflect.Ptr,
+				structType:  fieldType,
+				kind:        fieldType.Kind(),
+				isPointer:   isPointer,
+				jsonDecode:  jsonDecode,
 			}
 		}
-		if !found && table.ErrorOnUnknownFields {
-			return nil, fmt.Errorf("vstreamclient: field %s not found in provided data type", mappedFieldName)
+	}
+
+	if table.ErrorOnUnknownFields {
+		for _, f := range fields {
+			if _, ok := fieldMap[f.Name]; !ok {
+				return nil, fmt.Errorf("vstreamclient: field %s not found in provided data type", f.Name)
+			}
 		}
 	}
 
@@ -262,10 +320,35 @@ func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]
 	return fieldMap, nil
 }
 
+func parseVStreamTag(tag string) (name string, jsonDecode bool) {
+	if tag == "" {
+		return "", false
+	}
+
+	parts := strings.Split(tag, ",")
+	name = strings.TrimSpace(parts[0])
+	for _, opt := range parts[1:] {
+		if strings.EqualFold(strings.TrimSpace(opt), "json") {
+			jsonDecode = true
+		}
+	}
+
+	return name, jsonDecode
+}
+
+func parseTagName(tag string) string {
+	if tag == "" {
+		return ""
+	}
+
+	name, _, _ := strings.Cut(tag, ",")
+	return strings.TrimSpace(name)
+}
+
 func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats *VStreamStats) error {
 	shard, ok := table.shards[ev.Shard]
 	if !ok {
-		return fmt.Errorf("unexpected shard: %s", ev.Shard)
+		return fmt.Errorf("vstreamclient: unexpected shard: %s", ev.Shard)
 	}
 
 	table.currentBatch = slices.Grow(table.currentBatch, len(ev.RowChanges))
@@ -293,31 +376,33 @@ func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats
 			table.stats.RowUpdateCount++
 		}
 
+		var data any
+
 		// create a new struct for the row
-		v := reflect.New(table.underlyingType)
+		var v reflect.Value
+		if row != nil {
+			v = reflect.New(table.underlyingType)
+
+			if table.implementsScanner {
+				scanner := v.Interface().(VStreamScanner)
+				if err := scanner.VStreamScan(shard.fields, row, ev, rc); err != nil {
+					return fmt.Errorf("vstreamclient: client scan failed: %w", err)
+				}
+			} else {
+				err := copyRowToStruct(shard, row, v)
+				if err != nil {
+					return err
+				}
+			}
+
+			data = v.Interface()
+		}
+
 		table.currentBatch = append(table.currentBatch, Row{
 			RowEvent:  ev,
 			RowChange: rc,
-			Data:      v.Interface(),
+			Data:      data,
 		})
-
-		// use the custom scanner if available
-		if table.implementsScanner {
-			returnVals := v.MethodByName("VStreamScan").Call([]reflect.Value{
-				reflect.ValueOf(shard.fields),
-				reflect.ValueOf(row),
-				reflect.ValueOf(ev),
-				reflect.ValueOf(rc),
-			})
-			if !returnVals[0].IsNil() {
-				return fmt.Errorf("vstreamclient: client scan failed: %w", returnVals[0].Interface().(error))
-			}
-		} else {
-			err := copyRowToStruct(shard, row, v)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -3,7 +3,6 @@ package vstreamclient
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -224,12 +223,62 @@ func validateTableConfig(providedTables, dbTables map[string]*TableConfig) error
 	providedTablesMap := tablesToDBTableConfig(providedTables)
 	dbTablesMap := tablesToDBTableConfig(dbTables)
 
-	if !maps.Equal(providedTablesMap, dbTablesMap) {
-		// TODO: this could be more user-friendly and show the differences
-		return errors.New("vstreamclient: provided tables do not match stored tables")
+	keys := make([]string, 0, len(providedTablesMap)+len(dbTablesMap))
+	seen := make(map[string]struct{}, len(providedTablesMap)+len(dbTablesMap))
+	for key := range providedTablesMap {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	for key := range dbTablesMap {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	diffs := make([]string, 0)
+	for _, key := range keys {
+		provided, providedOK := providedTablesMap[key]
+		stored, storedOK := dbTablesMap[key]
+
+		switch {
+		case providedOK && !storedOK:
+			diffs = append(diffs, fmt.Sprintf("table %s is new in provided config", formatTableConfigName(key, provided)))
+
+		case !providedOK && storedOK:
+			diffs = append(diffs, fmt.Sprintf("table %s is missing from provided config", formatTableConfigName(key, stored)))
+
+		case provided != stored:
+			tableName := formatTableConfigName(key, provided)
+			if storedName := formatTableConfigName(key, stored); storedName != tableName {
+				diffs = append(diffs, fmt.Sprintf("table %s identity changed: provided %q, stored %q", key, tableName, storedName))
+				continue
+			}
+
+			if provided.Query != stored.Query {
+				diffs = append(diffs, fmt.Sprintf("table %s query changed: provided %q, stored %q", tableName, provided.Query, stored.Query))
+			}
+		}
+	}
+
+	if len(diffs) > 0 {
+		return fmt.Errorf("vstreamclient: provided tables do not match stored tables: %s", strings.Join(diffs, "; "))
 	}
 
 	return nil
+}
+
+func formatTableConfigName(key string, table dbTableConfig) string {
+	if table.Keyspace != "" && table.Table != "" {
+		return qualifiedTableName(table.Keyspace, table.Table)
+	}
+
+	return key
 }
 
 func (table *TableConfig) resetBatch() {

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -31,8 +31,12 @@ type TableConfig struct {
 	//     holding too much memory in the rows slice.
 	MaxRowsPerFlush int
 
-	// if true, will reuse the same slice for each batch, which can reduce memory allocations. It does mean
-	// that the caller must copy the data if they want to keep it, because the slice will be reused.
+	// ReuseBatchSlice will reuse the backing array of the `rows []Row` slice passed to FlushFn
+	// across successive batches, which can reduce memory allocations.
+	//
+	// DANGER: If true, the caller MUST NOT retain references to the `rows` slice or any of its
+	// elements after FlushFn returns. The slice and its contents will be aggressively mutated
+	// in place by the internal processing loop. Retaining pointers will lead to data corruption.
 	ReuseBatchSlice bool
 
 	// if true, will error and block the stream if there are fields in the result that don't match the struct

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -55,6 +55,7 @@ type TableConfig struct {
 	DataType          any
 	underlyingType    reflect.Type
 	implementsScanner bool
+	timeLocation      *time.Location
 
 	// this stores the current batch of rows for this table, which caches the results until the next flush.
 	currentBatch []Row
@@ -310,8 +311,27 @@ func (table *TableConfig) handleFieldEvent(ev *binlogdatapb.FieldEvent) error {
 
 func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]fieldMapping, error) {
 	fieldMap := make(map[string]fieldMapping, len(fields))
+	table.reflectMapStructFields(table.underlyingType, nil, fields, fieldMap)
 
-	for structField := range table.underlyingType.Fields() {
+	if table.ErrorOnUnknownFields {
+		for _, f := range fields {
+			if _, ok := fieldMap[f.Name]; !ok {
+				return nil, fmt.Errorf("vstreamclient: field %s not found in provided data type", f.Name)
+			}
+		}
+	}
+
+	// sanity check that we found at least one field
+	if len(fieldMap) == 0 {
+		return nil, fmt.Errorf("vstreamclient: no matching fields found for table %s", table.Table)
+	}
+
+	return fieldMap, nil
+}
+
+func (table *TableConfig) reflectMapStructFields(structType reflect.Type, indexPrefix []int, fields []*querypb.Field, fieldMap map[string]fieldMapping) {
+	for i := range structType.NumField() {
+		structField := structType.Field(i)
 		if !structField.IsExported() {
 			continue
 		}
@@ -327,6 +347,13 @@ func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]
 		if mappedFieldName == "" {
 			mappedFieldName = parseTagName(structField.Tag.Get("json"))
 		}
+
+		fullIndex := append(append([]int(nil), indexPrefix...), structField.Index...)
+		if table.shouldRecurseStructField(structField, mappedFieldName, jsonDecode, fields) {
+			table.reflectMapStructFields(structField.Type, fullIndex, fields, fieldMap)
+			continue
+		}
+
 		if mappedFieldName == "" {
 			mappedFieldName = structField.Name
 		}
@@ -344,7 +371,7 @@ func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]
 
 			fieldMap[mappedFieldName] = fieldMapping{
 				rowIndex:    j,
-				structIndex: structField.Index,
+				structIndex: fullIndex,
 				structType:  fieldType,
 				kind:        fieldType.Kind(),
 				isPointer:   isPointer,
@@ -352,21 +379,21 @@ func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]
 			}
 		}
 	}
+}
 
-	if table.ErrorOnUnknownFields {
-		for _, f := range fields {
-			if _, ok := fieldMap[f.Name]; !ok {
-				return nil, fmt.Errorf("vstreamclient: field %s not found in provided data type", f.Name)
-			}
+func (table *TableConfig) shouldRecurseStructField(structField reflect.StructField, mappedFieldName string, jsonDecode bool, fields []*querypb.Field) bool {
+	if mappedFieldName != "" || jsonDecode {
+		return false
+	}
+	if structField.Type.Kind() != reflect.Struct || structField.Type == reflect.TypeFor[time.Time]() {
+		return false
+	}
+	for _, field := range fields {
+		if field.Name == structField.Name {
+			return false
 		}
 	}
-
-	// sanity check that we found at least one field
-	if len(fieldMap) == 0 {
-		return nil, fmt.Errorf("vstreamclient: no matching fields found for table %s", table.Table)
-	}
-
-	return fieldMap, nil
+	return true
 }
 
 func parseVStreamTag(tag string) (name string, jsonDecode bool) {
@@ -460,7 +487,7 @@ func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats
 					return fmt.Errorf("vstreamclient: client scan failed: %w", err)
 				}
 			} else {
-				err := copyRowToStruct(shard, row, v)
+				err := copyRowToStructInLocation(shard, row, v, table.timeLocation)
 				if err != nil {
 					return err
 				}

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -350,8 +350,7 @@ func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]
 }
 
 func (table *TableConfig) reflectMapStructFields(structType reflect.Type, indexPrefix []int, fields []*querypb.Field, fieldMap map[string]fieldMapping) {
-	for i := range structType.NumField() {
-		structField := structType.Field(i)
+	for structField := range structType.Fields() {
 		if !structField.IsExported() {
 			continue
 		}
@@ -384,7 +383,7 @@ func (table *TableConfig) reflectMapStructFields(structType reflect.Type, indexP
 			}
 
 			fieldType := structField.Type
-			isPointer := fieldType.Kind() == reflect.Ptr
+			isPointer := fieldType.Kind() == reflect.Pointer
 			if isPointer {
 				fieldType = fieldType.Elem()
 			}

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -190,9 +190,6 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 			return fmt.Errorf("vstreamclient: max rows per flush must be positive for table %s.%s, got %d", table.Keyspace, table.Table, table.MaxRowsPerFlush)
 		}
 
-		// if the data type implements VStreamScanner, we will use that to scan the results
-		_, table.implementsScanner = table.DataType.(VStreamScanner)
-
 		// regardless whether the user provided a pointer to a struct or a struct, we want to store the
 		// underlying type of the struct, so we can create new instances of it later
 		table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
@@ -200,6 +197,10 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 		if table.underlyingType.Kind() != reflect.Struct {
 			return fmt.Errorf("vstreamclient: data type for table %s.%s must be a struct", table.Keyspace, table.Table)
 		}
+
+		// Rows are always instantiated as pointers, so detect scanner support on *T even when the
+		// caller provides DataType as a value form T{}.
+		table.implementsScanner = reflect.PointerTo(table.underlyingType).Implements(reflect.TypeFor[VStreamScanner]())
 
 		table.shards = make(map[string]shardConfig)
 

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -156,6 +156,12 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 		if table.Table == "" {
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table in keyspace %q has no table name", table.Keyspace)
 		}
+
+		// vstreamer interprets rule matches beginning with "/" as regular expressions, so a legal
+		// quoted MySQL table name starting with "/" would silently become a pattern match
+		if strings.HasPrefix(table.Table, "/") {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table name %q is not supported: names beginning with '/' are interpreted as regular expressions by vstream", table.Table)
+		}
 		if table.FlushFn == nil {
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table %s.%s has no flush function", table.Keyspace, table.Table)
 		}
@@ -187,7 +193,10 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 
 		if table.MaxRowsPerFlush == 0 {
 			table.MaxRowsPerFlush = DefaultMaxRowsPerFlush
-		} else if table.MaxRowsPerFlush < 0 {
+		}
+		// revalidate after applying the default: DefaultMaxRowsPerFlush is a mutable package
+		// variable, and a non-positive effective value would panic later during chunking
+		if table.MaxRowsPerFlush <= 0 {
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: max rows per flush must be positive for table %s.%s, got %d", table.Keyspace, table.Table, table.MaxRowsPerFlush)
 		}
 

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -251,9 +251,8 @@ func (v *VStreamClient) lookupTable(tableName string) (*TableConfig, error) {
 	return matched, nil
 }
 
-func validateTableConfig(providedTables, dbTables map[string]*TableConfig) error {
+func validateTableConfig(providedTables map[string]*TableConfig, dbTablesMap map[string]dbTableConfig) error {
 	providedTablesMap := tablesToDBTableConfig(providedTables)
-	dbTablesMap := tablesToDBTableConfig(dbTables)
 
 	keys := make([]string, 0, len(providedTablesMap)+len(dbTablesMap))
 	seen := make(map[string]struct{}, len(providedTablesMap)+len(dbTablesMap))

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -63,9 +63,6 @@ type TableConfig struct {
 	// minFlushDuration has passed, or the maxRowsPerFlush has been exceeded.
 	FlushFn FlushFunc
 
-	// TODO: translate this to *sql.Tx so we can pass it to the flush function
-	FlushInTx bool
-
 	// purposefully not exported, so we don't have to use a mutex to access it. The idea is that the consumer only
 	// needs to access this when they are flushing the rows, so they can copy the data if they want to keep it. If
 	// there is a use case for accessing this outside of the flush function, we can add a getter method.

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vstreamclient
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -28,6 +27,8 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 // TableConfig is the configuration for a table, which is used to configure filtering and scanning of the results
@@ -125,11 +126,11 @@ type fieldMapping struct {
 // That'd be a much better user experience, but a decent amount of added complexity.
 func (v *VStreamClient) initTables(tables []TableConfig) error {
 	if len(v.tables) > 0 {
-		return fmt.Errorf("vstreamclient: %d tables already configured", len(v.tables))
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: %d tables already configured", len(v.tables))
 	}
 
 	if len(tables) == 0 {
-		return errors.New("vstreamclient: no tables provided")
+		return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: no tables provided")
 	}
 
 	queriesByTableName := make(map[string]string)
@@ -137,38 +138,38 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 	for _, table := range tables {
 		// basic validation
 		if table.DataType == nil {
-			return fmt.Errorf("vstreamclient: table %s.%s has no data type", table.Keyspace, table.Table)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table %s.%s has no data type", table.Keyspace, table.Table)
 		}
 
 		dataTypeValue := reflect.ValueOf(table.DataType)
 		switch dataTypeValue.Kind() {
 		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 			if dataTypeValue.IsNil() {
-				return fmt.Errorf("vstreamclient: table %s.%s has no data type", table.Keyspace, table.Table)
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table %s.%s has no data type", table.Keyspace, table.Table)
 			}
 		}
 
 		if table.Keyspace == "" {
-			return fmt.Errorf("vstreamclient: table %q has no keyspace", table.Table)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table %q has no keyspace", table.Table)
 		}
 
 		if table.Table == "" {
-			return fmt.Errorf("vstreamclient: table in keyspace %q has no table name", table.Keyspace)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table in keyspace %q has no table name", table.Keyspace)
 		}
 		if table.FlushFn == nil {
-			return fmt.Errorf("vstreamclient: table %s.%s has no flush function", table.Keyspace, table.Table)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: table %s.%s has no flush function", table.Keyspace, table.Table)
 		}
 
 		// make sure the keyspace exists in the cluster
 		_, ok := v.shardsByKeyspace[table.Keyspace]
 		if !ok {
-			return fmt.Errorf("vstreamclient: keyspace %s not found in the cluster", table.Keyspace)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s not found in the cluster", table.Keyspace)
 		}
 
 		k := qualifiedTableName(table.Keyspace, table.Table)
 
 		if _, ok = v.tables[k]; ok {
-			return fmt.Errorf("vstreamclient: duplicate table %s", k)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: duplicate table %s", k)
 		}
 
 		// set defaults if not provided
@@ -180,14 +181,14 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 		// end up sharing whichever rule is matched first. Requiring identical queries makes
 		// that overlap harmless instead of silently applying the wrong filter/projection.
 		if existingQuery, ok := queriesByTableName[table.Table]; ok && existingQuery != table.Query {
-			return fmt.Errorf("vstreamclient: same table name across keyspaces must use identical queries: %s", table.Table)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: same table name across keyspaces must use identical queries: %s", table.Table)
 		}
 		queriesByTableName[table.Table] = table.Query
 
 		if table.MaxRowsPerFlush == 0 {
 			table.MaxRowsPerFlush = DefaultMaxRowsPerFlush
 		} else if table.MaxRowsPerFlush < 0 {
-			return fmt.Errorf("vstreamclient: max rows per flush must be positive for table %s.%s, got %d", table.Keyspace, table.Table, table.MaxRowsPerFlush)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: max rows per flush must be positive for table %s.%s, got %d", table.Keyspace, table.Table, table.MaxRowsPerFlush)
 		}
 
 		// regardless whether the user provided a pointer to a struct or a struct, we want to store the
@@ -195,7 +196,7 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 		table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 
 		if table.underlyingType.Kind() != reflect.Struct {
-			return fmt.Errorf("vstreamclient: data type for table %s.%s must be a struct", table.Keyspace, table.Table)
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: data type for table %s.%s must be a struct", table.Keyspace, table.Table)
 		}
 
 		// Rows are always instantiated as pointers, so detect scanner support on *T even when the
@@ -229,13 +230,13 @@ func (v *VStreamClient) lookupTable(tableName string) (*TableConfig, error) {
 			continue
 		}
 		if matched != nil {
-			return nil, fmt.Errorf("vstreamclient: ambiguous table name: %s", tableName)
+			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vstreamclient: ambiguous table name: %s", tableName)
 		}
 		matched = table
 	}
 
 	if matched == nil {
-		return nil, fmt.Errorf("vstreamclient: unexpected table name: %s", tableName)
+		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vstreamclient: unexpected table name: %s", tableName)
 	}
 
 	return matched, nil
@@ -289,7 +290,7 @@ func validateTableConfig(providedTables, dbTables map[string]*TableConfig) error
 	}
 
 	if len(diffs) > 0 {
-		return fmt.Errorf("vstreamclient: provided tables do not match stored tables: %s", strings.Join(diffs, "; "))
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: provided tables do not match stored tables: %s", strings.Join(diffs, "; "))
 	}
 
 	return nil
@@ -337,14 +338,14 @@ func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]
 	if table.ErrorOnUnknownFields {
 		for _, f := range fields {
 			if _, ok := fieldMap[f.Name]; !ok {
-				return nil, fmt.Errorf("vstreamclient: field %s not found in provided data type", f.Name)
+				return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: field %s not found in provided data type", f.Name)
 			}
 		}
 	}
 
 	// sanity check that we found at least one field
 	if len(fieldMap) == 0 {
-		return nil, fmt.Errorf("vstreamclient: no matching fields found for table %s", table.Table)
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: no matching fields found for table %s", table.Table)
 	}
 
 	return fieldMap, nil
@@ -449,11 +450,11 @@ func (table *TableConfig) validateRowChangeForDefaultDecoding(rc *binlogdatapb.R
 	qualifiedName := qualifiedTableName(table.Keyspace, table.Table)
 
 	if rc.JsonPartialValues != nil {
-		return fmt.Errorf("vstreamclient: partial JSON updates are unsupported for default decoding on table %s; implement VStreamScanner to handle RowChange bitmaps explicitly", qualifiedName)
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: partial JSON updates are unsupported for default decoding on table %s; implement VStreamScanner to handle RowChange bitmaps explicitly", qualifiedName)
 	}
 
 	if rc.DataColumns != nil {
-		return fmt.Errorf("vstreamclient: partial row images are unsupported for default decoding on table %s; implement VStreamScanner to handle RowChange bitmaps explicitly", qualifiedName)
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: partial row images are unsupported for default decoding on table %s; implement VStreamScanner to handle RowChange bitmaps explicitly", qualifiedName)
 	}
 
 	return nil
@@ -462,7 +463,7 @@ func (table *TableConfig) validateRowChangeForDefaultDecoding(rc *binlogdatapb.R
 func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats *VStreamStats) error {
 	shard, ok := table.shards[ev.Shard]
 	if !ok {
-		return fmt.Errorf("vstreamclient: unexpected shard: %s", ev.Shard)
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vstreamclient: unexpected shard: %s", ev.Shard)
 	}
 
 	table.currentBatch = slices.Grow(table.currentBatch, len(ev.RowChanges))

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -149,11 +149,11 @@ func (v *VStreamClient) initTables(tables []TableConfig) error {
 		}
 
 		if table.Keyspace == "" {
-			return fmt.Errorf("vstreamclient: table %v has no keyspace", table)
+			return fmt.Errorf("vstreamclient: table %q has no keyspace", table.Table)
 		}
 
 		if table.Table == "" {
-			return fmt.Errorf("vstreamclient: table %v has no table name", table)
+			return fmt.Errorf("vstreamclient: table in keyspace %q has no table name", table.Keyspace)
 		}
 		if table.FlushFn == nil {
 			return fmt.Errorf("vstreamclient: table %s.%s has no flush function", table.Keyspace, table.Table)

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -448,7 +448,7 @@ func parseTagName(tag string) string {
 }
 
 func (table *TableConfig) validateRowChangeForDefaultDecoding(rc *binlogdatapb.RowChange) error {
-	if table.implementsScanner || rc == nil || rc.After == nil {
+	if table.implementsScanner || rc.After == nil {
 		return nil
 	}
 
@@ -474,6 +474,9 @@ func (table *TableConfig) handleRowEvent(ev *binlogdatapb.RowEvent, vstreamStats
 	table.currentBatch = slices.Grow(table.currentBatch, len(ev.RowChanges))
 
 	for _, rc := range ev.RowChanges {
+		if rc == nil || (rc.Before == nil && rc.After == nil) {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vstreamclient: row change has neither a before nor an after image for table %s", qualifiedTableName(table.Keyspace, table.Table))
+		}
 		if err := table.validateRowChangeForDefaultDecoding(rc); err != nil {
 			return err
 		}

--- a/go/vt/vstreamclient/table.go
+++ b/go/vt/vstreamclient/table.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vstreamclient
 
 import (
+	"cmp"
 	"fmt"
 	"reflect"
 	"slices"
@@ -100,20 +101,29 @@ type TableStats struct {
 
 // shardConfig is the per-shard configuration for a table, which is used to scan the results
 type shardConfig struct {
-	fieldMap map[string]fieldMapping
-	fields   []*querypb.Field
+	fieldMappings []fieldMapping
+	fields        []*querypb.Field
 }
 
 // fieldMapping caches the mapping of table fields to struct fields, to reduce reflection overhead. This is
 // configured once per shard, and used for all rows in that shard, unless a DDL event changes the schema,
 // in which case the mapping is updated.
 type fieldMapping struct {
+	name        string
 	rowIndex    int
 	structIndex []int
 	structType  reflect.Type
 	kind        reflect.Kind
 	isPointer   bool
 	jsonDecode  bool
+
+	// Whether the addressable field implements the interfaces tryScanSpecialField
+	// looks for. These depend only on the struct type, so resolving them per row
+	// costs two reflect.Type.Implements calls and a reflect.Type.ptrTo allocation
+	// for an answer that cannot change.
+	isTime                    bool
+	implementsSQLScanner      bool
+	implementsTextUnmarshaler bool
 }
 
 // TODO: there's a consolidation issue to deal with here. Someone could easily add a new table in
@@ -318,25 +328,25 @@ func (table *TableConfig) resetBatch() {
 }
 
 func (table *TableConfig) handleFieldEvent(ev *binlogdatapb.FieldEvent) error {
-	var fieldMap map[string]fieldMapping
+	var fieldMappings []fieldMapping
 	var err error
 
 	if !table.implementsScanner {
-		fieldMap, err = table.reflectMapFields(ev.Fields)
+		fieldMappings, err = table.reflectMapFields(ev.Fields)
 		if err != nil {
 			return err
 		}
 	}
 
 	table.shards[ev.Shard] = shardConfig{
-		fieldMap: fieldMap,
-		fields:   ev.Fields,
+		fieldMappings: fieldMappings,
+		fields:        ev.Fields,
 	}
 
 	return nil
 }
 
-func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]fieldMapping, error) {
+func (table *TableConfig) reflectMapFields(fields []*querypb.Field) ([]fieldMapping, error) {
 	fieldMap := make(map[string]fieldMapping, len(fields))
 	table.reflectMapStructFields(table.underlyingType, nil, fields, fieldMap)
 
@@ -353,7 +363,18 @@ func (table *TableConfig) reflectMapFields(fields []*querypb.Field) (map[string]
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: no matching fields found for table %s", table.Table)
 	}
 
-	return fieldMap, nil
+	// Every row iterates these mappings, so hand back a slice rather than the
+	// map: it drops the map iterator per row and reads in wire order. Sorting
+	// by rowIndex also makes multi-field errors deterministic.
+	mappings := make([]fieldMapping, 0, len(fieldMap))
+	for _, mapping := range fieldMap {
+		mappings = append(mappings, mapping)
+	}
+	slices.SortFunc(mappings, func(a, b fieldMapping) int {
+		return cmp.Compare(a.rowIndex, b.rowIndex)
+	})
+
+	return mappings, nil
 }
 
 func (table *TableConfig) reflectMapStructFields(structType reflect.Type, indexPrefix []int, fields []*querypb.Field, fieldMap map[string]fieldMapping) {
@@ -395,13 +416,20 @@ func (table *TableConfig) reflectMapStructFields(structType reflect.Type, indexP
 				fieldType = fieldType.Elem()
 			}
 
+			// copyRowToStructInLocation dereferences pointer fields before
+			// scanning, so the addressable value is always *fieldType.
+			addrType := reflect.PointerTo(fieldType)
 			fieldMap[mappedFieldName] = fieldMapping{
-				rowIndex:    j,
-				structIndex: fullIndex,
-				structType:  fieldType,
-				kind:        fieldType.Kind(),
-				isPointer:   isPointer,
-				jsonDecode:  jsonDecode,
+				name:                      mappedFieldName,
+				rowIndex:                  j,
+				structIndex:               fullIndex,
+				structType:                fieldType,
+				kind:                      fieldType.Kind(),
+				isPointer:                 isPointer,
+				jsonDecode:                jsonDecode,
+				isTime:                    fieldType == timeType,
+				implementsSQLScanner:      addrType.Implements(sqlScannerType),
+				implementsTextUnmarshaler: addrType.Implements(textUnmarshalerType),
 			}
 		}
 	}

--- a/go/vt/vstreamclient/table_test.go
+++ b/go/vt/vstreamclient/table_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResetBatch_ReuseBatchSlice pins the batch reuse contract deterministically: the test holds a
+// reference into the previous batch's backing array, so with reuse enabled the next batch must
+// land at the same address, and with reuse disabled it cannot (the held reference keeps the old
+// array alive, so the allocator cannot hand the same memory back).
+func TestResetBatch_ReuseBatchSlice(t *testing.T) {
+	newTable := func(reuse bool) *TableConfig {
+		table := &TableConfig{
+			Keyspace:        "ks",
+			Table:           "t",
+			MaxRowsPerFlush: 4,
+			ReuseBatchSlice: reuse,
+		}
+		table.resetBatch()
+		return table
+	}
+
+	t.Run("reuses the backing array when enabled", func(t *testing.T) {
+		table := newTable(true)
+		table.currentBatch = append(table.currentBatch, Row{Data: "first"})
+		held := &table.currentBatch[0]
+
+		table.resetBatch()
+		require.Empty(t, table.currentBatch)
+
+		table.currentBatch = append(table.currentBatch, Row{Data: "second"})
+		assert.Same(t, held, &table.currentBatch[0])
+	})
+
+	t.Run("allocates a fresh array when disabled", func(t *testing.T) {
+		table := newTable(false)
+		table.currentBatch = append(table.currentBatch, Row{Data: "first"})
+		held := &table.currentBatch[0]
+
+		table.resetBatch()
+		require.Empty(t, table.currentBatch)
+
+		table.currentBatch = append(table.currentBatch, Row{Data: "second"})
+		assert.NotSame(t, held, &table.currentBatch[0])
+	})
+
+	t.Run("clears retained row data when reusing", func(t *testing.T) {
+		table := newTable(true)
+		table.currentBatch = append(table.currentBatch, Row{Data: "first"})
+
+		table.resetBatch()
+
+		// slices.Delete must zero the vacated elements so reused batches don't leak the
+		// previous batch's rows to the garbage collector or to the next flush
+		spare := table.currentBatch[:1]
+		assert.Nil(t, spare[0].Data)
+	})
+}

--- a/go/vt/vstreamclient/table_test.go
+++ b/go/vt/vstreamclient/table_test.go
@@ -21,7 +21,31 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
+
+func TestHandleRowEvent_RejectsMissingRowImages(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		change *binlogdatapb.RowChange
+	}{
+		{name: "nil row change"},
+		{name: "missing images", change: &binlogdatapb.RowChange{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			table := &TableConfig{Keyspace: "ks", Table: "t", shards: map[string]shardConfig{"0": {}}}
+			stats := &VStreamStats{}
+			var err error
+			require.NotPanics(t, func() {
+				err = table.handleRowEvent(&binlogdatapb.RowEvent{TableName: "ks.t", Shard: "0", RowChanges: []*binlogdatapb.RowChange{tt.change}}, stats)
+			})
+			require.ErrorContains(t, err, "row change has neither a before nor an after image")
+			assert.Empty(t, table.currentBatch)
+			assert.Zero(t, stats.RowDeleteCount)
+		})
+	}
+}
 
 // TestResetBatch_ReuseBatchSlice pins the batch reuse contract deterministically: the test holds a
 // reference into the previous batch's backing array, so with reuse enabled the next batch must

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -1,0 +1,222 @@
+package vstreamclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	_ "vitess.io/vitess/go/vt/vtctl/grpcvtctlclient"
+	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+// VStreamClient is the primary struct
+type VStreamClient struct {
+	name string
+	conn *vtgateconn.VTGateConn
+
+	// this session is used to obtain the shards for the keyspace, and to manage the state table
+	session *vtgateconn.VTGateSession
+
+	// the reader is the vstream reader, which is used to read the binlog events
+	reader vtgateconn.VStreamReader
+	filter *binlogdatapb.Filter
+	flags  *vtgatepb.VStreamFlags
+
+	// vgtidStateKeyspace and vgtidStateTable are the keyspace and table where the last VGtid is stored
+	vgtidStateKeyspace string
+	vgtidStateTable    string
+
+	// may not be necessary...
+	shardsByKeyspace map[string][]string
+
+	// keep per table state and config, which is used to generate the vgtid filter.
+	// this is a map of keyspace.table to TableConfig, since that's how the binlog table is stored
+	tables map[string]*TableConfig
+
+	// to avoid flushing too often, we will only flush if it has been at least minFlushDuration since the last flush.
+	// we're relying on heartbeat events to handle max duration between flushes, in case there are no other events.
+	minFlushDuration time.Duration
+
+	// this is the duration between heartbeat events. This is not a duration because the server side
+	// parameter only has a granularity of seconds.
+	heartbeatSeconds int
+
+	// lastEventReceivedAtUnix is the time the last event was received, which is used in the heartbeat monitor
+	// to let us know if we've been disconnected from the stream.
+	lastEventReceivedAtUnix atomic.Int64
+	// lastFlushedVgtid is the last vgtid that was flushed, which is compared to the latestVgtid to determine
+	// if we need to flush again.
+	lastFlushedVgtid, latestVgtid *binlogdatapb.VGtid
+
+	stats VStreamStats
+
+	// these are the optional functions that are called for each event type
+	eventFuncs map[binlogdatapb.VEventType]EventFunc
+}
+
+// VStreamStats keeps track of the number of rows processed and flushed for the whole stream
+type VStreamStats struct {
+	// how many rows have been processed for the whole stream, across all tables. These are incremented as each row
+	// is processed, regardless of whether it is flushed.
+	RowInsertCount int
+	RowUpdateCount int
+	RowDeleteCount int
+
+	FlushedRowCount int // sum of rows flushed, regardless of table and including all insert/update/delete events
+
+	// how many times the flush function was executed for the whole stream. Not incremented for no-ops
+	FlushCount int
+	// sum of successful, individual, table flush functions. Only increments if the table flush func is called
+	TableFlushCount int
+
+	LastFlushedAt time.Time // only set after a flush successfully completes
+}
+
+// New initializes a new VStreamClient, which is used to stream binlog events from Vitess.
+func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables []TableConfig, opts ...Option) (*VStreamClient, error) {
+	// validate required parameters
+	if len(name) > 64 {
+		return nil, fmt.Errorf("vstreamclient: name must be 64 characters or less, got %d", len(name))
+	}
+
+	if conn == nil {
+		return nil, fmt.Errorf("vstreamclient: conn is required")
+	}
+
+	// initialize the VStreamClient, with options and settings to be set later
+	v := &VStreamClient{
+		name:             name,
+		conn:             conn,
+		session:          conn.Session("", nil),
+		tables:           make(map[string]*TableConfig),
+		minFlushDuration: DefaultMinFlushDuration,
+	}
+
+	var err error
+
+	// load all shards, so we can validate settings before starting. It's not technically necessary to do this here,
+	// but it's more user-friendly to fail early if there is misconfiguration. This needs to be done before running
+	// the options, so that the shards are available for validation.
+	v.shardsByKeyspace, err = getShardsByKeyspace(ctx, v.session)
+	if err != nil {
+		return nil, err
+	}
+
+	err = v.initTables(tables)
+	if err != nil {
+		return nil, err
+	}
+
+	// set options from the variadic list
+	for _, opt := range opts {
+		if err = opt(v); err != nil {
+			return nil, err
+		}
+	}
+
+	// validate required options and set defaults where possible
+
+	if len(v.tables) == 0 {
+		return nil, fmt.Errorf("vstreamclient: no tables configured")
+	}
+
+	// convert the tables into filter + rules
+
+	rules := make([]*binlogdatapb.Rule, 0, len(v.tables))
+
+	for _, table := range v.tables {
+		rules = append(rules, &binlogdatapb.Rule{
+			Match:  table.Keyspace,
+			Filter: table.Query,
+		})
+	}
+
+	v.filter = &binlogdatapb.Filter{
+		Rules: rules,
+	}
+
+	if v.flags == nil {
+		v.flags = DefaultFlags()
+		if v.heartbeatSeconds > 0 {
+			v.flags.HeartbeatInterval = uint32(v.heartbeatSeconds)
+		}
+	}
+
+	// handle state lookup
+
+	err = initStateTable(ctx, v.session, v.vgtidStateKeyspace, v.vgtidStateTable)
+	if err != nil {
+		return nil, err
+	}
+
+	var storedTableConfig map[string]*TableConfig
+	var copyCompleted bool
+	v.latestVgtid, storedTableConfig, copyCompleted, err = getLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.latestVgtid == nil {
+		// we need to bootstrap the stream, which means we need to create a new vgtid and store the table config
+		v.latestVgtid, err = initVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.tables, v.shardsByKeyspace)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// we need to check if the tables have changed since the last stream, to make
+		// sure users aren't expecting to catch up on a new table that was added after the last stream.
+		err = validateTableConfig(v.tables, storedTableConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		// since we have a vgtid, but the copy never completed, vstream docs say we need to restart from the beginning
+		if !copyCompleted {
+			// TODO: we could probably handle the recovery, by resetting the vgtid to nil, and calling some user
+			//       defined function to have them truncate/recreate the intended destination tables.
+			return nil, errors.New("vstreamclient: copy phase not completed, need to restart stream")
+		}
+	}
+
+	// initialize the streamer
+
+	v.reader, err = conn.VStream(ctx, topodatapb.TabletType_REPLICA, v.latestVgtid, v.filter, v.flags)
+	if err != nil {
+		return nil, fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
+	}
+
+	return v, nil
+}
+
+// Close closes the VStreamClient, which stops the stream and cleans up resources.
+func (v *VStreamClient) Close(ctx context.Context) error {
+	return nil
+}
+
+func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession) (map[string][]string, error) {
+	query := "SHOW VITESS_SHARDS"
+	result, err := session.Execute(ctx, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("vstreamclient: failed to get shards by keyspace: %w", err)
+	}
+
+	shardsByKeyspace := make(map[string][]string)
+
+	for _, row := range result.Rows {
+		keyspace, shard, found := strings.Cut(row[0].ToString(), "/")
+		if !found {
+			return nil, fmt.Errorf("vstreamclient: failed to parse keyspace_id: %s", row[0].ToString())
+		}
+
+		shardsByKeyspace[keyspace] = append(shardsByKeyspace[keyspace], shard)
+	}
+
+	return shardsByKeyspace, nil
+}

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -51,9 +51,9 @@ type VStreamClient struct {
 	// parameter only has a granularity of seconds.
 	heartbeatSeconds int
 
-	// lastEventProcessedAtUnixNano is the time after the last event was processed, including time for the user
-	// provided flush function to complete, which is used in the heartbeat monitor to let us know if we've been
-	// disconnected from the stream.
+	// lastEventProcessedAtUnixNano is the time after the last event batch was processed, including time for the
+	// user provided flush function to complete. A zero value means Run has not successfully processed any events yet,
+	// so heartbeat liveness checks should not trigger startup cancellation.
 	lastEventProcessedAtUnixNano atomic.Int64
 	isProcessingEvents           atomic.Bool
 

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -20,21 +20,13 @@ import (
 
 // VStreamClient is the primary struct
 type VStreamClient struct {
-	name string
-	conn *vtgateconn.VTGateConn
+	cfg clientConfig
 
 	// this session is used to obtain the shards for the keyspace, and to manage the state table
 	session *vtgateconn.VTGateSession
 
 	// the reader is the vstream reader, which is used to read the binlog events
-	reader     vtgateconn.VStreamReader
-	filter     *binlogdatapb.Filter
-	flags      *vtgatepb.VStreamFlags
-	tabletType topodatapb.TabletType
-
-	// vgtidStateKeyspace and vgtidStateTable are the keyspace and table where the last VGtid is stored
-	vgtidStateKeyspace string
-	vgtidStateTable    string
+	reader vtgateconn.VStreamReader
 
 	// may not be necessary...
 	shardsByKeyspace map[string][]string
@@ -42,14 +34,6 @@ type VStreamClient struct {
 	// keep per table state and config, which is used to generate the vgtid filter.
 	// this is a map of keyspace.table to TableConfig, since that's how the binlog table is stored
 	tables map[string]*TableConfig
-
-	// to avoid flushing too often, we will only flush if it has been at least minFlushDuration since the last flush.
-	// we're relying on heartbeat events to handle max duration between flushes, in case there are no other events.
-	minFlushDuration time.Duration
-
-	// this is the duration between heartbeat events. This is not a duration because the server side
-	// parameter only has a granularity of seconds.
-	heartbeatSeconds int
 
 	// lastEventProcessedAtUnixNano is the time after the last event batch was processed, including time for the
 	// user provided flush function to complete. A zero value means Run has not successfully processed any events yet,
@@ -63,15 +47,36 @@ type VStreamClient struct {
 
 	stats VStreamStats
 
-	// these are the optional functions that are called for each event type
-	eventFuncs map[binlogdatapb.VEventType]EventFunc
-
 	lifecycle lifecycleState
+}
 
-	// these fields configure how graceful shutdown is requested from outside the run loop.
+type clientConfig struct {
+	name string
+	conn *vtgateconn.VTGateConn
+
+	filter     *binlogdatapb.Filter
+	flags      *vtgatepb.VStreamFlags
+	tabletType topodatapb.TabletType
+
+	// vgtidStateKeyspace and vgtidStateTable are the keyspace and table where the last VGtid is stored
+	vgtidStateKeyspace string
+	vgtidStateTable    string
+
+	// to avoid flushing too often, we will only flush if it has been at least minFlushDuration since the last flush.
+	// we're relying on heartbeat events to handle max duration between flushes, in case there are no other events.
+	minFlushDuration time.Duration
+
+	// this is the duration between heartbeat events. This is not a duration because the server side
+	// parameter only has a granularity of seconds.
+	heartbeatSeconds int
+
+	// these fields configure how graceful shutdown is configured
 	gracefulShutdownChan    <-chan struct{}
 	gracefulShutdownSignals []os.Signal
 	gracefulShutdownWaitDur time.Duration
+
+	// eventFuncs is a map of event type to the user provided function that should be called for that event type.
+	eventFuncs map[binlogdatapb.VEventType]EventFunc
 }
 
 type lifecycleState struct {
@@ -120,13 +125,15 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 	// initialize the VStreamClient, with options and settings to be set later
 	v := &VStreamClient{
-		name:                    name,
-		conn:                    conn,
-		session:                 conn.Session("", nil),
-		tables:                  make(map[string]*TableConfig),
-		minFlushDuration:        DefaultMinFlushDuration,
-		tabletType:              topodatapb.TabletType_REPLICA,
-		gracefulShutdownWaitDur: DefaultGracefulShutdownWaitDur,
+		cfg: clientConfig{
+			name:                    name,
+			conn:                    conn,
+			minFlushDuration:        DefaultMinFlushDuration,
+			tabletType:              topodatapb.TabletType_REPLICA,
+			gracefulShutdownWaitDur: DefaultGracefulShutdownWaitDur,
+		},
+		session: conn.Session("", nil),
+		tables:  make(map[string]*TableConfig),
 	}
 
 	var err error
@@ -168,34 +175,34 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		})
 	}
 
-	v.filter = &binlogdatapb.Filter{
+	v.cfg.filter = &binlogdatapb.Filter{
 		Rules: rules,
 	}
 
-	if v.flags == nil {
-		v.flags = DefaultFlags()
+	if v.cfg.flags == nil {
+		v.cfg.flags = DefaultFlags()
 	}
 
-	if v.flags.HeartbeatInterval == 0 {
+	if v.cfg.flags.HeartbeatInterval == 0 {
 		return nil, errors.New("vstreamclient: HeartbeatInterval must be positive")
 	}
-	if v.heartbeatSeconds > 0 {
-		v.flags.HeartbeatInterval = uint32(v.heartbeatSeconds)
+	if v.cfg.heartbeatSeconds > 0 {
+		v.cfg.flags.HeartbeatInterval = uint32(v.cfg.heartbeatSeconds)
 	}
 
 	// handle state lookup
-	if v.vgtidStateKeyspace == "" || v.vgtidStateTable == "" {
+	if v.cfg.vgtidStateKeyspace == "" || v.cfg.vgtidStateTable == "" {
 		return nil, errors.New("vstreamclient: state table not configured (use WithStateTable)")
 	}
 
 	explicitStartingVGtid := v.latestVgtid
 
-	err = initStateTable(ctx, v.session, v.vgtidStateKeyspace, v.vgtidStateTable)
+	err = initStateTable(ctx, v.session, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)
 	if err != nil {
 		return nil, err
 	}
 
-	storedVGtid, storedTableConfig, copyCompleted, err := getLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable)
+	storedVGtid, storedTableConfig, copyCompleted, err := getLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)
 	if err != nil {
 		return nil, err
 	}
@@ -206,14 +213,14 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	switch {
 	case useExplicitStartingVGtid:
 		// if the caller explicitly provided a starting point, prefer it over persisted state.
-		err = initStartingVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.latestVgtid, v.tables)
+		err = initStartingVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.latestVgtid, v.tables)
 		if err != nil {
 			return nil, err
 		}
 
 	case v.latestVgtid == nil:
 		// we need to bootstrap the stream, which means we need to create a new vgtid and store the table config
-		v.latestVgtid, err = initVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.tables, v.shardsByKeyspace)
+		v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.tables, v.shardsByKeyspace)
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +235,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 		// since we have a vgtid, but the copy never completed, restart the copy from the beginning
 		if !copyCompleted {
-			v.latestVgtid, err = initVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.tables, v.shardsByKeyspace)
+			v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.tables, v.shardsByKeyspace)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -195,6 +196,9 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	if v.cfg.heartbeatSeconds > 0 {
 		v.cfg.flags.HeartbeatInterval = uint32(v.cfg.heartbeatSeconds)
 	}
+	if err = validateTableNameMode(v.tables, v.cfg.flags); err != nil {
+		return nil, err
+	}
 
 	// handle state lookup
 	if v.cfg.vgtidStateKeyspace == "" || v.cfg.vgtidStateTable == "" {
@@ -372,4 +376,32 @@ func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession)
 	}
 
 	return shardsByKeyspace, nil
+}
+
+func validateTableNameMode(tables map[string]*TableConfig, flags *vtgatepb.VStreamFlags) error {
+	if flags == nil || !flags.ExcludeKeyspaceFromTableName {
+		return nil
+	}
+
+	keyspacesByTable := make(map[string][]string)
+	for _, table := range tables {
+		keyspacesByTable[table.Table] = append(keyspacesByTable[table.Table], table.Keyspace)
+	}
+
+	var ambiguous []string
+	for tableName, keyspaces := range keyspacesByTable {
+		if len(keyspaces) < 2 {
+			continue
+		}
+
+		slices.Sort(keyspaces)
+		ambiguous = append(ambiguous, fmt.Sprintf("%s (%s)", tableName, strings.Join(keyspaces, ", ")))
+	}
+
+	if len(ambiguous) == 0 {
+		return nil
+	}
+
+	slices.Sort(ambiguous)
+	return fmt.Errorf("vstreamclient: ExcludeKeyspaceFromTableName cannot be used with same-named tables across keyspaces: %s", strings.Join(ambiguous, "; "))
 }

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -25,9 +27,10 @@ type VStreamClient struct {
 	session *vtgateconn.VTGateSession
 
 	// the reader is the vstream reader, which is used to read the binlog events
-	reader vtgateconn.VStreamReader
-	filter *binlogdatapb.Filter
-	flags  *vtgatepb.VStreamFlags
+	reader     vtgateconn.VStreamReader
+	filter     *binlogdatapb.Filter
+	flags      *vtgatepb.VStreamFlags
+	tabletType topodatapb.TabletType
 
 	// vgtidStateKeyspace and vgtidStateTable are the keyspace and table where the last VGtid is stored
 	vgtidStateKeyspace string
@@ -48,9 +51,12 @@ type VStreamClient struct {
 	// parameter only has a granularity of seconds.
 	heartbeatSeconds int
 
-	// lastEventReceivedAtUnix is the time the last event was received, which is used in the heartbeat monitor
-	// to let us know if we've been disconnected from the stream.
-	lastEventReceivedAtUnix atomic.Int64
+	// lastEventProcessedAtUnixNano is the time after the last event was processed, including time for the user
+	// provided flush function to complete, which is used in the heartbeat monitor to let us know if we've been
+	// disconnected from the stream.
+	lastEventProcessedAtUnixNano atomic.Int64
+	isProcessingEvents           atomic.Bool
+
 	// lastFlushedVgtid is the last vgtid that was flushed, which is compared to the latestVgtid to determine
 	// if we need to flush again.
 	lastFlushedVgtid, latestVgtid *binlogdatapb.VGtid
@@ -59,6 +65,17 @@ type VStreamClient struct {
 
 	// these are the optional functions that are called for each event type
 	eventFuncs map[binlogdatapb.VEventType]EventFunc
+
+	// keeping this here allows for us to cancel the context when GracefulShutdown is called
+	cancelRunCtxFn context.CancelFunc
+
+	// these fields are used by the graceful shutdown process
+	isClosing                 atomic.Bool
+	gracefulShutdownFlushChan chan struct{}
+	gracefulShutdownFlushOnce sync.Once
+	gracefulShutdownChan      <-chan struct{}
+	gracefulShutdownSignals   []os.Signal
+	gracefulShutdownWaitDur   time.Duration
 }
 
 // VStreamStats keeps track of the number of rows processed and flushed for the whole stream
@@ -82,21 +99,31 @@ type VStreamStats struct {
 // New initializes a new VStreamClient, which is used to stream binlog events from Vitess.
 func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables []TableConfig, opts ...Option) (*VStreamClient, error) {
 	// validate required parameters
+	if name == "" {
+		return nil, errors.New("vstreamclient: name is required")
+	}
+
 	if len(name) > 64 {
 		return nil, fmt.Errorf("vstreamclient: name must be 64 characters or less, got %d", len(name))
 	}
 
 	if conn == nil {
-		return nil, fmt.Errorf("vstreamclient: conn is required")
+		return nil, errors.New("vstreamclient: conn is required")
 	}
 
 	// initialize the VStreamClient, with options and settings to be set later
 	v := &VStreamClient{
-		name:             name,
-		conn:             conn,
-		session:          conn.Session("", nil),
-		tables:           make(map[string]*TableConfig),
-		minFlushDuration: DefaultMinFlushDuration,
+		name:                    name,
+		conn:                    conn,
+		session:                 conn.Session("", nil),
+		tables:                  make(map[string]*TableConfig),
+		minFlushDuration:        DefaultMinFlushDuration,
+		tabletType:              topodatapb.TabletType_REPLICA,
+		gracefulShutdownWaitDur: DefaultGracefulShutdownWaitDur,
+
+		// we expect this channel to be closed by the last flush operation during GracefulShutdown, whether or not it
+		// succeeds. there is no guarantee that it will be closed before Run exits, if no flush boundary happens.
+		gracefulShutdownFlushChan: make(chan struct{}),
 	}
 
 	var err error
@@ -124,7 +151,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	// validate required options and set defaults where possible
 
 	if len(v.tables) == 0 {
-		return nil, fmt.Errorf("vstreamclient: no tables configured")
+		return nil, errors.New("vstreamclient: no tables configured")
 	}
 
 	// convert the tables into filter + rules
@@ -133,7 +160,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 	for _, table := range v.tables {
 		rules = append(rules, &binlogdatapb.Rule{
-			Match:  table.Keyspace,
+			Match:  table.Table,
 			Filter: table.Query,
 		})
 	}
@@ -144,32 +171,51 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 	if v.flags == nil {
 		v.flags = DefaultFlags()
-		if v.heartbeatSeconds > 0 {
-			v.flags.HeartbeatInterval = uint32(v.heartbeatSeconds)
-		}
+	}
+
+	if v.flags.HeartbeatInterval == 0 {
+		return nil, errors.New("vstreamclient: HeartbeatInterval must be positive")
+	}
+	if v.heartbeatSeconds > 0 {
+		v.flags.HeartbeatInterval = uint32(v.heartbeatSeconds)
 	}
 
 	// handle state lookup
+	if v.vgtidStateKeyspace == "" || v.vgtidStateTable == "" {
+		return nil, errors.New("vstreamclient: state table not configured (use WithStateTable)")
+	}
+
+	explicitStartingVGtid := v.latestVgtid
 
 	err = initStateTable(ctx, v.session, v.vgtidStateKeyspace, v.vgtidStateTable)
 	if err != nil {
 		return nil, err
 	}
 
-	var storedTableConfig map[string]*TableConfig
-	var copyCompleted bool
-	v.latestVgtid, storedTableConfig, copyCompleted, err = getLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable)
+	storedVGtid, storedTableConfig, copyCompleted, err := getLatestVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable)
 	if err != nil {
 		return nil, err
 	}
 
-	if v.latestVgtid == nil {
+	var useExplicitStartingVGtid bool
+	v.latestVgtid, useExplicitStartingVGtid = resolveLatestVGtid(explicitStartingVGtid, storedVGtid)
+
+	switch {
+	case useExplicitStartingVGtid:
+		// if the caller explicitly provided a starting point, prefer it over persisted state.
+		err = initStartingVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.latestVgtid, v.tables)
+		if err != nil {
+			return nil, err
+		}
+
+	case v.latestVgtid == nil:
 		// we need to bootstrap the stream, which means we need to create a new vgtid and store the table config
 		v.latestVgtid, err = initVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.tables, v.shardsByKeyspace)
 		if err != nil {
 			return nil, err
 		}
-	} else {
+
+	default:
 		// we need to check if the tables have changed since the last stream, to make
 		// sure users aren't expecting to catch up on a new table that was added after the last stream.
 		err = validateTableConfig(v.tables, storedTableConfig)
@@ -177,32 +223,66 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 			return nil, err
 		}
 
-		// since we have a vgtid, but the copy never completed, vstream docs say we need to restart from the beginning
+		// since we have a vgtid, but the copy never completed, restart the copy from the beginning
 		if !copyCompleted {
-			// TODO: we could probably handle the recovery, by resetting the vgtid to nil, and calling some user
-			//       defined function to have them truncate/recreate the intended destination tables.
-			return nil, errors.New("vstreamclient: copy phase not completed, need to restart stream")
+			v.latestVgtid, err = initVGtid(ctx, v.session, v.name, v.vgtidStateKeyspace, v.vgtidStateTable, v.tables, v.shardsByKeyspace)
+			if err != nil {
+				return nil, err
+			}
 		}
-	}
-
-	// initialize the streamer
-
-	v.reader, err = conn.VStream(ctx, topodatapb.TabletType_REPLICA, v.latestVgtid, v.filter, v.flags)
-	if err != nil {
-		return nil, fmt.Errorf("vstreamclient: failed to create vstream: %w", err)
 	}
 
 	return v, nil
 }
 
-// Close closes the VStreamClient, which stops the stream and cleans up resources.
-func (v *VStreamClient) Close(ctx context.Context) error {
-	return nil
+func resolveLatestVGtid(explicit, stored *binlogdatapb.VGtid) (*binlogdatapb.VGtid, bool) {
+	if explicit != nil {
+		return explicit, true
+	}
+
+	return stored, false
+}
+
+// GracefulShutdown waits up to the provided duration for the next safe flush boundary,
+// then cancels the active Run call.
+//   - if a safe event happens before the wait ends, buffered rows may be flushed and the
+//     client will stop processing the stream immediately afterward
+//   - if no safe event happens during that window, any buffered rows stay uncheckpointed
+//     and will be reprocessed when the stream is restarted
+//
+// GracefulShutdown returns immediately if wait is 0, or it has already been called.
+//
+// The return value does not guarantee whether one final buffered flush happened before shutdown;
+// uncheckpointed work is replayed on the next startup.
+//
+// GracefulShutdown closes the client immediately. As with any completed Run attempt,
+// call New(...) to create a fresh client before running again.
+func (v *VStreamClient) GracefulShutdown(wait time.Duration) {
+	firstCaller := v.isClosing.CompareAndSwap(false, true)
+	if !firstCaller {
+		return
+	}
+
+	if v.cancelRunCtxFn == nil {
+		return
+	}
+
+	if wait == 0 {
+		v.cancelRunCtxFn()
+		return
+	}
+
+	select {
+	case <-time.After(wait):
+	case <-v.gracefulShutdownFlushChan:
+	}
+
+	v.cancelRunCtxFn()
 }
 
 func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession) (map[string][]string, error) {
 	query := "SHOW VITESS_SHARDS"
-	result, err := session.Execute(ctx, query, nil)
+	result, err := session.Execute(ctx, query, nil, false)
 	if err != nil {
 		return nil, fmt.Errorf("vstreamclient: failed to get shards by keyspace: %w", err)
 	}

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -66,16 +66,23 @@ type VStreamClient struct {
 	// these are the optional functions that are called for each event type
 	eventFuncs map[binlogdatapb.VEventType]EventFunc
 
-	// keeping this here allows for us to cancel the context when GracefulShutdown is called
-	cancelRunCtxFn context.CancelFunc
+	lifecycle lifecycleState
 
-	// these fields are used by the graceful shutdown process
-	isClosing                 atomic.Bool
+	// these fields configure how graceful shutdown is requested from outside the run loop.
+	gracefulShutdownChan    <-chan struct{}
+	gracefulShutdownSignals []os.Signal
+	gracefulShutdownWaitDur time.Duration
+}
+
+type lifecycleState struct {
+	mu                sync.Mutex
+	runUsed           bool
+	runActive         bool
+	shutdownRequested bool
+	cancelRunCtxFn    context.CancelFunc
+
 	gracefulShutdownFlushChan chan struct{}
 	gracefulShutdownFlushOnce sync.Once
-	gracefulShutdownChan      <-chan struct{}
-	gracefulShutdownSignals   []os.Signal
-	gracefulShutdownWaitDur   time.Duration
 }
 
 // VStreamStats keeps track of the number of rows processed and flushed for the whole stream
@@ -120,10 +127,6 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		minFlushDuration:        DefaultMinFlushDuration,
 		tabletType:              topodatapb.TabletType_REPLICA,
 		gracefulShutdownWaitDur: DefaultGracefulShutdownWaitDur,
-
-		// we expect this channel to be closed by the last flush operation during GracefulShutdown, whether or not it
-		// succeeds. there is no guarantee that it will be closed before Run exits, if no flush boundary happens.
-		gracefulShutdownFlushChan: make(chan struct{}),
 	}
 
 	var err error
@@ -258,26 +261,83 @@ func resolveLatestVGtid(explicit, stored *binlogdatapb.VGtid) (*binlogdatapb.VGt
 // GracefulShutdown closes the client immediately. As with any completed Run attempt,
 // call New(...) to create a fresh client before running again.
 func (v *VStreamClient) GracefulShutdown(wait time.Duration) {
-	firstCaller := v.isClosing.CompareAndSwap(false, true)
-	if !firstCaller {
-		return
-	}
-
-	if v.cancelRunCtxFn == nil {
+	cancelRunCtxFn, gracefulShutdownFlushChan, ok := v.requestShutdown()
+	if !ok {
 		return
 	}
 
 	if wait == 0 {
-		v.cancelRunCtxFn()
+		cancelRunCtxFn()
 		return
 	}
 
 	select {
 	case <-time.After(wait):
-	case <-v.gracefulShutdownFlushChan:
+	case <-gracefulShutdownFlushChan:
 	}
 
-	v.cancelRunCtxFn()
+	cancelRunCtxFn()
+}
+
+func (v *VStreamClient) beginRun(cancelRunCtxFn context.CancelFunc) bool {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	if v.lifecycle.runUsed {
+		return false
+	}
+	v.lifecycle.runUsed = true
+	v.lifecycle.runActive = true
+	v.lifecycle.shutdownRequested = false
+	v.lifecycle.cancelRunCtxFn = cancelRunCtxFn
+	v.lifecycle.gracefulShutdownFlushChan = make(chan struct{})
+	v.lifecycle.gracefulShutdownFlushOnce = sync.Once{}
+	return true
+}
+
+func (v *VStreamClient) endRun() {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	v.lifecycle.runActive = false
+	v.lifecycle.shutdownRequested = false
+	v.lifecycle.cancelRunCtxFn = nil
+}
+
+func (v *VStreamClient) requestShutdown() (context.CancelFunc, <-chan struct{}, bool) {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	if !v.lifecycle.runActive || v.lifecycle.shutdownRequested || v.lifecycle.cancelRunCtxFn == nil {
+		return nil, nil, false
+	}
+	v.lifecycle.shutdownRequested = true
+	return v.lifecycle.cancelRunCtxFn, v.lifecycle.gracefulShutdownFlushChan, true
+}
+
+func (v *VStreamClient) isShutdownRequested() bool {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	return v.lifecycle.shutdownRequested
+}
+
+func (v *VStreamClient) getGracefulShutdownFlushChan() <-chan struct{} {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	return v.lifecycle.gracefulShutdownFlushChan
+}
+
+func (v *VStreamClient) signalGracefulShutdownFlushed() {
+	v.lifecycle.mu.Lock()
+	shutdownRequested := v.lifecycle.shutdownRequested
+	gracefulShutdownFlushChan := v.lifecycle.gracefulShutdownFlushChan
+	gracefulShutdownFlushOnce := &v.lifecycle.gracefulShutdownFlushOnce
+	v.lifecycle.mu.Unlock()
+
+	if !shutdownRequested || gracefulShutdownFlushChan == nil {
+		return
+	}
+
+	gracefulShutdownFlushOnce.Do(func() {
+		close(gracefulShutdownFlushChan)
+	})
 }
 
 func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession) (map[string][]string, error) {

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -69,6 +69,7 @@ type clientConfig struct {
 	// this is the duration between heartbeat events. This is not a duration because the server side
 	// parameter only has a granularity of seconds.
 	heartbeatSeconds int
+	timeLocation     *time.Location
 
 	// these fields configure how graceful shutdown is configured
 	gracefulShutdownChan    <-chan struct{}
@@ -129,6 +130,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 			name:                    name,
 			conn:                    conn,
 			minFlushDuration:        DefaultMinFlushDuration,
+			timeLocation:            time.UTC,
 			tabletType:              topodatapb.TabletType_REPLICA,
 			gracefulShutdownWaitDur: DefaultGracefulShutdownWaitDur,
 		},
@@ -156,6 +158,10 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		if err = opt(v); err != nil {
 			return nil, err
 		}
+	}
+
+	for _, table := range v.tables {
+		table.timeLocation = v.cfg.timeLocation
 	}
 
 	// validate required options and set defaults where possible

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -64,6 +64,12 @@ type VStreamClient struct {
 	// if we need to flush again.
 	lastFlushedVgtid, latestVgtid *binlogdatapb.VGtid
 
+	// inTransaction tracks whether the stream is between a BEGIN and its terminating event. Only
+	// touched by the Run goroutine. With TransactionChunkSize enabled, VTGate can deliver a
+	// transaction across multiple batches while heartbeats keep arriving independently, so
+	// heartbeat-triggered flushes must be deferred until the transaction terminates.
+	inTransaction bool
+
 	stats VStreamStats
 
 	lifecycle lifecycleState

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -268,6 +268,11 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		}
 	}
 
+	// every branch above leaves the state table holding exactly latestVgtid, so seed lastFlushedVgtid
+	// with it. Otherwise the first flush on an idle stream would issue a no-op update, which MySQL
+	// reports as RowsAffected=0 and updateLatestVGtid would treat as a missing state row.
+	v.lastFlushedVgtid = v.latestVgtid
+
 	return v, nil
 }
 

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -260,7 +260,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		return nil, err
 	}
 
-	storedVGtid, storedTableConfig, copyCompleted, rowExists, err := getLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)
+	storedVGtid, storedTableConfig, copyCompleted, rowExists, observedOwnerToken, err := getLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)
 	if err != nil {
 		return nil, err
 	}
@@ -303,20 +303,18 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	}
 
 	// claiming ownership and persisting the starting state are the only state-mutating steps,
-	// and they run last. The claim fences out a still-running client with the same stream name;
-	// the follow-up write is predicated on our token, so a stale constructor cannot steal
-	// ownership back from a newer client.
+	// and they run last, as a single compare-and-swap against the owner token observed when
+	// state was read: it fences out a still-running client with the same stream name, while a
+	// stale constructor that lost the race fails with ErrFenced instead of stealing ownership
+	// back from a newer client.
 	if rowExists {
-		err = claimStateOwnership(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken)
+		if persistVGtid != nil {
+			err = updateStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, observedOwnerToken, persistVGtid, v.tables, persistCopyCompleted)
+		} else {
+			err = claimStateOwnership(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, observedOwnerToken)
+		}
 		if err != nil {
 			return nil, err
-		}
-
-		if persistVGtid != nil {
-			err = updateStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, persistVGtid, v.tables, persistCopyCompleted)
-			if err != nil {
-				return nil, err
-			}
 		}
 	} else {
 		err = insertStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, persistVGtid, v.tables, persistCopyCompleted)

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -88,6 +88,12 @@ type clientConfig struct {
 	heartbeatSeconds int
 	timeLocation     *time.Location
 
+	// startupTimeout is how long the client waits for the first event after Run starts before shutting
+	// itself down. heartbeatTimeoutMultiplier controls the liveness window after the first event, as a
+	// multiple of the heartbeat interval.
+	startupTimeout             time.Duration
+	heartbeatTimeoutMultiplier int
+
 	// these fields configure how graceful shutdown is configured
 	gracefulShutdownChan    <-chan struct{}
 	gracefulShutdownSignals []os.Signal
@@ -102,7 +108,7 @@ type lifecycleState struct {
 	runUsed           bool
 	runActive         bool
 	shutdownRequested bool
-	cancelRunCtxFn    context.CancelFunc
+	cancelRunCtxFn    context.CancelCauseFunc
 
 	gracefulShutdownFlushChan chan struct{}
 	gracefulShutdownFlushOnce sync.Once
@@ -144,12 +150,14 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	// initialize the VStreamClient, with options and settings to be set later
 	v := &VStreamClient{
 		cfg: clientConfig{
-			name:                    name,
-			conn:                    conn,
-			minFlushDuration:        DefaultMinFlushDuration,
-			timeLocation:            time.UTC,
-			tabletType:              topodatapb.TabletType_REPLICA,
-			gracefulShutdownWaitDur: DefaultGracefulShutdownWaitDur,
+			name:                       name,
+			conn:                       conn,
+			minFlushDuration:           DefaultMinFlushDuration,
+			timeLocation:               time.UTC,
+			tabletType:                 topodatapb.TabletType_REPLICA,
+			gracefulShutdownWaitDur:    DefaultGracefulShutdownWaitDur,
+			startupTimeout:             DefaultStartupTimeout,
+			heartbeatTimeoutMultiplier: DefaultHeartbeatTimeoutMultiplier,
 		},
 		session: conn.Session("", nil),
 		tables:  make(map[string]*TableConfig),
@@ -299,13 +307,19 @@ func resolveLatestVGtid(explicit, stored *binlogdatapb.VGtid) (*binlogdatapb.VGt
 // GracefulShutdown closes the client immediately. As with any completed Run attempt,
 // call New(...) to create a fresh client before running again.
 func (v *VStreamClient) GracefulShutdown(wait time.Duration) {
+	v.gracefulShutdownWithCause(wait, nil)
+}
+
+// gracefulShutdownWithCause is the internal implementation of GracefulShutdown. The cause, if not nil,
+// is recorded as the cancel cause of the Run context, so Run can surface why the stream was stopped.
+func (v *VStreamClient) gracefulShutdownWithCause(wait time.Duration, cause error) {
 	cancelRunCtxFn, gracefulShutdownFlushChan, ok := v.requestShutdown()
 	if !ok {
 		return
 	}
 
 	if wait == 0 {
-		cancelRunCtxFn()
+		cancelRunCtxFn(cause)
 		return
 	}
 
@@ -314,10 +328,10 @@ func (v *VStreamClient) GracefulShutdown(wait time.Duration) {
 	case <-gracefulShutdownFlushChan:
 	}
 
-	cancelRunCtxFn()
+	cancelRunCtxFn(cause)
 }
 
-func (v *VStreamClient) beginRun(cancelRunCtxFn context.CancelFunc) bool {
+func (v *VStreamClient) beginRun(cancelRunCtxFn context.CancelCauseFunc) bool {
 	v.lifecycle.mu.Lock()
 	defer v.lifecycle.mu.Unlock()
 	if v.lifecycle.runUsed {
@@ -340,7 +354,7 @@ func (v *VStreamClient) endRun() {
 	v.lifecycle.cancelRunCtxFn = nil
 }
 
-func (v *VStreamClient) requestShutdown() (context.CancelFunc, <-chan struct{}, bool) {
+func (v *VStreamClient) requestShutdown() (context.CancelCauseFunc, <-chan struct{}, bool) {
 	v.lifecycle.mu.Lock()
 	defer v.lifecycle.mu.Unlock()
 	if !v.lifecycle.runActive || v.lifecycle.shutdownRequested || v.lifecycle.cancelRunCtxFn == nil {

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -242,14 +242,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		return nil, err
 	}
 
-	// claim ownership before reading state, so a still-running client with the same stream name is
-	// fenced out before we decide where to resume from
-	err = claimStateOwnership(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken)
-	if err != nil {
-		return nil, err
-	}
-
-	storedVGtid, storedTableConfig, copyCompleted, err := getLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)
+	storedVGtid, storedTableConfig, copyCompleted, rowExists, err := getLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)
 	if err != nil {
 		return nil, err
 	}
@@ -257,35 +250,60 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	var useExplicitStartingVGtid bool
 	v.latestVgtid, useExplicitStartingVGtid = resolveLatestVGtid(explicitStartingVGtid, storedVGtid)
 
-	switch {
-	case useExplicitStartingVGtid:
-		// if the caller explicitly provided a starting point, prefer it over persisted state.
-		err = initStartingVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, v.latestVgtid, v.tables)
-		if err != nil {
-			return nil, err
-		}
-
-	case v.latestVgtid == nil:
-		// we need to bootstrap the stream, which means we need to create a new vgtid and store the table config
-		v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, v.tables, v.shardsByKeyspace)
-		if err != nil {
-			return nil, err
-		}
-
-	default:
-		// we need to check if the tables have changed since the last stream, to make
-		// sure users aren't expecting to catch up on a new table that was added after the last stream.
+	// validate before mutating any state, so a constructor that fails can never leave a healthy
+	// running client fenced. Resuming from stored state requires the tables to still match, to
+	// make sure users aren't expecting to catch up on a table that was added after the last run.
+	if !useExplicitStartingVGtid && storedVGtid != nil {
 		err = validateTableConfig(v.tables, storedTableConfig)
 		if err != nil {
 			return nil, err
 		}
+	}
 
-		// since we have a vgtid, but the copy never completed, restart the copy from the beginning
-		if !copyCompleted {
-			v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, v.tables, v.shardsByKeyspace)
+	// decide what needs to be persisted
+	var persistVGtid *binlogdatapb.VGtid
+	var persistCopyCompleted bool
+
+	switch {
+	case useExplicitStartingVGtid:
+		// the caller explicitly provided a starting point: prefer it over persisted state, and
+		// persist copy_completed so no copy phase runs, now or on restart
+		persistVGtid, persistCopyCompleted = v.latestVgtid, true
+
+	case v.latestVgtid == nil, !copyCompleted:
+		// either there is no usable stored position, or the previous copy never finished:
+		// (re)start the copy from the beginning with a fresh vgtid, and reset copy_completed
+		// so a crash mid-copy is never mistaken for completed state
+		v.latestVgtid, err = newVGtid(v.tables, v.shardsByKeyspace)
+		if err != nil {
+			return nil, err
+		}
+		persistVGtid, persistCopyCompleted = v.latestVgtid, false
+
+	default:
+		// resume from the stored checkpoint; nothing to persist beyond claiming ownership
+	}
+
+	// claiming ownership and persisting the starting state are the only state-mutating steps,
+	// and they run last. The claim fences out a still-running client with the same stream name;
+	// the follow-up write is predicated on our token, so a stale constructor cannot steal
+	// ownership back from a newer client.
+	if rowExists {
+		err = claimStateOwnership(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken)
+		if err != nil {
+			return nil, err
+		}
+
+		if persistVGtid != nil {
+			err = updateStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, persistVGtid, v.tables, persistCopyCompleted)
 			if err != nil {
 				return nil, err
 			}
+		}
+	} else {
+		err = insertStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, persistVGtid, v.tables, persistCopyCompleted)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -19,6 +19,7 @@ package vstreamclient
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
 	"slices"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
@@ -198,6 +200,11 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	}
 
 	err = validateKeyspaceRuleSets(v.tables)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateBinlogRowImage(ctx, conn, v.tables)
 	if err != nil {
 		return nil, err
 	}
@@ -476,6 +483,38 @@ func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession)
 	}
 
 	return shardsByKeyspace, nil
+}
+
+// validateBinlogRowImage checks that every streamed source keyspace uses binlog_row_image=FULL.
+// With NOBLOB or MINIMAL, delete before-images can omit column values in a way that is
+// indistinguishable from SQL NULL to both the default decoder and custom scanners, silently
+// corrupting nullable fields downstream. If the setting cannot be queried (e.g. restricted
+// permissions), a warning is logged and the check is skipped.
+func validateBinlogRowImage(ctx context.Context, conn *vtgateconn.VTGateConn, tables map[string]*TableConfig) error {
+	keyspaces := make(map[string]bool)
+	for _, table := range tables {
+		keyspaces[table.Keyspace] = true
+	}
+
+	for _, keyspace := range slices.Sorted(maps.Keys(keyspaces)) {
+		session := conn.Session(keyspace, nil)
+		result, err := session.Execute(ctx, "select @@global.binlog_row_image", nil, false)
+		if err != nil || len(result.Rows) == 0 || len(result.Rows[0]) == 0 {
+			log.Warn(
+				"vstreamclient: could not verify binlog_row_image; delete events may be silently corrupted unless it is FULL",
+				slog.String("keyspace", keyspace),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		rowImage := result.Rows[0][0].ToString()
+		if !strings.EqualFold(rowImage, "FULL") {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s uses binlog_row_image=%s, but this client requires FULL: with partial row images, omitted delete before-image values are indistinguishable from NULL", keyspace, rowImage)
+		}
+	}
+
+	return nil
 }
 
 // validateKeyspaceRuleSets rejects configurations whose (table, query) rule sets differ across

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -19,6 +19,7 @@ package vstreamclient
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -181,6 +182,11 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	}
 
 	err = v.initTables(tables)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateKeyspaceRuleSets(v.tables)
 	if err != nil {
 		return nil, err
 	}
@@ -418,6 +424,39 @@ func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession)
 	}
 
 	return shardsByKeyspace, nil
+}
+
+// validateKeyspaceRuleSets rejects configurations whose (table, query) rule sets differ across
+// keyspaces. A single vstream filter is forwarded to every keyspace in the vgtid, so with
+// heterogeneous sets each keyspace would also receive the other keyspaces' rules: the copy phase
+// can fail on tables that don't exist there, and if a same-named foreign table does exist, its
+// rows are streamed and then rejected or misrouted by this client.
+func validateKeyspaceRuleSets(tables map[string]*TableConfig) error {
+	rulesByKeyspace := make(map[string][]string)
+	for _, table := range tables {
+		rulesByKeyspace[table.Keyspace] = append(rulesByKeyspace[table.Keyspace], table.Table+" -> "+table.Query)
+	}
+
+	if len(rulesByKeyspace) <= 1 {
+		return nil
+	}
+
+	var referenceKeyspace, referenceRules string
+	for _, keyspace := range slices.Sorted(maps.Keys(rulesByKeyspace)) {
+		rules := rulesByKeyspace[keyspace]
+		slices.Sort(rules)
+		joined := strings.Join(rules, "; ")
+
+		if referenceKeyspace == "" {
+			referenceKeyspace, referenceRules = keyspace, joined
+			continue
+		}
+		if joined != referenceRules {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspaces %s and %s have different table/query sets, but a single vstream filter applies every rule to every keyspace; configure identical sets per keyspace or use a separate client per keyspace", referenceKeyspace, keyspace)
+		}
+	}
+
+	return nil
 }
 
 func validateTableNameMode(tables map[string]*TableConfig, flags *vtgatepb.VStreamFlags) error {

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -44,10 +44,8 @@ type VStreamClient struct {
 	// this session is used to obtain the shards for the keyspace, and to manage the state table
 	session *vtgateconn.VTGateSession
 
-	// the reader is the vstream reader, which is used to read the binlog events
-	reader vtgateconn.VStreamReader
-
-	// may not be necessary...
+	// shardsByKeyspace caches the cluster's serving shards per keyspace, used to validate
+	// configured keyspaces and to bootstrap the initial vgtid
 	shardsByKeyspace map[string][]string
 
 	// keep per table state and config, which is used to generate the vgtid filter.
@@ -199,10 +197,6 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 	// validate required options and set defaults where possible
 
-	if len(v.tables) == 0 {
-		return nil, errors.New("vstreamclient: no tables configured")
-	}
-
 	// convert the tables into filter + rules
 
 	rules := make([]*binlogdatapb.Rule, 0, len(v.tables))
@@ -222,9 +216,6 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		v.cfg.flags = DefaultFlags()
 	}
 
-	if v.cfg.flags.HeartbeatInterval == 0 {
-		return nil, errors.New("vstreamclient: HeartbeatInterval must be positive")
-	}
 	if v.cfg.heartbeatSeconds > 0 {
 		v.cfg.flags.HeartbeatInterval = uint32(v.cfg.heartbeatSeconds)
 	}

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
@@ -78,6 +80,11 @@ type clientConfig struct {
 	// vgtidStateKeyspace and vgtidStateTable are the keyspace and table where the last VGtid is stored
 	vgtidStateKeyspace string
 	vgtidStateTable    string
+
+	// ownerToken uniquely identifies this client instance in the state row. New claims it on startup,
+	// and checkpoint writes require it to still match, so of two clients running with the same stream
+	// name, the newest one wins and the older one fails fast with ErrFenced.
+	ownerToken string
 
 	// to avoid flushing too often, we will only flush if it has been at least minFlushDuration since the last flush.
 	// we're relying on heartbeat events to handle max duration between flushes, in case there are no other events.
@@ -158,6 +165,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 			gracefulShutdownWaitDur:    DefaultGracefulShutdownWaitDur,
 			startupTimeout:             DefaultStartupTimeout,
 			heartbeatTimeoutMultiplier: DefaultHeartbeatTimeoutMultiplier,
+			ownerToken:                 uuid.NewString(),
 		},
 		session: conn.Session("", nil),
 		tables:  make(map[string]*TableConfig),
@@ -236,6 +244,13 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		return nil, err
 	}
 
+	// claim ownership before reading state, so a still-running client with the same stream name is
+	// fenced out before we decide where to resume from
+	err = claimStateOwnership(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken)
+	if err != nil {
+		return nil, err
+	}
+
 	storedVGtid, storedTableConfig, copyCompleted, err := getLatestVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)
 	if err != nil {
 		return nil, err
@@ -247,14 +262,14 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	switch {
 	case useExplicitStartingVGtid:
 		// if the caller explicitly provided a starting point, prefer it over persisted state.
-		err = initStartingVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.latestVgtid, v.tables)
+		err = initStartingVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, v.latestVgtid, v.tables)
 		if err != nil {
 			return nil, err
 		}
 
 	case v.latestVgtid == nil:
 		// we need to bootstrap the stream, which means we need to create a new vgtid and store the table config
-		v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.tables, v.shardsByKeyspace)
+		v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, v.tables, v.shardsByKeyspace)
 		if err != nil {
 			return nil, err
 		}
@@ -269,7 +284,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 		// since we have a vgtid, but the copy never completed, restart the copy from the beginning
 		if !copyCompleted {
-			v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.tables, v.shardsByKeyspace)
+			v.latestVgtid, err = initVGtid(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, v.tables, v.shardsByKeyspace)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -18,7 +18,6 @@ package vstreamclient
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -32,7 +31,9 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	_ "vitess.io/vitess/go/vt/vtctl/grpcvtctlclient"
+	"vitess.io/vitess/go/vt/vterrors"
 	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
@@ -141,15 +142,15 @@ type VStreamStats struct {
 func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables []TableConfig, opts ...Option) (*VStreamClient, error) {
 	// validate required parameters
 	if name == "" {
-		return nil, errors.New("vstreamclient: name is required")
+		return nil, vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: name is required")
 	}
 
 	if len(name) > 64 {
-		return nil, fmt.Errorf("vstreamclient: name must be 64 characters or less, got %d", len(name))
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: name must be 64 characters or less, got %d", len(name))
 	}
 
 	if conn == nil {
-		return nil, errors.New("vstreamclient: conn is required")
+		return nil, vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: conn is required")
 	}
 
 	// initialize the VStreamClient, with options and settings to be set later
@@ -225,7 +226,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 	// handle state lookup
 	if v.cfg.vgtidStateKeyspace == "" || v.cfg.vgtidStateTable == "" {
-		return nil, errors.New("vstreamclient: state table not configured (use WithStateTable)")
+		return nil, vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state table not configured (use WithStateTable)")
 	}
 
 	explicitStartingVGtid := v.latestVgtid
@@ -410,7 +411,7 @@ func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession)
 	for _, row := range result.Rows {
 		keyspace, shard, found := strings.Cut(row[0].ToString(), "/")
 		if !found {
-			return nil, fmt.Errorf("vstreamclient: failed to parse keyspace_id: %s", row[0].ToString())
+			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vstreamclient: failed to parse keyspace_id: %s", row[0].ToString())
 		}
 
 		shardsByKeyspace[keyspace] = append(shardsByKeyspace[keyspace], shard)
@@ -444,5 +445,5 @@ func validateTableNameMode(tables map[string]*TableConfig, flags *vtgatepb.VStre
 	}
 
 	slices.Sort(ambiguous)
-	return fmt.Errorf("vstreamclient: ExcludeKeyspaceFromTableName cannot be used with same-named tables across keyspaces: %s", strings.Join(ambiguous, "; "))
+	return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: ExcludeKeyspaceFromTableName cannot be used with same-named tables across keyspaces: %s", strings.Join(ambiguous, "; "))
 }

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -117,6 +117,11 @@ type lifecycleState struct {
 	shutdownRequested bool
 	cancelRunCtxFn    context.CancelCauseFunc
 
+	// shutdownCause records why the shutdown was requested (e.g. ErrHeartbeatTimeout); nil for
+	// user-initiated graceful shutdowns. It is preserved so Run surfaces the cause even when the
+	// final graceful flush succeeds.
+	shutdownCause error
+
 	gracefulShutdownFlushChan chan struct{}
 	gracefulShutdownFlushOnce sync.Once
 }
@@ -342,9 +347,10 @@ func (v *VStreamClient) GracefulShutdown(wait time.Duration) {
 }
 
 // gracefulShutdownWithCause is the internal implementation of GracefulShutdown. The cause, if not nil,
-// is recorded as the cancel cause of the Run context, so Run can surface why the stream was stopped.
+// is recorded before waiting, so Run surfaces why the stream was stopped even when the final graceful
+// flush succeeds during the wait.
 func (v *VStreamClient) gracefulShutdownWithCause(wait time.Duration, cause error) {
-	cancelRunCtxFn, gracefulShutdownFlushChan, ok := v.requestShutdown()
+	cancelRunCtxFn, gracefulShutdownFlushChan, ok := v.requestShutdown(cause)
 	if !ok {
 		return
 	}
@@ -371,6 +377,7 @@ func (v *VStreamClient) beginRun(cancelRunCtxFn context.CancelCauseFunc) bool {
 	v.lifecycle.runUsed = true
 	v.lifecycle.runActive = true
 	v.lifecycle.shutdownRequested = false
+	v.lifecycle.shutdownCause = nil
 	v.lifecycle.cancelRunCtxFn = cancelRunCtxFn
 	v.lifecycle.gracefulShutdownFlushChan = make(chan struct{})
 	v.lifecycle.gracefulShutdownFlushOnce = sync.Once{}
@@ -379,26 +386,47 @@ func (v *VStreamClient) beginRun(cancelRunCtxFn context.CancelCauseFunc) bool {
 
 func (v *VStreamClient) endRun() {
 	v.lifecycle.mu.Lock()
-	defer v.lifecycle.mu.Unlock()
 	v.lifecycle.runActive = false
 	v.lifecycle.shutdownRequested = false
 	v.lifecycle.cancelRunCtxFn = nil
+	gracefulShutdownFlushChan := v.lifecycle.gracefulShutdownFlushChan
+	gracefulShutdownFlushOnce := &v.lifecycle.gracefulShutdownFlushOnce
+	v.lifecycle.mu.Unlock()
+
+	// wake any GracefulShutdown caller still waiting for a flush: once Run has exited, no
+	// future flush can ever close the channel, so the caller would otherwise block for its
+	// entire wait duration
+	if gracefulShutdownFlushChan != nil {
+		gracefulShutdownFlushOnce.Do(func() {
+			close(gracefulShutdownFlushChan)
+		})
+	}
 }
 
-func (v *VStreamClient) requestShutdown() (context.CancelCauseFunc, <-chan struct{}, bool) {
+func (v *VStreamClient) requestShutdown(cause error) (context.CancelCauseFunc, <-chan struct{}, bool) {
 	v.lifecycle.mu.Lock()
 	defer v.lifecycle.mu.Unlock()
 	if !v.lifecycle.runActive || v.lifecycle.shutdownRequested || v.lifecycle.cancelRunCtxFn == nil {
 		return nil, nil, false
 	}
 	v.lifecycle.shutdownRequested = true
+	v.lifecycle.shutdownCause = cause
 	return v.lifecycle.cancelRunCtxFn, v.lifecycle.gracefulShutdownFlushChan, true
 }
 
-func (v *VStreamClient) isShutdownRequested() bool {
+// ShutdownRequested reports whether a graceful shutdown has been requested for the active Run,
+// either by a GracefulShutdown call or by the internal liveness monitor. Flush functions can use
+// it to detect that the current flush is the last one before the stream stops.
+func (v *VStreamClient) ShutdownRequested() bool {
 	v.lifecycle.mu.Lock()
 	defer v.lifecycle.mu.Unlock()
 	return v.lifecycle.shutdownRequested
+}
+
+func (v *VStreamClient) getShutdownCause() error {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	return v.lifecycle.shutdownCause
 }
 
 func (v *VStreamClient) getGracefulShutdownFlushChan() <-chan struct{} {

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -235,6 +235,16 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		}
 	}
 
+	if v.cfg.flags == nil {
+		v.cfg.flags = DefaultFlags()
+	}
+	if v.cfg.heartbeatSeconds > 0 {
+		v.cfg.flags.HeartbeatInterval = uint32(v.cfg.heartbeatSeconds)
+	}
+	if v.cfg.flags.HeartbeatInterval == 0 {
+		return nil, vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: HeartbeatInterval must be positive")
+	}
+
 	v.shardsByKeyspace, err = getShardsByKeyspace(ctx, conn.Session("@"+topoproto.TabletTypeLString(v.cfg.tabletType), nil))
 	if err != nil {
 		return nil, err
@@ -289,13 +299,6 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		Rules: rules,
 	}
 
-	if v.cfg.flags == nil {
-		v.cfg.flags = DefaultFlags()
-	}
-
-	if v.cfg.heartbeatSeconds > 0 {
-		v.cfg.flags.HeartbeatInterval = uint32(v.cfg.heartbeatSeconds)
-	}
 	if err = validateTableNameMode(v.tables, v.cfg.flags); err != nil {
 		return nil, err
 	}
@@ -351,7 +354,7 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	}
 
 	// New deliberately performs no state mutation: the ownership takeover (a compare-and-swap
-	// against the owner token observed above) is deferred until Run has established the stream,
+	// against the owner token observed above) is deferred until Run receives the first stream response,
 	// so a constructed-but-abandoned client or a failed stream setup never fences the incumbent
 	// consumer. See takeStateOwnership.
 	v.pendingTakeover = &stateTakeover{
@@ -593,19 +596,25 @@ func (v *VStreamClient) validateBinlogRowImage(ctx context.Context) error {
 		keyspaces[table.Keyspace] = true
 	}
 
+	tabletTypes := []topodatapb.TabletType{topodatapb.TabletType_PRIMARY}
+	if v.cfg.tabletType != topodatapb.TabletType_PRIMARY {
+		tabletTypes = append(tabletTypes, v.cfg.tabletType)
+	}
+
 	for _, keyspace := range slices.Sorted(maps.Keys(keyspaces)) {
 		for _, shard := range v.shardsByKeyspace[keyspace] {
-			// target each shard individually: an untargeted probe would only observe one
-			// arbitrary shard, and another shard's primary could still use NOBLOB
-			session := v.cfg.conn.Session(keyspace+":"+shard, nil)
-			result, err := session.Execute(ctx, "select @@global.binlog_row_image", nil, false)
-			if err != nil || len(result.Rows) == 0 || len(result.Rows[0]) == 0 {
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: could not verify binlog_row_image on shard %s/%s (use WithSkipRowImageCheck to bypass at your own risk): %v", keyspace, shard, err)
-			}
+			for _, tabletType := range tabletTypes {
+				target := keyspace + ":" + shard + "@" + topoproto.TabletTypeLString(tabletType)
+				session := v.cfg.conn.Session(target, nil)
+				result, err := session.Execute(ctx, "select @@global.binlog_row_image", nil, false)
+				if err != nil || len(result.Rows) == 0 || len(result.Rows[0]) == 0 {
+					return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: could not verify binlog_row_image on target %s (use WithSkipRowImageCheck to bypass at your own risk): %v", target, err)
+				}
 
-			rowImage := result.Rows[0][0].ToString()
-			if !strings.EqualFold(rowImage, "FULL") {
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: shard %s/%s uses binlog_row_image=%s, but this client requires FULL: with partial row images, omitted delete before-image values are indistinguishable from NULL", keyspace, shard, rowImage)
+				rowImage := result.Rows[0][0].ToString()
+				if !strings.EqualFold(rowImage, "FULL") {
+					return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: target %s uses binlog_row_image=%s, but this client requires FULL: with partial row images, omitted delete before-image values are indistinguishable from NULL", target, rowImage)
+				}
 			}
 		}
 	}

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -19,7 +19,6 @@ package vstreamclient
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"maps"
 	"os"
 	"slices"
@@ -115,6 +114,9 @@ type clientConfig struct {
 	// multiple of the heartbeat interval.
 	startupTimeout             time.Duration
 	heartbeatTimeoutMultiplier int
+
+	// skipRowImageCheck disables the per-shard binlog_row_image=FULL verification
+	skipRowImageCheck bool
 
 	// these fields configure how graceful shutdown is configured
 	gracefulShutdownChan    <-chan struct{}
@@ -240,16 +242,17 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		return nil, err
 	}
 
-	err = validateBinlogRowImage(ctx, conn, v.tables)
-	if err != nil {
-		return nil, err
-	}
-
 	// set options from the variadic list
 	for _, opt := range opts {
 		if err = opt(v); err != nil {
 			return nil, err
 		}
+	}
+
+	// after options, so WithSkipRowImageCheck can opt out
+	err = v.validateBinlogRowImage(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, table := range v.tables {
@@ -540,32 +543,41 @@ func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession)
 	return shardsByKeyspace, nil
 }
 
-// validateBinlogRowImage checks that every streamed source keyspace uses binlog_row_image=FULL.
-// With NOBLOB or MINIMAL, delete before-images can omit column values in a way that is
-// indistinguishable from SQL NULL to both the default decoder and custom scanners, silently
-// corrupting nullable fields downstream. If the setting cannot be queried (e.g. restricted
-// permissions), a warning is logged and the check is skipped.
-func validateBinlogRowImage(ctx context.Context, conn *vtgateconn.VTGateConn, tables map[string]*TableConfig) error {
-	keyspaces := make(map[string]bool)
-	for _, table := range tables {
+// validateBinlogRowImage checks that every shard of every streamed source keyspace uses
+// binlog_row_image=FULL. With NOBLOB or MINIMAL, delete before-images can omit column values in a
+// way that is indistinguishable from SQL NULL to both the default decoder and custom scanners,
+// silently corrupting nullable fields downstream. The check fails closed: a shard that cannot be
+// probed is treated as unverified, unless the caller explicitly opted out with
+// WithSkipRowImageCheck.
+//
+// Note this can only verify the current value on each shard: events replayed from a position
+// written while a different row image was active are not detectable. FULL must have been in
+// effect for the entire retained replay range.
+func (v *VStreamClient) validateBinlogRowImage(ctx context.Context) error {
+	if v.cfg.skipRowImageCheck {
+		log.Warn("vstreamclient: binlog_row_image verification skipped; delete events are silently corrupted unless every source shard uses FULL")
+		return nil
+	}
+
+	keyspaces := make(map[string]bool, len(v.tables))
+	for _, table := range v.tables {
 		keyspaces[table.Keyspace] = true
 	}
 
 	for _, keyspace := range slices.Sorted(maps.Keys(keyspaces)) {
-		session := conn.Session(keyspace, nil)
-		result, err := session.Execute(ctx, "select @@global.binlog_row_image", nil, false)
-		if err != nil || len(result.Rows) == 0 || len(result.Rows[0]) == 0 {
-			log.Warn(
-				"vstreamclient: could not verify binlog_row_image; delete events may be silently corrupted unless it is FULL",
-				slog.String("keyspace", keyspace),
-				slog.Any("error", err),
-			)
-			continue
-		}
+		for _, shard := range v.shardsByKeyspace[keyspace] {
+			// target each shard individually: an untargeted probe would only observe one
+			// arbitrary shard, and another shard's primary could still use NOBLOB
+			session := v.cfg.conn.Session(keyspace+":"+shard, nil)
+			result, err := session.Execute(ctx, "select @@global.binlog_row_image", nil, false)
+			if err != nil || len(result.Rows) == 0 || len(result.Rows[0]) == 0 {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: could not verify binlog_row_image on shard %s/%s (use WithSkipRowImageCheck to bypass at your own risk): %v", keyspace, shard, err)
+			}
 
-		rowImage := result.Rows[0][0].ToString()
-		if !strings.EqualFold(rowImage, "FULL") {
-			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: keyspace %s uses binlog_row_image=%s, but this client requires FULL: with partial row images, omitted delete before-image values are indistinguishable from NULL", keyspace, rowImage)
+			rowImage := result.Rows[0][0].ToString()
+			if !strings.EqualFold(rowImage, "FULL") {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: shard %s/%s uses binlog_row_image=%s, but this client requires FULL: with partial row images, omitted delete before-image values are indistinguishable from NULL", keyspace, shard, rowImage)
+			}
 		}
 	}
 

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"vitess.io/vitess/go/sqltypes"
+
 	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -71,6 +73,11 @@ type VStreamClient struct {
 	// transaction across multiple batches while heartbeats keep arriving independently, so
 	// heartbeat-triggered flushes must be deferred until the transaction terminates.
 	inTransaction bool
+
+	// pendingTakeover carries the state write New prepared but deliberately did not execute:
+	// taking ownership is deferred until Run has established the stream, so a
+	// constructed-but-never-run client can never fence the incumbent consumer.
+	pendingTakeover *stateTakeover
 
 	stats VStreamStats
 
@@ -116,6 +123,19 @@ type clientConfig struct {
 
 	// eventFuncs is a map of event type to the user provided function that should be called for that event type.
 	eventFuncs map[binlogdatapb.VEventType]EventFunc
+}
+
+// stateTakeover is the state write prepared during New and executed by Run once the stream is
+// established: either a claim-only ownership rotation (resume) or a full persist of the starting
+// position, both as a compare-and-swap against the owner token observed when state was read.
+type stateTakeover struct {
+	// persistVGtid is the position to persist together with the ownership claim; nil means the
+	// stream resumes from stored state and only the ownership claim is needed
+	persistVGtid         *binlogdatapb.VGtid
+	persistCopyCompleted bool
+
+	rowExists          bool
+	observedOwnerToken sqltypes.Value
 }
 
 type lifecycleState struct {
@@ -302,33 +322,54 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		// resume from the stored checkpoint; nothing to persist beyond claiming ownership
 	}
 
-	// claiming ownership and persisting the starting state are the only state-mutating steps,
-	// and they run last, as a single compare-and-swap against the owner token observed when
-	// state was read: it fences out a still-running client with the same stream name, while a
-	// stale constructor that lost the race fails with ErrFenced instead of stealing ownership
-	// back from a newer client.
-	if rowExists {
-		if persistVGtid != nil {
-			err = updateStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, observedOwnerToken, persistVGtid, v.tables, persistCopyCompleted)
-		} else {
-			err = claimStateOwnership(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, observedOwnerToken)
-		}
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err = insertStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, persistVGtid, v.tables, persistCopyCompleted)
-		if err != nil {
-			return nil, err
-		}
+	// New deliberately performs no state mutation: the ownership takeover (a compare-and-swap
+	// against the owner token observed above) is deferred until Run has established the stream,
+	// so a constructed-but-abandoned client or a failed stream setup never fences the incumbent
+	// consumer. See takeStateOwnership.
+	v.pendingTakeover = &stateTakeover{
+		persistVGtid:         persistVGtid,
+		persistCopyCompleted: persistCopyCompleted,
+		rowExists:            rowExists,
+		observedOwnerToken:   observedOwnerToken,
 	}
 
-	// every branch above leaves the state table holding exactly latestVgtid, so seed lastFlushedVgtid
-	// with it. Otherwise the first flush on an idle stream would issue a no-op update, which MySQL
-	// reports as RowsAffected=0 and updateLatestVGtid would treat as a missing state row.
+	return v, nil
+}
+
+// takeStateOwnership executes the state write prepared by New: it claims ownership of the state
+// row (fencing out a still-running client with the same stream name) and persists the starting
+// position when needed. It runs from Run once the stream is established, as a compare-and-swap
+// against the owner token observed when state was read, so a stale constructor that lost a race
+// fails with ErrFenced instead of stealing ownership back from a newer client.
+func (v *VStreamClient) takeStateOwnership(ctx context.Context) error {
+	takeover := v.pendingTakeover
+	if takeover == nil {
+		return nil
+	}
+
+	var err error
+	switch {
+	case !takeover.rowExists:
+		err = insertStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, takeover.persistVGtid, v.tables, takeover.persistCopyCompleted)
+
+	case takeover.persistVGtid != nil:
+		err = updateStateRow(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, takeover.observedOwnerToken, takeover.persistVGtid, v.tables, takeover.persistCopyCompleted)
+
+	default:
+		err = claimStateOwnership(ctx, v.session, v.cfg.name, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable, v.cfg.ownerToken, takeover.observedOwnerToken)
+	}
+	if err != nil {
+		return err
+	}
+
+	v.pendingTakeover = nil
+
+	// the takeover leaves the state table holding exactly latestVgtid, so seed lastFlushedVgtid
+	// with it. Otherwise the first flush on an idle stream would issue a no-op update, which
+	// MySQL reports as RowsAffected=0 and updateLatestVGtid would treat as a missing state row.
 	v.lastFlushedVgtid = v.latestVgtid
 
-	return v, nil
+	return nil
 }
 
 func resolveLatestVGtid(explicit, stored *binlogdatapb.VGtid) (*binlogdatapb.VGtid, bool) {

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -19,13 +19,11 @@ package vstreamclient
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"maps"
 	"os"
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -37,6 +35,7 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	_ "vitess.io/vitess/go/vt/vtctl/grpcvtctlclient"
 	"vitess.io/vitess/go/vt/vterrors"
 	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
@@ -54,8 +53,7 @@ type VStreamClient struct {
 	// configured keyspaces and to bootstrap the initial vgtid
 	shardsByKeyspace map[string][]string
 
-	// shardedByKeyspace caches each keyspace's vschema sharded property; nil when the vschema
-	// could not be read, in which case validation falls back to the shard-name heuristic
+	// shardedByKeyspace caches each keyspace's vschema sharded property.
 	shardedByKeyspace map[string]bool
 
 	// keep per table state and config, which is used to generate the vgtid filter.
@@ -65,8 +63,9 @@ type VStreamClient struct {
 	// lastEventProcessedAtUnixNano is the time after the last event batch was processed, including time for the
 	// user provided flush function to complete. A zero value means Run has not successfully processed any events yet,
 	// so heartbeat liveness checks should not trigger startup cancellation.
-	lastEventProcessedAtUnixNano atomic.Int64
-	isProcessingEvents           atomic.Bool
+	eventMu                      sync.Mutex
+	lastEventProcessedAtUnixNano int64
+	isProcessingEvents           bool
 
 	// lastFlushedVgtid is the last vgtid that was flushed, which is compared to the latestVgtid to determine
 	// if we need to flush again.
@@ -100,7 +99,7 @@ type clientConfig struct {
 	vgtidStateKeyspace string
 	vgtidStateTable    string
 
-	// ownerToken uniquely identifies this client instance in the state row. New claims it on startup,
+	// ownerToken uniquely identifies this client instance in the state row. Run claims it on startup,
 	// and checkpoint writes require it to still match, so of two clients running with the same stream
 	// name, the newest one wins and the older one fails fast with ErrFenced.
 	ownerToken string
@@ -229,20 +228,21 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 
 	var err error
 
-	// load all shards, so we can validate settings before starting. It's not technically necessary to do this here,
-	// but it's more user-friendly to fail early if there is misconfiguration. This needs to be done before running
-	// the options, so that the shards are available for validation.
-	v.shardsByKeyspace, err = getShardsByKeyspace(ctx, v.session)
+	// set options from the variadic list
+	for _, opt := range opts {
+		if err = opt(v); err != nil {
+			return nil, err
+		}
+	}
+
+	v.shardsByKeyspace, err = getShardsByKeyspace(ctx, conn.Session("@"+topoproto.TabletTypeLString(v.cfg.tabletType), nil))
 	if err != nil {
 		return nil, err
 	}
 
 	v.shardedByKeyspace, err = getShardedByKeyspace(ctx, v.session)
 	if err != nil {
-		// older vtgates may not support SHOW VSCHEMA KEYSPACES; validation falls back to the
-		// shard-name heuristic in that case
-		log.Warn("vstreamclient: could not read vschema keyspace sharding", slog.Any("error", err))
-		v.shardedByKeyspace = nil
+		return nil, vterrors.Wrap(err, "vstreamclient: could not read vschema keyspace sharding")
 	}
 
 	err = v.initTables(tables)
@@ -255,11 +255,11 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		return nil, err
 	}
 
-	// set options from the variadic list
-	for _, opt := range opts {
-		if err = opt(v); err != nil {
-			return nil, err
-		}
+	if err = v.validateStateTable(); err != nil {
+		return nil, err
+	}
+	if err = v.validateStartingVGtid(); err != nil {
+		return nil, err
 	}
 
 	// after options, so WithSkipRowImageCheck can opt out
@@ -301,10 +301,6 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	}
 
 	// handle state lookup
-	if v.cfg.vgtidStateKeyspace == "" || v.cfg.vgtidStateTable == "" {
-		return nil, vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: state table not configured (use WithStateTable)")
-	}
-
 	explicitStartingVGtid := v.latestVgtid
 
 	err = initStateTable(ctx, v.session, v.cfg.vgtidStateKeyspace, v.cfg.vgtidStateTable)

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -19,6 +19,7 @@ package vstreamclient
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
 	"slices"
@@ -52,6 +53,10 @@ type VStreamClient struct {
 	// shardsByKeyspace caches the cluster's serving shards per keyspace, used to validate
 	// configured keyspaces and to bootstrap the initial vgtid
 	shardsByKeyspace map[string][]string
+
+	// shardedByKeyspace caches each keyspace's vschema sharded property; nil when the vschema
+	// could not be read, in which case validation falls back to the shard-name heuristic
+	shardedByKeyspace map[string]bool
 
 	// keep per table state and config, which is used to generate the vgtid filter.
 	// this is a map of keyspace.table to TableConfig, since that's how the binlog table is stored
@@ -230,6 +235,14 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	v.shardsByKeyspace, err = getShardsByKeyspace(ctx, v.session)
 	if err != nil {
 		return nil, err
+	}
+
+	v.shardedByKeyspace, err = getShardedByKeyspace(ctx, v.session)
+	if err != nil {
+		// older vtgates may not support SHOW VSCHEMA KEYSPACES; validation falls back to the
+		// shard-name heuristic in that case
+		log.Warn("vstreamclient: could not read vschema keyspace sharding", slog.Any("error", err))
+		v.shardedByKeyspace = nil
 	}
 
 	err = v.initTables(tables)
@@ -541,6 +554,26 @@ func getShardsByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession)
 	}
 
 	return shardsByKeyspace, nil
+}
+
+// getShardedByKeyspace reads each keyspace's vschema sharded property, which is authoritative in
+// a way physical shard names are not: a sharded keyspace can have a single arbitrary shard today
+// and gain shards through resharding later.
+func getShardedByKeyspace(ctx context.Context, session *vtgateconn.VTGateSession) (map[string]bool, error) {
+	result, err := session.Execute(ctx, "SHOW VSCHEMA KEYSPACES", nil, false)
+	if err != nil {
+		return nil, err
+	}
+
+	shardedByKeyspace := make(map[string]bool, len(result.Rows))
+	for _, row := range result.Rows {
+		if len(row) < 2 {
+			continue
+		}
+		shardedByKeyspace[row[0].ToString()] = strings.EqualFold(row[1].ToString(), "true")
+	}
+
+	return shardedByKeyspace, nil
 }
 
 // validateBinlogRowImage checks that every shard of every streamed source keyspace uses

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"os"
 	"slices"
 	"strings"
@@ -243,6 +244,10 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 	}
 	if v.cfg.flags.HeartbeatInterval == 0 {
 		return nil, vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: HeartbeatInterval must be positive")
+	}
+	heartbeatDuration := time.Duration(v.cfg.flags.HeartbeatInterval) * time.Second
+	if heartbeatDuration > time.Duration(math.MaxInt64)/time.Duration(v.cfg.heartbeatTimeoutMultiplier) {
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: heartbeat liveness window exceeds maximum duration (interval %d seconds, multiplier %d)", v.cfg.flags.HeartbeatInterval, v.cfg.heartbeatTimeoutMultiplier)
 	}
 
 	v.shardsByKeyspace, err = getShardsByKeyspace(ctx, conn.Session("@"+topoproto.TabletTypeLString(v.cfg.tabletType), nil))

--- a/go/vt/vstreamclient/vstreamclient.go
+++ b/go/vt/vstreamclient/vstreamclient.go
@@ -204,6 +204,22 @@ func New(ctx context.Context, name string, conn *vtgateconn.VTGateConn, tables [
 		tables:  make(map[string]*TableConfig),
 	}
 
+	// the mutable package defaults are documented as safely modifiable, so validate the
+	// effective values instead of trusting them: non-positive timeouts would otherwise cause
+	// immediate startup or heartbeat cancellation at runtime
+	if v.cfg.minFlushDuration <= 0 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: DefaultMinFlushDuration must be positive, got %s", v.cfg.minFlushDuration)
+	}
+	if v.cfg.startupTimeout <= 0 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: DefaultStartupTimeout must be positive, got %s", v.cfg.startupTimeout)
+	}
+	if v.cfg.heartbeatTimeoutMultiplier <= 0 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: DefaultHeartbeatTimeoutMultiplier must be positive, got %d", v.cfg.heartbeatTimeoutMultiplier)
+	}
+	if v.cfg.gracefulShutdownWaitDur <= 0 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vstreamclient: DefaultGracefulShutdownWaitDur must be positive, got %s", v.cfg.gracefulShutdownWaitDur)
+	}
+
 	var err error
 
 	// load all shards, so we can validate settings before starting. It's not technically necessary to do this here,

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Vitess Authors.
+Copyright 2026 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -1,0 +1,267 @@
+package vstreamclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"vitess.io/vitess/go/sqltypes"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+// Customer is the concrete type that will be built from the stream
+type Customer struct {
+	ID        int64     `vstream:"customer_id"`
+	Email     string    `vstream:"email"`
+	DeletedAt time.Time `vstream:"-"`
+}
+
+func getConn(t *testing.T, ctx context.Context) *vtgateconn.VTGateConn {
+	t.Helper()
+	conn, err := vtgateconn.Dial(ctx, "localhost:15991")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
+}
+
+// To run the tests, this currently expects the local example to be running
+// ./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql; ./201_customer_tablets.sh; ./202_move_tables.sh; ./203_switch_reads.sh; ./204_switch_writes.sh; ./205_clean_commerce.sh; ./301_customer_sharded.sh; ./302_new_shards.sh; ./303_reshard.sh; ./304_switch_reads.sh; ./305_switch_writes.sh; ./306_down_shard_0.sh; ./307_delete_shard_0.sh
+func TestVStreamClient(t *testing.T) {
+	conn := getConn(t, context.Background())
+	defer conn.Close()
+
+	flushCount := 0
+	gotCustomers := make([]*Customer, 0)
+
+	tables := []TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		MaxRowsPerFlush: 7,
+		DataType:        &Customer{},
+		FlushFn: func(ctx context.Context, rows []Row, meta FlushMeta) error {
+			flushCount++
+
+			fmt.Printf("upserting %d customers\n", len(rows))
+			for i, row := range rows {
+				switch {
+				// delete event
+				case row.RowChange.After == nil:
+					customer := row.Data.(*Customer)
+					customer.DeletedAt = time.Now()
+
+					gotCustomers = append(gotCustomers, customer)
+					fmt.Printf("deleting customer %d: %v\n", i, row)
+
+				// insert event
+				case row.RowChange.Before == nil:
+					gotCustomers = append(gotCustomers, row.Data.(*Customer))
+					fmt.Printf("inserting customer %d: %v\n", i, row)
+
+				// update event
+				case row.RowChange.Before != nil:
+					gotCustomers = append(gotCustomers, row.Data.(*Customer))
+					fmt.Printf("updating customer %d: %v\n", i, row)
+				}
+			}
+
+			// a real implementation would do something more meaningful here. For a data warehouse type workload,
+			// it would probably look like streaming rows into the data warehouse, or for more complex versions,
+			// write newline delimited json or a parquet file to object storage, then trigger a load job.
+			return nil
+		},
+	}}
+
+	t.Run("first vstream run, should succeed", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		vstreamClient, err := New(ctx, "bob", conn, tables,
+			WithMinFlushDuration(500*time.Millisecond),
+			WithHeartbeatSeconds(1),
+			WithStateTable("commerce", "vstreams"),
+			WithEventFunc(func(ctx context.Context, ev *binlogdatapb.VEvent) error {
+				fmt.Printf("** FIELD EVENT: %v\n", ev)
+				return nil
+			}, binlogdatapb.VEventType_FIELD),
+		)
+		if err != nil {
+			t.Fatalf("failed to create VStreamClient: %v", err)
+		}
+
+		err = vstreamClient.Run(ctx)
+		if err != nil && ctx.Err() == nil {
+			t.Fatalf("failed to run vstreamclient: %v", err)
+		}
+
+		slices.SortFunc(gotCustomers, func(a, b *Customer) int {
+			return int(a.ID - b.ID)
+		})
+
+		wantCustomers := []*Customer{
+			{ID: 1, Email: "alice@domain.com"},
+			{ID: 2, Email: "bob@domain.com"},
+			{ID: 3, Email: "charlie@domain.com"},
+			{ID: 4, Email: "dan@domain.com"},
+			{ID: 5, Email: "eve@domain.com"},
+		}
+
+		fmt.Printf("got %d customers | flushed %d times\n", len(gotCustomers), flushCount)
+		if !reflect.DeepEqual(gotCustomers, wantCustomers) {
+			t.Fatalf("got %d customers, want %d", len(gotCustomers), len(wantCustomers))
+		}
+	})
+
+	// this should fail because we're going to restart the stream, but with an additional table
+	t.Run("second vstream run, should fail", func(t *testing.T) {
+		withAdditionalTable := append(tables, TableConfig{
+			Keyspace: "customer",
+			Table:    "corder",
+			DataType: &Customer{},
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		_, err := New(ctx, "bob", conn, withAdditionalTable,
+			WithStateTable("commerce", "vstreams"),
+		)
+		if err == nil {
+			t.Fatalf("expected VStreamClient error, got nil")
+		} else if err.Error() != "vstreamclient: provided tables do not match stored tables" {
+			t.Fatalf("expected error 'vstreamclient: provided tables do not match stored tables', got '%v'", err)
+		}
+	})
+}
+
+// Customer is the concrete type that will be built from the stream. This version implements
+// the VStreamScanner interface to do custom mapping of fields.
+type CustomerWithScan struct {
+	ID    int64
+	Email string
+
+	// the fields below aren't actually in the schema, but are added for illustrative purposes
+	EmailConfirmed bool
+	Details        map[string]any
+	CreatedAt      time.Time
+}
+
+var _ VStreamScanner = (*CustomerWithScan)(nil)
+
+func (customer *CustomerWithScan) VStreamScan(fields []*querypb.Field, row []sqltypes.Value, rowEvent *binlogdatapb.RowEvent, rowChange *binlogdatapb.RowChange) error {
+	var err error
+
+	for i := range row {
+		if row[i].IsNull() {
+			continue
+		}
+
+		switch fields[i].Name {
+		case "customer_id":
+			customer.ID, err = row[i].ToCastInt64()
+
+		case "email":
+			customer.Email = row[i].ToString()
+
+		// the fields below aren't actually in the example schema, but are added to
+		// show how you should handle different data types
+
+		case "email_confirmed":
+			customer.EmailConfirmed, err = row[i].ToBool()
+
+		case "details":
+			// assume the details field is a json blob
+			var b []byte
+			b, err = row[i].ToBytes()
+			if err == nil {
+				err = json.Unmarshal(b, &customer.Details)
+			}
+
+		case "created_at":
+			customer.CreatedAt, err = row[i].ToTime()
+		}
+		if err != nil {
+			return fmt.Errorf("error processing field %s: %w", fields[i].Name, err)
+		}
+	}
+
+	return nil
+}
+
+// To run the tests, this currently expects the local example to be running
+// ./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql; ./201_customer_tablets.sh; ./202_move_tables.sh; ./203_switch_reads.sh; ./204_switch_writes.sh; ./205_clean_commerce.sh; ./301_customer_sharded.sh; ./302_new_shards.sh; ./303_reshard.sh; ./304_switch_reads.sh; ./305_switch_writes.sh; ./306_down_shard_0.sh; ./307_delete_shard_0.sh
+func TestVStreamClientWithScan(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := vtgateconn.Dial(ctx, "localhost:15991")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	flushCount := 0
+	gotCustomers := make([]*CustomerWithScan, 0)
+
+	tables := []TableConfig{{
+		Keyspace:        "customer",
+		Table:           "customer",
+		MaxRowsPerFlush: 7,
+		FlushFn: func(ctx context.Context, rows []Row, meta FlushMeta) error {
+			flushCount++
+
+			fmt.Printf("upserting %d customers\n", len(rows))
+			for i, row := range rows {
+				gotCustomers = append(gotCustomers, row.Data.(*CustomerWithScan))
+				fmt.Printf("upserting customer %d: %v\n", i, row)
+			}
+
+			// a real implementation would do something more meaningful here. For a data warehouse type workload,
+			// it would probably look like streaming rows into the data warehouse, or for more complex versions,
+			// write newline delimited json or a parquet file to object storage, then trigger a load job.
+			return nil
+		},
+		DataType: &CustomerWithScan{},
+	}}
+
+	vstreamClient, err := New(ctx, "bob2", conn, tables,
+		WithMinFlushDuration(500*time.Millisecond),
+		WithHeartbeatSeconds(1),
+		WithStateTable("commerce", "vstreams"),
+		WithEventFunc(func(ctx context.Context, ev *binlogdatapb.VEvent) error {
+			fmt.Printf("** FIELD EVENT: %v\n", ev)
+			return nil
+		}, binlogdatapb.VEventType_FIELD),
+	)
+	if err != nil {
+		t.Fatalf("failed to create VStreamClient: %v", err)
+	}
+
+	err = vstreamClient.Run(ctx)
+	if err != nil && ctx.Err() == nil {
+		t.Fatalf("failed to run vstreamclient: %v", err)
+	}
+
+	slices.SortFunc(gotCustomers, func(a, b *CustomerWithScan) int {
+		return int(a.ID - b.ID)
+	})
+
+	wantCustomers := []*CustomerWithScan{
+		{ID: 1, Email: "alice@domain.com"},
+		{ID: 2, Email: "bob@domain.com"},
+		{ID: 3, Email: "charlie@domain.com"},
+		{ID: 4, Email: "dan@domain.com"},
+		{ID: 5, Email: "eve@domain.com"},
+	}
+
+	fmt.Printf("got %d customers | flushed %d times\n", len(gotCustomers), flushCount)
+	if !reflect.DeepEqual(gotCustomers, wantCustomers) {
+		t.Fatalf("got %d customers, want %d", len(gotCustomers), len(wantCustomers))
+	}
+}

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -2,266 +2,335 @@ package vstreamclient
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"reflect"
-	"slices"
+	"math"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/sqltypes"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
-// Customer is the concrete type that will be built from the stream
-type Customer struct {
-	ID        int64     `vstream:"customer_id"`
-	Email     string    `vstream:"email"`
-	DeletedAt time.Time `vstream:"-"`
-}
-
-func getConn(t *testing.T, ctx context.Context) *vtgateconn.VTGateConn {
-	t.Helper()
-	conn, err := vtgateconn.Dial(ctx, "localhost:15991")
-	if err != nil {
-		t.Fatal(err)
+func TestResolveLatestVGtid(t *testing.T) {
+	explicit := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
 	}
-	return conn
+	stored := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/2"}},
+	}
+
+	got, explicitUsed := resolveLatestVGtid(explicit, stored)
+	assert.True(t, explicitUsed)
+	assert.Equal(t, explicit, got)
+
+	got, explicitUsed = resolveLatestVGtid(nil, stored)
+	assert.False(t, explicitUsed)
+	assert.Equal(t, stored, got)
 }
 
-// To run the tests, this currently expects the local example to be running
-// ./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql; ./201_customer_tablets.sh; ./202_move_tables.sh; ./203_switch_reads.sh; ./204_switch_writes.sh; ./205_clean_commerce.sh; ./301_customer_sharded.sh; ./302_new_shards.sh; ./303_reshard.sh; ./304_switch_reads.sh; ./305_switch_writes.sh; ./306_down_shard_0.sh; ./307_delete_shard_0.sh
-func TestVStreamClient(t *testing.T) {
-	conn := getConn(t, context.Background())
-	defer conn.Close()
+func TestDefaultFlagsExcludeKeyspaceFromTableName(t *testing.T) {
+	flags := DefaultFlags()
+	assert.False(t, flags.ExcludeKeyspaceFromTableName)
+}
 
-	flushCount := 0
-	gotCustomers := make([]*Customer, 0)
+func TestNew_ValidatesName(t *testing.T) {
+	_, err := New(context.Background(), "", nil, nil)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "name is required")
 
-	tables := []TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		MaxRowsPerFlush: 7,
-		DataType:        &Customer{},
-		FlushFn: func(ctx context.Context, rows []Row, meta FlushMeta) error {
-			flushCount++
+	_, err = New(context.Background(), strings.Repeat("a", 65), nil, nil)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "name must be 64 characters or less")
+}
 
-			fmt.Printf("upserting %d customers\n", len(rows))
-			for i, row := range rows {
-				switch {
-				// delete event
-				case row.RowChange.After == nil:
-					customer := row.Data.(*Customer)
-					customer.DeletedAt = time.Now()
+func TestWithMinFlushDuration_RejectsNonPositive(t *testing.T) {
+	v := &VStreamClient{}
+	err := WithMinFlushDuration(0)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "minimum flush duration")
+}
 
-					gotCustomers = append(gotCustomers, customer)
-					fmt.Printf("deleting customer %d: %v\n", i, row)
+func TestWithHeartbeatSeconds_RejectsNonPositive(t *testing.T) {
+	v := &VStreamClient{}
+	err := WithHeartbeatSeconds(0)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "heartbeat seconds")
+}
 
-				// insert event
-				case row.RowChange.Before == nil:
-					gotCustomers = append(gotCustomers, row.Data.(*Customer))
-					fmt.Printf("inserting customer %d: %v\n", i, row)
+func TestWithHeartbeatSeconds_RejectsOverflow(t *testing.T) {
+	overflow := uint64(math.MaxUint32) + 1
+	if strconv.IntSize < 64 || overflow > uint64(^uint(0)>>1) {
+		t.Skip("int cannot represent a value larger than uint32 on this platform")
+	}
 
-				// update event
-				case row.RowChange.Before != nil:
-					gotCustomers = append(gotCustomers, row.Data.(*Customer))
-					fmt.Printf("updating customer %d: %v\n", i, row)
-				}
-			}
+	v := &VStreamClient{}
+	err := WithHeartbeatSeconds(int(overflow))(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "heartbeat seconds must be")
+	assert.ErrorContains(t, err, "or less")
+}
 
-			// a real implementation would do something more meaningful here. For a data warehouse type workload,
-			// it would probably look like streaming rows into the data warehouse, or for more complex versions,
-			// write newline delimited json or a parquet file to object storage, then trigger a load job.
-			return nil
+func TestWithTabletType_Validation(t *testing.T) {
+	v := &VStreamClient{}
+
+	err := WithTabletType(topodatapb.TabletType_UNKNOWN)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "tablet type cannot be UNKNOWN")
+
+	err = WithTabletType(topodatapb.TabletType_RDONLY)(v)
+	assert.NoError(t, err)
+	assert.Equal(t, topodatapb.TabletType_RDONLY, v.tabletType)
+}
+
+func TestWithFlags_RejectsNil(t *testing.T) {
+	v := &VStreamClient{}
+	err := WithFlags(nil)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "flags cannot be nil")
+}
+
+func TestWithGracefulShutdownChan_Validation(t *testing.T) {
+	v := &VStreamClient{}
+
+	err := WithGracefulShutdownChan(nil, time.Second)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "graceful shutdown channel")
+
+	err = WithGracefulShutdownChan(make(chan struct{}), 0)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "graceful shutdown wait")
+
+	ch := make(chan struct{})
+	err = WithGracefulShutdownChan(ch, time.Second)(v)
+	assert.NoError(t, err)
+	assert.Equal(t, (<-chan struct{})(ch), v.gracefulShutdownChan)
+	assert.Equal(t, time.Second, v.gracefulShutdownWaitDur)
+}
+
+func TestWithGracefulShutdownSignals_Validation(t *testing.T) {
+	v := &VStreamClient{}
+
+	err := WithGracefulShutdownSignals(time.Second)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "graceful shutdown signals")
+
+	err = WithGracefulShutdownSignals(0, os.Interrupt)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "graceful shutdown wait")
+
+	err = WithGracefulShutdownSignals(time.Second, os.Interrupt)(v)
+	assert.NoError(t, err)
+	assert.Equal(t, []os.Signal{os.Interrupt}, v.gracefulShutdownSignals)
+	assert.Equal(t, time.Second, v.gracefulShutdownWaitDur)
+}
+
+func TestWithEventFunc_Validation(t *testing.T) {
+	v := &VStreamClient{}
+	fn := func(_ context.Context, _ *binlogdatapb.VEvent) error { return nil }
+
+	err := WithEventFunc(fn)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "no event types provided")
+
+	err = WithEventFunc(fn, binlogdatapb.VEventType_FIELD)(v)
+	assert.NoError(t, err)
+
+	err = WithEventFunc(fn, binlogdatapb.VEventType_FIELD)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "already has a function")
+}
+
+func TestLookupTable(t *testing.T) {
+	t.Run("qualified name matches exactly", func(t *testing.T) {
+		want := &TableConfig{Keyspace: "ks", Table: "t"}
+		v := &VStreamClient{tables: map[string]*TableConfig{
+			qualifiedTableName("ks", "t"): want,
+		}}
+
+		got, err := v.lookupTable("ks.t")
+		assert.NoError(t, err)
+		assert.Same(t, want, got)
+	})
+
+	t.Run("bare name matches uniquely", func(t *testing.T) {
+		want := &TableConfig{Keyspace: "ks", Table: "t"}
+		v := &VStreamClient{tables: map[string]*TableConfig{
+			qualifiedTableName("ks", "t"): want,
+		}}
+
+		got, err := v.lookupTable("t")
+		assert.NoError(t, err)
+		assert.Same(t, want, got)
+	})
+
+	t.Run("bare name is rejected when ambiguous", func(t *testing.T) {
+		v := &VStreamClient{tables: map[string]*TableConfig{
+			qualifiedTableName("ks1", "t"): {Keyspace: "ks1", Table: "t"},
+			qualifiedTableName("ks2", "t"): {Keyspace: "ks2", Table: "t"},
+		}}
+
+		_, err := v.lookupTable("t")
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "ambiguous table name")
+	})
+}
+
+func TestIsFinalCopyCompletedEvent(t *testing.T) {
+	t.Run("shard scoped event is not final", func(t *testing.T) {
+		assert.False(t, isFinalCopyCompletedEvent(&binlogdatapb.VEvent{
+			Type:     binlogdatapb.VEventType_COPY_COMPLETED,
+			Keyspace: "ks",
+			Shard:    "-80",
+		}))
+	})
+
+	t.Run("aggregate event is final", func(t *testing.T) {
+		assert.True(t, isFinalCopyCompletedEvent(&binlogdatapb.VEvent{
+			Type: binlogdatapb.VEventType_COPY_COMPLETED,
+		}))
+	})
+}
+
+// TestRun_RejectsClosedClient verifies a client cannot be reused after a prior Run attempt.
+func TestRun_RejectsClosedClient(t *testing.T) {
+	v := &VStreamClient{}
+	v.isClosing.Store(true)
+
+	err := v.Run(context.Background())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "client is closed")
+}
+
+func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	}
+	v := &VStreamClient{
+		tables:                    map[string]*TableConfig{},
+		latestVgtid:               vgtid,
+		lastFlushedVgtid:          proto.Clone(vgtid).(*binlogdatapb.VGtid),
+		gracefulShutdownFlushChan: make(chan struct{}),
+	}
+	v.isClosing.Store(true)
+
+	err := v.flush(context.Background(), false)
+	assert.NoError(t, err)
+
+	select {
+	case <-v.gracefulShutdownFlushChan:
+	default:
+		t.Fatal("expected graceful shutdown flush channel to be closed")
+	}
+}
+
+func TestShouldFlush_ForceBypassesThresholds(t *testing.T) {
+	v := &VStreamClient{
+		minFlushDuration: time.Hour,
+		stats:            VStreamStats{LastFlushedAt: time.Now()},
+		tables: map[string]*TableConfig{
+			qualifiedTableName("ks", "t"): {
+				Keyspace:        "ks",
+				Table:           "t",
+				MaxRowsPerFlush: 10,
+				currentBatch:    []Row{{Data: "row"}},
+			},
 		},
-	}}
-
-	t.Run("first vstream run, should succeed", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		vstreamClient, err := New(ctx, "bob", conn, tables,
-			WithMinFlushDuration(500*time.Millisecond),
-			WithHeartbeatSeconds(1),
-			WithStateTable("commerce", "vstreams"),
-			WithEventFunc(func(ctx context.Context, ev *binlogdatapb.VEvent) error {
-				fmt.Printf("** FIELD EVENT: %v\n", ev)
-				return nil
-			}, binlogdatapb.VEventType_FIELD),
-		)
-		if err != nil {
-			t.Fatalf("failed to create VStreamClient: %v", err)
-		}
-
-		err = vstreamClient.Run(ctx)
-		if err != nil && ctx.Err() == nil {
-			t.Fatalf("failed to run vstreamclient: %v", err)
-		}
-
-		slices.SortFunc(gotCustomers, func(a, b *Customer) int {
-			return int(a.ID - b.ID)
-		})
-
-		wantCustomers := []*Customer{
-			{ID: 1, Email: "alice@domain.com"},
-			{ID: 2, Email: "bob@domain.com"},
-			{ID: 3, Email: "charlie@domain.com"},
-			{ID: 4, Email: "dan@domain.com"},
-			{ID: 5, Email: "eve@domain.com"},
-		}
-
-		fmt.Printf("got %d customers | flushed %d times\n", len(gotCustomers), flushCount)
-		if !reflect.DeepEqual(gotCustomers, wantCustomers) {
-			t.Fatalf("got %d customers, want %d", len(gotCustomers), len(wantCustomers))
-		}
-	})
-
-	// this should fail because we're going to restart the stream, but with an additional table
-	t.Run("second vstream run, should fail", func(t *testing.T) {
-		withAdditionalTable := append(tables, TableConfig{
-			Keyspace: "customer",
-			Table:    "corder",
-			DataType: &Customer{},
-		})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		_, err := New(ctx, "bob", conn, withAdditionalTable,
-			WithStateTable("commerce", "vstreams"),
-		)
-		if err == nil {
-			t.Fatalf("expected VStreamClient error, got nil")
-		} else if err.Error() != "vstreamclient: provided tables do not match stored tables" {
-			t.Fatalf("expected error 'vstreamclient: provided tables do not match stored tables', got '%v'", err)
-		}
-	})
-}
-
-// Customer is the concrete type that will be built from the stream. This version implements
-// the VStreamScanner interface to do custom mapping of fields.
-type CustomerWithScan struct {
-	ID    int64
-	Email string
-
-	// the fields below aren't actually in the schema, but are added for illustrative purposes
-	EmailConfirmed bool
-	Details        map[string]any
-	CreatedAt      time.Time
-}
-
-var _ VStreamScanner = (*CustomerWithScan)(nil)
-
-func (customer *CustomerWithScan) VStreamScan(fields []*querypb.Field, row []sqltypes.Value, rowEvent *binlogdatapb.RowEvent, rowChange *binlogdatapb.RowChange) error {
-	var err error
-
-	for i := range row {
-		if row[i].IsNull() {
-			continue
-		}
-
-		switch fields[i].Name {
-		case "customer_id":
-			customer.ID, err = row[i].ToCastInt64()
-
-		case "email":
-			customer.Email = row[i].ToString()
-
-		// the fields below aren't actually in the example schema, but are added to
-		// show how you should handle different data types
-
-		case "email_confirmed":
-			customer.EmailConfirmed, err = row[i].ToBool()
-
-		case "details":
-			// assume the details field is a json blob
-			var b []byte
-			b, err = row[i].ToBytes()
-			if err == nil {
-				err = json.Unmarshal(b, &customer.Details)
-			}
-
-		case "created_at":
-			customer.CreatedAt, err = row[i].ToTime()
-		}
-		if err != nil {
-			return fmt.Errorf("error processing field %s: %w", fields[i].Name, err)
-		}
 	}
 
-	return nil
+	shouldFlush, reason := v.shouldFlush(true, false)
+	assert.False(t, shouldFlush)
+	assert.Equal(t, FlushReasonNone, reason)
+
+	shouldFlush, reason = v.shouldFlush(true, true)
+	assert.True(t, shouldFlush)
+	assert.Equal(t, FlushReasonForced, reason)
 }
 
-// To run the tests, this currently expects the local example to be running
-// ./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql; ./201_customer_tablets.sh; ./202_move_tables.sh; ./203_switch_reads.sh; ./204_switch_writes.sh; ./205_clean_commerce.sh; ./301_customer_sharded.sh; ./302_new_shards.sh; ./303_reshard.sh; ./304_switch_reads.sh; ./305_switch_writes.sh; ./306_down_shard_0.sh; ./307_delete_shard_0.sh
-func TestVStreamClientWithScan(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+func TestShouldFlush_ReturnsReason(t *testing.T) {
+	t.Run("min flush duration", func(t *testing.T) {
+		v := &VStreamClient{
+			minFlushDuration: time.Second,
+			stats:            VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+		}
+
+		shouldFlush, reason := v.shouldFlush(true, false)
+		assert.True(t, shouldFlush)
+		assert.Equal(t, FlushReasonMinDuration, reason)
+	})
+
+	t.Run("rowless checkpoint still uses last flush time", func(t *testing.T) {
+		v := &VStreamClient{
+			minFlushDuration: time.Second,
+			stats:            VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+		}
+
+		shouldFlush, reason := v.shouldFlush(false, false)
+		assert.True(t, shouldFlush)
+		assert.Equal(t, FlushReasonMinDuration, reason)
+	})
+
+	t.Run("max rows per flush", func(t *testing.T) {
+		v := &VStreamClient{
+			minFlushDuration: time.Hour,
+			stats:            VStreamStats{LastFlushedAt: time.Now()},
+			tables: map[string]*TableConfig{
+				qualifiedTableName("ks", "t"): {
+					Keyspace:        "ks",
+					Table:           "t",
+					MaxRowsPerFlush: 1,
+					currentBatch:    []Row{{Data: "row"}},
+				},
+			},
+		}
+
+		shouldFlush, reason := v.shouldFlush(true, false)
+		assert.True(t, shouldFlush)
+		assert.Equal(t, FlushReasonMaxRowsPerFlush, reason)
+	})
+
+	t.Run("graceful shutdown", func(t *testing.T) {
+		v := &VStreamClient{
+			minFlushDuration: time.Hour,
+			stats:            VStreamStats{LastFlushedAt: time.Now()},
+		}
+		v.isClosing.Store(true)
+
+		shouldFlush, reason := v.shouldFlush(false, false)
+		assert.True(t, shouldFlush)
+		assert.Equal(t, FlushReasonGracefulShutdown, reason)
+	})
+}
+
+func TestMonitorHeartbeat_ShutsDownWhenNoInitialEventArrives(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conn, err := vtgateconn.Dial(ctx, "localhost:15991")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer conn.Close()
-
-	flushCount := 0
-	gotCustomers := make([]*CustomerWithScan, 0)
-
-	tables := []TableConfig{{
-		Keyspace:        "customer",
-		Table:           "customer",
-		MaxRowsPerFlush: 7,
-		FlushFn: func(ctx context.Context, rows []Row, meta FlushMeta) error {
-			flushCount++
-
-			fmt.Printf("upserting %d customers\n", len(rows))
-			for i, row := range rows {
-				gotCustomers = append(gotCustomers, row.Data.(*CustomerWithScan))
-				fmt.Printf("upserting customer %d: %v\n", i, row)
-			}
-
-			// a real implementation would do something more meaningful here. For a data warehouse type workload,
-			// it would probably look like streaming rows into the data warehouse, or for more complex versions,
-			// write newline delimited json or a parquet file to object storage, then trigger a load job.
-			return nil
-		},
-		DataType: &CustomerWithScan{},
-	}}
-
-	vstreamClient, err := New(ctx, "bob2", conn, tables,
-		WithMinFlushDuration(500*time.Millisecond),
-		WithHeartbeatSeconds(1),
-		WithStateTable("commerce", "vstreams"),
-		WithEventFunc(func(ctx context.Context, ev *binlogdatapb.VEvent) error {
-			fmt.Printf("** FIELD EVENT: %v\n", ev)
-			return nil
-		}, binlogdatapb.VEventType_FIELD),
-	)
-	if err != nil {
-		t.Fatalf("failed to create VStreamClient: %v", err)
+	v := &VStreamClient{
+		flags:                     DefaultFlags(),
+		gracefulShutdownFlushChan: make(chan struct{}),
+		gracefulShutdownWaitDur:   0,
+		cancelRunCtxFn:            cancel,
 	}
 
-	err = vstreamClient.Run(ctx)
-	if err != nil && ctx.Err() == nil {
-		t.Fatalf("failed to run vstreamclient: %v", err)
-	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		v.monitorHeartbeat(ctx)
+	}()
 
-	slices.SortFunc(gotCustomers, func(a, b *CustomerWithScan) int {
-		return int(a.ID - b.ID)
-	})
-
-	wantCustomers := []*CustomerWithScan{
-		{ID: 1, Email: "alice@domain.com"},
-		{ID: 2, Email: "bob@domain.com"},
-		{ID: 3, Email: "charlie@domain.com"},
-		{ID: 4, Email: "dan@domain.com"},
-		{ID: 5, Email: "eve@domain.com"},
-	}
-
-	fmt.Printf("got %d customers | flushed %d times\n", len(gotCustomers), flushCount)
-	if !reflect.DeepEqual(gotCustomers, wantCustomers) {
-		t.Fatalf("got %d customers, want %d", len(gotCustomers), len(wantCustomers))
-	}
+	assert.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 4*time.Second, 100*time.Millisecond)
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	assert.True(t, v.isClosing.Load())
 }

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -61,6 +61,10 @@ func (t *testVTGateImpl) VStream(context.Context, topodatapb.TabletType, *binlog
 	return t.reader, nil
 }
 
+func (t *testVTGateImpl) BinlogDumpGTID(context.Context, string, string, topodatapb.TabletType, *topodatapb.TabletAlias, string, uint64, string, uint32) (vtgateconn.BinlogDumpGTIDReader, error) {
+	return nil, fmt.Errorf("unexpected BinlogDumpGTID call")
+}
+
 func (t *testVTGateImpl) Close() {}
 
 type testVStreamReader struct {

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -9,7 +9,9 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -65,6 +67,23 @@ type testVStreamReader struct {
 	batches [][]*binlogdatapb.VEvent
 	err     error
 	index   int
+}
+
+func setLifecycleState(v *VStreamClient, runUsed, runActive, shutdownRequested bool, cancelRunCtxFn context.CancelFunc) {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	v.lifecycle.runUsed = runUsed
+	v.lifecycle.runActive = runActive
+	v.lifecycle.shutdownRequested = shutdownRequested
+	v.lifecycle.cancelRunCtxFn = cancelRunCtxFn
+	v.lifecycle.gracefulShutdownFlushChan = make(chan struct{})
+	v.lifecycle.gracefulShutdownFlushOnce = sync.Once{}
+}
+
+func getLifecycleState(v *VStreamClient) (runUsed, runActive, shutdownRequested bool) {
+	v.lifecycle.mu.Lock()
+	defer v.lifecycle.mu.Unlock()
+	return v.lifecycle.runUsed, v.lifecycle.runActive, v.lifecycle.shutdownRequested
 }
 
 func (r *testVStreamReader) Recv() ([]*binlogdatapb.VEvent, error) {
@@ -264,7 +283,7 @@ func TestIsFinalCopyCompletedEvent(t *testing.T) {
 // TestRun_RejectsClosedClient verifies a client cannot be reused after a prior Run attempt.
 func TestRun_RejectsClosedClient(t *testing.T) {
 	v := &VStreamClient{}
-	v.isClosing.Store(true)
+	setLifecycleState(v, true, false, false, nil)
 
 	err := v.Run(context.Background())
 	assert.Error(t, err)
@@ -323,11 +342,10 @@ func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
 	defer conn.Close()
 
 	v := &VStreamClient{
-		conn:                      conn,
-		tables:                    map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
-		flags:                     DefaultFlags(),
-		filter:                    &binlogdatapb.Filter{},
-		gracefulShutdownFlushChan: make(chan struct{}),
+		conn:   conn,
+		tables: map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+		flags:  DefaultFlags(),
+		filter: &binlogdatapb.Filter{},
 	}
 
 	err = v.Run(context.Background())
@@ -347,18 +365,17 @@ func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
 	}
 	v := &VStreamClient{
-		tables:                    map[string]*TableConfig{},
-		latestVgtid:               vgtid,
-		lastFlushedVgtid:          proto.Clone(vgtid).(*binlogdatapb.VGtid),
-		gracefulShutdownFlushChan: make(chan struct{}),
+		tables:           map[string]*TableConfig{},
+		latestVgtid:      vgtid,
+		lastFlushedVgtid: proto.Clone(vgtid).(*binlogdatapb.VGtid),
 	}
-	v.isClosing.Store(true)
+	setLifecycleState(v, false, false, true, nil)
 
 	err := v.flush(context.Background(), false)
 	assert.NoError(t, err)
 
 	select {
-	case <-v.gracefulShutdownFlushChan:
+	case <-v.getGracefulShutdownFlushChan():
 	default:
 		t.Fatal("expected graceful shutdown flush channel to be closed")
 	}
@@ -434,11 +451,53 @@ func TestShouldFlush_ReturnsReason(t *testing.T) {
 			minFlushDuration: time.Hour,
 			stats:            VStreamStats{LastFlushedAt: time.Now()},
 		}
-		v.isClosing.Store(true)
+		setLifecycleState(v, false, false, true, nil)
 
 		shouldFlush, reason := v.shouldFlush(false, false)
 		assert.True(t, shouldFlush)
 		assert.Equal(t, FlushReasonGracefulShutdown, reason)
+	})
+}
+
+func TestGracefulShutdown_BeforeRunDoesNothing(t *testing.T) {
+	v := &VStreamClient{}
+
+	v.GracefulShutdown(time.Second)
+
+	runUsed, runActive, shutdownRequested := getLifecycleState(v)
+	assert.False(t, runUsed)
+	assert.False(t, runActive)
+	assert.False(t, shutdownRequested)
+}
+
+func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		v := &VStreamClient{}
+		setLifecycleState(v, true, true, false, cancel)
+		defer v.endRun()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			v.GracefulShutdown(5 * time.Second)
+		}()
+
+		synctest.Wait()
+		assert.True(t, v.isShutdownRequested())
+		assert.NoError(t, ctx.Err())
+
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+
+		select {
+		case <-done:
+		default:
+			t.Fatal("GracefulShutdown did not return after wait elapsed")
+		}
+		assert.ErrorIs(t, ctx.Err(), context.Canceled)
 	})
 }
 
@@ -447,11 +506,10 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 	defer cancel()
 
 	v := &VStreamClient{
-		flags:                     DefaultFlags(),
-		gracefulShutdownFlushChan: make(chan struct{}),
-		gracefulShutdownWaitDur:   0,
-		cancelRunCtxFn:            cancel,
+		flags:                   DefaultFlags(),
+		gracefulShutdownWaitDur: 0,
 	}
+	setLifecycleState(v, true, true, false, cancel)
 
 	done := make(chan struct{})
 	go func() {
@@ -468,7 +526,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 		}
 	}, 2500*time.Millisecond, 100*time.Millisecond)
 	assert.NoError(t, ctx.Err())
-	assert.False(t, v.isClosing.Load())
+	assert.False(t, v.isShutdownRequested())
 
 	cancel()
 	assert.Eventually(t, func() bool {
@@ -480,7 +538,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 		}
 	}, time.Second, 50*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
-	assert.False(t, v.isClosing.Load())
+	assert.False(t, v.isShutdownRequested())
 }
 
 func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.T) {
@@ -488,11 +546,10 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 	defer cancel()
 
 	v := &VStreamClient{
-		flags:                     DefaultFlags(),
-		gracefulShutdownFlushChan: make(chan struct{}),
-		gracefulShutdownWaitDur:   0,
-		cancelRunCtxFn:            cancel,
+		flags:                   DefaultFlags(),
+		gracefulShutdownWaitDur: 0,
 	}
+	setLifecycleState(v, true, true, false, cancel)
 	v.lastEventProcessedAtUnixNano.Store(time.Now().Add(-3 * time.Second).UnixNano())
 
 	done := make(chan struct{})
@@ -510,5 +567,5 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 		}
 	}, 2*time.Second, 100*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
-	assert.True(t, v.isClosing.Load())
+	assert.True(t, v.isShutdownRequested())
 }

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -463,6 +463,55 @@ func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
 	}
 }
 
+func TestFlush_ConsumerMutationDoesNotAffectInternalCheckpoint(t *testing.T) {
+	session, _ := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}})
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	}
+
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: 10,
+		currentBatch:    []Row{{Data: "row"}},
+	}
+
+	var seenFlushVGtid *binlogdatapb.VGtid
+	table.FlushFn = func(_ context.Context, _ []Row, meta FlushMeta) error {
+		seenFlushVGtid = meta.LatestVGtid
+		meta.LatestVGtid.ShardGtids[0].Gtid = "mutated"
+		meta.LatestVGtid.ShardGtids = append(meta.LatestVGtid.ShardGtids, &binlogdatapb.ShardGtid{Keyspace: "ks", Shard: "1", Gtid: "mutated"})
+		return nil
+	}
+
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Hour,
+		},
+		session:     session,
+		latestVgtid: vgtid,
+		tables: map[string]*TableConfig{
+			qualifiedTableName("ks", "t"): table,
+		},
+	}
+
+	err := v.flush(context.Background(), true)
+	assert.NoError(t, err)
+	assert.NotNil(t, seenFlushVGtid)
+	assert.NotSame(t, v.latestVgtid, seenFlushVGtid)
+	if assert.Len(t, seenFlushVGtid.ShardGtids, 2) {
+		assert.Equal(t, "mutated", seenFlushVGtid.ShardGtids[0].Gtid)
+	}
+	if assert.Len(t, v.latestVgtid.ShardGtids, 1) {
+		assert.Equal(t, "MySQL56/1", v.latestVgtid.ShardGtids[0].Gtid)
+	}
+	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
+}
+
 func TestShouldFlush_ForceBypassesThresholds(t *testing.T) {
 	v := &VStreamClient{
 		cfg:   clientConfig{minFlushDuration: time.Hour},

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vstreamclient
 
 import (

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -69,6 +69,44 @@ type testVStreamReader struct {
 	index   int
 }
 
+type newTestVTGateImpl struct {
+	testVTGateImpl
+}
+
+func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error) {
+	switch {
+	case query == "SHOW VITESS_SHARDS":
+		return session, sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("shard", "varchar"),
+			"customer/0",
+			"accounting/0",
+			"commerce/0",
+		), nil
+
+	case strings.HasPrefix(query, "create table if not exists "):
+		return session, &sqltypes.Result{RowsAffected: 1}, nil
+
+	case strings.HasPrefix(query, "select latest_vgtid, table_config, copy_completed from "):
+		return session, &sqltypes.Result{}, nil
+
+	case strings.HasPrefix(query, "insert into "):
+		return session, &sqltypes.Result{RowsAffected: 1}, nil
+	}
+
+	return nil, nil, fmt.Errorf("unexpected Execute call: %s", query)
+}
+
+func newConstructorTestConn(t *testing.T) *vtgateconn.VTGateConn {
+	t.Helper()
+
+	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+		return &newTestVTGateImpl{}, nil
+	}, "")
+	assert.NoError(t, err)
+	t.Cleanup(conn.Close)
+	return conn
+}
+
 func setLifecycleState(v *VStreamClient, runUsed, runActive, shutdownRequested bool, cancelRunCtxFn context.CancelFunc) {
 	v.lifecycle.mu.Lock()
 	defer v.lifecycle.mu.Unlock()
@@ -130,6 +168,35 @@ func TestNew_ValidatesName(t *testing.T) {
 	_, err = New(context.Background(), strings.Repeat("a", 65), nil, nil)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "name must be 64 characters or less")
+}
+
+func TestNew_RejectsAmbiguousBareTableNamesAcrossKeyspaces(t *testing.T) {
+	conn := newConstructorTestConn(t)
+
+	_, err := New(context.Background(), "test-stream", conn, []TableConfig{
+		{
+			Keyspace:        "customer",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1 and 10",
+			MaxRowsPerFlush: 1,
+			DataType:        &testRowSmall{},
+			FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+		},
+		{
+			Keyspace:        "accounting",
+			Table:           "customer",
+			Query:           "select * from customer where id between 1 and 10",
+			MaxRowsPerFlush: 1,
+			DataType:        &testRowSmall{},
+			FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+		},
+	},
+		WithStateTable("commerce", "vstreams"),
+		WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
+	)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ExcludeKeyspaceFromTableName")
+	assert.ErrorContains(t, err, "customer")
 }
 
 func TestWithMinFlushDuration_RejectsNonPositive(t *testing.T) {

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -442,7 +442,7 @@ func TestShouldFlush_ReturnsReason(t *testing.T) {
 	})
 }
 
-func TestMonitorHeartbeat_ShutsDownWhenNoInitialEventArrives(t *testing.T) {
+func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -459,6 +459,18 @@ func TestMonitorHeartbeat_ShutsDownWhenNoInitialEventArrives(t *testing.T) {
 		v.monitorHeartbeat(ctx)
 	}()
 
+	assert.Never(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 2500*time.Millisecond, 100*time.Millisecond)
+	assert.NoError(t, ctx.Err())
+	assert.False(t, v.isClosing.Load())
+
+	cancel()
 	assert.Eventually(t, func() bool {
 		select {
 		case <-done:
@@ -466,7 +478,37 @@ func TestMonitorHeartbeat_ShutsDownWhenNoInitialEventArrives(t *testing.T) {
 		default:
 			return false
 		}
-	}, 4*time.Second, 100*time.Millisecond)
+	}, time.Second, 50*time.Millisecond)
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	assert.False(t, v.isClosing.Load())
+}
+
+func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	v := &VStreamClient{
+		flags:                     DefaultFlags(),
+		gracefulShutdownFlushChan: make(chan struct{}),
+		gracefulShutdownWaitDur:   0,
+		cancelRunCtxFn:            cancel,
+	}
+	v.lastEventProcessedAtUnixNano.Store(time.Now().Add(-3 * time.Second).UnixNano())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		v.monitorHeartbeat(ctx)
+	}()
+
+	assert.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 100*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
 	assert.True(t, v.isClosing.Load())
 }

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -401,7 +401,7 @@ func TestShouldFlush_ForceBypassesThresholds(t *testing.T) {
 
 	shouldFlush, reason = v.shouldFlush(true, true)
 	assert.True(t, shouldFlush)
-	assert.Equal(t, FlushReasonForced, reason)
+	assert.Equal(t, FlushReasonCopyCompleted, reason)
 }
 
 func TestShouldFlush_ReturnsReason(t *testing.T) {

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -2,8 +2,11 @@ package vstreamclient
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"math"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -12,9 +15,71 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
+	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
+
+type testVTGateImpl struct {
+	reader vtgateconn.VStreamReader
+}
+
+func (t *testVTGateImpl) Execute(context.Context, *vtgatepb.Session, string, map[string]*querypb.BindVariable, bool) (*vtgatepb.Session, *sqltypes.Result, error) {
+	return nil, nil, fmt.Errorf("unexpected Execute call")
+}
+
+func (t *testVTGateImpl) ExecuteBatch(context.Context, *vtgatepb.Session, []string, []map[string]*querypb.BindVariable) (*vtgatepb.Session, []sqltypes.QueryResponse, error) {
+	return nil, nil, fmt.Errorf("unexpected ExecuteBatch call")
+}
+
+func (t *testVTGateImpl) StreamExecute(context.Context, *vtgatepb.Session, string, map[string]*querypb.BindVariable, func(*vtgatepb.StreamExecuteResponse)) (sqltypes.ResultStream, error) {
+	return nil, fmt.Errorf("unexpected StreamExecute call")
+}
+
+func (t *testVTGateImpl) ExecuteMulti(context.Context, *vtgatepb.Session, string) (*vtgatepb.Session, []*sqltypes.Result, error) {
+	return nil, nil, fmt.Errorf("unexpected ExecuteMulti call")
+}
+
+func (t *testVTGateImpl) StreamExecuteMulti(context.Context, *vtgatepb.Session, string, func(*vtgatepb.StreamExecuteMultiResponse)) (sqltypes.MultiResultStream, error) {
+	return nil, fmt.Errorf("unexpected StreamExecuteMulti call")
+}
+
+func (t *testVTGateImpl) Prepare(context.Context, *vtgatepb.Session, string) (*vtgatepb.Session, []*querypb.Field, uint16, error) {
+	return nil, nil, 0, fmt.Errorf("unexpected Prepare call")
+}
+
+func (t *testVTGateImpl) CloseSession(context.Context, *vtgatepb.Session) error {
+	return fmt.Errorf("unexpected CloseSession call")
+}
+
+func (t *testVTGateImpl) VStream(context.Context, topodatapb.TabletType, *binlogdatapb.VGtid, *binlogdatapb.Filter, *vtgatepb.VStreamFlags) (vtgateconn.VStreamReader, error) {
+	return t.reader, nil
+}
+
+func (t *testVTGateImpl) Close() {}
+
+type testVStreamReader struct {
+	batches [][]*binlogdatapb.VEvent
+	err     error
+	index   int
+}
+
+func (r *testVStreamReader) Recv() ([]*binlogdatapb.VEvent, error) {
+	if r.index < len(r.batches) {
+		batch := r.batches[r.index]
+		r.index++
+		return batch, nil
+	}
+
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return nil, io.EOF
+}
 
 func TestResolveLatestVGtid(t *testing.T) {
 	explicit := &binlogdatapb.VGtid{
@@ -204,6 +269,77 @@ func TestRun_RejectsClosedClient(t *testing.T) {
 	err := v.Run(context.Background())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
+}
+
+func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
+	reader := &testVStreamReader{
+		batches: [][]*binlogdatapb.VEvent{{
+			{
+				Type: binlogdatapb.VEventType_FIELD,
+				FieldEvent: &binlogdatapb.FieldEvent{
+					TableName: "ks.t",
+					Shard:     "0",
+					Fields: []*querypb.Field{{
+						Name: "id",
+						Type: querypb.Type_INT64,
+					}},
+				},
+			},
+			{
+				Type: binlogdatapb.VEventType_ROW,
+				RowEvent: &binlogdatapb.RowEvent{
+					TableName: "ks.t",
+					Shard:     "0",
+					RowChanges: []*binlogdatapb.RowChange{{
+						After: &querypb.Row{Lengths: []int64{1}, Values: []byte("7")},
+					}},
+				},
+			},
+			{
+				Type:  binlogdatapb.VEventType_VGTID,
+				Vgtid: &binlogdatapb.VGtid{ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}}},
+			},
+		}},
+		err: io.EOF,
+	}
+
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		DataType:        &testRowSmall{},
+		MaxRowsPerFlush: 10,
+		FlushFn: func(context.Context, []Row, FlushMeta) error {
+			return nil
+		},
+		shards: map[string]shardConfig{},
+	}
+	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
+	table.resetBatch()
+
+	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+		return &testVTGateImpl{reader: reader}, nil
+	}, "")
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	v := &VStreamClient{
+		conn:                      conn,
+		tables:                    map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+		flags:                     DefaultFlags(),
+		filter:                    &binlogdatapb.Filter{},
+		gracefulShutdownFlushChan: make(chan struct{}),
+	}
+
+	err = v.Run(context.Background())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected EOF")
+	assert.Nil(t, v.lastFlushedVgtid)
+	if assert.Len(t, table.currentBatch, 1) {
+		row, ok := table.currentBatch[0].Data.(*testRowSmall)
+		if assert.True(t, ok) {
+			assert.Equal(t, int64(7), row.ID)
+		}
+	}
 }
 
 func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -168,7 +168,7 @@ func TestWithTabletType_Validation(t *testing.T) {
 
 	err = WithTabletType(topodatapb.TabletType_RDONLY)(v)
 	assert.NoError(t, err)
-	assert.Equal(t, topodatapb.TabletType_RDONLY, v.tabletType)
+	assert.Equal(t, topodatapb.TabletType_RDONLY, v.cfg.tabletType)
 }
 
 func TestWithFlags_RejectsNil(t *testing.T) {
@@ -192,8 +192,8 @@ func TestWithGracefulShutdownChan_Validation(t *testing.T) {
 	ch := make(chan struct{})
 	err = WithGracefulShutdownChan(ch, time.Second)(v)
 	assert.NoError(t, err)
-	assert.Equal(t, (<-chan struct{})(ch), v.gracefulShutdownChan)
-	assert.Equal(t, time.Second, v.gracefulShutdownWaitDur)
+	assert.Equal(t, (<-chan struct{})(ch), v.cfg.gracefulShutdownChan)
+	assert.Equal(t, time.Second, v.cfg.gracefulShutdownWaitDur)
 }
 
 func TestWithGracefulShutdownSignals_Validation(t *testing.T) {
@@ -209,8 +209,8 @@ func TestWithGracefulShutdownSignals_Validation(t *testing.T) {
 
 	err = WithGracefulShutdownSignals(time.Second, os.Interrupt)(v)
 	assert.NoError(t, err)
-	assert.Equal(t, []os.Signal{os.Interrupt}, v.gracefulShutdownSignals)
-	assert.Equal(t, time.Second, v.gracefulShutdownWaitDur)
+	assert.Equal(t, []os.Signal{os.Interrupt}, v.cfg.gracefulShutdownSignals)
+	assert.Equal(t, time.Second, v.cfg.gracefulShutdownWaitDur)
 }
 
 func TestWithEventFunc_Validation(t *testing.T) {
@@ -342,10 +342,12 @@ func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
 	defer conn.Close()
 
 	v := &VStreamClient{
-		conn:   conn,
+		cfg: clientConfig{
+			conn:   conn,
+			flags:  DefaultFlags(),
+			filter: &binlogdatapb.Filter{},
+		},
 		tables: map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
-		flags:  DefaultFlags(),
-		filter: &binlogdatapb.Filter{},
 	}
 
 	err = v.Run(context.Background())
@@ -383,8 +385,8 @@ func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
 
 func TestShouldFlush_ForceBypassesThresholds(t *testing.T) {
 	v := &VStreamClient{
-		minFlushDuration: time.Hour,
-		stats:            VStreamStats{LastFlushedAt: time.Now()},
+		cfg:   clientConfig{minFlushDuration: time.Hour},
+		stats: VStreamStats{LastFlushedAt: time.Now()},
 		tables: map[string]*TableConfig{
 			qualifiedTableName("ks", "t"): {
 				Keyspace:        "ks",
@@ -407,8 +409,8 @@ func TestShouldFlush_ForceBypassesThresholds(t *testing.T) {
 func TestShouldFlush_ReturnsReason(t *testing.T) {
 	t.Run("min flush duration", func(t *testing.T) {
 		v := &VStreamClient{
-			minFlushDuration: time.Second,
-			stats:            VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+			cfg:   clientConfig{minFlushDuration: time.Second},
+			stats: VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
 		}
 
 		shouldFlush, reason := v.shouldFlush(true, false)
@@ -418,8 +420,8 @@ func TestShouldFlush_ReturnsReason(t *testing.T) {
 
 	t.Run("rowless checkpoint still uses last flush time", func(t *testing.T) {
 		v := &VStreamClient{
-			minFlushDuration: time.Second,
-			stats:            VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+			cfg:   clientConfig{minFlushDuration: time.Second},
+			stats: VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
 		}
 
 		shouldFlush, reason := v.shouldFlush(false, false)
@@ -429,8 +431,8 @@ func TestShouldFlush_ReturnsReason(t *testing.T) {
 
 	t.Run("max rows per flush", func(t *testing.T) {
 		v := &VStreamClient{
-			minFlushDuration: time.Hour,
-			stats:            VStreamStats{LastFlushedAt: time.Now()},
+			cfg:   clientConfig{minFlushDuration: time.Hour},
+			stats: VStreamStats{LastFlushedAt: time.Now()},
 			tables: map[string]*TableConfig{
 				qualifiedTableName("ks", "t"): {
 					Keyspace:        "ks",
@@ -448,8 +450,8 @@ func TestShouldFlush_ReturnsReason(t *testing.T) {
 
 	t.Run("graceful shutdown", func(t *testing.T) {
 		v := &VStreamClient{
-			minFlushDuration: time.Hour,
-			stats:            VStreamStats{LastFlushedAt: time.Now()},
+			cfg:   clientConfig{minFlushDuration: time.Hour},
+			stats: VStreamStats{LastFlushedAt: time.Now()},
 		}
 		setLifecycleState(v, false, false, true, nil)
 
@@ -506,8 +508,10 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 	defer cancel()
 
 	v := &VStreamClient{
-		flags:                   DefaultFlags(),
-		gracefulShutdownWaitDur: 0,
+		cfg: clientConfig{
+			flags:                   DefaultFlags(),
+			gracefulShutdownWaitDur: 0,
+		},
 	}
 	setLifecycleState(v, true, true, false, cancel)
 
@@ -546,8 +550,10 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 	defer cancel()
 
 	v := &VStreamClient{
-		flags:                   DefaultFlags(),
-		gracefulShutdownWaitDur: 0,
+		cfg: clientConfig{
+			flags:                   DefaultFlags(),
+			gracefulShutdownWaitDur: 0,
+		},
 	}
 	setLifecycleState(v, true, true, false, cancel)
 	v.lastEventProcessedAtUnixNano.Store(time.Now().Add(-3 * time.Second).UnixNano())

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -159,6 +159,19 @@ func TestWithHeartbeatSeconds_RejectsOverflow(t *testing.T) {
 	assert.ErrorContains(t, err, "or less")
 }
 
+func TestWithTimeLocation_Validation(t *testing.T) {
+	v := &VStreamClient{}
+
+	err := WithTimeLocation(nil)(v)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "time location")
+
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	err = WithTimeLocation(loc)(v)
+	assert.NoError(t, err)
+	assert.Same(t, loc, v.cfg.timeLocation)
+}
+
 func TestWithTabletType_Validation(t *testing.T) {
 	v := &VStreamClient{}
 

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -18,6 +18,7 @@ package vstreamclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -46,31 +47,31 @@ type testVTGateImpl struct {
 }
 
 func (t *testVTGateImpl) Execute(context.Context, *vtgatepb.Session, string, map[string]*querypb.BindVariable, bool) (*vtgatepb.Session, *sqltypes.Result, error) {
-	return nil, nil, fmt.Errorf("unexpected Execute call")
+	return nil, nil, errors.New("unexpected Execute call")
 }
 
 func (t *testVTGateImpl) ExecuteBatch(context.Context, *vtgatepb.Session, []string, []map[string]*querypb.BindVariable) (*vtgatepb.Session, []sqltypes.QueryResponse, error) {
-	return nil, nil, fmt.Errorf("unexpected ExecuteBatch call")
+	return nil, nil, errors.New("unexpected ExecuteBatch call")
 }
 
 func (t *testVTGateImpl) StreamExecute(context.Context, *vtgatepb.Session, string, map[string]*querypb.BindVariable, func(*vtgatepb.StreamExecuteResponse)) (sqltypes.ResultStream, error) {
-	return nil, fmt.Errorf("unexpected StreamExecute call")
+	return nil, errors.New("unexpected StreamExecute call")
 }
 
 func (t *testVTGateImpl) ExecuteMulti(context.Context, *vtgatepb.Session, string) (*vtgatepb.Session, []*sqltypes.Result, error) {
-	return nil, nil, fmt.Errorf("unexpected ExecuteMulti call")
+	return nil, nil, errors.New("unexpected ExecuteMulti call")
 }
 
 func (t *testVTGateImpl) StreamExecuteMulti(context.Context, *vtgatepb.Session, string, func(*vtgatepb.StreamExecuteMultiResponse)) (sqltypes.MultiResultStream, error) {
-	return nil, fmt.Errorf("unexpected StreamExecuteMulti call")
+	return nil, errors.New("unexpected StreamExecuteMulti call")
 }
 
 func (t *testVTGateImpl) Prepare(context.Context, *vtgatepb.Session, string) (*vtgatepb.Session, []*querypb.Field, uint16, error) {
-	return nil, nil, 0, fmt.Errorf("unexpected Prepare call")
+	return nil, nil, 0, errors.New("unexpected Prepare call")
 }
 
 func (t *testVTGateImpl) CloseSession(context.Context, *vtgatepb.Session) error {
-	return fmt.Errorf("unexpected CloseSession call")
+	return errors.New("unexpected CloseSession call")
 }
 
 func (t *testVTGateImpl) VStream(context.Context, topodatapb.TabletType, *binlogdatapb.VGtid, *binlogdatapb.Filter, *vtgatepb.VStreamFlags) (vtgateconn.VStreamReader, error) {
@@ -78,7 +79,7 @@ func (t *testVTGateImpl) VStream(context.Context, topodatapb.TabletType, *binlog
 }
 
 func (t *testVTGateImpl) BinlogDumpGTID(context.Context, string, string, topodatapb.TabletType, *topodatapb.TabletAlias, string, uint64, string, uint32) (vtgateconn.BinlogDumpGTIDReader, error) {
-	return nil, fmt.Errorf("unexpected BinlogDumpGTID call")
+	return nil, errors.New("unexpected BinlogDumpGTID call")
 }
 
 func (t *testVTGateImpl) Close() {}

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -123,7 +124,7 @@ func newConstructorTestConn(t *testing.T) *vtgateconn.VTGateConn {
 	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
 		return &newTestVTGateImpl{}, nil
 	}, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(conn.Close)
 	return conn
 }
@@ -256,7 +257,7 @@ func TestWithTimeLocation_Validation(t *testing.T) {
 
 	loc := time.FixedZone("UTC-5", -5*60*60)
 	err = WithTimeLocation(loc)(v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Same(t, loc, v.cfg.timeLocation)
 }
 
@@ -268,7 +269,7 @@ func TestWithTabletType_Validation(t *testing.T) {
 	assert.ErrorContains(t, err, "tablet type cannot be UNKNOWN")
 
 	err = WithTabletType(topodatapb.TabletType_RDONLY)(v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, topodatapb.TabletType_RDONLY, v.cfg.tabletType)
 }
 
@@ -292,7 +293,7 @@ func TestWithGracefulShutdownChan_Validation(t *testing.T) {
 
 	ch := make(chan struct{})
 	err = WithGracefulShutdownChan(ch, time.Second)(v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, (<-chan struct{})(ch), v.cfg.gracefulShutdownChan)
 	assert.Equal(t, time.Second, v.cfg.gracefulShutdownWaitDur)
 }
@@ -309,7 +310,7 @@ func TestWithGracefulShutdownSignals_Validation(t *testing.T) {
 	assert.ErrorContains(t, err, "graceful shutdown wait")
 
 	err = WithGracefulShutdownSignals(time.Second, os.Interrupt)(v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []os.Signal{os.Interrupt}, v.cfg.gracefulShutdownSignals)
 	assert.Equal(t, time.Second, v.cfg.gracefulShutdownWaitDur)
 }
@@ -323,7 +324,7 @@ func TestWithEventFunc_Validation(t *testing.T) {
 	assert.ErrorContains(t, err, "no event types provided")
 
 	err = WithEventFunc(fn, binlogdatapb.VEventType_FIELD)(v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = WithEventFunc(fn, binlogdatapb.VEventType_FIELD)(v)
 	assert.Error(t, err)
@@ -338,7 +339,7 @@ func TestLookupTable(t *testing.T) {
 		}}
 
 		got, err := v.lookupTable("ks.t")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Same(t, want, got)
 	})
 
@@ -349,7 +350,7 @@ func TestLookupTable(t *testing.T) {
 		}}
 
 		got, err := v.lookupTable("t")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Same(t, want, got)
 	})
 
@@ -439,7 +440,7 @@ func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
 	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
 		return &testVTGateImpl{reader: reader}, nil
 	}, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer conn.Close()
 
 	v := &VStreamClient{
@@ -455,12 +456,10 @@ func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "unexpected EOF")
 	assert.Nil(t, v.lastFlushedVgtid)
-	if assert.Len(t, table.currentBatch, 1) {
-		row, ok := table.currentBatch[0].Data.(*testRowSmall)
-		if assert.True(t, ok) {
-			assert.Equal(t, int64(7), row.ID)
-		}
-	}
+	require.Len(t, table.currentBatch, 1)
+	row, ok := table.currentBatch[0].Data.(*testRowSmall)
+	require.True(t, ok)
+	assert.Equal(t, int64(7), row.ID)
 }
 
 func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
@@ -475,7 +474,7 @@ func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
 	setLifecycleState(v, false, false, true, nil)
 
 	err := v.flush(context.Background(), false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	select {
 	case <-v.getGracefulShutdownFlushChan():
@@ -521,15 +520,13 @@ func TestFlush_ConsumerMutationDoesNotAffectInternalCheckpoint(t *testing.T) {
 	}
 
 	err := v.flush(context.Background(), true)
-	assert.NoError(t, err)
-	assert.NotNil(t, seenFlushVGtid)
+	require.NoError(t, err)
+	require.NotNil(t, seenFlushVGtid)
 	assert.NotSame(t, v.latestVgtid, seenFlushVGtid)
-	if assert.Len(t, seenFlushVGtid.ShardGtids, 2) {
-		assert.Equal(t, "mutated", seenFlushVGtid.ShardGtids[0].Gtid)
-	}
-	if assert.Len(t, v.latestVgtid.ShardGtids, 1) {
-		assert.Equal(t, "MySQL56/1", v.latestVgtid.ShardGtids[0].Gtid)
-	}
+	require.Len(t, seenFlushVGtid.ShardGtids, 2)
+	assert.Equal(t, "mutated", seenFlushVGtid.ShardGtids[0].Gtid)
+	require.Len(t, v.latestVgtid.ShardGtids, 1)
+	assert.Equal(t, "MySQL56/1", v.latestVgtid.ShardGtids[0].Gtid)
 	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
 }
 

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -163,6 +163,12 @@ func (r *testVStreamReader) Recv() ([]*binlogdatapb.VEvent, error) {
 	return nil, io.EOF
 }
 
+func TestFlushReason_StringNeverPanics(t *testing.T) {
+	assert.Equal(t, "unknown(0)", FlushReason(0).String())
+	assert.Equal(t, "unknown(99)", FlushReason(99).String())
+	assert.Equal(t, "minDuration", FlushReasonMinDuration.String())
+}
+
 func TestResolveLatestVGtid(t *testing.T) {
 	explicit := &binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -124,7 +124,7 @@ func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session
 func newConstructorTestConn(t *testing.T) *vtgateconn.VTGateConn {
 	t.Helper()
 
-	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+	conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
 		return &newTestVTGateImpl{}, nil
 	}, "")
 	require.NoError(t, err)
@@ -186,11 +186,11 @@ func TestDefaultFlagsExcludeKeyspaceFromTableName(t *testing.T) {
 }
 
 func TestNew_ValidatesName(t *testing.T) {
-	_, err := New(context.Background(), "", nil, nil)
+	_, err := New(t.Context(), "", nil, nil)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "name is required")
 
-	_, err = New(context.Background(), strings.Repeat("a", 65), nil, nil)
+	_, err = New(t.Context(), strings.Repeat("a", 65), nil, nil)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "name must be 64 characters or less")
 }
@@ -199,7 +199,7 @@ func TestNew_RejectsAmbiguousBareTableNamesAcrossKeyspaces(t *testing.T) {
 	conn := newConstructorTestConn(t)
 
 	_, err := New(
-		context.Background(), "test-stream", conn, []TableConfig{
+		t.Context(), "test-stream", conn, []TableConfig{
 			{
 				Keyspace:        "customer",
 				Table:           "customer",
@@ -391,7 +391,7 @@ func TestRun_RejectsClosedClient(t *testing.T) {
 	v := &VStreamClient{}
 	setLifecycleState(v, true, false, false, nil)
 
-	err := v.Run(context.Background())
+	err := v.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
 }
@@ -441,7 +441,7 @@ func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
 	table.underlyingType = reflect.Indirect(reflect.ValueOf(table.DataType)).Type()
 	table.resetBatch()
 
-	conn, err := vtgateconn.DialCustom(context.Background(), func(context.Context, string) (vtgateconn.Impl, error) {
+	conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
 		return &testVTGateImpl{reader: reader}, nil
 	}, "")
 	require.NoError(t, err)
@@ -456,7 +456,7 @@ func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
 		tables: map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
 	}
 
-	err = v.Run(context.Background())
+	err = v.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "unexpected EOF")
 	assert.Nil(t, v.lastFlushedVgtid)
@@ -477,7 +477,7 @@ func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
 	}
 	setLifecycleState(v, false, false, true, nil)
 
-	err := v.flush(context.Background(), false)
+	err := v.flush(t.Context(), false)
 	require.NoError(t, err)
 
 	select {
@@ -523,7 +523,7 @@ func TestFlush_ConsumerMutationDoesNotAffectInternalCheckpoint(t *testing.T) {
 		},
 	}
 
-	err := v.flush(context.Background(), true)
+	err := v.flush(t.Context(), true)
 	require.NoError(t, err)
 	require.NotNil(t, seenFlushVGtid)
 	assert.NotSame(t, v.latestVgtid, seenFlushVGtid)
@@ -807,6 +807,8 @@ func TestGracefulShutdown_BeforeRunDoesNothing(t *testing.T) {
 
 func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
+		// deliberately not t.Context(): contexts created outside the synctest bubble
+		// don't participate in its fake-time blocking semantics
 		ctx, cancel := context.WithCancelCause(context.Background())
 		defer cancel(nil)
 
@@ -837,7 +839,7 @@ func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
 }
 
 func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(t.Context())
 	defer cancel(nil)
 
 	v := &VStreamClient{
@@ -879,7 +881,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 }
 
 func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.T) {
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(t.Context())
 	defer cancel(nil)
 
 	v := &VStreamClient{
@@ -911,7 +913,7 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 }
 
 func TestMonitorHeartbeat_StartupTimeoutShutsDownWithCause(t *testing.T) {
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(t.Context())
 	defer cancel(nil)
 
 	v := &VStreamClient{
@@ -947,7 +949,7 @@ func TestShouldExitRun_SurfacesCancelCause(t *testing.T) {
 	v := &VStreamClient{}
 	setLifecycleState(v, true, true, true, nil)
 
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(t.Context())
 	cancel(ErrHeartbeatTimeout)
 
 	shouldExit, err := v.shouldExitRun(ctx)
@@ -959,7 +961,7 @@ func TestShouldExitRun_PlainCancelReturnsContextError(t *testing.T) {
 	v := &VStreamClient{}
 	setLifecycleState(v, true, true, true, nil)
 
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(t.Context())
 	cancel(nil)
 
 	shouldExit, err := v.shouldExitRun(ctx)

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -108,7 +108,7 @@ func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session
 	case strings.HasPrefix(query, "create table if not exists "):
 		return session, &sqltypes.Result{RowsAffected: 1}, nil
 
-	case strings.HasPrefix(query, "select latest_vgtid, table_config, copy_completed from "):
+	case strings.HasPrefix(query, "select latest_vgtid, table_config, copy_completed"):
 		return session, &sqltypes.Result{}, nil
 
 	case strings.HasPrefix(query, "insert into "):

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -114,8 +114,11 @@ func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session
 	case strings.HasPrefix(query, "insert into "):
 		return session, &sqltypes.Result{RowsAffected: 1}, nil
 
-	case strings.HasPrefix(query, "update ") && strings.Contains(query, "set owner_token = :owner_token"):
+	case strings.HasPrefix(query, "update ") && strings.Contains(query, "owner_token"):
 		return session, &sqltypes.Result{RowsAffected: 1}, nil
+
+	case strings.Contains(query, "binlog_row_image"):
+		return session, sqltypes.MakeTestResult(sqltypes.MakeTestFields("@@global.binlog_row_image", "varchar"), "FULL"), nil
 	}
 
 	return nil, nil, fmt.Errorf("unexpected Execute call: %s", query)

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -534,6 +534,188 @@ func TestFlush_ConsumerMutationDoesNotAffectInternalCheckpoint(t *testing.T) {
 	assert.Same(t, v.latestVgtid, v.lastFlushedVgtid)
 }
 
+func TestFlush_ChunksBatchesByMaxRowsPerFlush(t *testing.T) {
+	session, impl := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}})
+
+	var chunkSizes []int
+	var reasons []FlushReason
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: 2,
+		FlushFn: func(_ context.Context, rows []Row, meta FlushMeta) error {
+			chunkSizes = append(chunkSizes, len(rows))
+			reasons = append(reasons, meta.FlushReason)
+			return nil
+		},
+		currentBatch: []Row{{Data: "1"}, {Data: "2"}, {Data: "3"}, {Data: "4"}, {Data: "5"}},
+	}
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	}
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Second,
+		},
+		session:     session,
+		latestVgtid: vgtid,
+		stats:       VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+		tables:      map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+	}
+
+	err := v.flush(t.Context(), false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{2, 2, 1}, chunkSizes)
+	assert.Equal(t, []FlushReason{FlushReasonMinDuration, FlushReasonMinDuration, FlushReasonMinDuration}, reasons)
+	assert.Empty(t, table.currentBatch)
+
+	assert.Equal(t, 3, table.stats.FlushCount)
+	assert.Equal(t, 5, table.stats.FlushedRowCount)
+	assert.False(t, table.stats.LastFlushedAt.IsZero())
+	assert.Equal(t, 1, v.stats.FlushCount)
+	assert.Equal(t, 3, v.stats.TableFlushCount)
+	assert.Equal(t, 5, v.stats.FlushedRowCount)
+
+	// all chunks are covered by a single checkpoint write
+	assert.Same(t, vgtid, v.lastFlushedVgtid)
+	require.Len(t, impl.queries, 1)
+	assert.Contains(t, impl.queries[0], "update ks.state set latest_vgtid = :latest_vgtid")
+}
+
+func TestFlush_FlushFnErrorStopsFlushAndPreservesState(t *testing.T) {
+	session, impl := newStateTestSession(t)
+
+	flushErr := errors.New("sink write failed")
+	calls := 0
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: 2,
+		FlushFn: func(_ context.Context, _ []Row, _ FlushMeta) error {
+			calls++
+			if calls == 2 {
+				return flushErr
+			}
+			return nil
+		},
+		currentBatch: []Row{{Data: "1"}, {Data: "2"}, {Data: "3"}, {Data: "4"}, {Data: "5"}},
+	}
+
+	lastFlushedAt := time.Now().Add(-2 * time.Second)
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Second,
+		},
+		session: session,
+		latestVgtid: &binlogdatapb.VGtid{
+			ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+		},
+		stats:  VStreamStats{LastFlushedAt: lastFlushedAt},
+		tables: map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+	}
+
+	err := v.flush(t.Context(), false)
+	require.ErrorIs(t, err, flushErr)
+	require.ErrorContains(t, err, "error flushing table t")
+
+	// the batch is preserved for replay, no checkpoint is written, and stream-level flush
+	// state is untouched; only the successfully flushed first chunk was counted
+	assert.Len(t, table.currentBatch, 5)
+	assert.Nil(t, v.lastFlushedVgtid)
+	assert.Empty(t, impl.queries)
+	assert.Equal(t, 1, table.stats.FlushCount)
+	assert.Equal(t, 2, table.stats.FlushedRowCount)
+	assert.Equal(t, 0, v.stats.FlushCount)
+	assert.Equal(t, lastFlushedAt, v.stats.LastFlushedAt)
+}
+
+func TestFlush_ReuseBatchSliceKeepsBackingArrayAcrossFlushes(t *testing.T) {
+	session, _ := newStateTestSession(t, stateExecuteResponse{result: &sqltypes.Result{RowsAffected: 1}})
+
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: 4,
+		ReuseBatchSlice: true,
+		FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+	}
+	table.resetBatch()
+	table.currentBatch = append(table.currentBatch, Row{Data: "1"}, Row{Data: "2"})
+	held := &table.currentBatch[0]
+
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Second,
+		},
+		session: session,
+		latestVgtid: &binlogdatapb.VGtid{
+			ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+		},
+		stats:  VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+		tables: map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+	}
+
+	err := v.flush(t.Context(), false)
+	require.NoError(t, err)
+
+	require.Empty(t, table.currentBatch)
+	table.currentBatch = append(table.currentBatch, Row{Data: "3"})
+	assert.Same(t, held, &table.currentBatch[0])
+}
+
+func TestFlush_SkipsCheckpointWhenVGtidUnchanged(t *testing.T) {
+	session, impl := newStateTestSession(t)
+
+	flushed := 0
+	table := &TableConfig{
+		Keyspace:        "ks",
+		Table:           "t",
+		MaxRowsPerFlush: 2,
+		FlushFn: func(_ context.Context, rows []Row, _ FlushMeta) error {
+			flushed += len(rows)
+			return nil
+		},
+		currentBatch: []Row{{Data: "1"}},
+	}
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{Keyspace: "ks", Shard: "0", Gtid: "MySQL56/1"}},
+	}
+	v := &VStreamClient{
+		cfg: clientConfig{
+			name:               "stream",
+			vgtidStateKeyspace: "ks",
+			vgtidStateTable:    "state",
+			minFlushDuration:   time.Second,
+		},
+		session:          session,
+		latestVgtid:      vgtid,
+		lastFlushedVgtid: proto.Clone(vgtid).(*binlogdatapb.VGtid),
+		stats:            VStreamStats{LastFlushedAt: time.Now().Add(-2 * time.Second)},
+		tables:           map[string]*TableConfig{qualifiedTableName("ks", "t"): table},
+	}
+
+	err := v.flush(t.Context(), false)
+	require.NoError(t, err)
+
+	// buffered rows still flush, but the no-op checkpoint update is skipped, since MySQL
+	// reports RowsAffected=0 for an update that changes nothing
+	assert.Equal(t, 1, flushed)
+	assert.Empty(t, table.currentBatch)
+	assert.Empty(t, impl.queries)
+}
+
 func TestShouldFlush_ForceBypassesThresholds(t *testing.T) {
 	v := &VStreamClient{
 		cfg:   clientConfig{minFlushDuration: time.Hour},

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -883,7 +883,7 @@ func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
 		}()
 
 		synctest.Wait()
-		assert.True(t, v.isShutdownRequested())
+		assert.True(t, v.ShutdownRequested())
 		assert.NoError(t, ctx.Err())
 
 		time.Sleep(5 * time.Second)
@@ -925,7 +925,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 		}
 	}, 2500*time.Millisecond, 100*time.Millisecond)
 	assert.NoError(t, ctx.Err())
-	assert.False(t, v.isShutdownRequested())
+	assert.False(t, v.ShutdownRequested())
 
 	cancel(nil)
 	assert.Eventually(t, func() bool {
@@ -937,7 +937,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 		}
 	}, time.Second, 50*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
-	assert.False(t, v.isShutdownRequested())
+	assert.False(t, v.ShutdownRequested())
 }
 
 func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.T) {
@@ -969,7 +969,7 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 	}, 2*time.Second, 100*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
 	require.ErrorIs(t, context.Cause(ctx), ErrHeartbeatTimeout)
-	assert.True(t, v.isShutdownRequested())
+	assert.True(t, v.ShutdownRequested())
 }
 
 func TestMonitorHeartbeat_StartupTimeoutShutsDownWithCause(t *testing.T) {
@@ -1002,7 +1002,72 @@ func TestMonitorHeartbeat_StartupTimeoutShutsDownWithCause(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 	require.ErrorIs(t, ctx.Err(), context.Canceled)
 	require.ErrorIs(t, context.Cause(ctx), ErrStartupTimeout)
-	assert.True(t, v.isShutdownRequested())
+	assert.True(t, v.ShutdownRequested())
+}
+
+func TestShouldExitRun_ReturnsMonitorCauseAfterFinalFlush(t *testing.T) {
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	v := &VStreamClient{}
+	setLifecycleState(v, true, true, false, cancel)
+
+	// a monitor-initiated shutdown whose final flush succeeds must still surface its cause,
+	// or applications that restart only on errors would silently stop consuming
+	_, _, ok := v.requestShutdown(ErrHeartbeatTimeout)
+	require.True(t, ok)
+	v.signalGracefulShutdownFlushed()
+
+	shouldExit, err := v.shouldExitRun(t.Context())
+	assert.True(t, shouldExit)
+	require.ErrorIs(t, err, ErrHeartbeatTimeout)
+}
+
+func TestShouldExitRun_UserShutdownAfterFinalFlushReturnsNil(t *testing.T) {
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	v := &VStreamClient{}
+	setLifecycleState(v, true, true, false, cancel)
+
+	_, _, ok := v.requestShutdown(nil)
+	require.True(t, ok)
+	v.signalGracefulShutdownFlushed()
+
+	shouldExit, err := v.shouldExitRun(t.Context())
+	assert.True(t, shouldExit)
+	require.NoError(t, err)
+}
+
+func TestEndRun_WakesBlockedGracefulShutdownWaiter(t *testing.T) {
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	v := &VStreamClient{}
+	setLifecycleState(v, true, true, false, cancel)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		v.GracefulShutdown(time.Hour)
+	}()
+
+	assert.Eventually(t, v.ShutdownRequested, 30*time.Second, 10*time.Millisecond)
+
+	// once Run has exited, no future flush can close the channel; endRun must wake the waiter
+	// instead of leaving it blocked for the full wait duration
+	v.endRun()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "GracefulShutdown did not return after endRun")
+	}
+}
+
+func TestEffectiveStartupTimeout_FlooredAtLivenessWindow(t *testing.T) {
+	assert.Equal(t, 10*time.Second, effectiveStartupTimeout(time.Second, 10*time.Second))
+	assert.Equal(t, 5*time.Minute, effectiveStartupTimeout(5*time.Minute, 2*time.Second))
 }
 
 func TestShouldExitRun_SurfacesCancelCause(t *testing.T) {

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -113,6 +113,9 @@ func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session
 
 	case strings.HasPrefix(query, "insert into "):
 		return session, &sqltypes.Result{RowsAffected: 1}, nil
+
+	case strings.HasPrefix(query, "update ") && strings.Contains(query, "set owner_token = :owner_token"):
+		return session, &sqltypes.Result{RowsAffected: 1}, nil
 	}
 
 	return nil, nil, fmt.Errorf("unexpected Execute call: %s", query)

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -483,7 +483,7 @@ func TestFlush_ClosesGracefulShutdownWhenAlreadyFlushed(t *testing.T) {
 	select {
 	case <-v.getGracefulShutdownFlushChan():
 	default:
-		t.Fatal("expected graceful shutdown flush channel to be closed")
+		require.FailNow(t, "expected graceful shutdown flush channel to be closed")
 	}
 }
 
@@ -830,7 +830,7 @@ func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
 		select {
 		case <-done:
 		default:
-			t.Fatal("GracefulShutdown did not return after wait elapsed")
+			require.FailNow(t, "GracefulShutdown did not return after wait elapsed")
 		}
 		assert.ErrorIs(t, ctx.Err(), context.Canceled)
 	})

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -129,7 +129,7 @@ func newConstructorTestConn(t *testing.T) *vtgateconn.VTGateConn {
 	return conn
 }
 
-func setLifecycleState(v *VStreamClient, runUsed, runActive, shutdownRequested bool, cancelRunCtxFn context.CancelFunc) {
+func setLifecycleState(v *VStreamClient, runUsed, runActive, shutdownRequested bool, cancelRunCtxFn context.CancelCauseFunc) {
 	v.lifecycle.mu.Lock()
 	defer v.lifecycle.mu.Unlock()
 	v.lifecycle.runUsed = runUsed
@@ -195,24 +195,25 @@ func TestNew_ValidatesName(t *testing.T) {
 func TestNew_RejectsAmbiguousBareTableNamesAcrossKeyspaces(t *testing.T) {
 	conn := newConstructorTestConn(t)
 
-	_, err := New(context.Background(), "test-stream", conn, []TableConfig{
-		{
-			Keyspace:        "customer",
-			Table:           "customer",
-			Query:           "select * from customer where id between 1 and 10",
-			MaxRowsPerFlush: 1,
-			DataType:        &testRowSmall{},
-			FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+	_, err := New(
+		context.Background(), "test-stream", conn, []TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1 and 10",
+				MaxRowsPerFlush: 1,
+				DataType:        &testRowSmall{},
+				FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+			},
+			{
+				Keyspace:        "accounting",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1 and 10",
+				MaxRowsPerFlush: 1,
+				DataType:        &testRowSmall{},
+				FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+			},
 		},
-		{
-			Keyspace:        "accounting",
-			Table:           "customer",
-			Query:           "select * from customer where id between 1 and 10",
-			MaxRowsPerFlush: 1,
-			DataType:        &testRowSmall{},
-			FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
-		},
-	},
 		WithStateTable("commerce", "vstreams"),
 		WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
 	)
@@ -621,8 +622,8 @@ func TestGracefulShutdown_BeforeRunDoesNothing(t *testing.T) {
 
 func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
 
 		v := &VStreamClient{}
 		setLifecycleState(v, true, true, false, cancel)
@@ -651,8 +652,8 @@ func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
 }
 
 func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
 
 	v := &VStreamClient{
 		cfg: clientConfig{
@@ -679,7 +680,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 	assert.NoError(t, ctx.Err())
 	assert.False(t, v.isShutdownRequested())
 
-	cancel()
+	cancel(nil)
 	assert.Eventually(t, func() bool {
 		select {
 		case <-done:
@@ -693,8 +694,8 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 }
 
 func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
 
 	v := &VStreamClient{
 		cfg: clientConfig{
@@ -720,5 +721,64 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 		}
 	}, 2*time.Second, 100*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, context.Cause(ctx), ErrHeartbeatTimeout)
 	assert.True(t, v.isShutdownRequested())
+}
+
+func TestMonitorHeartbeat_StartupTimeoutShutsDownWithCause(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	v := &VStreamClient{
+		cfg: clientConfig{
+			flags:                      DefaultFlags(),
+			gracefulShutdownWaitDur:    0,
+			startupTimeout:             100 * time.Millisecond,
+			heartbeatTimeoutMultiplier: DefaultHeartbeatTimeoutMultiplier,
+		},
+	}
+	setLifecycleState(v, true, true, false, cancel)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		v.monitorHeartbeat(ctx)
+	}()
+
+	assert.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, context.Cause(ctx), ErrStartupTimeout)
+	assert.True(t, v.isShutdownRequested())
+}
+
+func TestShouldExitRun_SurfacesCancelCause(t *testing.T) {
+	v := &VStreamClient{}
+	setLifecycleState(v, true, true, true, nil)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrHeartbeatTimeout)
+
+	shouldExit, err := v.shouldExitRun(ctx)
+	assert.True(t, shouldExit)
+	require.ErrorIs(t, err, ErrHeartbeatTimeout)
+}
+
+func TestShouldExitRun_PlainCancelReturnsContextError(t *testing.T) {
+	v := &VStreamClient{}
+	setLifecycleState(v, true, true, true, nil)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(nil)
+
+	shouldExit, err := v.shouldExitRun(ctx)
+	assert.True(t, shouldExit)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, ErrHeartbeatTimeout)
 }

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -201,6 +201,60 @@ func TestNew_ValidatesName(t *testing.T) {
 	assert.ErrorContains(t, err, "name must be 64 characters or less")
 }
 
+func TestNew_RejectsHeterogeneousKeyspaceTableSets(t *testing.T) {
+	conn := newConstructorTestConn(t)
+
+	_, err := New(
+		t.Context(), "test-stream", conn, []TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1 and 10",
+				MaxRowsPerFlush: 1,
+				DataType:        &testRowSmall{},
+				FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+			},
+			{
+				Keyspace:        "accounting",
+				Table:           "invoices",
+				Query:           "select * from invoices",
+				MaxRowsPerFlush: 1,
+				DataType:        &testRowSmall{},
+				FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+			},
+		},
+		WithStateTable("commerce", "vstreams"),
+	)
+	require.ErrorContains(t, err, "different table/query sets")
+}
+
+func TestNew_AllowsIdenticalTableSetsAcrossKeyspaces(t *testing.T) {
+	conn := newConstructorTestConn(t)
+
+	_, err := New(
+		t.Context(), "test-stream", conn, []TableConfig{
+			{
+				Keyspace:        "customer",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1 and 10",
+				MaxRowsPerFlush: 1,
+				DataType:        &testRowSmall{},
+				FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+			},
+			{
+				Keyspace:        "accounting",
+				Table:           "customer",
+				Query:           "select * from customer where id between 1 and 10",
+				MaxRowsPerFlush: 1,
+				DataType:        &testRowSmall{},
+				FlushFn:         func(context.Context, []Row, FlushMeta) error { return nil },
+			},
+		},
+		WithStateTable("commerce", "vstreams"),
+	)
+	require.NoError(t, err)
+}
+
 func TestNew_RejectsAmbiguousBareTableNamesAcrossKeyspaces(t *testing.T) {
 	conn := newConstructorTestConn(t)
 

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -93,11 +93,18 @@ type testVStreamReader struct {
 
 type newTestVTGateImpl struct {
 	testVTGateImpl
+	shardsByTarget   map[string][]string
+	discoveryTargets []string
+	vschemaErr       error
 }
 
 func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error) {
 	switch {
 	case query == "SHOW VITESS_SHARDS":
+		t.discoveryTargets = append(t.discoveryTargets, session.TargetString)
+		if shards, ok := t.shardsByTarget[session.TargetString]; ok {
+			return session, sqltypes.MakeTestResult(sqltypes.MakeTestFields("shard", "varchar"), shards...), nil
+		}
 		return session, sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields("shard", "varchar"),
 			"customer/0",
@@ -121,6 +128,9 @@ func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session
 		return session, sqltypes.MakeTestResult(sqltypes.MakeTestFields("@@global.binlog_row_image", "varchar"), "FULL"), nil
 
 	case query == "SHOW VSCHEMA KEYSPACES":
+		if t.vschemaErr != nil {
+			return session, nil, t.vschemaErr
+		}
 		return session, sqltypes.MakeTestResult(
 			sqltypes.MakeTestFields("Keyspace|Sharded|Foreign Key|Comment", "varchar|varchar|varchar|varchar"),
 			"customer|false|unmanaged|",
@@ -204,12 +214,181 @@ func TestDefaultFlagsExcludeKeyspaceFromTableName(t *testing.T) {
 
 func TestNew_ValidatesName(t *testing.T) {
 	_, err := New(t.Context(), "", nil, nil)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "name is required")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "name is required")
 
 	_, err = New(t.Context(), strings.Repeat("a", 65), nil, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "name must be 64 characters or less")
+}
+
+func TestNew_DiscoversShardsForConfiguredTabletType(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		tabletType topodatapb.TabletType
+		target     string
+		shards     []string
+		explicit   bool
+	}{
+		{name: "default replica", target: "@replica", shards: []string{"-80", "80-"}},
+		{name: "primary", tabletType: topodatapb.TabletType_PRIMARY, target: "@primary", shards: []string{"0"}},
+		{name: "rdonly", tabletType: topodatapb.TabletType_RDONLY, target: "@rdonly", shards: []string{"-40", "40-"}},
+		{name: "explicit replica position before tablet option", tabletType: topodatapb.TabletType_REPLICA, target: "@replica", shards: []string{"-80", "80-"}, explicit: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &newTestVTGateImpl{shardsByTarget: map[string][]string{
+				"@primary": {"customer/0", "commerce/0"},
+				"@replica": {"customer/-80", "customer/80-"},
+				"@rdonly":  {"customer/-40", "customer/40-"},
+			}}
+			conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
+				return impl, nil
+			}, "")
+			require.NoError(t, err)
+			t.Cleanup(conn.Close)
+
+			opts := []Option{WithStateTable("commerce", "state")}
+			if tt.explicit {
+				position := &binlogdatapb.VGtid{}
+				for _, shard := range tt.shards {
+					position.ShardGtids = append(position.ShardGtids, &binlogdatapb.ShardGtid{Keyspace: "customer", Shard: shard, Gtid: testConcretePosition})
+				}
+				opts = append(opts, WithStartingVGtid(position))
+			}
+			if tt.tabletType != topodatapb.TabletType_UNKNOWN {
+				opts = append(opts, WithTabletType(tt.tabletType))
+			}
+			optionCalls := 0
+			opts = append(opts, func(*VStreamClient) error {
+				optionCalls++
+				return nil
+			})
+			table := newStateTestTableConfig()
+			table.Keyspace = "customer"
+			v, err := New(t.Context(), "stream", conn, []TableConfig{table}, opts...)
+			require.NoError(t, err)
+			assert.Equal(t, []string{tt.target}, impl.discoveryTargets)
+			assert.Equal(t, 1, optionCalls)
+			shards := make([]string, 0, len(v.latestVgtid.ShardGtids))
+			for _, position := range v.latestVgtid.ShardGtids {
+				assert.Equal(t, "customer", position.Keyspace)
+				shards = append(shards, position.Shard)
+			}
+			assert.ElementsMatch(t, tt.shards, shards)
+		})
+	}
+}
+
+func TestNew_RequiresStateKeyspaceShardingMetadata(t *testing.T) {
+	impl := &newTestVTGateImpl{vschemaErr: errors.New("vschema unavailable")}
+	conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
+		return impl, nil
+	}, "")
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+	table := newStateTestTableConfig()
+	table.Keyspace = "customer"
+	_, err = New(t.Context(), "stream", conn, []TableConfig{table}, WithStateTable("commerce", "state"))
+	require.ErrorContains(t, err, "vschema unavailable")
+}
+
+func TestMonitorHeartbeat_DoesNotWaitForGracefulShutdown(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		startup           bool
+		shutdownRequested bool
+		cause             error
+	}{
+		{name: "heartbeat", cause: ErrHeartbeatTimeout},
+		{name: "startup", startup: true, cause: ErrStartupTimeout},
+		{name: "heartbeat during requested shutdown", shutdownRequested: true, cause: ErrHeartbeatTimeout},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancelCause(t.Context())
+				v := &VStreamClient{cfg: clientConfig{
+					flags: DefaultFlags(), startupTimeout: 5 * time.Second,
+					gracefulShutdownWaitDur:    time.Hour,
+					heartbeatTimeoutMultiplier: 2,
+				}}
+				setLifecycleState(v, true, true, tt.shutdownRequested, cancel)
+				t.Cleanup(func() { cancel(nil); v.endRun() })
+				if !tt.startup {
+					v.lastEventProcessedAtUnixNano = time.Now().Add(-3 * time.Second).UnixNano()
+				}
+				done := make(chan struct{})
+				go func() { defer close(done); v.monitorHeartbeat(ctx) }()
+				select {
+				case <-done:
+					require.ErrorIs(t, context.Cause(ctx), tt.cause)
+				case <-time.After(30 * time.Second):
+					assert.Fail(t, "liveness cancellation waited for the graceful shutdown window")
+				}
+			})
+		})
+	}
+}
+
+func TestMonitorHeartbeat_DefaultToleratesShortSilence(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn, _ := newStateTestConn(t, shardsAndStateTableResponses(nil)...)
+		v, err := New(t.Context(), "stream", conn, []TableConfig{newStateTestTableConfig()}, WithStateTable("stateks", "state"))
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancelCause(t.Context())
+		t.Cleanup(func() { cancel(nil); v.endRun() })
+		setLifecycleState(v, true, true, false, cancel)
+		v.lastEventProcessedAtUnixNano = time.Now().UnixNano()
+		go v.monitorHeartbeat(ctx)
+
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.NoError(t, ctx.Err())
+
+		time.Sleep(6 * time.Second)
+		synctest.Wait()
+		require.ErrorIs(t, context.Cause(ctx), ErrHeartbeatTimeout)
+	})
+}
+
+func TestMonitorHeartbeat_TimeoutExcludesNewEventBatch(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	t.Cleanup(func() { cancel(nil) })
+	cancelStarted := make(chan struct{})
+	releaseCancel := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseCancel) })
+	hookCalled := make(chan struct{}, 1)
+	v := &VStreamClient{cfg: clientConfig{flags: DefaultFlags(), heartbeatTimeoutMultiplier: 2, eventFuncs: map[binlogdatapb.VEventType]EventFunc{
+		binlogdatapb.VEventType_HEARTBEAT: func(context.Context, *binlogdatapb.VEvent) error {
+			hookCalled <- struct{}{}
+			return nil
+		},
+	}}}
+	setLifecycleState(v, true, true, false, func(cause error) {
+		close(cancelStarted)
+		<-releaseCancel
+		cancel(cause)
+	})
+	v.lastEventProcessedAtUnixNano = time.Now().Add(-3 * time.Second).UnixNano()
+	go v.monitorHeartbeat(ctx)
+	select {
+	case <-cancelStarted:
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "liveness cancellation did not start")
+	}
+	eventsDone := make(chan error, 1)
+	go func() {
+		eventsDone <- v.handleEvents(ctx, []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_HEARTBEAT}})
+	}()
+	assert.Never(t, func() bool { return len(hookCalled) != 0 }, 30*time.Second, 10*time.Millisecond)
+	releaseOnce.Do(func() { close(releaseCancel) })
+	select {
+	case err := <-eventsDone:
+		require.ErrorIs(t, err, ErrHeartbeatTimeout)
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "event processing did not return after cancellation")
+	}
+	assert.Empty(t, hookCalled)
 }
 
 func TestNew_ValidatesMutableDefaults(t *testing.T) {
@@ -226,6 +405,24 @@ func TestNew_ValidatesMutableDefaults(t *testing.T) {
 		original := DefaultHeartbeatTimeoutMultiplier
 		t.Cleanup(func() { DefaultHeartbeatTimeoutMultiplier = original })
 		DefaultHeartbeatTimeoutMultiplier = -1
+
+		_, err := New(t.Context(), "stream", newConstructorTestConn(t), nil)
+		require.ErrorContains(t, err, "DefaultHeartbeatTimeoutMultiplier must be positive")
+	})
+
+	t.Run("negative startup timeout", func(t *testing.T) {
+		original := DefaultStartupTimeout
+		t.Cleanup(func() { DefaultStartupTimeout = original })
+		DefaultStartupTimeout = -time.Second
+
+		_, err := New(t.Context(), "stream", newConstructorTestConn(t), nil)
+		require.ErrorContains(t, err, "DefaultStartupTimeout must be positive")
+	})
+
+	t.Run("zero heartbeat timeout multiplier", func(t *testing.T) {
+		original := DefaultHeartbeatTimeoutMultiplier
+		t.Cleanup(func() { DefaultHeartbeatTimeoutMultiplier = original })
+		DefaultHeartbeatTimeoutMultiplier = 0
 
 		_, err := New(t.Context(), "stream", newConstructorTestConn(t), nil)
 		require.ErrorContains(t, err, "DefaultHeartbeatTimeoutMultiplier must be positive")
@@ -329,22 +526,22 @@ func TestNew_RejectsAmbiguousBareTableNamesAcrossKeyspaces(t *testing.T) {
 		WithStateTable("commerce", "vstreams"),
 		WithFlags(&vtgatepb.VStreamFlags{HeartbeatInterval: 1, ExcludeKeyspaceFromTableName: true}),
 	)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "ExcludeKeyspaceFromTableName")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ExcludeKeyspaceFromTableName")
 	assert.ErrorContains(t, err, "customer")
 }
 
 func TestWithMinFlushDuration_RejectsNonPositive(t *testing.T) {
 	v := &VStreamClient{}
 	err := WithMinFlushDuration(0)(v)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "minimum flush duration")
 }
 
 func TestWithHeartbeatSeconds_RejectsNonPositive(t *testing.T) {
 	v := &VStreamClient{}
 	err := WithHeartbeatSeconds(0)(v)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "heartbeat seconds")
 }
 
@@ -356,8 +553,8 @@ func TestWithHeartbeatSeconds_RejectsOverflow(t *testing.T) {
 
 	v := &VStreamClient{}
 	err := WithHeartbeatSeconds(int(overflow))(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "heartbeat seconds must be")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "heartbeat seconds must be")
 	assert.ErrorContains(t, err, "or less")
 }
 
@@ -365,8 +562,8 @@ func TestWithTimeLocation_Validation(t *testing.T) {
 	v := &VStreamClient{}
 
 	err := WithTimeLocation(nil)(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "time location")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "time location")
 
 	loc := time.FixedZone("UTC-5", -5*60*60)
 	err = WithTimeLocation(loc)(v)
@@ -378,8 +575,8 @@ func TestWithTabletType_Validation(t *testing.T) {
 	v := &VStreamClient{}
 
 	err := WithTabletType(topodatapb.TabletType_UNKNOWN)(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "tablet type cannot be UNKNOWN")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "tablet type cannot be UNKNOWN")
 
 	err = WithTabletType(topodatapb.TabletType_RDONLY)(v)
 	require.NoError(t, err)
@@ -389,7 +586,7 @@ func TestWithTabletType_Validation(t *testing.T) {
 func TestWithFlags_RejectsNil(t *testing.T) {
 	v := &VStreamClient{}
 	err := WithFlags(nil)(v)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "flags cannot be nil")
 }
 
@@ -397,12 +594,12 @@ func TestWithGracefulShutdownChan_Validation(t *testing.T) {
 	v := &VStreamClient{}
 
 	err := WithGracefulShutdownChan(nil, time.Second)(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "graceful shutdown channel")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "graceful shutdown channel")
 
 	err = WithGracefulShutdownChan(make(chan struct{}), 0)(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "graceful shutdown wait")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "graceful shutdown wait")
 
 	ch := make(chan struct{})
 	err = WithGracefulShutdownChan(ch, time.Second)(v)
@@ -415,12 +612,12 @@ func TestWithGracefulShutdownSignals_Validation(t *testing.T) {
 	v := &VStreamClient{}
 
 	err := WithGracefulShutdownSignals(time.Second)(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "graceful shutdown signals")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "graceful shutdown signals")
 
 	err = WithGracefulShutdownSignals(0, os.Interrupt)(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "graceful shutdown wait")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "graceful shutdown wait")
 
 	err = WithGracefulShutdownSignals(time.Second, os.Interrupt)(v)
 	require.NoError(t, err)
@@ -433,14 +630,14 @@ func TestWithEventFunc_Validation(t *testing.T) {
 	fn := func(_ context.Context, _ *binlogdatapb.VEvent) error { return nil }
 
 	err := WithEventFunc(fn)(v)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "no event types provided")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no event types provided")
 
 	err = WithEventFunc(fn, binlogdatapb.VEventType_FIELD)(v)
 	require.NoError(t, err)
 
 	err = WithEventFunc(fn, binlogdatapb.VEventType_FIELD)(v)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "already has a function")
 }
 
@@ -474,7 +671,7 @@ func TestLookupTable(t *testing.T) {
 		}}
 
 		_, err := v.lookupTable("t")
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.ErrorContains(t, err, "ambiguous table name")
 	})
 }
@@ -501,7 +698,7 @@ func TestRun_RejectsClosedClient(t *testing.T) {
 	setLifecycleState(v, true, false, false, nil)
 
 	err := v.Run(t.Context())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, "client is closed")
 }
 
@@ -566,8 +763,8 @@ func TestRun_EOFReturnsErrorAndLeavesBufferedRowsUnflushed(t *testing.T) {
 	}
 
 	err = v.Run(t.Context())
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "unexpected EOF")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unexpected EOF")
 	assert.Nil(t, v.lastFlushedVgtid)
 	require.Len(t, table.currentBatch, 1)
 	row, ok := table.currentBatch[0].Data.(*testRowSmall)
@@ -933,7 +1130,7 @@ func TestGracefulShutdown_CancelsActiveRunAfterWait(t *testing.T) {
 
 		synctest.Wait()
 		assert.True(t, v.ShutdownRequested())
-		assert.NoError(t, ctx.Err())
+		require.NoError(t, ctx.Err())
 
 		time.Sleep(5 * time.Second)
 		synctest.Wait()
@@ -973,7 +1170,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 			return false
 		}
 	}, 2500*time.Millisecond, 100*time.Millisecond)
-	assert.NoError(t, ctx.Err())
+	require.NoError(t, ctx.Err())
 	assert.False(t, v.ShutdownRequested())
 
 	cancel(nil)
@@ -985,7 +1182,7 @@ func TestMonitorHeartbeat_DoesNotShutdownBeforeFirstEvent(t *testing.T) {
 			return false
 		}
 	}, time.Second, 50*time.Millisecond)
-	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
 	assert.False(t, v.ShutdownRequested())
 }
 
@@ -995,12 +1192,13 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 
 	v := &VStreamClient{
 		cfg: clientConfig{
-			flags:                   DefaultFlags(),
-			gracefulShutdownWaitDur: 0,
+			flags:                      DefaultFlags(),
+			gracefulShutdownWaitDur:    0,
+			heartbeatTimeoutMultiplier: 2,
 		},
 	}
 	setLifecycleState(v, true, true, false, cancel)
-	v.lastEventProcessedAtUnixNano.Store(time.Now().Add(-3 * time.Second).UnixNano())
+	v.lastEventProcessedAtUnixNano = time.Now().Add(-3 * time.Second).UnixNano()
 
 	done := make(chan struct{})
 	go func() {
@@ -1016,7 +1214,7 @@ func TestMonitorHeartbeat_ShutsDownWhenHeartbeatStopsAfterFirstEvent(t *testing.
 			return false
 		}
 	}, 2*time.Second, 100*time.Millisecond)
-	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
 	require.ErrorIs(t, context.Cause(ctx), ErrHeartbeatTimeout)
 	assert.True(t, v.ShutdownRequested())
 }
@@ -1030,7 +1228,7 @@ func TestMonitorHeartbeat_StartupTimeoutShutsDownWithCause(t *testing.T) {
 			flags:                      DefaultFlags(),
 			gracefulShutdownWaitDur:    0,
 			startupTimeout:             100 * time.Millisecond,
-			heartbeatTimeoutMultiplier: DefaultHeartbeatTimeoutMultiplier,
+			heartbeatTimeoutMultiplier: 2,
 		},
 	}
 	setLifecycleState(v, true, true, false, cancel)

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -204,6 +204,44 @@ func TestNew_ValidatesName(t *testing.T) {
 	assert.ErrorContains(t, err, "name must be 64 characters or less")
 }
 
+func TestNew_ValidatesMutableDefaults(t *testing.T) {
+	t.Run("startup timeout", func(t *testing.T) {
+		original := DefaultStartupTimeout
+		t.Cleanup(func() { DefaultStartupTimeout = original })
+		DefaultStartupTimeout = 0
+
+		_, err := New(t.Context(), "stream", newConstructorTestConn(t), nil)
+		require.ErrorContains(t, err, "DefaultStartupTimeout must be positive")
+	})
+
+	t.Run("heartbeat timeout multiplier", func(t *testing.T) {
+		original := DefaultHeartbeatTimeoutMultiplier
+		t.Cleanup(func() { DefaultHeartbeatTimeoutMultiplier = original })
+		DefaultHeartbeatTimeoutMultiplier = -1
+
+		_, err := New(t.Context(), "stream", newConstructorTestConn(t), nil)
+		require.ErrorContains(t, err, "DefaultHeartbeatTimeoutMultiplier must be positive")
+	})
+
+	t.Run("min flush duration", func(t *testing.T) {
+		original := DefaultMinFlushDuration
+		t.Cleanup(func() { DefaultMinFlushDuration = original })
+		DefaultMinFlushDuration = 0
+
+		_, err := New(t.Context(), "stream", newConstructorTestConn(t), nil)
+		require.ErrorContains(t, err, "DefaultMinFlushDuration must be positive")
+	})
+
+	t.Run("graceful shutdown wait", func(t *testing.T) {
+		original := DefaultGracefulShutdownWaitDur
+		t.Cleanup(func() { DefaultGracefulShutdownWaitDur = original })
+		DefaultGracefulShutdownWaitDur = 0
+
+		_, err := New(t.Context(), "stream", newConstructorTestConn(t), nil)
+		require.ErrorContains(t, err, "DefaultGracefulShutdownWaitDur must be positive")
+	})
+}
+
 func TestNew_RejectsHeterogeneousKeyspaceTableSets(t *testing.T) {
 	conn := newConstructorTestConn(t)
 

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -89,6 +89,7 @@ type testVStreamReader struct {
 	batches [][]*binlogdatapb.VEvent
 	err     error
 	index   int
+	recvFn  func() ([]*binlogdatapb.VEvent, error)
 }
 
 type newTestVTGateImpl struct {
@@ -96,6 +97,7 @@ type newTestVTGateImpl struct {
 	shardsByTarget   map[string][]string
 	discoveryTargets []string
 	vschemaErr       error
+	rowImageByTarget map[string]string
 }
 
 func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error) {
@@ -125,6 +127,9 @@ func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session
 		return session, &sqltypes.Result{RowsAffected: 1}, nil
 
 	case strings.Contains(query, "binlog_row_image"):
+		if rowImage, ok := t.rowImageByTarget[session.TargetString]; ok {
+			return session, sqltypes.MakeTestResult(sqltypes.MakeTestFields("@@global.binlog_row_image", "varchar"), rowImage), nil
+		}
 		return session, sqltypes.MakeTestResult(sqltypes.MakeTestFields("@@global.binlog_row_image", "varchar"), "FULL"), nil
 
 	case query == "SHOW VSCHEMA KEYSPACES":
@@ -171,6 +176,9 @@ func getLifecycleState(v *VStreamClient) (runUsed, runActive, shutdownRequested 
 }
 
 func (r *testVStreamReader) Recv() ([]*binlogdatapb.VEvent, error) {
+	if r.recvFn != nil {
+		return r.recvFn()
+	}
 	if r.index < len(r.batches) {
 		batch := r.batches[r.index]
 		r.index++
@@ -276,6 +284,27 @@ func TestNew_DiscoversShardsForConfiguredTabletType(t *testing.T) {
 			}
 			assert.ElementsMatch(t, tt.shards, shards)
 		})
+	}
+}
+
+func TestNew_RejectsNonFullRowImageOnConfiguredTabletType(t *testing.T) {
+	for _, tabletType := range []topodatapb.TabletType{topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY} {
+		for _, rowImage := range []string{"NOBLOB", "MINIMAL"} {
+			t.Run(tabletType.String()+"/"+rowImage, func(t *testing.T) {
+				target := "customer:0@" + strings.ToLower(tabletType.String())
+				impl := &newTestVTGateImpl{rowImageByTarget: map[string]string{target: rowImage}}
+				conn, err := vtgateconn.DialCustom(t.Context(), func(context.Context, string) (vtgateconn.Impl, error) {
+					return impl, nil
+				}, "")
+				require.NoError(t, err)
+				t.Cleanup(conn.Close)
+				table := newStateTestTableConfig()
+				table.Keyspace = "customer"
+				_, err = New(t.Context(), "stream", conn, []TableConfig{table}, WithStateTable("commerce", "state"), WithTabletType(tabletType))
+				require.ErrorContains(t, err, "requires FULL")
+				assert.ErrorContains(t, err, target)
+			})
+		}
 	}
 }
 

--- a/go/vt/vstreamclient/vstreamclient_test.go
+++ b/go/vt/vstreamclient/vstreamclient_test.go
@@ -119,6 +119,14 @@ func (t *newTestVTGateImpl) Execute(_ context.Context, session *vtgatepb.Session
 
 	case strings.Contains(query, "binlog_row_image"):
 		return session, sqltypes.MakeTestResult(sqltypes.MakeTestFields("@@global.binlog_row_image", "varchar"), "FULL"), nil
+
+	case query == "SHOW VSCHEMA KEYSPACES":
+		return session, sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("Keyspace|Sharded|Foreign Key|Comment", "varchar|varchar|varchar|varchar"),
+			"customer|false|unmanaged|",
+			"accounting|false|unmanaged|",
+			"commerce|false|unmanaged|",
+		), nil
 	}
 
 	return nil, nil, fmt.Errorf("unexpected Execute call: %s", query)

--- a/test/config.json
+++ b/test/config.json
@@ -336,6 +336,18 @@
       "Tags": [],
       "Needs": []
     },
+    "vstreamclient": {
+      "File": "vstreamclient_test.go",
+      "Packages": [
+        "vitess.io/vitess/go/test/endtoend/vstreamclient"
+      ],
+      "Args": [],
+      "Command": [],
+      "Manual": false,
+      "Shard": "12",
+      "Tags": [],
+      "Needs": []
+    },
     "clustertest": {
       "File": "unused.go",
       "Packages": [

--- a/test/config.json
+++ b/test/config.json
@@ -341,7 +341,10 @@
       "Packages": [
         "vitess.io/vitess/go/test/endtoend/vstreamclient"
       ],
-      "Args": [],
+      "Args": [
+        "-timeout",
+        "30m"
+      ],
       "Command": [],
       "Manual": false,
       "Shard": "12",


### PR DESCRIPTION
## Description

Implementation for #17221. I did a walkthrough in the [March community meeting](https://zoom.us/rec/play/hB_PHlpsVn0vQX8jiSoaxHM_ADHxV2N7BfGmvyh2_ulSVXcJWEEvwj9Ev9g_4u_FnNbDkchOmv3GVWKC.xtlM08B5s2qlXo-Z?eagerLoadZvaPages=sidemenu.billing.plan_management&accessLevel=meeting&canPlayFromShare=true&from=share_recording_detail&continueMode=true&oldStyle=true&componentName=rec-play&originRequestUrl=https%3A%2F%2Fzoom.us%2Frec%2Fshare%2F8xyrtfTc8QpK0pcaK8CFlp7xt7aiu86joKoJ_ErsDfaP5p_RXPUn7C2fsw_kshvK.m_-wn6ENSflhxEZG), starting at 7:18.

The actual code was 95% written by me, tests were 95% written by AI

## Related Issue(s)

- Fixes #17221

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

Adds the public `go/vt/vstreamclient` package for checkpointed Vitess event consumption.

- Checkpoints require a separate unsharded state keyspace. Construction requires readable VSchema sharding metadata and executes CREATE TABLE IF NOT EXISTS, even for a pre-provisioned table.
- All source primaries, eligible stream tablets, and writer/replication sessions must use FULL row images throughout the retained replay range. New probes each shard's primary and configured stream tablet type; unverifiable targets fail closed unless explicitly bypassed after out-of-band verification.
- Run claims ownership after receiving its first successful VStream response. Initial receive failures and startup timeouts leave the incumbent's owner token untouched. State-row fencing protects checkpoints; concurrent consumers still require serialized handoffs or sink-enforced fencing/version checks.
- Explicit starting positions must be concrete and cover every configured source shard for the selected tablet type. Symbolic positions and TablePKs copy cursors are rejected.
- The default liveness window is now ten seconds. Liveness failures cancel immediately; WithHeartbeatSeconds overrides WithFlags.HeartbeatInterval regardless of option order, including when the supplied flags leave the interval at zero.
- Graceful shutdown can complete at a ROLLBACK boundary without waiting for a later heartbeat.
- Construction rejects heartbeat intervals and timeout multipliers whose combined liveness window exceeds the maximum supported duration.
