### PR TITLE
Flaky TestTickSkip: Remove inherently flaky test

### DIFF
--- a/go/timer/randticker_test.go
+++ b/go/timer/randticker_test.go
@@ -43,21 +43,3 @@ func TestTick(t *testing.T) {
 		t.Error("Channel was not closed")
 	}
 }
-
-func TestTickSkip(t *testing.T) {
-	tkr := NewRandTicker(10*time.Millisecond, 1*time.Millisecond)
-	time.Sleep(35 * time.Millisecond)
-	end := <-tkr.C
-	diff := time.Since(end)
-	if diff < 20*time.Millisecond {
-		t.Errorf("diff: %v, want >20ms", diff)
-	}
-
-	// This tick should be up-to-date
-	end = <-tkr.C
-	diff = time.Since(end)
-	if diff > 1*time.Millisecond {
-		t.Errorf("diff: %v, want <1ms", diff)
-	}
-	tkr.Stop()
-}


### PR DESCRIPTION
## Description

Removing test that is very dependent on elapsed and local time. Noticed because it fails occassionally in CI requiring the entire unit test workflow to be rerun. Fails consistently 1-3% of the time locally. 

We are already testing the basic functionality elsewhere, so seemed a better option to remove than to try and fine tune the tolerance for the test.

Test has been around for 10 years, so backporting to supported versions.

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
