### PR TITLE
Feature Request: Change varbinary to varchar in schemas used in examples folder

### DIFF
--- a/examples/backups/create_commerce_schema.sql
+++ b/examples/backups/create_commerce_schema.sql
@@ -1,6 +1,6 @@
 create table if not exists product(
-    sku varbinary(128),
-    description varbinary(128),
+    sku varchar(128),
+    description varchar(128),
     price bigint,
     primary key(sku)
 ) ENGINE=InnoDB;

--- a/examples/backups/create_customer_schema.sql
+++ b/examples/backups/create_customer_schema.sql
@@ -1,13 +1,13 @@
 create table if not exists customer(
     customer_id bigint not null,
-    email varbinary(128),
+    email varchar(128),
     primary key(customer_id)
 ) ENGINE=InnoDB;
 
 create table if not exists corder(
     order_id bigint not null,
     customer_id bigint,
-    sku varbinary(128),
+    sku varchar(128),
     price bigint,
     primary key(order_id)
 ) ENGINE=InnoDB;

--- a/examples/compose/default_vschema.json
+++ b/examples/compose/default_vschema.json
@@ -1,7 +1,7 @@
 {
   "sharded": false,
   "vindexes": {
-    "hash": {
+    "xxhash": {
       "type": "xxhash"
     }
   }

--- a/examples/compose/default_vschema.json
+++ b/examples/compose/default_vschema.json
@@ -2,7 +2,7 @@
   "sharded": false,
   "vindexes": {
     "hash": {
-      "type": "hash"
+      "type": "xxhash"
     }
   }
 }

--- a/examples/compose/lookup_keyspace_vschema.json
+++ b/examples/compose/lookup_keyspace_vschema.json
@@ -5,7 +5,7 @@
 			"column_vindexes": [
 				{
 					"column": "id",
-					"name": "hash"
+					"name": "xxhash"
 				}
 			]
 		},
@@ -13,7 +13,7 @@
 			"column_vindexes": [
 				{
 					"column": "id",
-					"name": "hash"
+					"name": "xxhash"
 				}
 			]
 		}

--- a/examples/compose/lookup_keyspace_vschema.json
+++ b/examples/compose/lookup_keyspace_vschema.json
@@ -20,7 +20,7 @@
 	},
 	"vindexes": {
 		"hash": {
-			"type": "hash"
+			"type": "xxhash"
 		}
 	}
 }

--- a/examples/compose/lookup_keyspace_vschema.json
+++ b/examples/compose/lookup_keyspace_vschema.json
@@ -19,7 +19,7 @@
 		}
 	},
 	"vindexes": {
-		"hash": {
+		"xxhash": {
 			"type": "xxhash"
 		}
 	}

--- a/examples/compose/test_keyspace_vschema.json
+++ b/examples/compose/test_keyspace_vschema.json
@@ -5,7 +5,7 @@
 			"column_vindexes": [
 				{
 					"column": "page",
-					"name": "hash"
+					"name": "xxhash"
 				},
 				{
 					"column": "message",
@@ -17,7 +17,7 @@
 			"column_vindexes": [
 				{
 					"column": "page",
-					"name": "hash"
+					"name": "xxhash"
 				},
 				{
 					"column": "token",

--- a/examples/compose/test_keyspace_vschema.json
+++ b/examples/compose/test_keyspace_vschema.json
@@ -28,7 +28,7 @@
 	},
 	"vindexes": {
 		"hash": {
-			"type": "hash"
+			"type": "xxhash"
 		},
 		"messages_message_lookup": {
 			"type": "lookup_hash",

--- a/examples/compose/test_keyspace_vschema.json
+++ b/examples/compose/test_keyspace_vschema.json
@@ -27,7 +27,7 @@
 		}
 	},
 	"vindexes": {
-		"hash": {
+		"xxhash": {
 			"type": "xxhash"
 		},
 		"messages_message_lookup": {

--- a/examples/compose/vtcompose/base_vschema.json
+++ b/examples/compose/vtcompose/base_vschema.json
@@ -1,7 +1,7 @@
 {
   "sharded": true,
   "vindexes": {
-    "hash": {
+    "xxhash": {
       "type": "xxhash"
     }
   },

--- a/examples/compose/vtcompose/base_vschema.json
+++ b/examples/compose/vtcompose/base_vschema.json
@@ -2,9 +2,8 @@
   "sharded": true,
   "vindexes": {
     "hash": {
-      "type": "hash"
+      "type": "xxhash"
     }
   },
-  "tables": {
-  }
+  "tables": {}
 }

--- a/examples/demo/schema/customer/vschema.json
+++ b/examples/demo/schema/customer/vschema.json
@@ -34,7 +34,7 @@
       "column_vindexes": [
         {
           "column": "customer_id",
-          "name": "hash"
+          "name": "xxhash"
         }
       ],
       "auto_increment": {
@@ -46,7 +46,7 @@
       "column_vindexes": [
         {
           "column": "customer_id",
-          "name": "hash"
+          "name": "xxhash"
         },
         {
           "column": "corder_id",

--- a/examples/demo/schema/customer/vschema.json
+++ b/examples/demo/schema/customer/vschema.json
@@ -1,7 +1,7 @@
 {
   "sharded": true,
   "vindexes": {
-    "hash": {
+    "xxhash": {
       "type": "xxhash"
     },
     "corder_keyspace_idx": {

--- a/examples/demo/schema/customer/vschema.json
+++ b/examples/demo/schema/customer/vschema.json
@@ -2,7 +2,7 @@
   "sharded": true,
   "vindexes": {
     "hash": {
-      "type": "hash"
+      "type": "xxhash"
     },
     "corder_keyspace_idx": {
       "type": "consistent_lookup_unique",
@@ -31,49 +31,63 @@
   },
   "tables": {
     "customer": {
-      "column_vindexes": [{
-        "column": "customer_id",
-        "name": "hash"
-      }],
+      "column_vindexes": [
+        {
+          "column": "customer_id",
+          "name": "hash"
+        }
+      ],
       "auto_increment": {
         "column": "customer_id",
         "sequence": "product.customer_seq"
       }
     },
     "corder": {
-      "column_vindexes": [{
-        "column": "customer_id",
-        "name": "hash"
-      }, {
-        "column": "corder_id",
-        "name": "corder_keyspace_idx"
-      }, {
-        "columns": ["oname", "corder_id"],
-        "name": "oname_keyspace_idx"
-      }],
+      "column_vindexes": [
+        {
+          "column": "customer_id",
+          "name": "hash"
+        },
+        {
+          "column": "corder_id",
+          "name": "corder_keyspace_idx"
+        },
+        {
+          "columns": [
+            "oname",
+            "corder_id"
+          ],
+          "name": "oname_keyspace_idx"
+        }
+      ],
       "auto_increment": {
         "column": "corder_id",
         "sequence": "product.corder_seq"
       }
     },
     "corder_event": {
-      "column_vindexes": [{
-        "column": "corder_id",
-        "name": "corder_keyspace_idx"
-      }, {
-        "column": "keyspace_id",
-        "name": "binary"
-      }],
+      "column_vindexes": [
+        {
+          "column": "corder_id",
+          "name": "corder_keyspace_idx"
+        },
+        {
+          "column": "keyspace_id",
+          "name": "binary"
+        }
+      ],
       "auto_increment": {
         "column": "corder_event_id",
         "sequence": "product.corder_event_seq"
       }
     },
     "oname_keyspace_idx": {
-      "column_vindexes": [{
-        "column": "oname",
-        "name": "unicode_loose_md5"
-      }]
+      "column_vindexes": [
+        {
+          "column": "oname",
+          "name": "unicode_loose_md5"
+        }
+      ]
     }
   }
 }

--- a/examples/local/create_commerce_schema.sql
+++ b/examples/local/create_commerce_schema.sql
@@ -1,18 +1,18 @@
 create table if not exists product(
-  sku varbinary(128),
-  description varbinary(128),
+  sku varchar(128),
+  description varchar(128),
   price bigint,
   primary key(sku)
 ) ENGINE=InnoDB;
 create table if not exists customer(
   customer_id bigint not null auto_increment,
-  email varbinary(128),
+  email varchar(128),
   primary key(customer_id)
 ) ENGINE=InnoDB;
 create table if not exists corder(
   order_id bigint not null auto_increment,
   customer_id bigint,
-  sku varbinary(128),
+  sku varchar(128),
   price bigint,
   primary key(order_id)
 ) ENGINE=InnoDB;

--- a/examples/local/vschema.json
+++ b/examples/local/vschema.json
@@ -10,7 +10,7 @@
       "column_vindexes": [
         {
           "column": "page",
-          "name": "hash"
+          "name": "xxhash"
         }
       ]
     }

--- a/examples/local/vschema.json
+++ b/examples/local/vschema.json
@@ -1,7 +1,7 @@
 {
   "sharded": true,
   "vindexes": {
-    "hash": {
+    "xxhash": {
       "type": "xxhash"
     }
   },

--- a/examples/local/vschema.json
+++ b/examples/local/vschema.json
@@ -2,7 +2,7 @@
   "sharded": true,
   "vindexes": {
     "hash": {
-      "type": "hash"
+      "type": "xxhash"
     }
   },
   "tables": {

--- a/examples/local/vschema_customer_sharded.json
+++ b/examples/local/vschema_customer_sharded.json
@@ -1,7 +1,7 @@
 {
     "sharded": true,
     "vindexes": {
-        "hash": {
+        "xxhash": {
             "type": "xxhash"
         }
     },

--- a/examples/local/vschema_customer_sharded.json
+++ b/examples/local/vschema_customer_sharded.json
@@ -10,7 +10,7 @@
             "column_vindexes": [
                 {
                     "column": "customer_id",
-                    "name": "hash"
+                    "name": "xxhash"
                 }
             ],
             "auto_increment": {
@@ -22,7 +22,7 @@
             "column_vindexes": [
                 {
                     "column": "customer_id",
-                    "name": "hash"
+                    "name": "xxhash"
                 }
             ],
             "auto_increment": {

--- a/examples/local/vschema_customer_sharded.json
+++ b/examples/local/vschema_customer_sharded.json
@@ -2,7 +2,7 @@
     "sharded": true,
     "vindexes": {
         "hash": {
-            "type": "hash"
+            "type": "xxhash"
         }
     },
     "tables": {

--- a/examples/operator/create_commerce_schema.sql
+++ b/examples/operator/create_commerce_schema.sql
@@ -1,18 +1,18 @@
 create table if not exists product(
-  sku varbinary(128),
-  description varbinary(128),
+  sku varchar(128),
+  description varchar(128),
   price bigint,
   primary key(sku)
 ) ENGINE=InnoDB;
 create table if not exists customer(
   customer_id bigint not null auto_increment,
-  email varbinary(128),
+  email varchar(128),
   primary key(customer_id)
 ) ENGINE=InnoDB;
 create table if not exists corder(
   order_id bigint not null auto_increment,
   customer_id bigint,
-  sku varbinary(128),
+  sku varchar(128),
   price bigint,
   primary key(order_id)
 ) ENGINE=InnoDB;

--- a/examples/operator/vschema_customer_sharded.json
+++ b/examples/operator/vschema_customer_sharded.json
@@ -1,7 +1,7 @@
 {
     "sharded": true,
     "vindexes": {
-        "hash": {
+        "xxhash": {
             "type": "xxhash"
         }
     },

--- a/examples/operator/vschema_customer_sharded.json
+++ b/examples/operator/vschema_customer_sharded.json
@@ -10,7 +10,7 @@
             "column_vindexes": [
                 {
                     "column": "customer_id",
-                    "name": "hash"
+                    "name": "xxhash"
                 }
             ],
             "auto_increment": {
@@ -22,7 +22,7 @@
             "column_vindexes": [
                 {
                     "column": "customer_id",
-                    "name": "hash"
+                    "name": "xxhash"
                 }
             ],
             "auto_increment": {

--- a/examples/operator/vschema_customer_sharded.json
+++ b/examples/operator/vschema_customer_sharded.json
@@ -2,7 +2,7 @@
     "sharded": true,
     "vindexes": {
         "hash": {
-            "type": "hash"
+            "type": "xxhash"
         }
     },
     "tables": {

--- a/examples/region_sharding/create_main_schema.sql
+++ b/examples/region_sharding/create_main_schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS customer (
   id int NOT NULL,
-  fullname varbinary(256),
-  nationalid varbinary(256),
-  country varbinary(256),
+  fullname varchar(256),
+  nationalid varchar(256),
+  country varchar(256),
   primary key(id)
   );


### PR DESCRIPTION
## Description

This changes usage of `varbinary` to `varchar` in schemas used in the `/examples` folder. Schema fields like `keyspace_id` that use `varbinary` are excluded from the change.

## Related Issue(s)

This PR fixes #15997 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation: https://github.com/vitessio/website/pull/1901