### PR TITLE
Always return a valid timezone in cursor

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -164,7 +164,7 @@ func (t *noopVCursor) Environment() *vtenv.Environment {
 }
 
 func (t *noopVCursor) TimeZone() *time.Location {
-	return nil
+	return time.Local
 }
 
 func (t *noopVCursor) SQLMode() string {

--- a/go/vt/vtgate/evalengine/fn_time.go
+++ b/go/vt/vtgate/evalengine/fn_time.go
@@ -256,7 +256,7 @@ func (call *builtinNow) constant() bool {
 
 func (call *builtinSysdate) eval(env *ExpressionEnv) (eval, error) {
 	now := SystemTime()
-	if tz := env.currentTimezone(); tz != nil {
+	if tz := env.currentTimezone(); tz != time.Local {
 		now = now.In(tz)
 	}
 	return newEvalDateTime(datetime.NewDateTimeFromStd(now), int(call.prec), false), nil
@@ -701,7 +701,7 @@ func (b *builtinFromUnixtime) eval(env *ExpressionEnv) (eval, error) {
 	}
 
 	t := time.Unix(sec, frac)
-	if tz := env.currentTimezone(); tz != nil {
+	if tz := env.currentTimezone(); tz != time.Local {
 		t = t.In(tz)
 	}
 

--- a/go/vt/vtgate/executorcontext/safe_session.go
+++ b/go/vt/vtgate/executorcontext/safe_session.go
@@ -656,17 +656,18 @@ func (session *SafeSession) TimeZone() *time.Location {
 	session.mu.Unlock()
 
 	if !ok {
-		return nil
+		return time.Local
 	}
 
 	tz, err := sqltypes.DecodeStringSQL(zoneSQL)
 	if err != nil {
-		return nil
+		return time.Local
 	}
 
-	loc, _ := datetime.ParseTimeZone(tz)
-	// it's safe to ignore the error - if we get an error, loc will be nil,
-	// and this is exactly the behaviour we want anyway
+	loc, err := datetime.ParseTimeZone(tz)
+	if err != nil {
+		return time.Local
+	}
 	return loc
 }
 

--- a/go/vt/vtgate/executorcontext/safe_session_test.go
+++ b/go/vt/vtgate/executorcontext/safe_session_test.go
@@ -174,6 +174,10 @@ func TestTimeZone(t *testing.T) {
 		want string
 	}{
 		{
+			tz:   "",
+			want: time.Local.String(),
+		},
+		{
 			tz:   "'Europe/Amsterdam'",
 			want: "Europe/Amsterdam",
 		},
@@ -183,16 +187,18 @@ func TestTimeZone(t *testing.T) {
 		},
 		{
 			tz:   "foo",
-			want: (*time.Location)(nil).String(),
+			want: time.Local.String(),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.tz, func(t *testing.T) {
+			sysvars := map[string]string{}
+			if tc.tz != "" {
+				sysvars["time_zone"] = tc.tz
+			}
 			session := NewSafeSession(&vtgatepb.Session{
-				SystemVariables: map[string]string{
-					"time_zone": tc.tz,
-				},
+				SystemVariables: sysvars,
 			})
 
 			assert.Equal(t, tc.want, session.TimeZone().String())


### PR DESCRIPTION
Conversion functions into a Go `time.Time` expect to have a valid `*time.Location` and will panic if passed in `nil`.

Before we used also here `nil` to signal no timezone is set (and thus falling back to `time.Local` implicitly, but it's better to always return a timezone explicitly and use `time.Local` where appropriate then.

## Related Issue(s)

Fixes #17545 

Marked also for back porting as this can panic. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required