### PR TITLE
Add support for receiving `grpc_bind_adress` on `vttestserver`

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -169,6 +169,11 @@ func GRPCPort() int {
 	return gRPCPort
 }
 
+// GRPCPort returns the value of the `--grpc_bind_address` flag.
+func GRPCBindAddress() string {
+	return gRPCBindAddress
+}
+
 // isGRPCEnabled returns true if gRPC server is set
 func isGRPCEnabled() bool {
 	if gRPCPort != 0 {

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -660,6 +660,7 @@ func (db *LocalCluster) JSONConfig() any {
 	config := map[string]any{
 		"bind_address":       db.vt.BindAddress,
 		"port":               db.vt.Port,
+		"grpc_bind_address":  db.vt.BindAddressGprc,
 		"socket":             db.mysql.UnixSocket(),
 		"vtcombo_mysql_port": db.Env.PortForProtocol("vtcombo_mysql_port", ""),
 		"mysql":              db.Env.PortForProtocol("mysql", ""),


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

When  `--grpc_bind_address` is supplied to `vttestserver`, it is now forwarded up to `vtcombo`.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Part of https://github.com/vitessio/vitess/issues/16798

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
