### PR TITLE
benchmark: TwoPC commit mode

### DIFF
--- a/go/test/endtoend/transaction/benchmark/bench_test.go
+++ b/go/test/endtoend/transaction/benchmark/bench_test.go
@@ -100,6 +100,13 @@ func cleanup(b *testing.B) {
 
 // BenchmarkTwoPCCommit benchmarks the performance of a two-phase commit transaction
 // with varying numbers of inserts.
+// Recommended run options:
+/*
+export ver=v1 p=~/path && go test \
+-run '^$' -bench '^BenchmarkTwoPCCommit' \
+-benchtime 3s -count 6 -cpu 8
+| tee $p/${ver}.txt
+*/
 func BenchmarkTwoPCCommit(b *testing.B) {
 	// Pre-generate 100 random strings
 	const sampleSize = 100
@@ -119,10 +126,9 @@ func BenchmarkTwoPCCommit(b *testing.B) {
 	// Incremental id for inserts
 	id := 1
 
-	for _, commitMode := range []string{"multi", "twopc"} {
-
-		for _, tc := range testCases {
-			conn, done := start(b)
+	for _, tc := range testCases {
+		for _, commitMode := range []string{"twopc", "multi"} {
+			conn, _ := start(b)
 			_, err := conn.ExecuteFetch(fmt.Sprintf("set transaction_mode = %s", commitMode), 0, false)
 			if err != nil {
 				b.Fatal(err)
@@ -151,7 +157,7 @@ func BenchmarkTwoPCCommit(b *testing.B) {
 					}
 				}
 			})
-			done()
+			conn.Close()
 		}
 	}
 }

--- a/go/test/endtoend/transaction/benchmark/bench_test.go
+++ b/go/test/endtoend/transaction/benchmark/bench_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	twopcutil "vitess.io/vitess/go/test/endtoend/transaction/twopc/utils"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	keyspaceName    = "ks"
+	cell            = "zone1"
+	hostname        = "localhost"
+	sidecarDBName   = "vt_ks"
+
+	//go:embed schema.sql
+	SchemaSQL string
+
+	//go:embed vschema.json
+	VSchema string
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitcode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:             keyspaceName,
+			SchemaSQL:        SchemaSQL,
+			VSchema:          VSchema,
+			SidecarDBName:    sidecarDBName,
+			DurabilityPolicy: "semi_sync",
+		}
+		if err := clusterInstance.StartKeyspace(*keyspace, []string{"-40", "40-80", "80-c0", "c0-"}, 1, false); err != nil {
+			return 1
+		}
+
+		// Start Vtgate
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+		vtParams = clusterInstance.GetVTParams(keyspaceName)
+
+		return m.Run()
+	}()
+	os.Exit(exitcode)
+}
+
+func start(b *testing.B) (*mysql.Conn, func()) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(b, err)
+	cleanup(b)
+
+	return conn, func() {
+		conn.Close()
+		cleanup(b)
+	}
+}
+
+func cleanup(b *testing.B) {
+	twopcutil.ClearOutTable(b, vtParams, "test")
+}
+
+// BenchmarkTwoPCCommit benchmarks the performance of a two-phase commit transaction
+// with varying numbers of inserts.
+func BenchmarkTwoPCCommit(b *testing.B) {
+	// Pre-generate 100 random strings
+	const sampleSize = 100
+	randomStrings := generateRandomStrings(sampleSize, 25)
+
+	// Define table-driven test cases
+	testCases := []struct {
+		name       string
+		shardStart []int // Number of different shard involved per transaction
+	}{
+		{name: "SingleShard", shardStart: []int{1}},
+		{name: "TwoShards", shardStart: []int{3, 4}},
+		{name: "ThreeShards", shardStart: []int{2, 3, 4}},
+		{name: "FourShards", shardStart: []int{4, 3, 2, 1}},
+	}
+
+	// Incremental id for inserts
+	id := 1
+
+	for _, commitMode := range []string{"multi", "twopc"} {
+
+		for _, tc := range testCases {
+			conn, done := start(b)
+			_, err := conn.ExecuteFetch(fmt.Sprintf("set transaction_mode = %s", commitMode), 0, false)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Run(commitMode+tc.name, func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, err = conn.ExecuteFetch("begin", 0, false)
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					randomMsg := randomStrings[id%sampleSize]
+					// Perform the specified number of inserts to specific shards
+					for _, val := range tc.shardStart {
+						_, err = conn.ExecuteFetch(fmt.Sprintf("insert into test(id, msg) values(%d, '%s')", val+(4*id), randomMsg), 0, false)
+						if err != nil {
+							b.Fatal(err)
+						}
+					}
+					id++
+
+					_, err = conn.ExecuteFetch("commit", 0, false)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			done()
+		}
+	}
+}
+
+// generateRandomStrings generates 'n' random strings, each of length 'length'.
+func generateRandomStrings(n, length int) []string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]string, n)
+	for i := range result {
+		b := make([]byte, length)
+		for j := range b {
+			b[j] = charset[rand.Intn(len(charset))]
+		}
+		result[i] = string(b)
+	}
+	return result
+}

--- a/go/test/endtoend/transaction/benchmark/schema.sql
+++ b/go/test/endtoend/transaction/benchmark/schema.sql
@@ -1,0 +1,5 @@
+create table test (
+    id bigint,
+    msg varchar(25),
+    primary key (id)
+) Engine=InnoDB;

--- a/go/test/endtoend/transaction/benchmark/vschema.json
+++ b/go/test/endtoend/transaction/benchmark/vschema.json
@@ -1,0 +1,18 @@
+{
+  "sharded":true,
+  "vindexes": {
+    "hash_index": {
+      "type": "reverse_bits"
+    }
+  },
+  "tables": {
+    "test": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "hash_index"
+        }
+      ]
+    }
+  }
+}

--- a/go/test/endtoend/transaction/twopc/utils/utils.go
+++ b/go/test/endtoend/transaction/twopc/utils/utils.go
@@ -44,7 +44,7 @@ const (
 
 // ClearOutTable deletes everything from a table. Sometimes the table might have more rows than allowed in a single delete query,
 // so we have to do the deletions iteratively.
-func ClearOutTable(t *testing.T, vtParams mysql.ConnParams, tableName string) {
+func ClearOutTable(t testing.TB, vtParams mysql.ConnParams, tableName string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	for {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR benchmarks two Commit Modes:
1. Best Effort Commit (multi) – commits sequentially across shards.
2. Atomic Commit (TwoPC) – ensures atomicity through a multi-step process with parallel phases.

The benchmarks measure performance across transactions involving varying numbers of shards. 
Results are provided for 4, 8, and 16 shard configurations. 

4 shards
```
                          │ multi_v4.txt │             twopc_v4.txt             │
                          │    sec/op    │    sec/op     vs base                │
TwoPCCommit/SingleShard-8    756.5µ ± 1%   764.6µ ±  2%         ~ (p=0.180 n=6)
TwoPCCommit/TwoShards-8      1.545m ± 4%   3.386m ±  4%  +119.08% (p=0.002 n=6)
TwoPCCommit/ThreeShards-8    2.393m ± 2%   4.877m ± 14%  +103.82% (p=0.002 n=6)
TwoPCCommit/FourShards-8     3.309m ± 4%   6.098m ±  6%   +84.29% (p=0.002 n=6)
geomean                      1.744m        2.962m         +69.82%
```

8 shards
```
                          │ multi_8shards.txt │          twopc_8shards.txt           │
                          │      sec/op       │    sec/op     vs base                │
TwoPCCommit/SingleShard-8        750.3µ ±  1%    754.0µ ± 1%         ~ (p=0.818 n=6)
TwoPCCommit/TwoShards-8          1.528m ±  8%    3.448m ± 4%  +125.63% (p=0.002 n=6)
TwoPCCommit/FourShards-8         3.269m ±  3%    6.149m ± 5%   +88.10% (p=0.002 n=6)
TwoPCCommit/SixShards-8          5.176m ±  6%    8.577m ± 7%   +65.71% (p=0.002 n=6)
TwoPCCommit/EightShards-8        7.140m ± 11%   10.968m ± 5%   +53.62% (p=0.002 n=6)
geomean                          2.681m          4.320m        +61.12%
```



16 shards
```
                            │ multi_16shards.txt │          twopc_16shards.txt          │
                            │       sec/op       │    sec/op      vs base               │
TwoPCCommit/EightShards-8           7.611m ±  6%   11.261m ± 11%  +47.97% (p=0.002 n=6)
TwoPCCommit/TwelveShard-8           12.19m ± 10%    17.21m ± 11%  +41.18% (p=0.002 n=6)
TwoPCCommit/SixteenShards-8         17.35m ± 15%    24.06m ± 10%  +38.69% (p=0.002 n=6)
geomean                             11.72m          16.71m        +42.56%
```

Summary
* Best Effort Commit scales poorly as the number of shards increases due to its sequential execution of commits.
* Atomic Commit (TwoPC) incurs higher overhead but offers atomicity guarantees. Its parallel phases help reduce the performance gap as the shard count grows.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes #16245 

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
