### PR TITLE
[release-21.0] Bump go version to 1.23.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ $(PROTO_GO_OUTS): minimaltools install_protoc-gen-go proto/*.proto
 # This rule builds the bootstrap images for all flavors.
 DOCKER_IMAGES_FOR_TEST = mysql80 percona80
 DOCKER_IMAGES = common $(DOCKER_IMAGES_FOR_TEST)
-BOOTSTRAP_VERSION=37.0
+BOOTSTRAP_VERSION=37.1
 ensure_bootstrap_version:
 	find docker/ -type f -exec sed -i "s/^\(ARG bootstrap_version\)=.*/\1=${BOOTSTRAP_VERSION}/" {} \;
 	sed -i 's/\(^.*flag.String(\"bootstrap-version\",\) *\"[^\"]\+\"/\1 \"${BOOTSTRAP_VERSION}\"/' test.go

--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.23.3 || echo "Go version reported: `go version`. Version 1.23.3+ recommended. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.23.4 || echo "Go version reported: `go version`. Version 1.23.4+ recommended. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin

--- a/docker/bootstrap/CHANGELOG.md
+++ b/docker/bootstrap/CHANGELOG.md
@@ -150,3 +150,7 @@ List of changes between bootstrap image versions.
 ## [37.0] - 2024-11-11
 ### Changes
 - Update build to golang 1.23.3
+
+## [37.1] - 2024-12-04
+### Changes
+- Update build to golang 1.23.4

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.23.3-bullseye
+FROM --platform=linux/amd64 golang:1.23.4-bullseye
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.3-bullseye AS builder
+FROM --platform=linux/amd64 golang:1.23.4-bullseye AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.3-bullseye AS builder
+FROM --platform=linux/amd64 golang:1.23.4-bullseye AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.3-bullseye AS builder
+FROM --platform=linux/amd64 golang:1.23.4-bullseye AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.23.3
+go 1.23.4
 
 require (
 	cloud.google.com/go/storage v1.43.0

--- a/test.go
+++ b/test.go
@@ -77,7 +77,7 @@ For example:
 // Flags
 var (
 	flavor           = flag.String("flavor", "mysql80", "comma-separated bootstrap flavor(s) to run against (when using Docker mode). Available flavors: all,"+flavors)
-	bootstrapVersion = flag.String("bootstrap-version", "37.0", "the version identifier to use for the docker images")
+	bootstrapVersion = flag.String("bootstrap-version", "37.1", "the version identifier to use for the docker images")
 	runCount         = flag.Int("runs", 1, "run each test this many times")
 	retryMax         = flag.Int("retry", 3, "max number of retries, to detect flaky tests")
 	logPass          = flag.Bool("log-pass", false, "log test output even if it passes")

--- a/test/templates/dockerfile.tpl
+++ b/test/templates/dockerfile.tpl
@@ -1,4 +1,4 @@
-ARG bootstrap_version=37.0
+ARG bootstrap_version=37.1
 ARG image="vitess/bootstrap:${bootstrap_version}-{{.Platform}}"
 
 FROM "${image}"


### PR DESCRIPTION
## Description

This PR bumps the go version to `go1.23.4`.