### PR TITLE
CobraDocs: Remove commit hash from docs. Fix issue with workdir replacement

### DIFF
--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -171,6 +171,12 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 				continue
 			}
 			f := filepath.Join(dir, fullCmdFilename+".md")
+			if _, err := os.Stat(f); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					continue
+				}
+				return fmt.Errorf("failed to get file info for %s: %w", f, err)
+			}
 			if err := anonymizeHomedir(f); err != nil {
 				return fmt.Errorf("failed to anonymize homedir in help text for command %s: %w", f, err)
 			}

--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -171,12 +171,7 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 				continue
 			}
 			f := filepath.Join(dir, fullCmdFilename+".md")
-			if _, err := os.Stat(f); err != nil {
-				continue
-			}
-			if err := anonymizeHomedir(f); err != nil {
-				return fmt.Errorf("failed to anonymize homedir in help text for command %s: %w", f, err)
-			}
+			_ = anonymizeHomedir(f) // it is possible that the file does not exist, so we ignore the error
 			continue
 		}
 	}

--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -194,7 +194,7 @@ func anonymizeHomedir(file string) (err error) {
 	// We're replacing the stuff inside the square brackets in the example sed
 	// below:
 	// 	's:Paths to search for config files in. (default \[.*\])$:Paths to search for config files in. (default \[<WORKDIR>\]):'
-	sed := exec.Command("sed", "-i", "-e", fmt.Sprintf("s:%s:<WORKDIR>:i", wd), file)
+	sed := exec.Command("sed", "-i", "", "-e", fmt.Sprintf("s:%s:%s:", wd, "<WORKDIR>"), file)
 	if out, err := sed.CombinedOutput(); err != nil {
 		return fmt.Errorf("%w: %s", err, out)
 	}
@@ -224,7 +224,6 @@ func getCommitID(ref string) (string, error) {
 const frontmatter = `---
 title: %s
 series: %s
-commit: %s
 ---
 `
 
@@ -240,7 +239,7 @@ func frontmatterFilePrepender(sha string) func(filename string) string {
 
 		cmdName = strings.ReplaceAll(cmdName, "_", " ")
 
-		return fmt.Sprintf(frontmatter, cmdName, root, sha)
+		return fmt.Sprintf(frontmatter, cmdName, root)
 	}
 }
 

--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -172,10 +172,7 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 			}
 			f := filepath.Join(dir, fullCmdFilename+".md")
 			if _, err := os.Stat(f); err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					continue
-				}
-				return fmt.Errorf("failed to get file info for %s: %w", f, err)
+				continue
 			}
 			if err := anonymizeHomedir(f); err != nil {
 				return fmt.Errorf("failed to anonymize homedir in help text for command %s: %w", f, err)

--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -201,6 +201,9 @@ func anonymizeHomedir(file string) (err error) {
 	if err != nil {
 		return err
 	}
+	if _, err := os.Stat(file); err != nil {
+		return nil
+	}
 
 	// We're replacing the stuff inside the square brackets in the example sed
 	// below:

--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -116,7 +116,6 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 		fullCmdFilename := strings.Join([]string{name, cmd.Name()}, "_")
 
 		children := cmd.Commands()
-
 		switch {
 		case len(children) > 0:
 			// Command (top-level or not) with children.
@@ -151,7 +150,6 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 
 			oldName := filepath.Join(rootDir, fullCmdFilename+".md")
 			newName := filepath.Join(dir, fullCmdFilename+".md")
-
 			if err := os.Rename(oldName, newName); err != nil {
 				return fmt.Errorf("failed to move child command %s to its parent's dir: %w", fullCmdFilename, err)
 			}
@@ -166,6 +164,16 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 			}
 		default:
 			// Top-level command without children. Nothing to restructure.
+			// However we still need to anonymize the homedir in the help text.
+			if cmd.Name() == "help" {
+				// all commands with children have their own "help" subcommand,
+				// which we do not generate docs for
+				continue
+			}
+			f := filepath.Join(dir, fullCmdFilename+".md")
+			if err := anonymizeHomedir(f); err != nil {
+				return fmt.Errorf("failed to anonymize homedir in help text for command %s: %w", f, err)
+			}
 			continue
 		}
 	}

--- a/go/cmd/internal/docgen/docgen_test.go
+++ b/go/cmd/internal/docgen/docgen_test.go
@@ -41,7 +41,7 @@ func TestGenerateMarkdownTree(t *testing.T) {
 			name:      "current dir",
 			dir:       "./",
 			cmd:       &cobra.Command{},
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name:      "Permission denied",


### PR DESCRIPTION
## Description

* We remove the commit hash from the generated docs which resulted in unnecessary commits
* There was a failure in the `sed` command to replace `<WORKDIR>` due to incorrect sed invocation. Fixed here.
* There were files where the `WORKDIR` sed was not happening: fixed

## Related Issue(s)

There is a related website PR https://github.com/vitessio/website/pull/1904 which will enhance the current `make` target to generate the docs to add modified content files to git with an appropriate git message including the current vitess hash.

We need to first merge this PR into main and then run `make generated-docs` in the website PR before it is ready.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
