### PR TITLE
Remove unused code for old START_GTID logic

### DIFF
--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -701,11 +701,11 @@ func TestTxPoolBeginStatements(t *testing.T) {
 		expBeginSQL:      "set transaction isolation level serializable; start transaction read only",
 	}, {
 		txIsolationLevel: querypb.ExecuteOptions_CONSISTENT_SNAPSHOT_READ_ONLY,
-		expBeginSQL:      "set session session_track_gtids = START_GTID; set transaction isolation level repeatable read; start transaction with consistent snapshot, read only",
+		expBeginSQL:      "set transaction isolation level repeatable read; start transaction with consistent snapshot, read only",
 	}, {
 		txIsolationLevel: querypb.ExecuteOptions_CONSISTENT_SNAPSHOT_READ_ONLY,
 		readOnly:         true,
-		expBeginSQL:      "set session session_track_gtids = START_GTID; set transaction isolation level repeatable read; start transaction with consistent snapshot, read only",
+		expBeginSQL:      "set transaction isolation level repeatable read; start transaction with consistent snapshot, read only",
 	}, {
 		txIsolationLevel: querypb.ExecuteOptions_AUTOCOMMIT,
 		expBeginSQL:      "",


### PR DESCRIPTION
This was disabled in #16424, but we can clean up this additional code since it's unused.

## Related Issue(s)

Follow up to #16424

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required