### PR TITLE
Fix golang dependencies upgrade workflow

### DIFF
--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -16,16 +16,16 @@ jobs:
     name: Update Golang Dependencies
     runs-on: ubuntu-24.04
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version-file: go.mod
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
           persist-credentials: 'false'
+
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
 
       - name: Upgrade the Golang Dependencies
         id: detect-and-update


### PR DESCRIPTION
## Description

Small fix to the golang auto deps upgrade workflow, we were reading `go.mod` before checking out the code.