### PR TITLE
Fix fuzzer paths

### DIFF
--- a/go/test/fuzzing/oss_fuzz_build.sh
+++ b/go/test/fuzzing/oss_fuzz_build.sh
@@ -54,10 +54,10 @@ mv api_marshal_fuzzer.go $SRC/vitess/go/test/fuzzing/
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzAPIMarshal api_marshal_fuzzer
 
 # collation fuzzer
-mv ./go/mysql/collations/uca_test.go \
-   ./go/mysql/collations/uca_test_fuzz.go
+mv ./go/mysql/collations/colldata/uca_test.go \
+   ./go/mysql/collations/colldata/uca_test_fuzz.go
 
-compile_go_fuzzer vitess.io/vitess/go/mysql/collations FuzzCollations fuzz_collations
+compile_go_fuzzer vitess.io/vitess/go/mysql/collations/colldata FuzzCollations fuzz_collations
 
 
 compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/planbuilder FuzzTestBuilder fuzz_test_builder gofuzz


### PR DESCRIPTION
These files were moved quite some time ago but the fuzzer build script was never updated with the new paths. This fixes that issue.

The refactor happened in https://github.com/vitessio/vitess/pull/13868

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required