### PR TITLE
Add multi table updates in the 2pc fuzzer testing 

### DIFF
--- a/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
@@ -53,7 +53,9 @@ var (
 	}
 
 	insertIntoFuzzUpdate   = "INSERT INTO twopc_fuzzer_update (id, col) VALUES (%d, %d)"
+	insertIntoFuzzMulti    = "INSERT INTO twopc_fuzzer_multi (id) VALUES (%d)"
 	updateFuzzUpdate       = "UPDATE twopc_fuzzer_update SET col = col + %d WHERE id = %d"
+	updateFuzzUpdateMulti  = "UPDATE twopc_fuzzer_update join twopc_fuzzer_multi using (id) SET col = col + %d WHERE id = %d"
 	insertIntoFuzzInsert   = "INSERT INTO twopc_fuzzer_insert (id, updateSet, threadId) VALUES (%d, %d, %d)"
 	selectFromFuzzUpdate   = "SELECT col FROM twopc_fuzzer_update WHERE id = %d"
 	selectIdFromFuzzInsert = "SELECT threadId FROM twopc_fuzzer_insert WHERE updateSet = %d AND id = %d ORDER BY col"
@@ -294,6 +296,10 @@ func (fz *fuzzer) initialize(t *testing.T, conn *mysql.Conn) {
 		for _, id := range updateSet {
 			_, err := conn.ExecuteFetch(fmt.Sprintf(insertIntoFuzzUpdate, id, 0), 0, false)
 			require.NoError(t, err)
+			// We insert the same id values in multi table as we in the update table. We use this for running
+			// multi-table updates and inserts.
+			_, err = conn.ExecuteFetch(fmt.Sprintf(insertIntoFuzzMulti, id), 0, false)
+			require.NoError(t, err)
 		}
 	}
 }
@@ -331,12 +337,22 @@ func (fz *fuzzer) generateAndExecuteTransaction(threadId int) {
 	_, _ = conn.ExecuteFetch(finalCommand, 0, false)
 }
 
+func getUpdateQuery(incrementVal int32, id int) string {
+	if rand.Intn(2) == 1 {
+		x := fmt.Sprintf(updateFuzzUpdateMulti, incrementVal, id)
+		log.Errorf(x)
+		return x
+	}
+	return fmt.Sprintf(updateFuzzUpdate, incrementVal, id)
+}
+
 // generateUpdateQueries generates the queries to run updates on the twopc_fuzzer_update table.
 // It takes the update set index and the value to increment the set by.
 func (fz *fuzzer) generateUpdateQueries(updateSet int, incrementVal int32) []string {
 	var queries []string
 	for _, id := range fz.updateRowsVals[updateSet] {
-		queries = append(queries, fmt.Sprintf(updateFuzzUpdate, incrementVal, id))
+		// Use multi table DML queries half the time.
+		queries = append(queries, getUpdateQuery(incrementVal, id))
 	}
 	rand.Shuffle(len(queries), func(i, j int) {
 		queries[i], queries[j] = queries[j], queries[i]
@@ -427,7 +443,7 @@ func (fz *fuzzer) randomDML() string {
 	}
 	// Generate UPDATE
 	updateId := fz.updateRowsVals[rand.Intn(len(fz.updateRowsVals))][rand.Intn(len(updateRowBaseVals))]
-	return fmt.Sprintf(updateFuzzUpdate, rand.Intn(100000), updateId)
+	return getUpdateQuery(rand.Int31n(100000), updateId)
 }
 
 /*

--- a/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/fuzzer_test.go
@@ -339,9 +339,7 @@ func (fz *fuzzer) generateAndExecuteTransaction(threadId int) {
 
 func getUpdateQuery(incrementVal int32, id int) string {
 	if rand.Intn(2) == 1 {
-		x := fmt.Sprintf(updateFuzzUpdateMulti, incrementVal, id)
-		log.Errorf(x)
-		return x
+		return fmt.Sprintf(updateFuzzUpdateMulti, incrementVal, id)
 	}
 	return fmt.Sprintf(updateFuzzUpdate, incrementVal, id)
 }

--- a/go/test/endtoend/transaction/twopc/fuzz/main_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/main_test.go
@@ -126,5 +126,6 @@ func cleanup(t *testing.T) {
 
 	utils.ClearOutTable(t, vtParams, "twopc_fuzzer_insert")
 	utils.ClearOutTable(t, vtParams, "twopc_fuzzer_update")
+	utils.ClearOutTable(t, vtParams, "twopc_fuzzer_multi")
 	utils.ClearOutTable(t, vtParams, "twopc_t1")
 }

--- a/go/test/endtoend/transaction/twopc/fuzz/schema.sql
+++ b/go/test/endtoend/transaction/twopc/fuzz/schema.sql
@@ -4,6 +4,11 @@ create table twopc_fuzzer_update (
     primary key (id)
 ) Engine=InnoDB;
 
+create table twopc_fuzzer_multi (
+    id bigint,
+    primary key (id)
+) Engine=InnoDB;
+
 create table twopc_fuzzer_insert (
     id bigint,
     updateSet bigint,

--- a/go/test/endtoend/transaction/twopc/fuzz/vschema.json
+++ b/go/test/endtoend/transaction/twopc/fuzz/vschema.json
@@ -3,6 +3,9 @@
   "vindexes": {
     "reverse_bits": {
       "type": "reverse_bits"
+    },
+    "xxhash": {
+      "type": "xxhash"
     }
   },
   "tables": {
@@ -19,6 +22,14 @@
         {
           "column": "id",
           "name": "reverse_bits"
+        }
+      ]
+    },
+    "twopc_fuzzer_multi": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
         }
       ]
     },


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds multi-table updates to the two pc fuzzer testing we have. This ensures we process multi-table DMLs correctly in our atomic transactions implementation. We didn't expect that there would be anything special about them to begin with, but it is always nice to have the assertions backed by actual tests.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/16245

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
