### PR TITLE
Fix potential deadlock in health streamer

### DIFF
--- a/go/vt/vttablet/tabletserver/health_streamer.go
+++ b/go/vt/vttablet/tabletserver/health_streamer.go
@@ -293,8 +293,10 @@ func (hs *healthStreamer) SetUnhealthyThreshold(v time.Duration) {
 // so it can read and write to the MySQL instance for schema-tracking.
 func (hs *healthStreamer) MakePrimary(serving bool) {
 	hs.fieldsMu.Lock()
-	defer hs.fieldsMu.Unlock()
 	hs.isServingPrimary = serving
+	// We let go of the lock here because we don't want to hold the lock when calling RegisterNotifier.
+	// If we keep holding the lock, there is a potential deadlock that can happen.
+	hs.fieldsMu.Unlock()
 	// We register for notifications from the schema Engine only when schema tracking is enabled,
 	// and we are going to a serving primary state.
 	if serving && hs.signalWhenSchemaChange {

--- a/go/vt/vttablet/tabletserver/health_streamer_test.go
+++ b/go/vt/vttablet/tabletserver/health_streamer_test.go
@@ -592,13 +592,14 @@ func TestDeadlockBwCloseAndReload(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)
-	// Try running Close and reload in parallel multiple times.
+	// Try running Close & MakePrimary and reload in parallel multiple times.
 	// This reproduces the deadlock quite readily.
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
 			hs.Close()
 			hs.Open()
+			hs.MakePrimary(true)
 		}
 	}()
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
While we fixed a couple of deadlocks in https://github.com/vitessio/vitess/pull/17230, one was left pending. It was found while testing for deadlocks in https://github.com/vitessio/vitess/pull/17238. 

The deadlock is similar to the ones fixed in https://github.com/vitessio/vitess/pull/17230, it was occurring between MakePrimary and the reload. The fix employed is to let go of the lock once it is not required instead of defering its unlocking.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #17229 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
