### PR TITLE
Online DDL: publish `vreplication_lag_seconds` from vreplication progress

### DIFF
--- a/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
+++ b/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
     `message_timestamp`               timestamp(6)     NULL     DEFAULT NULL,
     `eta_seconds`                     bigint           NOT NULL DEFAULT '-1',
     `rows_copied`                     bigint unsigned  NOT NULL DEFAULT '0',
+    `vreplication_lag_seconds`        bigint unsigned  NOT NULL DEFAULT '0',
     `table_rows`                      bigint           NOT NULL DEFAULT '0',
     `added_unique_keys`               int unsigned     NOT NULL DEFAULT '0',
     `removed_unique_keys`             int unsigned     NOT NULL DEFAULT '0',

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -87,6 +87,11 @@ const (
 		WHERE
 			migration_uuid=%a
 	`
+	sqlUpdateMigrationVreplicationLagSeconds = `UPDATE _vt.schema_migrations
+			SET vreplication_lag_seconds=%a
+		WHERE
+			migration_uuid=%a
+	`
 	sqlUpdateMigrationIsView = `UPDATE _vt.schema_migrations
 			SET is_view=%a
 		WHERE

--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/mysql/collations/charset"
@@ -94,6 +95,19 @@ func (v *VReplStream) hasError() (isTerminal bool, vreplError error) {
 		return false, errors.New(v.message)
 	}
 	return false, nil
+}
+
+// Lag returns the vreplication lag, as determined by the higher of the transaction timestamp and the time updated.
+func (s *VReplStream) Lag() time.Duration {
+	durationDiff := func(t1, t2 time.Time) time.Duration {
+		return t1.Sub(t2).Abs()
+	}
+	timeNow := time.Now()
+	timeUpdated := time.Unix(s.timeUpdated, 0)
+	// Let's look at transaction timestamp. This gets written by any ongoing
+	// writes on the server (whether on this table or any other table)
+	transactionTimestamp := time.Unix(s.transactionTimestamp, 0)
+	return max(durationDiff(timeNow, timeUpdated), durationDiff(timeNow, transactionTimestamp))
 }
 
 // VRepl is an online DDL helper for VReplication based migrations (ddl_strategy="online")


### PR DESCRIPTION
## Description

A new column in `schema_migrations`: `vreplication_lag_seconds` publishes the `vreplication` (rather, `vplayer`) lag on a vreplication migration. This is computed by the higher difference of vreplication's time updted and transaction timestamp compared with time now.

This just adds more visibility into the underlying workflow.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17264

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
