### PR TITLE
CI: fix to Online DDL flow test, do not t.Log from within a goroutine

### DIFF
--- a/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
+++ b/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
@@ -244,7 +244,7 @@ func TestOnlineDDLFlow(t *testing.T) {
 						select {
 						case <-ticker.C:
 						case <-workloadCtx.Done():
-							t.Logf("Terminating routine throttler check")
+							fmt.Println("Terminating routine throttler check")
 							return
 						}
 					}
@@ -258,8 +258,8 @@ func TestOnlineDDLFlow(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer cancel()
-					defer t.Logf("Terminating workload")
 					defer wg.Done()
+					defer fmt.Println("Terminating workload")
 					runMultipleConnections(workloadCtx, t)
 				}()
 			})


### PR DESCRIPTION
## Description

Quick fix to Online DDL flow test flakiness, caused to to logging in a goroutine. We can add more synchronization to ensure the logging is only ever done while the tests is still running, but then again this logging is for convenience only. Switched to `fmt.Println` instead, it's just as informative.

## Related Issue(s)

https://github.com/vitessio/vitess/actions/runs/12676221410/job/35328963706?pr=17443

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
