### PR TITLE
Fix how we generate the query serving error documentation

### DIFF
--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -243,8 +243,15 @@ func errorWithoutState(id string, code vtrpcpb.Code, short, long string) func(ar
 
 func errorWithState(id string, code vtrpcpb.Code, state State, short, long string) func(args ...any) *VitessError {
 	return func(args ...any) *VitessError {
+		var err error
+		if len(args) != 0 {
+			err = NewErrorf(code, state, id+": "+short, args...)
+		} else {
+			err = NewError(code, state, id+": "+short)
+		}
+
 		return &VitessError{
-			Err:         NewErrorf(code, state, id+": "+short, args...),
+			Err:         err,
 			Description: long,
 			ID:          id,
 			State:       state,


### PR DESCRIPTION
## Description

A small change introduced to our error code led to the query serving error documentation generation to not work as expected: It was trying to parse the arguments (%s, %d, etc) in the strings and was printing things like `'%!s(MISSING)'` instead of `'%s'`. The issue is visible [in this PR](https://github.com/vitessio/website/pull/1905), specifically this commit: [vitessio/website@`98b15a1` (#1905)](https://github.com/vitessio/website/pull/1905/commits/98b15a1fcb8a153aad7f0b636b01b673e272b6f6).

We should backport this to 21.0 as the issue was first introduced there.

I have updated https://github.com/vitessio/website/pull/1905 with the newly generated docs for each branch (from 19 to main).