### PR TITLE
Flaky Migrate e2e tests: try explicitly killing processes before setting up new cluster

### DIFF
--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -933,6 +933,19 @@ func (vc *VitessCluster) startQuery(t *testing.T, query string) (func(t *testing
 	return commit, rollback
 }
 
+func killBinaries() {
+	binaries := []string{"mysqld_safe", "mysqld", "etcd", "mysqlctl", "mysqlctld", "vtgate", "vttablet", "vtctld", "vtctl", "vtorc"}
+	for _, bin := range binaries {
+		cmd := exec.Command("pkill", fmt.Sprintf(".*%s.*", bin))
+		err := cmd.Run()
+		if err != nil {
+			log.Infof("Error killing %s: %v", bin, err)
+		} else {
+			log.Infof("Killed %s", bin)
+		}
+	}
+}
+
 // setupDBTypeVersion will perform any work needed to enable a specific
 // database type and version if not already installed. It returns a
 // function to reset any environment changes made.

--- a/go/test/endtoend/vreplication/migrate_test.go
+++ b/go/test/endtoend/vreplication/migrate_test.go
@@ -48,6 +48,7 @@ func insertInitialDataIntoExternalCluster(t *testing.T, conn *mysql.Conn) {
 // hence the VTDATAROOT env variable gets overwritten.
 // Each time we need to create vt processes in the "other" cluster we need to set the appropriate VTDATAROOT
 func TestVtctlMigrate(t *testing.T) {
+	killBinaries()
 	vc = NewVitessCluster(t, nil)
 
 	oldDefaultReplicas := defaultReplicas
@@ -175,6 +176,7 @@ func TestVtctlMigrate(t *testing.T) {
 // hence the VTDATAROOT env variable gets overwritten.
 // Each time we need to create vt processes in the "other" cluster we need to set the appropriate VTDATAROOT
 func TestVtctldMigrateUnsharded(t *testing.T) {
+	killBinaries()
 	vc = NewVitessCluster(t, nil)
 
 	oldDefaultReplicas := defaultReplicas
@@ -320,6 +322,7 @@ func TestVtctldMigrateUnsharded(t *testing.T) {
 // doesn't match that of the source cluster. The test migrates from a cluster with keyspace customer to an "external"
 // cluster with keyspace rating.
 func TestVtctldMigrateSharded(t *testing.T) {
+	killBinaries()
 	setSidecarDBName("_vt")
 	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
 	oldDefaultReplicas := defaultReplicas


### PR DESCRIPTION
## Description

There has been a lot of flakiness in the e2e VReplication Migrate tests. Each of the ones I checked had a process not starting because a previous one had not been stopped. This happened even for the first test in the CI workflow. So possibly this is happening from previous workflows in reused test VMs or there is a bug somewhere in our cluster management.

Trying explicitly `pkill`ing the processes a test cluster creates to see if we can work around this.

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
