### PR TITLE
VDiff: fix race when a vdiff resumes on vttablet restart

### DIFF
--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -85,7 +85,7 @@ func (tm *TabletManager) shardSyncLoop(ctx context.Context, notifyChan <-chan st
 			// We don't use the watch event except to know that we should
 			// re-read the shard record, and to know if the watch dies.
 			log.Info("Change in shard record")
-			if event.Err != nil {
+			if event != nil && event.Err != nil {
 				// The watch failed. Stop it so we start a new one if needed.
 				log.Errorf("Shard watch failed: %v", event.Err)
 				shardWatch.stop()

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -85,10 +85,15 @@ func (tm *TabletManager) shardSyncLoop(ctx context.Context, notifyChan <-chan st
 			// We don't use the watch event except to know that we should
 			// re-read the shard record, and to know if the watch dies.
 			log.Info("Change in shard record")
-			if event != nil && event.Err != nil {
-				// The watch failed. Stop it so we start a new one if needed.
-				log.Errorf("Shard watch failed: %v", event.Err)
-				shardWatch.stop()
+
+			if event != nil {
+				if event.Err != nil {
+					// The watch failed. Stop it so we start a new one if needed.
+					log.Errorf("Shard watch failed: %v", event.Err)
+					shardWatch.stop()
+				}
+			} else {
+				log.Infof("Got a nil event from the shard watcher for %s. This should not happen.", tm.tabletAlias)
 			}
 		case <-ctx.Done():
 			// Our context was cancelled. Terminate the loop.

--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -83,7 +83,7 @@ type controller struct {
 	TableDiffPhaseTimings *stats.Timings
 }
 
-func newController(ctx context.Context, row sqltypes.RowNamedValues, dbClientFactory func() binlogplayer.DBClient,
+func newController(row sqltypes.RowNamedValues, dbClientFactory func() binlogplayer.DBClient,
 	ts *topo.Server, vde *Engine, options *tabletmanagerdata.VDiffOptions) (*controller, error) {
 
 	log.Infof("VDiff controller initializing for %+v", row)

--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -104,9 +104,6 @@ func newController(ctx context.Context, row sqltypes.RowNamedValues, dbClientFac
 		TableDiffRowCounts:    stats.NewCountersWithSingleLabel("", "", "Rows"),
 		TableDiffPhaseTimings: stats.NewTimings("", "", "", "TablePhase"),
 	}
-	ctx, ct.cancel = context.WithCancel(ctx)
-	go ct.run(ctx)
-
 	return ct, nil
 }
 

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -221,6 +221,11 @@ func (vde *Engine) addController(row sqltypes.RowNamedValues, options *tabletman
 	globalStats.mu.Lock()
 	defer globalStats.mu.Unlock()
 	globalStats.controllers[ct.id] = ct
+
+	// run() can start a vdiff in pending/started state, so we should init the stats first before starting it.
+	controllerCtx, cancel := context.WithCancel(vde.ctx)
+	ct.cancel = cancel
+	go ct.run(controllerCtx)
 	return nil
 }
 

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -146,6 +146,8 @@ func (vde *Engine) openLocked(ctx context.Context) error {
 		vde.resetControllers()
 	}
 
+	globalStats.initControllerStats()
+
 	// At this point the tablet has no controllers running. So
 	// we want to start any VDiffs that have not been explicitly
 	// stopped or otherwise finished.
@@ -222,7 +224,6 @@ func (vde *Engine) addController(row sqltypes.RowNamedValues, options *tabletman
 	defer globalStats.mu.Unlock()
 	globalStats.controllers[ct.id] = ct
 
-	// run() can start a vdiff in pending/started state, so we should init the stats first before starting it.
 	controllerCtx, cancel := context.WithCancel(vde.ctx)
 	ct.cancel = cancel
 	go ct.run(controllerCtx)

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -153,12 +153,12 @@ func (vde *Engine) openLocked(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	vde.ctx, vde.cancel = context.WithCancel(ctx)
 	vde.isOpen = true // now we are open and have things to close
 	if err := vde.initControllers(rows); err != nil {
 		return err
 	}
-	vde.updateStats()
 
 	// At this point we've fully and successfully opened so begin
 	// retrying error'd VDiffs until the engine is closed.
@@ -400,16 +400,4 @@ func (vde *Engine) resetControllers() {
 		ct.Stop()
 	}
 	vde.controllers = make(map[int64]*controller)
-	vde.updateStats()
-}
-
-// updateStats must only be called while holding the engine lock.
-func (vre *Engine) updateStats() {
-	globalStats.mu.Lock()
-	defer globalStats.mu.Unlock()
-
-	globalStats.controllers = make(map[int64]*controller, len(vre.controllers))
-	for id, ct := range vre.controllers {
-		globalStats.controllers[id] = ct
-	}
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -212,7 +212,7 @@ func (vde *Engine) retry(ctx context.Context, err error) {
 // addController creates a new controller using the given vdiff record and adds it to the engine.
 // You must already have the main engine mutex (mu) locked before calling this.
 func (vde *Engine) addController(row sqltypes.RowNamedValues, options *tabletmanagerdata.VDiffOptions) error {
-	ct, err := newController(vde.ctx, row, vde.dbClientFactoryDba, vde.ts, vde, options)
+	ct, err := newController(row, vde.dbClientFactoryDba, vde.ts, vde, options)
 	if err != nil {
 		return fmt.Errorf("controller could not be initialized for stream %+v on tablet %v",
 			row, vde.thisTablet.Alias)

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -693,7 +693,7 @@ func (tvde *testVDiffEnv) createController(t *testing.T, id int) *controller {
 
 func (tvde *testVDiffEnv) newController(t *testing.T, controllerQR *sqltypes.Result) *controller {
 	ctx := context.Background()
-	ct, err := newController(ctx, controllerQR.Named().Row(), tvde.dbClientFactory, tstenv.TopoServ, tvde.vde, tvde.opts)
+	ct, err := newController(controllerQR.Named().Row(), tvde.dbClientFactory, tstenv.TopoServ, tvde.vde, tvde.opts)
 	require.NoError(t, err)
 	ctx2, cancel := context.WithCancel(ctx)
 	ct.cancel = cancel

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -676,8 +676,7 @@ func (tvde *testVDiffEnv) createController(t *testing.T, id int) *controller {
 		fmt.Sprintf("%d|%s|%s|%s|%s|%s|%s|%s|", id, uuid.New(), tvde.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 	tvde.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vdiff where id = %d", id), noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), tvde.dbClientFactory, tstenv.TopoServ, tvde.vde, tvde.opts)
-	require.NoError(t, err)
+	ct := tvde.newController(t, controllerQR)
 	ct.sources = map[string]*migrationSource{
 		tstenv.ShardName: {
 			vrID: 1,
@@ -688,5 +687,16 @@ func (tvde *testVDiffEnv) createController(t *testing.T, id int) *controller {
 		},
 	}
 	ct.sourceKeyspace = tstenv.KeyspaceName
+
+	return ct
+}
+
+func (tvde *testVDiffEnv) newController(t *testing.T, controllerQR *sqltypes.Result) *controller {
+	ctx := context.Background()
+	ct, err := newController(ctx, controllerQR.Named().Row(), tvde.dbClientFactory, tstenv.TopoServ, tvde.vde, tvde.opts)
+	require.NoError(t, err)
+	ctx2, cancel := context.WithCancel(ctx)
+	ct.cancel = cancel
+	go ct.run(ctx2)
 	return ct
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/stats.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/stats.go
@@ -49,6 +49,7 @@ func (vds *vdiffStats) register() {
 	globalStats.ErrorCount = stats.NewCounter("", "")
 	globalStats.RestartedTableDiffs = stats.NewCountersWithSingleLabel("", "", "Table")
 	globalStats.RowsDiffedCount = stats.NewCounter("", "")
+	globalStats.controllers = make(map[int64]*controller)
 
 	stats.NewGaugeFunc("VDiffCount", "Number of current vdiffs", vds.numControllers)
 

--- a/go/vt/vttablet/tabletmanager/vdiff/stats.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/stats.go
@@ -44,12 +44,18 @@ type vdiffStats struct {
 	RowsDiffedCount     *stats.Counter
 }
 
+func (vds *vdiffStats) initControllerStats() {
+	vds.mu.Lock()
+	defer vds.mu.Unlock()
+	vds.controllers = make(map[int64]*controller)
+}
+
 func (vds *vdiffStats) register() {
 	globalStats.Count = stats.NewGauge("", "")
 	globalStats.ErrorCount = stats.NewCounter("", "")
 	globalStats.RestartedTableDiffs = stats.NewCountersWithSingleLabel("", "", "Table")
 	globalStats.RowsDiffedCount = stats.NewCounter("", "")
-	globalStats.controllers = make(map[int64]*controller)
+	globalStats.initControllerStats()
 
 	stats.NewGaugeFunc("VDiffCount", "Number of current vdiffs", vds.numControllers)
 

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vdiff
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -49,8 +48,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 	)
 
 	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
-	require.NoError(t, err)
+	ct := vdenv.newController(t, controllerQR)
 	ct.sources = map[string]*migrationSource{
 		tstenv.ShardName: {
 			vrID: 1,
@@ -698,9 +696,7 @@ func TestBuildPlanFailure(t *testing.T) {
 		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
-	require.NoError(t, err)
-
+	ct := vdenv.newController(t, controllerQR)
 	testcases := []struct {
 		input *binlogdatapb.Rule
 		err   string


### PR DESCRIPTION
## Description

There is a race when vttablet starts and the vdiff engine opens. It starts vdiffs which need to be resumed where we restart vdiffs in error state concurrently with the vdiff engine init. It is possible that `globalStats` map is not initialized when a new controller gets added and the controller adds it self to the map.

This PR starts the goroutine that runs the controller thread only after the inits have been done.

```
if err := vde.initControllers(rows); err != nil {
		return err
	}
	vde.updateStats()

	// At this point we've fully and successfully opened so begin
	// retrying error'd VDiffs until the engine is closed.
	vde.wg.Add(1)
	go func() {
		defer vde.wg.Done()
		if vde.fortests {
			return
		}
		vde.retryErroredVDiffs()
	}()
```

This was added way back, so we backport to all supported versions: https://github.com/vitessio/vitess/pull/10639/files#diff-931d120fc70d7007ffd77176f54c526f678c1a6c4e703dbf54b3086c967dbd3dR323

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/17637

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
