### PR TITLE
test: make it easier to run tests without a main keyspace

### DIFF
--- a/go/test/vschemawrapper/vschema_wrapper.go
+++ b/go/test/vschemawrapper/vschema_wrapper.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"vitess.io/vitess/go/mysql/collations"
@@ -300,11 +301,19 @@ func (vw *VSchemaWrapper) AnyKeyspace() (*vindexes.Keyspace, error) {
 		return ks.Keyspace, nil
 	}
 
-	for _, ks := range vw.V.Keyspaces {
-		return ks.Keyspace, nil
+	size := len(vw.V.Keyspaces)
+	if size == 0 {
+		return nil, errors.New("no keyspace found in vschema")
 	}
 
-	return nil, errors.New("no keyspace found in vschema")
+	// Find the first keyspace in the map alphabetically to get deterministic results
+	keys := make([]string, size)
+	for key := range vw.V.Keyspaces {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return vw.V.Keyspaces[keys[0]].Keyspace, nil
 }
 
 func (vw *VSchemaWrapper) FirstSortedKeyspace() (*vindexes.Keyspace, error) {


### PR DESCRIPTION
## Description
When using keyspaces in tests, the current schema wrapper we use makes it hard if we are missing a `main` keyspace. This change makes it easier to handle situations without this keyspace.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
