### PR TITLE
Add infinite buffer to health check consumers

### DIFF
--- a/go/vt/concurrency/message_queue.go
+++ b/go/vt/concurrency/message_queue.go
@@ -50,6 +50,13 @@ func (mq *MessageQueue[T]) Send(value T) {
 	mq.cond.Signal() // Notify a waiting receiver.
 }
 
+// Length returns the length.
+func (mq *MessageQueue[T]) Length() int {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	return len(mq.queue)
+}
+
 // Receive fetches a message of type T from the queue.
 // Blocks if no messages are available or until the queue is closed.
 func (mq *MessageQueue[T]) Receive() (T, bool) {

--- a/go/vt/concurrency/message_queue.go
+++ b/go/vt/concurrency/message_queue.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrency
+
+import (
+	"sync"
+)
+
+// MessageQueue provides semantics required from a message queue.
+// It behaves like a channel with an infinite capacity, where-in the
+// sender never blocks, and the receiver is guaranteed to see all updates.
+type MessageQueue[T any] struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	queue  []T
+	closed bool
+}
+
+// NewMessageQueue creates a new generic MessageQueue.
+func NewMessageQueue[T any]() *MessageQueue[T] {
+	mq := &MessageQueue[T]{}
+	mq.cond = sync.NewCond(&mq.mu)
+	return mq
+}
+
+// Send adds a message of type T to the queue.
+func (mq *MessageQueue[T]) Send(value T) {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	if mq.closed {
+		// We panic here just like a channel would
+		// if the user tried to send on a closed channel.
+		panic("cannot send on closed MessageQueue")
+	}
+	mq.queue = append(mq.queue, value)
+	mq.cond.Signal() // Notify a waiting receiver.
+}
+
+// Receive fetches a message of type T from the queue.
+// Blocks if no messages are available or until the queue is closed.
+func (mq *MessageQueue[T]) Receive() (T, bool) {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	var zeroValue T // Zero value of T
+
+	// Wait until a message is available or the queue is closed.
+	for len(mq.queue) == 0 && !mq.closed {
+		mq.cond.Wait()
+	}
+
+	if len(mq.queue) == 0 && mq.closed {
+		return zeroValue, false // Queue is closed and empty.
+	}
+
+	// Get the first message from the queue.
+	value := mq.queue[0]
+	mq.queue = mq.queue[1:]
+	return value, true
+}
+
+// Close signals that no more messages will be sent.
+func (mq *MessageQueue[T]) Close() {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	mq.closed = true
+	mq.cond.Broadcast() // Notify all waiting receivers.
+}

--- a/go/vt/concurrency/message_queue_test.go
+++ b/go/vt/concurrency/message_queue_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrency
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageQueue_SendReceive(t *testing.T) {
+	queue := NewMessageQueue[int]()
+	defer queue.Close()
+
+	// Send some data
+	queue.Send(10)
+	queue.Send(20)
+
+	// Receive data and validate
+	value, ok := queue.Receive()
+	require.True(t, ok)
+	require.EqualValues(t, 10, value)
+
+	value, ok = queue.Receive()
+	require.True(t, ok)
+	require.EqualValues(t, 20, value)
+
+	// Ensure receiving from empty queue blocks
+	done := make(chan struct{})
+	go func() {
+		_, _ = queue.Receive() // Should block
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Error("expected Receive to block on empty queue")
+	case <-time.After(100 * time.Millisecond):
+		// Test passes if it doesn't unblock
+	}
+}
+
+func TestMessageQueue_Close(t *testing.T) {
+	queue := NewMessageQueue[string]()
+	// Close the queue and validate behavior
+	queue.Close()
+
+	_, ok := queue.Receive()
+	require.False(t, ok, "expected Receive to return false when queue is closed")
+
+	// Sending to a closed queue should panic
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on Send to closed queue, got none")
+		}
+	}()
+	queue.Send("test")
+}
+
+func TestMessageQueue_ConcurrentAccess(t *testing.T) {
+	queue := NewMessageQueue[int]()
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	// Producer goroutine
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			queue.Send(i)
+		}
+		queue.Close()
+	}()
+
+	// Consumer goroutine
+	go func() {
+		defer wg.Done()
+		count := 0
+		for {
+			value, ok := queue.Receive()
+			if !ok {
+				break
+			}
+			require.EqualValues(t, count, value)
+			count++
+		}
+		require.EqualValues(t, 100, count, "expected to receive 100 values")
+	}()
+
+	wg.Wait()
+}
+
+func TestMessageQueue_BlockingReceive(t *testing.T) {
+	queue := NewMessageQueue[int]()
+
+	// Test that Receive blocks until data is sent
+	done := make(chan struct{})
+	go func() {
+		value, ok := queue.Receive()
+		require.True(t, ok)
+		require.EqualValues(t, 42, value)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Error("expected Receive to block, but it returned immediately")
+	case <-time.After(50 * time.Millisecond):
+		// Pass: Receive is blocking
+	}
+
+	// Unblock Receive by sending data
+	queue.Send(42)
+
+	select {
+	case <-done:
+		// Pass: Receive unblocked
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected Receive to unblock after data was sent")
+	}
+}
+
+func TestMessageQueue_MultipleReceivers(t *testing.T) {
+	queue := NewMessageQueue[int]()
+	wg := sync.WaitGroup{}
+	numReceivers := 5
+	numMessages := 50
+
+	wg.Add(numReceivers)
+	valCounts := make([]int, numReceivers)
+
+	// Start multiple receivers
+	for i := 0; i < numReceivers; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				_, ok := queue.Receive()
+				if !ok {
+					return
+				}
+				valCounts[i]++
+			}
+		}(i)
+	}
+
+	// Send messages
+	for i := 0; i < numMessages; i++ {
+		queue.Send(i)
+	}
+	queue.Close()
+
+	wg.Wait()
+
+	// Verify all messages were received by someone.
+	totalReceived := 0
+	for i := 0; i < numReceivers; i++ {
+		totalReceived += valCounts[i]
+	}
+	require.EqualValues(t, numMessages, totalReceived, "expected all messages to be received")
+}

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -654,7 +654,9 @@ func (hc *HealthCheckImpl) Subscribe() chan *TabletHealth {
 			} else {
 				// Message queue closed, so we should close the channel too.
 				close(c)
+				hc.subMu.Lock()
 				delete(hc.subscribers, c)
+				hc.subMu.Unlock()
 				return
 			}
 		}

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -1557,11 +1557,11 @@ func BenchmarkAccess_SlowConsumer(b *testing.B) {
 		ch := hc.Subscribe()
 		go func() {
 			for range ch {
-				time.Sleep(100 * time.Second)
+				time.Sleep(50 * time.Millisecond)
 			}
 		}()
 
-		for id := 0; id < 1000; id++ {
+		for id := 0; id < 100; id++ {
 			hc.broadcast(&TabletHealth{})
 		}
 		hc.Unsubscribe(ch)

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -1487,6 +1487,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	hc := createTestHc(ctx, ts)
 	// close healthcheck
 	defer hc.Close()
+	th := &TabletHealth{}
 
 	// Subscribe to the healthcheck
 	// Make the receiver keep track of the updates received.
@@ -1504,7 +1505,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	// one after the other.
 	totalUpdates := 10
 	for i := 0; i < totalUpdates; i++ {
-		hc.broadcast(&TabletHealth{})
+		hc.broadcast(th)
 	}
 	// Unsubscribe from the healthcheck
 	// and verify we process all the updates eventually.
@@ -1525,6 +1526,7 @@ func BenchmarkAccess_FastConsumer(b *testing.B) {
 	// close healthcheck
 	defer hc.Close()
 
+	th := &TabletHealth{}
 	for i := 0; i < b.N; i++ {
 		// Subscribe to the healthcheck with a fast consumer.
 		ch := hc.Subscribe()
@@ -1534,7 +1536,7 @@ func BenchmarkAccess_FastConsumer(b *testing.B) {
 		}()
 
 		for id := 0; id < 1000; id++ {
-			hc.broadcast(&TabletHealth{})
+			hc.broadcast(th)
 		}
 		hc.Unsubscribe(ch)
 		waitForEmptyMessageQueue(hc.subscribers[ch])
@@ -1552,6 +1554,7 @@ func BenchmarkAccess_SlowConsumer(b *testing.B) {
 	// close healthcheck
 	defer hc.Close()
 
+	th := &TabletHealth{}
 	for i := 0; i < b.N; i++ {
 		// Subscribe to the healthcheck with a slow consumer.
 		ch := hc.Subscribe()
@@ -1562,7 +1565,7 @@ func BenchmarkAccess_SlowConsumer(b *testing.B) {
 		}()
 
 		for id := 0; id < 100; id++ {
-			hc.broadcast(&TabletHealth{})
+			hc.broadcast(th)
 		}
 		hc.Unsubscribe(ch)
 		waitForEmptyMessageQueue(hc.subscribers[ch])

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/utils"
-	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -1539,7 +1538,7 @@ func BenchmarkAccess_FastConsumer(b *testing.B) {
 			hc.broadcast(th)
 		}
 		hc.Unsubscribe(ch)
-		waitForEmptyMessageQueue(hc.subscribers[ch])
+		waitForEmptyMessageQueue(ch)
 	}
 }
 
@@ -1568,13 +1567,13 @@ func BenchmarkAccess_SlowConsumer(b *testing.B) {
 			hc.broadcast(th)
 		}
 		hc.Unsubscribe(ch)
-		waitForEmptyMessageQueue(hc.subscribers[ch])
+		waitForEmptyMessageQueue(ch)
 	}
 }
 
-func waitForEmptyMessageQueue(queue *concurrency.MessageQueue[*TabletHealth]) {
+func waitForEmptyMessageQueue(ch chan *TabletHealth) {
 	for {
-		if queue.Length() == 0 {
+		if len(ch) == 0 {
 			return
 		}
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the problem described in https://github.com/vitessio/vitess/issues/17629. As pointed out in the issue, the problem is that the consumers aren't fast enough to ingest all the health check updates and that causes them to miss some of them. 

To prevent this, this PR adds a new message queue which keeps track of messages with an infinite capacity (we'll OOM eventually), while continuing to support the same semantics from the client side. The message queue has been added in a higher level package so that it can shared across the codebase if the use case for it arrises in the future.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #17629 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
