### PR TITLE
Replace uses of os.Create with os2.Create within backup/restore workflows

### DIFF
--- a/go/os2/file.go
+++ b/go/os2/file.go
@@ -16,10 +16,35 @@ limitations under the License.
 
 package os2
 
-import "os"
+import (
+	"io/fs"
+	"os"
+)
+
+const (
+	// PermFile is a FileMode for regular files without world permission bits.
+	PermFile fs.FileMode = 0660
+	// PermDirectory is a FileMode for directories without world permission bits.
+	PermDirectory fs.FileMode = 0770
+)
 
 // Create is identical to os.Create except uses 0660 permission
 // rather than 0666, to exclude world read/write bit.
 func Create(name string) (*os.File, error) {
-	return os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
+	return os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, PermFile)
+}
+
+// WriteFile is identical to os.WriteFile except permission of 0660 is used.
+func WriteFile(name string, data []byte) error {
+	return os.WriteFile(name, data, PermFile)
+}
+
+// Mkdir is identical to os.Mkdir except permission of 0770 is used.
+func Mkdir(path string) error {
+	return os.Mkdir(path, PermDirectory)
+}
+
+// MkdirAll is identical to os.MkdirAll except permission of 0770 is used.
+func MkdirAll(path string) error {
+	return os.MkdirAll(path, PermDirectory)
 }

--- a/go/os2/file.go
+++ b/go/os2/file.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package os2
+
+import "os"
+
+// Create is identical to os.Create except uses 0660 permission
+// rather than 0666, to exclude world read/write bit.
+func Create(name string) (*os.File, error) {
+	return os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
+}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -431,7 +431,7 @@ func TestBackup(t *testing.T, setupType int, streamMode string, stripes int, cDe
 		for _, ks := range localCluster.Keyspaces {
 			for _, shard := range ks.Shards {
 				for _, tablet := range shard.Vttablets {
-					cluster.ConfirmDataDirHasNoGlobalPerms(t, tablet)
+					tablet.VttabletProcess.ConfirmDataDirHasNoGlobalPerms(t)
 				}
 			}
 		}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -425,6 +425,18 @@ func TestBackup(t *testing.T, setupType int, streamMode string, stripes int, cDe
 			return vterrors.Errorf(vtrpc.Code_UNKNOWN, "test failure: %s", test.name)
 		}
 	}
+
+	t.Run("check for files created with global permissions", func(t *testing.T) {
+		t.Logf("Confirming that none of the MySQL data directories that we've created have files with global permissions")
+		for _, ks := range localCluster.Keyspaces {
+			for _, shard := range ks.Shards {
+				for _, tablet := range shard.Vttablets {
+					cluster.ConfirmDataDirHasNoGlobalPerms(t, tablet)
+				}
+			}
+		}
+	})
+
 	return nil
 }
 

--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -18,10 +18,8 @@ package cluster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"reflect"
 	"strings"
@@ -510,20 +508,4 @@ func PrintFiles(t *testing.T, dir string, files ...string) {
 			log.Errorf("%v", string(res))
 		}
 	}
-}
-
-// ConfirmDataDirHasNoGlobalPerms confirms that no files in the tablet's data directory
-// have any global/other permissions set.
-func ConfirmDataDirHasNoGlobalPerms(t *testing.T, tablet *Vttablet) {
-	datadir := tablet.VttabletProcess.Directory
-	if _, err := os.Stat(datadir); errors.Is(err, os.ErrNotExist) {
-		t.Logf("Data directory %s no longer exists, skipping permissions check", datadir)
-		return
-	}
-	// List any files which have any of the other bits set.
-	cmd := exec.Command("find", datadir, "-perm", "+00007")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "Error running find command: %s", string(out))
-	so := string(out)
-	require.Empty(t, so, "Found files with global permissions: %s", so)
 }

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -734,6 +734,7 @@ func (vttablet *VttabletProcess) ConfirmDataDirHasNoGlobalPerms(t *testing.T) {
 		path.Join("data", "client-cert.pem"),
 		path.Join("data", "public_key.pem"),
 		path.Join("data", "server-cert.pem"),
+		"mysql.sock", // Must have global perms for anyone to use it
 	}
 
 	var matches []string

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -723,6 +723,12 @@ func (vttablet *VttabletProcess) ConfirmDataDirHasNoGlobalPerms(t *testing.T) {
 		return
 	}
 
+	// These are intentionally created with the world/other read bit set by mysqld itself
+	// during the --initialize[-insecure] step.
+	// See: https://dev.mysql.com/doc/mysql-security-excerpt/en/creating-ssl-rsa-files-using-mysql.html
+	// "On Unix and Unix-like systems, the file access mode is 644 for certificate files
+	// (that is, world readable) and 600 for key files (that is, accessible only by the
+	// account that runs the server)."
 	var allowedFiles = []string{
 		path.Join("data", "ca.pem"),
 		path.Join("data", "client-cert.pem"),

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -723,18 +723,22 @@ func (vttablet *VttabletProcess) ConfirmDataDirHasNoGlobalPerms(t *testing.T) {
 		return
 	}
 
-	// These are intentionally created with the world/other read bit set by mysqld itself
-	// during the --initialize[-insecure] step.
-	// See: https://dev.mysql.com/doc/mysql-security-excerpt/en/creating-ssl-rsa-files-using-mysql.html
-	// "On Unix and Unix-like systems, the file access mode is 644 for certificate files
-	// (that is, world readable) and 600 for key files (that is, accessible only by the
-	// account that runs the server)."
 	var allowedFiles = []string{
+		// These are intentionally created with the world/other read bit set by mysqld itself
+		// during the --initialize[-insecure] step.
+		// See: https://dev.mysql.com/doc/mysql-security-excerpt/en/creating-ssl-rsa-files-using-mysql.html
+		// "On Unix and Unix-like systems, the file access mode is 644 for certificate files
+		// (that is, world readable) and 600 for key files (that is, accessible only by the
+		// account that runs the server)."
 		path.Join("data", "ca.pem"),
 		path.Join("data", "client-cert.pem"),
 		path.Join("data", "public_key.pem"),
 		path.Join("data", "server-cert.pem"),
-		"mysql.sock", // Must have global perms for anyone to use it
+		// The domain socket must have global perms for anyone to use it.
+		"mysql.sock",
+		// These files are created by xtrabackup.
+		path.Join("tmp", "xtrabackup_checkpoints"),
+		path.Join("tmp", "xtrabackup_info"),
 	}
 
 	var matches []string

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -31,6 +31,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/os2"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
@@ -723,7 +724,7 @@ func createStateFile(cnf *Mycnf) error {
 	// rename func to openStateFile
 	// change to return a *File
 	fname := filepath.Join(cnf.TabletDir(), RestoreState)
-	fd, err := os.Create(fname)
+	fd, err := os2.Create(fname)
 	if err != nil {
 		return fmt.Errorf("unable to create file: %v", err)
 	}

--- a/go/vt/mysqlctl/blackbox/utils.go
+++ b/go/vt/mysqlctl/blackbox/utils.go
@@ -30,6 +30,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/capabilities"
+	"vitess.io/vitess/go/os2"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
@@ -182,7 +183,7 @@ func createBackupDir(root string, dirs ...string) error {
 
 func createBackupFiles(root string, fileCount int, ext string) error {
 	for i := 0; i < fileCount; i++ {
-		f, err := os.Create(path.Join(root, fmt.Sprintf("%d.%s", i, ext)))
+		f, err := os2.Create(path.Join(root, fmt.Sprintf("%d.%s", i, ext)))
 		if err != nil {
 			return err
 		}

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -207,7 +207,7 @@ func (fe *FileEntry) open(cnf *Mycnf, readOnly bool) (*os.File, error) {
 		}
 	} else {
 		dir := path.Dir(name)
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(dir, 0770); err != nil {
 			return nil, vterrors.Wrapf(err, "cannot create destination directory %v", dir)
 		}
 		if fd, err = os2.Create(name); err != nil {

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -39,6 +39,7 @@ import (
 	"vitess.io/vitess/go/ioutil"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/os2"
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -209,7 +210,7 @@ func (fe *FileEntry) open(cnf *Mycnf, readOnly bool) (*os.File, error) {
 		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 			return nil, vterrors.Wrapf(err, "cannot create destination directory %v", dir)
 		}
-		if fd, err = os.Create(name); err != nil {
+		if fd, err = os2.Create(name); err != nil {
 			return nil, vterrors.Wrapf(err, "cannot create destination file %v", name)
 		}
 	}

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -207,7 +207,7 @@ func (fe *FileEntry) open(cnf *Mycnf, readOnly bool) (*os.File, error) {
 		}
 	} else {
 		dir := path.Dir(name)
-		if err := os.MkdirAll(dir, 0770); err != nil {
+		if err := os2.MkdirAll(dir); err != nil {
 			return nil, vterrors.Wrapf(err, "cannot create destination directory %v", dir)
 		}
 		if fd, err = os2.Create(name); err != nil {

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -173,13 +173,13 @@ func (fbs *FileBackupStorage) ListBackups(ctx context.Context, dir string) ([]ba
 func (fbs *FileBackupStorage) StartBackup(ctx context.Context, dir, name string) (backupstorage.BackupHandle, error) {
 	// Make sure the directory exists.
 	p := path.Join(FileBackupStorageRoot, dir)
-	if err := os.MkdirAll(p, 0770); err != nil {
+	if err := os2.MkdirAll(p); err != nil {
 		return nil, err
 	}
 
 	// Create the subdirectory for this named backup.
 	p = path.Join(p, name)
-	if err := os.Mkdir(p, 0770); err != nil {
+	if err := os2.Mkdir(p); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -173,13 +173,13 @@ func (fbs *FileBackupStorage) ListBackups(ctx context.Context, dir string) ([]ba
 func (fbs *FileBackupStorage) StartBackup(ctx context.Context, dir, name string) (backupstorage.BackupHandle, error) {
 	// Make sure the directory exists.
 	p := path.Join(FileBackupStorageRoot, dir)
-	if err := os.MkdirAll(p, os.ModePerm); err != nil {
+	if err := os.MkdirAll(p, 0770); err != nil {
 		return nil, err
 	}
 
 	// Create the subdirectory for this named backup.
 	p = path.Join(p, name)
-	if err := os.Mkdir(p, os.ModePerm); err != nil {
+	if err := os.Mkdir(p, 0770); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"vitess.io/vitess/go/os2"
 	"vitess.io/vitess/go/vt/mysqlctl/errors"
 
 	"vitess.io/vitess/go/ioutil"
@@ -96,7 +97,7 @@ func (fbh *FileBackupHandle) AddFile(ctx context.Context, filename string, files
 		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
 	}
 	p := path.Join(FileBackupStorageRoot, fbh.dir, fbh.name, filename)
-	f, err := os.Create(p)
+	f, err := os2.Create(p)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -47,6 +47,7 @@ import (
 	"vitess.io/vitess/config"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/sqlerror"
+	"vitess.io/vitess/go/os2"
 	"vitess.io/vitess/go/osutil"
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
@@ -901,7 +902,7 @@ func (mysqld *Mysqld) initConfig(cnf *Mycnf, outFile string) error {
 		return err
 	}
 
-	return os.WriteFile(outFile, []byte(configData), 0o664)
+	return os2.WriteFile(outFile, []byte(configData))
 }
 
 func (mysqld *Mysqld) getMycnfTemplate() string {
@@ -1051,7 +1052,7 @@ func (mysqld *Mysqld) ReinitConfig(ctx context.Context, cnf *Mycnf) error {
 func (mysqld *Mysqld) createDirs(cnf *Mycnf) error {
 	tabletDir := cnf.TabletDir()
 	log.Infof("creating directory %s", tabletDir)
-	if err := os.MkdirAll(tabletDir, os.ModePerm); err != nil {
+	if err := os2.MkdirAll(tabletDir); err != nil {
 		return err
 	}
 	for _, dir := range TopLevelDirs() {
@@ -1061,7 +1062,7 @@ func (mysqld *Mysqld) createDirs(cnf *Mycnf) error {
 	}
 	for _, dir := range cnf.directoryList() {
 		log.Infof("creating directory %s", dir)
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		if err := os2.MkdirAll(dir); err != nil {
 			return err
 		}
 		// FIXME(msolomon) validate permissions?
@@ -1085,14 +1086,14 @@ func (mysqld *Mysqld) createTopDir(cnf *Mycnf, dir string) error {
 		if os.IsNotExist(err) {
 			topdir := path.Join(tabletDir, dir)
 			log.Infof("creating directory %s", topdir)
-			return os.MkdirAll(topdir, os.ModePerm)
+			return os2.MkdirAll(topdir)
 		}
 		return err
 	}
 	linkto := path.Join(target, vtname)
 	source := path.Join(tabletDir, dir)
 	log.Infof("creating directory %s", linkto)
-	err = os.MkdirAll(linkto, os.ModePerm)
+	err = os2.MkdirAll(linkto)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This abstracts this ever so slightly into a new `os2.Create` to replace usages of `os.Create` across packages.

I didn't want to address every single use of `os.Create` within this PR, but ideally we'd review other uses and swap them to use this version.

This prevents files from being created and written with world read/write privileges. I strongly don't think any of these cases, that behavior was intentional, rather implicit due to using `os.Create` which internally uses 0666 permissions.

> [!NOTE]
> I think that this should be backported to all supported releases (back to v19 today) since it improves the product's security posture.

## Related Issue(s)

Fixes #17647

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
