### PR TITLE
sizegen: do not ignore type aliases

### DIFF
--- a/go/mysql/collations/colldata/cached_size.go
+++ b/go/mysql/collations/colldata/cached_size.go
@@ -19,6 +19,10 @@ package colldata
 
 import hack "vitess.io/vitess/go/hack"
 
+type cachedObject interface {
+	CachedSize(alloc bool) int64
+}
+
 func (cached *eightbitWildcard) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -58,6 +62,10 @@ func (cached *unicodeWildcard) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(48)
+	}
+	// field charset vitess.io/vitess/go/mysql/collations/charset.Charset
+	if cc, ok := cached.charset.(cachedObject); ok {
+		size += cc.CachedSize(true)
 	}
 	// field pattern []rune
 	{

--- a/go/sqltypes/cached_size.go
+++ b/go/sqltypes/cached_size.go
@@ -37,6 +37,14 @@ func (cached *Result) CachedSize(alloc bool) int64 {
 	// field Rows []vitess.io/vitess/go/sqltypes.Row
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Rows)) * int64(24))
+		for _, elem := range cached.Rows {
+			{
+				size += hack.RuntimeAllocSize(int64(cap(elem)) * int64(32))
+				for _, elem := range elem {
+					size += elem.CachedSize(false)
+				}
+			}
+		}
 	}
 	// field SessionStateChanges string
 	size += hack.RuntimeAllocSize(int64(len(cached.SessionStateChanges)))

--- a/go/tools/sizegen/sizegen.go
+++ b/go/tools/sizegen/sizegen.go
@@ -163,6 +163,8 @@ func (sizegen *sizegen) generateTyp(tt types.Type) {
 		sizegen.generateKnownType(tt)
 	case *types.Alias:
 		sizegen.generateTyp(types.Unalias(tt))
+	default:
+		panic(fmt.Sprintf("unhandled type: %v (%T)", tt, tt))
 	}
 }
 
@@ -490,9 +492,11 @@ func (sizegen *sizegen) sizeStmtForType(fieldName *jen.Statement, field types.Ty
 		// assume that function pointers do not allocate (although they might, if they're closures)
 		return nil, 0
 
+	case *types.Alias:
+		return sizegen.sizeStmtForType(fieldName, types.Unalias(node), alloc)
+
 	default:
-		log.Printf("unhandled type: %T", node)
-		return nil, 0
+		panic(fmt.Sprintf("unhandled type: %v (%T)", node, node))
 	}
 }
 

--- a/go/vt/proto/query/cached_size.go
+++ b/go/vt/proto/query/cached_size.go
@@ -27,6 +27,10 @@ func (cached *BindVariable) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(96)
 	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
+	}
 	// field Value []byte
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Value)))
@@ -47,6 +51,10 @@ func (cached *Field) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(160)
+	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Name string
 	size += hack.RuntimeAllocSize(int64(len(cached.Name)))
@@ -70,6 +78,10 @@ func (cached *QueryWarning) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(64)
 	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
+	}
 	// field Message string
 	size += hack.RuntimeAllocSize(int64(len(cached.Message)))
 	return size
@@ -81,6 +93,10 @@ func (cached *Target) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(96)
+	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Keyspace string
 	size += hack.RuntimeAllocSize(int64(len(cached.Keyspace)))
@@ -97,6 +113,10 @@ func (cached *Value) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(80)
+	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Value []byte
 	{

--- a/go/vt/proto/topodata/cached_size.go
+++ b/go/vt/proto/topodata/cached_size.go
@@ -27,6 +27,10 @@ func (cached *KeyRange) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(96)
 	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
+	}
 	// field Start []byte
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Start)))
@@ -44,6 +48,10 @@ func (cached *ThrottledAppRule) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(80)
+	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	// field Name string
 	size += hack.RuntimeAllocSize(int64(len(cached.Name)))

--- a/go/vt/proto/vttime/cached_size.go
+++ b/go/vt/proto/vttime/cached_size.go
@@ -17,6 +17,8 @@ limitations under the License.
 
 package vttime
 
+import hack "vitess.io/vitess/go/hack"
+
 func (cached *Time) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -24,6 +26,10 @@ func (cached *Time) CachedSize(alloc bool) int64 {
 	size := int64(0)
 	if alloc {
 		size += int64(64)
+	}
+	// field unknownFields google.golang.org/protobuf/runtime/protoimpl.UnknownFields
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.unknownFields)))
 	}
 	return size
 }


### PR DESCRIPTION
## Description

Important fix for memory calculations of in-memory data structures. Was causing OOMs in production.

In Go 1.23 a new type alias node was introduced for reflection, see https://github.com/golang/go/issues/63223. This initially caused the sizegen generation to crash, which was fixed by @systay in https://github.com/golang/go/issues/63223 but that fix was not complete. It still creates a ton of warnings since that change that were never fixed:

```
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 WARNING: size of external type regexp.Regexp cannot be fully calculated
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 WARNING: size of external type math/big.Int cannot be fully calculated
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 WARNING: size of external type regexp.Regexp cannot be fully calculated
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 unhandled type: *types.Alias
2025/01/16 15:51:18 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/key/cached_size.go'
2025/01/16 15:51:18 saved '/Users/dirkjan/code/vitessio/vitess/go/pools/smartconnpool/cached_size.go'
2025/01/16 15:51:18 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vtgate/engine/cached_size.go'
2025/01/16 15:51:18 saved '/Users/dirkjan/code/vitessio/vitess/go/mysql/collations/colldata/cached_size.go'
2025/01/16 15:51:18 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/tableacl/cached_size.go'
2025/01/16 15:51:18 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/schema/cached_size.go'
2025/01/16 15:51:18 saved '/Users/dirkjan/code/vitessio/vitess/go/sqltypes/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vtgate/evalengine/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vttablet/tabletserver/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/proto/query/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/srvtopo/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/sqlparser/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vtenv/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/proto/topodata/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/mysql/collations/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/mysql/json/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/mysql/decimal/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vtgate/vindexes/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vttablet/tabletserver/rules/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vttablet/tabletserver/planbuilder/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/vttablet/tabletserver/schema/cached_size.go'
2025/01/16 15:51:19 saved '/Users/dirkjan/code/vitessio/vitess/go/vt/proto/vttime/cached_size.go'
```

This might have looked innocent, but it certainly is not. The problem we found here specifically starts showing up in the `vttablet` consolidation logic. The problem is that we need these sizes to properly compute the cache. We have a type alias for `Row` to `[]Value` for the actual row storage which is now ignored.

This means that the cache in use size for the consolidator did not actually count the row data! This is basically the main part of what it needs to measure. This in turns leads to excessive memory usage by the consolidator. 

This also applies to the normal query consolidator, to the query cache, and any other piece of code that was depending on CachedSize to be accurate in order to limit vttablet memory usage. We're hoping this will cut down on the amount of OOMs we see in production.

cc @dbussink 

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/17555

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
