### PR TITLE
`schemadiff` textual annotation fix + tests

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -73,6 +73,13 @@ func TestDiffTables(t *testing.T) {
 			action:   "alter",
 			fromName: "t",
 			toName:   "t",
+			annotated: []string{
+				" CREATE TABLE `t` (",
+				" 	`id` int,",
+				"+	`i` int,",
+				"+	`b` tinyint(1),",
+				" 	PRIMARY KEY (`id`)",
+				" )"},
 		},
 		{
 			name: "alter columns from tinyint(1) to boolean",
@@ -93,6 +100,14 @@ func TestDiffTables(t *testing.T) {
 			action:   "alter",
 			fromName: "t",
 			toName:   "t",
+			annotated: []string{
+				" CREATE TABLE `t` (",
+				" 	`id` int,",
+				"+	`i` int,",
+				"+	`b` tinyint(1) DEFAULT '1',",
+				" 	PRIMARY KEY (`id`)",
+				" )",
+			},
 		},
 		{
 			name:     "change of columns, boolean type, invalid default",
@@ -103,6 +118,14 @@ func TestDiffTables(t *testing.T) {
 			action:   "alter",
 			fromName: "t",
 			toName:   "t",
+			annotated: []string{
+				" CREATE TABLE `t` (",
+				" 	`id` int,",
+				"+	`i` int,",
+				"+	`b` tinyint(1),",
+				" 	PRIMARY KEY (`id`)",
+				" )",
+			},
 		},
 		{
 			name:   "create",
@@ -139,6 +162,14 @@ func TestDiffTables(t *testing.T) {
 			hints: &DiffHints{
 				TableQualifierHint: TableQualifierDeclared,
 			},
+			annotated: []string{
+				" CREATE TABLE `t1` (",
+				" 	`id` int,",
+				"-	`name` int,",
+				"+	`name` bigint,",
+				" 	PRIMARY KEY (`id`)",
+				" )",
+			},
 		},
 		{
 			name:   "TableQualifierDeclared hint, from has qualifier",
@@ -150,6 +181,14 @@ func TestDiffTables(t *testing.T) {
 			hints: &DiffHints{
 				TableQualifierHint: TableQualifierDeclared,
 			},
+			annotated: []string{
+				" CREATE TABLE `_vt`.`t1` (",
+				" 	`id` int,",
+				"-	`name` int,",
+				"+	`name` bigint,",
+				" 	PRIMARY KEY (`id`)",
+				" )",
+			},
 		},
 		{
 			name:   "TableQualifierDefault, from has qualifier",
@@ -158,6 +197,14 @@ func TestDiffTables(t *testing.T) {
 			diff:   "alter table _vt.t1 modify column `name` bigint",
 			cdiff:  "ALTER TABLE `_vt`.`t1` MODIFY COLUMN `name` bigint",
 			action: "alter",
+			annotated: []string{
+				" CREATE TABLE `_vt`.`t1` (",
+				" 	`id` int,",
+				"-	`name` int,",
+				"+	`name` bigint,",
+				" 	PRIMARY KEY (`id`)",
+				" )",
+			},
 		},
 		{
 			name:   "TableQualifierDefault, both have qualifiers",
@@ -166,6 +213,14 @@ func TestDiffTables(t *testing.T) {
 			diff:   "alter table _vt.t1 modify column `name` bigint",
 			cdiff:  "ALTER TABLE `_vt`.`t1` MODIFY COLUMN `name` bigint",
 			action: "alter",
+			annotated: []string{
+				" CREATE TABLE `_vt`.`t1` (",
+				" 	`id` int,",
+				"-	`name` int,",
+				"+	`name` bigint,",
+				" 	PRIMARY KEY (`id`)",
+				" )",
+			},
 		},
 		{
 			name:   "TableQualifierDefault, create",
@@ -174,6 +229,12 @@ func TestDiffTables(t *testing.T) {
 			cdiff:  "CREATE TABLE `_vt`.`t` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
 			action: "create",
 			toName: "t",
+			annotated: []string{
+				"+CREATE TABLE `_vt`.`t` (",
+				"+	`id` int,",
+				"+	PRIMARY KEY (`id`)",
+				"+)",
+			},
 		},
 		{
 			name:   "TableQualifierDeclared, create",
@@ -185,6 +246,12 @@ func TestDiffTables(t *testing.T) {
 			hints: &DiffHints{
 				TableQualifierHint: TableQualifierDeclared,
 			},
+			annotated: []string{
+				"+CREATE TABLE `_vt`.`t` (",
+				"+	`id` int,",
+				"+	PRIMARY KEY (`id`)",
+				"+)",
+			},
 		},
 		{
 			name:     "TableQualifierDefault, drop",
@@ -193,6 +260,12 @@ func TestDiffTables(t *testing.T) {
 			cdiff:    "DROP TABLE `_vt`.`t`",
 			action:   "drop",
 			fromName: "t",
+			annotated: []string{
+				"-CREATE TABLE `_vt`.`t` (",
+				"-	`id` int,",
+				"-	PRIMARY KEY (`id`)",
+				"-)",
+			},
 		},
 		{
 			name:     "TableQualifierDeclared, drop",
@@ -203,6 +276,12 @@ func TestDiffTables(t *testing.T) {
 			fromName: "t",
 			hints: &DiffHints{
 				TableQualifierHint: TableQualifierDeclared,
+			},
+			annotated: []string{
+				"-CREATE TABLE `_vt`.`t` (",
+				"-	`id` int,",
+				"-	PRIMARY KEY (`id`)",
+				"-)",
 			},
 		},
 		{
@@ -254,6 +333,12 @@ func TestDiffTables(t *testing.T) {
 				AlterTableAlgorithmStrategy: AlterTableAlgorithmStrategyCopy,
 				TableCharsetCollateStrategy: TableCharsetCollateStrict,
 			},
+			annotated: []string{
+				" CREATE TABLE `t` (",
+				" 	`a` varchar(64) COLLATE latin1_bin",
+				"-) CHARSET latin1",
+				" )",
+			},
 		},
 		{
 			name:     "changing table level defaults with column specific settings, table already normalized",
@@ -267,6 +352,13 @@ func TestDiffTables(t *testing.T) {
 				AlterTableAlgorithmStrategy: AlterTableAlgorithmStrategyCopy,
 				TableCharsetCollateStrategy: TableCharsetCollateStrict,
 			},
+			annotated: []string{
+				" CREATE TABLE `t` (",
+				"-	`a` varchar(64)",
+				"-) CHARSET latin1",
+				"+	`a` varchar(64) CHARACTER SET latin1 COLLATE latin1_bin",
+				" )",
+			},
 		},
 		{
 			name:   "changing table level charset to default",
@@ -275,6 +367,12 @@ func TestDiffTables(t *testing.T) {
 			action: "alter",
 			diff:   "alter table t charset utf8mb4",
 			cdiff:  "ALTER TABLE `t` CHARSET utf8mb4",
+			annotated: []string{
+				" CREATE TABLE `t` (",
+				" 	`i` int",
+				"-) CHARSET latin1",
+				" )",
+			},
 		},
 		{
 			name: "no changes with normalization and utf8mb4",
@@ -406,11 +504,11 @@ func TestDiffTables(t *testing.T) {
 					require.NotNil(t, from)
 					require.NotNil(t, to)
 					require.NotNil(t, unified)
-					if ts.annotated != nil {
-						// Optional test for assorted scenarios.
-						unifiedExport := unified.Export()
-						assert.Equal(t, ts.annotated, strings.Split(unifiedExport, "\n"))
+					if ts.annotated == nil {
+						ts.annotated = []string{}
 					}
+					unifiedExport := unified.Export()
+					assert.Equal(t, ts.annotated, strings.Split(unifiedExport, "\n"))
 				})
 				// let's also check dq, and also validate that dq's statement is identical to d's
 				assert.NoError(t, dqerr)

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -705,6 +705,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER TABLE `t` MODIFY COLUMN `v` varchar(20)",
 			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int,\n-\t`v` varchar(10),\n+\t`v` varchar(20),\n \tPRIMARY KEY (`id`)\n )",
+			},
 		},
 		{
 			name: "change of table column tinyint 1 to longer",
@@ -715,6 +718,9 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			cdiffs: []string{
 				"ALTER TABLE `t` MODIFY COLUMN `i` tinyint",
+			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int,\n-\t`i` tinyint(1),\n+\t`i` tinyint,\n \tPRIMARY KEY (`id`)\n )",
 			},
 		},
 		{
@@ -727,6 +733,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER TABLE `t` MODIFY COLUMN `i` tinyint(1)",
 			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int,\n-\t`i` tinyint,\n+\t`i` tinyint(1),\n \tPRIMARY KEY (`id`)\n )",
+			},
 		},
 		{
 			name: "change of table columns, added",
@@ -737,6 +746,9 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			cdiffs: []string{
 				"ALTER TABLE `t` ADD COLUMN `i` int",
+			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int,\n+\t`i` int,\n \tPRIMARY KEY (`id`)\n )",
 			},
 		},
 		{
@@ -749,6 +761,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER TABLE `identifiers` ADD COLUMN `company_id` mediumint unsigned NOT NULL FIRST",
 			},
+			annotated: []string{
+				" CREATE TABLE `identifiers` (\n+\t`company_id` mediumint unsigned NOT NULL,\n \t`id` binary(16) NOT NULL DEFAULT (uuid_to_bin(uuid(), true))\n )",
+			},
 		},
 		{
 			name: "change within functional index",
@@ -759,6 +774,9 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			cdiffs: []string{
 				"ALTER TABLE `t1` DROP KEY `deleted_check`, ADD UNIQUE KEY `deleted_check` (`id`, (if(`deleted_at` IS NOT NULL, 0, NULL)))",
+			},
+			annotated: []string{
+				" CREATE TABLE `t1` (\n \t`id` mediumint unsigned NOT NULL,\n \t`deleted_at` timestamp NULL,\n \tPRIMARY KEY (`id`),\n-\tUNIQUE KEY `deleted_check` (`id`, (if(`deleted_at` IS NULL, 0, NULL)))\n+\tUNIQUE KEY `deleted_check` (`id`, (if(`deleted_at` IS NOT NULL, 0, NULL)))\n )",
 			},
 		},
 		{
@@ -771,6 +789,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER TABLE `t` DROP CHECK `Check1`, ADD CONSTRAINT `RenamedCheck1` CHECK (`test` >= 0)",
 			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int NOT NULL,\n \t`test` int NOT NULL DEFAULT '0',\n \tPRIMARY KEY (`id`),\n-\tCONSTRAINT `Check1` CHECK (`test` >= 0)\n+\tCONSTRAINT `RenamedCheck1` CHECK (`test` >= 0)\n )",
+			},
 		},
 		{
 			name: "not enforce a check",
@@ -781,6 +802,9 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			cdiffs: []string{
 				"ALTER TABLE `t` ALTER CHECK `Check1` NOT ENFORCED",
+			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int NOT NULL,\n \t`test` int NOT NULL DEFAULT '0',\n \tPRIMARY KEY (`id`),\n-\tCONSTRAINT `Check1` CHECK (`test` >= 0)\n+\tCONSTRAINT `Check1` CHECK (`test` >= 0) NOT ENFORCED\n )",
 			},
 		},
 		{
@@ -793,6 +817,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER TABLE `t` ALTER CHECK `Check1` ENFORCED",
 			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int NOT NULL,\n \t`test` int NOT NULL DEFAULT '0',\n \tPRIMARY KEY (`id`),\n-\tCONSTRAINT `Check1` CHECK (`test` >= 0) NOT ENFORCED\n+\tCONSTRAINT `Check1` CHECK (`test` >= 0)\n )",
+			},
 		},
 		{
 			name: "change of table columns, removed",
@@ -804,6 +831,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER TABLE `t` DROP COLUMN `i`",
 			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int,\n-\t`i` int,\n \tPRIMARY KEY (`id`)\n )",
+			},
 		},
 		{
 			name: "create table",
@@ -813,6 +843,9 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			cdiffs: []string{
 				"CREATE TABLE `t` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
+			},
+			annotated: []string{
+				"+CREATE TABLE `t` (\n+\t`id` int,\n+\tPRIMARY KEY (`id`)\n+)",
 			},
 		},
 		{
@@ -874,6 +907,10 @@ func TestDiffSchemas(t *testing.T) {
 				"DROP TABLE `t2`",
 				"CREATE TABLE `t3` (\n\t`id` int unsigned,\n\tPRIMARY KEY (`id`)\n)",
 			},
+			annotated: []string{
+				"-CREATE TABLE `t2` (\n-\t`id` int unsigned,\n-\tPRIMARY KEY (`id`)\n-)",
+				"+CREATE TABLE `t3` (\n+\t`id` int unsigned,\n+\tPRIMARY KEY (`id`)\n+)",
+			},
 		},
 		{
 			name: "identical tables: heuristic rename",
@@ -910,6 +947,14 @@ func TestDiffSchemas(t *testing.T) {
 				"CREATE TABLE `t2b` (\n\t`id` int unsigned,\n\tPRIMARY KEY (`id`)\n)",
 				"CREATE TABLE `t3b` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
 			},
+			annotated: []string{
+				"-CREATE TABLE `t3a` (\n-\t`id` smallint,\n-\tPRIMARY KEY (`id`)\n-)",
+				"-CREATE TABLE `t2a` (\n-\t`id` int unsigned,\n-\tPRIMARY KEY (`id`)\n-)",
+				"-CREATE TABLE `t1a` (\n-\t`id` int,\n-\tPRIMARY KEY (`id`)\n-)",
+				"+CREATE TABLE `t1b` (\n+\t`id` bigint,\n+\tPRIMARY KEY (`id`)\n+)",
+				"+CREATE TABLE `t2b` (\n+\t`id` int unsigned,\n+\tPRIMARY KEY (`id`)\n+)",
+				"+CREATE TABLE `t3b` (\n+\t`id` int,\n+\tPRIMARY KEY (`id`)\n+)",
+			},
 		},
 		{
 			name: "identical tables: multiple heuristic rename",
@@ -928,6 +973,12 @@ func TestDiffSchemas(t *testing.T) {
 				"RENAME TABLE `t1a` TO `t3b`",
 			},
 			tableRename: TableRenameHeuristicStatement,
+			annotated: []string{
+				"-CREATE TABLE `t3a` (\n-\t`id` smallint,\n-\tPRIMARY KEY (`id`)\n-)",
+				"+CREATE TABLE `t1b` (\n+\t`id` bigint,\n+\tPRIMARY KEY (`id`)\n+)",
+				"-CREATE TABLE `t2a` (\n-\t`id` int unsigned,\n-\tPRIMARY KEY (`id`)\n-)\n+CREATE TABLE `t2b` (\n+\t`id` int unsigned,\n+\tPRIMARY KEY (`id`)\n+)",
+				"-CREATE TABLE `t1a` (\n-\t`id` int,\n-\tPRIMARY KEY (`id`)\n-)\n+CREATE TABLE `t3b` (\n+\t`id` int,\n+\tPRIMARY KEY (`id`)\n+)",
+			},
 		},
 		{
 			name: "tables with irregular names",
@@ -940,6 +991,10 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER TABLE `t.2` MODIFY COLUMN `id` bigint",
 				"ALTER TABLE `t3` MODIFY COLUMN `i.d` int unsigned",
+			},
+			annotated: []string{
+				" CREATE TABLE `t.2` (\n-\t`id` int,\n+\t`id` bigint,\n \tPRIMARY KEY (`id`)\n )",
+				" CREATE TABLE `t3` (\n-\t`i.d` int,\n+\t`i.d` int unsigned,\n \tPRIMARY KEY (`i.d`)\n )",
 			},
 		},
 		// Foreign keys
@@ -955,6 +1010,11 @@ func TestDiffSchemas(t *testing.T) {
 				"CREATE TABLE `t7` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
 				"CREATE TABLE `t4` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f4` (`i`),\n\tCONSTRAINT `f4` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n)",
 				"CREATE TABLE `t5` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f5` (`i`),\n\tCONSTRAINT `f5` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n)",
+			},
+			annotated: []string{
+				"+CREATE TABLE `t7` (\n+\t`id` int,\n+\tPRIMARY KEY (`id`)\n+)",
+				"+CREATE TABLE `t4` (\n+\t`id` int,\n+\t`i` int,\n+\tPRIMARY KEY (`id`),\n+\tKEY `f4` (`i`),\n+\tCONSTRAINT `f4` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n+)",
+				"+CREATE TABLE `t5` (\n+\t`id` int,\n+\t`i` int,\n+\tPRIMARY KEY (`id`),\n+\tKEY `f5` (`i`),\n+\tCONSTRAINT `f5` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n+)",
 			},
 		},
 		{
@@ -995,6 +1055,10 @@ func TestDiffSchemas(t *testing.T) {
 				"CREATE TABLE `t12` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f1201c` (`i`),\n\tCONSTRAINT `f1201c` FOREIGN KEY (`i`) REFERENCES `t11` (`id`) ON DELETE SET NULL\n)",
 			},
 			fkStrategy: ForeignKeyCheckStrategyIgnore,
+			annotated: []string{
+				"+CREATE TABLE `t11` (\n+\t`id` int,\n+\t`i` int,\n+\tPRIMARY KEY (`id`),\n+\tKEY `f1101c` (`i`),\n+\tCONSTRAINT `f1101c` FOREIGN KEY (`i`) REFERENCES `t12` (`id`) ON DELETE RESTRICT\n+)",
+				"+CREATE TABLE `t12` (\n+\t`id` int,\n+\t`i` int,\n+\tPRIMARY KEY (`id`),\n+\tKEY `f1201c` (`i`),\n+\tCONSTRAINT `f1201c` FOREIGN KEY (`i`) REFERENCES `t11` (`id`) ON DELETE SET NULL\n+)",
+			},
 		},
 		{
 			name: "drop tables with foreign keys, expect specific order",
@@ -1009,6 +1073,11 @@ func TestDiffSchemas(t *testing.T) {
 				"DROP TABLE `t4`",
 				"DROP TABLE `t7`",
 			},
+			annotated: []string{
+				"-CREATE TABLE `t5` (\n-\t`id` int,\n-\t`i` int,\n-\tPRIMARY KEY (`id`),\n-\tKEY `f5` (`i`),\n-\tCONSTRAINT `f5` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n-)",
+				"-CREATE TABLE `t4` (\n-\t`id` int,\n-\t`i` int,\n-\tPRIMARY KEY (`id`),\n-\tKEY `f4` (`i`),\n-\tCONSTRAINT `f4` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n-)",
+				"-CREATE TABLE `t7` (\n-\t`id` int,\n-\tPRIMARY KEY (`id`)\n-)",
+			},
 		},
 		{
 			name: "rename index used by foreign keys",
@@ -1019,6 +1088,9 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			cdiffs: []string{
 				"ALTER TABLE `t` RENAME INDEX `i_idx` TO `i_alternative`",
+			},
+			annotated: []string{
+				" CREATE TABLE `t` (\n \t`id` int,\n \t`i` int,\n \tPRIMARY KEY (`id`),\n-\tKEY `i_idx` (`i`),\n+\tKEY `i_alternative` (`i`),\n \tCONSTRAINT `f` FOREIGN KEY (`i`) REFERENCES `parent` (`id`)\n )",
 			},
 		},
 		// Views
@@ -1037,6 +1109,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"ALTER VIEW `v1` AS SELECT `id` FROM `t`",
 			},
+			annotated: []string{
+				"-CREATE VIEW `v1` AS SELECT * FROM `t`\n+CREATE VIEW `v1` AS SELECT `id` FROM `t`",
+			},
 		},
 		{
 			name: "drop view",
@@ -1048,6 +1123,9 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"DROP VIEW `v1`",
 			},
+			annotated: []string{
+				"-CREATE VIEW `v1` AS SELECT * FROM `t`",
+			},
 		},
 		{
 			name: "create view",
@@ -1058,6 +1136,9 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			cdiffs: []string{
 				"CREATE VIEW `v1` AS SELECT `id` FROM `t`",
+			},
+			annotated: []string{
+				"+CREATE VIEW `v1` AS SELECT `id` FROM `t`",
 			},
 		},
 		{
@@ -1078,6 +1159,10 @@ func TestDiffSchemas(t *testing.T) {
 				"DROP TABLE `v1`",
 				"CREATE VIEW `v1` AS SELECT * FROM `t`",
 			},
+			annotated: []string{
+				"-CREATE TABLE `v1` (\n-\t`id` int\n-)",
+				"+CREATE VIEW `v1` AS SELECT * FROM `t`",
+			},
 		},
 		{
 			name: "convert view to table",
@@ -1090,6 +1175,10 @@ func TestDiffSchemas(t *testing.T) {
 			cdiffs: []string{
 				"DROP VIEW `v1`",
 				"CREATE TABLE `v1` (\n\t`id` int\n)",
+			},
+			annotated: []string{
+				"-CREATE VIEW `v1` AS SELECT * FROM `t`",
+				"+CREATE TABLE `v1` (\n+\t`id` int\n+)",
 			},
 		},
 		{
@@ -1118,6 +1207,14 @@ func TestDiffSchemas(t *testing.T) {
 				"CREATE VIEW `v0` AS SELECT * FROM `v2`, `t2`",
 				"CREATE TABLE `t4` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
 			},
+			annotated: []string{
+				"-CREATE VIEW `v1` AS SELECT * FROM `t1`",
+				"-CREATE TABLE `t1` (\n-\t`id` int,\n-\tPRIMARY KEY (`id`)\n-)",
+				" CREATE TABLE `t2` (\n-\t`id` int,\n+\t`id` bigint,\n \tPRIMARY KEY (`id`)\n )",
+				"-CREATE VIEW `v2` AS SELECT * FROM `t2`\n+CREATE VIEW `v2` AS SELECT `id` FROM `t2`",
+				"+CREATE VIEW `v0` AS SELECT * FROM `v2`, `t2`",
+				"+CREATE TABLE `t4` (\n+\t`id` int,\n+\tPRIMARY KEY (`id`)\n+)",
+			},
 		},
 		{
 			// Making sure schemadiff distinguishes between VIEWs with different casing
@@ -1133,6 +1230,11 @@ func TestDiffSchemas(t *testing.T) {
 				"DROP VIEW `v1`",
 				"DROP VIEW `V1`",
 				"DROP TABLE `t`",
+			},
+			annotated: []string{
+				"-CREATE VIEW `v1` AS SELECT * FROM `t`",
+				"-CREATE VIEW `V1` AS SELECT * FROM `t`",
+				"-CREATE TABLE `t` (\n-\t`id` int,\n-\tPRIMARY KEY (`id`)\n-)",
 			},
 		},
 	}
@@ -1192,13 +1294,13 @@ func TestDiffSchemas(t *testing.T) {
 						assert.Equal(t, dTo.Name(), clonedTo.Name())
 					}
 				}
-				if ts.annotated != nil {
-					// Optional test for assorted scenarios.
-					if assert.Equalf(t, len(diffs), len(ts.annotated), "%+v", cstatements) {
-						for i, d := range diffs {
-							_, _, unified := d.Annotated()
-							assert.Equal(t, ts.annotated[i], unified.Export())
-						}
+				if ts.annotated == nil {
+					ts.annotated = []string{}
+				}
+				if assert.Equalf(t, len(diffs), len(ts.annotated), "%+v", cstatements) {
+					for i, d := range diffs {
+						_, _, unified := d.Annotated()
+						assert.Equal(t, ts.annotated[i], unified.Export())
 					}
 				}
 

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -654,12 +654,13 @@ func TestDiffViews(t *testing.T) {
 					_, err = env.Parser().ParseStrictDDL(canonicalDiff)
 					assert.NoError(t, err)
 				}
-				if ts.annotated != nil {
-					// Optional test for assorted scenarios.
-					_, _, unified := d.Annotated()
-					unifiedExport := unified.Export()
-					assert.Equal(t, ts.annotated, strings.Split(unifiedExport, "\n"))
+				if ts.annotated == nil {
+					ts.annotated = []string{}
 				}
+				_, _, unified := d.Annotated()
+				unifiedExport := unified.Export()
+				assert.Equal(t, ts.annotated, strings.Split(unifiedExport, "\n"))
+
 				// let's also check dq, and also validate that dq's statement is identical to d's
 				assert.NoError(t, dqerr)
 				require.NotNil(t, dq)
@@ -1191,7 +1192,6 @@ func TestDiffSchemas(t *testing.T) {
 						assert.Equal(t, dTo.Name(), clonedTo.Name())
 					}
 				}
-
 				if ts.annotated != nil {
 					// Optional test for assorted scenarios.
 					if assert.Equalf(t, len(diffs), len(ts.annotated), "%+v", cstatements) {

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1689,6 +1689,7 @@ func (c *CreateTableEntity) diffKeys(alterTable *sqlparser.AlterTable,
 						NewName: t2Key.Info.Name,
 					}
 					alterTable.AlterOptions = append(alterTable.AlterOptions, renameIndex)
+					annotations.MarkAdded(sqlparser.CanonicalString(t2Key))
 					convertedToRename = true
 				}
 			}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -829,6 +829,10 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t2 (`id` int primary key, i int, key i2_alternative (`i`, id), key i_idx ( i ) )",
 			diff:  "alter table t1 rename index i2_idx to i2_alternative",
 			cdiff: "ALTER TABLE `t1` RENAME INDEX `i2_idx` TO `i2_alternative`",
+			textdiffs: []string{
+				"-	KEY `i2_idx` (`i`, `id`)",
+				"+	KEY `i2_alternative` (`i`, `id`)",
+			},
 		},
 		{
 			name:  "reordered and renamed keys",
@@ -836,6 +840,12 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t2 (`id` int primary key, i int, key i2_alternative (`i`, id), key i_alternative ( i ) )",
 			diff:  "alter table t1 rename index i2_idx to i2_alternative, rename index i_idx to i_alternative",
 			cdiff: "ALTER TABLE `t1` RENAME INDEX `i2_idx` TO `i2_alternative`, RENAME INDEX `i_idx` TO `i_alternative`",
+			textdiffs: []string{
+				"-	KEY `i_idx` (`i`)",
+				"-	KEY `i2_idx` (`i`, `id`)",
+				"+	KEY `i_alternative` (`i`)",
+				"+	KEY `i2_alternative` (`i`, `id`)",
+			},
 		},
 		{
 			name:  "multiple similar keys, one rename",
@@ -843,6 +853,10 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t2 (`id` int primary key, i int, key i_idx(i), key i2_alternative(i))",
 			diff:  "alter table t1 rename index i2_idx to i2_alternative",
 			cdiff: "ALTER TABLE `t1` RENAME INDEX `i2_idx` TO `i2_alternative`",
+			textdiffs: []string{
+				"-	KEY `i2_idx` (`i`)",
+				"+	KEY `i2_alternative` (`i`)",
+			},
 		},
 		{
 			name:  "multiple similar keys, two renames",
@@ -850,6 +864,12 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t2 (`id` int primary key, i int, key i_alternative(i), key i2_alternative(i))",
 			diff:  "alter table t1 rename index i_idx to i_alternative, rename index i2_idx to i2_alternative",
 			cdiff: "ALTER TABLE `t1` RENAME INDEX `i_idx` TO `i_alternative`, RENAME INDEX `i2_idx` TO `i2_alternative`",
+			textdiffs: []string{
+				"-	KEY `i_idx` (`i`)",
+				"-	KEY `i2_idx` (`i`)",
+				"+	KEY `i_alternative` (`i`)",
+				"+	KEY `i2_alternative` (`i`)",
+			},
 		},
 		{
 			name:  "multiple similar keys, two renames, reorder",
@@ -857,6 +877,12 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t2 (`id` int primary key, i int, key i_alternative(i), key i2_alternative(i), key i0 (i, id))",
 			diff:  "alter table t1 rename index i_idx to i_alternative, rename index i2_idx to i2_alternative",
 			cdiff: "ALTER TABLE `t1` RENAME INDEX `i_idx` TO `i_alternative`, RENAME INDEX `i2_idx` TO `i2_alternative`",
+			textdiffs: []string{
+				"-	KEY `i_idx` (`i`)",
+				"-	KEY `i2_idx` (`i`)",
+				"+	KEY `i_alternative` (`i`)",
+				"+	KEY `i2_alternative` (`i`)",
+			},
 		},
 		{
 			name:  "key made visible",
@@ -1866,6 +1892,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) ",
 			diff:  "alter table t1 row_format DEFAULT",
 			cdiff: "ALTER TABLE `t1` ROW_FORMAT DEFAULT",
+			textdiffs: []string{
+				"-) ROW_FORMAT COMPRESSED",
+			},
 		},
 		{
 			name:  "remove table option 2",
@@ -1873,6 +1902,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) ",
 			diff:  "alter table t1 checksum 0",
 			cdiff: "ALTER TABLE `t1` CHECKSUM 0",
+			textdiffs: []string{
+				"-) CHECKSUM 1",
+			},
 		},
 		{
 			name:  "remove table option 3",
@@ -1880,6 +1912,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) ",
 			diff:  "alter table t1 checksum 0",
 			cdiff: "ALTER TABLE `t1` CHECKSUM 0",
+			textdiffs: []string{
+				"-) CHECKSUM 1",
+			},
 		},
 		{
 			name:  "remove table option 4",
@@ -1887,6 +1922,10 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t2 (id int auto_increment primary key)",
 			diff:  "alter table t1 key_block_size 0 compression ''",
 			cdiff: "ALTER TABLE `t1` KEY_BLOCK_SIZE 0 COMPRESSION ''",
+			textdiffs: []string{
+				"-) KEY_BLOCK_SIZE 16",
+				"-  COMPRESSION 'zlib'",
+			},
 		},
 		{
 			name:  "add, modify and remove table option",
@@ -1894,6 +1933,12 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) row_format=compressed, engine=innodb, charset=utf8mb4",
 			diff:  "alter table t1 checksum 0 charset utf8mb4 row_format COMPRESSED",
 			cdiff: "ALTER TABLE `t1` CHECKSUM 0 CHARSET utf8mb4 ROW_FORMAT COMPRESSED",
+			textdiffs: []string{
+				"+) ROW_FORMAT COMPRESSED",
+				"-  CHARSET utf8mb3,",
+				"-  CHECKSUM 1",
+				"+  CHARSET utf8mb4",
+			},
 		},
 		{
 			name: "ignore AUTO_INCREMENT addition",
@@ -1907,6 +1952,9 @@ func TestCreateTableDiff(t *testing.T) {
 			autoinc: AutoIncrementApplyHigher,
 			diff:    "alter table t1 auto_increment 300",
 			cdiff:   "ALTER TABLE `t1` AUTO_INCREMENT 300",
+			textdiffs: []string{
+				"+) AUTO_INCREMENT 300",
+			},
 		},
 		{
 			name: "ignore AUTO_INCREMENT removal",
@@ -1931,6 +1979,10 @@ func TestCreateTableDiff(t *testing.T) {
 			autoinc: AutoIncrementApplyHigher,
 			diff:    "alter table t1 auto_increment 300",
 			cdiff:   "ALTER TABLE `t1` AUTO_INCREMENT 300",
+			textdiffs: []string{
+				"-) AUTO_INCREMENT 100",
+				"+) AUTO_INCREMENT 300",
+			},
 		},
 		{
 			name:    "ignore AUTO_INCREMENT decrease",
@@ -1945,6 +1997,10 @@ func TestCreateTableDiff(t *testing.T) {
 			autoinc: AutoIncrementApplyAlways,
 			diff:    "alter table t1 auto_increment 100",
 			cdiff:   "ALTER TABLE `t1` AUTO_INCREMENT 100",
+			textdiffs: []string{
+				"-) AUTO_INCREMENT 300",
+				"+) AUTO_INCREMENT 100",
+			},
 		},
 		{
 			name:  "apply table charset",
@@ -1952,6 +2008,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t (id int, primary key(id)) DEFAULT CHARSET = utf8mb4",
 			diff:  "alter table t charset utf8mb4",
 			cdiff: "ALTER TABLE `t` CHARSET utf8mb4",
+			textdiffs: []string{
+				"+) CHARSET utf8mb4",
+			},
 		},
 		{
 			name:    "ignore empty table charset",
@@ -1978,6 +2037,10 @@ func TestCreateTableDiff(t *testing.T) {
 			charset: TableCharsetCollateIgnoreEmpty,
 			diff:    "alter table t collate utf8mb4_0900_ai_ci",
 			cdiff:   "ALTER TABLE `t` COLLATE utf8mb4_0900_ai_ci",
+			textdiffs: []string{
+				"-) COLLATE utf8mb4_0900_bin",
+				"+) COLLATE utf8mb4_0900_ai_ci",
+			},
 		},
 		{
 			name:    "ignore empty table charset and collate in target",
@@ -2003,6 +2066,10 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t (id int, primary key(id)) DEFAULT CHARSET = utf8mb4",
 			diff:  "alter table t charset utf8mb4",
 			cdiff: "ALTER TABLE `t` CHARSET utf8mb4",
+			textdiffs: []string{
+				"-) CHARSET utf8",
+				"+) CHARSET utf8mb4",
+			},
 		},
 		{
 			name:  `change table charset and columns`,
@@ -2010,6 +2077,16 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t (id int primary key, t1 varchar(128) not null, t2 varchar(128) not null, t3 tinytext, t4 tinytext charset latin1) default charset=utf8mb4",
 			diff:  "alter table t modify column t1 varchar(128) not null, modify column t2 varchar(128) not null, modify column t3 tinytext, charset utf8mb4",
 			cdiff: "ALTER TABLE `t` MODIFY COLUMN `t1` varchar(128) NOT NULL, MODIFY COLUMN `t2` varchar(128) NOT NULL, MODIFY COLUMN `t3` tinytext, CHARSET utf8mb4",
+			textdiffs: []string{
+				"-	`t1` varchar(128),",
+				"-	`t2` varchar(128) NOT NULL,",
+				"-	`t3` tinytext CHARACTER SET latin1,",
+				"+	`t1` varchar(128) NOT NULL",
+				"+	`t2` varchar(128) NOT NULL",
+				"+	`t3` tinytext",
+				"-) CHARSET utf8",
+				"+) CHARSET utf8mb4",
+			},
 		},
 		{
 			name:  "change table collation",
@@ -2017,6 +2094,10 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t (id int, primary key(id)) DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_0900_bin",
 			diff:  "alter table t collate utf8mb4_0900_bin",
 			cdiff: "ALTER TABLE `t` COLLATE utf8mb4_0900_bin",
+			textdiffs: []string{
+				"-  COLLATE utf8mb4_0900_ai_ci",
+				"+  COLLATE utf8mb4_0900_bin",
+			},
 		},
 		{
 			name:  "change table collation with textual column",
@@ -2024,6 +2105,12 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t (id int, t varchar(192) not null) DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_0900_bin",
 			diff:  "alter table t modify column t varchar(192) not null, collate utf8mb4_0900_bin",
 			cdiff: "ALTER TABLE `t` MODIFY COLUMN `t` varchar(192) NOT NULL, COLLATE utf8mb4_0900_bin",
+			textdiffs: []string{
+				"-	`t` varchar(192) NOT NULL",
+				"+	`t` varchar(192) NOT NULL",
+				"-  COLLATE utf8mb4_0900_ai_ci",
+				"+  COLLATE utf8mb4_0900_bin",
+			},
 		},
 		{
 			name:  "change table collation with textual column that has collation",
@@ -2031,6 +2118,10 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t (id int, t varchar(192) not null collate utf8mb4_0900_bin) DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_0900_bin",
 			diff:  "alter table t collate utf8mb4_0900_bin",
 			cdiff: "ALTER TABLE `t` COLLATE utf8mb4_0900_bin",
+			textdiffs: []string{
+				"-  COLLATE utf8mb4_0900_ai_ci",
+				"+  COLLATE utf8mb4_0900_bin",
+			},
 		},
 		{
 			name: "ignore identical implicit charset",
@@ -2073,6 +2164,10 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int unsigned primary key)",
 			diff:  "alter table t1 modify column id int unsigned",
 			cdiff: "ALTER TABLE `t1` MODIFY COLUMN `id` int unsigned",
+			textdiffs: []string{
+				"-	`id` int,",
+				"+	`id` int unsigned,",
+			},
 		},
 		{
 			name:  "normalized ENGINE InnoDB value",
@@ -2111,6 +2206,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) engine=memory, character set=utf8",
 			diff:  "alter table t1 engine MEMORY",
 			cdiff: "ALTER TABLE `t1` ENGINE MEMORY",
+			textdiffs: []string{
+				"+) ENGINE MEMORY",
+			},
 		},
 		{
 			name:  "normalized CHARSET value",
@@ -2118,6 +2216,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) engine=innodb, character set=UTF8MB4",
 			diff:  "alter table t1 charset utf8mb4",
 			cdiff: "ALTER TABLE `t1` CHARSET utf8mb4",
+			textdiffs: []string{
+				"+  CHARSET utf8mb4",
+			},
 		},
 		{
 			name:  "normalized CHARSET utf8 value",
@@ -2125,6 +2226,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) engine=innodb, character set=UTF8",
 			diff:  "alter table t1 charset utf8mb3",
 			cdiff: "ALTER TABLE `t1` CHARSET utf8mb3",
+			textdiffs: []string{
+				"+  CHARSET utf8mb3",
+			},
 		},
 		{
 			name:  "normalized COLLATE value",
@@ -2132,6 +2236,9 @@ func TestCreateTableDiff(t *testing.T) {
 			to:    "create table t1 (id int primary key) engine=innodb, collate=UTF8_BIN",
 			diff:  "alter table t1 collate utf8mb3_bin",
 			cdiff: "ALTER TABLE `t1` COLLATE utf8mb3_bin",
+			textdiffs: []string{
+				"+  COLLATE utf8mb3_bin",
+			},
 		},
 		{
 			name:  "remove table comment",
@@ -2160,6 +2267,9 @@ func TestCreateTableDiff(t *testing.T) {
 				)`,
 			diff:  "alter table t4 add key index_on_company_id ((cast(json_unquote(json_extract(properties, _utf8mb4 '$.company_id')) as signed)))",
 			cdiff: "ALTER TABLE `t4` ADD KEY `index_on_company_id` ((CAST(JSON_UNQUOTE(JSON_EXTRACT(`properties`, _utf8mb4 '$.company_id')) AS signed)))",
+			textdiffs: []string{
+				"+	KEY `index_on_company_id` ((CAST(JSON_UNQUOTE(JSON_EXTRACT(`properties`, _utf8mb4 '$.company_id')) AS signed)))",
+			},
 		},
 		{
 			// validates that CanonicalString prints 'interval 30 minute' and not ' INTERVAL 30 MINUTE', as MySQL's `SHOW CREATE TABLE` outputs lower case 'interval 30 minute'
@@ -2175,6 +2285,9 @@ func TestCreateTableDiff(t *testing.T) {
 				)`,
 			diff:  "alter table t4 add column created_at datetime(6) not null default (now() + interval 30 minute)",
 			cdiff: "ALTER TABLE `t4` ADD COLUMN `created_at` datetime(6) NOT NULL DEFAULT (now() + INTERVAL 30 minute)",
+			textdiffs: []string{
+				"+	`created_at` datetime(6) NOT NULL DEFAULT (now() + INTERVAL 30 minute)",
+			},
 		},
 		// algorithm
 		{
@@ -2184,6 +2297,9 @@ func TestCreateTableDiff(t *testing.T) {
 			diff:      "alter table t1 add column i int not null default 0, algorithm = COPY",
 			cdiff:     "ALTER TABLE `t1` ADD COLUMN `i` int NOT NULL DEFAULT 0, ALGORITHM = COPY",
 			algorithm: AlterTableAlgorithmStrategyCopy,
+			textdiffs: []string{
+				"+	`i` int NOT NULL DEFAULT 0",
+			},
 		},
 		{
 			name:      "algorithm: INPLACE",
@@ -2192,6 +2308,9 @@ func TestCreateTableDiff(t *testing.T) {
 			diff:      "alter table t1 add column i int not null default 0, algorithm = INPLACE",
 			cdiff:     "ALTER TABLE `t1` ADD COLUMN `i` int NOT NULL DEFAULT 0, ALGORITHM = INPLACE",
 			algorithm: AlterTableAlgorithmStrategyInplace,
+			textdiffs: []string{
+				"+	`i` int NOT NULL DEFAULT 0",
+			},
 		},
 		{
 			name:      "algorithm: INSTANT",
@@ -2200,6 +2319,9 @@ func TestCreateTableDiff(t *testing.T) {
 			diff:      "alter table t1 add column i int not null default 0, algorithm = INSTANT",
 			cdiff:     "ALTER TABLE `t1` ADD COLUMN `i` int NOT NULL DEFAULT 0, ALGORITHM = INSTANT",
 			algorithm: AlterTableAlgorithmStrategyInstant,
+			textdiffs: []string{
+				"+	`i` int NOT NULL DEFAULT 0",
+			},
 		},
 	}
 	standardHints := DiffHints{}
@@ -2362,18 +2484,16 @@ func TestCreateTableDiff(t *testing.T) {
 							assert.NotEqual(t, eToStatementString, annotatedToString)
 						}
 					}
-					if len(ts.textdiffs) > 0 { // Still incomplete.
-						// For this test, we should validate the given diffs
-						uniqueDiffs := make(map[string]bool)
-						for _, textdiff := range ts.textdiffs {
-							uniqueDiffs[textdiff] = true
-						}
-						require.Equal(t, len(uniqueDiffs), len(ts.textdiffs)) // integrity of test
-						for _, textdiff := range ts.textdiffs {
-							assert.Containsf(t, annotatedUnifiedString, textdiff, annotatedUnifiedString)
-						}
-						assert.Equalf(t, len(annotatedUnified.Removed())+len(annotatedUnified.Added()), len(ts.textdiffs), annotatedUnifiedString)
+					require.NotEmpty(t, ts.textdiffs)
+					uniqueDiffs := make(map[string]bool)
+					for _, textdiff := range ts.textdiffs {
+						uniqueDiffs[textdiff] = true
 					}
+					require.Equal(t, len(uniqueDiffs), len(ts.textdiffs)) // integrity of test
+					for _, textdiff := range ts.textdiffs {
+						assert.Containsf(t, annotatedUnifiedString, textdiff, "unified: %s\nfrom: %s\nto: %s\nstmt: %s", annotatedUnifiedString, annotatedFromString, annotatedToString, alterEntityDiff.CanonicalStatementString())
+					}
+					assert.Equalf(t, len(annotatedUnified.Removed())+len(annotatedUnified.Added()), len(ts.textdiffs), annotatedUnifiedString)
 				}
 			}
 			{


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR adds one fix to `RENAME KEY` annotation, and adds full annotation coverage in all relevant tests (thus far annotations were only tested for selected cases; from now on this is mandatory for all relevant tests).

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/15387
- Followup to https://github.com/vitessio/vitess/pull/15388

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
