### PR TITLE
Fix crash in the evalengine

### DIFF
--- a/go/vt/vtgate/evalengine/arena.go
+++ b/go/vt/vtgate/evalengine/arena.go
@@ -71,7 +71,7 @@ func (a *Arena) newEvalEnum(raw []byte, values *EnumSetValues) *evalEnum {
 	} else {
 		a.aEnum = append(a.aEnum, evalEnum{})
 	}
-	val := &a.aEnum[len(a.aInt64)-1]
+	val := &a.aEnum[len(a.aEnum)-1]
 	s := string(raw)
 	val.string = s
 	val.value = valueIdx(values, s)
@@ -84,7 +84,7 @@ func (a *Arena) newEvalSet(raw []byte, values *EnumSetValues) *evalSet {
 	} else {
 		a.aSet = append(a.aSet, evalSet{})
 	}
-	val := &a.aSet[len(a.aInt64)-1]
+	val := &a.aSet[len(a.aSet)-1]
 	s := string(raw)
 	val.string = s
 	val.set = evalSetBits(values, s)

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -760,6 +760,20 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `WEEK(timestamp '2024-01-01 10:34:58', 1)`,
 			result:     `INT64(1)`,
 		},
+		{
+			expression: `column0 + 1`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte("foo"))},
+			// Returns 0, as unknown enums evaluate here to -1. We have this test to
+			// exercise the path to push enums onto the stack.
+			result: `FLOAT64(0)`,
+		},
+		{
+			expression: `column0 + 1`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte("foo"))},
+			// Returns 1, as unknown sets evaluate here to 0. We have this test to
+			// exercise the path to push sets onto the stack.
+			result: `FLOAT64(1)`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")


### PR DESCRIPTION
The allocation arena used here the wrong type to check for the size. The logic here was copied, but this case was missed.

We add a test here and fix the bug. It applies to both enums and sets.

Should be backported to all supported versions as this can lead to a panic. 

## Related Issue(s)

Fixes #17486

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required