### PR TITLE
Add the concept of thirdparty impls to Vitess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ report
 # mise files
 .mise.toml
 /errors/
+
+# thirdparty
+/go/thirdparty/

--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -82,7 +82,7 @@ var (
 func init() {
 	srvTopoCounts = stats.NewCountersWithSingleLabel("ResilientSrvTopoServer", "Resilient srvtopo server operations", "type")
 	// Initalize any third party implementations for vitess
-	thirdparty.InitializeThirdParty()
+	thirdparty.InitializeThirdParty(Main)
 }
 
 // CheckCellFlags will check validation of cell and cells_to_watch flag

--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/thirdparty"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/srvtopo"
@@ -80,6 +81,8 @@ var (
 
 func init() {
 	srvTopoCounts = stats.NewCountersWithSingleLabel("ResilientSrvTopoServer", "Resilient srvtopo server operations", "type")
+	// Initalize any third party implementations for vitess
+	thirdparty.InitializeThirdParty()
 }
 
 // CheckCellFlags will check validation of cell and cells_to_watch flag

--- a/go/mysql/auth_server.go
+++ b/go/mysql/auth_server.go
@@ -581,6 +581,7 @@ func RegisterAuthServer(name string, authServer AuthServer) {
 		log.Fatalf("AuthServer named %v already exists", name)
 	}
 	authServers[name] = authServer
+	log.Infof("registered auth server %v", name)
 }
 
 // GetAuthServer returns an AuthServer by name, or log.Exitf.

--- a/go/thirdparty/thirdparty.go
+++ b/go/thirdparty/thirdparty.go
@@ -2,14 +2,16 @@ package thirdparty
 
 import (
 	"sync"
+
+	"github.com/spf13/cobra"
 )
 
 var once sync.Once
 
-func InitializeThirdParty() {
+func InitializeThirdParty(command *cobra.Command) {
 	// only initialize once
 	once.Do(func() {
-		// initialize/register any third part implemenations
+		// initialize/register any third part implementations
 
 	})
 }

--- a/go/thirdparty/thirdparty.go
+++ b/go/thirdparty/thirdparty.go
@@ -1,0 +1,15 @@
+package thirdparty
+
+import (
+	"sync"
+)
+
+var once sync.Once
+
+func InitializeThirdParty() {
+	// only initialize once
+	once.Do(func() {
+		// initialize/register any third part implemenations
+
+	})
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
## What:
- This introduces the concept of thirdparty code/implantation for Vitess
- This specifically enables thirdparty for `vtgate`
- `thirdparty.go` is intentially a no-op for "base" vitess and is implemented by the thirdparty
    - This file needs to exist in base so that golang will import/init/build the thirdparty packages
- `vtgate/cli/clig.go` was updated to initialize and *potential* third party code

Fixes/Updates:
- `auth_server.go` logging was added to log what is being registered
- `plugin_mysql_server.go` enhanced `RegisterPluginInitializer` to support initialization priority to aid in ordering (if necessary) vtgate plugin inits

## Why:
- This allows thirdparty (IE HubSpot) to create flags/implementations (vtgate for this commit specifically) that can accessed in the runtime instead of forking the original code
- This code otherwise has no change the current behaviour
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
[Feature Request: Create a third-party folder for company specific code/implementations](https://github.com/vitessio/vitess/issues/17707)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
