### PR TITLE
Update the how to release java docs

### DIFF
--- a/doc/internal/release/how-to-release.md
+++ b/doc/internal/release/how-to-release.md
@@ -364,7 +364,8 @@ You will need administrator privileges on the vitess repository to be able to ma
 
     ```bash
     cd ./java/
-    mvn clean deploy -P release -DskipTests
+    # For <= v21.0, we must use -DskipTests in the mvn command below
+    mvn clean deploy -P release
     cd ..
     ```
 


### PR DESCRIPTION
## Description

Skipping tests when releasing the Java packages is no longer required for versions >= v22.0.