### PR TITLE
`sendBinlogDumpCommand`: apply BinlogThroughGTID flag

### DIFF
--- a/go/mysql/binlog_dump.go
+++ b/go/mysql/binlog_dump.go
@@ -75,16 +75,14 @@ func (c *Conn) parseComBinlogDumpGTID(data []byte) (logFile string, logPos uint6
 	if flags2&BinlogDumpNonBlock != 0 {
 		return logFile, logPos, position, io.EOF
 	}
-	if flags2&BinlogThroughGTID != 0 {
-		dataSize, pos, ok := readUint32(data, pos)
-		if !ok {
-			return logFile, logPos, position, readPacketErr
-		}
-		if gtid := string(data[pos : pos+int(dataSize)]); gtid != "" {
-			position, err = replication.DecodePosition(gtid)
-			if err != nil {
-				return logFile, logPos, position, err
-			}
+	dataSize, pos, ok := readUint32(data, pos)
+	if !ok {
+		return logFile, logPos, position, readPacketErr
+	}
+	if gtid := string(data[pos : pos+int(dataSize)]); gtid != "" {
+		position, err = replication.DecodePosition(gtid)
+		if err != nil {
+			return logFile, logPos, position, err
 		}
 	}
 

--- a/go/mysql/binlog_dump.go
+++ b/go/mysql/binlog_dump.go
@@ -72,9 +72,6 @@ func (c *Conn) parseComBinlogDumpGTID(data []byte) (logFile string, logPos uint6
 		return logFile, logPos, position, readPacketErr
 	}
 
-	if flags2&BinlogDumpNonBlock != 0 {
-		return logFile, logPos, position, io.EOF
-	}
 	dataSize, pos, ok := readUint32(data, pos)
 	if !ok {
 		return logFile, logPos, position, readPacketErr
@@ -84,6 +81,9 @@ func (c *Conn) parseComBinlogDumpGTID(data []byte) (logFile string, logPos uint6
 		if err != nil {
 			return logFile, logPos, position, err
 		}
+	}
+	if flags2&BinlogDumpNonBlock != 0 {
+		return logFile, logPos, position, io.EOF
 	}
 
 	return logFile, logPos, position, nil

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -219,7 +219,14 @@ func (mysqlFlavor) sendBinlogDumpCommand(c *Conn, serverID uint32, binlogFilenam
 
 	// Build the command.
 	sidBlock := gtidSet.SIDBlock()
-	return c.WriteComBinlogDumpGTID(serverID, binlogFilename, 4, 0, sidBlock)
+	var flags2 uint16
+	if binlogFilename != "" {
+		flags2 |= BinlogThroughPosition
+	}
+	if len(sidBlock) > 0 {
+		flags2 |= BinlogThroughGTID
+	}
+	return c.WriteComBinlogDumpGTID(serverID, binlogFilename, 4, flags2, sidBlock)
 }
 
 // setReplicationPositionCommands is part of the Flavor interface.

--- a/go/mysql/replication/mysql56_gtid_set_test.go
+++ b/go/mysql/replication/mysql56_gtid_set_test.go
@@ -854,3 +854,18 @@ func TestMysql56GTIDSet_RemoveUUID(t *testing.T) {
 		})
 	}
 }
+
+func TestSIDs(t *testing.T) {
+	var set Mysql56GTIDSet // nil
+	sids := set.SIDs()
+	assert.NotNil(t, sids)
+	assert.Empty(t, sids)
+
+	gtid := "8bc65cca-3fe4-11ed-bbfb-091034d48b3e:1:4-24"
+	gtidSet, err := ParseMysql56GTIDSet(gtid)
+	require.NoError(t, err)
+	sids = gtidSet.SIDs()
+	assert.NotNil(t, sids)
+	require.Len(t, sids, 1)
+	assert.Equal(t, "8bc65cca-3fe4-11ed-bbfb-091034d48b3e", sids[0].String())
+}

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -90,7 +90,9 @@ func TestComBinlogDumpGTID(t *testing.T) {
 
 	t.Run("WriteComBinlogDumpGTID", func(t *testing.T) {
 		// Write ComBinlogDumpGTID packet, read it, compare.
-		err := cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, 0x0d0e, []byte{0xfa, 0xfb})
+		var flags uint16 = 0x0d0e
+		assert.Equal(t, flags, flags|BinlogThroughGTID)
+		err := cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, flags, []byte{0xfa, 0xfb})
 		assert.NoError(t, err)
 		data, err := sConn.ReadPacket()
 		require.NoError(t, err, "sConn.ReadPacket - ComBinlogDumpGTID failed: %v", err)


### PR DESCRIPTION
## Description

The current MySQL flavor implementation for `ComBinlogDumpGTID` does not populate the event flags, and sends just 0. When requesting a GTID position, the flags must include `BinlogThroughGTID`. This is then reflected when parsing the event:

https://github.com/vitessio/vitess/blob/10ff5e372de283dbded889152abefccbb2f2c1f0/go/mysql/binlog_dump.go#L78-L89

If we don't populate the flag, we don't parse the GTID value.

this PR adds the necessary flag.

Furthermore, in compliance with MySQL server, we now actually also ignore the flag when parsing a ComBinlogDumpGTID packet. The `datasize` value is enough to determine that there is a GTID payload.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/17579

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
