### PR TITLE
Allow for dynamic configuration of DDL settings

### DIFF
--- a/go/vt/vtgate/dynamicconfig/config.go
+++ b/go/vt/vtgate/dynamicconfig/config.go
@@ -1,0 +1,6 @@
+package dynamicconfig
+
+type DDL interface {
+	OnlineEnabled() bool
+	DirectEnabled() bool
+}

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -131,7 +131,7 @@ func (cached *DDL) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(64)
+		size += int64(80)
 	}
 	// field Keyspace *vitess.io/vitess/go/vt/vtgate/vindexes.Keyspace
 	size += cached.Keyspace.CachedSize(true)
@@ -145,6 +145,10 @@ func (cached *DDL) CachedSize(alloc bool) int64 {
 	size += cached.NormalDDL.CachedSize(true)
 	// field OnlineDDL *vitess.io/vitess/go/vt/vtgate/engine.OnlineDDL
 	size += cached.OnlineDDL.CachedSize(true)
+	// field Config vitess.io/vitess/go/vt/vtgate/dynamicconfig.DDL
+	if cc, ok := cached.Config.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
 	return size
 }
 func (cached *DML) CachedSize(alloc bool) int64 {

--- a/go/vt/vtgate/engine/ddl_test.go
+++ b/go/vt/vtgate/engine/ddl_test.go
@@ -27,13 +27,23 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
+type ddlConfig struct{}
+
+func (ddlConfig) DirectEnabled() bool {
+	return true
+}
+
+func (ddlConfig) OnlineEnabled() bool {
+	return true
+}
+
 func TestDDL(t *testing.T) {
 	ddl := &DDL{
 		DDL: &sqlparser.CreateTable{
 			Table: sqlparser.NewTableName("a"),
 		},
-		DirectDDLEnabled: true,
-		OnlineDDL:        &OnlineDDL{},
+		Config:    ddlConfig{},
+		OnlineDDL: &OnlineDDL{},
 		NormalDDL: &Send{
 			Keyspace: &vindexes.Keyspace{
 				Name:    "ks",

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1174,7 +1174,11 @@ func (e *Executor) buildStatement(
 	reservedVars *sqlparser.ReservedVars,
 	bindVarNeeds *sqlparser.BindVarNeeds,
 ) (*engine.Plan, error) {
-	plan, err := planbuilder.BuildFromStmt(ctx, query, stmt, reservedVars, vcursor, bindVarNeeds, enableOnlineDDL, enableDirectDDL)
+	cfg := &dynamicViperConfig{
+		onlineDDL: enableOnlineDDL,
+		directDDL: enableDirectDDL,
+	}
+	plan, err := planbuilder.BuildFromStmt(ctx, query, stmt, reservedVars, vcursor, bindVarNeeds, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/executor_ddl_test.go
+++ b/go/vt/vtgate/executor_ddl_test.go
@@ -27,8 +27,8 @@ import (
 
 func TestDDLFlags(t *testing.T) {
 	defer func() {
-		enableOnlineDDL = true
-		enableDirectDDL = true
+		enableOnlineDDL.Set(true)
+		enableDirectDDL.Set(true)
 	}()
 	testcases := []struct {
 		enableDirectDDL bool
@@ -57,8 +57,8 @@ func TestDDLFlags(t *testing.T) {
 		t.Run(fmt.Sprintf("%s-%v-%v", testcase.sql, testcase.enableDirectDDL, testcase.enableOnlineDDL), func(t *testing.T) {
 			executor, _, _, _, ctx := createExecutorEnv(t)
 			session := NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded})
-			enableDirectDDL = testcase.enableDirectDDL
-			enableOnlineDDL = testcase.enableOnlineDDL
+			enableDirectDDL.Set(testcase.enableDirectDDL)
+			enableOnlineDDL.Set(testcase.enableOnlineDDL)
 			_, err := executor.Execute(ctx, nil, "TestDDLFlags", session, testcase.sql, nil)
 			if testcase.wantErr {
 				require.EqualError(t, err, testcase.err)

--- a/go/vt/vtgate/planbuilder/migration.go
+++ b/go/vt/vtgate/planbuilder/migration.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/dynamicconfig"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
@@ -80,8 +81,8 @@ func buildAlterMigrationThrottleAppPlan(query string, alterMigration *sqlparser.
 	}), nil
 }
 
-func buildAlterMigrationPlan(query string, alterMigration *sqlparser.AlterMigration, vschema plancontext.VSchema, enableOnlineDDL bool) (*planResult, error) {
-	if !enableOnlineDDL {
+func buildAlterMigrationPlan(query string, alterMigration *sqlparser.AlterMigration, vschema plancontext.VSchema, cfg dynamicconfig.DDL) (*planResult, error) {
+	if !cfg.OnlineEnabled() {
 		return nil, schema.ErrOnlineDDLDisabled
 	}
 
@@ -118,8 +119,8 @@ func buildAlterMigrationPlan(query string, alterMigration *sqlparser.AlterMigrat
 	return newPlanResult(send), nil
 }
 
-func buildRevertMigrationPlan(query string, stmt *sqlparser.RevertMigration, vschema plancontext.VSchema, enableOnlineDDL bool) (*planResult, error) {
-	if !enableOnlineDDL {
+func buildRevertMigrationPlan(query string, stmt *sqlparser.RevertMigration, vschema plancontext.VSchema, cfg dynamicconfig.DDL) (*planResult, error) {
+	if !cfg.OnlineEnabled() {
 		return nil, schema.ErrOnlineDDLDisabled
 	}
 	dest, ks, tabletType, err := vschema.TargetDestination("")
@@ -147,8 +148,8 @@ func buildRevertMigrationPlan(query string, stmt *sqlparser.RevertMigration, vsc
 	return newPlanResult(emig), nil
 }
 
-func buildShowMigrationLogsPlan(query string, vschema plancontext.VSchema, enableOnlineDDL bool) (*planResult, error) {
-	if !enableOnlineDDL {
+func buildShowMigrationLogsPlan(query string, vschema plancontext.VSchema, cfg dynamicconfig.DDL) (*planResult, error) {
+	if !cfg.OnlineEnabled() {
 		return nil, schema.ErrOnlineDDLDisabled
 	}
 	dest, ks, tabletType, err := vschema.TargetDestination("")

--- a/go/vt/vtgate/planbuilder/simplifier_test.go
+++ b/go/vt/vtgate/planbuilder/simplifier_test.go
@@ -135,12 +135,12 @@ func keepSameError(query string, reservedVars *sqlparser.ReservedVars, vschema *
 	}
 	rewritten, _ := sqlparser.RewriteAST(stmt, vschema.CurrentDb(), sqlparser.SQLSelectLimitUnset, "", nil, nil, nil)
 	ast := rewritten.AST
-	_, expected := BuildFromStmt(context.Background(), query, ast, reservedVars, vschema, rewritten.BindVarNeeds, true, true)
+	_, expected := BuildFromStmt(context.Background(), query, ast, reservedVars, vschema, rewritten.BindVarNeeds, staticConfig{})
 	if expected == nil {
 		panic("query does not fail to plan")
 	}
 	return func(statement sqlparser.SelectStatement) bool {
-		_, myErr := BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, true, true)
+		_, myErr := BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, staticConfig{})
 		if myErr == nil {
 			return false
 		}
@@ -162,7 +162,7 @@ func keepPanicking(query string, reservedVars *sqlparser.ReservedVars, vschema *
 			}
 		}()
 		log.Errorf("trying %s", sqlparser.String(statement))
-		_, _ = BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, true, true)
+		_, _ = BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, staticConfig{})
 		log.Errorf("did not panic")
 
 		return false

--- a/go/vt/vtgate/viperconfig.go
+++ b/go/vt/vtgate/viperconfig.go
@@ -1,0 +1,16 @@
+package vtgate
+
+import "vitess.io/vitess/go/viperutil"
+
+type dynamicViperConfig struct {
+	onlineDDL viperutil.Value[bool]
+	directDDL viperutil.Value[bool]
+}
+
+func (d *dynamicViperConfig) OnlineEnabled() bool {
+	return d.onlineDDL.Get()
+}
+
+func (d *dynamicViperConfig) DirectEnabled() bool {
+	return d.directDDL.Get()
+}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -34,6 +34,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/tb"
+	"vitess.io/vitess/go/viperutil"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
@@ -93,8 +94,24 @@ var (
 	foreignKeyMode     = "allow"
 	dbDDLPlugin        = "fail"
 	defaultDDLStrategy = string(schema.DDLStrategyDirect)
-	enableOnlineDDL    = true
-	enableDirectDDL    = true
+
+	enableOnlineDDL = viperutil.Configure(
+		"enable_online_ddl",
+		viperutil.Options[bool]{
+			FlagName: "enable_online_ddl",
+			Default:  true,
+			Dynamic:  true,
+		},
+	)
+
+	enableDirectDDL = viperutil.Configure(
+		"enable_direct_ddl",
+		viperutil.Options[bool]{
+			FlagName: "enable_direct_ddl",
+			Default:  true,
+			Dynamic:  true,
+		},
+	)
 
 	// schema tracking flags
 	enableSchemaChangeSignal = true
@@ -141,8 +158,8 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&lockHeartbeatTime, "lock_heartbeat_time", lockHeartbeatTime, "If there is lock function used. This will keep the lock connection active by using this heartbeat")
 	fs.BoolVar(&warnShardedOnly, "warn_sharded_only", warnShardedOnly, "If any features that are only available in unsharded mode are used, query execution warnings will be added to the session")
 	fs.StringVar(&foreignKeyMode, "foreign_key_mode", foreignKeyMode, "This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow")
-	fs.BoolVar(&enableOnlineDDL, "enable_online_ddl", enableOnlineDDL, "Allow users to submit, review and control Online DDL")
-	fs.BoolVar(&enableDirectDDL, "enable_direct_ddl", enableDirectDDL, "Allow users to submit direct DDL statements")
+	fs.Bool("enable_online_ddl", enableOnlineDDL.Default(), "Allow users to submit, review and control Online DDL")
+	fs.Bool("enable_direct_ddl", enableDirectDDL.Default(), "Allow users to submit direct DDL statements")
 	fs.BoolVar(&enableSchemaChangeSignal, "schema_change_signal", enableSchemaChangeSignal, "Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work")
 	fs.IntVar(&queryTimeout, "query-timeout", queryTimeout, "Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)")
 	fs.StringVar(&queryLogToFile, "log_queries_to_file", queryLogToFile, "Enable query logging to the specified file")
@@ -154,6 +171,8 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&warmingReadsPercent, "warming-reads-percent", 0, "Percentage of reads on the primary to forward to replicas. Useful for keeping buffer pools warm")
 	fs.IntVar(&warmingReadsConcurrency, "warming-reads-concurrency", 500, "Number of concurrent warming reads allowed")
 	fs.DurationVar(&warmingReadsQueryTimeout, "warming-reads-query-timeout", 5*time.Second, "Timeout of warming read queries")
+
+	viperutil.BindFlags(fs, enableOnlineDDL, enableDirectDDL)
 }
 
 func init() {


### PR DESCRIPTION
This allows configuring the vtgate DDL flags dynamically. With this, both online DDL and direct DDL can be disabled and enabled in vtgate without having to restart.

## Related Issue(s)

Fixes #17327 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required