### PR TITLE
Performance Optimisation Around Dependency Calculations

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -120,17 +120,18 @@ func cloneASTAndSemState[T sqlparser.SQLNode](ctx *plancontext.PlanningContext, 
 }
 
 // findTablesContained returns the TableSet of all the contained
-func findTablesContained(ctx *plancontext.PlanningContext, node sqlparser.SQLNode) (result semantics.TableSet) {
+func findTablesContained(ctx *plancontext.PlanningContext, node sqlparser.SQLNode) semantics.TableSet {
+	var tables semantics.MutableTableSet
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
 		t, ok := node.(*sqlparser.AliasedTableExpr)
 		if !ok {
 			return true, nil
 		}
 		ts := ctx.SemTable.TableSetFor(t)
-		result = result.Merge(ts)
+		tables.MergeInPlace(ts)
 		return true, nil
 	}, node)
-	return
+	return tables.ToImmutable()
 }
 
 // joinPredicateCollector is used to inspect the predicates inside the subquery, looking for any

--- a/go/vt/vtgate/planbuilder/operators/helpers.go
+++ b/go/vt/vtgate/planbuilder/operators/helpers.go
@@ -71,14 +71,15 @@ type tableIDIntroducer interface {
 	introducesTableID() semantics.TableSet
 }
 
-func TableID(op Operator) (result semantics.TableSet) {
+func TableID(op Operator) semantics.TableSet {
+	var tables semantics.MutableTableSet
 	_ = Visit(op, func(this Operator) error {
 		if tbl, ok := this.(tableIDIntroducer); ok {
-			result = result.Merge(tbl.introducesTableID())
+			tables.MergeInPlace(tbl.introducesTableID())
 		}
 		return nil
 	})
-	return
+	return tables.ToImmutable()
 }
 
 // TableUser is used to signal that this operator directly interacts with one or more tables

--- a/go/vt/vtgate/planbuilder/operators/querygraph.go
+++ b/go/vt/vtgate/planbuilder/operators/querygraph.go
@@ -66,11 +66,11 @@ var _ Operator = (*QueryGraph)(nil)
 
 // Introduces implements the tableIDIntroducer interface
 func (qg *QueryGraph) introducesTableID() semantics.TableSet {
-	var ts semantics.TableSet
+	var ts semantics.MutableTableSet
 	for _, table := range qg.Tables {
-		ts = ts.Merge(table.ID)
+		ts.MergeInPlace(table.ID)
 	}
-	return ts
+	return ts.ToImmutable()
 }
 
 // GetPredicates returns the predicates that are applicable for the two given TableSets

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -806,9 +806,9 @@ func (r *Route) getTruncateColumnCount() int {
 }
 
 func (r *Route) introducesTableID() semantics.TableSet {
-	id := semantics.EmptyTableSet()
+	var tables semantics.MutableTableSet
 	for _, route := range r.MergedWith {
-		id = id.Merge(TableID(route))
+		tables.MergeInPlace(TableID(route))
 	}
-	return id
+	return tables.ToImmutable()
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -872,3 +872,41 @@ func benchmarkPlanner(b *testing.B, version plancontext.PlannerVersion, testCase
 		}
 	}
 }
+
+func (s *planTestSuite) TestMy() {
+	vschema, err := vschemawrapper.NewVschemaWrapper(
+		vtenv.NewTestEnv(),
+		loadSchema(s.T(), "vschemas/my_schema.json", true),
+		TestBuilder,
+	)
+	require.NoError(s.T(), err)
+	// vschema := &vschemawrapper.VSchemaWrapper{
+	// 	V:             loadSchema(s.T(), "vschemas/my_schema.json", true),
+	// 	SysVarEnabled: true,
+	// 	Version:       Gen4,
+	// 	Env:           vtenv.NewTestEnv(),
+	// }
+
+	s.testFile("my.json", vschema, false)
+}
+
+func BenchmarkMine(b *testing.B) {
+	vschema, err := vschemawrapper.NewVschemaWrapper(
+		vtenv.NewTestEnv(),
+		loadSchema(b, "vschemas/my_schema.json", true),
+		TestBuilder,
+	)
+	require.NoError(b, err)
+	testCases := readJSONTests("my.json")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		for _, tcase := range testCases {
+			plan, _ := TestBuilder(tcase.Query, vschema, vschema.CurrentDb())
+			if plan == nil {
+				panic("")
+			}
+		}
+	}
+}

--- a/go/vt/vtgate/planbuilder/testdata/my.json
+++ b/go/vt/vtgate/planbuilder/testdata/my.json
@@ -1,0 +1,740 @@
+[
+  {
+    "comment": "Add your test case here for debugging and run go test -run=One.",
+    "query": "select col04, col03, col01, col02 from my_table where id in ((select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '2XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'VXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '6XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'6FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'ZXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'GXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '8XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'FXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'0FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'FXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'YXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'YXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '1XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'WXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '2XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'HXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'QXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'0FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'ZXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'NXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'WXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'PXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'3FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'BXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'TXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '4XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'KXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '3XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'FFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '0XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '1XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'3FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'SXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '5XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'KXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'FFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'HXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '5XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'CXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'NXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'TXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'DXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'GXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000)) order by col01 desc, sdKey desc, col02 desc limit 0, 500000;",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select col04, col03, col01, col02 from my_table where id in ((select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '2XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'VXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '6XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'6FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'ZXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'GXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '8XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'FXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'0FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'FXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'YXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'YXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '1XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'WXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '2XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'HXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'QXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'0FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'ZXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'NXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'WXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'PXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'3FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'BXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'TXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '4XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'KXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '3XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'FFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '0XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '1XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'3FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'SXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '5XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'KXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'FFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'HXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '5XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'CXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'NXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'TXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'DXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'GXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000)) order by col01 desc, sdKey desc, col02 desc limit 0, 500000;",
+      "Instructions": {
+        "OperatorType": "Limit",
+        "Count": "500000",
+        "Offset": "0",
+        "Inputs": [
+          {
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutIn",
+            "PulloutVars": [
+              "__sq_has_values",
+              "__sq1"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Concatenate",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '2XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'VXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '6XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'6FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'o\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'ZXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'_\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "(select id from my_table force index (MY_INDEX) where 1 != 1) union all (select id from my_table force index (MY_INDEX) where 1 != 1) union all (select id from my_table force index (MY_INDEX) where 1 != 1)",
+                    "Query": "(select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'GXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '8XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000)",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'FXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'0FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\u000f\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'FXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'_\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'YXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'/\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'YXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '1XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "(select id from my_table force index (MY_INDEX) where 1 != 1) union all (select id from my_table force index (MY_INDEX) where 1 != 1)",
+                    "Query": "(select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000)",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'WXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '2XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'O\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'HXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'QXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'0FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\u000f\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'ZXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "(select id from my_table force index (MY_INDEX) where 1 != 1) union all (select id from my_table force index (MY_INDEX) where 1 != 1)",
+                    "Query": "(select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'NXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000) union all (select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000)",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'WXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'PXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'3FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'?\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'BXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'O\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'_\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'TXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'O\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '4XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'KXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'O\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '3XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'FFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '0XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'AFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '1XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'JXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'3FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'?\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'SXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '5XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'/\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'KXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'5FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'_\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'7FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'XXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'FFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'HXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'2FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'/\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = '5XxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'CXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'DFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'NXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'EFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'TXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'CFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'DXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'9FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'GXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'4FFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'O\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select id from my_table force index (MY_INDEX) where 1 != 1",
+                    "Query": "select id from my_table force index (MY_INDEX) where col02 <= 1234567890000 and col10 = 1234567890000000000 and col06 = 0 and col02 >= 1000000000000 and col01 = 'RXxXxXxXxXxXxXxXxXxXxXx' and sdKey = X'BFFF' order by col02 desc limit 0, 10000",
+                    "Table": "my_table",
+                    "Values": [
+                      "_binary'\ufffd\ufffd'"
+                    ],
+                    "Vindex": "binary_vdx"
+                  }
+                ]
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": true
+                },
+                "FieldQuery": "select col04, col03, col01, col02, sdKey from my_table where 1 != 1",
+                "OrderBy": "2 DESC COLLATE latin1_swedish_ci, 4 DESC, 3 DESC",
+                "Query": "select col04, col03, col01, col02, sdKey from my_table where :__sq_has_values and id in ::__sq1 order by my_table.col01 desc, sdKey desc, my_table.col02 desc",
+                "ResultColumns": 4,
+                "Table": "my_table"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.my_table"
+      ]
+    }
+  }
+]

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/my_schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/my_schema.json
@@ -1,0 +1,110 @@
+{
+  "keyspaces": {
+    "unsharded_ns": {
+      "sharded": false,
+      "tables": {
+        "my_table_seq": {
+          "type": "sequence",
+          "columns": [
+            {
+              "name": "next_id",
+              "type": "UINT64"
+            },
+            {
+              "name": "cache",
+              "type": "UINT32"
+            },
+            {
+              "name": "id",
+              "type": "UINT64"
+            }
+          ],
+          "column_list_authoritative": true
+        }
+      }
+    },
+    "main": {
+      "sharded": true,
+      "vindexes": {
+        "binary_vdx": {
+          "type": "binary"
+        }
+      },
+      "tables": {
+        "my_table": {
+          "column_vindexes": [
+            {
+              "columns": [
+                "sdKey"
+              ],
+              "name": "binary_vdx"
+            }
+          ],
+          "auto_increment": {
+            "column": "id",
+            "sequence": "my_table_seq"
+          },
+          "columns": [
+            {
+              "name": "col01",
+              "type": "VARCHAR"
+            },
+            {
+              "name": "col02",
+              "type": "INT64"
+            },
+            {
+              "name": "col03",
+              "type": "BLOB"
+            },
+            {
+              "name": "col04",
+              "type": "VARCHAR"
+            },
+            {
+              "name": "col05",
+              "type": "VARBINARY"
+            },
+            {
+              "name": "col06",
+              "type": "INT8"
+            },
+            {
+              "name": "col07",
+              "type": "INT64"
+            },
+            {
+              "name": "col08",
+              "type": "VARBINARY"
+            },
+            {
+              "name": "sdKey",
+              "type": "VARBINARY"
+            },
+            {
+              "name": "col09",
+              "type": "INT64"
+            },
+            {
+              "name": "col10",
+              "type": "INT64"
+            },
+            {
+              "name": "col11",
+              "type": "INT64"
+            },
+            {
+              "name": "col12",
+              "type": "INT64"
+            },
+            {
+              "name": "id",
+              "type": "UINT64"
+            }
+          ],
+          "column_list_authoritative": true
+        }
+      }
+    }
+  }
+}

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -174,7 +174,7 @@ func (a *analyzer) newSemTable(
 		Direct:                    a.binder.direct,
 		ExprTypes:                 a.typer.m,
 		Tables:                    a.tables.Tables,
-		DMLTargets:                a.binder.targets,
+		DMLTargets:                a.binder.targets.ToImmutable(),
 		NotSingleRouteErr:         a.notSingleRouteErr,
 		NotUnshardedErr:           a.unshardedErr,
 		Warning:                   a.warning,

--- a/go/vt/vtgate/semantics/bitset/mutable.go
+++ b/go/vt/vtgate/semantics/bitset/mutable.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bitset
+
+// Mutable is a growable, in-place version that we can OR bits into
+// and eventually turn into a stable (immutable) TableSet.
+type Mutable struct {
+	data []byte
+}
+
+// Or merges another TableSet into this Mutable, resizing if needed.
+func (m *Mutable) Or(ts Bitset) {
+	// If ts is longer than our current data, grow to accommodate it.
+	if len(ts) > len(m.data) {
+		oldData := m.data
+		m.data = make([]byte, len(ts))
+		copy(m.data, oldData)
+	}
+	// Merge in-place.
+	for i := 0; i < len(ts); i++ {
+		m.data[i] |= ts[i]
+	}
+}
+
+// AsImmutable finalizes the Mutable into a TableSet, trimming trailing zeros.
+func (m *Mutable) AsImmutable() Bitset {
+	trim := len(m.data)
+	for trim > 0 && m.data[trim-1] == 0 {
+		trim--
+	}
+	return toBitset(m.data[:trim])
+}

--- a/go/vt/vtgate/semantics/cte_table.go
+++ b/go/vt/vtgate/semantics/cte_table.go
@@ -163,10 +163,11 @@ type CTE struct {
 	Merged bool
 }
 
-func (cte *CTE) recursive(org originable) (id TableSet) {
+func (cte *CTE) recursive(org originable) TableSet {
 	if cte.recursiveDeps != nil {
 		return *cte.recursiveDeps
 	}
+	var id MutableTableSet
 
 	// We need to find the recursive dependencies of the CTE
 	// We'll do this by walking the inner query and finding all the tables
@@ -175,8 +176,8 @@ func (cte *CTE) recursive(org originable) (id TableSet) {
 		if !ok {
 			return true, nil
 		}
-		id = id.Merge(org.tableSetFor(ate))
+		id.MergeInPlace(org.tableSetFor(ate))
 		return true, nil
 	}, cte.Query)
-	return
+	return id.ToImmutable()
 }

--- a/go/vt/vtgate/semantics/derived_table.go
+++ b/go/vt/vtgate/semantics/derived_table.go
@@ -92,12 +92,15 @@ func handleAliasedExpr(vTbl *DerivedTable, expr *sqlparser.AliasedExpr, cols sql
 }
 
 func handleUnexpandedStarExpression(tables []TableInfo, vTbl *DerivedTable, org originable) {
+	var tableSets MutableTableSet
 	for _, table := range tables {
-		vTbl.tables = vTbl.tables.Merge(table.getTableSet(org))
+		ts := table.getTableSet(org)
+		tableSets.MergeInPlace(ts)
 		if !table.authoritative() {
 			vTbl.isAuthoritative = false
 		}
 	}
+	vTbl.tables = tableSets.ToImmutable()
 }
 
 // dependencies implements the TableInfo interface

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -228,12 +228,11 @@ func (s *scoper) up(cursor *sqlparser.Cursor) error {
 			s.popScope()
 		}
 	case *sqlparser.Select, *sqlparser.GroupBy, *sqlparser.Update, *sqlparser.Insert, *sqlparser.Union, *sqlparser.Delete:
-		id := EmptyTableSet()
+		var id MutableTableSet
 		for _, tableInfo := range s.currentScope().tables {
-			set := tableInfo.getTableSet(s.org)
-			id = id.Merge(set)
+			id.MergeInPlace(tableInfo.getTableSet(s.org))
 		}
-		s.statementIDs[s.currentScope().stmt] = id
+		s.statementIDs[s.currentScope().stmt] = id.ToImmutable()
 		s.popScope()
 	case *sqlparser.Where:
 		if node.Type != sqlparser.HavingClause {

--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -190,13 +190,15 @@ var ErrNotSingleTable = vterrors.VT13001("should only be used for single tables"
 
 // CopyDependencies copies the dependencies from one expression into the other
 func (st *SemTable) CopyDependencies(from, to sqlparser.Expr) {
-	if ValidAsMapKey(to) {
-		st.Recursive[to] = st.RecursiveDeps(from)
-		st.Direct[to] = st.DirectDeps(from)
-		if ValidAsMapKey(from) {
-			if typ, found := st.ExprTypes[from]; found {
-				st.ExprTypes[to] = typ
-			}
+	if ValidAsMapKey(to) && ValidAsMapKey(from) {
+		if deps, found := st.Recursive[from]; found {
+			st.Recursive[to] = deps
+		}
+		if deps, found := st.Direct[from]; found {
+			st.Direct[to] = deps
+		}
+		if typ, found := st.ExprTypes[from]; found {
+			st.ExprTypes[to] = typ
 		}
 	}
 }

--- a/go/vt/vtgate/semantics/table_set.go
+++ b/go/vt/vtgate/semantics/table_set.go
@@ -123,7 +123,14 @@ func MergeTableSets(tss ...TableSet) TableSet {
 	return TableSet(result)
 }
 
-// TableSetFromIds returns TableSet for all the id passed in argument.
-func TableSetFromIds(tids ...int) (ts TableSet) {
-	return TableSet(bitset.Build(tids...))
+type MutableTableSet struct {
+	bitset bitset.Mutable
+}
+
+func (ts *MutableTableSet) MergeInPlace(other TableSet) {
+	ts.bitset.Or(bitset.Bitset(other))
+}
+
+func (ts *MutableTableSet) ToImmutable() TableSet {
+	return TableSet(ts.bitset.AsImmutable())
 }

--- a/go/vt/vtgate/semantics/vtable.go
+++ b/go/vt/vtgate/semantics/vtable.go
@@ -165,12 +165,14 @@ func selectExprsToInfos(
 				colNames = append(colNames, expr.As.String())
 			}
 		case *sqlparser.StarExpr:
+			var tableSets MutableTableSet
 			for _, table := range tables {
-				ts = ts.Merge(table.getTableSet(org))
+				tableSets.MergeInPlace(table.getTableSet(org))
 				if !table.authoritative() {
 					isAuthoritative = false
 				}
 			}
+			ts = tableSets.ToImmutable()
 		}
 	}
 	return


### PR DESCRIPTION
```
                                            │ ../old.bench │            ../new.bench             │
                                            │    sec/op    │   sec/op     vs base                │
OLTP-20                                        238.5µ ± 6%   252.7µ ± 2%   +5.94% (p=0.005 n=10)
TPCC-20                                        1.702m ± 3%   1.760m ± 1%   +3.42% (p=0.000 n=10)
TPCH-20                                        10.08m ± 1%   10.06m ± 1%        ~ (p=0.971 n=10)
Planner/from_cases.json-gen4-20                7.376m ± 1%   7.502m ± 1%   +1.70% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20              147.5m ± 0%   149.4m ± 0%   +1.27% (p=0.000 n=10)
Planner/large_cases.json-gen4-20               464.7µ ± 0%   464.5µ ± 1%        ~ (p=0.631 n=10)
Planner/aggr_cases.json-gen4-20                13.10m ± 0%   13.13m ± 0%        ~ (p=0.315 n=10)
Planner/select_cases.json-gen4-20              10.66m ± 1%   10.65m ± 1%        ~ (p=0.971 n=10)
Planner/union_cases.json-gen4-20               3.808m ± 0%   3.879m ± 0%   +1.87% (p=0.000 n=10)
SemAnalysis-20                                 28.74m ± 1%   29.26m ± 1%   +1.81% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20       875.9µ ± 1%   965.0µ ± 2%  +10.17% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20    1.871m ± 0%   1.622m ± 1%  -13.30% (p=0.000 n=10)
BaselineVsMirrored/Baseline-20                 126.2µ ± 1%   128.4µ ± 1%   +1.71% (p=0.000 n=10)
BaselineVsMirrored/Mirrored-20                 333.7µ ± 0%   340.2µ ± 1%   +1.95% (p=0.000 n=10)
Mine-20                                        5.684m ± 0%   5.409m ± 0%   -4.84% (p=0.000 n=10)
geomean                                        2.971m        2.990m        +0.65%

                                            │ ../old.bench  │             ../new.bench             │
                                            │     B/op      │     B/op      vs base                │
OLTP-20                                        155.1Ki ± 0%   155.3Ki ± 0%   +0.15% (p=0.000 n=10)
TPCC-20                                        1.029Mi ± 0%   1.030Mi ± 0%   +0.11% (p=0.000 n=10)
TPCH-20                                        5.324Mi ± 0%   5.135Mi ± 0%   -3.55% (p=0.000 n=10)
Planner/from_cases.json-gen4-20                4.567Mi ± 0%   4.550Mi ± 0%   -0.37% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20              20.13Mi ± 0%   20.05Mi ± 0%   -0.41% (p=0.000 n=10)
Planner/large_cases.json-gen4-20               276.6Ki ± 0%   277.4Ki ± 0%   +0.29% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20                7.350Mi ± 0%   7.196Mi ± 0%   -2.10% (p=0.000 n=10)
Planner/select_cases.json-gen4-20              6.334Mi ± 0%   6.203Mi ± 0%   -2.08% (p=0.000 n=10)
Planner/union_cases.json-gen4-20               2.269Mi ± 0%   2.272Mi ± 0%   +0.14% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20       594.6Ki ± 0%   652.6Ki ± 0%   +9.76% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20   1128.1Ki ± 0%   975.8Ki ± 0%  -13.50% (p=0.000 n=10)
BaselineVsMirrored/Baseline-20                 88.03Ki ± 0%   88.04Ki ± 0%   +0.01% (p=0.033 n=10)
BaselineVsMirrored/Mirrored-20                 208.0Ki ± 0%   208.3Ki ± 0%   +0.13% (p=0.000 n=10)
Mine-20                                        3.515Mi ± 0%   3.243Mi ± 0%   -7.76% (p=0.000 n=10)
geomean                                        1.374Mi        1.353Mi        -1.49%

                                            │ ../old.bench │             ../new.bench             │
                                            │  allocs/op   │  allocs/op   vs base                 │
OLTP-20                                        3.859k ± 0%   3.929k ± 0%  +1.81% (p=0.000 n=10)
TPCC-20                                        25.63k ± 0%   26.02k ± 0%  +1.55% (p=0.000 n=10)
TPCH-20                                        134.9k ± 0%   136.1k ± 0%  +0.88% (p=0.000 n=10)
Planner/from_cases.json-gen4-20                107.9k ± 0%   110.6k ± 0%  +2.48% (p=0.000 n=10)
Planner/filter_cases.json-gen4-20              534.4k ± 0%   538.1k ± 0%  +0.68% (p=0.000 n=10)
Planner/large_cases.json-gen4-20               10.71k ± 0%   11.29k ± 0%  +5.42% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-20                168.1k ± 0%   171.3k ± 0%  +1.89% (p=0.000 n=10)
Planner/select_cases.json-gen4-20              147.8k ± 0%   150.7k ± 0%  +1.95% (p=0.000 n=10)
Planner/union_cases.json-gen4-20               53.22k ± 0%   54.11k ± 0%  +1.67% (p=0.000 n=10)
SelectVsDML/DML_(random_sample,_N=32)-20       12.53k ± 0%   13.20k ± 0%  +5.36% (p=0.000 n=10)
SelectVsDML/Select_(random_sample,_N=32)-20    25.82k ± 0%   23.52k ± 0%  -8.93% (p=0.000 n=10)
BaselineVsMirrored/Baseline-20                 2.276k ± 0%   2.276k ± 0%       ~ (p=1.000 n=10) ¹
BaselineVsMirrored/Mirrored-20                 5.837k ± 0%   6.006k ± 0%  +2.90% (p=0.000 n=10)
Mine-20                                        74.51k ± 0%   72.65k ± 0%  -2.50% (p=0.000 n=10)
geomean                                        34.58k        34.93k       +1.02%
```

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
