### PR TITLE
Flaky TestMoveTables(Un)sharded: Handle race condition 

### DIFF
--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -126,7 +126,7 @@ var Cases = []TestCase{
 	{Run: FnSHA1},
 	{Run: FnSHA2},
 	{Run: FnRandomBytes},
-	// Temporarily commenting failing test // {Run: FnDateFormat},
+	{Run: FnDateFormat},
 	{Run: FnConvertTz},
 	{Run: FnDate},
 	{Run: FnDayOfMonth},

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -126,7 +126,7 @@ var Cases = []TestCase{
 	{Run: FnSHA1},
 	{Run: FnSHA2},
 	{Run: FnRandomBytes},
-	{Run: FnDateFormat},
+	// Temporarily commenting failing test // {Run: FnDateFormat},
 	{Run: FnConvertTz},
 	{Run: FnDate},
 	{Run: FnDayOfMonth},

--- a/go/vt/vttablet/tabletconntest/fakequeryservice.go
+++ b/go/vt/vttablet/tabletconntest/fakequeryservice.go
@@ -702,7 +702,8 @@ func (f *FakeQueryService) StreamHealth(ctx context.Context, callback func(*quer
 
 // VStream is part of the queryservice.QueryService interface
 func (f *FakeQueryService) VStream(ctx context.Context, request *binlogdatapb.VStreamRequest, send func([]*binlogdatapb.VEvent) error) error {
-	panic("not implemented")
+	// This is called as part of vreplication unit tests, so we don't panic here.
+	return fmt.Errorf("VStream not implemented")
 }
 
 // VStreamRows is part of the QueryService interface.

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/constants/sidecar"
@@ -1783,6 +1785,14 @@ func addInvariants(dbClient *binlogplayer.MockDBClient, vreplID, sourceTabletUID
 	))
 	dbClient.AddInvariant(fmt.Sprintf(updatePickedSourceTablet, cell, sourceTabletUID, vreplID), &sqltypes.Result{})
 	dbClient.AddInvariant("update _vt.vreplication set state='Running', message='' where id=1", &sqltypes.Result{})
+	dbClient.AddInvariant(vreplication.SqlMaxAllowedPacket, sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"@@max_allowed_packet",
+			"int64",
+		),
+		"65536",
+	))
+	dbClient.AddInvariant("update _vt.vreplication set message", &sqltypes.Result{})
 }
 
 func addMaterializeSettingsTablesToSchema(ms *vtctldatapb.MaterializeSettings, tenv *testEnv, venv *vtenv.Environment) {

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -1787,7 +1787,7 @@ func addInvariants(dbClient *binlogplayer.MockDBClient, vreplID, sourceTabletUID
 	dbClient.AddInvariant("update _vt.vreplication set state='Running', message='' where id=1", &sqltypes.Result{})
 	dbClient.AddInvariant(vreplication.SqlMaxAllowedPacket, sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
-			"@@max_allowed_packet",
+			"max_allowed_packet",
 			"int64",
 		),
 		"65536",

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -125,7 +125,7 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 		settings.StopPos = pausePos
 		saveStop = false
 	}
-
+	log.Infof("Starting VReplication player id: %v, startPos: %v, stop: %v, filter: %v", vr.id, settings.StartPos, settings.StopPos, vr.source)
 	queryFunc := func(ctx context.Context, sql string) (*sqltypes.Result, error) {
 		return vr.dbClient.ExecuteWithRetry(ctx, sql)
 	}
@@ -142,7 +142,7 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 		maxAllowedPacket := int64(vr.workflowConfig.RelayLogMaxSize)
 		// We explicitly do NOT want to batch this, we want to send it down the wire
 		// immediately so we use ExecuteFetch directly.
-		res, err := vr.dbClient.ExecuteFetch("select @@session.max_allowed_packet as max_allowed_packet", 1)
+		res, err := vr.dbClient.ExecuteFetch(SqlMaxAllowedPacket, 1)
 		if err != nil {
 			log.Errorf("Error getting max_allowed_packet, will use the relay_log_max_size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err)
 		} else {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -125,7 +125,8 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 		settings.StopPos = pausePos
 		saveStop = false
 	}
-	log.Infof("Starting VReplication player id: %v, startPos: %v, stop: %v, filter: %v", vr.id, settings.StartPos, settings.StopPos, vr.source)
+	log.Infof("Starting VReplication player id: %v, startPos: %v, stop: %v, filter: %+v",
+		vr.id, settings.StartPos, settings.StopPos, vr.source.Filter)
 	queryFunc := func(ctx context.Context, sql string) (*sqltypes.Result, error) {
 		return vr.dbClient.ExecuteWithRetry(ctx, sql)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -89,6 +89,7 @@ const (
 	json_unquote(json_extract(action, '$.type'))=%a and vrepl_id=%a and table_name=%a`
 	sqlDeletePostCopyAction = `delete from _vt.post_copy_action where vrepl_id=%a and
 	table_name=%a and id=%a`
+	SqlMaxAllowedPacket = "select @@session.max_allowed_packet as max_allowed_packet"
 )
 
 // vreplicator provides the core logic to start vreplication streams


### PR DESCRIPTION
## Description

There is a `goroutine` that runs which starts the `vplayer` thread for each workflow which is triggered by updating the `_vt.vreplication` table using `VExe`c . Now most of the time the test ends before it starts doing anything significant. The failure happens when it runs for a bit.

https://github.com/vitessio/vitess/pull/17166 has added a new query to that path and this was not expected by the db mock layer, which was the reported failure. But the solution is a bit more involved than just adding that query as an expected query. When the vplayer runs it requires some more mocking support. Needed to add an additional query and update the mock object for the `VStream()` API to return rather than panic. It doesn't matter what this mock returns since the test doesn't make use of the response from that API.

Not sure if there are other flakiness causes here, since this has been flaky for a while but local tests which were erroring out earlier about 5% of the time are passing now.

Tested by running `TestMoveTablesSharded` several 100s of times, both MoveTables tests 100 times and all test in the directory 50 times.

This happens on v21 as well, so we backport there.

## Related Issues

Previous flaky test fix: https://github.com/vitessio/vitess/pull/17343

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
