### PR TITLE
LookupVindex: fix CLI to allow creating non-unique lookups with single column

### DIFF
--- a/go/test/endtoend/vreplication/lookupindex_helper_test.go
+++ b/go/test/endtoend/vreplication/lookupindex_helper_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+type lookupIndex struct {
+	typ                string
+	name               string
+	tableKeyspace      string
+	table              string
+	columns            []string
+	ownerTable         string
+	ownerTableKeyspace string
+	ignoreNulls        bool
+
+	t *testing.T
+}
+
+func (li *lookupIndex) String() string {
+	return li.typ + " " + li.name + " on " + li.tableKeyspace + "." + li.table + " (" + li.columns[0] + ")"
+}
+
+func (li *lookupIndex) create() {
+	cols := strings.Join(li.columns, ",")
+	args := []string{
+		"LookupVindex",
+		"--name", li.name,
+		"--table-keyspace=" + li.ownerTableKeyspace,
+		"create",
+		"--keyspace=" + li.tableKeyspace,
+		"--type=" + li.typ,
+		"--table-owner=" + li.ownerTable,
+		"--table-owner-columns=" + cols,
+		"--tablet-types=PRIMARY",
+	}
+	if li.ignoreNulls {
+		args = append(args, "--ignore-nulls")
+	}
+
+	err := vc.VtctldClient.ExecuteCommand(args...)
+	require.NoError(li.t, err, "error executing LookupVindex create: %v", err)
+	waitForWorkflowState(li.t, vc, fmt.Sprintf("%s.%s", li.ownerTableKeyspace, li.name), binlogdatapb.VReplicationWorkflowState_Running.String())
+}
+
+func (li *lookupIndex) cancel() error {
+	return nil
+}
+
+func (li *lookupIndex) externalize() error {
+	return nil
+}
+
+func (li *lookupIndex) show() error {
+	return nil
+}

--- a/go/test/endtoend/vreplication/lookupindex_helper_test.go
+++ b/go/test/endtoend/vreplication/lookupindex_helper_test.go
@@ -47,8 +47,6 @@ func (li *lookupIndex) String() string {
 }
 
 func (li *lookupIndex) create() {
-	//err = vc.VtctldClient.ExecuteCommand("LookupVindex", "--name", vindexName, "--table-keyspace=product", "create", "--keyspace=customer",
-	//			"--type=consistent_lookup", "--table-owner=customer", "--table-owner-columns=name,cid", "--ignore-nulls", "--tablet-types=PRIMARY")
 	cols := strings.Join(li.columns, ",")
 	args := []string{
 		"LookupVindex",

--- a/go/test/endtoend/vreplication/lookupindex_test.go
+++ b/go/test/endtoend/vreplication/lookupindex_test.go
@@ -57,7 +57,7 @@ var lookupClusterSpec = TestClusterSpec{
 create table t1(
 	c1 int,
 	c2 int,
-    val varchar(128),
+	val varchar(128),
 	primary key(c1)
 );
 `,
@@ -67,7 +67,7 @@ func setupLookupIndexKeyspace(t *testing.T) map[string]*cluster.VttabletProcess 
 	tablets := make(map[string]*cluster.VttabletProcess)
 	if _, err := vc.AddKeyspace(t, []*Cell{vc.Cells["zone1"]}, lookupClusterSpec.keyspaceName, "-80,80-",
 		lookupClusterSpec.vschema, lookupClusterSpec.schema, defaultReplicas, defaultRdonly, 200, nil); err != nil {
-		t.Fatal(err)
+		require.NoError(t, err)
 	}
 	defaultCell := vc.Cells[vc.CellNames[0]]
 	ks := vc.Cells[defaultCell.Name].Keyspaces[lookupClusterSpec.keyspaceName]
@@ -101,8 +101,7 @@ func TestLookupIndex(t *testing.T) {
 	defer vc.TearDown()
 	vttablet.InitVReplicationConfigDefaults()
 
-	tabs := setupLookupIndexKeyspace(t)
-	_ = tabs
+	_ = setupLookupIndexKeyspace(t)
 
 	initQuery := "insert into t1 (c1, c2, val) values (1, 1, 'val1'), (2, 2, 'val2'), (3, 3, 'val3')"
 	runningQuery := "insert into t1 (c1, c2, val) values (4, 4, 'val4'), (5, 5, 'val5'), (6, 6, 'val6')"

--- a/go/test/endtoend/vreplication/lookupindex_test.go
+++ b/go/test/endtoend/vreplication/lookupindex_test.go
@@ -98,6 +98,7 @@ func TestLookupIndex(t *testing.T) {
 	defaultReplicas = 1
 	defaultRdonly = 0
 	vc = setupMinimalCluster(t)
+	defer vc.TearDown()
 	vttablet.InitVReplicationConfigDefaults()
 
 	tabs := setupLookupIndexKeyspace(t)

--- a/go/test/endtoend/vreplication/lookupindex_test.go
+++ b/go/test/endtoend/vreplication/lookupindex_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	vttablet "vitess.io/vitess/go/vt/vttablet/common"
+)
+
+type TestClusterSpec struct {
+	keyspaceName string
+	vschema      string
+	schema       string
+}
+
+var lookupClusterSpec = TestClusterSpec{
+	keyspaceName: "lookuptest",
+	vschema: `
+{
+  "sharded": true,
+  "vindexes": {
+    "reverse_bits": {
+      "type": "reverse_bits"
+    }
+  },
+  "tables": {
+	"t1": {
+	      "column_vindexes": [
+	        {
+	          "column": "c1",
+	          "name": "reverse_bits"
+	        }
+	      ]
+	}
+  }
+}
+`,
+	schema: `
+create table t1(
+	c1 int,
+	c2 int,
+    val varchar(128),
+	primary key(c1)
+);
+`,
+}
+
+func setupLookupIndexKeyspace(t *testing.T) map[string]*cluster.VttabletProcess {
+	tablets := make(map[string]*cluster.VttabletProcess)
+	if _, err := vc.AddKeyspace(t, []*Cell{vc.Cells["zone1"]}, lookupClusterSpec.keyspaceName, "-80,80-",
+		lookupClusterSpec.vschema, lookupClusterSpec.schema, defaultReplicas, defaultRdonly, 200, nil); err != nil {
+		t.Fatal(err)
+	}
+	defaultCell := vc.Cells[vc.CellNames[0]]
+	ks := vc.Cells[defaultCell.Name].Keyspaces[lookupClusterSpec.keyspaceName]
+	targetTab1 = ks.Shards["-80"].Tablets["zone1-200"].Vttablet
+	targetTab2 = ks.Shards["80-"].Tablets["zone1-300"].Vttablet
+	tablets["-80"] = targetTab1
+	tablets["80-"] = targetTab2
+	return tablets
+}
+
+func TestLookupIndex(t *testing.T) {
+	setSidecarDBName("_vt")
+	origDefaultReplicas := defaultReplicas
+	origDefaultRdonly := defaultRdonly
+	defer func() {
+		defaultReplicas = origDefaultReplicas
+		defaultRdonly = origDefaultRdonly
+	}()
+	defaultReplicas = 1
+	defaultRdonly = 0
+	vc = setupMinimalCluster(t)
+	vttablet.InitVReplicationConfigDefaults()
+
+	tabs := setupLookupIndexKeyspace(t)
+	_ = tabs
+
+	vtgateConn, cancel := getVTGateConn()
+	defer cancel()
+	_, err := vtgateConn.ExecuteFetch("insert into t1 (c1, c2, val) values (1, 1, 'val1'), (2, 2, 'val2'), (3, 3, 'val3')", 1000, false)
+	require.NoError(t, err)
+	rows := 3
+
+	vindexName := "t1_c2_lookup"
+	lks := lookupClusterSpec.keyspaceName
+	err = vc.VtctldClient.ExecuteCommand("LookupVindex", "--name", vindexName, "--table-keyspace="+lks, "create", "--keyspace="+lks,
+		"--type=lookup", "--table-owner=t1", "--table-owner-columns=c2", "--ignore-nulls", "--tablet-types=PRIMARY")
+	require.NoError(t, err, "error executing LookupVindex create: %v", err)
+	waitForWorkflowState(t, vc, fmt.Sprintf(lks+".%s", vindexName), binlogdatapb.VReplicationWorkflowState_Running.String())
+	waitForRowCount(t, vtgateConn, lks, vindexName, rows)
+	vschema, err := vc.VtctldClient.ExecuteCommandWithOutput("GetVSchema", lks)
+	require.NoError(t, err, "error executing GetVSchema: %v", err)
+	vdx := gjson.Get(vschema, fmt.Sprintf("vindexes.%s", vindexName))
+	require.NotNil(t, vdx, "lookup vindex %s not found", vindexName)
+	require.Equal(t, "true", vdx.Get("params.write_only").String(), "expected write_only parameter to be true")
+
+	_, err = vtgateConn.ExecuteFetch("insert into t1 (c1, c2, val) values (4, 4, 'val4'), (5, 5, 'val5'), (6, 6, 'val6')", 1000, false)
+	require.NoError(t, err)
+	rows = 6
+	waitForRowCount(t, vtgateConn, lks, vindexName, rows)
+
+}

--- a/go/vt/vtctl/workflow/materializer_test.go
+++ b/go/vt/vtctl/workflow/materializer_test.go
@@ -2601,7 +2601,7 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 					},
 				},
 			},
-			err: "non-unique vindex 'from' should have more than one column",
+			err: "",
 		},
 		{
 			description: "vindex not found",

--- a/go/vt/vtctl/workflow/materializer_test.go
+++ b/go/vt/vtctl/workflow/materializer_test.go
@@ -2588,7 +2588,7 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 			err: "unique vindex 'from' should have only one column",
 		},
 		{
-			description: "non-unique lookup should have more than one column",
+			description: "non-unique lookup can have only one column",
 			input: &vschemapb.Keyspace{
 				Vindexes: map[string]*vschemapb.Vindex{
 					"v": {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -4026,10 +4026,6 @@ func (s *Server) prepareCreateLookup(ctx context.Context, workflow, keyspace str
 		if len(vindexFromCols) != 1 {
 			return nil, nil, nil, nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unique vindex 'from' should have only one column")
 		}
-	} else {
-		if len(vindexFromCols) < 2 {
-			return nil, nil, nil, nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "non-unique vindex 'from' should have more than one column")
-		}
 	}
 	vindexToCol = vindex.Params["to"]
 	// Make the vindex write_only. If one exists already in the vschema,

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -551,11 +551,8 @@ func (wr *Wrangler) prepareCreateLookup(ctx context.Context, keyspace string, sp
 		if len(vindexFromCols) != 1 {
 			return nil, nil, nil, fmt.Errorf("unique vindex 'from' should have only one column: %v", vindex)
 		}
-	} else {
-		if len(vindexFromCols) < 2 {
-			return nil, nil, nil, fmt.Errorf("non-unique vindex 'from' should have more than one column: %v", vindex)
-		}
 	}
+
 	vindexToCol = vindex.Params["to"]
 	// Make the vindex write_only. If one exists already in the vschema,
 	// it will need to match this vindex exactly, including the write_only setting.

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -1612,7 +1612,7 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 				},
 			},
 		},
-		err: "non-unique vindex 'from' should have more than one column",
+		err: "",
 	}, {
 		description: "vindex not found",
 		input: &vschemapb.Keyspace{

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -1599,7 +1599,7 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 		},
 		err: "unique vindex 'from' should have only one column",
 	}, {
-		description: "non-unique lookup should have more than one column",
+		description: "non-unique lookup can have only one column",
 		input: &vschemapb.Keyspace{
 			Vindexes: map[string]*vschemapb.Vindex{
 				"v": {

--- a/test/config.json
+++ b/test/config.json
@@ -1373,6 +1373,15 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"loopkup_index": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestLookupIndex"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vreplication_vtctldclient_vdiff2_movetables_tz",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtadmin": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtadmin"],


### PR DESCRIPTION
## Description

There was an incorrect validation in `LookupIndex` that a non-unique vindex should have more than one columns. This PR removes that check.

We also add a new e2e test specifically around lookup vindexes to validate this change and add a framework to test lookup vindexes more extensively in the future.

This bug has been around since the beginning, so we should backport this to supported versions.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17302

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

