### PR TITLE
VDiff: Remove extra % sign in vdiff text report template

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
+++ b/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go
@@ -436,7 +436,7 @@ State:        {{.State}}
 RowsCompared: {{.RowsCompared}}
 HasMismatch:  {{.HasMismatch}}
 StartedAt:    {{.StartedAt}}
-{{if (eq .State "started")}}Progress:     {{printf "%.2f" .Progress.Percentage}}%%{{if .Progress.ETA}}, ETA: {{.Progress.ETA}}{{end}}{{end}}
+{{if (eq .State "started")}}Progress:     {{printf "%.2f" .Progress.Percentage}}%{{if .Progress.ETA}}, ETA: {{.Progress.ETA}}{{end}}{{end}}
 {{if .CompletedAt}}CompletedAt:  {{.CompletedAt}}{{end}}
 {{range $table := .TableSummaryMap}} 
 Table {{$table.TableName}}:


### PR DESCRIPTION
## Description

The text template used for VDiff reports had an extraneous `%` sign in it (needed for `printf`, but NOT templates): https://github.com/vitessio/vitess/blob/eaaa2063ef870391bf17dbf3599978c4eba20868/go/cmd/vtctldclient/command/vreplication/vdiff/vdiff.go#L439

I would notice this every once in a while, but then forget about it. I'm finally cleaning that up here. 🙂 

Manual test :
```
cd examples/local

./101_initial_cluster.sh && mysql < ../common/insert_commerce_data.sql && ./201_customer_tablets.sh

table_file="${VTDATAROOT}/vt_0000000100/data/vt_commerce/customer.ibd"
commerce_primary_uid=$(vtctldclient GetTablets --keyspace commerce --tablet-type primary --shard "0" | awk '{print $1}' | cut -d- -f2 | bc)

# Generate 5MiB of initial data
size=$((5*1024*1024))
while [[ $(stat -f "%z" "${table_file}") -lt ${size} ]]; do
    command mysql -u root --socket "${VTDATAROOT}/vt_0000000${commerce_primary_uid}/mysql.sock" vt_commerce -e "insert into customer (customer_id, email) values (${RANDOM}*${RANDOM}, '${RANDOM}_person@planetscale.com')" 2> /dev/null
done

# Get us up to 64MiB of data
size=$((64*1024*1024))
i=1
while [[ $(stat -f "%z" "${table_file}") -lt ${size} ]]; do
    command mysql -u root --socket "${VTDATAROOT}/vt_0000000${commerce_primary_uid}/mysql.sock" vt_commerce -e "insert into customer (email) select concat(${i}, email) from customer limit 5000000"
    let i=i+1
done

./202_move_tables.sh

vtctldclient vdiff --target-keyspace customer --workflow commerce2customer create --max-diff-duration 1s --auto-retry=false --update-table-stats

❯ vtctldclient vdiff --target-keyspace customer --workflow commerce2customer show last

VDiff Summary for customer.commerce2customer (17605a53-0055-4f88-9335-5ff24fc61be8)
State:        started
RowsCompared: 644217
HasMismatch:  false
StartedAt:    2025-01-18 21:06:26
Progress:     38.38%, ETA: 2025-01-18 21:06:28

Use "--format=json" for more detailed output.
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required