### PR TITLE
VReplication: CODEOWNERS and unit test housekeeping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,7 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/vt/vttablet/tabletmanager/rpc_throttler.go @shlomi-noach @mattlord @timvaillancourt
 /go/vt/vttablet/tabletserver/throttle @shlomi-noach @mattlord @timvaillancourt
 /go/vt/vttablet/tabletmanager/vreplication @rohit-nayak-ps @mattlord
+/go/vt/vttablet/tabletmanager/vdiff @rohit-nayak-ps @mattlord
 /go/vt/vttablet/tabletmanager/vstreamer @rohit-nayak-ps @mattlord
 /go/vt/vttablet/tabletserver* @harshit-gangal @systay @shlomi-noach @rohit-nayak-ps @timvaillancourt
 /go/vt/vttablet/tabletserver/messager @mattlord @rohit-nayak-ps @derekperkins

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -966,7 +966,8 @@ func TestCancelMigration_TABLES(t *testing.T) {
 	err = topo.CheckKeyspaceLocked(ctx, ts.sourceKeyspace)
 	require.NoError(t, err)
 
-	ts.cancelMigration(ctx, sm)
+	err = ts.cancelMigration(ctx, sm)
+	require.NoError(t, err)
 
 	// Expect the queries to be cleared
 	assert.Empty(t, env.tmc.vrQueries[100])
@@ -1027,7 +1028,8 @@ func TestCancelMigration_SHARDS(t *testing.T) {
 	err = topo.CheckKeyspaceLocked(ctx, ts.sourceKeyspace)
 	require.NoError(t, err)
 
-	ts.cancelMigration(ctx, sm)
+	err = ts.cancelMigration(ctx, sm)
+	require.NoError(t, err)
 
 	// Expect the queries to be cleared
 	assert.Empty(t, env.tmc.vrQueries[100])


### PR DESCRIPTION
## Description

This PR makes two minor changes:
  1. Adds `tabletmanager/vdiff` to GitHub CODEOWNERS (I noticed that it was not there from a recent PR)
  2. Makes two minor unit test adjustments to deal with `golangci-lint` failures now on main:
  ```
  ❯ $(go env GOPATH)/bin/golangci-lint run go/... --timeout 10m
go/vt/vtctl/workflow/traffic_switcher_test.go:969:20: Error return value of `ts.cancelMigration` is not checked (errcheck)
        ts.cancelMigration(ctx, sm)
                          ^
go/vt/vtctl/workflow/traffic_switcher_test.go:1030:20: Error return value of `ts.cancelMigration` is not checked (errcheck)
        ts.cancelMigration(ctx, sm)
                          ^
```

This occurred because of two PRs that got merged concurrently today (new unit tests and changes to cancelMigration).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required