### PR TITLE
VReplication: Address SwitchTraffic bugs around replication lag and cancel on error

### DIFF
--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -856,7 +856,7 @@ func (vc *VitessCluster) getVttabletsInKeyspace(t *testing.T, cell *Cell, ksName
 	tablets := make(map[string]*cluster.VttabletProcess)
 	for _, shard := range keyspace.Shards {
 		for _, tablet := range shard.Tablets {
-			if tablet.Vttablet.GetTabletStatus() == "SERVING" {
+			if tablet.Vttablet.GetTabletStatus() == "SERVING" && (tabletType == "" || strings.EqualFold(tablet.Vttablet.GetTabletType(), tabletType)) {
 				log.Infof("Serving status of tablet %s is %s, %s", tablet.Name, tablet.Vttablet.ServingStatus, tablet.Vttablet.GetTabletStatus())
 				tablets[tablet.Name] = tablet.Vttablet
 			}

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -842,7 +842,8 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 			numTestRows := 100
 			addTestRows := func() {
 				for i := 0; i < numTestRows; i++ {
-					execQuery(t, productConn, fmt.Sprintf("insert into customer (cid, name) values (%d, 'laggingCustomer')", startingTestRowID+i))
+					execQuery(t, productConn, fmt.Sprintf("insert into customer (cid, name) values (%d, 'laggingCustomer')",
+						startingTestRowID+i))
 				}
 			}
 			deleteTestRows := func() {
@@ -885,9 +886,9 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 				waitForNoWorkflowLag(t, vc, targetKs, workflow)
 			}
 
-			// First let's test that the pre-checks work as expected.
-			// We ALTER the table on the customer (target) shard to
-			// add a unique index on the name field.
+			// First let's test that the pre-checks work as expected. We ALTER
+			// the table on the customer (target) shard to add a unique index on
+			// the name field.
 			addIndex()
 			// Then we insert some test rows across both shards in the product
 			// (source) keyspace.
@@ -907,11 +908,12 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 			waitForTargetToCatchup()
 
 			// Now let's test that the cancel works by setting the command timeout
-			// to half the duration. Lock the customer table on the target tablets
-			// so that we cannot apply the INSERTs and catch up.
+			// to a fraction (6s) of the default max repl lag duration (30s). First
+			// we lock the customer table on the target tablets so that we cannot
+			// apply the INSERTs and catch up.
 			lockTargetTable()
 			addTestRows()
-			timeout := lagDuration * 2
+			timeout := lagDuration * 2 // 6s
 			// Use the default max-replication-lag-allowed value of 30s.
 			out, err = vc.VtctldClient.ExecuteCommandWithOutput(workflowType, "--workflow", workflow, "--target-keyspace", targetKs,
 				"SwitchTraffic", "--tablet-types=primary", "--timeout", timeout.String())

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -904,6 +904,7 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 			require.Error(t, err)
 			require.Regexp(t, fmt.Sprintf(".*cannot switch traffic for workflow %s at this time: replication lag [0-9]+s is higher than allowed lag %s.*",
 				workflow, lagDuration.String()), out)
+			require.NotContains(t, out, "cancel migration failed")
 			cleanupTestData()
 			waitForTargetToCatchup()
 
@@ -921,6 +922,7 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 			// successfully cancel.
 			require.Error(t, err)
 			require.Contains(t, out, "failed to sync up replication between the source and target")
+			require.NotContains(t, out, "cancel migration failed")
 			unlockTargetTable()
 			deleteTestRows()
 			waitForTargetToCatchup()

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -905,6 +905,8 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 			require.Regexp(t, fmt.Sprintf(".*cannot switch traffic for workflow %s at this time: replication lag [0-9]+s is higher than allowed lag %s.*",
 				workflow, lagDuration.String()), out)
 			require.NotContains(t, out, "cancel migration failed")
+			// Confirm that queries still work fine.
+			execVtgateQuery(t, vtgateConn, sourceKs, "select * from customer limit 1")
 			cleanupTestData()
 			waitForTargetToCatchup()
 
@@ -923,6 +925,8 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 			require.Error(t, err)
 			require.Contains(t, out, "failed to sync up replication between the source and target")
 			require.NotContains(t, out, "cancel migration failed")
+			// Confirm that queries still work fine.
+			execVtgateQuery(t, vtgateConn, sourceKs, "select * from customer limit 1")
 			unlockTargetTable()
 			deleteTestRows()
 			waitForTargetToCatchup()

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -3075,7 +3075,8 @@ func (s *Server) canSwitch(ctx context.Context, ts *trafficSwitcher, maxAllowedR
 				return cannotSwitchFrozen, nil
 			}
 			// If no new events have been replicated after the copy phase then it will be 0.
-			if vreplLag := time.Now().Unix() - st.TimeUpdated.Seconds; vreplLag > maxAllowedReplLagSecs {
+			vreplLag := int64(getVReplicationTrxLag(st.TransactionTimestamp, st.TimeUpdated, binlogdatapb.VReplicationWorkflowState(binlogdatapb.VReplicationWorkflowState_value[st.State])))
+			if vreplLag > maxAllowedReplLagSecs {
 				return fmt.Sprintf(cannotSwitchHighLag, vreplLag, maxAllowedReplLagSecs), nil
 			}
 			switch st.State {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -3069,8 +3069,8 @@ func (s *Server) canSwitch(ctx context.Context, ts *trafficSwitcher, maxAllowedR
 	if err != nil {
 		return "", err
 	}
-	if wf.MaxVReplicationLag > maxAllowedReplLagSecs {
-		return fmt.Sprintf(cannotSwitchHighLag, wf.MaxVReplicationLag, maxAllowedReplLagSecs), nil
+	if wf.MaxVReplicationTransactionLag > maxAllowedReplLagSecs {
+		return fmt.Sprintf(cannotSwitchHighLag, wf.MaxVReplicationTransactionLag, maxAllowedReplLagSecs), nil
 	}
 	for _, stream := range wf.ShardStreams {
 		for _, st := range stream.GetStreams() {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2951,7 +2951,7 @@ func (s *Server) switchWrites(ctx context.Context, req *vtctldatapb.WorkflowSwit
 				}
 			}
 			if cerr := sw.cancelMigration(ctx, sm); cerr != nil {
-				err = vterrors.Wrap(err, fmt.Sprintf("(%v)", cerr))
+				err = vterrors.Errorf(vtrpcpb.Code_CANCELED, "%v\n\n%v", err, cerr)
 			}
 			return handleError(fmt.Sprintf("failed to stop the workflow streams in the %s keyspace", ts.SourceKeyspaceName()), err)
 		}
@@ -2963,7 +2963,7 @@ func (s *Server) switchWrites(ctx context.Context, req *vtctldatapb.WorkflowSwit
 			for cnt := 1; cnt <= lockTablesCycles; cnt++ {
 				if err := ts.executeLockTablesOnSource(ctx); err != nil {
 					if cerr := sw.cancelMigration(ctx, sm); cerr != nil {
-						err = vterrors.Wrap(err, fmt.Sprintf("(%v)", cerr))
+						err = vterrors.Errorf(vtrpcpb.Code_CANCELED, "%v\n\n%v", err, cerr)
 					}
 					return handleError(fmt.Sprintf("failed to execute LOCK TABLES (attempt %d of %d) on sources", cnt, lockTablesCycles), err)
 				}

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -210,7 +210,7 @@ func (sm *StreamMigrator) CancelStreamMigrations(ctx context.Context) error {
 	errs := &concurrency.AllErrorRecorder{}
 
 	if err := sm.deleteTargetStreams(ctx); err != nil {
-		errs.RecordError(err)
+		errs.RecordError(fmt.Errorf("could not delete target streams: %v", err))
 	}
 
 	// Restart the source streams, but leave the Reshard workflow's reverse
@@ -224,7 +224,7 @@ func (sm *StreamMigrator) CancelStreamMigrations(ctx context.Context) error {
 		return err
 	})
 	if err != nil {
-		errs.RecordError(err)
+		errs.RecordError(fmt.Errorf("could not restart source streams: %v", err))
 		sm.logger.Errorf("Cancel stream migrations failed: could not restart source streams: %v", err)
 	}
 	if errs.HasErrors() {

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -124,8 +124,8 @@ func (r *switcher) stopStreams(ctx context.Context, sm *StreamMigrator) ([]strin
 	return sm.StopStreams(ctx)
 }
 
-func (r *switcher) cancelMigration(ctx context.Context, sm *StreamMigrator) {
-	r.ts.cancelMigration(ctx, sm)
+func (r *switcher) cancelMigration(ctx context.Context, sm *StreamMigrator) error {
+	return r.ts.cancelMigration(ctx, sm)
 }
 
 func (r *switcher) lockKeyspace(ctx context.Context, keyspace, action string, opts ...topo.LockOption) (context.Context, func(*error), error) {

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -301,8 +301,9 @@ func (dr *switcherDryRun) stopStreams(ctx context.Context, sm *StreamMigrator) (
 	return nil, nil
 }
 
-func (dr *switcherDryRun) cancelMigration(ctx context.Context, sm *StreamMigrator) {
+func (dr *switcherDryRun) cancelMigration(ctx context.Context, sm *StreamMigrator) error {
 	dr.drLog.Log("Cancel migration as requested")
+	return nil
 }
 
 func (dr *switcherDryRun) lockKeyspace(ctx context.Context, keyspace, _ string, _ ...topo.LockOption) (context.Context, func(*error), error) {

--- a/go/vt/vtctl/workflow/switcher_interface.go
+++ b/go/vt/vtctl/workflow/switcher_interface.go
@@ -27,7 +27,7 @@ import (
 
 type iswitcher interface {
 	lockKeyspace(ctx context.Context, keyspace, action string, opts ...topo.LockOption) (context.Context, func(*error), error)
-	cancelMigration(ctx context.Context, sm *StreamMigrator)
+	cancelMigration(ctx context.Context, sm *StreamMigrator) error
 	stopStreams(ctx context.Context, sm *StreamMigrator) ([]string, error)
 	stopSourceWrites(ctx context.Context) error
 	waitForCatchup(ctx context.Context, filteredReplicationWaitTime time.Duration) error

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1074,11 +1074,12 @@ func (ts *trafficSwitcher) stopSourceWrites(ctx context.Context) error {
 }
 
 // switchDeniedTables switches the denied tables rules for the traffic switch.
-// They are removed on the source side and added on the target side.
-// If backward is true, then we swap this logic, removing on the target side
-// and adding on the source side. You would want to do that e.g. when canceling
-// a failed (and currently partial) traffic switch as the source and target
-// have already been switched in the trafficSwitcher.
+// They are added on the source side and removed on the target side.
+// If backward is true, then we swap this logic, removing on the source side
+// and adding on the target side. You would want to do that e.g. when canceling
+// a failed (and currently partial) traffic switch as we may have already
+// switched the denied tables entries and in any event we need to go back to
+// the original state.
 func (ts *trafficSwitcher) switchDeniedTables(ctx context.Context, backward bool) error {
 	if ts.MigrationType() != binlogdatapb.MigrationType_TABLES {
 		return nil

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1150,10 +1150,10 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 	// context being canceled prior to or during the cancel operation itself.
 	// First we create a copy of the parent context, so that we maintain the locks, but which cannot be
 	// canceled by the parent context.
-	cctx := context.WithoutCancel(ctx)
+	wcCtx := context.WithoutCancel(ctx)
 	// Now we create a child context from that which has a timeout.
 	cmTimeout := 60 * time.Second
-	cmCtx, cmCancel := context.WithTimeout(cctx, cmTimeout)
+	cmCtx, cmCancel := context.WithTimeout(wcCtx, cmTimeout)
 	defer cmCancel()
 
 	if ts.MigrationType() == binlogdatapb.MigrationType_TABLES {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1148,8 +1148,11 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 
 	// We create a new context while canceling the migration, so that we are independent of the original
 	// context being cancelled prior to or during the cancel operation.
+	// Create a child context that cannot be canceled by the parent, so that we maintain the locks.
+	cctx := context.WithoutCancel(ctx)
+	// Now create a child context from that which has a timeout.
 	cmTimeout := 60 * time.Second
-	cmCtx, cmCancel := context.WithTimeout(context.Background(), cmTimeout)
+	cmCtx, cmCancel := context.WithTimeout(cctx, cmTimeout)
 	defer cmCancel()
 
 	if ts.MigrationType() == binlogdatapb.MigrationType_TABLES {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1147,10 +1147,11 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 	}
 
 	// We create a new context while canceling the migration, so that we are independent of the original
-	// context being cancelled prior to or during the cancel operation.
-	// Create a child context that cannot be canceled by the parent, so that we maintain the locks.
+	// context being canceled prior to or during the cancel operation itself.
+	// First we create a copy of the parent context, so that we maintain the locks, but which cannot be
+	// canceled by the parent context.
 	cctx := context.WithoutCancel(ctx)
-	// Now create a child context from that which has a timeout.
+	// Now we create a child context from that which has a timeout.
 	cmTimeout := 60 * time.Second
 	cmCtx, cmCancel := context.WithTimeout(cctx, cmTimeout)
 	defer cmCancel()

--- a/go/vt/vtctl/workflow/workflows.go
+++ b/go/vt/vtctl/workflow/workflows.go
@@ -656,6 +656,9 @@ func getStreamState(stream *vtctldatapb.Workflow_Stream, rstream *tabletmanagerd
 // switching during the copy phase, so in that case we just return a large lag.
 // All timestamps are in seconds since epoch.
 func getVReplicationTrxLag(trxTs, updatedTs, heartbeatTs *vttimepb.Time, state binlogdatapb.VReplicationWorkflowState) float64 {
+	if state == binlogdatapb.VReplicationWorkflowState_Copying {
+		return math.MaxInt64
+	}
 	if trxTs == nil {
 		trxTs = &vttimepb.Time{}
 	}
@@ -668,9 +671,6 @@ func getVReplicationTrxLag(trxTs, updatedTs, heartbeatTs *vttimepb.Time, state b
 		heartbeatTs = &vttimepb.Time{}
 	}
 	lastHeartbeatTime := heartbeatTs.Seconds
-	if state == binlogdatapb.VReplicationWorkflowState_Copying {
-		return math.MaxInt64
-	}
 	// We do NOT update the heartbeat timestamp when we are regularly updating the
 	// position as we replicate transactions (GTIDs).
 	// When we DO record a heartbeat, we set the updated time to the same value.

--- a/go/vt/vtctl/workflow/workflows.go
+++ b/go/vt/vtctl/workflow/workflows.go
@@ -667,11 +667,11 @@ func getVReplicationTrxLag(trxTs, updatedTs *vttimepb.Time, state binlogdatapb.V
 	if state == binlogdatapb.VReplicationWorkflowState_Copying {
 		return math.MaxInt64
 	}
-	if lastTransactionTime == 0 /* no new events after copy */ ||
-		lastUpdateTime > lastTransactionTime /* no recent transactions, so all caught up */ {
-
+	if state == binlogdatapb.VReplicationWorkflowState_Running && // We could be in the ERROR state
+		(lastTransactionTime == 0 /* No new events after copy */ ||
+			lastUpdateTime > lastTransactionTime /* No recent transactions, so all caught up */) {
 		lastTransactionTime = lastUpdateTime
 	}
-	now := time.Now().Unix() /* seconds since epoch */
+	now := time.Now().Unix() // Seconds since epoch
 	return float64(now - lastTransactionTime)
 }

--- a/go/vt/vtctl/workflow/workflows.go
+++ b/go/vt/vtctl/workflow/workflows.go
@@ -647,16 +647,6 @@ func getStreamState(stream *vtctldatapb.Workflow_Stream, rstream *tabletmanagerd
 	return rstream.State.String()
 }
 
-type GenericStream interface {
-	*tabletmanagerdatapb.ReadVReplicationWorkflowResponse_Stream | *vtctldatapb.Workflow_Stream
-}
-
-type Stream[T GenericStream] struct {
-	TransactionTimestamp *vttimepb.Time
-	TimeUpdated          *vttimepb.Time
-	State                binlogdatapb.VReplicationWorkflowState
-}
-
 // getVReplicationTrxLag estimates the actual statement processing lag between the
 // source and the target. If we are still processing source events it is the
 // difference between current time and the timestamp of the last event. If

--- a/go/vt/vtctl/workflow/workflows.go
+++ b/go/vt/vtctl/workflow/workflows.go
@@ -672,7 +672,7 @@ func getVReplicationTrxLag(trxTs, updatedTs, heartbeatTs *vttimepb.Time, state b
 		return math.MaxInt64
 	}
 	// We do NOT update the heartbeat timestamp when we are regularly updating the
-	// position as we replication transactions (GTIDs).
+	// position as we replicate transactions (GTIDs).
 	// When we DO record a heartbeat, we set the updated time to the same value.
 	// When recording that we are throttled, we update the updated time but NOT
 	// the heartbeat time.


### PR DESCRIPTION
## Description

This PR improves the error handling for cancel failures (see [issue](https://github.com/vitessio/vitess/issues/17620)). When the context changes are commented out in the PR branch we can see the new error handling in action here when using the manual test in the issue:
```
❯ vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer switchtraffic
E0123 10:57:24.082537   40795 main.go:60] rpc error: code = Unknown desc = failed to sync up replication between the source and target: rpc error: code = DeadlineExceeded desc = context deadline exceeded

could not revert denied tables / shard access: Code: INTERNAL
keyspace commerce is not locked (no locksInfo)

cancel migration failed, manual cleanup work may be necessary
```

And with the context changes in place:
```
❯ vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer switchtraffic
E0123 11:28:24.848992   80414 main.go:60] rpc error: code = Unknown desc = failed to sync up replication between the source and target: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

This PR also addresses the inaccuracy of the `max_v_replication_transaction_lag` value as noted in [the issue](https://github.com/vitessio/vitess/issues/17620). After adjusting this calculation, the manual test now fails in the `canSwitch()` pre-check as expected:
```
...
vtctldclient MoveTables --workflow commerce2customer --target-keyspace customer switchtraffic
E0123 13:09:33.292425    7651 main.go:60] rpc error: code = Unknown desc = cannot switch traffic for workflow commerce2customer at this time: replication lag 84s is higher than allowed lag 30s
```
And when monitoring the lag as the test runs you can see it correctly measured when there is little to no lag, you can see it increase as the actual lag increases, and then see it go back down (it is NOT included in the output when the value is 0):
```
❯ while true; do vtctldclient GetWorkflows customer --compact --include-logs=false | grep max_v_replication_transaction_lag; sleep 1; done
...
      "max_v_replication_transaction_lag": "1",
      "max_v_replication_transaction_lag": "1",
      "max_v_replication_transaction_lag": "2",
      "max_v_replication_transaction_lag": "1",
...
      "max_v_replication_transaction_lag": "84",
      "max_v_replication_transaction_lag": "85",
      "max_v_replication_transaction_lag": "86",
      "max_v_replication_transaction_lag": "87",
      "max_v_replication_transaction_lag": "73",
      "max_v_replication_transaction_lag": "74",
      "max_v_replication_transaction_lag": "75",
...
      "max_v_replication_transaction_lag": "93",
      "max_v_replication_transaction_lag": "94",
      "max_v_replication_transaction_lag": "1",
      "max_v_replication_transaction_lag": "1",
      "max_v_replication_transaction_lag": "1",
      "max_v_replication_transaction_lag": "1",
```

Lastly, for `MoveTables` switch writes specifically, we were not properly undoing or canceling the switching of the tablet_controls->denied_tables list.

> [!NOTE]
> I think that we should backport this all the way to v19 as each of the issues fixed here — 1) the context usage 2) the vreplication transaction lag calculation 3) the MoveTables switch writes cancel denied tables changes  — impact v19+.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/17620

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required