### PR TITLE
Increase health check channel buffer

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -632,7 +632,7 @@ func (hc *HealthCheckImpl) recomputeHealthy(key KeyspaceShardTabletType) {
 func (hc *HealthCheckImpl) Subscribe() chan *TabletHealth {
 	hc.subMu.Lock()
 	defer hc.subMu.Unlock()
-	c := make(chan *TabletHealth, 2)
+	c := make(chan *TabletHealth, 1024)
 	hc.subscribers[c] = struct{}{}
 	return c
 }

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -1557,11 +1557,11 @@ func BenchmarkAccess_SlowConsumer(b *testing.B) {
 		ch := hc.Subscribe()
 		go func() {
 			for range ch {
-				time.Sleep(100 * time.Second)
+				time.Sleep(50 * time.Millisecond)
 			}
 		}()
 
-		for id := 0; id < 1000; id++ {
+		for id := 0; id < 100; id++ {
 			hc.broadcast(&TabletHealth{})
 		}
 		hc.Unsubscribe(ch)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the problem described in https://github.com/vitessio/vitess/issues/17629. As pointed out in the issue, the problem is that the consumers aren't fast enough to ingest all the health check updates and that causes them to miss some of them.

This PR just increases the buffer size from 2 to 1024, so that the messages aren't dropped.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #17629 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
