### PR TITLE
Supporting `InnoDBParallelReadThreadsCapability`

### DIFF
--- a/go/mysql/capabilities/capability.go
+++ b/go/mysql/capabilities/capability.go
@@ -42,6 +42,7 @@ const (
 	InstantExpandEnumCapability                                           //
 	InstantChangeColumnVisibilityCapability                               //
 	MySQLUpgradeInServerFlavorCapability                                  //
+	InnoDBParallelReadThreadsCapability                                   // Supported in 8.0.14 and above, introducing innodb_parallel_read_threads variable
 	DynamicRedoLogCapacityFlavorCapability                                // supported in MySQL 8.0.30 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html
 	DisableRedoLogFlavorCapability                                        // supported in MySQL 8.0.21 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-21.html
 	CheckConstraintsCapability                                            // supported in MySQL 8.0.16 and above: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-16.html
@@ -100,6 +101,8 @@ func MySQLVersionHasCapability(serverVersion string, capability FlavorCapability
 		return atLeast(8, 0, 1)
 	case PerformanceSchemaMetadataLocksTableCapability:
 		return atLeast(8, 0, 2)
+	case InnoDBParallelReadThreadsCapability:
+		return atLeast(8, 0, 14)
 	case MySQLUpgradeInServerFlavorCapability:
 		return atLeast(8, 0, 16)
 	case CheckConstraintsCapability:

--- a/go/mysql/capabilities/capability_test.go
+++ b/go/mysql/capabilities/capability_test.go
@@ -155,6 +155,21 @@ func TestMySQLVersionCapableOf(t *testing.T) {
 			isCapable:  false,
 		},
 		{
+			version:    "8.0.13",
+			capability: InnoDBParallelReadThreadsCapability,
+			isCapable:  false,
+		},
+		{
+			version:    "8.0.14",
+			capability: InnoDBParallelReadThreadsCapability,
+			isCapable:  true,
+		},
+		{
+			version:    "8.4.1",
+			capability: InnoDBParallelReadThreadsCapability,
+			isCapable:  true,
+		},
+		{
 			version:    "8.0.30",
 			capability: DynamicRedoLogCapacityFlavorCapability,
 			isCapable:  true,


### PR DESCRIPTION

## Description

`go/mysql/capabilities` identifies and supports  `InnoDBParallelReadThreadsCapability`, which maps to [innodb_parallel_read_threads](https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_parallel_read_threads) introduced in `8.0.14`.


Now used yet at this time. To be potentially used in Online DDL, running a `SELECT COUNT(*)` exact row count while migration is running, so as to improve ETA/ratio

## Related Issue(s)

https://github.com/vitessio/vitess/pull/10445

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
