### PR TITLE
schemadiff: skip keys with expressions in Online DDL analysis

### DIFF
--- a/go/vt/schemadiff/key.go
+++ b/go/vt/schemadiff/key.go
@@ -68,6 +68,16 @@ func (i *IndexDefinitionEntity) IsUnique() bool {
 	return i.IndexDefinition.Info.IsUnique()
 }
 
+// IsUnique returns true if the index uses an expression, e.g. `KEY idx1 ((id + 1))`.
+func (i *IndexDefinitionEntity) HasExpression() bool {
+	for _, col := range i.IndexDefinition.Columns {
+		if col.Expression != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // HasNullable returns true if any of the columns in the index are nullable.
 func (i *IndexDefinitionEntity) HasNullable() bool {
 	for _, col := range i.ColumnList.Entities {

--- a/go/vt/schemadiff/key.go
+++ b/go/vt/schemadiff/key.go
@@ -68,7 +68,7 @@ func (i *IndexDefinitionEntity) IsUnique() bool {
 	return i.IndexDefinition.Info.IsUnique()
 }
 
-// IsUnique returns true if the index uses an expression, e.g. `KEY idx1 ((id + 1))`.
+// HasExpression returns true if the index uses an expression, e.g. `KEY idx1 ((id + 1))`.
 func (i *IndexDefinitionEntity) HasExpression() bool {
 	for _, col := range i.IndexDefinition.Columns {
 		if col.Expression != nil {

--- a/go/vt/schemadiff/onlineddl.go
+++ b/go/vt/schemadiff/onlineddl.go
@@ -162,6 +162,11 @@ func PrioritizedUniqueKeys(createTableEntity *CreateTableEntity) *IndexDefinitio
 		if !key.IsUnique() {
 			continue
 		}
+		if key.HasExpression() {
+			// If the key has an expression this means it unreliably covers the columns,
+			// we cannot trust it.
+			continue
+		}
 		uniqueKeys = append(uniqueKeys, key)
 	}
 	sort.SliceStable(uniqueKeys, func(i, j int) bool {

--- a/go/vt/schemadiff/onlineddl_test.go
+++ b/go/vt/schemadiff/onlineddl_test.go
@@ -932,6 +932,11 @@ func TestRevertible(t *testing.T) {
 			toSchema:            `id int primary key, e1 set('a', 'b'), e2 set('a'), e3 set('a', 'b', 'c'), e4 set('a', 'x'), e5 set('a', 'x', 'b'), e6 set('b'), e7 varchar(1), e8 tinyint`,
 			expandedColumnNames: `e3,e4,e5,e6,e7,e8`,
 		},
+		{
+			name:       "index with expression",
+			fromSchema: "id int, primary key (id), key idx1 ((id + 1))",
+			toSchema:   "id int, primary key (id), key idx2 ((id + 2))",
+		},
 	}
 
 	var (

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -500,9 +500,14 @@ func (c *CreateTableEntity) IndexDefinitionEntities() []*IndexDefinitionEntity {
 	keys := c.CreateTable.TableSpec.Indexes
 	entities := make([]*IndexDefinitionEntity, len(keys))
 	for i, key := range keys {
-		colEntities := make([]*ColumnDefinitionEntity, len(key.Columns))
-		for i, keyCol := range key.Columns {
-			colEntities[i] = colMap[keyCol.Column.Lowered()]
+		colEntities := []*ColumnDefinitionEntity{}
+		for _, keyCol := range key.Columns {
+			colEntity, ok := colMap[keyCol.Column.Lowered()]
+			if !ok {
+				// This can happen if the index is on an expression, e.g. `KEY idx1 ((id + 1))`.
+				continue
+			}
+			colEntities = append(colEntities, colEntity)
 		}
 		entities[i] = NewIndexDefinitionEntity(c.Env, key, NewColumnDefinitionEntityList(colEntities))
 	}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -891,6 +891,18 @@ func TestCreateTableDiff(t *testing.T) {
 				"+	KEY `i_idx` (`i`) INVISIBLE",
 			},
 		},
+		{
+			name:  "keys with expression",
+			from:  "create table t1 (id int, primary key (id), key idx1 ((id + 1)))",
+			to:    "create table t1 (id int, primary key (id), key idx2 ((id + 2)))",
+			diff:  "alter table t1 drop key idx1, add key idx2 ((id + 2))",
+			cdiff: "ALTER TABLE `t1` DROP KEY `idx1`, ADD KEY `idx2` ((`id` + 2))",
+			textdiffs: []string{
+				"-	KEY `idx1` ((`id` + 1))",
+				"+	KEY `idx2` ((`id` + 2))",
+			},
+		},
+
 		// FULLTEXT keys
 		{
 			name:  "add one fulltext key",
@@ -2563,6 +2575,12 @@ func TestValidate(t *testing.T) {
 			from:      "create table t (id int primary key, i1 int, i2 int, primary key (id))",
 			alter:     "alter table t engine=innodb",
 			expectErr: &DuplicateKeyNameError{Table: "t", Key: "PRIMARY"},
+		},
+		{
+			name:  "key with expression",
+			from:  "create table t (id int, primary key (id), key idx1 ((id + 1)))",
+			alter: "alter table t add key idx2 ((id + 2))",
+			to:    "create table t (id int, primary key (id), key idx1 ((id + 1)), key idx2 ((id + 2)))",
 		},
 		// partitions
 		{


### PR DESCRIPTION
## Description

Keys may cover expressions, such as in `KEY idx1 ((id + 1))`. Such keys are not eligible for Online DDL (vreplication) iteration, because even if defined as `UNIQUE`, they cannot be trusted; the expression might un-unique the value (consider `((id * 0))` as a trivial example).

With this PR `schemadiff`s Online DDL analysis ignores keys that have expressions. The function `IndexDefinitionEntities()` likewise does not attempt to read column information from an index that has an expression.

Added various tests that would otherwise either return incorrect answer or panic with `panic: runtime error: invalid memory address or nil pointer dereference`.

## Backport

As this can cause a crash scenario, marking for backport.

## Related Issue(s)

- fixes https://github.com/vitessio/vitess/issues/17477
- #10203 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
