### PR TITLE
Ignore execution time errors for schemadiff view analysis

### DIFF
--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1085,6 +1085,11 @@ func (s *Schema) ValidateViewReferences() error {
 					View:   view.Name(),
 					Column: e.Column.Name.String(),
 				}
+			case *semantics.UnsupportedConstruct:
+				// These are error types from semantic analysis for executing queries. When we
+				// have a view, we don't have Vitess execute these queries but MySQL does, so
+				// we don't want to return errors for these.
+				return nil
 			}
 			return err
 		}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -570,6 +570,20 @@ func TestInvalidSchema(t *testing.T) {
 			`,
 			expectErr: &DuplicateForeignKeyConstraintNameError{Table: "t2", Constraint: "const_id"},
 		},
+		{
+			schema: `
+CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255));
+CREATE VIEW user_earnings_ranking AS
+SELECT
+    u.id AS user_id,
+    e.total_earnings AS total_earnings,
+    ROW_NUMBER() OVER (
+        ORDER BY e.total_earnings DESC, u.id ASC
+    ) AS ranking
+FROM users AS u JOIN earnings AS e ON e.user_id = u.id;
+`,
+			expectErr: &ViewDependencyUnresolvedError{View: "user_earnings_ranking"},
+		},
 	}
 	for _, ts := range tt {
 		t.Run(ts.schema, func(t *testing.T) {


### PR DESCRIPTION
The UnsupportedConstruct error is returned for execution of select queries inside vtgate, but when we analyze views we don't care about those.

Views here are executed at the MySQL level though and always inside a single shard, so we don't want to return these errors.

The test example here shows a case where it thinks it's in sharded mode because of a missing dependency, but we only want to show that we're missing a table dependency.

## Related Issue(s)

Part of #10203 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required