### PR TITLE
[release-21.0] S3 Backups: optional endpoint resolver

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -505,13 +505,17 @@ func (bs *S3BackupStorage) client() (*s3.Client, error) {
 			return nil, err
 		}
 
+		var endpointResolverV2 func(options *s3.Options) = nil
+		if endpoint != "" {
+			endpointResolverV2 = s3.WithEndpointResolverV2(newEndpointResolver())
+		}
 		bs._client = s3.NewFromConfig(cfg, func(o *s3.Options) {
 			o.UsePathStyle = forcePath
 			if retryCount >= 0 {
 				o.RetryMaxAttempts = retryCount
 				o.Retryer = &ClosedConnectionRetryer{}
 			}
-		}, s3.WithEndpointResolverV2(newEndpointResolver()))
+		}, endpointResolverV2)
 
 		if len(bucket) == 0 {
 			return nil, fmt.Errorf("--s3_backup_storage_bucket required")


### PR DESCRIPTION
## Description

This PR backports two fixes added by https://github.com/vitessio/vitess/pull/17271: the endpoint resolver is now optional, the AWS retrier is correctly created.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/16664#issuecomment-2508981276


