### PR TITLE
Support `last_insert_id()` with argument in SELECT

### DIFF
--- a/changelog/22.0/22.0.0/summary.md
+++ b/changelog/22.0/22.0.0/summary.md
@@ -8,8 +8,10 @@
   - **[RPC Changes](#rpc-changes)**
   - **[Prefer not promoting a replica that is currently taking a backup](#reparents-prefer-not-backing-up)**
   - **[VTOrc Config File Changes](#vtorc-config-file-changes)**
+  - **[Added support for LAST_INSERT_ID(expr)](#last_insert_id)**
 - **[Minor Changes](#minor-changes)**
   - **[VTTablet Flags](#flags-vttablet)**
+
 
 
 ## <a id="major-changes"/>Major Changes</a>
@@ -59,6 +61,9 @@ The following fields can be dynamically changed -
 
 To upgrade to the newer version of the configuration file, first switch to using the flags in your current deployment before upgrading. Then you can switch to using the configuration file in the newer release.
 
+### <a id="last_insert_id"/>Added support for LAST_INSERT_ID(expr)
+
+Added support for LAST_INSERT_ID(expr) to align with MySQL behavior, enabling session-level assignment of the last insert ID via query expressions.
 
 ## <a id="minor-changes"/>Minor Changes</a>
 

--- a/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
+++ b/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
@@ -65,3 +65,6 @@ from (select id, count(*) as num_segments from t1 group by 1 order by 2 desc lim
 
 select name
 from (select name from t1 group by name having count(t1.id) > 1) t1;
+
+# this query uses last_insert_id with a column argument to show that this works well
+select id, last_insert_id(count(*)) as num_segments from t1 group by id;

--- a/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
+++ b/go/test/endtoend/vtgate/vitess_tester/aggregation/aggregation.test
@@ -68,3 +68,6 @@ from (select name from t1 group by name having count(t1.id) > 1) t1;
 
 # this query uses last_insert_id with a column argument to show that this works well
 select id, last_insert_id(count(*)) as num_segments from t1 group by id;
+
+# checking that we stored the correct value in the last_insert_id
+select last_insert_id();

--- a/go/test/endtoend/vtgate/vitess_tester/expressions/expressions.test
+++ b/go/test/endtoend/vtgate/vitess_tester/expressions/expressions.test
@@ -28,3 +28,7 @@ SELECT (~ (1 || 0)) IS NULL;
 
 SELECT 1
 WHERE (~ (1 || 0)) IS NULL;
+
+select last_insert_id(12);
+
+select last_insert_id();

--- a/go/vt/sqlparser/copy_on_write.go
+++ b/go/vt/sqlparser/copy_on_write.go
@@ -53,6 +53,9 @@ func CopyOnRewrite(
 	return out
 }
 
+// CopyAndReplaceExpr traverses a syntax tree recursively, starting with root,
+// and replaceFn is called for each node that is an Expr. If replaceFn returns
+// true, the node is replaced with the returned node.
 func CopyAndReplaceExpr(node SQLNode, replaceFn func(node Expr) (Expr, bool)) SQLNode {
 	var replace Expr
 	pre := func(node, _ SQLNode) bool {

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -1083,6 +1083,24 @@ func (cached *SQLCalcFoundRows) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
+func (cached *SaveToSession) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(32)
+	}
+	// field Source vitess.io/vitess/go/vt/vtgate/engine.Primitive
+	if cc, ok := cached.Source.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	// field Offset vitess.io/vitess/go/vt/vtgate/evalengine.Expr
+	if cc, ok := cached.Offset.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	return size
+}
 func (cached *ScalarAggregate) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -263,6 +263,10 @@ func (t *noopVCursor) SetFoundRows(u uint64) {
 	panic("implement me")
 }
 
+func (t *noopVCursor) SetLastInsertID(id uint64) {
+	panic("implement me")
+}
+
 func (t *noopVCursor) InTransactionAndIsDML() bool {
 	panic("implement me")
 }
@@ -498,6 +502,9 @@ func (f *loggingVCursor) GetSystemVariables(func(k string, v string)) {
 }
 
 func (f *loggingVCursor) SetFoundRows(u uint64) {
+	panic("implement me")
+}
+func (f *loggingVCursor) SetLastInsertID(id uint64) {
 	panic("implement me")
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -182,7 +182,7 @@ type (
 		SetPriority(string)
 		SetExecQueryTimeout(timeout *int)
 		SetFoundRows(uint64)
-
+		SetLastInsertID(uint64)
 		SetDDLStrategy(string)
 		GetDDLStrategy() string
 		SetMigrationContext(string)

--- a/go/vt/vtgate/engine/save_to_session.go
+++ b/go/vt/vtgate/engine/save_to_session.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+)
+
+type SaveToSession struct {
+	noTxNeeded
+
+	Source Primitive
+	Offset evalengine.Expr
+}
+
+var _ Primitive = (*SaveToSession)(nil)
+
+func (s *SaveToSession) RouteType() string {
+	return s.Source.RouteType()
+}
+
+func (s *SaveToSession) GetKeyspaceName() string {
+	return s.Source.GetKeyspaceName()
+}
+
+func (s *SaveToSession) GetTableName() string {
+	return s.Source.GetTableName()
+}
+
+func (s *SaveToSession) GetFields(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return s.Source.GetFields(ctx, vcursor, bindVars)
+}
+
+// TryExecute on SaveToSession will execute the Source and save the last row's value of Offset into the session.
+func (s *SaveToSession) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	result, err := s.Source.TryExecute(ctx, vcursor, bindVars, wantfields)
+	if err != nil {
+		return nil, err
+	}
+
+	intEvalResult, ok, err := s.getUintFromOffset(ctx, vcursor, bindVars, result)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		vcursor.Session().SetLastInsertID(intEvalResult)
+	}
+	return result, nil
+}
+
+func (s *SaveToSession) getUintFromOffset(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, result *sqltypes.Result) (uint64, bool, error) {
+	if len(result.Rows) == 0 {
+		return 0, false, nil
+	}
+
+	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
+	env.Row = result.Rows[len(result.Rows)-1] // last row
+	evalResult, err := env.Evaluate(s.Offset)
+	if err != nil {
+		return 0, false, err
+	}
+	value, err := evalResult.Value(vcursor.ConnCollation()).ToCastUint64()
+	if err != nil {
+		return 0, false, err
+	}
+	return value, true, nil
+}
+
+// TryStreamExecute on SaveToSession will execute the Source and save the last row's value of Offset into the session.
+func (s *SaveToSession) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	var value *uint64
+
+	f := func(qr *sqltypes.Result) error {
+		v, ok, err := s.getUintFromOffset(ctx, vcursor, bindVars, qr)
+		if err != nil {
+			return err
+		}
+		if ok {
+			value = &v
+		}
+		return callback(qr)
+	}
+
+	err := s.Source.TryStreamExecute(ctx, vcursor, bindVars, wantfields, f)
+	if err != nil {
+		return err
+	}
+	if value != nil {
+		vcursor.Session().SetLastInsertID(*value)
+	}
+
+	return nil
+}
+
+func (s *SaveToSession) Inputs() ([]Primitive, []map[string]any) {
+	return []Primitive{s.Source}, nil
+}
+
+func (s *SaveToSession) description() PrimitiveDescription {
+	return PrimitiveDescription{
+		OperatorType: "SaveToSession",
+		Other: map[string]interface{}{
+			"Offset": sqlparser.String(s.Offset),
+		},
+	}
+}

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1130,8 +1130,8 @@ func (vc *VCursorImpl) SetFoundRows(foundRows uint64) {
 	vc.SafeSession.SetFoundRows(foundRows)
 }
 
-func (vc *vcursorImpl) SetLastInsertID(id uint64) {
-	vc.safeSession.LastInsertId = id
+func (vc *VCursorImpl) SetLastInsertID(id uint64) {
+	vc.SafeSession.LastInsertId = id
 }
 
 // SetDDLStrategy implements the SessionActions interface

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1130,6 +1130,10 @@ func (vc *VCursorImpl) SetFoundRows(foundRows uint64) {
 	vc.SafeSession.SetFoundRows(foundRows)
 }
 
+func (vc *vcursorImpl) SetLastInsertID(id uint64) {
+	vc.safeSession.LastInsertId = id
+}
+
 // SetDDLStrategy implements the SessionActions interface
 func (vc *VCursorImpl) SetDDLStrategy(strategy string) {
 	vc.SafeSession.SetDDLStrategy(strategy)

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -489,13 +489,18 @@ func transformSaveToSession(ctx *plancontext.PlanningContext, op *operators.Save
 		return nil, err
 	}
 
+	v := op.Offset
+	return createSaveToSessionOnOffset(ctx, v, src)
+}
+
+func createSaveToSessionOnOffset(ctx *plancontext.PlanningContext, v int, src engine.Primitive) (engine.Primitive, error) {
 	cfg := &evalengine.Config{
 		ResolveType: ctx.TypeForExpr,
 		Collation:   ctx.SemTable.Collation,
 		Environment: ctx.VSchema.Environment(),
 	}
 
-	offset, err := evalengine.Translate(sqlparser.NewOffset(op.Offset, nil), cfg)
+	offset, err := evalengine.Translate(sqlparser.NewOffset(v, nil), cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -849,7 +849,9 @@ func handleLastInsertIDColumns(ctx *plancontext.PlanningContext, output Operator
 		newExpr := sqlparser.CopyAndReplaceExpr(ae.Expr, replaceFn)
 		ae.Expr = newExpr.(sqlparser.Expr)
 	}
-
+	if offset == -1 {
+		panic(vterrors.VT12001("last_insert_id(<expr>) only supported in the select list"))
+	}
 	if topLevel {
 		return &SaveToSession{
 			unaryOperator: unaryOperator{

--- a/go/vt/vtgate/planbuilder/operators/save_to_session.go
+++ b/go/vt/vtgate/planbuilder/operators/save_to_session.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+)
+
+// SaveToSession is used to save a value to the session.
+// At the moment it's only used for last_insert_id, but it could be used for other things in the future.
+type SaveToSession struct {
+	unaryOperator
+	Offset int
+}
+
+var _ Operator = (*SaveToSession)(nil)
+
+func (s *SaveToSession) Clone(inputs []Operator) Operator {
+	k := *s
+	k.Source = inputs[0]
+	return &k
+}
+
+func (s *SaveToSession) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) Operator {
+	src := s.Source.AddPredicate(ctx, expr)
+	s.Source = src
+	return s
+}
+
+func (s *SaveToSession) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, expr *sqlparser.AliasedExpr) int {
+	return s.Source.AddColumn(ctx, reuseExisting, addToGroupBy, expr)
+}
+
+func (s *SaveToSession) AddWSColumn(ctx *plancontext.PlanningContext, offset int, underRoute bool) int {
+	return s.Source.AddWSColumn(ctx, offset, underRoute)
+}
+
+func (s *SaveToSession) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr, underRoute bool) int {
+	return s.Source.FindCol(ctx, expr, underRoute)
+}
+
+func (s *SaveToSession) GetColumns(ctx *plancontext.PlanningContext) []*sqlparser.AliasedExpr {
+	return s.Source.GetColumns(ctx)
+}
+
+func (s *SaveToSession) GetSelectExprs(ctx *plancontext.PlanningContext) sqlparser.SelectExprs {
+	return s.Source.GetSelectExprs(ctx)
+}
+
+func (s *SaveToSession) ShortDescription() string {
+	return ""
+}
+
+func (s *SaveToSession) GetOrdering(ctx *plancontext.PlanningContext) []OrderBy {
+	return s.Source.GetOrdering(ctx)
+}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -4135,6 +4135,34 @@
     }
   },
   {
+    "comment": "Save the count in last_insert_id",
+    "query": "select id, last_insert_id(count(*)) as num_segments from user group by id",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select id, last_insert_id(count(*)) as num_segments from user group by id",
+      "Instructions": {
+        "OperatorType": "SaveToSession",
+        "Offset": "_vt_column_1",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, last_insert_id(count(*)) as num_segments from `user` where 1 != 1 group by id",
+            "Query": "select id, last_insert_id(count(*)) as num_segments from `user` group by id",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "Aggregations from derived table used in arithmetic outside derived table",
     "query": "select A.a, A.b, (A.a / A.b) as d from (select sum(a) as a, sum(b) as b from user) A",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2177,8 +2177,8 @@
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select 12 from dual where 1 != 1",
-            "Query": "select 12 from dual",
+            "FieldQuery": "select last_insert_id(12) from dual where 1 != 1",
+            "Query": "select last_insert_id(12) from dual",
             "Table": "dual"
           }
         ]
@@ -2205,8 +2205,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select bar, 12, foo from `user` where 1 != 1",
-            "Query": "select bar, 12, foo from `user`",
+            "FieldQuery": "select bar, 12, last_insert_id(foo) from `user` where 1 != 1",
+            "Query": "select bar, 12, last_insert_id(foo) from `user`",
             "Table": "`user`"
           }
         ]
@@ -5687,8 +5687,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user`",
+            "FieldQuery": "select last_insert_id(id) from `user` where 1 != 1",
+            "Query": "select last_insert_id(id) from `user`",
             "Table": "`user`"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2177,8 +2177,8 @@
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select last_insert_id(12) from dual where 1 != 1",
-            "Query": "select last_insert_id(12) from dual",
+            "FieldQuery": "select 12 from dual where 1 != 1",
+            "Query": "select 12 from dual",
             "Table": "dual"
           }
         ]
@@ -2205,8 +2205,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select bar, 12, last_insert_id(foo) from `user` where 1 != 1",
-            "Query": "select bar, 12, last_insert_id(foo) from `user`",
+            "FieldQuery": "select bar, 12, foo from `user` where 1 != 1",
+            "Query": "select bar, 12, foo from `user`",
             "Table": "`user`"
           }
         ]
@@ -5687,8 +5687,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select last_insert_id(id) from `user` where 1 != 1",
-            "Query": "select last_insert_id(id) from `user`",
+            "FieldQuery": "select id from `user` where 1 != 1",
+            "Query": "select id from `user`",
             "Table": "`user`"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2217,6 +2217,34 @@
     }
   },
   {
+    "comment": "save column value to session - unsharded",
+    "query": "select bar, 12, last_insert_id(foo) from unsharded",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select bar, 12, last_insert_id(foo) from unsharded",
+      "Instructions": {
+        "OperatorType": "SaveToSession",
+        "Offset": "_vt_column_2",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select bar, 12, last_insert_id(foo) from unsharded where 1 != 1",
+            "Query": "select bar, 12, last_insert_id(foo) from unsharded",
+            "Table": "unsharded"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
     "comment": "sql_calc_found_rows with SelectEqualUnique plans",
     "query": "select sql_calc_found_rows * from music where user_id = 1 limit 2",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2161,6 +2161,62 @@
     }
   },
   {
+    "comment": "save literal to session",
+    "query": "select last_insert_id(12)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select last_insert_id(12)",
+      "Instructions": {
+        "OperatorType": "SaveToSession",
+        "Offset": "_vt_column_0",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Reference",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select last_insert_id(12) from dual where 1 != 1",
+            "Query": "select last_insert_id(12) from dual",
+            "Table": "dual"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.dual"
+      ]
+    }
+  },
+  {
+    "comment": "save column value to session - sharded",
+    "query": "select bar, 12, last_insert_id(foo) from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select bar, 12, last_insert_id(foo) from user",
+      "Instructions": {
+        "OperatorType": "SaveToSession",
+        "Offset": "_vt_column_2",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select bar, 12, last_insert_id(foo) from `user` where 1 != 1",
+            "Query": "select bar, 12, last_insert_id(foo) from `user`",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "sql_calc_found_rows with SelectEqualUnique plans",
     "query": "select sql_calc_found_rows * from music where user_id = 1 limit 2",
     "plan": {
@@ -5593,15 +5649,21 @@
       "QueryType": "SELECT",
       "Original": "select last_insert_id(id) from user",
       "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "Scatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select last_insert_id(id) from `user` where 1 != 1",
-        "Query": "select last_insert_id(id) from `user`",
-        "Table": "`user`"
+        "OperatorType": "SaveToSession",
+        "Offset": "_vt_column_0",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select last_insert_id(id) from `user` where 1 != 1",
+            "Query": "select last_insert_id(id) from `user`",
+            "Table": "`user`"
+          }
+        ]
       },
       "TablesUsed": [
         "user.user"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2190,10 +2190,10 @@
   },
   {
     "comment": "save column value to session - sharded",
-    "query": "select bar, 12, last_insert_id(foo) from user",
+    "query": "select col, 12, last_insert_id(intcol) from user",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select bar, 12, last_insert_id(foo) from user",
+      "Original": "select col, 12, last_insert_id(intcol) from user",
       "Instructions": {
         "OperatorType": "SaveToSession",
         "Offset": "_vt_column_2",
@@ -2205,8 +2205,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select bar, 12, last_insert_id(foo) from `user` where 1 != 1",
-            "Query": "select bar, 12, last_insert_id(foo) from `user`",
+            "FieldQuery": "select col, 12, last_insert_id(intcol) from `user` where 1 != 1",
+            "Query": "select col, 12, last_insert_id(intcol) from `user`",
             "Table": "`user`"
           }
         ]
@@ -2218,10 +2218,10 @@
   },
   {
     "comment": "save column value to session - unsharded",
-    "query": "select bar, 12, last_insert_id(foo) from unsharded",
+    "query": "select col1, 12, last_insert_id(id) from unsharded",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select bar, 12, last_insert_id(foo) from unsharded",
+      "Original": "select col1, 12, last_insert_id(id) from unsharded",
       "Instructions": {
         "OperatorType": "SaveToSession",
         "Offset": "_vt_column_2",
@@ -2233,8 +2233,8 @@
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select bar, 12, last_insert_id(foo) from unsharded where 1 != 1",
-            "Query": "select bar, 12, last_insert_id(foo) from unsharded",
+            "FieldQuery": "select col1, 12, last_insert_id(id) from unsharded where 1 != 1",
+            "Query": "select col1, 12, last_insert_id(id) from unsharded",
             "Table": "unsharded"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -383,5 +383,10 @@
     "comment": "SOME/ANY/ALL comparison operator not supported for unsharded queries",
     "query": "select 1 from user where foo = ALL (select 1 from user_extra where foo = 1)",
     "plan": "VT12001: unsupported: ANY/ALL/SOME comparison operator"
+  },
+  {
+    "comment": "last_insert_id(<expr>) only supported in the select list",
+    "query": "select id, foo from user where last_insert_id(bar) = 12",
+    "plan": "VT12001: unsupported: last_insert_id(<expr>) only supported in the select list"
   }
 ]

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -151,7 +151,7 @@ func (a *analyzer) newSemTable(
 			ExpandedColumns:           map[sqlparser.TableName][]*sqlparser.ColName{},
 			columns:                   map[*sqlparser.Union]sqlparser.SelectExprs{},
 			StatementIDs:              a.scoper.statementIDs,
-			QuerySignature:            QuerySignature{},
+			QuerySignature:            a.sig,
 			childForeignKeysInvolved:  map[TableSet][]vindexes.ChildFKInfo{},
 			parentForeignKeysInvolved: map[TableSet][]vindexes.ParentFKInfo{},
 			childFkToUpdExprs:         map[string]sqlparser.UpdateExprs{},
@@ -360,6 +360,10 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 	_ = sqlparser.Rewrite(statement, a.earlyTables.down, a.earlyTables.up)
 	if a.err != nil {
 		return a.err
+	}
+
+	if a.earlyTables.lastInsertIdWithArgument {
+		a.sig.LastInsertIDArg = true
 	}
 
 	if a.canShortCut(statement) {

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -463,6 +463,10 @@ func (a *analyzer) noteQuerySignature(node sqlparser.SQLNode) {
 		a.sig.Aggregation = true
 	case *sqlparser.Delete, *sqlparser.Update, *sqlparser.Insert:
 		a.sig.DML = true
+	case *sqlparser.FuncExpr:
+		if len(node.Exprs) == 1 && node.Name.EqualString("last_insert_id") {
+			a.sig.LastInsertIDArg = true
+		}
 	}
 }
 

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -467,10 +467,6 @@ func (a *analyzer) noteQuerySignature(node sqlparser.SQLNode) {
 		a.sig.Aggregation = true
 	case *sqlparser.Delete, *sqlparser.Update, *sqlparser.Insert:
 		a.sig.DML = true
-	case *sqlparser.FuncExpr:
-		if len(node.Exprs) == 1 && node.Name.EqualString("last_insert_id") {
-			a.sig.LastInsertIDArg = true
-		}
 	}
 }
 

--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -80,13 +80,14 @@ type (
 
 	// QuerySignature is used to identify shortcuts in the planning process
 	QuerySignature struct {
-		Aggregation  bool
-		DML          bool
-		Distinct     bool
-		HashJoin     bool
-		SubQueries   bool
-		Union        bool
-		RecursiveCTE bool
+		Aggregation     bool
+		DML             bool
+		Distinct        bool
+		HashJoin        bool
+		SubQueries      bool
+		Union           bool
+		RecursiveCTE    bool
+		LastInsertIDArg bool // LastInsertIDArg is true if the query has a LAST_INSERT_ID(x) with an argument
 	}
 
 	// MirrorInfo stores information used to produce mirror

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -46,6 +46,10 @@ type (
 
 		// cte is a map of CTE definitions that are used in the query
 		cte map[string]*CTE
+
+		// lastInsertIdWithArgument is used to signal to later stages that we
+		// need to do special handling of the engine primitive
+		lastInsertIdWithArgument bool
 	}
 )
 
@@ -59,16 +63,19 @@ func newEarlyTableCollector(si SchemaInformation, currentDb string) *earlyTableC
 }
 
 func (etc *earlyTableCollector) down(cursor *sqlparser.Cursor) bool {
-	with, ok := cursor.Node().(*sqlparser.With)
-	if !ok {
-		return true
-	}
-	for _, cte := range with.CTEs {
-		etc.cte[cte.ID.String()] = &CTE{
-			Name:      cte.ID.String(),
-			Query:     cte.Subquery,
-			Columns:   cte.Columns,
-			Recursive: with.Recursive,
+	switch node := cursor.Node().(type) {
+	case *sqlparser.With:
+		for _, cte := range node.CTEs {
+			etc.cte[cte.ID.String()] = &CTE{
+				Name:      cte.ID.String(),
+				Query:     cte.Subquery,
+				Columns:   cte.Columns,
+				Recursive: node.Recursive,
+			}
+		}
+	case *sqlparser.FuncExpr:
+		if node.Name.EqualString("last_insert_id") && len(node.Exprs) == 1 {
+			etc.lastInsertIdWithArgument = true
 		}
 	}
 	return true


### PR DESCRIPTION
## Description
This PR adds support for `LAST_INSERT_ID(expr)` in Vitess. The feature allows the argument `expr` to be evaluated and stored as the session’s last insert ID, aligning with MySQL’s behavior. This extends Vitess’ compatibility for queries that rely on setting or retrieving session-level last insert ID values programmatically.

However, unlike MySQL, this feature is limited to usage within SELECT expressions only (i.e., it cannot be used in WHERE, GROUP BY, HAVING, or other non-SELECT contexts), which introduces a remaining compatibility gap.

## Related Issue(s)
Work towards fixing #6087

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x]  Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
