### PR TITLE
`parseComBinlogDumpGTID`: GTID payload is always 5.6 flavor

### DIFF
--- a/go/mysql/binlog_dump.go
+++ b/go/mysql/binlog_dump.go
@@ -77,7 +77,8 @@ func (c *Conn) parseComBinlogDumpGTID(data []byte) (logFile string, logPos uint6
 		return logFile, logPos, position, readPacketErr
 	}
 	if gtid := string(data[pos : pos+int(dataSize)]); gtid != "" {
-		position, err = replication.DecodePosition(gtid)
+		// ComBinlogDumpGTID is a MySQL specific protocol. The GTID flavor is necessarily MySQL 56
+		position, _, err = replication.DecodePositionMySQL56(gtid)
 		if err != nil {
 			return logFile, logPos, position, err
 		}

--- a/go/mysql/binlog_dump.go
+++ b/go/mysql/binlog_dump.go
@@ -76,12 +76,13 @@ func (c *Conn) parseComBinlogDumpGTID(data []byte) (logFile string, logPos uint6
 	if !ok {
 		return logFile, logPos, position, readPacketErr
 	}
-	if gtid := string(data[pos : pos+int(dataSize)]); gtid != "" {
-		// ComBinlogDumpGTID is a MySQL specific protocol. The GTID flavor is necessarily MySQL 56
-		position, _, err = replication.DecodePositionMySQL56(gtid)
+	if gtidBytes := data[pos : pos+int(dataSize)]; len(gtidBytes) != 0 {
+		gtid, err := replication.NewMysql56GTIDSetFromSIDBlock(gtidBytes)
 		if err != nil {
-			return logFile, logPos, position, err
+			return logFile, logPos, position, vterrors.Wrapf(err, "error parsing GTID from BinlogDumpGTID packet")
 		}
+		// ComBinlogDumpGTID is a MySQL specific protocol. The GTID flavor is necessarily MySQL 56
+		position = replication.Position{GTIDSet: gtid}
 	}
 	if flags2&BinlogDumpNonBlock != 0 {
 		return logFile, logPos, position, io.EOF

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -218,7 +218,10 @@ func (mysqlFlavor) sendBinlogDumpCommand(c *Conn, serverID uint32, binlogFilenam
 	}
 
 	// Build the command.
-	sidBlock := gtidSet.SIDBlock()
+	var sidBlock []byte
+	if gtidSet != nil {
+		sidBlock = gtidSet.SIDBlock()
+	}
 	var flags2 uint16
 	if binlogFilename != "" {
 		flags2 |= BinlogThroughPosition

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/test/utils"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -88,14 +89,15 @@ func TestComBinlogDumpGTID(t *testing.T) {
 		cConn.Close()
 	}()
 
-	t.Run("WriteComBinlogDumpGTID", func(t *testing.T) {
+	t.Run("WriteComBinlogDumpGTIDEmptyGTID", func(t *testing.T) {
 		// Write ComBinlogDumpGTID packet, read it, compare.
 		var flags uint16 = 0x0d0e
-		assert.Equal(t, flags, flags|BinlogThroughGTID)
-		err := cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, flags, []byte{0xfa, 0xfb})
+		err := cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, flags, []byte{})
 		assert.NoError(t, err)
 		data, err := sConn.ReadPacket()
 		require.NoError(t, err, "sConn.ReadPacket - ComBinlogDumpGTID failed: %v", err)
+		require.NotEmpty(t, data)
+		require.EqualValues(t, data[0], ComBinlogDumpGTID)
 
 		expectedData := []byte{
 			ComBinlogDumpGTID,
@@ -104,10 +106,46 @@ func TestComBinlogDumpGTID(t *testing.T) {
 			0x07, 0x00, 0x00, 0x00, // binlog-filename-len
 			'm', 'o', 'o', 'f', 'a', 'r', 'm', // bilog-filename
 			0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06, 0x05, // binlog-pos
-			0x02, 0x00, 0x00, 0x00, // data-size
-			0xfa, 0xfb, // data
+			0x00, 0x00, 0x00, 0x00, // data-size is zero, no GTID payload
 		}
 		assert.Equal(t, expectedData, data)
+		logFile, logPos, pos, err := sConn.parseComBinlogDumpGTID(data)
+		require.NoError(t, err, "parseComBinlogDumpGTID failed: %v", err)
+		assert.Equal(t, "moofarm", logFile)
+		assert.Equal(t, uint64(0x05060708090a0b0c), logPos)
+		assert.True(t, pos.IsZero())
+	})
+
+	t.Run("WriteComBinlogDumpGTID", func(t *testing.T) {
+		// Write ComBinlogDumpGTID packet, read it, compare.
+		var flags uint16 = 0x0d0e
+		assert.Equal(t, flags, flags|BinlogThroughGTID)
+		gtidSet, err := replication.ParseMysql56GTIDSet("16b1039f-22b6-11ed-b765-0a43f95f28a3:1-243")
+		require.NoError(t, err)
+		// dataSize := uint32(len(gtidSet.String()))
+		err = cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, flags, []byte(gtidSet.String()))
+		assert.NoError(t, err)
+		data, err := sConn.ReadPacket()
+		require.NoError(t, err, "sConn.ReadPacket - ComBinlogDumpGTID failed: %v", err)
+		require.NotEmpty(t, data)
+		require.EqualValues(t, data[0], ComBinlogDumpGTID)
+
+		expectedData := []byte{
+			ComBinlogDumpGTID,
+			0x0e, 0x0d, // flags
+			0x04, 0x03, 0x02, 0x01, // server-id
+			0x07, 0x00, 0x00, 0x00, // binlog-filename-len
+			'm', 'o', 'o', 'f', 'a', 'r', 'm', // bilog-filename
+			0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06, 0x05, // binlog-pos
+			0x02a, 0x00, 0x00, 0x00, // data-size
+			0x31, 0x36, 0x62, 0x31, 0x30, 0x33, 0x39, 0x66, 0x2d, 0x32, 0x32, 0x62, 0x36, 0x2d, 0x31, 0x31, 0x65, 0x64, 0x2d, 0x62, 0x37, 0x36, 0x35, 0x2d, 0x30, 0x61, 0x34, 0x33, 0x66, 0x39, 0x35, 0x66, 0x32, 0x38, 0x61, 0x33, 0x3a, 0x31, 0x2d, 0x32, 0x34, 0x33, // data
+		}
+		assert.Equal(t, expectedData, data)
+		logFile, logPos, pos, err := sConn.parseComBinlogDumpGTID(data)
+		require.NoError(t, err, "parseComBinlogDumpGTID failed: %v", err)
+		assert.Equal(t, "moofarm", logFile)
+		assert.Equal(t, uint64(0x05060708090a0b0c), logPos)
+		assert.Equal(t, gtidSet, pos.GTIDSet)
 	})
 
 	sConn.sequence = 0

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -122,8 +122,10 @@ func TestComBinlogDumpGTID(t *testing.T) {
 		assert.Equal(t, flags, flags|BinlogThroughGTID)
 		gtidSet, err := replication.ParseMysql56GTIDSet("16b1039f-22b6-11ed-b765-0a43f95f28a3:1-243")
 		require.NoError(t, err)
-		// dataSize := uint32(len(gtidSet.String()))
-		err = cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, flags, []byte(gtidSet.String()))
+		sidBlock := gtidSet.SIDBlock()
+		assert.Len(t, sidBlock, 0x30) // 48 bytes
+
+		err = cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, flags, sidBlock)
 		assert.NoError(t, err)
 		data, err := sConn.ReadPacket()
 		require.NoError(t, err, "sConn.ReadPacket - ComBinlogDumpGTID failed: %v", err)
@@ -137,9 +139,9 @@ func TestComBinlogDumpGTID(t *testing.T) {
 			0x07, 0x00, 0x00, 0x00, // binlog-filename-len
 			'm', 'o', 'o', 'f', 'a', 'r', 'm', // bilog-filename
 			0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06, 0x05, // binlog-pos
-			0x02a, 0x00, 0x00, 0x00, // data-size
-			0x31, 0x36, 0x62, 0x31, 0x30, 0x33, 0x39, 0x66, 0x2d, 0x32, 0x32, 0x62, 0x36, 0x2d, 0x31, 0x31, 0x65, 0x64, 0x2d, 0x62, 0x37, 0x36, 0x35, 0x2d, 0x30, 0x61, 0x34, 0x33, 0x66, 0x39, 0x35, 0x66, 0x32, 0x38, 0x61, 0x33, 0x3a, 0x31, 0x2d, 0x32, 0x34, 0x33, // data
+			0x30, 0x00, 0x00, 0x00, // data-size
 		}
+		expectedData = append(expectedData, sidBlock...) // data
 		assert.Equal(t, expectedData, data)
 		logFile, logPos, pos, err := sConn.parseComBinlogDumpGTID(data)
 		require.NoError(t, err, "parseComBinlogDumpGTID failed: %v", err)

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -116,6 +116,8 @@ func TestComBinlogDumpGTID(t *testing.T) {
 		assert.True(t, pos.IsZero())
 	})
 
+	sConn.sequence = 0
+
 	t.Run("WriteComBinlogDumpGTID", func(t *testing.T) {
 		// Write ComBinlogDumpGTID packet, read it, compare.
 		var flags uint16 = 0x0d0e

--- a/go/mysql/replication_test.go
+++ b/go/mysql/replication_test.go
@@ -125,7 +125,7 @@ func TestComBinlogDumpGTID(t *testing.T) {
 		gtidSet, err := replication.ParseMysql56GTIDSet("16b1039f-22b6-11ed-b765-0a43f95f28a3:1-243")
 		require.NoError(t, err)
 		sidBlock := gtidSet.SIDBlock()
-		assert.Len(t, sidBlock, 0x30) // 48 bytes
+		assert.Len(t, sidBlock, 48)
 
 		err = cConn.WriteComBinlogDumpGTID(0x01020304, "moofarm", 0x05060708090a0b0c, flags, sidBlock)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Description

Quick followup/fix to https://github.com/vitessio/vitess/pull/17580. https://github.com/vitessio/vitess/pull/17580 wasn't well tested, and although nothing in Vitess is actually calling `ComBinlogDumpGTID` with a GTID payload -- such calls fail. This is because the function attempts to run:
```go
		position, err = replication.DecodePosition(gtid)
```
However, the encoded GTID does not have a `MySQL56/` prefix. Rightly so, because that's not in the MySQL protocol. The command `ComBinlogDumpGTID` is MySQL-specific (ie not MariaDB or any other flavor) and thus the GTID payload is necessarily a `MySQL56` flavor.

In addition, the GTID is written in `ComBinlogDumpGTID` as a SID block. This PR now also parses it back from a SID block form.

This PR fixes the issue and adds appropriate testing.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17579

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
