### PR TITLE
Expose underlying LocalAddr()

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -730,6 +730,11 @@ func (c *Conn) RemoteAddr() net.Addr {
 	return c.conn.RemoteAddr()
 }
 
+// LocalAddr returns the underlying socket LocalAddr().
+func (c *Conn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
 // ID returns the MySQL connection ID for this connection.
 func (c *Conn) ID() int64 {
 	return int64(c.ConnectionID)


### PR DESCRIPTION
When using multiple IPs its sometime nice to know which IP the client connected to.

Issue: https://github.com/vitessio/vitess/issues/17255
