### PR TITLE
VReplication: recover from closed connection

### DIFF
--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -40,6 +40,7 @@ type DBClient interface {
 	Commit() error
 	Rollback() error
 	Close()
+	IsClosed() bool
 	ExecuteFetch(query string, maxrows int) (qr *sqltypes.Result, err error)
 	ExecuteFetchMulti(query string, maxrows int) (qrs []*sqltypes.Result, err error)
 	SupportsCapability(capability capabilities.FlavorCapability) (bool, error)
@@ -123,6 +124,10 @@ func (dc *dbClientImpl) Rollback() error {
 
 func (dc *dbClientImpl) Close() {
 	dc.dbConn.Close()
+}
+
+func (dc *dbClientImpl) IsClosed() bool {
+	return dc.dbConn.IsClosed()
 }
 
 func (dc *dbClientImpl) SupportsCapability(capability capabilities.FlavorCapability) (bool, error) {

--- a/go/vt/binlog/binlogplayer/fake_dbclient.go
+++ b/go/vt/binlog/binlogplayer/fake_dbclient.go
@@ -56,6 +56,10 @@ func (dc *fakeDBClient) Rollback() error {
 func (dc *fakeDBClient) Close() {
 }
 
+func (dc *fakeDBClient) IsClosed() bool {
+	return false
+}
+
 func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (qr *sqltypes.Result, err error) {
 	query = strings.ToLower(query)
 	switch {

--- a/go/vt/binlog/binlogplayer/mock_dbclient.go
+++ b/go/vt/binlog/binlogplayer/mock_dbclient.go
@@ -181,6 +181,10 @@ func (dc *MockDBClient) Rollback() error {
 func (dc *MockDBClient) Close() {
 }
 
+func (dc *MockDBClient) IsClosed() bool {
+	return false
+}
+
 // ExecuteFetch is part of the DBClient interface
 func (dc *MockDBClient) ExecuteFetch(query string, maxrows int) (qr *sqltypes.Result, err error) {
 	// Serialize ExecuteFetch to enforce a strict order on shared dbClients.

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -396,6 +396,10 @@ func (dbc *realDBClient) Close() {
 	dbc.conn.Close()
 }
 
+func (dbc *realDBClient) IsClosed() bool {
+	return dbc.conn.IsClosed()
+}
+
 func (dbc *realDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {
 	// Use Clone() because the contents of memory region referenced by
 	// string can change when clients (e.g. vcopier) use unsafe string methods.

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -479,6 +479,10 @@ func (dbc *realDBClient) Close() {
 	dbc.conn.Close()
 }
 
+func (dbc *realDBClient) IsClosed() bool {
+	return dbc.conn.IsClosed()
+}
+
 func (dbc *realDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {
 	// Use Clone() because the contents of memory region referenced by
 	// string can change when clients (e.g. vcopier) use unsafe string methods.

--- a/go/vt/wrangler/fake_dbclient_test.go
+++ b/go/vt/wrangler/fake_dbclient_test.go
@@ -153,6 +153,10 @@ func (dc *fakeDBClient) Rollback() error {
 func (dc *fakeDBClient) Close() {
 }
 
+func (dc *fakeDBClient) IsClosed() bool {
+	return false
+}
+
 // ExecuteFetch is part of the DBClient interface
 func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {
 	dc.mu.Lock()


### PR DESCRIPTION

## Description

When `vreplicator` fails, check if its connection is closed, and if so, reopen it. This addresses https://github.com/vitessio/vitess/issues/17248 where the binlog connection auto closes itself in response to a bad commit (MySQL error `1180`), but will just as well apply to any situation where the connection closes. It's imperative to open the connection so as to be able to set state/message.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/17248

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
