### PR TITLE
[Java] Fix dependency issues in Java package 

### DIFF
--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.28</version>
+      <version>8.0.33</version>
       <optional>false</optional>
     </dependency>
 

--- a/java/grpc-client/src/test/resources/ca.config
+++ b/java/grpc-client/src/test/resources/ca.config
@@ -2,6 +2,7 @@
  default_bits           = 1024
  default_keyfile        = keyfile.pem
  distinguished_name     = req_distinguished_name
+ x509_extensions        = v3_ca
  attributes             = req_attributes
  prompt                 = no
  output_password        = mypass
@@ -15,3 +16,5 @@
  emailAddress           = test@email.address
 [ req_attributes ]
  challengePassword      = A challenge password
+[ v3_ca ]
+ basicConstraints       = CA:TRUE

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,8 +72,8 @@
     <netty.handler.version>4.1.110.Final</netty.handler.version>
     <tcnative.boring.ssl.version>2.0.65.Final</tcnative.boring.ssl.version>
 
-    <protobuf.java.version>4.28.3</protobuf.java.version>
-    <protobuf.protoc.version>3.24.3</protobuf.protoc.version>
+    <protobuf.java.version>3.25.5</protobuf.java.version>
+    <protobuf.protoc.version>3.25.5</protobuf.protoc.version>
     <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
     <log4j2.version>2.24.1</log4j2.version>
   </properties>


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes 3 things
1. Protobuf java and protoc version
2. Mysql connection version upgrade to remove security alert (used only in test in vitess repo)
3. Fix TLS test by fixing the ca config.

Backport: Protobuf java and protoc version is mismatch in v21 causing issue in Debezium connector `vitess-grpc-client` upgrade.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/17482

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
