### PR TITLE
Reduce VTGate Normalizer multiple AST walks 

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -48,7 +48,8 @@ type normalizer struct {
 	reserved  *ReservedVars
 	vals      map[Literal]string
 	err       error
-	inDerived bool
+	inDerived int
+	inSelect  int
 }
 
 func newNormalizer(reserved *ReservedVars, bindVars map[string]*querypb.BindVariable) *normalizer {
@@ -64,30 +65,43 @@ func (nz *normalizer) walkStatementUp(cursor *Cursor) bool {
 	if nz.err != nil {
 		return false
 	}
-	node, isLiteral := cursor.Node().(*Literal)
-	if !isLiteral {
-		return true
+	switch node := cursor.node.(type) {
+	case *DerivedTable:
+		nz.inDerived--
+	case *Select:
+		nz.inSelect--
+	case *Literal:
+		parent := cursor.Parent()
+		switch parent.(type) {
+		case *Order, *GroupBy:
+			return true
+		case *Limit:
+			nz.convertLiteral(node, cursor)
+		default:
+			if nz.inSelect == 0 {
+				nz.convertLiteral(node, cursor)
+			} else {
+				nz.convertLiteralDedup(node, cursor)
+			}
+		}
 	}
-	nz.convertLiteral(node, cursor)
 	return nz.err == nil // only continue if we haven't found any errors
 }
 
 // walkStatementDown is the top level walk function.
 // If it encounters a Select, it switches to a mode
 // where variables are deduped.
-func (nz *normalizer) walkStatementDown(node, parent SQLNode) bool {
+func (nz *normalizer) walkStatementDown(node, _ SQLNode) bool {
 	switch node := node.(type) {
 	// no need to normalize the statement types
 	case *Set, *Show, *Begin, *Commit, *Rollback, *Savepoint, DDLStatement, *SRollback, *Release, *OtherAdmin, *Analyze:
 		return false
+	case *DerivedTable:
+		nz.inDerived++
 	case *Select:
-		_, isDerived := parent.(*DerivedTable)
-		var tmp bool
-		tmp, nz.inDerived = nz.inDerived, isDerived
-		_ = SafeRewrite(node, nz.walkDownSelect, nz.walkUpSelect)
-		// Don't continue
-		nz.inDerived = tmp
-		return false
+		nz.inSelect++
+	case SelectExprs:
+		return nz.inDerived == 0
 	case *ComparisonExpr:
 		nz.convertComparison(node)
 	case *UpdateExpr:
@@ -98,62 +112,9 @@ func (nz *normalizer) walkStatementDown(node, parent SQLNode) bool {
 		return false
 	case *ConvertType: // we should not rewrite the type description
 		return false
-	}
-	return nz.err == nil // only continue if we haven't found any errors
-}
-
-// walkDownSelect normalizes the AST in Select mode.
-func (nz *normalizer) walkDownSelect(node, parent SQLNode) bool {
-	switch node := node.(type) {
-	case *Select:
-		_, isDerived := parent.(*DerivedTable)
-		if !isDerived {
-			return true
-		}
-		var tmp bool
-		tmp, nz.inDerived = nz.inDerived, isDerived
-		// initiating a new AST walk here means that we might change something while walking down on the tree,
-		// but since we are only changing literals, we can be safe that we are not changing the SELECT struct,
-		// only something much further down, and that should be safe
-		_ = SafeRewrite(node, nz.walkDownSelect, nz.walkUpSelect)
-		// Don't continue
-		nz.inDerived = tmp
-		return false
-	case SelectExprs:
-		return !nz.inDerived
-	case *ComparisonExpr:
-		nz.convertComparison(node)
 	case *FramePoint:
 		// do not make a bind var for rows and range
 		return false
-	case *ColName, TableName:
-		// Common node types that never contain Literals or ListArgs but create a lot of object
-		// allocations.
-		return false
-	case *ConvertType:
-		// we should not rewrite the type description
-		return false
-	}
-	return nz.err == nil // only continue if we haven't found any errors
-}
-
-// walkUpSelect normalizes the Literals in Select mode.
-func (nz *normalizer) walkUpSelect(cursor *Cursor) bool {
-	if nz.err != nil {
-		return false
-	}
-	node, isLiteral := cursor.Node().(*Literal)
-	if !isLiteral {
-		return true
-	}
-	parent := cursor.Parent()
-	switch parent.(type) {
-	case *Order, *GroupBy:
-		return true
-	case *Limit:
-		nz.convertLiteral(node, cursor)
-	default:
-		nz.convertLiteralDedup(node, cursor)
 	}
 	return nz.err == nil // only continue if we haven't found any errors
 }

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -71,6 +71,10 @@ func (nz *normalizer) walkStatementUp(cursor *Cursor) bool {
 	case *Select:
 		nz.inSelect--
 	case *Literal:
+		if nz.inSelect == 0 {
+			nz.convertLiteral(node, cursor)
+			return nz.err == nil
+		}
 		parent := cursor.Parent()
 		switch parent.(type) {
 		case *Order, *GroupBy:
@@ -78,11 +82,7 @@ func (nz *normalizer) walkStatementUp(cursor *Cursor) bool {
 		case *Limit:
 			nz.convertLiteral(node, cursor)
 		default:
-			if nz.inSelect == 0 {
-				nz.convertLiteral(node, cursor)
-			} else {
-				nz.convertLiteralDedup(node, cursor)
-			}
+			nz.convertLiteralDedup(node, cursor)
 		}
 	}
 	return nz.err == nil // only continue if we haven't found any errors


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR reduces the ast walk in VTGate normalizer code.

Benchmark shows `~5% normalizer` improvement
```
goos: darwin
goarch: arm64
pkg: vitess.io/vitess/go/vt/sqlparser
cpu: Apple M1 Max
                                     │ /Users/planetscale/benchmark/v2.txt │ /Users/planetscale/benchmark/v3.txt │
                                     │               sec/op                │    sec/op     vs base               │
Normalize-4                                                    1.217µ ± 5%    1.103µ ± 1%   -9.41% (p=0.002 n=6)
NormalizeTraces/django_queries.txt-4                           185.9µ ± 2%    167.3µ ± 1%  -10.04% (p=0.002 n=6)
NormalizeTraces/lobsters.sql.gz-4                              9.613m ± 3%    8.348m ± 2%  -13.16% (p=0.002 n=6)
NormalizeVTGate-4                                              71.89m ± 1%    70.74m ± 1%   -1.60% (p=0.041 n=6)
NormalizeTPCCBinds-4                                           18.04µ ± 1%    17.97µ ± 1%        ~ (p=0.093 n=6)
NormalizeTPCCInsert-4                                          63.65m ± 2%    63.75m ± 1%        ~ (p=0.937 n=6)
NormalizeTPCC-4                                                51.59m ± 1%    50.73m ± 2%   -1.67% (p=0.026 n=6)
geomean                                                        1.374m         1.302m        -5.30%

                                     │ /Users/planetscale/benchmark/v2.txt │ /Users/planetscale/benchmark/v3.txt │
                                     │                B/op                 │     B/op      vs base               │
NormalizeTraces/django_queries.txt-4                          178.3Ki ± 0%   167.1Ki ± 0%   -6.28% (p=0.002 n=6)
NormalizeTraces/lobsters.sql.gz-4                             7.072Mi ± 0%   6.277Mi ± 0%  -11.25% (p=0.002 n=6)
NormalizeVTGate-4                                             48.27Mi ± 0%   47.46Mi ± 0%   -1.67% (p=0.002 n=6)
NormalizeTPCCBinds-4                                          11.35Ki ± 0%   11.36Ki ± 0%   +0.13% (p=0.002 n=6)
NormalizeTPCCInsert-4                                         50.63Mi ± 0%   50.65Mi ± 0%   +0.04% (p=0.002 n=6)
NormalizeTPCC-4                                               35.77Mi ± 0%   35.40Mi ± 0%   -1.02% (p=0.002 n=6)
geomean                                                       3.257Mi        3.145Mi        -3.43%

                                     │ /Users/planetscale/benchmark/v2.txt │ /Users/planetscale/benchmark/v3.txt  │
                                     │              allocs/op              │  allocs/op   vs base                 │
NormalizeTraces/django_queries.txt-4                           6.025k ± 0%   5.389k ± 0%  -10.56% (p=0.002 n=6)
NormalizeTraces/lobsters.sql.gz-4                              252.3k ± 0%   213.2k ± 0%  -15.49% (p=0.002 n=6)
NormalizeVTGate-4                                              1.112M ± 0%   1.073M ± 0%   -3.51% (p=0.002 n=6)
NormalizeTPCCBinds-4                                            301.0 ± 0%    301.0 ± 0%        ~ (p=1.000 n=6) ¹
NormalizeTPCCInsert-4                                          958.0k ± 0%   958.0k ± 0%        ~ (p=0.671 n=6)
NormalizeTPCC-4                                                836.9k ± 0%   818.5k ± 0%   -2.20% (p=0.002 n=6)
geomean                                                        86.11k        81.40k        -5.48%
¹ all samples are equal

```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
