### PR TITLE
Remove deprecated syntax

### DIFF
--- a/java/example/src/main/java/io/vitess/example/MysqlJDBCExample.java
+++ b/java/example/src/main/java/io/vitess/example/MysqlJDBCExample.java
@@ -109,7 +109,7 @@ public class MysqlJDBCExample {
   }
 
   private static void validateReplica(Connection conn) throws SQLException {
-    String sql = "show slave status";
+    String sql = "show replica status";
     try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql)) {
       if (!rs.next()) {
         throw new RuntimeException("connected to wrong tablet");


### PR DESCRIPTION
This uses the new style. We run this against a new enough MySQL version that this also works.

## Related Issue(s)

Should have changed this already as part of earlier #16466 work where we stopped using the old syntax on new enough MySQL.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required