### PR TITLE
Tablet picker: Handle the case where a primary tablet is not setup for a shard

### DIFF
--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -62,6 +62,33 @@ func TestPickPrimary(t *testing.T) {
 	assert.True(t, proto.Equal(want, tablet), "Pick: %v, want %v", tablet, want)
 }
 
+// TestPickNoPrimary confirms that if the picker was setup only for primary tablets but
+// there is no primary setup for the shard we correctly return an error.
+func TestPickNoPrimary(t *testing.T) {
+	defer utils.EnsureNoLeaks(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	te := newPickerTestEnv(t, ctx, []string{"cell", "otherCell"})
+	want := addTablet(ctx, te, 100, topodatapb.TabletType_PRIMARY, "cell", true, true)
+	defer deleteTablet(t, te, want)
+	ctx, cancel = context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+	_, err := te.topoServ.UpdateShardFields(ctx, te.keyspace, te.shard, func(si *topo.ShardInfo) error {
+		si.PrimaryAlias = nil // force a missing primary
+		return nil
+	})
+	require.NoError(t, err)
+
+	tp, err := NewTabletPicker(ctx, te.topoServ, []string{"otherCell"}, "cell", te.keyspace, te.shard, "primary", TabletPickerOptions{})
+	require.NoError(t, err)
+
+	ctx2, cancel2 := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel2()
+	_, err = tp.PickForStreaming(ctx2)
+	require.Errorf(t, err, "No healthy serving tablet")
+}
+
 func TestPickLocalPreferences(t *testing.T) {
 	defer utils.EnsureNoLeaks(t)
 	type tablet struct {

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -492,6 +492,9 @@ func (ts *Server) GetTabletMap(ctx context.Context, tabletAliases []*topodatapb.
 	)
 
 	for _, tabletAlias := range tabletAliases {
+		if tabletAlias == nil {
+			return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "nil tablet alias in list")
+		}
 		wg.Add(1)
 		go func(tabletAlias *topodatapb.TabletAlias) {
 			defer wg.Done()


### PR DESCRIPTION

## Description

During a VReplication workflow, if the workflow has its `tablet_types` setup as `primary`, it would panic. This PR fixes that.

This was added a while back, so we should backport to supported versions: https://github.com/vitessio/vitess/pull/14224/files#diff-1bcb2314a21db237d254efff723def4a78db39c34298592d0b0a9a72a58ef575R372

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17571

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
