### PR TITLE
Errant GTID detection fix for VTOrc

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -397,6 +397,11 @@ func detectErrantGTIDs(tabletAlias string, instance *Instance, tablet *topodatap
 		var primaryInstance *Instance
 		primaryAlias, _, _ := ReadShardPrimaryInformation(tablet.Keyspace, tablet.Shard)
 		if primaryAlias != "" {
+			// Check if the current tablet is the primary.
+			// If it is, then we don't need to run errant gtid detection on it.
+			if primaryAlias == tabletAlias {
+				return nil
+			}
 			primaryInstance, _, _ = ReadInstance(primaryAlias)
 		}
 		// Only run errant GTID detection, if we are sure that the data read of the current primary

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -881,7 +881,8 @@ func TestDetectErrantGTIDs(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err = detectErrantGTIDs(topoproto.TabletAliasString(tablet.Alias), tt.instance, tablet)
+			tt.instance.InstanceAlias = topoproto.TabletAliasString(tablet.Alias)
+			err = detectErrantGTIDs(tt.instance, tablet)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -912,6 +913,7 @@ func TestPrimaryErrantGTIDs(t *testing.T) {
 	instance := &Instance{
 		SourceHost:      "",
 		ExecutedGtidSet: "230ea8ea-81e3-11e4-972a-e25ec4bd140a:1-10589,8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-34,316d193c-70e5-11e5-adb2-ecf4bb2262ff:1-341",
+		InstanceAlias:   topoproto.TabletAliasString(tablet.Alias),
 	}
 
 	// Save shard record for the primary tablet.
@@ -921,7 +923,6 @@ func TestPrimaryErrantGTIDs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store the tablet record and the instance.
-	instance.InstanceAlias = topoproto.TabletAliasString(tablet.Alias)
 	err = SaveTablet(tablet)
 	require.NoError(t, err)
 	err = WriteInstance(instance, true, nil)
@@ -931,7 +932,7 @@ func TestPrimaryErrantGTIDs(t *testing.T) {
 	// gtid set further, we shouldn't be detecting errant GTIDs on it since it is the primary!
 	// We shouldn't be comparing it with a previous version of itself!
 	instance.ExecutedGtidSet = "230ea8ea-81e3-11e4-972a-e25ec4bd140a:1-10589,8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-34,316d193c-70e5-11e5-adb2-ecf4bb2262ff:1-351"
-	err = detectErrantGTIDs(topoproto.TabletAliasString(tablet.Alias), instance, tablet)
+	err = detectErrantGTIDs(instance, tablet)
 	require.NoError(t, err)
 	require.EqualValues(t, "", instance.GtidErrant)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue described in https://github.com/vitessio/vitess/issues/17286. The problem was fixed by adding a conditional check to see if the tablet we're detecting errant GTIDs on is the primary tablet itself.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/17286

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
