### PR TITLE
`schemadiff`: validate uniqueness of `CHECK` and of `FOREIGN KEY` constraints

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -497,3 +497,21 @@ type NonDeterministicDefaultError struct {
 func (e *NonDeterministicDefaultError) Error() string {
 	return fmt.Sprintf("column %s.%s default value uses non-deterministic function: %s", sqlescape.EscapeID(e.Table), sqlescape.EscapeID(e.Column), e.Function)
 }
+
+type DuplicateCheckConstraintNameError struct {
+	Table      string
+	Constraint string
+}
+
+func (e *DuplicateCheckConstraintNameError) Error() string {
+	return fmt.Sprintf("duplicate check constraint name %s in table %s", sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
+}
+
+type DuplicateForeignKeyConstraintNameError struct {
+	Table      string
+	Constraint string
+}
+
+func (e *DuplicateForeignKeyConstraintNameError) Error() string {
+	return fmt.Sprintf("duplicate foreign key constraint name %s in table %s", sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
+}

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -1327,6 +1327,10 @@ func TestSchemaDiff(t *testing.T) {
 // TestDiffFiles diffs two schema files on the local file system. It requires the $TEST_SCHEMADIFF_DIFF_FILES
 // environment variable to be set to a comma-separated list of two file paths, e.g. "/tmp/from.sql,/tmp/to.sql".
 // If the variable is unspecified, the test is skipped. It is useful for ad-hoc testing of schema diffs.
+// The way to run this test is:
+// ```sh
+// $ TEST_SCHEMADIFF_DIFF_FILES=/tmp/1.sql,/tmp/2.sql go test -v -count=1 -run TestDiffFiles ./go/vt/schemadiff/
+// ```
 func TestDiffFiles(t *testing.T) {
 	ctx := context.Background()
 

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -287,11 +287,11 @@ func TestTableForeignKeyOrdering(t *testing.T) {
 		"create table t11 (id int primary key, i int, key ix (i), constraint f12 foreign key (i) references t12(id) on delete restrict, constraint f20 foreign key (i) references t20(id) on delete restrict)",
 		"create table t15(id int, primary key(id))",
 		"create view v09 as select * from v13, t17",
-		"create table t20 (id int primary key, i int, key ix (i), constraint f15 foreign key (i) references t15(id) on delete restrict)",
+		"create table t20 (id int primary key, i int, key ix (i), constraint f2015 foreign key (i) references t15(id) on delete restrict)",
 		"create view v13 as select * from t20",
-		"create table t12 (id int primary key, i int, key ix (i), constraint f15 foreign key (i) references t15(id) on delete restrict)",
-		"create table t17 (id int primary key, i int, key ix (i), constraint f11 foreign key (i) references t11(id) on delete restrict, constraint f15 foreign key (i) references t15(id) on delete restrict)",
-		"create table t16 (id int primary key, i int, key ix (i), constraint f11 foreign key (i) references t11(id) on delete restrict, constraint f15 foreign key (i) references t15(id) on delete restrict)",
+		"create table t12 (id int primary key, i int, key ix (i), constraint f1215 foreign key (i) references t15(id) on delete restrict)",
+		"create table t17 (id int primary key, i int, key ix (i), constraint f1711 foreign key (i) references t11(id) on delete restrict, constraint f1715 foreign key (i) references t15(id) on delete restrict)",
+		"create table t16 (id int primary key, i int, key ix (i), constraint f1611 foreign key (i) references t11(id) on delete restrict, constraint f1615 foreign key (i) references t15(id) on delete restrict)",
 		"create table t14 (id int primary key, i int, key ix (i), constraint f14 foreign key (i) references t14(id) on delete restrict)",
 	}
 	expectSortedTableNames := []string{

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -527,10 +527,19 @@ func TestInvalidSchema(t *testing.T) {
 			schema: `create table t1 (id int primary key, CONSTRAINT const_id CHECK (id > 0))`,
 		},
 		{
+			schema: `create table t1 (id int primary key, CONSTRAINT const_id1 CHECK (id > 0), CONSTRAINT const_id2 CHECK (id < 10));`,
+		},
+		{
 			schema: `
 				create table t1 (id int primary key, CONSTRAINT const_id CHECK (id > 0), CONSTRAINT const_id CHECK (id < 10));
 			`,
 			expectErr: &DuplicateCheckConstraintNameError{Table: "t1", Constraint: "const_id"},
+		},
+		{
+			schema: `
+			create table t1 (id int primary key, CONSTRAINT const_id1 CHECK (id > 0));
+			create table t2 (id int primary key, CONSTRAINT const_id2 CHECK (id > 0));
+			`,
 		},
 		{
 			schema: `


### PR DESCRIPTION
## Description

This PR adds schema-scope validations:

- In the same schema, no two `CHECK` constraints have the same name.
- In the same schema, no two `FOREIGN KEY` constraints have the same name.

Note: there is no problem for a `CHECK` constraint and for a `FOREIGN KEY` constraint to have the same name.

These validations are compliant with MySQL and are required, as MySQL strictly enforces this uniqueness.

## Related Issue(s)

- #10203 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
