### PR TITLE
refactor: rename DefaultKeyspace() to CurrentKeyspace()

### DIFF
--- a/go/test/vschemawrapper/vschema_wrapper.go
+++ b/go/test/vschemawrapper/vschema_wrapper.go
@@ -299,12 +299,12 @@ func (vw *VSchemaWrapper) getActualKeyspace() string {
 	return ks.Name
 }
 
-func (vw *VSchemaWrapper) DefaultKeyspace() (*vindexes.Keyspace, error) {
+func (vw *VSchemaWrapper) CurrentKeyspace() (*vindexes.Keyspace, error) {
 	return vw.V.Keyspaces["main"].Keyspace, nil
 }
 
 func (vw *VSchemaWrapper) AnyKeyspace() (*vindexes.Keyspace, error) {
-	return vw.DefaultKeyspace()
+	return vw.CurrentKeyspace()
 }
 
 func (vw *VSchemaWrapper) FirstSortedKeyspace() (*vindexes.Keyspace, error) {

--- a/go/test/vschemawrapper/vschema_wrapper.go
+++ b/go/test/vschemawrapper/vschema_wrapper.go
@@ -299,12 +299,12 @@ func (vw *VSchemaWrapper) getActualKeyspace() string {
 	return ks.Name
 }
 
-func (vw *VSchemaWrapper) CurrentKeyspace() (*vindexes.Keyspace, error) {
+func (vw *VSchemaWrapper) SelectedKeyspace() (*vindexes.Keyspace, error) {
 	return vw.V.Keyspaces["main"].Keyspace, nil
 }
 
 func (vw *VSchemaWrapper) AnyKeyspace() (*vindexes.Keyspace, error) {
-	return vw.CurrentKeyspace()
+	return vw.SelectedKeyspace()
 }
 
 func (vw *VSchemaWrapper) FirstSortedKeyspace() (*vindexes.Keyspace, error) {

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -275,7 +275,7 @@ func buildDBDDLPlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vschema
 	dbDDLstmt := stmt.(sqlparser.DBDDLStatement)
 	ksName := dbDDLstmt.GetDatabaseName()
 	if ksName == "" {
-		ks, err := vschema.CurrentKeyspace()
+		ks, err := vschema.SelectedKeyspace()
 		if err != nil {
 			return nil, err
 		}
@@ -310,7 +310,7 @@ func buildDBDDLPlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vschema
 }
 
 func buildLoadPlan(query string, vschema plancontext.VSchema) (*planResult, error) {
-	keyspace, err := vschema.CurrentKeyspace()
+	keyspace, err := vschema.SelectedKeyspace()
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func buildFlushOptions(stmt *sqlparser.Flush, vschema plancontext.VSchema) (*pla
 		return nil, vterrors.VT09012("FLUSH", vschema.TabletType().String())
 	}
 
-	keyspace, err := vschema.CurrentKeyspace()
+	keyspace, err := vschema.SelectedKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -275,7 +275,7 @@ func buildDBDDLPlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vschema
 	dbDDLstmt := stmt.(sqlparser.DBDDLStatement)
 	ksName := dbDDLstmt.GetDatabaseName()
 	if ksName == "" {
-		ks, err := vschema.DefaultKeyspace()
+		ks, err := vschema.CurrentKeyspace()
 		if err != nil {
 			return nil, err
 		}
@@ -310,7 +310,7 @@ func buildDBDDLPlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vschema
 }
 
 func buildLoadPlan(query string, vschema plancontext.VSchema) (*planResult, error) {
-	keyspace, err := vschema.DefaultKeyspace()
+	keyspace, err := vschema.CurrentKeyspace()
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func buildFlushOptions(stmt *sqlparser.Flush, vschema plancontext.VSchema) (*pla
 		return nil, vterrors.VT09012("FLUSH", vschema.TabletType().String())
 	}
 
-	keyspace, err := vschema.DefaultKeyspace()
+	keyspace, err := vschema.CurrentKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/bypass.go
+++ b/go/vt/vtgate/planbuilder/bypass.go
@@ -26,7 +26,7 @@ import (
 )
 
 func buildPlanForBypass(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vschema plancontext.VSchema) (*planResult, error) {
-	keyspace, err := vschema.DefaultKeyspace()
+	keyspace, err := vschema.CurrentKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/bypass.go
+++ b/go/vt/vtgate/planbuilder/bypass.go
@@ -26,7 +26,7 @@ import (
 )
 
 func buildPlanForBypass(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vschema plancontext.VSchema) (*planResult, error) {
-	keyspace, err := vschema.CurrentKeyspace()
+	keyspace, err := vschema.SelectedKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -81,7 +81,7 @@ func buildGeneralDDLPlan(ctx context.Context, sql string, ddlStatement sqlparser
 }
 
 func buildByPassPlan(sql string, vschema plancontext.VSchema, isDDL bool) (*planResult, error) {
-	keyspace, err := vschema.CurrentKeyspace()
+	keyspace, err := vschema.SelectedKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -81,7 +81,7 @@ func buildGeneralDDLPlan(ctx context.Context, sql string, ddlStatement sqlparser
 }
 
 func buildByPassPlan(sql string, vschema plancontext.VSchema, isDDL bool) (*planResult, error) {
-	keyspace, err := vschema.DefaultKeyspace()
+	keyspace, err := vschema.CurrentKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -545,7 +545,7 @@ func routeToEngineRoute(ctx *plancontext.PlanningContext, op *operators.Route, h
 }
 
 func newRoutingParams(ctx *plancontext.PlanningContext, opCode engine.Opcode) *engine.RoutingParameters {
-	ks, _ := ctx.VSchema.DefaultKeyspace()
+	ks, _ := ctx.VSchema.CurrentKeyspace()
 	if ks == nil {
 		// if we don't have a selected keyspace, any keyspace will do
 		// this is used by operators that do not set the keyspace

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -545,7 +545,7 @@ func routeToEngineRoute(ctx *plancontext.PlanningContext, op *operators.Route, h
 }
 
 func newRoutingParams(ctx *plancontext.PlanningContext, opCode engine.Opcode) *engine.RoutingParameters {
-	ks, _ := ctx.VSchema.CurrentKeyspace()
+	ks, _ := ctx.VSchema.SelectedKeyspace()
 	if ks == nil {
 		// if we don't have a selected keyspace, any keyspace will do
 		// this is used by operators that do not set the keyspace

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -91,7 +91,7 @@ func CreatePlanningContext(stmt sqlparser.Statement,
 	version querypb.ExecuteOptions_PlannerVersion,
 ) (*PlanningContext, error) {
 	ksName := ""
-	if ks, _ := vschema.CurrentKeyspace(); ks != nil {
+	if ks, _ := vschema.SelectedKeyspace(); ks != nil {
 		ksName = ks.Name
 	}
 

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -91,7 +91,7 @@ func CreatePlanningContext(stmt sqlparser.Statement,
 	version querypb.ExecuteOptions_PlannerVersion,
 ) (*PlanningContext, error) {
 	ksName := ""
-	if ks, _ := vschema.DefaultKeyspace(); ks != nil {
+	if ks, _ := vschema.CurrentKeyspace(); ks != nil {
 		ksName = ks.Name
 	}
 

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context_test.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context_test.go
@@ -201,7 +201,7 @@ func (v *vschema) FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Ta
 	panic("implement me")
 }
 
-func (v *vschema) DefaultKeyspace() (*vindexes.Keyspace, error) {
+func (v *vschema) CurrentKeyspace() (*vindexes.Keyspace, error) {
 	// TODO implement me
 	panic("implement me")
 }

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context_test.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context_test.go
@@ -201,7 +201,7 @@ func (v *vschema) FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Ta
 	panic("implement me")
 }
 
-func (v *vschema) CurrentKeyspace() (*vindexes.Keyspace, error) {
+func (v *vschema) SelectedKeyspace() (*vindexes.Keyspace, error) {
 	// TODO implement me
 	panic("implement me")
 }

--- a/go/vt/vtgate/planbuilder/plancontext/vschema.go
+++ b/go/vt/vtgate/planbuilder/plancontext/vschema.go
@@ -28,8 +28,8 @@ type VSchema interface {
 	FindView(name sqlparser.TableName) sqlparser.SelectStatement
 	FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, string, topodatapb.TabletType, key.Destination, error)
 
-	// CurrentKeyspace returns the current keyspace if set, otherwise returns an error
-	CurrentKeyspace() (*vindexes.Keyspace, error)
+	// SelectedKeyspace returns the current keyspace if set, otherwise returns an error
+	SelectedKeyspace() (*vindexes.Keyspace, error)
 	TargetString() string
 	Destination() key.Destination
 	TabletType() topodatapb.TabletType

--- a/go/vt/vtgate/planbuilder/plancontext/vschema.go
+++ b/go/vt/vtgate/planbuilder/plancontext/vschema.go
@@ -27,7 +27,9 @@ type VSchema interface {
 	FindTable(tablename sqlparser.TableName) (*vindexes.Table, string, topodatapb.TabletType, key.Destination, error)
 	FindView(name sqlparser.TableName) sqlparser.SelectStatement
 	FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, string, topodatapb.TabletType, key.Destination, error)
-	DefaultKeyspace() (*vindexes.Keyspace, error)
+
+	// CurrentKeyspace returns the current keyspace if set, otherwise returns an error
+	CurrentKeyspace() (*vindexes.Keyspace, error)
 	TargetString() string
 	Destination() key.Destination
 	TabletType() topodatapb.TabletType

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -46,7 +46,7 @@ func gen4SelectStmtPlanner(
 		}
 		if p != nil {
 			used := "dual"
-			keyspace, ksErr := vschema.CurrentKeyspace()
+			keyspace, ksErr := vschema.SelectedKeyspace()
 			if ksErr == nil {
 				// we are just getting the ks to log the correct table use.
 				// no need to fail this if we can't find the default keyspace
@@ -101,7 +101,7 @@ func gen4SelectStmtPlanner(
 
 func gen4planSQLCalcFoundRows(vschema plancontext.VSchema, sel *sqlparser.Select, query string, reservedVars *sqlparser.ReservedVars) (*planResult, error) {
 	ksName := ""
-	if ks, _ := vschema.CurrentKeyspace(); ks != nil {
+	if ks, _ := vschema.SelectedKeyspace(); ks != nil {
 		ksName = ks.Name
 	}
 	semTable, err := semantics.Analyze(sel, ksName, vschema)

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -46,7 +46,7 @@ func gen4SelectStmtPlanner(
 		}
 		if p != nil {
 			used := "dual"
-			keyspace, ksErr := vschema.DefaultKeyspace()
+			keyspace, ksErr := vschema.CurrentKeyspace()
 			if ksErr == nil {
 				// we are just getting the ks to log the correct table use.
 				// no need to fail this if we can't find the default keyspace
@@ -101,7 +101,7 @@ func gen4SelectStmtPlanner(
 
 func gen4planSQLCalcFoundRows(vschema plancontext.VSchema, sel *sqlparser.Select, query string, reservedVars *sqlparser.ReservedVars) (*planResult, error) {
 	ksName := ""
-	if ks, _ := vschema.DefaultKeyspace(); ks != nil {
+	if ks, _ := vschema.CurrentKeyspace(); ks != nil {
 		ksName = ks.Name
 	}
 	semTable, err := semantics.Analyze(sel, ksName, vschema)

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -676,7 +676,7 @@ func buildVschemaKeyspacesPlan(vschema plancontext.VSchema) (engine.Primitive, e
 
 func buildVschemaTablesPlan(vschema plancontext.VSchema) (engine.Primitive, error) {
 	vs := vschema.GetVSchema()
-	ks, err := vschema.DefaultKeyspace()
+	ks, err := vschema.CurrentKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -676,7 +676,7 @@ func buildVschemaKeyspacesPlan(vschema plancontext.VSchema) (engine.Primitive, e
 
 func buildVschemaTablesPlan(vschema plancontext.VSchema) (engine.Primitive, error) {
 	vs := vschema.GetVSchema()
-	ks, err := vschema.CurrentKeyspace()
+	ks, err := vschema.SelectedKeyspace()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -395,7 +395,7 @@ func (vc *vcursorImpl) getActualKeyspace() string {
 // DefaultKeyspace returns the default keyspace of the current request
 // if there is one. If the keyspace specified in the target cannot be
 // identified, it returns an error.
-func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
+func (vc *vcursorImpl) CurrentKeyspace() (*vindexes.Keyspace, error) {
 	if ignoreKeyspace(vc.keyspace) {
 		return nil, errNoKeyspace
 	}
@@ -409,7 +409,7 @@ func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
 var errNoDbAvailable = vterrors.NewErrorf(vtrpcpb.Code_FAILED_PRECONDITION, vterrors.NoDB, "no database available")
 
 func (vc *vcursorImpl) AnyKeyspace() (*vindexes.Keyspace, error) {
-	keyspace, err := vc.DefaultKeyspace()
+	keyspace, err := vc.CurrentKeyspace()
 	if err == nil {
 		return keyspace, nil
 	}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -392,10 +392,10 @@ func (vc *vcursorImpl) getActualKeyspace() string {
 	return ks.Name
 }
 
-// DefaultKeyspace returns the default keyspace of the current request
+// SelectedKeyspace returns the selected keyspace of the current request
 // if there is one. If the keyspace specified in the target cannot be
 // identified, it returns an error.
-func (vc *vcursorImpl) CurrentKeyspace() (*vindexes.Keyspace, error) {
+func (vc *vcursorImpl) SelectedKeyspace() (*vindexes.Keyspace, error) {
 	if ignoreKeyspace(vc.keyspace) {
 		return nil, errNoKeyspace
 	}
@@ -409,7 +409,7 @@ func (vc *vcursorImpl) CurrentKeyspace() (*vindexes.Keyspace, error) {
 var errNoDbAvailable = vterrors.NewErrorf(vtrpcpb.Code_FAILED_PRECONDITION, vterrors.NoDB, "no database available")
 
 func (vc *vcursorImpl) AnyKeyspace() (*vindexes.Keyspace, error) {
-	keyspace, err := vc.CurrentKeyspace()
+	keyspace, err := vc.SelectedKeyspace()
 	if err == nil {
 		return keyspace, nil
 	}


### PR DESCRIPTION
## Description
`DefaultKeyspace` is poorly named - it tells us which database the user has selected with `use` or using the connection string.

## Related Issue(s)

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
