### PR TITLE
schemadiff: `ViewDependencyUnresolvedError` lists missing referenced entities

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -394,11 +394,15 @@ type ViewDependencyUnresolvedError struct {
 }
 
 func (e *ViewDependencyUnresolvedError) Error() string {
-	s := make([]string, len(e.MissingReferencedEntities))
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("view %s has unresolved/loop dependencies: ", sqlescape.EscapeID(e.View)))
 	for i, entity := range e.MissingReferencedEntities {
-		s[i] = sqlescape.EscapeID(entity)
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		sqlescape.WriteEscapeID(&b, entity)
 	}
-	return fmt.Sprintf("view %s has unresolved/loop dependencies: %s", sqlescape.EscapeID(e.View), strings.Join(s, ", "))
+	return b.String()
 }
 
 type InvalidColumnReferencedInViewError struct {

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -389,11 +389,16 @@ func (e *IndexNeededByForeignKeyError) Error() string {
 }
 
 type ViewDependencyUnresolvedError struct {
-	View string
+	View                      string
+	MissingReferencedEntities []string
 }
 
 func (e *ViewDependencyUnresolvedError) Error() string {
-	return fmt.Sprintf("view %s has unresolved/loop dependencies", sqlescape.EscapeID(e.View))
+	s := make([]string, len(e.MissingReferencedEntities))
+	for i, entity := range e.MissingReferencedEntities {
+		s[i] = sqlescape.EscapeID(entity)
+	}
+	return fmt.Sprintf("view %s has unresolved/loop dependencies: %s", sqlescape.EscapeID(e.View), strings.Join(s, ", "))
 }
 
 type InvalidColumnReferencedInViewError struct {

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -395,7 +395,7 @@ type ViewDependencyUnresolvedError struct {
 
 func (e *ViewDependencyUnresolvedError) Error() string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("view %s has unresolved/loop dependencies: ", sqlescape.EscapeID(e.View)))
+	fmt.Fprintf(&b, "view %s has unresolved/loop dependencies: ", sqlescape.EscapeID(e.View))
 	for i, entity := range e.MissingReferencedEntities {
 		if i > 0 {
 			b.WriteString(", ")

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -341,7 +341,14 @@ func (s *Schema) normalize(hints *DiffHints) error {
 			if _, ok := dependencyLevels[v.Name()]; !ok {
 				// We _know_ that in this iteration, at least one view is found unassigned a dependency level.
 				// We gather all the errors.
-				errs = errors.Join(errs, &ViewDependencyUnresolvedError{View: v.ViewName.Name.String()})
+				dependentNames := getViewDependentTableNames(v.CreateView)
+				missingReferencedEntities := []string{}
+				for _, name := range dependentNames {
+					if _, ok := dependencyLevels[name]; !ok {
+						missingReferencedEntities = append(missingReferencedEntities, name)
+					}
+				}
+				errs = errors.Join(errs, &ViewDependencyUnresolvedError{View: v.ViewName.Name.String(), MissingReferencedEntities: missingReferencedEntities})
 				// We still add it so it shows up in the output if that is used for anything.
 				s.sorted = append(s.sorted, v)
 			}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -133,6 +133,7 @@ func TestNewSchemaFromQueriesUnresolvedMulti(t *testing.T) {
 	schema, err := NewSchemaFromQueries(NewTestEnv(), queries)
 	assert.Error(t, err)
 	assert.EqualError(t, err, (&ViewDependencyUnresolvedError{View: "v7", MissingReferencedEntities: []string{"v8", "t20", "v21"}}).Error())
+	assert.Equal(t, "view `v7` has unresolved/loop dependencies: `v8`, `t20`, `v21`", err.Error())
 	v := schema.sorted[len(schema.sorted)-1]
 	assert.IsType(t, &CreateViewEntity{}, v)
 	assert.Equal(t, "CREATE VIEW `v7` AS SELECT * FROM `v8`, `t2`, `t20`, `v21`", v.Create().CanonicalStatementString())


### PR DESCRIPTION

## Description

An enhancement to `ViewDependencyUnresolvedError`, which is now more detailed and lists the names of missing referenced entities.


## Related Issue(s)

#10203 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
