### PR TITLE
Fix typos in MySQL 8.4 Dockerfile

### DIFF
--- a/docker/vttestserver/Dockerfile.mysql84
+++ b/docker/vttestserver/Dockerfile.mysql84
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.4-bullseye AS builder
+FROM --platform=linux/amd64 golang:1.23.5-bookworm AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
@@ -31,7 +31,7 @@ COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
 RUN make install-testing PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM --platform=linux/amd64 debian:bullseye-slim
+FROM --platform=linux/amd64 debian:bookworm-slim
 
 # Install dependencies
 COPY docker/utils/install_dependencies.sh /vt/dist/install_dependencies.sh


### PR DESCRIPTION
## Description

Corrects the version of Go and Debian used.

Edit:
Use the proper versions in the vttestserver. There was some concurrency issue when merging https://github.com/vitessio/vitess/pull/17563, https://github.com/vitessio/vitess/pull/17529 and https://github.com/vitessio/vitess/pull/17552

