### PR TITLE
Improved Compatibility Around LAST_INSERT_ID - evalengine

### DIFF
--- a/changelog/22.0/22.0.0/summary.md
+++ b/changelog/22.0/22.0.0/summary.md
@@ -10,6 +10,7 @@
   - **[VTOrc Config File Changes](#vtorc-config-file-changes)**
   - **[VTGate Config File Changes](#vtgate-config-file-changes)**
   - **[Support for More Efficient JSON Replication](#efficient-json-replication)**
+  - **[Support for LAST_INSERT_ID(x)](#last-insert-id)**
 - **[Minor Changes](#minor-changes)**
   - **[VTTablet Flags](#flags-vttablet)**
   - **[Topology read concurrency behaviour changes](#topo-read-concurrency-changes)**
@@ -80,6 +81,12 @@ In [#7345](https://github.com/vitessio/vitess/pull/17345) we added support for [
 
 If you are using MySQL 8.0 or later and using JSON columns, you can now enable this MySQL feature across your Vitess cluster(s) to lower the disk space needed for binary logs and improve the CPU and memory usage in both `mysqld` (standard intrashard MySQL replication) and `vttablet` ([VReplication](https://vitess.io/docs/reference/vreplication/vreplication/)) without losing any capabilities or features.
 
+### <a id="last-insert-id"/>Support for `LAST_INSERT_ID(x)`</a>
+
+In [#17408](https://github.com/vitessio/vitess/pull/17408) and [#17409](https://github.com/vitessio/vitess/pull/17409), we added the ability to use `LAST_INSERT_ID(x)` in Vitess directly at vtgate. This improvement allows certain queries—like `SELECT last_insert_id(123);` or `SELECT last_insert_id(count(*)) ...`—to be handled without relying on MySQL for the final value.
+
+**Limitations**:
+- When using `LAST_INSERT_ID(x)` in ordered queries (e.g., `SELECT last_insert_id(col) FROM table ORDER BY foo`), MySQL sets the session’s last-insert-id value according to the *last row returned*. Vitess does not guarantee the same behavior.
 
 ## <a id="minor-changes"/>Minor Changes</a>
 

--- a/go/test/endtoend/utils/cmp.go
+++ b/go/test/endtoend/utils/cmp.go
@@ -215,8 +215,8 @@ func (mcmp *MySQLCompare) Exec(query string) *sqltypes.Result {
 	return vtQr
 }
 
-// ExecVitessAndMySQL executes Vitess and MySQL with the queries provided.
-func (mcmp *MySQLCompare) ExecVitessAndMySQL(vtQ, mQ string) *sqltypes.Result {
+// ExecVitessAndMySQLDifferentQueries executes Vitess and MySQL with the queries provided.
+func (mcmp *MySQLCompare) ExecVitessAndMySQLDifferentQueries(vtQ, mQ string) *sqltypes.Result {
 	mcmp.t.Helper()
 	vtQr, err := mcmp.VtConn.ExecuteFetch(vtQ, 1000, true)
 	require.NoError(mcmp.t, err, "[Vitess Error] for query: "+vtQ)

--- a/go/test/endtoend/vtgate/plan_tests/plan_e2e_test.go
+++ b/go/test/endtoend/vtgate/plan_tests/plan_e2e_test.go
@@ -49,7 +49,7 @@ func TestE2ECases(t *testing.T) {
 				require.NoError(mcmp.AsT(), err)
 				sqlparser.RemoveKeyspaceIgnoreSysSchema(stmt)
 
-				mcmp.ExecVitessAndMySQL(test.Query, sqlparser.String(stmt))
+				mcmp.ExecVitessAndMySQLDifferentQueries(test.Query, sqlparser.String(stmt))
 				pd := utils.ExecTrace(mcmp.AsT(), mcmp.VtConn, test.Query)
 				verifyTestExpectations(mcmp.AsT(), pd, test)
 				if mcmp.VtConn.IsClosed() {

--- a/go/test/endtoend/vtgate/queries/misc/main_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/main_test.go
@@ -95,7 +95,7 @@ func TestMain(m *testing.M) {
 		vtParams = clusterInstance.GetVTParams(keyspaceName)
 
 		// create mysql instance and connection parameters
-		conn, closer, err := utils.NewMySQL(clusterInstance, keyspaceName, schemaSQL)
+		conn, closer, err := utils.NewMySQL(clusterInstance, keyspaceName, schemaSQL, uschemaSQL)
 		if err != nil {
 			fmt.Println(err)
 			return 1

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -163,6 +163,7 @@ func TestSetAndGetLastInsertID(t *testing.T) {
 		"update t1 set id2 = last_insert_id(%d) where id1 = 2",
 		"update t1 set id2 = 88 where id1 = last_insert_id(%d)",
 		"delete from t1 where id1 = last_insert_id(%d)",
+		"select id2, last_insert_id(count(*)) from t1 where %d group by id2",
 	}
 
 	for _, workload := range []string{"olap", "oltp"} {
@@ -175,7 +176,7 @@ func TestSetAndGetLastInsertID(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Insert a row for UPDATE tests
+			// Insert a few rows for UPDATE tests
 			mcmp.Exec("insert into t1 (id1, id2) values (1, 10)")
 
 			for _, query := range queries {

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -917,3 +917,11 @@ func TestCloneComments(t *testing.T) {
 		assert.Equal(t, "b", val)
 	}
 }
+
+func TestRemoveKeyspace(t *testing.T) {
+	stmt, err := NewTestParser().Parse("select 1 from uks.unsharded")
+	require.NoError(t, err)
+	RemoveKeyspaceIgnoreSysSchema(stmt)
+
+	require.Equal(t, "select 1 from unsharded", String(stmt))
+}

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -465,7 +465,7 @@ func (cached *Insert) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(240)
+		size += int64(224)
 	}
 	// field InsertCommon vitess.io/vitess/go/vt/vtgate/engine.InsertCommon
 	size += cached.InsertCommon.CachedSize(false)

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -893,6 +893,9 @@ func (t *loggingVCursor) RecordMirrorStats(sourceExecTime, targetExecTime time.D
 	}
 }
 
+func (t *loggingVCursor) SetLastInsertID(id uint64) {}
+func (t *noopVCursor) SetLastInsertID(id uint64)    {}
+
 func (t *noopVCursor) VExplainLogging() {}
 func (t *noopVCursor) DisableLogging()  {}
 func (t *noopVCursor) GetVExplainLogs() []ExecuteEntry {

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -400,6 +400,20 @@ func (t *noopVCursor) GetDBDDLPluginName() string {
 	panic("unimplemented")
 }
 
+func (t *noopVCursor) SetLastInsertID(uint64) {}
+func (t *noopVCursor) VExplainLogging()       {}
+func (t *noopVCursor) DisableLogging()        {}
+func (t *noopVCursor) GetVExplainLogs() []ExecuteEntry {
+	return nil
+}
+func (t *noopVCursor) GetLogs() ([]ExecuteEntry, error) {
+	return nil, nil
+}
+
+// RecordMirrorStats implements VCursor.
+func (t *noopVCursor) RecordMirrorStats(sourceExecTime, targetExecTime time.Duration, targetErr error) {
+}
+
 var (
 	_ VCursor        = (*loggingVCursor)(nil)
 	_ SessionActions = (*loggingVCursor)(nil)
@@ -891,23 +905,6 @@ func (t *loggingVCursor) RecordMirrorStats(sourceExecTime, targetExecTime time.D
 	if t.onRecordMirrorStatsFn != nil {
 		t.onRecordMirrorStatsFn(sourceExecTime, targetExecTime, targetErr)
 	}
-}
-
-func (t *loggingVCursor) SetLastInsertID(id uint64) {}
-func (t *noopVCursor) SetLastInsertID(id uint64)    {}
-
-func (t *noopVCursor) VExplainLogging() {}
-func (t *noopVCursor) DisableLogging()  {}
-func (t *noopVCursor) GetVExplainLogs() []ExecuteEntry {
-	return nil
-}
-
-func (t *noopVCursor) GetLogs() ([]ExecuteEntry, error) {
-	return nil, nil
-}
-
-// RecordMirrorStats implements VCursor.
-func (t *noopVCursor) RecordMirrorStats(sourceExecTime, targetExecTime time.Duration, targetErr error) {
 }
 
 func expectResult(t *testing.T, result, want *sqltypes.Result) {

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -58,11 +58,9 @@ type Insert struct {
 
 	// Alias represents the row alias with columns if specified in the query.
 	Alias string
-
-	FetchLastInsertID bool
 }
 
-// newQueryInsert creates an Insert with a query string.
+// newQueryInsert creates an Insert with a query string. Used in testing.
 func newQueryInsert(opcode InsertOpcode, keyspace *vindexes.Keyspace, query string) *Insert {
 	return &Insert{
 		InsertCommon: InsertCommon{
@@ -73,7 +71,7 @@ func newQueryInsert(opcode InsertOpcode, keyspace *vindexes.Keyspace, query stri
 	}
 }
 
-// newInsert creates a new Insert.
+// newInsert creates a new Insert. Used in testing.
 func newInsert(
 	opcode InsertOpcode,
 	ignore bool,

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -161,7 +161,7 @@ func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor
 	if err != nil {
 		return nil, err
 	}
-	qr, err := execShard(ctx, loggingPrimitive, vcursor, query, bindVars, rss[0], true, !ins.PreventAutoCommit /* canAutocommit */, false)
+	qr, err := execShard(ctx, loggingPrimitive, vcursor, query, bindVars, rss[0], true, !ins.PreventAutoCommit /* canAutocommit */, ins.FetchLastInsertID)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/engine/insert_select.go
+++ b/go/vt/vtgate/engine/insert_select.go
@@ -51,7 +51,7 @@ type (
 	}
 )
 
-// newInsertSelect creates a new InsertSelect.
+// newInsertSelect creates a new InsertSelect. Used in testing.
 func newInsertSelect(
 	ignore bool,
 	keyspace *vindexes.Keyspace,

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -147,6 +147,8 @@ type (
 
 		// RecordMirrorStats is used to record stats about a mirror query.
 		RecordMirrorStats(time.Duration, time.Duration, error)
+
+		SetLastInsertID(uint64)
 	}
 
 	// SessionActions gives primitives ability to interact with the session state

--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -22,23 +22,18 @@ import (
 	"fmt"
 	"strings"
 
-	"vitess.io/vitess/go/vt/sqlparser"
-	"vitess.io/vitess/go/vt/sysvars"
-
-	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
-
-	"vitess.io/vitess/go/vt/log"
-
-	"vitess.io/vitess/go/vt/srvtopo"
-
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/sysvars"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1181,6 +1181,18 @@ func (cached *builtinLastDay) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinLastInsertID) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinLeftRight) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -5141,21 +5141,15 @@ func (asm *assembler) Introduce(offset int, t sqltypes.Type, col collations.Type
 
 func (asm *assembler) Fn_LAST_INSERT_ID() {
 	asm.emit(func(env *ExpressionEnv) int {
-		arg := env.vm.stack[env.vm.sp-1].(*evalUint64)
-		env.VCursor().SetLastInsertID(arg.u)
+		arg := env.vm.stack[env.vm.sp-1]
+		if arg == nil {
+			env.VCursor().SetLastInsertID(0)
+		} else {
+			iarg := evalToInt64(arg)
+			uarg := env.vm.arena.newEvalUint64(uint64(iarg.i))
+			env.vm.stack[env.vm.sp-1] = uarg
+			env.VCursor().SetLastInsertID(uarg.u)
+		}
 		return 1
 	}, "FN LAST_INSERT_ID UINT64(SP-1)")
-}
-
-func (asm *assembler) Fn_LAST_INSERT_ID_NULL() {
-	asm.emit(func(env *ExpressionEnv) int {
-		env.VCursor().SetLastInsertID(0)
-		return 1
-	}, "FN LAST_INSERT_ID NULL")
-}
-
-func (asm *assembler) addJump(end *jump) {
-	asm.emit(func(env *ExpressionEnv) int {
-		return end.offset()
-	}, "JUMP")
 }

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -5138,3 +5138,24 @@ func (asm *assembler) Introduce(offset int, t sqltypes.Type, col collations.Type
 		return 1
 	}, "INTRODUCE (SP-1)")
 }
+
+func (asm *assembler) Fn_LAST_INSERT_ID() {
+	asm.emit(func(env *ExpressionEnv) int {
+		arg := env.vm.stack[env.vm.sp-1].(*evalUint64)
+		env.VCursor().SetLastInsertID(arg.u)
+		return 1
+	}, "FN LAST_INSERT_ID UINT64(SP-1)")
+}
+
+func (asm *assembler) Fn_LAST_INSERT_ID_NULL() {
+	asm.emit(func(env *ExpressionEnv) int {
+		env.VCursor().SetLastInsertID(0)
+		return 1
+	}, "FN LAST_INSERT_ID NULL")
+}
+
+func (asm *assembler) addJump(end *jump) {
+	asm.emit(func(env *ExpressionEnv) int {
+		return end.offset()
+	}, "JUMP")
+}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -903,6 +903,99 @@ func TestBindVarLiteral(t *testing.T) {
 	}
 }
 
+type testVcursor struct {
+	lastInsertID *uint64
+	env          *vtenv.Environment
+}
+
+func (t *testVcursor) TimeZone() *time.Location {
+	return time.UTC
+}
+
+func (t *testVcursor) GetKeyspace() string {
+	return "apa"
+}
+
+func (t *testVcursor) SQLMode() string {
+	return "oltp"
+}
+
+func (t *testVcursor) Environment() *vtenv.Environment {
+	return t.env
+}
+
+func (t *testVcursor) SetLastInsertID(id uint64) {
+	t.lastInsertID = &id
+}
+
+var _ evalengine.VCursor = (*testVcursor)(nil)
+
+func TestLastInsertID(t *testing.T) {
+	var testCases = []struct {
+		expression string
+		result     uint64
+		missing    bool
+	}{
+		{
+			expression: `last_insert_id(1)`,
+			result:     1,
+		}, {
+			expression: `12`,
+			missing:    true,
+		}, {
+			expression: `last_insert_id(666)`,
+			result:     666,
+		}, {
+			expression: `last_insert_id(null)`,
+			result:     0,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			cfg := &evalengine.Config{
+				Collation:         collations.CollationUtf8mb4ID,
+				NoConstantFolding: true,
+				NoCompilation:     false,
+				Environment:       venv,
+			}
+			t.Run("eval", func(t *testing.T) {
+				cfg.NoCompilation = true
+				runTest(t, expr, cfg, tc)
+			})
+			t.Run("compiled", func(t *testing.T) {
+				cfg.NoCompilation = false
+				runTest(t, expr, cfg, tc)
+			})
+		})
+	}
+}
+
+func runTest(t *testing.T, expr sqlparser.Expr, cfg *evalengine.Config, tc struct {
+	expression string
+	result     uint64
+	missing    bool
+}) {
+	converted, err := evalengine.Translate(expr, cfg)
+	require.NoError(t, err)
+
+	vc := &testVcursor{env: vtenv.NewTestEnv()}
+	env := evalengine.NewExpressionEnv(context.Background(), nil, vc)
+
+	_, err = env.Evaluate(converted)
+	require.NoError(t, err)
+	if tc.missing {
+		require.Nil(t, vc.lastInsertID)
+	} else {
+		require.NotNil(t, vc.lastInsertID)
+		require.Equal(t, tc.result, *vc.lastInsertID)
+	}
+}
+
 func TestCompilerNonConstant(t *testing.T) {
 	var testCases = []struct {
 		expression string

--- a/go/vt/vtgate/evalengine/expr_env.go
+++ b/go/vt/vtgate/evalengine/expr_env.go
@@ -35,6 +35,7 @@ type VCursor interface {
 	GetKeyspace() string
 	SQLMode() string
 	Environment() *vtenv.Environment
+	SetLastInsertID(id uint64)
 }
 
 type (
@@ -140,6 +141,7 @@ func (e *emptyVCursor) GetKeyspace() string {
 func (e *emptyVCursor) SQLMode() string {
 	return config.DefaultSQLMode
 }
+func (e *emptyVCursor) SetLastInsertID(_ uint64) {}
 
 func NewEmptyVCursor(env *vtenv.Environment, tz *time.Location) VCursor {
 	return &emptyVCursor{env: env, tz: tz}

--- a/go/vt/vtgate/evalengine/fn_misc.go
+++ b/go/vt/vtgate/evalengine/fn_misc.go
@@ -219,19 +219,8 @@ func (call *builtinLastInsertID) compile(c *compiler) (ctype, error) {
 	if err != nil {
 		return ctype{}, err
 	}
-
-	setZero := c.compileNullCheck1(arg)
-	c.compileToUint64(arg, 1)
 	c.asm.Fn_LAST_INSERT_ID()
-	end := c.asm.jumpFrom()
-	c.asm.addJump(end)
-
-	c.asm.jumpDestination(setZero)
-	c.asm.Fn_LAST_INSERT_ID_NULL()
-
-	c.asm.jumpDestination(end)
-
-	return ctype{Type: sqltypes.Uint64, Flag: flagNullable, Col: collationNumeric}, nil
+	return ctype{Type: sqltypes.Uint64, Flag: arg.Flag & flagNullable, Col: collationNumeric}, nil
 }
 
 func printIPv6AsIPv4(addr netip.Addr) (netip.Addr, bool) {

--- a/go/vt/vtgate/evalengine/fn_misc.go
+++ b/go/vt/vtgate/evalengine/fn_misc.go
@@ -223,6 +223,10 @@ func (call *builtinLastInsertID) compile(c *compiler) (ctype, error) {
 	return ctype{Type: sqltypes.Uint64, Flag: arg.Flag & flagNullable, Col: collationNumeric}, nil
 }
 
+func (call *builtinLastInsertID) constant() bool {
+	return false // we don't want this function to be simplified away
+}
+
 func printIPv6AsIPv4(addr netip.Addr) (netip.Addr, bool) {
 	b := addr.AsSlice()
 	if len(b) != 16 {

--- a/go/vt/vtgate/evalengine/fn_misc.go
+++ b/go/vt/vtgate/evalengine/fn_misc.go
@@ -160,7 +160,6 @@ func (call *builtinInetNtoa) compile(c *compiler) (ctype, error) {
 	c.compileToUint64(arg, 1)
 	col := typedCoercionCollation(sqltypes.VarChar, call.collate)
 	c.asm.Fn_INET_NTOA(col)
-
 	c.asm.jumpDestination(skip)
 
 	return ctype{Type: sqltypes.VarChar, Flag: flagNullable, Col: col}, nil

--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -209,6 +209,10 @@ type vcursor struct {
 	env *vtenv.Environment
 }
 
+func (vc *vcursor) SetLastInsertID(id uint64) {}
+
+var _ evalengine.VCursor = (*vcursor)(nil)
+
 func (vc *vcursor) GetKeyspace() string {
 	return "vttest"
 }

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -662,6 +662,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 			return nil, argError(method)
 		}
 		return &builtinReplace{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "last_insert_id":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinLastInsertID{CallExpr: call}, nil
 	default:
 		return nil, translateExprNotSupported(fn)
 	}

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1594,3 +1594,9 @@ func (vc *VCursorImpl) GetContextWithTimeOut(ctx context.Context) (context.Conte
 func (vc *VCursorImpl) IgnoreMaxMemoryRows() bool {
 	return vc.ignoreMaxMemoryRows
 }
+
+func (vc *VCursorImpl) SetLastInsertID(id uint64) {
+	vc.SafeSession.mu.Lock()
+	defer vc.SafeSession.mu.Unlock()
+	vc.SafeSession.LastInsertId = id
+}

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -190,6 +190,7 @@ func transformInsertionSelection(ctx *plancontext.PlanningContext, op *operators
 			ForceNonStreaming: op.ForceNonStreaming,
 			Generate:          autoIncGenerate(ins.AutoIncrement),
 			ColVindexes:       ins.ColVindexes,
+			FetchLastInsertID: ctx.SemTable.ShouldFetchLastInsertID(),
 		},
 		VindexValueOffset: ins.VindexValueOffset,
 	}
@@ -659,9 +660,8 @@ func buildInsertPrimitive(
 	}
 
 	eins := &engine.Insert{
-		InsertCommon:      ic,
-		VindexValues:      ins.VindexValues,
-		FetchLastInsertID: ctx.SemTable.ShouldFetchLastInsertID(),
+		InsertCommon: ic,
+		VindexValues: ins.VindexValues,
 	}
 
 	// we would need to generate the query on the fly. The only exception here is

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6161,6 +6161,44 @@
     }
   },
   {
+    "comment": "last_insert_id on aggregation calculated at the vtgate level",
+    "query": "select last_insert_id(count(*)) from user",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select last_insert_id(count(*)) from user",
+      "Instructions": {
+        "OperatorType": "Projection",
+        "Expressions": [
+          "last_insert_id(count(*)) as last_insert_id(count(*))"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Scalar",
+            "Aggregates": "sum_count_star(0) AS count(*)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FetchLastInsertID": true,
+                "FieldQuery": "select count(*) from `user` where 1 != 1",
+                "Query": "select count(*) from `user`",
+                "Table": "`user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "aggregation on top of aggregation works fine",
     "query": "select distinct count(*) from user, (select distinct count(*) from user) X",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -2649,6 +2649,30 @@
     "skip_e2e": true
   },
   {
+    "comment": "insert using last_insert_id with argument",
+    "query": "insert into unsharded values(last_insert_id(24), 2)",
+    "plan": {
+      "QueryType": "INSERT",
+      "Original": "insert into unsharded values(last_insert_id(24), 2)",
+      "Instructions": {
+        "OperatorType": "Insert",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetTabletType": "PRIMARY",
+        "FetchLastInsertID": true,
+        "Query": "insert into unsharded values (last_insert_id(24), 2)",
+        "TableName": "unsharded"
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
     "comment": "update vindex value to null with multiple primary keyspace id",
     "query": "update user set name = null where id in (1, 2, 3)",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -2649,11 +2649,11 @@
     "skip_e2e": true
   },
   {
-    "comment": "insert using last_insert_id with argument",
-    "query": "insert into unsharded values(last_insert_id(24), 2, 2, 2, 2, 2)",
+    "comment": "insert using last_insert_id with argument (already an e2e test for this plan)",
+    "query": "insert into unsharded values(last_insert_id(789), 2)",
     "plan": {
       "QueryType": "INSERT",
-      "Original": "insert into unsharded values(last_insert_id(24), 2, 2, 2, 2, 2)",
+      "Original": "insert into unsharded values(last_insert_id(789), 2)",
       "Instructions": {
         "OperatorType": "Insert",
         "Variant": "Unsharded",
@@ -2663,13 +2663,14 @@
         },
         "TargetTabletType": "PRIMARY",
         "FetchLastInsertID": true,
-        "Query": "insert into unsharded values (last_insert_id(24), 2, 2, 2, 2, 2)",
+        "Query": "insert into unsharded values (last_insert_id(789), 2)",
         "TableName": "unsharded"
       },
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "update vindex value to null with multiple primary keyspace id",

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -2650,10 +2650,10 @@
   },
   {
     "comment": "insert using last_insert_id with argument",
-    "query": "insert into unsharded values(last_insert_id(24), 2)",
+    "query": "insert into unsharded values(last_insert_id(24), 2, 2, 2, 2, 2)",
     "plan": {
       "QueryType": "INSERT",
-      "Original": "insert into unsharded values(last_insert_id(24), 2)",
+      "Original": "insert into unsharded values(last_insert_id(24), 2, 2, 2, 2, 2)",
       "Instructions": {
         "OperatorType": "Insert",
         "Variant": "Unsharded",
@@ -2663,7 +2663,7 @@
         },
         "TargetTabletType": "PRIMARY",
         "FetchLastInsertID": true,
-        "Query": "insert into unsharded values (last_insert_id(24), 2)",
+        "Query": "insert into unsharded values (last_insert_id(24), 2, 2, 2, 2, 2)",
         "TableName": "unsharded"
       },
       "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -2669,8 +2669,7 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    },
-    "skip_e2e": true
+    }
   },
   {
     "comment": "update vindex value to null with multiple primary keyspace id",

--- a/go/vt/vtgate/planbuilder/testdata/set_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/set_cases.json
@@ -607,22 +607,26 @@
     }
   },
   {
-    "QueryType": "SET",
-    "Original": "set @foo = last_insert_id(1)",
-    "Instructions": {
-      "OperatorType": "Set",
-      "Ops": [
-        {
-          "Type": "UserDefinedVariable",
-          "Name": "foo",
-          "Expr": "last_insert_id(1)"
-        }
-      ],
-      "Inputs": [
-        {
-          "OperatorType": "SingleRow"
-        }
-      ]
+    "comment": "set last_insert_id with agrument to user defined variable",
+    "query": "set @foo = last_insert_id(1)",
+    "plan": {
+      "QueryType": "SET",
+      "Original": "set @foo = last_insert_id(1)",
+      "Instructions": {
+        "OperatorType": "Set",
+        "Ops": [
+          {
+            "Type": "UserDefinedVariable",
+            "Name": "foo",
+            "Expr": "last_insert_id(1)"
+          }
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "SingleRow"
+          }
+        ]
+      }
     }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/set_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/set_cases.json
@@ -605,5 +605,24 @@
         ]
       }
     }
+  },
+  {
+    "QueryType": "SET",
+    "Original": "set @foo = last_insert_id(1)",
+    "Instructions": {
+      "OperatorType": "Set",
+      "Ops": [
+        {
+          "Type": "UserDefinedVariable",
+          "Name": "foo",
+          "Expr": "last_insert_id(1)"
+        }
+      ],
+      "Inputs": [
+        {
+          "OperatorType": "SingleRow"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description
This PR improves `LAST_INSERT_ID(x)` behavior to align more closely with MySQL in various scenarios.

- **EvalEngine Enhancement**: We now handle `LAST_INSERT_ID(x)` queries directly in vtgate, allowing “dual-only” queries without sending them downstream to MySQL. 

```sql
select last_insert_id(123);
```

 - VTGate-Calculated Values: Queries like:

```sql
SELECT last_insert_id(count(*)) FROM user WHERE foo = 'bar';
```

can be processed at vtgate level (aggregation across shards), rather than relying on MySQL for the final result.

## Limitation

 - MySQL sets the session’s LAST_INSERT_ID value to the last row returned in ordered queries such as:

```sql
SELECT last_insert_id(col) FROM table ORDER BY foo;
```

In Vitess, we do **not** guarantee that the _last row_ dictates the session value. The session’s `LAST_INSERT_ID` might be derived from a different row.

---

This PR contains commits from #17408

When merging this, please also merge the docs PR: https://github.com/vitessio/website/pull/1913

## Related Issue(s)

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
