### PR TITLE
Faster dependency copying

### DIFF
--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -190,13 +190,15 @@ var ErrNotSingleTable = vterrors.VT13001("should only be used for single tables"
 
 // CopyDependencies copies the dependencies from one expression into the other
 func (st *SemTable) CopyDependencies(from, to sqlparser.Expr) {
-	if ValidAsMapKey(to) {
-		st.Recursive[to] = st.RecursiveDeps(from)
-		st.Direct[to] = st.DirectDeps(from)
-		if ValidAsMapKey(from) {
-			if typ, found := st.ExprTypes[from]; found {
-				st.ExprTypes[to] = typ
-			}
+	if ValidAsMapKey(to) && ValidAsMapKey(from) {
+		if ts, ok := st.Recursive[from]; ok {
+			st.Recursive[to] = ts
+		}
+		if ts, ok := st.Direct[from]; ok {
+			st.Direct[to] = ts
+		}
+		if typ, found := st.ExprTypes[from]; found {
+			st.ExprTypes[to] = typ
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR introduces a small but valuable optimization to how dependencies are copied, resulting in performance improvements.

1. During tree walking, we clone parts of the AST and copy dependency/type info for each node. For example:
	```go
	output := sqlparser.CopyOnRewrite(in, pre, post, ctx.SemTable.CopySemanticInfo)
	```
2. Here, `CopySemanticInfo` is called for each cloned node and internally invokes `CopyDependencies`.
3. Currently, `CopyDependencies` calculates dependencies by walking the entire subtree and then stores the results in the semantic table. This extra work is unnecessary—it can be done on demand.
4. This PR changes the logic to copy only the existing info for the specific node, rather than re-walking and recalculating for its entire subtree.

### Stats
```
                                 │ ../main.bench │     ../smart-deps-copy.bench      │
                                 │    sec/op     │   sec/op     vs base              │
OLTP-8                               229.2µ ± 3%   222.5µ ± 1%  -2.92% (p=0.002 n=6)
TPCC-8                               1.643m ± 1%   1.591m ± 1%  -3.16% (p=0.002 n=6)
TPCH-8                              10.114m ± 2%   9.581m ± 2%  -5.27% (p=0.002 n=6)
Planner/from_cases.json-gen4-8       7.213m ± 2%   6.924m ± 1%  -4.00% (p=0.002 n=6)
Planner/filter_cases.json-gen4-8     152.2m ± 1%   148.0m ± 0%  -2.77% (p=0.002 n=6)
Planner/large_cases.json-gen4-8      468.5µ ± 2%   450.0µ ± 1%  -3.95% (p=0.002 n=6)
Planner/aggr_cases.json-gen4-8       12.51m ± 0%   12.28m ± 1%  -1.84% (p=0.002 n=6)
Planner/select_cases.json-gen4-8    10.016m ± 1%   9.828m ± 1%  -1.88% (p=0.002 n=6)
Planner/union_cases.json-gen4-8      3.552m ± 0%   3.560m ± 1%       ~ (p=0.485 n=6)
SemAnalysis-8                        27.73m ± 0%   27.86m ± 0%  +0.48% (p=0.002 n=6)
BaselineVsMirrored/Baseline-8        113.7µ ± 3%   114.3µ ± 2%       ~ (p=0.589 n=6)
BaselineVsMirrored/Mirrored-8        319.4µ ± 3%   313.0µ ± 0%  -2.00% (p=0.002 n=6)
geomean                              3.128m        3.058m       -2.23%

                                 │ ../main.bench │      ../smart-deps-copy.bench      │
                                 │     B/op      │     B/op      vs base              │
OLTP-8                              151.2Ki ± 0%   151.2Ki ± 0%  -0.01% (p=0.002 n=6)
TPCC-8                              993.6Ki ± 0%   993.2Ki ± 0%  -0.04% (p=0.002 n=6)
TPCH-8                              5.226Mi ± 0%   5.034Mi ± 0%  -3.67% (p=0.002 n=6)
Planner/from_cases.json-gen4-8      4.419Mi ± 0%   4.396Mi ± 0%  -0.52% (p=0.002 n=6)
Planner/filter_cases.json-gen4-8    19.36Mi ± 0%   19.28Mi ± 0%  -0.42% (p=0.002 n=6)
Planner/large_cases.json-gen4-8     273.7Ki ± 0%   273.7Ki ± 0%  -0.02% (p=0.004 n=6)
Planner/aggr_cases.json-gen4-8      7.128Mi ± 0%   6.964Mi ± 0%  -2.29% (p=0.002 n=6)
Planner/select_cases.json-gen4-8    6.142Mi ± 0%   6.003Mi ± 0%  -2.27% (p=0.002 n=6)
Planner/union_cases.json-gen4-8     2.188Mi ± 0%   2.187Mi ± 0%  -0.07% (p=0.002 n=6)
SemAnalysis-8                       18.98Mi ± 0%   18.98Mi ± 0%       ~ (p=0.310 n=6)
BaselineVsMirrored/Baseline-8       81.69Ki ± 0%   81.68Ki ± 0%  -0.02% (p=0.002 n=6)
BaselineVsMirrored/Mirrored-8       201.5Ki ± 0%   201.5Ki ± 0%  -0.03% (p=0.002 n=6)
geomean                             1.675Mi        1.662Mi       -0.79%

                                 │ ../main.bench │      ../smart-deps-copy.bench       │
                                 │   allocs/op   │  allocs/op   vs base                │
OLTP-8                               3.705k ± 0%   3.705k ± 0%       ~ (p=1.000 n=6) ¹
TPCC-8                               23.71k ± 0%   23.71k ± 0%       ~ (p=0.455 n=6)
TPCH-8                               131.8k ± 0%   131.6k ± 0%  -0.22% (p=0.002 n=6)
Planner/from_cases.json-gen4-8       102.5k ± 0%   102.5k ± 0%  -0.04% (p=0.002 n=6)
Planner/filter_cases.json-gen4-8     508.9k ± 0%   508.7k ± 0%  -0.03% (p=0.002 n=6)
Planner/large_cases.json-gen4-8      10.61k ± 0%   10.61k ± 0%       ~ (p=1.000 n=6) ¹
Planner/aggr_cases.json-gen4-8       160.4k ± 0%   159.9k ± 0%  -0.32% (p=0.002 n=6)
Planner/select_cases.json-gen4-8     141.0k ± 0%   140.6k ± 0%  -0.26% (p=0.002 n=6)
Planner/union_cases.json-gen4-8      50.66k ± 0%   50.65k ± 0%  -0.00% (p=0.002 n=6)
SemAnalysis-8                        231.3k ± 0%   231.3k ± 0%       ~ (p=0.323 n=6)
BaselineVsMirrored/Baseline-8        2.017k ± 0%   2.017k ± 0%       ~ (p=1.000 n=6) ¹
BaselineVsMirrored/Mirrored-8        5.578k ± 0%   5.578k ± 0%       ~ (p=1.000 n=6) ¹
geomean                              40.44k        40.41k       -0.07%

```

## Related Issue(s)

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
