### PR TITLE
feat: add mysql 8.4 docker images

### DIFF
--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        branch: [ mysql80 ]
+        branch: [ mysql80, mysql84 ]
 
     steps:
       - name: Check out code
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        branch: [ latest, percona80 ]
+        branch: [ latest, mysql84, percona80 ]
 
     steps:
       - name: Check out code

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ $(PROTO_GO_OUTS): minimaltools install_protoc-gen-go proto/*.proto
 # Please read docker/README.md to understand the different available images.
 
 # This rule builds the bootstrap images for all flavors.
-DOCKER_IMAGES_FOR_TEST = mysql80 percona80
+DOCKER_IMAGES_FOR_TEST = mysql80 mysql84 percona80
 DOCKER_IMAGES = common $(DOCKER_IMAGES_FOR_TEST)
 BOOTSTRAP_VERSION=41
 ensure_bootstrap_version:
@@ -322,7 +322,7 @@ define build_docker_image
 	fi
 endef
 
-DOCKER_LITE_SUFFIX = percona80
+DOCKER_LITE_SUFFIX = mysql84 percona80
 DOCKER_LITE_TARGETS = $(addprefix docker_lite_,$(DOCKER_LITE_SUFFIX))
 $(DOCKER_LITE_TARGETS): docker_lite_%:
 	${call build_docker_image,docker/lite/Dockerfile.$*,vitess/lite:$*}

--- a/docker/bootstrap/CHANGELOG.md
+++ b/docker/bootstrap/CHANGELOG.md
@@ -162,3 +162,4 @@ List of changes between bootstrap image versions.
 ## [41] - 2025-01-15
 ### Changes
 - Update base image to bookworm
+- Add MySQL84 image

--- a/docker/bootstrap/Dockerfile.mysql84
+++ b/docker/bootstrap/Dockerfile.mysql84
@@ -1,0 +1,23 @@
+ARG bootstrap_version
+ARG image="vitess/bootstrap:${bootstrap_version}-common"
+
+FROM --platform=linux/amd64 "${image}"
+
+USER root
+
+# Install MySQL 8.4
+RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com 8C718D3B5072E1F5 && break; done && \
+    for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com A8D3785C && break; done && \
+    echo 'deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.4-lts' > /etc/apt/sources.list.d/mysql.list && \
+    for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 9334A25F8507EFA5 && break; done && \
+    echo 'deb http://repo.percona.com/pxb-84-lts/apt bookworm main' > /etc/apt/sources.list.d/percona.list && \
+    { \
+        echo debconf debconf/frontend select Noninteractive; \
+        echo percona-server-server-8.4 percona-server-server/root_password password 'unused'; \
+        echo percona-server-server-8.4 percona-server-server/root_password_again password 'unused'; \
+    } | debconf-set-selections && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev libdbd-mysql-perl rsync libev4 libcurl4-openssl-dev percona-xtrabackup-84 && \
+    rm -rf /var/lib/apt/lists/*
+
+USER vitess

--- a/docker/bootstrap/README.md
+++ b/docker/bootstrap/README.md
@@ -7,6 +7,7 @@ The `vitess/bootstrap` image comes in different flavors:
 
 * `vitess/bootstrap:common`    - dependencies that are common to all flavors
 * `vitess/bootstrap:mysql80`   - bootstrap image for MySQL 8.0
+* `vitess/bootstrap:mysql84`   - bootstrap image for MySQL 8.4
 * `vitess/bootstrap:percona80` - bootstrap image for Percona Server 8.0
 
 **NOTE: Unlike the base image that builds Vitess itself, this bootstrap image

--- a/docker/lite/Dockerfile.mysql84
+++ b/docker/lite/Dockerfile.mysql84
@@ -1,0 +1,63 @@
+# Copyright 2025 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM --platform=linux/amd64 golang:1.23.5-bookworm AS builder
+
+# Allows docker builds to set the BUILD_NUMBER
+ARG BUILD_NUMBER
+
+WORKDIR /vt/src/vitess.io/vitess
+
+# Create vitess user
+RUN groupadd -r vitess && useradd -r -g vitess vitess
+RUN mkdir -p /vt/vtdataroot /home/vitess
+RUN chown -R vitess:vitess /vt /home/vitess
+USER vitess
+
+# Re-copy sources from working tree.
+COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
+
+RUN make install PREFIX=/vt/install
+
+# Start over and build the final image.
+FROM --platform=linux/amd64 debian:bookworm-slim
+
+# Install locale required for mysqlsh
+RUN apt-get update && apt-get install -y locales \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen en_US.UTF-8
+
+# Install dependencies
+COPY docker/utils/install_dependencies.sh /vt/dist/install_dependencies.sh
+RUN /vt/dist/install_dependencies.sh mysql84
+
+# Set up Vitess user and directory tree.
+RUN groupadd -r vitess && useradd -r -g vitess vitess
+RUN mkdir -p /vt/vtdataroot /home/vitess && chown -R vitess:vitess /vt /home/vitess
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vt/vtdataroot
+ENV PATH $VTROOT/bin:$PATH
+
+# Copy artifacts from builder layer.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder --chown=vitess:vitess /vt/install /vt
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/web/vtadmin /vt/web/vtadmin
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/init_db.sql /vt/config/
+COPY --from=builder --chown=vitess:vitess /vt/src/vitess.io/vitess/config/mycnf /vt/config/
+
+# Create mount point for actual data (e.g. MySQL data dir)
+VOLUME /vt/vtdataroot
+USER vitess

--- a/docker/utils/install_dependencies.sh
+++ b/docker/utils/install_dependencies.sh
@@ -98,6 +98,33 @@ mysql80)
         percona-xtrabackup-80
     )
     ;;
+mysql84)
+    if [ -z "$VERSION" ]; then
+        VERSION=8.4.3
+    fi
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-common_${VERSION}-1debian12_amd64.deb /tmp/mysql-common_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/libmysqlclient24_${VERSION}-1debian12_amd64.deb /tmp/libmysqlclient24_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-community-client-core_${VERSION}-1debian12_amd64.deb /tmp/mysql-community-client-core_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-community-client-plugins_${VERSION}-1debian12_amd64.deb /tmp/mysql-community-client-plugins_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-community-client_${VERSION}-1debian12_amd64.deb /tmp/mysql-community-client_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-client_${VERSION}-1debian12_amd64.deb /tmp/mysql-client_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-community-server-core_${VERSION}-1debian12_amd64.deb /tmp/mysql-community-server-core_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-community-server_${VERSION}-1debian12_amd64.deb /tmp/mysql-community-server_${VERSION}-1debian12_amd64.deb
+    do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.4-lts/m/mysql-community/mysql-server_${VERSION}-1debian12_amd64.deb /tmp/mysql-server_${VERSION}-1debian12_amd64.deb
+    PACKAGES=(
+        /tmp/mysql-common_${VERSION}-1debian12_amd64.deb
+        /tmp/libmysqlclient24_${VERSION}-1debian12_amd64.deb
+        /tmp/mysql-community-client-core_${VERSION}-1debian12_amd64.deb
+        /tmp/mysql-community-client-plugins_${VERSION}-1debian12_amd64.deb
+        /tmp/mysql-community-client_${VERSION}-1debian12_amd64.deb
+        /tmp/mysql-client_${VERSION}-1debian12_amd64.deb
+        /tmp/mysql-community-server-core_${VERSION}-1debian12_amd64.deb
+        /tmp/mysql-community-server_${VERSION}-1debian12_amd64.deb
+        /tmp/mysql-server_${VERSION}-1debian12_amd64.deb
+        mysql-shell
+        percona-xtrabackup-84
+    )
+    ;;
 percona80)
     PACKAGES=(
         libperconaserverclient21
@@ -125,12 +152,18 @@ case "${FLAVOR}" in
 mysql80)
     echo 'deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.0' > /etc/apt/sources.list.d/mysql.list
     ;;
+mysql84)
+    echo 'deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.4-lts' > /etc/apt/sources.list.d/mysql.list
+    ;;
 esac
 
 # Add extra apt repositories for Percona Server and/or Percona XtraBackup.
 case "${FLAVOR}" in
 mysql80)
     echo 'deb http://repo.percona.com/apt bookworm main' > /etc/apt/sources.list.d/percona.list
+    ;;
+mysql84)
+    echo 'deb http://repo.percona.com/pxb-84-lts/apt bookworm main' > /etc/apt/sources.list.d/percona.list
     ;;
 percona80)
     echo 'deb http://repo.percona.com/apt bookworm main' > /etc/apt/sources.list.d/percona.list

--- a/docker/vttestserver/Dockerfile.mysql84
+++ b/docker/vttestserver/Dockerfile.mysql84
@@ -1,0 +1,59 @@
+# Copyright 2021 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM --platform=linux/amd64 golang:1.23.4-bullseye AS builder
+
+# Allows docker builds to set the BUILD_NUMBER
+ARG BUILD_NUMBER
+
+WORKDIR /vt/src/vitess.io/vitess
+
+# Create vitess user
+RUN groupadd -r vitess && useradd -r -g vitess vitess
+RUN mkdir -p /vt/vtdataroot /home/vitess
+RUN chown -R vitess:vitess /vt /home/vitess
+USER vitess
+
+# Re-copy sources from working tree.
+COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
+
+RUN make install-testing PREFIX=/vt/install
+
+# Start over and build the final image.
+FROM --platform=linux/amd64 debian:bullseye-slim
+
+# Install dependencies
+COPY docker/utils/install_dependencies.sh /vt/dist/install_dependencies.sh
+RUN /vt/dist/install_dependencies.sh mysql84
+
+# Set up Vitess user and directory tree.
+RUN groupadd -r vitess && useradd -r -g vitess vitess
+RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vt/vtdataroot
+ENV PATH $VTROOT/bin:$PATH
+
+# Copy artifacts from builder layer.
+COPY --from=builder --chown=vitess:vitess /vt/install /vt
+
+# Create mount point for actual data (e.g. MySQL data dir)
+VOLUME /vt/vtdataroot
+USER vitess
+
+COPY docker/vttestserver/setup_vschema_folder.sh /vt/setup_vschema_folder.sh
+COPY docker/vttestserver/run.sh /vt/run.sh
+
+CMD /vt/run.sh "8.4.3-Vitess"

--- a/go/tools/go-upgrade/go-upgrade.go
+++ b/go/tools/go-upgrade/go-upgrade.go
@@ -343,8 +343,10 @@ func replaceGoVersionInCodebase(old, new *version.Version) error {
 		"./build.env",
 		"./docker/bootstrap/Dockerfile.common",
 		"./docker/lite/Dockerfile",
+		"./docker/lite/Dockerfile.mysql84",
 		"./docker/lite/Dockerfile.percona80",
 		"./docker/vttestserver/Dockerfile.mysql80",
+		"./docker/vttestserver/Dockerfile.mysql84",
 	}
 	filesToChange, err := getListOfFilesInPaths(explore)
 	if err != nil {

--- a/test.go
+++ b/test.go
@@ -112,7 +112,7 @@ const (
 	configFileName = "test/config.json"
 
 	// List of flavors for which a bootstrap Docker image is available.
-	flavors = "mysql80,percona80"
+	flavors = "mysql80,mysql84,percona80"
 )
 
 // Config is the overall object serialized in test/config.json.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Add MySQL8.4 docker images

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #17519

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
