### PR TITLE
test: Add unit tests for `vtctl/workflow`

### DIFF
--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -272,7 +272,7 @@ type testTMClient struct {
 	createVReplicationWorkflowRequests map[uint32]*createVReplicationWorkflowRequestResponse
 	readVReplicationWorkflowRequests   map[uint32]*readVReplicationWorkflowRequestResponse
 	updateVReplicationWorklowsRequests map[uint32]*tabletmanagerdatapb.UpdateVReplicationWorkflowsRequest
-	applySchemaRequests                map[uint32]*applySchemaRequestResponse
+	applySchemaRequests                map[uint32][]*applySchemaRequestResponse
 	primaryPositions                   map[uint32]string
 	vdiffRequests                      map[uint32]*vdiffRequestResponse
 	refreshStateErrors                 map[uint32]error
@@ -296,7 +296,7 @@ func newTestTMClient(env *testEnv) *testTMClient {
 		createVReplicationWorkflowRequests: make(map[uint32]*createVReplicationWorkflowRequestResponse),
 		readVReplicationWorkflowRequests:   make(map[uint32]*readVReplicationWorkflowRequestResponse),
 		updateVReplicationWorklowsRequests: make(map[uint32]*tabletmanagerdatapb.UpdateVReplicationWorkflowsRequest),
-		applySchemaRequests:                make(map[uint32]*applySchemaRequestResponse),
+		applySchemaRequests:                make(map[uint32][]*applySchemaRequestResponse),
 		readVReplicationWorkflowsResponses: make(map[string][]*tabletmanagerdatapb.ReadVReplicationWorkflowsResponse),
 		primaryPositions:                   make(map[uint32]string),
 		vdiffRequests:                      make(map[uint32]*vdiffRequestResponse),
@@ -398,10 +398,9 @@ func (tmc *testTMClient) GetSchema(ctx context.Context, tablet *topodatapb.Table
 	schemaDefn := &tabletmanagerdatapb.SchemaDefinition{}
 	for _, table := range req.Tables {
 		if table == "/.*/" {
-			// Special case of all tables in keyspace.
-			for key, tableDefn := range tmc.schema {
+			for key, schemaDefinition := range tmc.schema {
 				if strings.HasPrefix(key, tablet.Keyspace+".") {
-					schemaDefn.TableDefinitions = append(schemaDefn.TableDefinitions, tableDefn.TableDefinitions...)
+					schemaDefn.TableDefinitions = append(schemaDefn.TableDefinitions, schemaDefinition.TableDefinitions...)
 				}
 			}
 			break
@@ -413,6 +412,12 @@ func (tmc *testTMClient) GetSchema(ctx context.Context, tablet *topodatapb.Table
 			continue
 		}
 		schemaDefn.TableDefinitions = append(schemaDefn.TableDefinitions, tableDefn.TableDefinitions...)
+	}
+	for key, schemaDefinition := range tmc.schema {
+		if strings.HasPrefix(key, tablet.Keyspace) {
+			schemaDefn.DatabaseSchema = schemaDefinition.DatabaseSchema
+			break
+		}
 	}
 	return schemaDefn, nil
 }
@@ -508,10 +513,10 @@ func (tmc *testTMClient) expectApplySchemaRequest(tabletID uint32, req *applySch
 	defer tmc.mu.Unlock()
 
 	if tmc.applySchemaRequests == nil {
-		tmc.applySchemaRequests = make(map[uint32]*applySchemaRequestResponse)
+		tmc.applySchemaRequests = make(map[uint32][]*applySchemaRequestResponse)
 	}
 
-	tmc.applySchemaRequests[tabletID] = req
+	tmc.applySchemaRequests[tabletID] = append(tmc.applySchemaRequests[tabletID], req)
 }
 
 // Note: ONLY breaks up change.SQL into individual statements and executes it. Does NOT fully implement ApplySchema.
@@ -519,11 +524,17 @@ func (tmc *testTMClient) ApplySchema(ctx context.Context, tablet *topodatapb.Tab
 	tmc.mu.Lock()
 	defer tmc.mu.Unlock()
 
-	if expect, ok := tmc.applySchemaRequests[tablet.Alias.Uid]; ok {
+	if requests, ok := tmc.applySchemaRequests[tablet.Alias.Uid]; ok {
+		if len(requests) == 0 {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected ApplySchema request on tablet %s: got %+v",
+				topoproto.TabletAliasString(tablet.Alias), change)
+		}
+		expect := requests[0]
 		if !reflect.DeepEqual(change, expect.change) {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected ApplySchema request on tablet %s: got %+v, want %+v",
 				topoproto.TabletAliasString(tablet.Alias), change, expect.change)
 		}
+		tmc.applySchemaRequests[tablet.Alias.Uid] = tmc.applySchemaRequests[tablet.Alias.Uid][1:]
 		return expect.res, expect.err
 	}
 
@@ -777,6 +788,10 @@ func (tmc *testTMClient) getVReplicationWorkflowsResponse(key string) *tabletman
 	resp := tmc.readVReplicationWorkflowsResponses[key][0]
 	tmc.readVReplicationWorkflowsResponses[key] = tmc.readVReplicationWorkflowsResponses[key][1:]
 	return resp
+}
+
+func (tmc *testTMClient) ReloadSchema(ctx context.Context, tablet *topodatapb.Tablet, waitPosition string) error {
+	return nil
 }
 
 //

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
+	"vitess.io/vitess/go/vt/proto/binlogdata"
 	"vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
@@ -902,4 +903,124 @@ func TestAddParticipatingTablesToKeyspace(t *testing.T) {
 	require.NotNil(t, vs.Tables["t2"])
 	assert.Len(t, vs.Tables["t1"].ColumnVindexes, 2)
 	assert.Len(t, vs.Tables["t2"].ColumnVindexes, 1)
+}
+
+func TestCancelMigration_TABLES(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	workflowName := "wf1"
+	tableName := "t1"
+
+	sourceKeyspace := &testKeyspace{
+		KeyspaceName: "sourceks",
+		ShardNames:   []string{"0"},
+	}
+	targetKeyspace := &testKeyspace{
+		KeyspaceName: "targetks",
+		ShardNames:   []string{"0"},
+	}
+
+	schema := map[string]*tabletmanagerdatapb.SchemaDefinition{
+		tableName: {
+			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+				{
+					Name:   tableName,
+					Schema: fmt.Sprintf("CREATE TABLE %s (id BIGINT, name VARCHAR(64), PRIMARY KEY (id))", tableName),
+				},
+			},
+		},
+	}
+
+	env := newTestEnv(t, ctx, defaultCellName, sourceKeyspace, targetKeyspace)
+	defer env.close()
+	env.tmc.schema = schema
+
+	ts, _, err := env.ws.getWorkflowState(ctx, targetKeyspace.KeyspaceName, workflowName)
+	require.NoError(t, err)
+
+	sm, err := BuildStreamMigrator(ctx, ts, false, sqlparser.NewTestParser())
+	require.NoError(t, err)
+
+	env.tmc.expectVRQuery(200, "update _vt.vreplication set state='Running', message='' where db_name='vt_targetks' and workflow='wf1'", &sqltypes.Result{})
+	env.tmc.expectVRQuery(100, "delete from _vt.vreplication where db_name = 'vt_sourceks' and workflow = 'wf1_reverse'", &sqltypes.Result{})
+
+	ctx, _, err = env.ts.LockKeyspace(ctx, targetKeyspace.KeyspaceName, "test")
+	require.NoError(t, err)
+
+	ctx, _, err = env.ts.LockKeyspace(ctx, sourceKeyspace.KeyspaceName, "test")
+	require.NoError(t, err)
+
+	err = topo.CheckKeyspaceLocked(ctx, ts.targetKeyspace)
+	require.NoError(t, err)
+
+	err = topo.CheckKeyspaceLocked(ctx, ts.sourceKeyspace)
+	require.NoError(t, err)
+
+	ts.cancelMigration(ctx, sm)
+
+	// Expect the queries to be cleared
+	assert.Empty(t, env.tmc.vrQueries[100])
+	assert.Empty(t, env.tmc.vrQueries[200])
+}
+
+func TestCancelMigration_SHARDS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	workflowName := "wf1"
+	tableName := "t1"
+
+	sourceKeyspace := &testKeyspace{
+		KeyspaceName: "sourceks",
+		ShardNames:   []string{"0"},
+	}
+	targetKeyspace := &testKeyspace{
+		KeyspaceName: "targetks",
+		ShardNames:   []string{"0"},
+	}
+
+	schema := map[string]*tabletmanagerdatapb.SchemaDefinition{
+		tableName: {
+			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+				{
+					Name:   tableName,
+					Schema: fmt.Sprintf("CREATE TABLE %s (id BIGINT, name VARCHAR(64), PRIMARY KEY (id))", tableName),
+				},
+			},
+		},
+	}
+
+	env := newTestEnv(t, ctx, defaultCellName, sourceKeyspace, targetKeyspace)
+	defer env.close()
+	env.tmc.schema = schema
+
+	ts, _, err := env.ws.getWorkflowState(ctx, targetKeyspace.KeyspaceName, workflowName)
+	require.NoError(t, err)
+	ts.migrationType = binlogdata.MigrationType_SHARDS
+
+	sm, err := BuildStreamMigrator(ctx, ts, false, sqlparser.NewTestParser())
+	require.NoError(t, err)
+
+	env.tmc.expectVRQuery(100, "update /*vt+ ALLOW_UNSAFE_VREPLICATION_WRITE */ _vt.vreplication set state='Running', stop_pos=null, message='' where db_name='vt_sourceks' and workflow != 'wf1_reverse'", &sqltypes.Result{})
+	env.tmc.expectVRQuery(200, "update _vt.vreplication set state='Running', message='' where db_name='vt_targetks' and workflow='wf1'", &sqltypes.Result{})
+	env.tmc.expectVRQuery(100, "delete from _vt.vreplication where db_name = 'vt_sourceks' and workflow = 'wf1_reverse'", &sqltypes.Result{})
+
+	ctx, _, err = env.ts.LockKeyspace(ctx, targetKeyspace.KeyspaceName, "test")
+	require.NoError(t, err)
+
+	ctx, _, err = env.ts.LockKeyspace(ctx, sourceKeyspace.KeyspaceName, "test")
+	require.NoError(t, err)
+
+	err = topo.CheckKeyspaceLocked(ctx, ts.targetKeyspace)
+	require.NoError(t, err)
+
+	err = topo.CheckKeyspaceLocked(ctx, ts.sourceKeyspace)
+	require.NoError(t, err)
+
+	ts.cancelMigration(ctx, sm)
+
+	// Expect the queries to be cleared
+	assert.Empty(t, env.tmc.vrQueries[100])
+	assert.Empty(t, env.tmc.vrQueries[200])
 }

--- a/go/vt/vtctl/workflow/utils_test.go
+++ b/go/vt/vtctl/workflow/utils_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/testfiles"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
@@ -22,6 +23,7 @@ import (
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topotools"
 
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	"vitess.io/vitess/go/vt/proto/vtctldata"
 )
 
@@ -280,4 +282,78 @@ func TestValidateSourceTablesExist(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLegacyBuildTargets(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	workflowName := "wf1"
+	tableName := "t1"
+
+	sourceKeyspace := &testKeyspace{
+		KeyspaceName: "sourceks",
+		ShardNames:   []string{"0"},
+	}
+	targetKeyspace := &testKeyspace{
+		KeyspaceName: "targetks",
+		ShardNames:   []string{"-80", "80-"},
+	}
+
+	schema := map[string]*tabletmanagerdatapb.SchemaDefinition{
+		tableName: {
+			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+				{
+					Name:   tableName,
+					Schema: fmt.Sprintf("CREATE TABLE %s (id BIGINT, name VARCHAR(64), PRIMARY KEY (id))", tableName),
+				},
+			},
+		},
+	}
+
+	env := newTestEnv(t, ctx, defaultCellName, sourceKeyspace, targetKeyspace)
+	defer env.close()
+	env.tmc.schema = schema
+
+	result1 := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"id|source|message|cell|tablet_types|workflow_type|workflow_sub_type|defer_secondary_keys",
+		"int64|varchar|varchar|varchar|varchar|int64|int64|int64"),
+		"1|keyspace:\"source\" shard:\"-80\" filter:{rules:{match:\"t1\"} rules:{match:\"t2\"}}||||0|0|0",
+	)
+	result2 := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"id|source|message|cell|tablet_types|workflow_type|workflow_sub_type|defer_secondary_keys",
+		"int64|varchar|varchar|varchar|varchar|int64|int64|int64"),
+		"1|keyspace:\"source\" shard:\"80-\" filter:{rules:{match:\"t1\"} rules:{match:\"t2\"}}||||0|0|0",
+		"2|keyspace:\"source\" shard:\"80-\" filter:{rules:{match:\"t3\"} rules:{match:\"t4\"}}||||0|0|0",
+	)
+	env.tmc.expectVRQuery(200, "select id, source, message, cell, tablet_types, workflow_type, workflow_sub_type, defer_secondary_keys from _vt.vreplication where workflow='wf1' and db_name='vt_targetks'", result1)
+	env.tmc.expectVRQuery(210, "select id, source, message, cell, tablet_types, workflow_type, workflow_sub_type, defer_secondary_keys from _vt.vreplication where workflow='wf1' and db_name='vt_targetks'", result2)
+
+	ti, err := LegacyBuildTargets(ctx, env.ts, env.tmc, targetKeyspace.KeyspaceName, workflowName, targetKeyspace.ShardNames)
+	require.NoError(t, err)
+	// Expect 2 targets as there are 2 target shards.
+	assert.Len(t, ti.Targets, 2)
+
+	assert.NotNil(t, ti.Targets["-80"])
+	assert.NotNil(t, ti.Targets["80-"])
+
+	t1 := ti.Targets["-80"]
+	t2 := ti.Targets["80-"]
+	assert.Len(t, t1.Sources, 1)
+	assert.Len(t, t2.Sources, 2)
+	assert.Len(t, t1.Sources[1].Filter.Rules, 2)
+
+	assert.Equal(t, t1.Sources[1].Filter.Rules[0].Match, "t1")
+	assert.Equal(t, t1.Sources[1].Filter.Rules[1].Match, "t2")
+	assert.Equal(t, t1.Sources[1].Shard, "-80")
+
+	assert.Len(t, t2.Sources[1].Filter.Rules, 2)
+	assert.Len(t, t2.Sources[2].Filter.Rules, 2)
+
+	assert.Equal(t, t2.Sources[1].Shard, "80-")
+	assert.Equal(t, t2.Sources[2].Shard, "80-")
+	assert.Equal(t, t2.Sources[1].Filter.Rules[0].Match, "t1")
+	assert.Equal(t, t2.Sources[1].Filter.Rules[1].Match, "t2")
+	assert.Equal(t, t2.Sources[2].Filter.Rules[0].Match, "t3")
+	assert.Equal(t, t2.Sources[2].Filter.Rules[1].Match, "t4")
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds multiple unit tests in `vtctl/workflow`.

Test coverage on this branch (tests-workflow-server):
```
coverage: 69.1% of statements
ok  	vitess.io/vitess/go/vt/vtctl/workflow	2.741s	coverage: 69.1% of statements
```

Test coverage on main:
```
coverage: 66.7% of statements
ok  	vitess.io/vitess/go/vt/vtctl/workflow	2.876s	coverage: 66.7% of statements
```

Command used:
```
go test ./go/vt/vtctl/workflow --coverprofile=c.out
```
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #17572
- #16499
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
