### PR TITLE
Fix deadlock in messager and health streamer

### DIFF
--- a/go/vt/vttablet/tabletserver/health_streamer_test.go
+++ b/go/vt/vttablet/tabletserver/health_streamer_test.go
@@ -572,3 +572,43 @@ func testStream(hs *healthStreamer) (<-chan *querypb.StreamHealthResponse, conte
 func testBlpFunc() (int64, int32) {
 	return 1, 2
 }
+
+// TestDeadlockBwCloseAndReload tests the deadlock observed between Close and Reload
+// functions. More details can be found in the issue https://github.com/vitessio/vitess/issues/17229.
+func TestDeadlockBwCloseAndReload(t *testing.T) {
+	cfg := newConfig(nil)
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TestNotServingPrimary")
+	alias := &topodatapb.TabletAlias{
+		Cell: "cell",
+		Uid:  1,
+	}
+	se := schema.NewEngineForTests()
+	// Create a new health streamer and set it to a serving primary state
+	hs := newHealthStreamer(env, alias, se)
+	hs.signalWhenSchemaChange = true
+	hs.Open()
+	hs.MakePrimary(true)
+	defer hs.Close()
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	// Try running Close and reload in parallel multiple times.
+	// This reproduces the deadlock quite readily.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			hs.Close()
+			hs.Open()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			se.BroadcastForTesting(nil, nil, nil, true)
+		}
+	}()
+
+	// Wait for wait group to finish.
+	wg.Wait()
+}

--- a/go/vt/vttablet/tabletserver/health_streamer_test.go
+++ b/go/vt/vttablet/tabletserver/health_streamer_test.go
@@ -574,7 +574,7 @@ func testBlpFunc() (int64, int32) {
 }
 
 // TestDeadlockBwCloseAndReload tests the deadlock observed between Close and Reload
-// functions. More details can be found in the issue https://github.com/vitessio/vitess/issues/17229.
+// functions. More details can be found in the issue https://github.com/vitessio/vitess/issues/17229#issuecomment-2476136610.
 func TestDeadlockBwCloseAndReload(t *testing.T) {
 	cfg := newConfig(nil)
 	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TestNotServingPrimary")

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -52,9 +52,16 @@ type VStreamer interface {
 
 // Engine is the engine for handling messages.
 type Engine struct {
-	mu       sync.Mutex
-	isOpen   bool
-	managers map[string]*messageManager
+	// mu is a mutex used to protect the isOpen variable
+	// and for ensuring we don't call setup functions in parallel.
+	mu     sync.Mutex
+	isOpen bool
+
+	// managersMu is a mutex used to protect the managers field.
+	// We require two separate mutexes, so that we don't have to acquire the same mutex
+	// in Close and schemaChanged which can lead to a deadlock described in https://github.com/vitessio/vitess/issues/17229.
+	managersMu sync.Mutex
+	managers   map[string]*messageManager
 
 	tsv          TabletService
 	se           *schema.Engine
@@ -76,15 +83,12 @@ func NewEngine(tsv TabletService, se *schema.Engine, vs VStreamer) *Engine {
 // Open starts the Engine service.
 func (me *Engine) Open() {
 	me.mu.Lock()
+	defer me.mu.Unlock()
 	if me.isOpen {
-		me.mu.Unlock()
 		return
 	}
 	me.isOpen = true
-	me.mu.Unlock()
 	log.Info("Messager: opening")
-	// Unlock before invoking RegisterNotifier because it
-	// obtains the same lock.
 	me.se.RegisterNotifier("messages", me.schemaChanged, true)
 }
 
@@ -102,6 +106,8 @@ func (me *Engine) Close() {
 	log.Infof("messager Engine - unregistering notifiers")
 	me.se.UnregisterNotifier("messages")
 	log.Infof("messager Engine - closing all managers")
+	me.managersMu.Lock()
+	defer me.managersMu.Unlock()
 	for _, mm := range me.managers {
 		mm.Close()
 	}
@@ -110,8 +116,8 @@ func (me *Engine) Close() {
 }
 
 func (me *Engine) GetGenerator(name string) (QueryGenerator, error) {
-	me.mu.Lock()
-	defer me.mu.Unlock()
+	me.managersMu.Lock()
+	defer me.managersMu.Unlock()
 	mm := me.managers[name]
 	if mm == nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "message table %s not found in schema", name)
@@ -132,6 +138,8 @@ func (me *Engine) Subscribe(ctx context.Context, name string, send func(*sqltype
 	if !me.isOpen {
 		return nil, vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "messager engine is closed, probably because this is not a primary any more")
 	}
+	me.managersMu.Lock()
+	defer me.managersMu.Unlock()
 	mm := me.managers[name]
 	if mm == nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "message table %s not found", name)
@@ -140,8 +148,8 @@ func (me *Engine) Subscribe(ctx context.Context, name string, send func(*sqltype
 }
 
 func (me *Engine) schemaChanged(tables map[string]*schema.Table, created, altered, dropped []*schema.Table, _ bool) {
-	me.mu.Lock()
-	defer me.mu.Unlock()
+	me.managersMu.Lock()
+	defer me.managersMu.Unlock()
 	for _, table := range append(dropped, altered...) {
 		name := table.Name.String()
 		mm := me.managers[name]

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -19,6 +19,7 @@ package messager
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -156,7 +157,7 @@ func newTestEngine() *Engine {
 	tsv := &fakeTabletServer{
 		Env: tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "MessagerTest"),
 	}
-	se := schema.NewEngine(tsv)
+	se := schema.NewEngineForTests()
 	te := NewEngine(tsv, se, newFakeVStreamer())
 	te.Open()
 	return te
@@ -168,4 +169,34 @@ func newEngineReceiver() (f func(qr *sqltypes.Result) error, ch chan *sqltypes.R
 		ch <- qr
 		return nil
 	}, ch
+}
+
+// TestDeadlockBwCloseAndSchemaChange tests the deadlock observed between Close and schemaChanged
+// functions. More details can be found in the issue https://github.com/vitessio/vitess/issues/17229.
+func TestDeadlockBwCloseAndSchemaChange(t *testing.T) {
+	engine := newTestEngine()
+	defer engine.Close()
+	se := engine.se
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	// Try running Close and schemaChanged in parallel multiple times.
+	// This reproduces the deadlock quite readily.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			engine.Close()
+			engine.Open()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			se.BroadcastForTesting(nil, nil, nil, true)
+		}
+	}()
+
+	// Wait for wait group to finish.
+	wg.Wait()
 }

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -865,6 +865,13 @@ func (se *Engine) broadcast(created, altered, dropped []*Table, udfsChanged bool
 	}
 }
 
+// BroadcastForTesting is meant to be a testing function that triggers a broadcast call.
+func (se *Engine) BroadcastForTesting(created, altered, dropped []*Table, udfsChanged bool) {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	se.broadcast(created, altered, dropped, udfsChanged)
+}
+
 // GetTable returns the info for a table.
 func (se *Engine) GetTable(tableName sqlparser.IdentifierCS) *Table {
 	se.mu.Lock()
@@ -951,6 +958,7 @@ func NewEngineForTests() *Engine {
 		tables:    make(map[string]*Table),
 		historian: newHistorian(false, 0, nil),
 		env:       tabletenv.NewEnv(vtenv.NewTestEnv(), tabletenv.NewDefaultConfig(), "SchemaEngineForTests"),
+		notifiers: make(map[string]notifier),
 	}
 	return se
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the deadlocks in messager and health streamer as pointed out in #17229.

The fix to the deadlock for both the cases was to use two different mutexes. One that only protects against calling setup functions like `Open` and `Close` concurrently, and the other one that actually protects the fields. This helps in removing the deadlock since the function that runs on a broadcast from the schema engine would acquire a different mutex than the call to Close.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #17229 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
