### PR TITLE
Remove broken panic handler

### DIFF
--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -58,7 +58,6 @@ func TestTabletInitialBackup(t *testing.T) {
 	//    - Take a Second Backup
 	//    - Bring up a second replica, and restore from the second backup
 	//    - list the backups, remove them
-	defer cluster.PanicHandler(t)
 
 	waitForReplicationToCatchup([]cluster.Vttablet{*replica1, *replica2})
 
@@ -102,7 +101,6 @@ func TestTabletBackupOnly(t *testing.T) {
 	//    - Take a Second Backup
 	//    - Bring up a second replica, and restore from the second backup
 	//    - list the backups, remove them
-	defer cluster.PanicHandler(t)
 
 	// Reset the tablet object values in order on init tablet in the next step.
 	primary.VttabletProcess.ServingStatus = "NOT_SERVING"

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -52,7 +52,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode, err := func() (int, error) {

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -405,7 +405,6 @@ func TestBackup(t *testing.T, setupType int, streamMode string, stripes int, cDe
 		}, //
 	}
 
-	defer cluster.PanicHandler(t)
 	// setup cluster for the testing
 	code, err := LaunchCluster(setupType, streamMode, stripes, cDetails)
 	require.Nilf(t, err, "setup failed with status code %d", code)
@@ -1507,7 +1506,6 @@ func getLastBackup(t *testing.T) string {
 
 func TestBackupEngineSelector(t *testing.T) {
 	defer setDefaultCommonArgs()
-	defer cluster.PanicHandler(t)
 
 	// launch the custer with xtrabackup as the default engine
 	code, err := LaunchCluster(XtraBackup, "xbstream", 0, &CompressionDetails{CompressorEngineName: "pgzip"})
@@ -1548,7 +1546,6 @@ func TestBackupEngineSelector(t *testing.T) {
 
 func TestRestoreAllowedBackupEngines(t *testing.T) {
 	defer setDefaultCommonArgs()
-	defer cluster.PanicHandler(t)
 
 	backupMsg := "right after xtrabackup backup"
 

--- a/go/test/endtoend/backup/vtctlbackup/pitr_test_framework.go
+++ b/go/test/endtoend/backup/vtctlbackup/pitr_test_framework.go
@@ -95,7 +95,6 @@ func waitForReplica(t *testing.T, replicaIndex int) int {
 // in between, it makes writes to the database, and takes notes: what data was available in what backup.
 // It then restores each and every one of those backups, in random order, and expects to find the specific data associated with the backup.
 func ExecTestIncrementalBackupAndRestoreToPos(t *testing.T, tcase *PITRTestCase) {
-	defer cluster.PanicHandler(t)
 
 	t.Run(tcase.Name, func(t *testing.T) {
 		// setup cluster for the testing
@@ -339,7 +338,6 @@ func ExecTestIncrementalBackupAndRestoreToPos(t *testing.T, tcase *PITRTestCase)
 
 // ExecTestIncrementalBackupAndRestoreToPos
 func ExecTestIncrementalBackupAndRestoreToTimestamp(t *testing.T, tcase *PITRTestCase) {
-	defer cluster.PanicHandler(t)
 
 	var lastInsertedRowTimestamp time.Time
 	insertRowOnPrimary := func(t *testing.T, hint string) {
@@ -605,7 +603,6 @@ func ExecTestIncrementalBackupAndRestoreToTimestamp(t *testing.T, tcase *PITRTes
 // Specifically, it's designed to test how incremental backups are taken by interleaved replicas, so that they successfully build on
 // one another.
 func ExecTestIncrementalBackupOnTwoTablets(t *testing.T, tcase *PITRTestCase) {
-	defer cluster.PanicHandler(t)
 
 	t.Run(tcase.Name, func(t *testing.T) {
 		// setup cluster for the testing

--- a/go/test/endtoend/cellalias/cell_alias_test.go
+++ b/go/test/endtoend/cellalias/cell_alias_test.go
@@ -90,7 +90,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/cellalias/cell_alias_test.go
+++ b/go/test/endtoend/cellalias/cell_alias_test.go
@@ -231,7 +231,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestAlias(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	insertInitialValues(t)
 	defer deleteInitialValues(t)
@@ -295,7 +294,6 @@ func TestAlias(t *testing.T) {
 }
 
 func TestAddAliasWhileVtgateUp(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	insertInitialValues(t)
 	defer deleteInitialValues(t)

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -1043,7 +1043,6 @@ func (cluster *LocalProcessCluster) StreamTabletHealthUntil(ctx context.Context,
 
 // Teardown brings down the cluster by invoking teardown for individual processes
 func (cluster *LocalProcessCluster) Teardown() {
-	PanicHandler(nil)
 	cluster.mx.Lock()
 	defer cluster.mx.Unlock()
 	if cluster.teardownCompleted {

--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -126,15 +126,6 @@ func VerifyRowsInTablet(t *testing.T, vttablet *Vttablet, ksName string, expecte
 	VerifyRowsInTabletForTable(t, vttablet, ksName, expectedRows, "vt_insert_test")
 }
 
-// PanicHandler handles the panic in the testcase.
-func PanicHandler(t testing.TB) {
-	err := recover()
-	if t == nil {
-		return
-	}
-	require.Nilf(t, err, "panic occured in testcase %v", t.Name())
-}
-
 // ListBackups Lists back preset in shard
 func (cluster LocalProcessCluster) ListBackups(shardKsName string) ([]string, error) {
 	output, err := cluster.VtctldClientProcess.ExecuteCommandWithOutput("GetBackups", shardKsName)

--- a/go/test/endtoend/clustertest/add_keyspace_test.go
+++ b/go/test/endtoend/clustertest/add_keyspace_test.go
@@ -61,7 +61,6 @@ primary key (id)
 )
 
 func TestAddKeyspace(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	if err := clusterInstance.StartKeyspace(*testKeyspace, []string{"-80", "80-"}, 0, false); err != nil {
 		log.Errorf("failed to AddKeyspace %v: %v", *testKeyspace, err)
 		t.Fatal(err)

--- a/go/test/endtoend/clustertest/etcd_test.go
+++ b/go/test/endtoend/clustertest/etcd_test.go
@@ -24,12 +24,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func TestEtcdServer(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// Confirm the basic etcd cluster health.
 	etcdHealthURL := fmt.Sprintf("http://%s:%d/health", clusterInstance.Hostname, clusterInstance.TopoPort)

--- a/go/test/endtoend/clustertest/main_test.go
+++ b/go/test/endtoend/clustertest/main_test.go
@@ -60,7 +60,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/clustertest/vtctld_test.go
+++ b/go/test/endtoend/clustertest/vtctld_test.go
@@ -30,8 +30,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 var (
@@ -44,7 +42,6 @@ var (
 )
 
 func TestVtctldProcess(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	url := fmt.Sprintf("http://%s:%d/api/keyspaces/", clusterInstance.Hostname, clusterInstance.VtctldHTTPPort)
 	testURL(t, url, "keyspace url")
 

--- a/go/test/endtoend/clustertest/vtgate_test.go
+++ b/go/test/endtoend/clustertest/vtgate_test.go
@@ -32,11 +32,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func TestVtgateProcess(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	verifyVtgateVariables(t, clusterInstance.VtgateProcess.VerifyURL)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)

--- a/go/test/endtoend/clustertest/vttablet_test.go
+++ b/go/test/endtoend/clustertest/vttablet_test.go
@@ -25,12 +25,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func TestVttabletProcess(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	firstTabletPort := clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].HTTPPort
 	testURL(t, fmt.Sprintf("http://localhost:%d/debug/vars/", firstTabletPort), "tablet debug var url")
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/vars", firstTabletPort))
@@ -48,7 +45,6 @@ func TestVttabletProcess(t *testing.T) {
 }
 
 func TestDeleteTablet(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	primary := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
 	require.NotNil(t, primary)
 	_, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("DeleteTablets", "--allow-primary", primary.Alias)

--- a/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
+++ b/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
@@ -42,7 +42,6 @@ var (
 
 // This test makes sure that we can use SSL replication with Vitess
 func TestSecure(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	testReplicationBase(t, true)
 	testReplicationBase(t, false)
 }

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -102,7 +102,6 @@ var (
 )
 
 func TestSecureTransport(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	flag.Parse()
 
 	// initialize cluster

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -166,7 +166,6 @@ func checkDurabilityPolicy(t *testing.T, durabilityPolicy string) {
 }
 
 func TestGetSrvKeyspaceNames(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	data, err := clusterForKSTest.VtctldClientProcess.ExecuteCommandWithOutput("GetSrvKeyspaceNames", cell)
 	require.Nil(t, err)
 
@@ -179,7 +178,6 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 }
 
 func TestGetSrvKeyspacePartitions(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	shardedSrvKeyspace := getSrvKeyspace(t, cell, keyspaceShardedName)
 	otherShardRefFound := false
 	for _, partition := range shardedSrvKeyspace.Partitions {
@@ -208,20 +206,17 @@ func TestGetSrvKeyspacePartitions(t *testing.T) {
 }
 
 func TestShardNames(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	output, err := clusterForKSTest.VtctldClientProcess.GetSrvKeyspaces(keyspaceShardedName, cell)
 	require.NoError(t, err)
 	require.NotNil(t, output[cell], "no srvkeyspace for cell %s", cell)
 }
 
 func TestGetKeyspace(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	_, err := clusterForKSTest.VtctldClientProcess.GetKeyspace(keyspaceUnshardedName)
 	require.Nil(t, err)
 }
 
 func TestDeleteKeyspace(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	_ = clusterForKSTest.VtctldClientProcess.CreateKeyspace("test_delete_keyspace", sidecar.DefaultName)
 	_ = clusterForKSTest.VtctldClientProcess.ExecuteCommand("CreateShard", "test_delete_keyspace/0")
 	_ = clusterForKSTest.InitTablet(&cluster.Vttablet{
@@ -352,7 +347,6 @@ func TestDeleteKeyspace(t *testing.T) {
 } */
 
 func TestShardCountForAllKeyspaces(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	testShardCountForKeyspace(t, keyspaceUnshardedName, 1)
 	testShardCountForKeyspace(t, keyspaceShardedName, 2)
 }
@@ -369,7 +363,6 @@ func testShardCountForKeyspace(t *testing.T, keyspace string, count int) {
 }
 
 func TestShardNameForAllKeyspaces(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	testShardNameForKeyspace(t, keyspaceUnshardedName, []string{"test_ks_unsharded"})
 	testShardNameForKeyspace(t, keyspaceShardedName, []string{"-80", "80-"})
 }
@@ -388,7 +381,6 @@ func testShardNameForKeyspace(t *testing.T, keyspace string, shardNames []string
 }
 
 func TestKeyspaceToShardName(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	var id []byte
 	srvKeyspace := getSrvKeyspace(t, cell, keyspaceShardedName)
 

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -81,7 +81,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/messaging/main_test.go
+++ b/go/test/endtoend/messaging/main_test.go
@@ -104,7 +104,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -375,7 +375,6 @@ func TestUnsharded(t *testing.T) {
 
 // TestReparenting checks the client connection count after reparenting.
 func TestReparenting(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	name := "sharded_message"
 
 	ctx := context.Background()
@@ -435,7 +434,6 @@ func TestReparenting(t *testing.T) {
 
 // TestConnection validate the connection count and message streaming.
 func TestConnection(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	name := "sharded_message"
 
@@ -494,7 +492,6 @@ func TestConnection(t *testing.T) {
 }
 
 func testMessaging(t *testing.T, name, ks string) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	stream, err := VtgateGrpcConn(ctx, clusterInstance)
 	require.Nil(t, err)

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -138,7 +138,6 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 }
 
 func TestRestart(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	err := primaryTablet.MysqlctlProcess.Stop()
 	require.NoError(t, err)
 	primaryTablet.MysqlctlProcess.CleanupFiles(primaryTablet.TabletUID)
@@ -147,7 +146,6 @@ func TestRestart(t *testing.T) {
 }
 
 func TestAutoDetect(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	err := clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].VttabletProcess.Setup()
 	require.NoError(t, err)

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -140,7 +140,6 @@ func initCluster(shardNames []string, totalTabletsRequired int) error {
 }
 
 func TestRestart(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	err := primaryTablet.MysqlctldProcess.Stop()
 	require.Nil(t, err)
 	require.Truef(t, primaryTablet.MysqlctldProcess.WaitForMysqlCtldShutdown(), "Mysqlctld has not stopped...")
@@ -150,7 +149,6 @@ func TestRestart(t *testing.T) {
 }
 
 func TestAutoDetect(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	err := clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].VttabletProcess.Setup()
 	require.Nil(t, err, "error should be nil")

--- a/go/test/endtoend/mysqlserver/main_test.go
+++ b/go/test/endtoend/mysqlserver/main_test.go
@@ -61,7 +61,6 @@ END;
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	// setting grpc max size

--- a/go/test/endtoend/mysqlserver/mysql_server_test.go
+++ b/go/test/endtoend/mysqlserver/mysql_server_test.go
@@ -35,14 +35,12 @@ import (
 	"vitess.io/vitess/go/mysql/sqlerror"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 
 	_ "github.com/go-sql-driver/mysql"
 )
 
 // TestMultiStmt checks that multiStatements=True and multiStatements=False work properly.
 func TestMultiStatement(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	// connect database with multiStatements=True
@@ -70,7 +68,6 @@ func TestMultiStatement(t *testing.T) {
 
 // TestLargeComment add large comment in insert stmt and validate the insert process.
 func TestLargeComment(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -89,7 +86,6 @@ func TestLargeComment(t *testing.T) {
 
 // TestInsertLargerThenGrpcLimit insert blob larger then grpc limit and verify the error.
 func TestInsertLargerThenGrpcLimit(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	ctx := context.Background()
 
@@ -109,7 +105,6 @@ func TestInsertLargerThenGrpcLimit(t *testing.T) {
 
 // TestTimeout executes sleep(5) with query_timeout of 1 second, and verifies the error.
 func TestTimeout(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -125,7 +120,6 @@ func TestTimeout(t *testing.T) {
 
 // TestInvalidField tries to fetch invalid column and verifies the error.
 func TestInvalidField(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -141,7 +135,6 @@ func TestInvalidField(t *testing.T) {
 
 // TestWarnings validates the behaviour of SHOW WARNINGS.
 func TestWarnings(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -183,7 +176,6 @@ func TestWarnings(t *testing.T) {
 // TestSelectWithUnauthorizedUser verifies that an unauthorized user
 // is not able to read from the table.
 func TestSelectWithUnauthorizedUser(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	tmpVtParam := vtParams
@@ -202,7 +194,6 @@ func TestSelectWithUnauthorizedUser(t *testing.T) {
 
 // TestPartitionedTable validates that partitioned tables are recognized by schema engine
 func TestPartitionedTable(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	tablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
 

--- a/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
+++ b/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
@@ -196,7 +196,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestOnlineDDLFlow(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	require.NotNil(t, clusterInstance)

--- a/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
+++ b/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
@@ -120,7 +120,6 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -203,7 +203,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestRevertSchemaChanges(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
 

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -137,7 +137,6 @@ type revertibleTestCase struct {
 }
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -239,7 +239,6 @@ func waitForMessage(t *testing.T, uuid string, messageSubstring string) {
 }
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -320,7 +320,6 @@ func TestSchedulerSchemaChanges(t *testing.T) {
 }
 
 func testScheduler(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
 
@@ -1592,7 +1591,6 @@ func testScheduler(t *testing.T) {
 }
 
 func testSingleton(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
 
@@ -1843,7 +1841,6 @@ DROP TABLE IF EXISTS stress_test
 	})
 }
 func testDeclarative(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
 
@@ -2515,7 +2512,6 @@ func testDeclarative(t *testing.T) {
 }
 
 func testForeignKeys(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	var (
 		createStatements = []string{

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -223,7 +223,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestVreplSchemaChanges(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 2, len(shards))

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -160,7 +160,6 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -225,7 +225,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestVreplMiniStressSchemaChanges(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	ctx := context.Background()
 

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -159,7 +159,6 @@ func nextOpOrder() int64 {
 }
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -477,7 +477,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestVreplStressSchemaChanges(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))

--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -407,7 +407,6 @@ func mysqlParams() *mysql.ConnParams {
 }
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -132,7 +132,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestVreplSuiteSchemaChanges(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	shards := clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -67,7 +67,6 @@ const (
 
 // Use $VREPL_SUITE_TEST_FILTER environment variable to filter tests by name.
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	testsFilter = os.Getenv(testFilterEnvVar)

--- a/go/test/endtoend/preparestmt/main_test.go
+++ b/go/test/endtoend/preparestmt/main_test.go
@@ -162,7 +162,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -27,20 +27,16 @@ import (
 	"github.com/icrowley/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 // TestSelect simple select the data without any condition.
 func TestSelect(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	selectWhere(t, dbo, "")
 }
 
 func TestSelectDatabase(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	prepare, err := dbo.Prepare("select database()")
@@ -58,7 +54,6 @@ func TestSelectDatabase(t *testing.T) {
 // TestInsertUpdateDelete validates all insert, update and
 // delete method on prepared statements.
 func TestInsertUpdateDelete(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	// prepare insert statement
@@ -134,7 +129,6 @@ func testReplica(t *testing.T) {
 
 // testcount validates inserted rows count with expected count.
 func testcount(t *testing.T, dbo *sql.DB, except int) {
-	defer cluster.PanicHandler(t)
 	r, err := dbo.Query("SELECT count(1) FROM " + tableName)
 	require.Nil(t, err)
 
@@ -148,7 +142,6 @@ func testcount(t *testing.T, dbo *sql.DB, except int) {
 // TestAutoIncColumns test insertion of row without passing
 // the value of auto increment columns (here it is id).
 func TestAutoIncColumns(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	// insert a row without id
@@ -227,7 +220,6 @@ func reconnectAndTest(t *testing.T) {
 // TestColumnParameter query database using column
 // parameter.
 func TestColumnParameter(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 
@@ -267,7 +259,6 @@ func TestColumnParameter(t *testing.T) {
 // TestWrongTableName query database using invalid
 // tablename and validate error.
 func TestWrongTableName(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	execWithError(t, dbo, []uint16{1146}, "select * from teseting_table;")
@@ -319,7 +310,6 @@ func getStringToString(x sql.NullString) string {
 }
 
 func TestSelectDBA(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 
@@ -381,7 +371,6 @@ func TestSelectDBA(t *testing.T) {
 }
 
 func TestSelectLock(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 
@@ -417,7 +406,6 @@ func TestSelectLock(t *testing.T) {
 }
 
 func TestShowColumns(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 
@@ -438,7 +426,6 @@ func TestShowColumns(t *testing.T) {
 }
 
 func TestBinaryColumn(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	dbo := Connect(t, "interpolateParams=false")
 	defer dbo.Close()
 

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -126,7 +126,6 @@ var (
 // - asserting that restoring to restoreTime2 (going from 2 shards to 2 shards with past time) is working, it will assert for both shards
 // - asserting that restoring to restoreTime3 is working, we should get complete data after restoring,  as we have in existing shards.
 func TestPITRRecovery(t *testing.T) {
-	defer cluster.PanicHandler(nil)
 	initializeCluster(t)
 	defer clusterInstance.Teardown()
 

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -524,7 +524,6 @@ func launchRecoveryTablet(t *testing.T, tablet *cluster.Vttablet, binlogServer *
 	tablet.MysqlctlProcess = *mysqlctlProcess
 	extraArgs := []string{"--db-credentials-file", dbCredentialFile}
 	tablet.MysqlctlProcess.InitDBFile = initDBFileWithPassword
-	tablet.VttabletProcess.DbPassword = mysqlPassword
 	tablet.MysqlctlProcess.ExtraArgs = extraArgs
 	err = tablet.MysqlctlProcess.Start()
 	require.NoError(t, err)
@@ -544,6 +543,7 @@ func launchRecoveryTablet(t *testing.T, tablet *cluster.Vttablet, binlogServer *
 		clusterInstance.VtTabletExtraArgs,
 		clusterInstance.DefaultCharset)
 	tablet.Alias = tablet.VttabletProcess.TabletPath
+	tablet.VttabletProcess.DbPassword = mysqlPassword
 	tablet.VttabletProcess.SupportsBackup = true
 	tablet.VttabletProcess.Keyspace = restoreKeyspaceName
 	tablet.VttabletProcess.ExtraArgs = []string{

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -72,7 +72,6 @@ var (
 
 // TestMainImpl creates cluster for unsharded recovery testing.
 func TestMainImpl(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode, err := func() (int, error) {

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -200,7 +200,6 @@ func TestMainImpl(m *testing.M) {
 //
 // 7. check that vtgate queries work correctly
 func TestRecoveryImpl(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	defer tabletsTeardown()
 	verifyInitialReplication(t)
 

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestTrivialERS(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -56,7 +55,6 @@ func TestTrivialERS(t *testing.T) {
 }
 
 func TestReparentIgnoreReplicas(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -98,7 +96,6 @@ func TestReparentIgnoreReplicas(t *testing.T) {
 }
 
 func TestReparentDownPrimary(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -134,7 +131,6 @@ func TestReparentDownPrimary(t *testing.T) {
 }
 
 func TestReparentNoChoiceDownPrimary(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -170,7 +166,6 @@ func TestReparentNoChoiceDownPrimary(t *testing.T) {
 
 func TestSemiSyncSetupCorrectly(t *testing.T) {
 	t.Run("semi-sync enabled", func(t *testing.T) {
-		defer cluster.PanicHandler(t)
 		clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 		defer utils.TeardownCluster(clusterInstance)
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -198,7 +193,6 @@ func TestSemiSyncSetupCorrectly(t *testing.T) {
 	})
 
 	t.Run("semi-sync disabled", func(t *testing.T) {
-		defer cluster.PanicHandler(t)
 		clusterInstance := utils.SetupReparentCluster(t, "none")
 		defer utils.TeardownCluster(clusterInstance)
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -228,7 +222,6 @@ func TestSemiSyncSetupCorrectly(t *testing.T) {
 
 // TestERSPromoteRdonly tests that we never end up promoting a rdonly instance as the primary
 func TestERSPromoteRdonly(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -256,7 +249,6 @@ func TestERSPromoteRdonly(t *testing.T) {
 
 // TestERSPreventCrossCellPromotion tests that we promote a replica in the same cell as the previous primary if prevent cross cell promotion flag is set
 func TestERSPreventCrossCellPromotion(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -279,7 +271,6 @@ func TestERSPreventCrossCellPromotion(t *testing.T) {
 // TestPullFromRdonly tests that if a rdonly tablet is the most advanced, then our promoted primary should have
 // caught up to it by pulling transactions from it
 func TestPullFromRdonly(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -351,7 +342,6 @@ func TestPullFromRdonly(t *testing.T) {
 // replicas which do not have any replication status and also succeeds if the io thread
 // is stopped on the primary elect.
 func TestNoReplicationStatusAndIOThreadStopped(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -451,7 +441,6 @@ func TestERSForInitialization(t *testing.T) {
 }
 
 func TestRecoverWithMultipleFailures(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -479,7 +468,6 @@ func TestRecoverWithMultipleFailures(t *testing.T) {
 // TestERSFailFast tests that ERS will fail fast if it cannot find any tablet which can be safely promoted instead of promoting
 // a tablet and hanging while inserting a row in the reparent journal on getting semi-sync ACKs
 func TestERSFailFast(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -519,7 +507,6 @@ func TestERSFailFast(t *testing.T) {
 // TestReplicationStopped checks that ERS ignores the tablets that have sql thread stopped.
 // If there are more than 1, we also fail.
 func TestReplicationStopped(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -36,7 +36,6 @@ import (
 // The test takes down the vttablets of the primary and a rdonly tablet and runs ERS with the
 // default values of remote_operation_timeout, lock-timeout flags and wait_replicas_timeout subflag.
 func TestRecoverWithMultipleVttabletFailures(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -68,7 +67,6 @@ func TestRecoverWithMultipleVttabletFailures(t *testing.T) {
 // and ERS succeeds.
 func TestSingleReplicaERS(t *testing.T) {
 	// Set up a cluster with none durability policy
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "none")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -104,7 +102,6 @@ func TestSingleReplicaERS(t *testing.T) {
 
 // TestTabletRestart tests that a running tablet can be  restarted and everything is still fine
 func TestTabletRestart(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -117,7 +114,6 @@ func TestTabletRestart(t *testing.T) {
 
 // Tests ensures that ChangeTabletType works even when semi-sync plugins are not loaded.
 func TestChangeTypeWithoutSemiSync(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "none")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -163,7 +159,6 @@ func TestChangeTypeWithoutSemiSync(t *testing.T) {
 // TestERSWithWriteInPromoteReplica tests that ERS doesn't fail even if there is a
 // write that happens when PromoteReplica is called.
 func TestERSWithWriteInPromoteReplica(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -181,7 +176,6 @@ func TestERSWithWriteInPromoteReplica(t *testing.T) {
 }
 
 func TestBufferingWithMultipleDisruptions(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupShardedReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 

--- a/go/test/endtoend/reparent/plannedreparent/reparent_range_based_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_range_based_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestReparentGracefulRangeBased(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	utils.ShardName = "0000000000000000-ffffffffffffffff"

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestPrimaryToSpareStateChangeImpossible(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -48,7 +47,6 @@ func TestPrimaryToSpareStateChangeImpossible(t *testing.T) {
 }
 
 func TestReparentCrossCell(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -62,7 +60,6 @@ func TestReparentCrossCell(t *testing.T) {
 }
 
 func TestReparentGraceful(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -85,7 +82,6 @@ func TestReparentGraceful(t *testing.T) {
 
 // TestPRSWithDrainedLaggingTablet tests that PRS succeeds even if we have a lagging drained tablet
 func TestPRSWithDrainedLaggingTablet(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -112,7 +108,6 @@ func TestPRSWithDrainedLaggingTablet(t *testing.T) {
 }
 
 func TestReparentReplicaOffline(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -130,7 +125,6 @@ func TestReparentReplicaOffline(t *testing.T) {
 }
 
 func TestReparentAvoid(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -178,14 +172,12 @@ func TestReparentAvoid(t *testing.T) {
 }
 
 func TestReparentFromOutside(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	reparentFromOutside(t, clusterInstance, false)
 }
 
 func TestReparentFromOutsideWithNoPrimary(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -285,7 +277,6 @@ func reparentFromOutside(t *testing.T, clusterInstance *cluster.LocalProcessClus
 }
 
 func TestReparentWithDownReplica(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -332,7 +323,6 @@ func TestReparentWithDownReplica(t *testing.T) {
 }
 
 func TestChangeTypeSemiSync(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -399,7 +389,6 @@ func TestChangeTypeSemiSync(t *testing.T) {
 // 1. When PRS is run with the cross_cell durability policy setup, then the semi-sync settings on all the tablets are as expected
 // 2. Bringing up a new vttablet should have its replication and semi-sync setup correctly without any manual intervention
 func TestCrossCellDurability(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "cross_cell")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
@@ -439,7 +428,6 @@ func TestCrossCellDurability(t *testing.T) {
 
 // TestFullStatus tests that the RPC FullStatus works as intended.
 func TestFullStatus(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets

--- a/go/test/endtoend/reparent/prscomplex/main_test.go
+++ b/go/test/endtoend/reparent/prscomplex/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/reparent/prssettingspool/main_test.go
+++ b/go/test/endtoend/reparent/prssettingspool/main_test.go
@@ -43,7 +43,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/reparent/semisync/semi_sync_test.go
+++ b/go/test/endtoend/reparent/semisync/semi_sync_test.go
@@ -33,7 +33,6 @@ func TestSemiSyncUpgradeDowngrade(t *testing.T) {
 	if ver != 21 {
 		t.Skip("We only want to run this test for v21 release")
 	}
-	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets

--- a/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
+++ b/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
@@ -131,7 +131,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchemadiffSchemaChanges(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	shards := clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
@@ -274,7 +273,6 @@ func testSingle(t *testing.T, testName string) {
 }
 
 // func TestRandomSchemaChanges(t *testing.T) {
-// 	defer cluster.PanicHandler(t)
 
 // 	hints := &schemadiff.DiffHints{AutoIncrementStrategy: schemadiff.AutoIncrementIgnore}
 // 	// count := 20

--- a/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
+++ b/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
@@ -68,7 +68,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -73,7 +73,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -101,7 +101,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestShardedKeyspace(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	shard1 := clusterInstance.Keyspaces[0].Shards[0]
 	shard2 := clusterInstance.Keyspaces[0].Shards[1]
 

--- a/go/test/endtoend/stress/stress_test.go
+++ b/go/test/endtoend/stress/stress_test.go
@@ -42,7 +42,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/stress/stress_test.go
+++ b/go/test/endtoend/stress/stress_test.go
@@ -83,7 +83,6 @@ func TestMain(m *testing.M) {
 // The stressor is started on its own goroutine while the end-to-end test
 // is executed on the same cluster.
 func TestSimpleStressTest(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	cfg := stress.DefaultConfig
 	cfg.ConnParams = &vtParams

--- a/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
+++ b/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
@@ -272,7 +272,6 @@ type BufferingTest struct {
 }
 
 func (bt *BufferingTest) Test(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	clusterInstance, exitCode := bt.createCluster()
 	if exitCode != 0 {
 		t.Fatal("failed to start cluster")

--- a/go/test/endtoend/tabletgateway/main_test.go
+++ b/go/test/endtoend/tabletgateway/main_test.go
@@ -61,7 +61,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -40,7 +40,6 @@ import (
 )
 
 func TestVtgateHealthCheck(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	// Healthcheck interval on tablet is set to 1s, so sleep for 2s
 	time.Sleep(2 * time.Second)
 	verifyVtgateVariables(t, clusterInstance.VtgateProcess.VerifyURL)
@@ -54,7 +53,6 @@ func TestVtgateHealthCheck(t *testing.T) {
 }
 
 func TestVtgateReplicationStatusCheck(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	// Healthcheck interval on tablet is set to 1s, so sleep for 2s
 	time.Sleep(2 * time.Second)
 	verifyVtgateVariables(t, clusterInstance.VtgateProcess.VerifyURL)
@@ -104,7 +102,6 @@ func TestVtgateReplicationStatusCheck(t *testing.T) {
 }
 
 func TestVtgateReplicationStatusCheckWithTabletTypeChange(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	// Healthcheck interval on tablet is set to 1s, so sleep for 2s
 	time.Sleep(2 * time.Second)
 	verifyVtgateVariables(t, clusterInstance.VtgateProcess.VerifyURL)
@@ -180,7 +177,6 @@ func retryNTimes(t *testing.T, maxRetries int, f func() bool) {
 
 func TestReplicaTransactions(t *testing.T) {
 	// TODO(deepthi): this test seems to depend on previous test. Fix tearDown so that tests are independent
-	defer cluster.PanicHandler(t)
 	// Healthcheck interval on tablet is set to 1s, so sleep for 2s
 	time.Sleep(2 * time.Second)
 	ctx := context.Background()
@@ -287,7 +283,6 @@ func TestReplicaTransactions(t *testing.T) {
 
 // TestStreamingRPCStuck tests that StreamExecute calls don't get stuck on the vttablets if a client stop reading from a stream.
 func TestStreamingRPCStuck(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtConn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -29,7 +29,6 @@ import (
 
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
@@ -44,7 +43,6 @@ var (
 
 // TabletCommands tests the basic tablet commands
 func TestTabletCommands(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &primaryTabletParams)
@@ -185,7 +183,6 @@ func assertExecuteMultiFetch(t *testing.T, qr string) {
 
 func TestHook(t *testing.T) {
 	// test a regular program works
-	defer cluster.PanicHandler(t)
 	runHookAndAssert(t, []string{
 		"ExecuteHook", primaryTablet.Alias, "test.sh", "--", "--flag1", "--param1=hello"}, 0, false, "")
 
@@ -226,7 +223,6 @@ func runHookAndAssert(t *testing.T, params []string, expectedStatus int64, expec
 
 func TestShardReplicationFix(t *testing.T) {
 	// make sure the replica is in the replication graph, 2 nodes: 1 primary, 1 replica
-	defer cluster.PanicHandler(t)
 	result, err := clusterInstance.VtctldClientProcess.GetShardReplication(keyspaceName, shardName, cell)
 	require.Nil(t, err, "error should be Nil")
 	require.NotNil(t, result[cell], "result should not be Nil")
@@ -250,7 +246,6 @@ func TestShardReplicationFix(t *testing.T) {
 }
 
 func TestGetSchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	res, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetSchema",
 		"--include-views", "--tables", "t1,v1",

--- a/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
+++ b/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestTopoCustomRule(t *testing.T) {
 
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &primaryTabletParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/tabletmanager/lock_unlock_test.go
+++ b/go/test/endtoend/tabletmanager/lock_unlock_test.go
@@ -30,12 +30,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 // TestLockAndUnlock tests the lock ability by locking a replica and asserting it does not see changes
 func TestLockAndUnlock(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &primaryTabletParams)
@@ -76,7 +74,6 @@ func TestLockAndUnlock(t *testing.T) {
 
 // TestStartReplicationUntilAfter tests by writing three rows, noting the gtid after each, and then replaying them one by one
 func TestStartReplicationUntilAfter(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &primaryTabletParams)
@@ -130,7 +127,6 @@ func TestStartReplicationUntilAfter(t *testing.T) {
 
 // TestLockAndTimeout tests that the lock times out and updates can be seen after timeout
 func TestLockAndTimeout(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	primaryConn, err := mysql.Connect(ctx, &primaryTabletParams)

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -79,7 +79,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/tabletmanager/primary/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/primary/tablet_test.go
@@ -69,7 +69,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/tabletmanager/primary/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/primary/tablet_test.go
@@ -115,7 +115,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestRepeatedInitShardPrimary(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	// Test that using InitShardPrimary can go back and forth between 2 hosts.
 
 	// Make replica tablet as primary
@@ -154,7 +153,6 @@ func TestRepeatedInitShardPrimary(t *testing.T) {
 }
 
 func TestPrimaryRestartSetsPTSTimestamp(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	// Test that PTS timestamp is set when we restart the PRIMARY vttablet.
 	// PTS = PrimaryTermStart.
 	// See StreamHealthResponse.primary_term_start_timestamp for details.

--- a/go/test/endtoend/tabletmanager/qps_test.go
+++ b/go/test/endtoend/tabletmanager/qps_test.go
@@ -24,12 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
 func TestQPS(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	vtParams := mysql.ConnParams{

--- a/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
@@ -73,7 +73,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -83,7 +83,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -39,7 +39,6 @@ import (
 
 // TabletReshuffle test if a vttablet can be pointed at an existing mysql
 func TestTabletReshuffle(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &primaryTabletParams)
@@ -92,7 +91,6 @@ func TestTabletReshuffle(t *testing.T) {
 
 func TestHealthCheck(t *testing.T) {
 	// Add one replica that starts not initialized
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	clusterInstance.DisableVTOrcRecoveries(t)
 	defer clusterInstance.EnableVTOrcRecoveries(t)
@@ -200,7 +198,6 @@ func TestHealthCheck(t *testing.T) {
 // TestHealthCheckSchemaChangeSignal tests the tables and views, which report their schemas have changed in the output of a StreamHealth.
 func TestHealthCheckSchemaChangeSignal(t *testing.T) {
 	// Add one replica that starts not initialized
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	vtParams := clusterInstance.GetVTParams(keyspaceName)
@@ -381,7 +378,6 @@ func TestHealthCheckDrainedStateDoesNotShutdownQueryService(t *testing.T) {
 	// - the query service won't be shutdown
 
 	// Wait if tablet is not in service state
-	defer cluster.PanicHandler(t)
 	clusterInstance.DisableVTOrcRecoveries(t)
 	defer clusterInstance.EnableVTOrcRecoveries(t)
 	err := rdonlyTablet.VttabletProcess.WaitForTabletStatus("SERVING")

--- a/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestFallbackSecurityPolicy(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	mTablet := clusterInstance.NewVttabletInstance("replica", 0, "")
 
@@ -84,7 +83,6 @@ func assertAllowedURLTest(t *testing.T, url string) {
 }
 
 func TestDenyAllSecurityPolicy(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	mTablet := clusterInstance.NewVttabletInstance("replica", 0, "")
 
@@ -116,7 +114,6 @@ func TestDenyAllSecurityPolicy(t *testing.T) {
 }
 
 func TestReadOnlySecurityPolicy(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	mTablet := clusterInstance.NewVttabletInstance("replica", 0, "")
 

--- a/go/test/endtoend/tabletmanager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_test.go
@@ -31,7 +31,6 @@ import (
 
 // TestEnsureDB tests that vttablet creates the db as needed
 func TestEnsureDB(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// Create new tablet
 	tablet := clusterInstance.NewVttabletInstance("replica", 0, "")
@@ -67,7 +66,6 @@ func TestEnsureDB(t *testing.T) {
 
 // TestResetReplicationParameters tests that the RPC ResetReplicationParameters works as intended.
 func TestResetReplicationParameters(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// Create new tablet
 	tablet := clusterInstance.NewVttabletInstance("replica", 0, "")

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -267,7 +267,6 @@ func vtgateExec(t *testing.T, query string, expectError string) *sqltypes.Result
 }
 
 func TestInitialThrottler(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	t.Run("validating OK response from disabled throttler", func(t *testing.T) {
 		waitForThrottleCheckStatus(t, primaryTablet, tabletmanagerdatapb.CheckThrottlerResponseCode_OK)
@@ -424,7 +423,6 @@ func TestInitialThrottler(t *testing.T) {
 }
 
 func TestThrottleViaApplySchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	t.Run("throttling via ApplySchema", func(t *testing.T) {
 		vtctlParams := &cluster.ApplySchemaParams{DDLStrategy: "online"}
 		_, err := clusterInstance.VtctldClientProcess.ApplySchemaWithOutput(
@@ -467,7 +465,6 @@ func TestThrottleViaApplySchema(t *testing.T) {
 }
 
 func TestThrottlerAfterMetricsCollected(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// By this time metrics will have been collected. We expect no lag, and something like:
 	// {"StatusCode":200,"Value":0.282278,"Threshold":1,"Message":""}
@@ -496,7 +493,6 @@ func TestThrottlerAfterMetricsCollected(t *testing.T) {
 }
 
 func TestLag(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	// Temporarily disable VTOrc recoveries because we want to
 	// STOP replication specifically in order to increase the
 	// lag and we DO NOT want VTOrc to try and fix this.
@@ -635,7 +631,6 @@ func TestLag(t *testing.T) {
 }
 
 func TestNoReplicas(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	t.Run("changing replica to RDONLY", func(t *testing.T) {
 		err := clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", replicaTablet.Alias, "RDONLY")
 		assert.NoError(t, err)
@@ -653,7 +648,6 @@ func TestNoReplicas(t *testing.T) {
 }
 
 func TestCustomQuery(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	t.Run("enabling throttler with custom query and threshold", func(t *testing.T) {
 		req := &vtctldatapb.UpdateThrottlerConfigRequest{Enable: true, Threshold: customThreshold, CustomQuery: customQuery}
@@ -721,7 +715,6 @@ func TestCustomQuery(t *testing.T) {
 }
 
 func TestRestoreDefaultQuery(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// Validate going back from custom-query to default-query (replication lag) still works.
 	t.Run("enabling throttler with default query and threshold", func(t *testing.T) {

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -100,7 +100,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/topoconncache/main_test.go
+++ b/go/test/endtoend/topoconncache/main_test.go
@@ -97,7 +97,6 @@ Topology: We create a keyspace with two shards , having 3 tablets each. Primarie
 to 'zone1' and replicas/rdonly belongs to cell2.
 */
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/topoconncache/topo_conn_cache_test.go
+++ b/go/test/endtoend/topoconncache/topo_conn_cache_test.go
@@ -37,7 +37,6 @@ import (
 4. 'ListAllTablets' should return all the new tablets.
 */
 func TestVtctldListAllTablets(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	url := fmt.Sprintf("http://%s:%d/api/keyspaces/", clusterInstance.Hostname, clusterInstance.VtctldHTTPPort)
 	testURL(t, url, "keyspace url")
 

--- a/go/test/endtoend/topotest/consul/main_test.go
+++ b/go/test/endtoend/topotest/consul/main_test.go
@@ -98,7 +98,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestTopoRestart(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",

--- a/go/test/endtoend/topotest/consul/main_test.go
+++ b/go/test/endtoend/topotest/consul/main_test.go
@@ -63,7 +63,6 @@ CREATE TABLE t1 (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/topotest/etcd2/main_test.go
+++ b/go/test/endtoend/topotest/etcd2/main_test.go
@@ -98,7 +98,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestTopoDownServingQuery(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",

--- a/go/test/endtoend/topotest/etcd2/main_test.go
+++ b/go/test/endtoend/topotest/etcd2/main_test.go
@@ -64,7 +64,6 @@ CREATE TABLE t1 (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/topotest/zk2/main_test.go
+++ b/go/test/endtoend/topotest/zk2/main_test.go
@@ -63,7 +63,6 @@ CREATE TABLE t1 (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/topotest/zk2/main_test.go
+++ b/go/test/endtoend/topotest/zk2/main_test.go
@@ -98,7 +98,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestTopoDownServingQuery(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",

--- a/go/test/endtoend/transaction/restart/main_test.go
+++ b/go/test/endtoend/transaction/restart/main_test.go
@@ -41,7 +41,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/transaction/rollback/txn_rollback_shutdown_test.go
+++ b/go/test/endtoend/transaction/rollback/txn_rollback_shutdown_test.go
@@ -48,7 +48,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/transaction/rollback/txn_rollback_shutdown_test.go
+++ b/go/test/endtoend/transaction/rollback/txn_rollback_shutdown_test.go
@@ -86,7 +86,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestTransactionRollBackWhenShutDown(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -121,7 +120,6 @@ func TestTransactionRollBackWhenShutDown(t *testing.T) {
 }
 
 func TestErrorInAutocommitSession(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/transaction/single/main_test.go
+++ b/go/test/endtoend/transaction/single/main_test.go
@@ -46,7 +46,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/transaction/twopc/fuzz/main_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/main_test.go
@@ -120,7 +120,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 }
 
 func cleanup(t *testing.T) {
-	cluster.PanicHandler(t)
 
 	utils.ClearOutTable(t, vtParams, "twopc_fuzzer_insert")
 	utils.ClearOutTable(t, vtParams, "twopc_fuzzer_update")

--- a/go/test/endtoend/transaction/twopc/fuzz/main_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/main_test.go
@@ -48,7 +48,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode := func() int {

--- a/go/test/endtoend/transaction/twopc/main_test.go
+++ b/go/test/endtoend/transaction/twopc/main_test.go
@@ -138,7 +138,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 }
 
 func cleanup(t *testing.T) {
-	cluster.PanicHandler(t)
 	twopcutil.ClearOutTable(t, vtParams, "twopc_user")
 	twopcutil.ClearOutTable(t, vtParams, "twopc_t1")
 	twopcutil.ClearOutTable(t, vtParams, "twopc_lookup")
@@ -163,7 +162,6 @@ func startWithMySQL(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/transaction/twopc/main_test.go
+++ b/go/test/endtoend/transaction/twopc/main_test.go
@@ -61,7 +61,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode := func() int {

--- a/go/test/endtoend/transaction/twopc/metric/main_test.go
+++ b/go/test/endtoend/transaction/twopc/metric/main_test.go
@@ -109,7 +109,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 }
 
 func cleanup(t *testing.T) {
-	cluster.PanicHandler(t)
 	twopcutil.ClearOutTable(t, vtParams, "twopc_user")
 	twopcutil.ClearOutTable(t, vtParams, "twopc_t1")
 }

--- a/go/test/endtoend/transaction/twopc/metric/main_test.go
+++ b/go/test/endtoend/transaction/twopc/metric/main_test.go
@@ -48,7 +48,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode := func() int {

--- a/go/test/endtoend/transaction/twopc/stress/main_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/main_test.go
@@ -122,7 +122,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 }
 
 func cleanup(t *testing.T) {
-	cluster.PanicHandler(t)
 	utils.ClearOutTable(t, vtParams, "twopc_t1")
 	utils.ClearOutTable(t, vtParams, "twopc_settings")
 }

--- a/go/test/endtoend/transaction/twopc/stress/main_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/main_test.go
@@ -48,7 +48,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode := func() int {

--- a/go/test/endtoend/transaction/tx_test.go
+++ b/go/test/endtoend/transaction/tx_test.go
@@ -93,7 +93,6 @@ func TestMain(m *testing.M) {
 
 // TestTransactionModes tests transactions using twopc mode
 func TestTransactionModes(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -139,7 +138,6 @@ func TestTransactionModes(t *testing.T) {
 
 // TestTransactionIsolation tests transaction isolation level.
 func TestTransactionIsolation(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -246,6 +244,5 @@ func start(t *testing.T) func() {
 
 	return func() {
 		deleteAll()
-		cluster.PanicHandler(t)
 	}
 }

--- a/go/test/endtoend/transaction/tx_test.go
+++ b/go/test/endtoend/transaction/tx_test.go
@@ -46,7 +46,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/utils/mysql_test.go
+++ b/go/test/endtoend/utils/mysql_test.go
@@ -50,7 +50,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 
 	exitCode := func() int {
 		clusterInstance = cluster.NewCluster(cell, "localhost")

--- a/go/test/endtoend/utils/mysqlvsvitess/main_test.go
+++ b/go/test/endtoend/utils/mysqlvsvitess/main_test.go
@@ -64,7 +64,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 
 	exitCode := func() int {
 		clusterInstance = cluster.NewCluster(cell, "localhost")

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -99,7 +99,6 @@ var (
 )
 
 func TestVaultAuth(t *testing.T) {
-	defer cluster.PanicHandler(nil)
 
 	// Instantiate Vitess Cluster objects and start topo
 	initializeClusterEarly(t)

--- a/go/test/endtoend/versionupgrade/upgrade_test.go
+++ b/go/test/endtoend/versionupgrade/upgrade_test.go
@@ -72,7 +72,6 @@ var (
 
 // TestMain is the main entry point
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/versionupgrade/upgrade_test.go
+++ b/go/test/endtoend/versionupgrade/upgrade_test.go
@@ -130,12 +130,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestShards(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	assert.Equal(t, 2, len(clusterInstance.Keyspaces[0].Shards))
 }
 
 func TestDeploySchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	if clusterInstance.ReusingVTDATAROOT {
 		// we assume data is already deployed
@@ -162,7 +160,6 @@ func TestDeploySchema(t *testing.T) {
 }
 
 func TestTablesExist(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	checkTables(t, "", totalTableCount)
 }

--- a/go/test/endtoend/vtadmin/main_test.go
+++ b/go/test/endtoend/vtadmin/main_test.go
@@ -91,7 +91,6 @@ func TestMain(m *testing.M) {
 
 // TestVtadminAPIs tests the vtadmin APIs.
 func TestVtadminAPIs(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// Test the vtadmin APIs
 	t.Run("keyspaces api", func(t *testing.T) {

--- a/go/test/endtoend/vtadmin/main_test.go
+++ b/go/test/endtoend/vtadmin/main_test.go
@@ -51,7 +51,6 @@ create table u_b
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/concurrentdml/main_test.go
+++ b/go/test/endtoend/vtgate/concurrentdml/main_test.go
@@ -66,7 +66,6 @@ INSERT INTO t1_seq (id, next_id, cache) values(0, 1, 1000);
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/concurrentdml/main_test.go
+++ b/go/test/endtoend/vtgate/concurrentdml/main_test.go
@@ -107,7 +107,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestInsertIgnoreOnLookupUniqueVindex(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -136,7 +135,6 @@ func TestInsertIgnoreOnLookupUniqueVindex(t *testing.T) {
 
 func TestOpenTxBlocksInSerial(t *testing.T) {
 	t.Skip("Update and Insert in same transaction does not work with the unique consistent lookup having same value.")
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -168,7 +166,6 @@ func TestOpenTxBlocksInSerial(t *testing.T) {
 
 func TestOpenTxBlocksInConcurrent(t *testing.T) {
 	t.Skip("Update and Insert in same transaction does not work with the unique consistent lookup having same value.")
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -206,7 +203,6 @@ func TestOpenTxBlocksInConcurrent(t *testing.T) {
 }
 
 func TestUpdateLookupUniqueVindex(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",

--- a/go/test/endtoend/vtgate/connectiondrain/main_test.go
+++ b/go/test/endtoend/vtgate/connectiondrain/main_test.go
@@ -86,7 +86,6 @@ func start(t *testing.T, vtParams mysql.ConnParams) (*mysql.Conn, func()) {
 	return vtConn, func() {
 		deleteAll()
 		vtConn.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/connectiondrain/main_test.go
+++ b/go/test/endtoend/vtgate/connectiondrain/main_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 	os.Exit(m.Run())
 }

--- a/go/test/endtoend/vtgate/consolidator/main_test.go
+++ b/go/test/endtoend/vtgate/consolidator/main_test.go
@@ -65,7 +65,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/createdb_plugin/main_test.go
+++ b/go/test/endtoend/vtgate/createdb_plugin/main_test.go
@@ -43,7 +43,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/createdb_plugin/main_test.go
+++ b/go/test/endtoend/vtgate/createdb_plugin/main_test.go
@@ -80,7 +80,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestDBDDLPlugin(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",

--- a/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
+++ b/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
@@ -66,7 +66,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/foreignkey/main_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/main_test.go
@@ -98,7 +98,6 @@ type fkReference struct {
 }
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/foreignkey/main_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/main_test.go
@@ -196,7 +196,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -652,7 +652,6 @@ func ExecuteFKTest(t *testing.T, tcase *testCase) {
 }
 
 func TestStressFK(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	t.Run("validate replication health", func(t *testing.T) {
 		validateReplicationIsHealthy(t, replicaNoFK)

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -335,7 +335,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/vtgate/gen4/column_name_test.go
+++ b/go/test/endtoend/vtgate/gen4/column_name_test.go
@@ -26,11 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func TestColumnNames(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &vtParams)

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -64,7 +64,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -151,6 +151,5 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }

--- a/go/test/endtoend/vtgate/gen4/system_schema_test.go
+++ b/go/test/endtoend/vtgate/gen4/system_schema_test.go
@@ -28,11 +28,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func TestDbNameOverride(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.Nil(t, err)
@@ -55,7 +53,6 @@ func TestDbNameOverride(t *testing.T) {
 }
 
 func TestInformationSchemaQuery(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -90,7 +87,6 @@ func assertSingleRowIsReturned(t *testing.T, conn *mysql.Conn, predicate string,
 }
 
 func TestInformationSchemaWithSubquery(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -101,7 +97,6 @@ func TestInformationSchemaWithSubquery(t *testing.T) {
 }
 
 func TestInformationSchemaQueryGetsRoutedToTheRightTableAndKeyspace(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -113,7 +108,6 @@ func TestInformationSchemaQueryGetsRoutedToTheRightTableAndKeyspace(t *testing.T
 }
 
 func TestFKConstraintUsingInformationSchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -131,7 +125,6 @@ func TestFKConstraintUsingInformationSchema(t *testing.T) {
 }
 
 func TestConnectWithSystemSchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	for _, dbname := range []string{"information_schema", "mysql", "performance_schema", "sys"} {
 		connParams := vtParams
@@ -144,7 +137,6 @@ func TestConnectWithSystemSchema(t *testing.T) {
 }
 
 func TestUseSystemSchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -156,7 +148,6 @@ func TestUseSystemSchema(t *testing.T) {
 }
 
 func TestSystemSchemaQueryWithoutQualifier(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -191,7 +182,6 @@ func TestSystemSchemaQueryWithoutQualifier(t *testing.T) {
 }
 
 func TestMultipleSchemaPredicates(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -217,7 +207,6 @@ func TestMultipleSchemaPredicates(t *testing.T) {
 }
 
 func TestQuerySystemTables(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtgate/godriver/main_test.go
+++ b/go/test/endtoend/vtgate/godriver/main_test.go
@@ -86,7 +86,6 @@ create table my_message(
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/godriver/main_test.go
+++ b/go/test/endtoend/vtgate/godriver/main_test.go
@@ -124,7 +124,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestStreamMessaging(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	cnf := vitessdriver.Configuration{
 		Protocol: "grpc",

--- a/go/test/endtoend/vtgate/grpc_api/main_test.go
+++ b/go/test/endtoend/vtgate/grpc_api/main_test.go
@@ -75,7 +75,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode := func() int {

--- a/go/test/endtoend/vtgate/keyspace_watches/keyspace_watch_test.go
+++ b/go/test/endtoend/vtgate/keyspace_watches/keyspace_watch_test.go
@@ -117,7 +117,6 @@ func createCluster(extraVTGateArgs []string) (*cluster.LocalProcessCluster, int)
 }
 
 func TestRoutingWithKeyspacesToWatch(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	clusterInstance, exitCode := createCluster(nil)
 	defer clusterInstance.Teardown()
@@ -141,7 +140,6 @@ func TestRoutingWithKeyspacesToWatch(t *testing.T) {
 }
 
 func TestVSchemaDDLWithKeyspacesToWatch(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	extraVTGateArgs := []string{
 		"--vschema_ddl_authorized_users", "%",

--- a/go/test/endtoend/vtgate/main_test.go
+++ b/go/test/endtoend/vtgate/main_test.go
@@ -121,6 +121,5 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 	return conn, func() {
 		deleteAll()
 		conn.Close()
-		cluster.PanicHandler(t)
 	}
 }

--- a/go/test/endtoend/vtgate/main_test.go
+++ b/go/test/endtoend/vtgate/main_test.go
@@ -54,7 +54,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 	exitCode := func() int {
 		clusterInstance = cluster.NewCluster(Cell, "localhost")

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -28,7 +28,6 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/sqlerror"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -783,7 +782,6 @@ func TestJoinWithMergedRouteWithPredicate(t *testing.T) {
 func TestRowCountExceed(t *testing.T) {
 	conn, _ := start(t)
 	defer func() {
-		cluster.PanicHandler(t)
 		// needs special delete logic as it exceeds row count.
 		for i := 50; i <= 300; i += 50 {
 			utils.Exec(t, conn, fmt.Sprintf("delete from t1 where id1 < %d", i))

--- a/go/test/endtoend/vtgate/mysql80/main_test.go
+++ b/go/test/endtoend/vtgate/mysql80/main_test.go
@@ -35,7 +35,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/mysql80/misc_test.go
+++ b/go/test/endtoend/vtgate/mysql80/misc_test.go
@@ -23,15 +23,12 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/utils"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
-
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
 )
 
 func TestFunctionInDefault(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -223,7 +220,6 @@ func BenchmarkReservedConnWhenSettingSysVar(b *testing.B) {
 }
 
 func TestJsonFunctions(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -45,7 +45,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/plan_tests/main_test.go
+++ b/go/test/endtoend/vtgate/plan_tests/main_test.go
@@ -41,8 +41,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
-
 	vschema := readFile("vschemas/schema.json")
 	userVs := extractUserKS(vschema)
 	mainVs := extractMainKS(vschema)

--- a/go/test/endtoend/vtgate/prefixfanout/main_test.go
+++ b/go/test/endtoend/vtgate/prefixfanout/main_test.go
@@ -157,7 +157,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestCFCPrefixQueryNoHash(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := clusterInstance.GetVTParams(sKs)
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -195,7 +194,6 @@ func TestCFCPrefixQueryNoHash(t *testing.T) {
 }
 
 func TestCFCPrefixQueryWithHash(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := clusterInstance.GetVTParams(sKsMD5)
 
@@ -238,7 +236,6 @@ func TestCFCPrefixQueryWithHash(t *testing.T) {
 }
 
 func TestCFCInsert(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	vtParams := clusterInstance.GetVTParams(sKs)

--- a/go/test/endtoend/vtgate/prefixfanout/main_test.go
+++ b/go/test/endtoend/vtgate/prefixfanout/main_test.go
@@ -109,7 +109,6 @@ PRIMARY KEY (c1)
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -66,7 +65,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/aggregation/main_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/benchmark/main_test.go
+++ b/go/test/endtoend/vtgate/queries/benchmark/main_test.go
@@ -65,7 +65,6 @@ var shards4 = []string{
 }
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/benchmark/main_test.go
+++ b/go/test/endtoend/vtgate/queries/benchmark/main_test.go
@@ -168,6 +168,5 @@ func start(b *testing.B) (*mysql.Conn, func()) {
 	return conn, func() {
 		deleteAll()
 		conn.Close()
-		cluster.PanicHandler(b)
 	}
 }

--- a/go/test/endtoend/vtgate/queries/derived/derived_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/derived_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -44,7 +43,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/derived/main_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/dml/main_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/main_test.go
@@ -66,7 +66,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/dml/main_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/main_test.go
@@ -147,6 +147,5 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }

--- a/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
@@ -21,12 +21,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
 func TestFoundRows(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	mcmp, err := utils.NewMySQLCompare(t, vtParams, mysqlParams)
 	require.NoError(t, err)
 	defer mcmp.Close()

--- a/go/test/endtoend/vtgate/queries/foundrows/main_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/main_test.go
@@ -46,7 +46,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -47,7 +46,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 
@@ -114,7 +112,6 @@ func TestFKConstraintUsingInformationSchema(t *testing.T) {
 }
 
 func TestConnectWithSystemSchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	for _, dbname := range []string{"information_schema", "mysql", "performance_schema", "sys"} {
 		vtConnParams := vtParams
 		vtConnParams.DbName = dbname

--- a/go/test/endtoend/vtgate/queries/informationschema/main_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/main_test.go
@@ -52,7 +52,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/kill/main_test.go
+++ b/go/test/endtoend/vtgate/queries/kill/main_test.go
@@ -50,7 +50,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
+++ b/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
@@ -49,7 +49,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
+++ b/go/test/endtoend/vtgate/queries/lookup_queries/main_test.go
@@ -118,7 +118,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/misc/main_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/main_test.go
@@ -48,7 +48,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -50,7 +49,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/no_scatter/main_test.go
+++ b/go/test/endtoend/vtgate/queries/no_scatter/main_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/no_scatter/queries_test.go
+++ b/go/test/endtoend/vtgate/queries/no_scatter/queries_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -43,7 +42,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 	return vtConn, func() {
 		deleteAll()
 		vtConn.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/normalize/main_test.go
+++ b/go/test/endtoend/vtgate/queries/normalize/main_test.go
@@ -39,7 +39,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/orderby/main_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
@@ -22,8 +22,6 @@ import (
 	"vitess.io/vitess/go/test/endtoend/utils"
 
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func start(t *testing.T) (utils.MySQLCompare, func()) {
@@ -44,7 +42,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/orderby/without_schematracker/main_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/without_schematracker/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/orderby/without_schematracker/orderby_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/without_schematracker/orderby_test.go
@@ -22,8 +22,6 @@ import (
 	"vitess.io/vitess/go/test/endtoend/utils"
 
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func start(t *testing.T) (utils.MySQLCompare, func()) {
@@ -44,7 +42,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/random/main_test.go
+++ b/go/test/endtoend/vtgate/queries/random/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/random/random_test.go
+++ b/go/test/endtoend/vtgate/queries/random/random_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -61,7 +60,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/reference/main_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/main_test.go
@@ -53,7 +53,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/reference/reference_test.go
+++ b/go/test/endtoend/vtgate/queries/reference/reference_test.go
@@ -24,8 +24,6 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/utils"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func start(t *testing.T) (*mysql.Conn, func()) {
@@ -35,7 +33,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 
 	return vtConn, func() {
 		vtConn.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/subquery/main_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -25,7 +25,6 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -47,7 +46,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/timeout/main_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/main_test.go
@@ -48,7 +48,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -45,7 +44,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/tpch/main_test.go
+++ b/go/test/endtoend/vtgate/queries/tpch/main_test.go
@@ -43,7 +43,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
+++ b/go/test/endtoend/vtgate/queries/tpch/tpch_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -43,7 +42,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/union/main_test.go
+++ b/go/test/endtoend/vtgate/queries/union/main_test.go
@@ -43,7 +43,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -19,7 +19,6 @@ package union
 import (
 	"testing"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	return mcmp, func() {
 		deleteAll()
 		mcmp.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/queries/vexplain/main_test.go
+++ b/go/test/endtoend/vtgate/queries/vexplain/main_test.go
@@ -43,7 +43,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
+++ b/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/utils"
@@ -49,7 +48,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 	return vtConn, func() {
 		deleteAll()
 		vtConn.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/readafterwrite/raw_test.go
+++ b/go/test/endtoend/vtgate/readafterwrite/raw_test.go
@@ -142,7 +142,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestRAWSettings(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	conn, err := mysql.Connect(context.Background(), &vtParams)
 	require.NoError(t, err)
 	defer conn.Close()

--- a/go/test/endtoend/vtgate/readafterwrite/raw_test.go
+++ b/go/test/endtoend/vtgate/readafterwrite/raw_test.go
@@ -100,7 +100,6 @@ CREATE TABLE test_vdx (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/reservedconn/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/main_test.go
@@ -101,7 +101,6 @@ CREATE TABLE test_vdx (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/reservedconn/reconnect1/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect1/main_test.go
@@ -63,7 +63,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/reservedconn/reconnect2/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect2/main_test.go
@@ -64,7 +64,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -29,11 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func TestSetSysVarSingle(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	type queriesWithExpectations struct {
 		name, expr string

--- a/go/test/endtoend/vtgate/reservedconn/udv_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/udv_test.go
@@ -31,11 +31,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 func TestSetUDV(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	type queriesWithExpectations struct {
@@ -123,7 +121,6 @@ func TestSetUDV(t *testing.T) {
 }
 
 func TestMysqlDumpInitialLog(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 
 	conn, err := mysql.Connect(ctx, &vtParams)

--- a/go/test/endtoend/vtgate/schema/schema_test.go
+++ b/go/test/endtoend/vtgate/schema/schema_test.go
@@ -55,7 +55,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/vtgate/schema/schema_test.go
+++ b/go/test/endtoend/vtgate/schema/schema_test.go
@@ -100,7 +100,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchemaChange(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	testWithInitialSchema(t)
 	testWithAlterSchema(t)
 	testWithAlterDatabase(t)

--- a/go/test/endtoend/vtgate/schematracker/loadkeyspace/schema_load_keyspace_test.go
+++ b/go/test/endtoend/vtgate/schematracker/loadkeyspace/schema_load_keyspace_test.go
@@ -57,7 +57,6 @@ var (
 )
 
 func TestLoadKeyspaceWithNoTablet(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	var err error
 
 	clusterInstance = cluster.NewCluster(cell, hostname)
@@ -100,7 +99,6 @@ func TestLoadKeyspaceWithNoTablet(t *testing.T) {
 }
 
 func TestNoInitialKeyspace(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	var err error
 
 	clusterInstance = cluster.NewCluster(cell, hostname)

--- a/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
+++ b/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
@@ -64,7 +64,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitcode := func() int {

--- a/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
+++ b/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
@@ -115,7 +115,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestVSchemaTrackerInit(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -136,7 +135,6 @@ func TestVSchemaTrackerInit(t *testing.T) {
 // properly handles primary tablet restarts -- meaning that we maintain
 // the exact same vschema state as before the restart.
 func TestVSchemaTrackerKeyspaceReInit(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	primaryTablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
 

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -48,7 +48,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -160,7 +160,6 @@ func TestNewTable(t *testing.T) {
 }
 
 func TestAmbiguousColumnJoin(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
@@ -207,7 +207,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestAddColumn(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
@@ -122,7 +122,6 @@ create table t8(
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -49,7 +49,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -111,7 +111,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestNewUnshardedTable(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// create a sql connection
 	ctx := context.Background()
@@ -181,7 +180,6 @@ func TestNewUnshardedTable(t *testing.T) {
 // creating two tables having the same name differing only in casing, but other operating systems don't.
 // More information at https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html#:~:text=Table%20names%20are%20stored%20in,lowercase%20on%20storage%20and%20lookup.
 func TestCaseSensitiveSchemaTracking(t *testing.T) {
-	defer cluster.PanicHandler(t)
 
 	// create a sql connection
 	ctx := context.Background()

--- a/go/test/endtoend/vtgate/sec_vind/main_test.go
+++ b/go/test/endtoend/vtgate/sec_vind/main_test.go
@@ -44,7 +44,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/sec_vind/main_test.go
+++ b/go/test/endtoend/vtgate/sec_vind/main_test.go
@@ -100,7 +100,6 @@ func start(t *testing.T) (*mysql.Conn, func()) {
 	return conn, func() {
 		deleteAll()
 		conn.Close()
-		cluster.PanicHandler(t)
 	}
 }
 

--- a/go/test/endtoend/vtgate/sequence/seq_test.go
+++ b/go/test/endtoend/vtgate/sequence/seq_test.go
@@ -215,7 +215,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestSeq(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -273,7 +272,6 @@ func TestSeq(t *testing.T) {
 }
 
 func TestDotTableSeq(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host:   "localhost",
@@ -296,7 +294,6 @@ func TestDotTableSeq(t *testing.T) {
 }
 
 func TestInsertAllDefaults(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host:   "localhost",

--- a/go/test/endtoend/vtgate/sequence/seq_test.go
+++ b/go/test/endtoend/vtgate/sequence/seq_test.go
@@ -174,7 +174,6 @@ CREATE TABLE allDefaults (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/tablet_healthcheck/reparent_test.go
+++ b/go/test/endtoend/vtgate/tablet_healthcheck/reparent_test.go
@@ -89,7 +89,6 @@ create table corder(
 
 // TestMain sets up the vitess cluster for any subsequent tests
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
+++ b/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
@@ -86,7 +86,6 @@ create table corder(
 
 // TestMain sets up the vitess cluster for any subsequent tests
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -191,7 +191,6 @@ func TestMain(m *testing.M) {
 func TestSelectIntoAndLoadFrom(t *testing.T) {
 	// Test is skipped because it requires secure-file-priv variable to be set to not NULL or empty.
 	t.Skip()
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -226,7 +225,6 @@ func TestSelectIntoAndLoadFrom(t *testing.T) {
 }
 
 func TestEmptyStatement(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -243,7 +241,6 @@ func TestEmptyStatement(t *testing.T) {
 }
 
 func TestTopoDownServingQuery(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -263,7 +260,6 @@ func TestTopoDownServingQuery(t *testing.T) {
 }
 
 func TestInsertAllDefaults(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -278,7 +274,6 @@ func TestInsertAllDefaults(t *testing.T) {
 }
 
 func TestDDLUnsharded(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -299,7 +294,6 @@ func TestDDLUnsharded(t *testing.T) {
 }
 
 func TestCallProcedure(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host:   "localhost",
@@ -346,7 +340,6 @@ func TestCallProcedure(t *testing.T) {
 }
 
 func TestTempTable(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -371,7 +364,6 @@ func TestTempTable(t *testing.T) {
 }
 
 func TestReservedConnDML(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
@@ -394,7 +386,6 @@ func TestReservedConnDML(t *testing.T) {
 }
 
 func TestNumericPrecisionScale(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
 		Host: "localhost",

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -147,7 +147,6 @@ END;
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/vindex_bindvars/main_test.go
+++ b/go/test/endtoend/vtgate/vindex_bindvars/main_test.go
@@ -265,7 +265,6 @@ CREATE TABLE thex (
 )
 
 func TestMain(m *testing.M) {
-	defer cluster.PanicHandler(nil)
 	flag.Parse()
 
 	exitCode := func() int {

--- a/go/test/endtoend/vtgate/vindex_bindvars/main_test.go
+++ b/go/test/endtoend/vtgate/vindex_bindvars/main_test.go
@@ -303,7 +303,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestVindexHexTypes(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.Nil(t, err)
@@ -325,7 +324,6 @@ func TestVindexHexTypes(t *testing.T) {
 }
 
 func TestVindexBindVarOverlap(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.Nil(t, err)

--- a/go/test/endtoend/vtgate/vschema/vschema_test.go
+++ b/go/test/endtoend/vtgate/vschema/vschema_test.go
@@ -123,7 +123,6 @@ func writeConfig(path string, cfg map[string]string) error {
 }
 
 func TestVSchema(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -33,7 +33,6 @@ import (
 
 // TestAPIEndpoints tests the various API endpoints that VTOrc offers.
 func TestAPIEndpoints(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")

--- a/go/test/endtoend/vtorc/api/config_test.go
+++ b/go/test/endtoend/vtorc/api/config_test.go
@@ -30,7 +30,6 @@ import (
 
 // TestDynamicConfigs tests the dyanamic configurations that VTOrc offers.
 func TestDynamicConfigs(t *testing.T) {
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{}, 1, "")
 	vtorc := clusterInfo.ClusterInstance.VTOrcProcesses[0]
 

--- a/go/test/endtoend/vtorc/api/main_test.go
+++ b/go/test/endtoend/vtorc/api/main_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
 )
 
@@ -52,8 +51,6 @@ func TestMain(m *testing.M) {
 
 		return m.Run(), nil
 	}()
-
-	cluster.PanicHandler(nil)
 
 	if clusterInfo != nil {
 		// stop vtorc first otherwise its logs get polluted

--- a/go/test/endtoend/vtorc/general/main_test.go
+++ b/go/test/endtoend/vtorc/general/main_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
 )
 
@@ -46,8 +45,6 @@ func TestMain(m *testing.M) {
 
 		return m.Run(), nil
 	}()
-
-	cluster.PanicHandler(nil)
 
 	if clusterInfo != nil {
 		// stop vtorc first otherwise its logs get polluted

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -40,7 +40,6 @@ import (
 // verify that with multiple vtorc instances, we still only have 1 PlannedReparentShard call
 func TestPrimaryElection(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 2, "")
@@ -66,7 +65,6 @@ func TestPrimaryElection(t *testing.T) {
 // if it has an errant GTID.
 func TestErrantGTIDOnPreviousPrimary(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 0, []string{"--change-tablets-with-errant-gtid-to-drained"}, cluster.VTOrcConfiguration{}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
@@ -126,7 +124,6 @@ func TestErrantGTIDOnPreviousPrimary(t *testing.T) {
 // verify replication is setup
 func TestSingleKeyspace(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 1, 1, []string{"--clusters_to_watch", "ks"}, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -145,7 +142,6 @@ func TestSingleKeyspace(t *testing.T) {
 // verify replication is setup
 func TestKeyspaceShard(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 1, 1, []string{"--clusters_to_watch", "ks/0"}, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -167,7 +163,6 @@ func TestKeyspaceShard(t *testing.T) {
 // 6. disable recoveries and make sure the detected problems are set correctly.
 func TestVTOrcRepairs(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 0, []string{"--change-tablets-with-errant-gtid-to-drained"}, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -346,7 +341,6 @@ func TestRepairAfterTER(t *testing.T) {
 	// test fails intermittently on CI, skip until it can be fixed.
 	t.SkipNow()
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 0, nil, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -480,7 +474,6 @@ func TestSemiSync(t *testing.T) {
 // TestVTOrcWithPrs tests that VTOrc works fine even when PRS is called from vtctld
 func TestVTOrcWithPrs(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 4, 0, nil, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -530,7 +523,6 @@ func TestVTOrcWithPrs(t *testing.T) {
 // TestMultipleDurabilities tests that VTOrc works with 2 keyspaces having 2 different durability policies
 func TestMultipleDurabilities(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	// Setup a normal cluster and start vtorc
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 1, 1, nil, cluster.VTOrcConfiguration{}, 1, "")
 	// Setup a semi-sync cluster
@@ -551,7 +543,6 @@ func TestMultipleDurabilities(t *testing.T) {
 // TestDrainedTablet tests that we don't forget drained tablets and they still show up in the vtorc output.
 func TestDrainedTablet(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 
 	// Setup a normal cluster and start vtorc
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 0, nil, cluster.VTOrcConfiguration{}, 1, "")
@@ -639,7 +630,6 @@ func TestDurabilityPolicySetLater(t *testing.T) {
 
 func TestFullStatusConnectionPooling(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 4, 0, []string{
 		"--tablet_manager_grpc_concurrency=1",
 	}, cluster.VTOrcConfiguration{

--- a/go/test/endtoend/vtorc/primaryfailure/main_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/main_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
 )
 
@@ -52,8 +51,6 @@ func TestMain(m *testing.M) {
 
 		return m.Run(), nil
 	}()
-
-	cluster.PanicHandler(nil)
 
 	if clusterInfo != nil {
 		// stop vtorc first otherwise its logs get polluted

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -39,7 +39,6 @@ import (
 // Also tests that VTOrc can handle multiple failures, if the durability policies allow it
 func TestDownPrimary(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	// We specify the --wait-replicas-timeout to a small value because we spawn a cross-cell replica later in the test.
 	// If that replica is more advanced than the same-cell-replica, then we try to promote the cross-cell replica as an intermediate source.
 	// If we don't specify a small value of --wait-replicas-timeout, then we would end up waiting for 30 seconds for the dead-primary to respond, failing this test.
@@ -116,7 +115,6 @@ func TestDownPrimary(t *testing.T) {
 // bring down primary before VTOrc has started, let vtorc repair.
 func TestDownPrimaryBeforeVTOrc(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{}, 0, "none")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
@@ -172,7 +170,6 @@ func TestDownPrimaryBeforeVTOrc(t *testing.T) {
 // delete the primary record and let vtorc repair.
 func TestDeletedPrimaryTablet(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, []string{"--remote_operation_timeout=10s"}, cluster.VTOrcConfiguration{}, 1, "none")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
@@ -239,7 +236,6 @@ func TestDeletedPrimaryTablet(t *testing.T) {
 // that primary is unreachable. This help us save few seconds depending on value of `RemoteOperationTimeout` flag.
 func TestDeadPrimaryRecoversImmediately(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	// We specify the --wait-replicas-timeout to a small value because we spawn a cross-cell replica later in the test.
 	// If that replica is more advanced than the same-cell-replica, then we try to promote the cross-cell replica as an intermediate source.
 	// If we don't specify a small value of --wait-replicas-timeout, then we would end up waiting for 30 seconds for the dead-primary to respond, failing this test.
@@ -322,7 +318,6 @@ func TestDeadPrimaryRecoversImmediately(t *testing.T) {
 // covers part of the test case master-failover-lost-replicas from orchestrator
 func TestCrossDataCenterFailure(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -368,7 +363,6 @@ func TestCrossDataCenterFailure(t *testing.T) {
 // In case of no viable candidates, we should error out
 func TestCrossDataCenterFailureError(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 1, 1, nil, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -415,7 +409,6 @@ func TestLostRdonlyOnPrimaryFailure(t *testing.T) {
 	// were detected by vtorc and could be configured to have their sources detached
 	t.Skip()
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 2, nil, cluster.VTOrcConfiguration{
 		PreventCrossCellFailover: true,
 	}, 1, "")
@@ -495,7 +488,6 @@ func TestLostRdonlyOnPrimaryFailure(t *testing.T) {
 // covers the test case master-failover-fail-promotion-lag-minutes-success from orchestrator
 func TestPromotionLagSuccess(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
 		ReplicationLagQuery:              "select 59",
 		FailPrimaryPromotionOnLagMinutes: 1,
@@ -545,7 +537,6 @@ func TestPromotionLagFailure(t *testing.T) {
 	// was smaller than the configured value, otherwise it would fail the promotion
 	t.Skip()
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 1, nil, cluster.VTOrcConfiguration{
 		ReplicationLagQuery:              "select 61",
 		FailPrimaryPromotionOnLagMinutes: 1,
@@ -598,7 +589,6 @@ func TestPromotionLagFailure(t *testing.T) {
 // That is the replica which should be promoted in case of primary failure
 func TestDownPrimaryPromotionRule(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
 		LockShardTimeoutSeconds: 5,
 	}, 1, "test")
@@ -646,7 +636,6 @@ func TestDownPrimaryPromotionRule(t *testing.T) {
 // It should also be caught up when it is promoted
 func TestDownPrimaryPromotionRuleWithLag(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
 		LockShardTimeoutSeconds: 5,
 	}, 1, "test")
@@ -726,7 +715,6 @@ func TestDownPrimaryPromotionRuleWithLag(t *testing.T) {
 // It should also be caught up when it is promoted
 func TestDownPrimaryPromotionRuleWithLagCrossCenter(t *testing.T) {
 	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
 		LockShardTimeoutSeconds:  5,
 		PreventCrossCellFailover: true,

--- a/test/config.json
+++ b/test/config.json
@@ -349,17 +349,6 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
-		"pitr": {
-			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/recovery/pitr"],
-			"Command": [],
-			"Manual": false,
-			"Shard": "10",
-			"RetryMax": 1,
-			"Tags": [
-				"site_test"
-			]
-		},
 		"recovery": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/recovery/unshardedrecovery"],


### PR DESCRIPTION
This handler would recover any arbitrary panic and make the test pass. This is a big anti-pattern since it means we can have many failing tests we don't know about and things are silently broken potentially.

Running against CI to test the fallout of this.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required