### PR TITLE
Change keys of the discovery flags such that they conform to the convention

### DIFF
--- a/changelog/22.0/22.0.0/summary.md
+++ b/changelog/22.0/22.0.0/summary.md
@@ -8,6 +8,7 @@
   - **[RPC Changes](#rpc-changes)**
   - **[Prefer not promoting a replica that is currently taking a backup](#reparents-prefer-not-backing-up)**
   - **[VTOrc Config File Changes](#vtorc-config-file-changes)**
+  - **[VTGate Config File Changes](#vtgate-config-file-changes)**
   - **[Support for More Efficient JSON Replication](#efficient-json-replication)**
 - **[Minor Changes](#minor-changes)**
   - **[VTTablet Flags](#flags-vttablet)**
@@ -59,6 +60,19 @@ The following fields can be dynamically changed -
 13. `change-tablets-with-errant-gtid-to-drained`
 
 To upgrade to the newer version of the configuration file, first switch to using the flags in your current deployment before upgrading. Then you can switch to using the configuration file in the newer release.
+
+### <a id="vtgate-config-file-changes"/>VTGate Config File Changes</a>
+
+The Viper configuration keys for the following flags has been changed to match their flag names. Previously they had a discovery prefix instead of it being part of the name. 
+
+| Flag Name                                        | Old Configuration Key                            | New Configuration Key                            |
+|--------------------------------------------------|--------------------------------------------------|--------------------------------------------------|
+| `discovery_low_replication_lag`                  | `discovery.low_replication_lag`                  | `discovery_low_replication_lag`                  |
+| `discovery_high_replication_lag_minimum_serving` | `discovery.high_replication_lag_minimum_serving` | `discovery_high_replication_lag_minimum_serving` |
+| `discovery_min_number_serving_vttablets`         | `discovery.min_number_serving_vttablets`         | `discovery_min_number_serving_vttablets`         |
+| `discovery_legacy_replication_lag_algorithm`     | `discovery.legacy_replication_lag_algorithm`     | `discovery_legacy_replication_lag_algorithm`     |
+
+To upgrade to the newer version of the configuration keys, first switch to using the flags in your current deployment before upgrading. Then you can switch to using the new configuration keys in the newer release.
 
 ### <a id="efficient-json-replication"/>Support for More Efficient JSON Replication</a>
 

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -70,7 +70,11 @@ type VtgateProcess struct {
 }
 
 type VTGateConfiguration struct {
-	TransactionMode string `json:"transaction_mode,omitempty"`
+	TransactionMode                   string `json:"transaction_mode,omitempty"`
+	DiscoveryLowReplicationLag        string `json:"discovery_low_replication_lag,omitempty"`
+	DiscoveryHighReplicationLag       string `json:"discovery_high_replication_lag,omitempty"`
+	DiscoveryMinServingVttablets      string `json:"discovery_min_number_serving_vttablets,omitempty"`
+	DiscoveryLegacyReplicationLagAlgo string `json:"discovery_legacy_replication_lag_algorithm"`
 }
 
 // ToJSONString will marshal this configuration as JSON

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -814,6 +814,81 @@ func TestDDLTargeted(t *testing.T) {
 	utils.AssertMatches(t, conn, `select id from ddl_targeted`, `[[INT64(1)]]`)
 }
 
+// TestDynamicConfig tests the dynamic configurations.
+func TestDynamicConfig(t *testing.T) {
+	t.Run("DiscoveryLowReplicationLag", func(t *testing.T) {
+		// Test initial config value
+		err := clusterInstance.VtgateProcess.WaitForConfig(`"discovery_low_replication_lag":30000000000`)
+		require.NoError(t, err)
+		defer func() {
+			// Restore default back.
+			clusterInstance.VtgateProcess.Config.DiscoveryLowReplicationLag = "30s"
+			err = clusterInstance.VtgateProcess.RewriteConfiguration()
+			require.NoError(t, err)
+		}()
+		clusterInstance.VtgateProcess.Config.DiscoveryLowReplicationLag = "15s"
+		err = clusterInstance.VtgateProcess.RewriteConfiguration()
+		require.NoError(t, err)
+		// Test final config value.
+		err = clusterInstance.VtgateProcess.WaitForConfig(`"discovery_low_replication_lag":"15s"`)
+		require.NoError(t, err)
+	})
+
+	t.Run("DiscoveryHighReplicationLag", func(t *testing.T) {
+		// Test initial config value
+		err := clusterInstance.VtgateProcess.WaitForConfig(`"discovery_high_replication_lag":7200000000000`)
+		require.NoError(t, err)
+		defer func() {
+			// Restore default back.
+			clusterInstance.VtgateProcess.Config.DiscoveryHighReplicationLag = "2h"
+			err = clusterInstance.VtgateProcess.RewriteConfiguration()
+			require.NoError(t, err)
+		}()
+		clusterInstance.VtgateProcess.Config.DiscoveryHighReplicationLag = "1h"
+		err = clusterInstance.VtgateProcess.RewriteConfiguration()
+		require.NoError(t, err)
+		// Test final config value.
+		err = clusterInstance.VtgateProcess.WaitForConfig(`"discovery_high_replication_lag":"1h"`)
+		require.NoError(t, err)
+	})
+
+	t.Run("DiscoveryMinServingVttablets", func(t *testing.T) {
+		// Test initial config value
+		err := clusterInstance.VtgateProcess.WaitForConfig(`"discovery_min_number_serving_vttablets":2`)
+		require.NoError(t, err)
+		defer func() {
+			// Restore default back.
+			clusterInstance.VtgateProcess.Config.DiscoveryMinServingVttablets = "2"
+			err = clusterInstance.VtgateProcess.RewriteConfiguration()
+			require.NoError(t, err)
+		}()
+		clusterInstance.VtgateProcess.Config.DiscoveryMinServingVttablets = "1"
+		err = clusterInstance.VtgateProcess.RewriteConfiguration()
+		require.NoError(t, err)
+		// Test final config value.
+		err = clusterInstance.VtgateProcess.WaitForConfig(`"discovery_min_number_serving_vttablets":"1"`)
+		require.NoError(t, err)
+	})
+
+	t.Run("DiscoveryLegacyReplicationLagAlgo", func(t *testing.T) {
+		// Test initial config value
+		err := clusterInstance.VtgateProcess.WaitForConfig(`"discovery_legacy_replication_lag_algorithm":""`)
+		require.NoError(t, err)
+		defer func() {
+			// Restore default back.
+			clusterInstance.VtgateProcess.Config.DiscoveryLegacyReplicationLagAlgo = "true"
+			err = clusterInstance.VtgateProcess.RewriteConfiguration()
+			require.NoError(t, err)
+		}()
+		clusterInstance.VtgateProcess.Config.DiscoveryLegacyReplicationLagAlgo = "false"
+		err = clusterInstance.VtgateProcess.RewriteConfiguration()
+		require.NoError(t, err)
+		// Test final config value.
+		err = clusterInstance.VtgateProcess.WaitForConfig(`"discovery_legacy_replication_lag_algorithm":"false"`)
+		require.NoError(t, err)
+	})
+}
+
 func TestLookupErrorMetric(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()

--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -28,10 +28,9 @@ import (
 )
 
 var (
-	configKey = viperutil.KeyPrefixFunc("discovery")
 	// lowReplicationLag defines the duration that replication lag is low enough that the VTTablet is considered healthy.
 	lowReplicationLag = viperutil.Configure(
-		configKey("low_replication_lag"),
+		"discovery_low_replication_lag",
 		viperutil.Options[time.Duration]{
 			FlagName: "discovery_low_replication_lag",
 			Default:  30 * time.Second,
@@ -39,7 +38,7 @@ var (
 		},
 	)
 	highReplicationLagMinServing = viperutil.Configure(
-		configKey("high_replication_lag"),
+		"discovery_high_replication_lag",
 		viperutil.Options[time.Duration]{
 			FlagName: "discovery_high_replication_lag_minimum_serving",
 			Default:  2 * time.Hour,
@@ -47,7 +46,7 @@ var (
 		},
 	)
 	minNumTablets = viperutil.Configure(
-		configKey("min_number_serving_vttablets"),
+		"discovery_min_number_serving_vttablets",
 		viperutil.Options[int]{
 			FlagName: "min_number_serving_vttablets",
 			Default:  2,
@@ -55,7 +54,7 @@ var (
 		},
 	)
 	legacyReplicationLagAlgorithm = viperutil.Configure(
-		configKey("legacy_replication_lag_algorithm"),
+		"discovery_legacy_replication_lag_algorithm",
 		viperutil.Options[bool]{
 			FlagName: "legacy_replication_lag_algorithm",
 			Default:  true,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Now that we have started making more and more flags as dynamic configurations in viper, we have settled on the default convention for this. We are using the same flag name as the key name in viper. The discovery flags that were added previously didn't follow this convention and have been changed to do so.

This PR is built on top of #17419 because it required some testing changes setup that that PR adds.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
