### PR TITLE
EXPERIMENTAL: do not close binlog connection on commit error

### DIFF
--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -107,7 +107,6 @@ func (dc *dbClientImpl) Commit() error {
 	_, err := dc.dbConn.ExecuteFetch("commit", 1, false)
 	if err != nil {
 		LogError("COMMIT failed w/ error", err)
-		dc.dbConn.Close()
 	}
 	return err
 }


### PR DESCRIPTION

## Description

Looking to see if/which tests fail if we do not close the connection on commit error. I suspect nothing will fail in the tests, because this particular error is so rare. Let's see what happens and continue the investigation from there on.

## Related Issue(s)


https://github.com/vitessio/vitess/issues/17248

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
