### PR TITLE
go/vt/vtgate: add mirror query stats to vtgate /debug/querylogz

### DIFF
--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -45,12 +45,15 @@ var (
 				<th>Duration</th>
 				<th>Plan Time</th>
 				<th>Execute Time</th>
+				<th>Mirror Source Execute Time</th>
+				<th>Mirror Target Execute Time</th>
 				<th>Commit Time</th>
 				<th>Stmt Type</th>
 				<th>SQL</th>
 				<th>ShardQueries</th>
 				<th>RowsAffected</th>
 				<th>Error</th>
+				<th>Mirror Target Error</th>
 			</tr>
 		</thead>
 	`)
@@ -71,12 +74,15 @@ var (
 			<td>{{.TotalTime.Seconds}}</td>
 			<td>{{.PlanTime.Seconds}}</td>
 			<td>{{.ExecuteTime.Seconds}}</td>
+			<td>{{.MirrorSourceExecuteTime.Seconds}}</td>
+			<td>{{.MirrorTargetExecuteTime.Seconds}}</td>
 			<td>{{.CommitTime.Seconds}}</td>
 			<td>{{.StmtType}}</td>
 			<td>{{.SQL | .Parser.TruncateForUI | unquote | cssWrappable}}</td>
 			<td>{{.ShardQueries}}</td>
 			<td>{{.RowsAffected}}</td>
 			<td>{{.ErrorStr}}</td>
+			<td>{{.MirrorTargetErrorStr}}</td>
 		</tr>
 	`))
 )


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Expose mirror query stats in VTGate `/debug/querylogz` output.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Closes #17697.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation ~was added or~ is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
