### PR TITLE
Fix `mysql_server_vault` CI test

### DIFF
--- a/build.env
+++ b/build.env
@@ -47,3 +47,4 @@ ln -sf "$PWD/misc/git/pre-commit" .git/hooks/pre-commit
 ln -sf "$PWD/misc/git/commit-msg" .git/hooks/commit-msg
 git config core.hooksPath .git/hooks
 export EXTRA_BIN=$PWD/test/bin
+:


### PR DESCRIPTION

## Description

The test is broken due to `EXTRA_BIN` directory non-existing. We ttempt to download the `vault` binary onto that directory, which of course fails:

https://github.com/vitessio/vitess/blob/e4dc8729ec6b987c8b582fcf0e2d7255e28d0694/go/test/endtoend/vault/vault_server.go#L61-L65

Initial commit: no fix; reproduce.

## Related Issue(s)

none.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
