### PR TITLE
VReplication: Enable VPlayerBatching in unit tests

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
@@ -163,8 +163,7 @@ func TestExternalConnectorPlay(t *testing.T) {
 
 	expectDBClientAndVreplicationQueries(t, []string{
 		"begin",
-		"insert into tab1(id,val) values (1,_binary'a')",
-		"insert into tab1(id,val) values (2,_binary'b')",
+		"insert into tab1(id,val) values (1,_binary'a'), (2,_binary'b')",
 		"/update _vt.vreplication set pos=",
 		"commit",
 	}, pos)

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -141,7 +141,6 @@ func setup(ctx context.Context) (func(), int) {
 	resetBinlogClient()
 
 	vttablet.InitVReplicationConfigDefaults()
-	vttablet.DefaultVReplicationConfig.ExperimentalFlags = 0
 
 	// Engines cannot be initialized in testenv because it introduces circular dependencies.
 	streamerEngine = vstreamer.NewEngine(env.TabletEnv, env.SrvTopo, env.SchemaEngine, nil, env.Cells[0])

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -684,6 +684,14 @@ func testPlayerCopyBigTable(t *testing.T) {
 	reset := vstreamer.AdjustPacketSize(1)
 	defer reset()
 
+	// The test is written to match the behavior w/o
+	// VReplicationExperimentalFlagOptimizeInserts enabled.
+	origExperimentalFlags := vttablet.DefaultVReplicationConfig.ExperimentalFlags
+	vttablet.DefaultVReplicationConfig.ExperimentalFlags = 0
+	defer func() {
+		vttablet.DefaultVReplicationConfig.ExperimentalFlags = origExperimentalFlags
+	}()
+
 	savedCopyPhaseDuration := vttablet.DefaultVReplicationConfig.CopyPhaseDuration
 	// copyPhaseDuration should be low enough to have time to send one row.
 	vttablet.DefaultVReplicationConfig.CopyPhaseDuration = 500 * time.Millisecond
@@ -813,6 +821,14 @@ func testPlayerCopyWildcardRule(t *testing.T) {
 
 	reset := vstreamer.AdjustPacketSize(1)
 	defer reset()
+
+	// The test is written to match the behavior w/o
+	// VReplicationExperimentalFlagOptimizeInserts enabled.
+	origExperimentalFlags := vttablet.DefaultVReplicationConfig.ExperimentalFlags
+	vttablet.DefaultVReplicationConfig.ExperimentalFlags = 0
+	defer func() {
+		vttablet.DefaultVReplicationConfig.ExperimentalFlags = origExperimentalFlags
+	}()
 
 	savedCopyPhaseDuration := vttablet.DefaultVReplicationConfig.CopyPhaseDuration
 	// copyPhaseDuration should be low enough to have time to send one row.

--- a/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
@@ -30,6 +30,8 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
+const beginStmtLen = int64(len("begin;"))
+
 // vdbClient is a wrapper on binlogplayer.DBClient.
 // It allows us to retry a failed transactions on lock errors.
 type vdbClient struct {
@@ -61,7 +63,7 @@ func (vc *vdbClient) Begin() error {
 		// starts with the BEGIN and ends with the COMMIT, so we
 		// do not send a BEGIN down the wire ahead of time.
 		vc.queriesPos = int64(len(vc.queries))
-		vc.batchSize = 6 // begin and semicolon
+		vc.batchSize = beginStmtLen
 	} else {
 		// We're not batching so we start the transaction here
 		// by sending the BEGIN down the wire.

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -133,7 +133,8 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 		return vr.dbClient.Commit()
 	}
 	batchMode := false
-	if vr.workflowConfig.ExperimentalFlags&vttablet.VReplicationExperimentalFlagVPlayerBatching != 0 {
+	// We only do batching in the running/replicating phase.
+	if len(copyState) == 0 && vr.workflowConfig.ExperimentalFlags&vttablet.VReplicationExperimentalFlagVPlayerBatching != 0 {
 		batchMode = true
 	}
 	if batchMode {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -628,7 +628,6 @@ func TestPlayerStatementModeWithFilterAndErrorHandling(t *testing.T) {
 
 	// It does not work when filter is enabled
 	output := qh.Expect(
-		"begin",
 		"rollback",
 		fmt.Sprintf("/update _vt.vreplication set message='%s", expectedMsg),
 	)
@@ -975,8 +974,7 @@ func TestPlayerFilters(t *testing.T) {
 		input: "insert into src4 values (1,100,'aaa'),(2,200,'bbb'),(3,100,'ccc')",
 		output: qh.Expect(
 			"begin",
-			"insert into dst4(id1,val) values (1,_binary'aaa')",
-			"insert into dst4(id1,val) values (3,_binary'ccc')",
+			"insert into dst4(id1,val) values (1,_binary'aaa'), (3,_binary'ccc')",
 			"/update _vt.vreplication set pos=",
 			"commit",
 		),
@@ -987,8 +985,7 @@ func TestPlayerFilters(t *testing.T) {
 		input: "insert into src5 values (1,100,'abc'),(2,200,'xyz'),(3,100,'xyz'),(4,300,'abc'),(5,200,'xyz')",
 		output: qh.Expect(
 			"begin",
-			"insert into dst5(id1,val) values (1,_binary'abc')",
-			"insert into dst5(id1,val) values (4,_binary'abc')",
+			"insert into dst5(id1,val) values (1,_binary'abc'), (4,_binary'abc')",
 			"/update _vt.vreplication set pos=",
 			"commit",
 		),
@@ -1495,9 +1492,7 @@ func TestPlayerRowMove(t *testing.T) {
 	})
 	expectDBClientQueries(t, qh.Expect(
 		"begin",
-		"insert into dst(val1,sval2,rcount) values (1,ifnull(1, 0),1) on duplicate key update sval2=sval2+ifnull(values(sval2), 0), rcount=rcount+1",
-		"insert into dst(val1,sval2,rcount) values (2,ifnull(2, 0),1) on duplicate key update sval2=sval2+ifnull(values(sval2), 0), rcount=rcount+1",
-		"insert into dst(val1,sval2,rcount) values (2,ifnull(3, 0),1) on duplicate key update sval2=sval2+ifnull(values(sval2), 0), rcount=rcount+1",
+		"insert into dst(val1,sval2,rcount) values (1,ifnull(1, 0),1), (2,ifnull(2, 0),1), (2,ifnull(3, 0),1) on duplicate key update sval2=sval2+ifnull(values(sval2), 0), rcount=rcount+1",
 		"/update _vt.vreplication set pos=",
 		"commit",
 	))
@@ -1505,7 +1500,7 @@ func TestPlayerRowMove(t *testing.T) {
 		{"1", "1", "1"},
 		{"2", "5", "2"},
 	})
-	validateQueryCountStat(t, "replicate", 3)
+	validateQueryCountStat(t, "replicate", 1)
 
 	execStatements(t, []string{
 		"update src set val1=1, val2=4 where id=3",
@@ -1521,7 +1516,7 @@ func TestPlayerRowMove(t *testing.T) {
 		{"1", "5", "2"},
 		{"2", "2", "1"},
 	})
-	validateQueryCountStat(t, "replicate", 5)
+	validateQueryCountStat(t, "replicate", 3)
 }
 
 func TestPlayerTypes(t *testing.T) {
@@ -1737,6 +1732,9 @@ func TestPlayerDDL(t *testing.T) {
 	pos1 := primaryPosition(t)
 	// The stop position must be the GTID of the first DDL
 	expectDBClientQueries(t, qh.Expect(
+		// The first state update comes from vreplicator, which is unaware of
+		// the vplayer batching, with the batch including the same update.
+		"/update _vt.vreplication set state='Stopped'",
 		"begin",
 		fmt.Sprintf("/update _vt.vreplication set pos='%s'", pos1),
 		"/update _vt.vreplication set state='Stopped'",
@@ -1757,6 +1755,9 @@ func TestPlayerDDL(t *testing.T) {
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
+		// The first state update comes from vreplicator, which is unaware of
+		// the vplayer batching, with the batch including the same update.
+		"/update _vt.vreplication set state='Stopped'",
 		"begin",
 		fmt.Sprintf("/update.*'%s'", pos2),
 		"/update _vt.vreplication set state='Stopped'",
@@ -1922,6 +1923,9 @@ func TestPlayerStopPos(t *testing.T) {
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
+		// The first state update comes from vreplicator, which is unaware of
+		// the vplayer batching, with the batch including the same update.
+		"/update.*'Stopped'",
 		"begin",
 		"insert into yes(id,val) values (1,'aaa')",
 		fmt.Sprintf("/update.*compress.*'%s'", stopPos),
@@ -1947,6 +1951,9 @@ func TestPlayerStopPos(t *testing.T) {
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
+		// The first state update comes from vreplicator, which is unaware of
+		// the vplayer batching, with the batch including the same update.
+		"/update.*'Stopped'",
 		"begin",
 		// Since 'no' generates empty transactions that are skipped by
 		// vplayer, a commit is done only for the stop position event.
@@ -2179,6 +2186,14 @@ func TestPlayerSplitTransaction(t *testing.T) {
 func TestPlayerLockErrors(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
+	// The immediate retry behavior does not apply when doing
+	// VPlayer Batching.
+	origExperimentalFlags := vttablet.DefaultVReplicationConfig.ExperimentalFlags
+	vttablet.DefaultVReplicationConfig.ExperimentalFlags = 0
+	defer func() {
+		vttablet.DefaultVReplicationConfig.ExperimentalFlags = origExperimentalFlags
+	}()
+
 	execStatements(t, []string{
 		"create table t1(id int, val varchar(128), primary key(id))",
 		fmt.Sprintf("create table %s.t1(id int, val varchar(128), primary key(id))", vrepldb),
@@ -2257,6 +2272,14 @@ func TestPlayerLockErrors(t *testing.T) {
 
 func TestPlayerCancelOnLock(t *testing.T) {
 	defer deleteTablet(addTablet(100))
+
+	// The immediate retry behavior does not apply when doing
+	// VPlayer Batching.
+	origExperimentalFlags := vttablet.DefaultVReplicationConfig.ExperimentalFlags
+	vttablet.DefaultVReplicationConfig.ExperimentalFlags = 0
+	defer func() {
+		vttablet.DefaultVReplicationConfig.ExperimentalFlags = origExperimentalFlags
+	}()
 
 	execStatements(t, []string{
 		"create table t1(id int, val varchar(128), primary key(id))",

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1732,9 +1732,6 @@ func TestPlayerDDL(t *testing.T) {
 	pos1 := primaryPosition(t)
 	// The stop position must be the GTID of the first DDL
 	expectDBClientQueries(t, qh.Expect(
-		// The first state update comes from vreplicator, which is unaware of
-		// the vplayer batching, with the batch including the same update.
-		"/update _vt.vreplication set state='Stopped'",
 		"begin",
 		fmt.Sprintf("/update _vt.vreplication set pos='%s'", pos1),
 		"/update _vt.vreplication set state='Stopped'",
@@ -1755,9 +1752,6 @@ func TestPlayerDDL(t *testing.T) {
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
-		// The first state update comes from vreplicator, which is unaware of
-		// the vplayer batching, with the batch including the same update.
-		"/update _vt.vreplication set state='Stopped'",
 		"begin",
 		fmt.Sprintf("/update.*'%s'", pos2),
 		"/update _vt.vreplication set state='Stopped'",
@@ -1923,9 +1917,6 @@ func TestPlayerStopPos(t *testing.T) {
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
-		// The first state update comes from vreplicator, which is unaware of
-		// the vplayer batching, with the batch including the same update.
-		"/update.*'Stopped'",
 		"begin",
 		"insert into yes(id,val) values (1,'aaa')",
 		fmt.Sprintf("/update.*compress.*'%s'", stopPos),
@@ -1951,9 +1942,6 @@ func TestPlayerStopPos(t *testing.T) {
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
-		// The first state update comes from vreplicator, which is unaware of
-		// the vplayer batching, with the batch including the same update.
-		"/update.*'Stopped'",
 		"begin",
 		// Since 'no' generates empty transactions that are skipped by
 		// vplayer, a commit is done only for the stop position event.

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -508,7 +508,7 @@ func (vr *vreplicator) setState(state binlogdatapb.VReplicationWorkflowState, me
 	}
 	vr.stats.State.Store(state.String())
 	query := fmt.Sprintf("update _vt.vreplication set state='%v', message=%v where id=%v", state, encodeString(binlogplayer.MessageTruncate(message)), vr.id)
-	// If we're batching and in a transaction, then include the state update
+	// If we're batching a transaction, then include the state update
 	// in the current transaction batch.
 	if vr.dbClient.InTransaction && vr.dbClient.maxBatchSize > 0 {
 		vr.dbClient.queries = append(vr.dbClient.queries, query)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -511,7 +511,7 @@ func (vr *vreplicator) setState(state binlogdatapb.VReplicationWorkflowState, me
 	// If we're batching a transaction, then include the state update
 	// in the current transaction batch.
 	if vr.dbClient.InTransaction && vr.dbClient.maxBatchSize > 0 {
-		vr.dbClient.queries = append(vr.dbClient.queries, query)
+		vr.dbClient.AddQueryToTrxBatch(query)
 	} else { // Otherwise, send it down the wire
 		if _, err := vr.dbClient.ExecuteFetch(query, 1); err != nil {
 			return fmt.Errorf("could not set state: %v: %v", query, err)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -508,8 +508,14 @@ func (vr *vreplicator) setState(state binlogdatapb.VReplicationWorkflowState, me
 	}
 	vr.stats.State.Store(state.String())
 	query := fmt.Sprintf("update _vt.vreplication set state='%v', message=%v where id=%v", state, encodeString(binlogplayer.MessageTruncate(message)), vr.id)
-	if _, err := vr.dbClient.ExecuteFetch(query, 1); err != nil {
-		return fmt.Errorf("could not set state: %v: %v", query, err)
+	// If we're batching and in a transaction, then include the state update
+	// in the current transaction batch.
+	if vr.dbClient.InTransaction && vr.dbClient.maxBatchSize > 0 {
+		vr.dbClient.queries = append(vr.dbClient.queries, query)
+	} else { // Otherwise, send it down the wire
+		if _, err := vr.dbClient.ExecuteFetch(query, 1); err != nil {
+			return fmt.Errorf("could not set state: %v: %v", query, err)
+		}
 	}
 	if state == vr.state {
 		return nil


### PR DESCRIPTION
## Description

This is a quick follow-up to https://github.com/vitessio/vitess/pull/17166. When working on that, I did not realize that the unit test framework was explicitly disabling all experimental flags and thus we were not testing the new flag/default behavior. This PR removes that `vttablet.DefaultVReplicationConfig.ExperimentalFlags = 0` line in `framework_test.go` and adjusts the unit test expectations accordingly.

In working on this, it surfaced an issue with an extraneous BEGIN being used when in batching mode that was also corrected in `vdbclient.go`. Similarly, the unit tests surfaced an extraneous state update that was corrected here in `vreplicator.go`. Lastly, it also updates the vplayer so that batching is only done when in the running/replicating phase as intended.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/17166

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required