### PR TITLE
[Direct PR] [V21 backport] CobraDocs: Remove commit hash from docs. Fix issue with workdir replacement (#17392)

### DIFF
--- a/go/cmd/internal/docgen/docgen_test.go
+++ b/go/cmd/internal/docgen/docgen_test.go
@@ -41,7 +41,7 @@ func TestGenerateMarkdownTree(t *testing.T) {
 			name:      "current dir",
 			dir:       "./",
 			cmd:       &cobra.Command{},
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name:      "Permission denied",


### PR DESCRIPTION
## Description

Manual backport of #17392 

We need to backport the original PR because we checkout previous releases while generating docs for previous versions and hence the older versions also need the fixes from #17392.

Hoping to piggyback backport these to v19/v20 as well using labels and not have to create manual backports.

## Related Issue(s)

#17392 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
