### PR TITLE
Use non-deprecated flags to skip replication

### DIFF
--- a/config/mycnf/default.cnf
+++ b/config/mycnf/default.cnf
@@ -16,10 +16,6 @@ secure-file-priv = {{.SecureFilePriv}}
 
 server-id = {{.ServerID}}
 
-# all db instances should skip starting replication threads - that way we can do any
-# additional configuration (like enabling semi-sync) before we connect to
-# the source.
-skip_slave_start
 socket = {{.SocketFile}}
 tmpdir = {{.TmpDir}}
 

--- a/config/mycnf/mariadb10.cnf
+++ b/config/mycnf/mariadb10.cnf
@@ -1,5 +1,10 @@
 # This file is auto-included when MariaDB 10 is detected.
 
+# all db instances should skip starting replication threads - that way we can do any
+# additional configuration (like enabling semi-sync) before we connect to
+# the source.
+skip_slave_start
+
 # Semi-sync replication is required for automated unplanned failover
 # (when the primary goes away). Here we just load the plugin so it's
 # available if desired, but it's disabled at startup.

--- a/config/mycnf/mysql57.cnf
+++ b/config/mycnf/mysql57.cnf
@@ -1,5 +1,10 @@
 # This file is auto-included when MySQL 5.7 is detected.
 
+# all db instances should skip starting replication threads - that way we can do any
+# additional configuration (like enabling semi-sync) before we connect to
+# the source.
+skip_slave_start
+
 # MySQL 5.7 does not enable the binary log by default, and 
 # info repositories default to file
 

--- a/config/mycnf/mysql80.cnf
+++ b/config/mycnf/mysql80.cnf
@@ -1,5 +1,10 @@
 # This file is auto-included when MySQL 8.0 is detected.
 
+# all db instances should skip starting replication threads - that way we can do any
+# additional configuration (like enabling semi-sync) before we connect to
+# the source.
+skip_slave_start
+
 # MySQL 8.0 enables binlog by default with sync_binlog and TABLE info repositories
 # It does not enable GTIDs or enforced GTID consistency
 

--- a/config/mycnf/mysql8026.cnf
+++ b/config/mycnf/mysql8026.cnf
@@ -1,5 +1,10 @@
 # This file is auto-included when MySQL 8.0.26 or later is detected.
 
+# all db instances should skip starting replication threads - that way we can do any
+# additional configuration (like enabling semi-sync) before we connect to
+# the source.
+skip_replica_start
+
 # MySQL 8.0 enables binlog by default with sync_binlog and TABLE info repositories
 # It does not enable GTIDs or enforced GTID consistency
 

--- a/config/mycnf/mysql84.cnf
+++ b/config/mycnf/mysql84.cnf
@@ -1,5 +1,10 @@
 # This file is auto-included when MySQL 8.4.0 or later is detected.
 
+# all db instances should skip starting replication threads - that way we can do any
+# additional configuration (like enabling semi-sync) before we connect to
+# the source.
+skip_replica_start
+
 # MySQL 8.0 enables binlog by default with sync_binlog and TABLE info repositories
 # It does not enable GTIDs or enforced GTID consistency
 

--- a/config/mycnf/sbr.cnf
+++ b/config/mycnf/sbr.cnf
@@ -1,3 +1,0 @@
-# This file is used to allow legacy tests to pass
-# In theory it should not be required
-binlog_format=statement


### PR DESCRIPTION
This currently triggers a warning on more recent MySQL versions. Instead we can move it to the version specific files so we can use the correct non-deprecated name.

## Related Issue(s)

Part of improving things for #16466

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required