### PR TITLE
A couple `endtoend` cluster tests enhancement

### DIFF
--- a/go/test/endtoend/cluster/vtctldclient_process.go
+++ b/go/test/endtoend/cluster/vtctldclient_process.go
@@ -41,6 +41,7 @@ type VtctldClientProcess struct {
 	TempDirectory            string
 	ZoneName                 string
 	VtctldClientMajorVersion int
+	Quiet                    bool
 }
 
 // ExecuteCommand executes any vtctldclient command
@@ -72,7 +73,9 @@ func (vtctldclient *VtctldClientProcess) ExecuteCommandWithOutput(args ...string
 			filterDoubleDashArgs(pArgs, vtctldclient.VtctldClientMajorVersion)...,
 		)
 		msg := binlogplayer.LimitString(strings.Join(tmpProcess.Args, " "), 256) // limit log line length
-		log.Infof("Executing vtctldclient with command: %v (attempt %d of %d)", msg, i+1, retries)
+		if !vtctldclient.Quiet {
+			log.Infof("Executing vtctldclient with command: %v (attempt %d of %d)", msg, i+1, retries)
+		}
 		resultByte, err = tmpProcess.CombinedOutput()
 		resultStr = string(resultByte)
 		if err == nil || !shouldRetry(resultStr) {

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -459,6 +459,16 @@ func (vttablet *VttabletProcess) QueryTablet(query string, keyspace string, useD
 	return executeQuery(conn, query)
 }
 
+// MultiQueryTablet lets you execute a query in this tablet and get the result
+func (vttablet *VttabletProcess) MultiQueryTablet(sql string, keyspace string, useDb bool) error {
+	conn, err := vttablet.TabletConn(keyspace, useDb)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return executeMultiQuery(conn, sql)
+}
+
 // SemiSyncExtensionLoaded returns what type of semi-sync extension is loaded
 func (vttablet *VttabletProcess) SemiSyncExtensionLoaded() (mysql.SemiSyncType, error) {
 	conn, err := vttablet.TabletConn("", false)


### PR DESCRIPTION

## Description

This PR adds two enhancements in `go/test/endtoend/cluster`:

- `VtctldClientProcess` supports `Quiet` mode, where it does not log the command line invocation to standard output. The `Quiet` field is not thread safe.
  This will be useful to reduce log clutter. I especially intend to use it to reduce `CheckThrottler` logs.
- `VttabletProcess` supports `MultiQueryTablet()`, complementing `MultiQueryTabletWithDB()`. This can be used to issue non-DB specific multi-query SQL from external source.

## Related Issue(s)

No issue for this PR.


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
