### PR TITLE
[Java]: Bump mysql-connector-java version from 8.0.33 to mysql-connector-j 8.4.0

### DIFF
--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -31,8 +31,8 @@
 
     <dependency>
       <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.33</version>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.4.0</version>
       <optional>false</optional>
     </dependency>
 

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessJDBCUrl.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessJDBCUrl.java
@@ -218,7 +218,7 @@ public class VitessJDBCUrl {
           }
         }
 
-        // Per the mysql-connector-java docs, passed in Properties values should take precedence
+        // Per the mysql-connector-j docs, passed in Properties values should take precedence
         // over
         // those in the URL. See javadoc for NonRegisteringDriver#connect
         if ((null != value && value.length() > 0) && (parameter.length() > 0) && null == info

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessParameterMetaData.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessParameterMetaData.java
@@ -25,7 +25,7 @@ public class VitessParameterMetaData implements ParameterMetaData {
   private final int parameterCount;
 
   /**
-   * This implementation (and defaults below) is equivalent to mysql-connector-java's "simple"
+   * This implementation (and defaults below) is equivalent to mysql-connector-j's "simple"
    * (non-server) statement metadata
    */
   VitessParameterMetaData(int count) {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessPreparedStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessPreparedStatement.java
@@ -426,7 +426,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
   }
 
   /**
-   * This function was ported from mysql-connector-java ParseInfo object and greatly simplified to
+   * This function was ported from mysql-connector-j ParseInfo object and greatly simplified to
    * just the parts for counting parameters
    */
   private int calculateParameterCount() throws SQLException {

--- a/java/jdbc/src/main/java/io/vitess/util/charset/CharsetMapping.java
+++ b/java/jdbc/src/main/java/io/vitess/util/charset/CharsetMapping.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * These classes were pulled from mysql-connector-java and simplified to just the parts supporting
+ * These classes were pulled from mysql-connector-j and simplified to just the parts supporting
  * the statically available charsets
  */
 public class CharsetMapping {

--- a/java/jdbc/src/main/java/io/vitess/util/charset/Collation.java
+++ b/java/jdbc/src/main/java/io/vitess/util/charset/Collation.java
@@ -17,7 +17,7 @@
 package io.vitess.util.charset;
 
 /**
- * These classes were pulled from mysql-connector-java and simplified to just the parts supporting
+ * These classes were pulled from mysql-connector-j and simplified to just the parts supporting
  * the statically available charsets
  */
 class Collation {

--- a/java/jdbc/src/main/java/io/vitess/util/charset/MysqlCharset.java
+++ b/java/jdbc/src/main/java/io/vitess/util/charset/MysqlCharset.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import java.util.Set;
 
 /**
- * These classes were pulled from mysql-connector-java and simplified to just the parts supporting
+ * These classes were pulled from mysql-connector-j and simplified to just the parts supporting
  * the statically available charsets
  */
 class MysqlCharset {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -252,7 +252,7 @@
               <failOnWarning>true</failOnWarning>
               <outputXML>true</outputXML>
               <ignoredUnusedDeclaredDependencies>
-                <dependency>mysql:mysql-connector-java</dependency>
+                <dependency>mysql:mysql-connector-j</dependency>
                 <dependency>io.grpc:grpc-context</dependency>
               </ignoredUnusedDeclaredDependencies>
             </configuration>


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR upgrades the the deprecated mysql-connection-java artifact to mysql-connector-j.

Backport: Resolving security alert. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
