### PR TITLE
test fix: make sure to keep the skipE2E field around

### DIFF
--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -664,8 +664,9 @@ func (s *planTestSuite) testFile(filename string, vschema *vschemawrapper.VSchem
 				continue
 			}
 			current := PlanTest{
-				Comment: testName,
+				Comment: tcase.Comment,
 				Query:   tcase.Query,
+				SkipE2E: tcase.SkipE2E,
 			}
 			vschema.Version = Gen4
 			out := getPlanOutput(tcase, vschema, render)

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -68,7 +68,6 @@
   {
     "comment": "join on sharding column with limit - should be a simple scatter query and limit on top with non resolved columns",
     "query": "select * from user u join user_metadata um on u.id = um.user_id where foo=41 limit 20",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user u join user_metadata um on u.id = um.user_id where foo=41 limit 20",
@@ -93,7 +92,8 @@
         "user.user",
         "user.user_metadata"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select with timeout directive sets QueryTimeout in the route",
@@ -180,7 +180,6 @@
   {
     "comment": "select limit with timeout directive sets QueryTimeout in the route",
     "query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from main.unsharded limit 10",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from main.unsharded limit 10",
@@ -199,7 +198,8 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select with partial scatter directive",
@@ -404,8 +404,8 @@
   {
     "comment": "test table lookup failure for authoritative code path",
     "query": "select a.* from authoritative",
-    "skip_e2e": true,
-    "plan": "Unknown table 'a'"
+    "plan": "Unknown table 'a'",
+    "skip_e2e": true
   },
   {
     "comment": "select * from qualified authoritative table",
@@ -455,7 +455,6 @@
   {
     "comment": "select authoritative.* with intermixing still expands",
     "query": "select user.id, a.*, user.col1 from authoritative a join user on a.user_id=user.id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.id, a.*, user.col1 from authoritative a join user on a.user_id=user.id",
@@ -474,12 +473,12 @@
         "user.authoritative",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "auto-resolve anonymous columns for simple route",
     "query": "select anon_col from user join user_extra on user.id = user_extra.user_id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select anon_col from user join user_extra on user.id = user_extra.user_id",
@@ -498,12 +497,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "json_arrayagg in single sharded query",
     "query": "select count(1) from user where id = 'abc' group by n_id having json_arrayagg(a_id) = '[]'",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select count(1) from user where id = 'abc' group by n_id having json_arrayagg(a_id) = '[]'",
@@ -525,12 +524,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "json_objectagg in single sharded query",
     "query": "select count(1) from user where id = 'abc' group by n_id having json_objectagg(a_id, b_id) = '[]'",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select count(1) from user where id = 'abc' group by n_id having json_objectagg(a_id, b_id) = '[]'",
@@ -552,24 +551,24 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "unsupported json aggregation expressions in scatter query",
     "query": "select count(1) from user where cola = 'abc' group by n_id having json_arrayagg(a_id) = '[]'",
-    "skip_e2e": true,
-    "plan": "VT12001: unsupported: in scatter query: aggregation function 'json_arrayagg(a_id)'"
+    "plan": "VT12001: unsupported: in scatter query: aggregation function 'json_arrayagg(a_id)'",
+    "skip_e2e": true
   },
   {
     "comment": "Cannot auto-resolve for cross-shard joins",
     "query": "select col from user join user_extra",
-    "skip_e2e": true,
-    "plan": "Column 'col' in field list is ambiguous"
+    "plan": "Column 'col' in field list is ambiguous",
+    "skip_e2e": true
   },
   {
     "comment": "Auto-resolve should work if unique vindex columns are referenced",
     "query": "select id, user_id from user join user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select id, user_id from user join user_extra",
@@ -607,12 +606,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "database calls should be substituted",
     "query": "select database() from dual",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select database() from dual",
@@ -630,12 +629,12 @@
       "TablesUsed": [
         "main.dual"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "last_insert_id for unsharded route",
     "query": "select last_insert_id() as x from main.unsharded",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select last_insert_id() as x from main.unsharded",
@@ -653,7 +652,8 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select from dual on unqualified keyspace",
@@ -706,13 +706,12 @@
   {
     "comment": "prefixing dual with a keyspace should not work",
     "query": "select 1 from user.dual",
-    "skip_e2e": true,
-    "plan": "table dual not found"
+    "plan": "table dual not found",
+    "skip_e2e": true
   },
   {
     "comment": "RHS route referenced",
     "query": "select user_extra.id from user join user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user_extra.id from user join user_extra",
@@ -750,12 +749,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Both routes referenced",
     "query": "select user.col, user_extra.id from user join user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.col, user_extra.id from user join user_extra",
@@ -793,12 +792,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Expression with single-route reference",
     "query": "select user.col, user_extra.id + user_extra.col from user join user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.col, user_extra.id + user_extra.col from user join user_extra",
@@ -836,12 +835,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "subquery with an aggregation in order by that can be merged into a single route",
     "query": "select col, trim((select user_name from user where id = 3)) val from user_extra where user_id = 3 group by col order by val",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select col, trim((select user_name from user where id = 3)) val from user_extra where user_id = 3 group by col order by val",
@@ -864,12 +863,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Jumbled references",
     "query": "select user.col, user_extra.id, user.col2 from user join user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.col, user_extra.id, user.col2 from user join user_extra",
@@ -907,12 +906,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Comments",
     "query": "select /* comment */ user.col from user join user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select /* comment */ user.col from user join user_extra",
@@ -950,12 +949,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "for update",
     "query": "select user.col from user join user_extra for update",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.col from user join user_extra for update",
@@ -993,12 +992,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Field query should work for joins select bind vars",
     "query": "select user.id, (select user.id+outm.m+unsharded.m from unsharded) from user join unsharded outm",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.id, (select user.id+outm.m+unsharded.m from unsharded) from user join unsharded outm",
@@ -1039,12 +1038,12 @@
         "main.unsharded",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Case preservation",
     "query": "select user.Col, user_extra.Id from user join user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.Col, user_extra.Id from user join user_extra",
@@ -1082,13 +1081,14 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "syntax error",
     "query": "the quick brown fox",
-    "skip_e2e": true,
-    "plan": "syntax error at position 4 near 'the'"
+    "plan": "syntax error at position 4 near 'the'",
+    "skip_e2e": true
   },
   {
     "comment": "Hex number is not treated as a simple value",
@@ -1119,7 +1119,6 @@
   {
     "comment": "Selection but explicitly ignore a vindex",
     "query": "select * from user ignore vindex (user_index) where id = 1",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user ignore vindex (user_index) where id = 1",
@@ -1137,12 +1136,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Selection but make the planner explicitly use a vindex",
     "query": "select intcol, id from user use vindex (name_user_map) where costly = 'aa' and name = 'bb' and id = 3",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select intcol, id from user use vindex (name_user_map) where costly = 'aa' and name = 'bb' and id = 3",
@@ -1189,13 +1188,14 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Vindex hint on a non-existing vindex",
     "query": "select * from user use vindex (does_not_exist) where id = 1",
-    "skip_e2e": true,
-    "plan": "VT09021: Vindex 'does_not_exist' does not exist in table 'user.user'"
+    "plan": "VT09021: Vindex 'does_not_exist' does not exist in table 'user.user'",
+    "skip_e2e": true
   },
   {
     "comment": "sharded limit offset",
@@ -1231,7 +1231,6 @@
   {
     "comment": "sharded limit offset with arguments",
     "query": "select user_id from music order by user_id limit :limit, :offset",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user_id from music order by user_id limit :limit, :offset",
@@ -1258,12 +1257,12 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Sharding Key Condition in Parenthesis",
     "query": "select * from user where name ='abc' AND (id = 4) limit 5",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user where name ='abc' AND (id = 4) limit 5",
@@ -1285,12 +1284,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Multiple parenthesized expressions",
     "query": "select * from user where (id = 4) AND (name ='abc') limit 5",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user where (id = 4) AND (name ='abc') limit 5",
@@ -1312,12 +1311,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Multiple parenthesized expressions",
     "query": "select * from user where (id = 4 and name ='abc') limit 5",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user where (id = 4 and name ='abc') limit 5",
@@ -1339,7 +1338,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Column Aliasing with Table.Column",
@@ -1396,7 +1396,6 @@
   {
     "comment": "Booleans and parenthesis",
     "query": "select * from user where (id = 1) AND name = true limit 5",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user where (id = 1) AND name = true limit 5",
@@ -1418,12 +1417,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Column as boolean-ish",
     "query": "select * from user where (id = 1) AND name limit 5",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user where (id = 1) AND name limit 5",
@@ -1445,12 +1444,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "PK as fake boolean, and column as boolean-ish",
     "query": "select * from user where (id = 5) AND name = true limit 5",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from user where (id = 5) AND name = true limit 5",
@@ -1472,12 +1471,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "top level subquery in select",
     "query": "select a, (select col from user) from unsharded",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select a, (select col from user) from unsharded",
@@ -1518,12 +1517,12 @@
         "main.unsharded",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "sub-expression subquery in select",
     "query": "select a, 1+(select col from user) from unsharded",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select a, 1+(select col from user) from unsharded",
@@ -1564,12 +1563,12 @@
         "main.unsharded",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select * from derived table expands specific columns",
     "query": "select * from (select user.id id1, user_extra.id id2 from user join user_extra) as t",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from (select user.id id1, user_extra.id id2 from user join user_extra) as t",
@@ -1607,24 +1606,24 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "duplicate columns not allowed in derived table",
     "query": "select * from (select user.id, user_extra.id from user join user_extra) as t",
-    "skip_e2e": true,
-    "plan": "Duplicate column name 'id'"
+    "plan": "Duplicate column name 'id'",
+    "skip_e2e": true
   },
   {
     "comment": "non-existent symbol in cross-shard derived table",
     "query": "select t.col from (select user.id from user join user_extra) as t",
-    "skip_e2e": true,
-    "plan": "column 't.col' not found"
+    "plan": "column 't.col' not found",
+    "skip_e2e": true
   },
   {
     "comment": "union with the same target shard",
     "query": "select * from music where user_id = 1 union select * from user where id = 1",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from music where user_id = 1 union select * from user where id = 1",
@@ -1647,12 +1646,12 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union with the same target shard last_insert_id",
     "query": "select *, last_insert_id() from music where user_id = 1 union select * from user where id = 1",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select *, last_insert_id() from music where user_id = 1 union select * from user where id = 1",
@@ -1675,7 +1674,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "unsharded union in derived table",
@@ -1815,7 +1815,6 @@
   {
     "comment": "routing rules: ensure directives are not lost",
     "query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from route2",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from route2",
@@ -1834,12 +1833,12 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "routing table on music",
     "query": "select * from second_user.bar where id > 2",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from second_user.bar where id > 2",
@@ -1857,7 +1856,8 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "testing SingleRow Projection",
@@ -1956,7 +1956,6 @@
   {
     "comment": "Complex expression in a subquery used in IN clause of an aggregate query",
     "query": "select count(*) from user where user.id = 2 or user.id in (select id from unsharded_a where colb = 2)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select count(*) from user where user.id = 2 or user.id in (select id from unsharded_a where colb = 2)",
@@ -2005,12 +2004,12 @@
         "main.unsharded_a",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Complex expression in a subquery used in NOT IN clause of an aggregate query",
     "query": "select count(*) from user where user.id = 2 or user.id not in (select id from unsharded_a where colb = 2)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select count(*) from user where user.id = 2 or user.id not in (select id from unsharded_a where colb = 2)",
@@ -2059,7 +2058,8 @@
         "main.unsharded_a",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "testing SingleRow Projection with arithmetics",
@@ -2262,19 +2262,18 @@
   {
     "comment": "sql_calc_found_rows in sub queries",
     "query": "select * from music where user_id IN (select sql_calc_found_rows * from music limit 10)",
-    "skip_e2e": true,
-    "plan": "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'"
+    "plan": "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
+    "skip_e2e": true
   },
   {
     "comment": "sql_calc_found_rows in derived table",
     "query": "select sql_calc_found_rows * from (select sql_calc_found_rows * from music limit 10) t limit 1",
-    "skip_e2e": true,
-    "plan": "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'"
+    "plan": "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
+    "skip_e2e": true
   },
   {
     "comment": "select from unsharded keyspace into dumpfile",
     "query": "select * from main.unsharded into Dumpfile 'x.txt'",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from main.unsharded into Dumpfile 'x.txt'",
@@ -2292,12 +2291,12 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select from unsharded keyspace into outfile",
     "query": "select * from main.unsharded into outfile 'x.txt' character set binary fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\n'",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from main.unsharded into outfile 'x.txt' character set binary fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\n'",
@@ -2315,12 +2314,12 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select from unsharded keyspace into outfile s3",
     "query": "select * from main.unsharded into outfile s3 'out_file_name' character set binary format csv header fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\n' manifest on overwrite off",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from main.unsharded into outfile s3 'out_file_name' character set binary format csv header fields terminated by 'term' optionally enclosed by 'c' escaped by 'e' lines starting by 'a' terminated by '\n' manifest on overwrite off",
@@ -2338,7 +2337,8 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "left join with a dual table on left - merge-able",
@@ -2549,20 +2549,20 @@
   {
     "comment": "Union after into outfile is incorrect",
     "query": "select id from user into outfile 'out_file_name' union all select id from music",
-    "skip_e2e": true,
-    "plan": "syntax error at position 55 near 'union'"
+    "plan": "syntax error at position 55 near 'union'",
+    "skip_e2e": true
   },
   {
     "comment": "Into outfile s3 in derived table is incorrect",
     "query": "select id from (select id from user into outfile s3 'inner_outfile') as t2",
-    "skip_e2e": true,
-    "plan": "syntax error at position 41 near 'into'"
+    "plan": "syntax error at position 41 near 'into'",
+    "skip_e2e": true
   },
   {
     "comment": "Into outfile s3 in derived table with union incorrect",
     "query": "select id from (select id from user into outfile s3 'inner_outfile' union select 1) as t2",
-    "skip_e2e": true,
-    "plan": "syntax error at position 41 near 'into'"
+    "plan": "syntax error at position 41 near 'into'",
+    "skip_e2e": true
   },
   {
     "comment": "select (select u.id from user as u where u.id = 1), a.id from user as a where a.id = 1",
@@ -2593,7 +2593,6 @@
   {
     "comment": "Add two tables with the same column in a join",
     "query": "select t.id, s.id from user t join user_extra s on t.id = s.user_id join unsharded",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select t.id, s.id from user t join user_extra s on t.id = s.user_id join unsharded",
@@ -2632,7 +2631,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "((((select 1))))",
@@ -2659,7 +2659,6 @@
   {
     "comment": "Merging dual with user",
     "query": "select 42, id from dual, user",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 42, id from dual, user",
@@ -2678,12 +2677,12 @@
         "main.dual",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "subquery in select expression of derived table",
     "query": "select t.a from (select (select col from user limit 1) as a from user join user_extra) t",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select t.a from (select (select col from user limit 1) as a from user join user_extra) t",
@@ -2749,12 +2748,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "ORDER BY subquery",
     "query": "select (select col from user limit 1) as a from user join user_extra order by a",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select (select col from user limit 1) as a from user join user_extra order by a",
@@ -2820,7 +2819,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "plan test for a natural character set string",
@@ -2847,7 +2847,6 @@
   {
     "comment": "select expression having dependencies on both sides of a join",
     "query": "select user.id * user_id as amount from user, user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.id * user_id as amount from user, user_extra",
@@ -2888,12 +2887,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Straight Join ensures specific ordering of joins",
     "query": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.foo",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.foo",
@@ -2934,7 +2933,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Dual query should be handled on the vtgate even with a LIMIT",
@@ -2961,7 +2961,6 @@
   {
     "comment": "PullOut subquery with an aggregation that should be typed in the final output",
     "query": "select (select sum(col) from user) from user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select (select sum(col) from user) from user_extra",
@@ -3009,12 +3008,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Straight Join preserved in MySQL query",
     "query": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.user_id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.id, user_extra.user_id from user straight_join user_extra where user.id = user_extra.user_id",
@@ -3033,12 +3032,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "correlated subquery in exists clause",
     "query": "select col from user where exists(select user_id from user_extra where user_id = 3 and user_id < user.id)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select col from user where exists(select user_id from user_extra where user_id = 3 and user_id < user.id)",
@@ -3092,12 +3091,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "correlated subquery in exists clause with an order by",
     "query": "select col from user where exists(select user_id from user_extra where user_id = 3 and user_id < user.id) order by col",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select col from user where exists(select user_id from user_extra where user_id = 3 and user_id < user.id) order by col",
@@ -3152,12 +3151,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "correlated subquery having dependencies on two tables",
     "query": "select 1 from user u1, user u2 where exists (select 1 from user_extra ue where ue.col = u1.col and ue.col = u2.col)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 1 from user u1, user u2 where exists (select 1 from user_extra ue where ue.col = u1.col and ue.col = u2.col)",
@@ -3226,12 +3225,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "correlated subquery using a column twice",
     "query": "select 1 from user u where exists (select 1 from user_extra ue where ue.col = u.col and u.col = ue.col2)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 1 from user u where exists (select 1 from user_extra ue where ue.col = u.col and u.col = ue.col2)",
@@ -3284,7 +3283,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "correlated subquery that is dependent on one side of a join, fully mergeable",
@@ -3316,7 +3316,6 @@
   {
     "comment": "Complex join with multiple conditions merged into single route",
     "query": "select 0 from user as u join user_extra as s on u.id = s.user_id join music as m on m.user_id = u.id and (s.foo or m.bar)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 0 from user as u join user_extra as s on u.id = s.user_id join music as m on m.user_id = u.id and (s.foo or m.bar)",
@@ -3336,7 +3335,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union as a derived table",
@@ -3380,7 +3380,6 @@
   {
     "comment": "use output column containing data from both sides of the join",
     "query": "select user_extra.col + user.col from user join user_extra on user.id = user_extra.id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user_extra.col + user.col from user join user_extra on user.id = user_extra.id",
@@ -3426,12 +3425,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "mergeable derived table with order by and limit",
     "query": "select 1 from (select col from main.unsharded order by main.unsharded.col1 desc limit 12 offset 0) as f left join unsharded as u on f.col = u.id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 1 from (select col from main.unsharded order by main.unsharded.col1 desc limit 12 offset 0) as f left join unsharded as u on f.col = u.id",
@@ -3449,12 +3448,12 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "mergeable derived table with group by and limit",
     "query": "select 1 from (select col, count(*) as a from main.unsharded group by col having a > 0 limit 12 offset 0) as f left join unsharded as u on f.col = u.id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 1 from (select col, count(*) as a from main.unsharded group by col having a > 0 limit 12 offset 0) as f left join unsharded as u on f.col = u.id",
@@ -3472,12 +3471,12 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select user.id, trim(leading 'x' from user.name) from user",
     "query": "select user.id, trim(leading 'x' from user.name) from user",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.id, trim(leading 'x' from user.name) from user",
@@ -3495,12 +3494,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "json utility functions",
     "query": "select jcol, JSON_STORAGE_SIZE(jcol), JSON_STORAGE_FREE(jcol), JSON_PRETTY(jcol) from user",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select jcol, JSON_STORAGE_SIZE(jcol), JSON_STORAGE_FREE(jcol), JSON_PRETTY(jcol) from user",
@@ -3518,7 +3517,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "dual query with exists clause",
@@ -3569,7 +3569,6 @@
   {
     "comment": "select (select id from user order by id limit 1) from user_extra",
     "query": "select (select id from user order by id limit 1) from user_extra",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select (select id from user order by id limit 1) from user_extra",
@@ -3617,7 +3616,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "yeah, it does not make sense, but it's valid",
@@ -3693,7 +3693,6 @@
   {
     "comment": "Json extract and json unquote shorthands",
     "query": "SELECT a->\"$[4]\", a->>\"$[3]\" FROM user",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT a->\"$[4]\", a->>\"$[3]\" FROM user",
@@ -3711,12 +3710,12 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "groupe by with non aggregated columns and table alias",
     "query": "select u.id, u.age from user u group by u.id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select u.id, u.age from user u group by u.id",
@@ -3734,7 +3733,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Functions that return JSON value attributes",
@@ -3922,7 +3922,6 @@
   {
     "comment": "insert function using column names as arguments",
     "query": "select insert(tcol1, id, 3, tcol2) from user",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select insert(tcol1, id, 3, tcol2) from user",
@@ -3940,7 +3939,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "gtid functions",
@@ -3967,7 +3967,6 @@
   {
     "comment": "Predicate in apply join which is merged",
     "query": "select user.col, user_metadata.user_id from user join user_extra on user.col = user_extra.col join user_metadata on user_extra.user_id = user_metadata.user_id where user.textcol1 = 'alice@gmail.com'",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.col, user_metadata.user_id from user join user_extra on user.col = user_extra.col join user_metadata on user_extra.user_id = user_metadata.user_id where user.textcol1 = 'alice@gmail.com'",
@@ -4009,12 +4008,12 @@
         "user.user_extra",
         "user.user_metadata"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Join across multiple tables, with conditions on different vindexes, but mergeable through join predicates",
     "query": "SELECT user.id FROM user INNER JOIN music_extra ON user.id = music_extra.user_id INNER JOIN music ON music_extra.user_id = music.user_id WHERE user.id = 123 and music.id = 456",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT user.id FROM user INNER JOIN music_extra ON user.id = music_extra.user_id INNER JOIN music ON music_extra.user_id = music.user_id WHERE user.id = 123 and music.id = 456",
@@ -4038,12 +4037,12 @@
         "user.music_extra",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "SQL_CALC_FOUND_ROWS with vindex lookup",
     "query": "select SQL_CALC_FOUND_ROWS id, name from user where name = 'aa' order by id limit 2",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select SQL_CALC_FOUND_ROWS id, name from user where name = 'aa' order by id limit 2",
@@ -4150,7 +4149,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "`None` route being merged with another route via join predicate on Vindex columns",
@@ -4178,7 +4178,6 @@
   {
     "comment": "Treating single value tuples as `EqualUnique` routes",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.user_id IN (5)) AND music.user_id = 5",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.user_id IN (5)) AND music.user_id = 5",
@@ -4200,7 +4199,8 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Subquery with `IN` condition using columns with matching lookup vindexes",
@@ -4257,7 +4257,6 @@
   {
     "comment": "Subquery with `IN` condition using columns with matching lookup vindexes, with inner scatter query",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.foo = 'bar') AND music.user_id IN (3, 4, 5)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.foo = 'bar') AND music.user_id IN (3, 4, 5)",
@@ -4279,7 +4278,8 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Subquery with `IN` condition using columns with matching lookup vindexes",
@@ -4376,7 +4376,6 @@
   {
     "comment": "Mergeable scatter subquery",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop')",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop')",
@@ -4394,12 +4393,12 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Mergeable scatter subquery with `GROUP BY` on unique vindex column",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop' GROUP BY music.id)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop' GROUP BY music.id)",
@@ -4417,12 +4416,12 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Unmergeable scatter subquery with `GROUP BY` on-non vindex column",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop' GROUP BY music.genre)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop' GROUP BY music.genre)",
@@ -4501,12 +4500,12 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Unmergeable scatter subquery with LIMIT",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop' LIMIT 10)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.genre = 'pop' LIMIT 10)",
@@ -4582,12 +4581,12 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Mergeable subquery with `MAX` aggregate and grouped by unique vindex",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id IN (5, 6) GROUP BY music.user_id)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id IN (5, 6) GROUP BY music.user_id)",
@@ -4661,7 +4660,8 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Unmergeable subquery with `MAX` aggregate",
@@ -4829,7 +4829,6 @@
   {
     "comment": "Mergeable subquery with `LIMIT` due to `EqualUnique` route",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id = 5 LIMIT 10)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id = 5 LIMIT 10)",
@@ -4903,7 +4902,8 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Mergeable subquery with multiple levels of derived statements",
@@ -4960,7 +4960,6 @@
   {
     "comment": "Unmergeable subquery with multiple levels of derived statements, using a multi value `IN` predicate",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT * FROM (SELECT * FROM (SELECT music.id FROM music WHERE music.user_id IN (5, 6) LIMIT 10) subquery_for_limit) subquery_for_limit)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT * FROM (SELECT * FROM (SELECT music.id FROM music WHERE music.user_id IN (5, 6) LIMIT 10) subquery_for_limit) subquery_for_limit)",
@@ -5040,12 +5039,12 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Unmergeable subquery with multiple levels of derived statements",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT * FROM (SELECT * FROM (SELECT music.id FROM music LIMIT 10) subquery_for_limit) subquery_for_limit)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT * FROM (SELECT * FROM (SELECT music.id FROM music LIMIT 10) subquery_for_limit) subquery_for_limit)",
@@ -5121,7 +5120,8 @@
       "TablesUsed": [
         "user.music"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "`None` subquery as top level predicate - outer query changes from `Scatter` to `None` on merge",
@@ -5270,7 +5270,6 @@
   {
     "comment": "limit on the vtgate has to be executed on the LHS of a join",
     "query": "select id from user join (select user_id from user_extra limit 10) ue on user.id = ue.user_id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select id from user join (select user_id from user_extra limit 10) ue on user.id = ue.user_id",
@@ -5321,12 +5320,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select user.a, t.b from user join (select id, count(*) b, req from user_extra group by req, id) as t on user.id = t.id",
     "query": "select user.a, t.b from user join (select id, count(*) b, req from user_extra group by req, id) as t on user.id = t.id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select user.a, t.b from user join (select id, count(*) b, req from user_extra group by req, id) as t on user.id = t.id",
@@ -5386,7 +5385,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "SELECT music.id FROM (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5) other JOIN music ON other.maxt = music.id",
@@ -5491,7 +5491,6 @@
   {
     "comment": "query with a derived table and dual table in unsharded keyspace",
     "query": "SELECT * FROM unsharded_a AS t1  JOIN (SELECT trim((SELECT MAX(name) FROM unsharded_a)) AS name) AS t2 WHERE t1.name >= t2.name ORDER BY t1.name ASC LIMIT 1;",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT * FROM unsharded_a AS t1  JOIN (SELECT trim((SELECT MAX(name) FROM unsharded_a)) AS name) AS t2 WHERE t1.name >= t2.name ORDER BY t1.name ASC LIMIT 1;",
@@ -5510,7 +5509,8 @@
         "main.dual",
         "main.unsharded_a"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "subquery having join table on clause, using column reference of outer select table",
@@ -5541,7 +5541,6 @@
   {
     "comment": "SOME modifier on unsharded table works well",
     "query": "select 1 from unsharded where foo = SOME (select 1 from unsharded_a where foo = 1)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 1 from unsharded where foo = SOME (select 1 from unsharded_a where foo = 1)",
@@ -5560,12 +5559,12 @@
         "main.unsharded",
         "main.unsharded_a"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "ALL modifier on unsharded table works well",
     "query": "select 1 from unsharded where foo = ALL (select 1 from unsharded_a where foo = 1)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 1 from unsharded where foo = ALL (select 1 from unsharded_a where foo = 1)",
@@ -5584,7 +5583,8 @@
         "main.unsharded",
         "main.unsharded_a"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "allow last_insert_id with argument",
@@ -5611,7 +5611,6 @@
   {
     "comment": "merge subquery using MAX and join into single route",
     "query": "select 1 from user join music_extra on user.id = music_extra.user_id where music_extra.music_id = (select max(music_id) from music_extra where user_id = user.id)",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select 1 from user join music_extra on user.id = music_extra.user_id where music_extra.music_id = (select max(music_id) from music_extra where user_id = user.id)",
@@ -5630,12 +5629,12 @@
         "user.music_extra",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Query with non-plannable lookup vindex",
     "query": "SELECT * FROM user_metadata WHERE user_metadata.non_planable = 'foo'",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT * FROM user_metadata WHERE user_metadata.non_planable = 'foo'",
@@ -5657,12 +5656,12 @@
       "TablesUsed": [
         "user.user_metadata"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "join query with lookup and join on different vindex column",
     "query": "select u.id from user u, user_metadata um where u.name = 'foo' and u.id = um.user_id",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select u.id from user u, user_metadata um where u.name = 'foo' and u.id = um.user_id",
@@ -5710,7 +5709,8 @@
         "user.user",
         "user.user_metadata"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "pick email as vindex lookup",
@@ -5788,7 +5788,6 @@
   {
     "comment": "name is in backfill vindex - not selected for vindex lookup",
     "query": "select * from customer where name = 'x'",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from customer where name = 'x'",
@@ -5806,7 +5805,8 @@
       "TablesUsed": [
         "user.customer"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "email vindex is costly than phone vindex - but phone vindex is backfiling hence ignored",
@@ -5913,7 +5913,6 @@
   {
     "comment": "invisible column is not expanded, but valid in predicate",
     "query": "select * from samecolvin where secret = 12",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select * from samecolvin where secret = 12",
@@ -5931,12 +5930,12 @@
       "TablesUsed": [
         "user.samecolvin"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "column with qualifier is correctly used",
     "query": "select u.foo, ue.foo as apa from user u, user_extra ue order by foo ",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select u.foo, ue.foo as apa from user u, user_extra ue order by foo ",
@@ -5975,12 +5974,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Derived tables going to a single shard still need to expand derived table columns",
     "query": "SELECT c.column_name FROM user c JOIN (SELECT table_name FROM unsharded LIMIT 1) AS tables ON tables.table_name = c.table_name",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT c.column_name FROM user c JOIN (SELECT table_name FROM unsharded LIMIT 1) AS tables ON tables.table_name = c.table_name",
@@ -6021,12 +6020,12 @@
         "main.unsharded",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "column name aliases in outer join queries",
     "query": "select name as t0, name as t1 from user left outer join user_extra on user.cola = user_extra.cola",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "select name as t0, name as t1 from user left outer join user_extra on user.cola = user_extra.cola",
@@ -6077,12 +6076,12 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Over clause works for unsharded tables",
     "query": "SELECT val, CUME_DIST() OVER w, ROW_NUMBER() OVER w, DENSE_RANK() OVER w, PERCENT_RANK() OVER w, RANK() OVER w AS 'cd' FROM unsharded_a",
-    "skip_e2e": true,
     "plan": {
       "QueryType": "SELECT",
       "Original": "SELECT val, CUME_DIST() OVER w, ROW_NUMBER() OVER w, DENSE_RANK() OVER w, PERCENT_RANK() OVER w, RANK() OVER w AS 'cd' FROM unsharded_a",
@@ -6100,7 +6099,8 @@
       "TablesUsed": [
         "main.unsharded_a"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "join with derived table with alias and join condition - merge into route",


### PR DESCRIPTION
## Description
In a recent PR, we added a new field to the plan tests. We forgot to keep them around when tests fail. This PR makes sure to keep the field around even if tests fail.

## Related Issue(s)
Issue introduced in #17117

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
