### PR TITLE
docgen tool: Remove sed usage 

### DIFF
--- a/go/cmd/internal/docgen/docgen.go
+++ b/go/cmd/internal/docgen/docgen.go
@@ -146,18 +146,10 @@ func restructure(rootDir string, dir string, name string, commands []*cobra.Comm
 				return fmt.Errorf("failed to move child command %s to its parent's dir: %w", fullCmdFilename, err)
 			}
 
-			sed := newParentLinkSedCommand(name, newName)
-			if out, err := sed.CombinedOutput(); err != nil {
-				return fmt.Errorf("failed to rewrite links to parent command in child %s: %w (extra: %s)", newName, err, out)
-			}
 		}
 	}
 
 	return nil
-}
-
-func newParentLinkSedCommand(parent string, file string) *exec.Cmd {
-	return exec.Command("xyz", "-i", "-e", fmt.Sprintf("s:(./%s/):(../):i", parent), file)
 }
 
 var (

--- a/go/cmd/internal/docgen/docgen_test.go
+++ b/go/cmd/internal/docgen/docgen_test.go
@@ -40,7 +40,7 @@ func TestGenerateMarkdownTree(t *testing.T) {
 			name:      "current dir",
 			dir:       "./",
 			cmd:       &cobra.Command{},
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			name:      "Permission denied",

--- a/go/cmd/internal/docgen/docgen_test.go
+++ b/go/cmd/internal/docgen/docgen_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package docgen
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -145,40 +144,6 @@ func TestLinkHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			str := linkHandler(tt.fileName)
 			require.Equal(t, tt.expectedStr, str)
-		})
-	}
-}
-
-func TestNewParentLinkSedCommand(t *testing.T) {
-	tests := []struct {
-		name           string
-		parentDir      string
-		fileName       string
-		expectedOutput string
-	}{
-		{
-			name:           "Empty values",
-			expectedOutput: "sed -i  -e s:(.//):(../):i ",
-		},
-		{
-			name:           "Normal value",
-			parentDir:      "./",
-			fileName:       "Some_value",
-			expectedOutput: "sed -i  -e s:(././/):(../):i Some_value",
-		},
-		{
-			name:           "Abnormal value",
-			parentDir:      "/root",
-			fileName:       `./.jash13_24`,
-			expectedOutput: "sed -i  -e s:(.//root/):(../):i ./.jash13_24",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd := newParentLinkSedCommand(tt.parentDir, tt.fileName)
-			// We only check for suffix because the sed command's actual path may differ on different machines.
-			require.True(t, strings.HasSuffix(cmd.String(), tt.expectedOutput))
 		})
 	}
 }


### PR DESCRIPTION
## Description

The `docgen` tool used to generate cobra docs from the website repo currently uses execs `sed` to replace the local directory (created in docs by the cobra module) with `<WORKDIR>` .

Unfortunately `sed` works differently in `macOS` and `linux` for the usage we need. This PR removes sed usage entirely and we will do the replacement in the website's `Makefile` target itself where we will check for the OS and use the different variants.

We backport to all supported versions since we can be generating docs for any of them.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
