### PR TITLE
CI: Add some randomness to the ports used in VReplication e2e tests

### DIFF
--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -297,11 +297,17 @@ func downloadDBTypeVersion(dbType string, majorVersion string, path string) erro
 }
 
 func getClusterConfig(idx int, dataRootDir string) *ClusterConfig {
+	offset := 0
+	if !debugMode {
+		// Add some randomness to the ports so that multiple tests can run in
+		// parallel on the same host.
+		offset = (idx + 1) * rand.IntN(1000)
+	}
 	basePort := 15000
 	etcdPort := 2379
 
-	basePort += idx * 10000
-	etcdPort += idx * 10000
+	basePort += (idx * 10000) + offset
+	etcdPort += (idx * 10000) + offset
 	if _, err := os.Stat(dataRootDir); os.IsNotExist(err) {
 		os.Mkdir(dataRootDir, 0700)
 	}

--- a/go/test/endtoend/vreplication/migrate_test.go
+++ b/go/test/endtoend/vreplication/migrate_test.go
@@ -96,8 +96,9 @@ func TestMigrateUnsharded(t *testing.T) {
 	var output, expected string
 
 	t.Run("mount external cluster", func(t *testing.T) {
+		etcdHostPort := fmt.Sprintf("localhost:%d", extVc.ClusterConfig.topoPort)
 		output, err := vc.VtctldClient.ExecuteCommandWithOutput("Mount", "register", "--name=ext1", "--topo-type=etcd2",
-			fmt.Sprintf("--topo-server=localhost:%d", extVc.ClusterConfig.topoPort), "--topo-root=/vitess/global")
+			"--topo-server", etcdHostPort, "--topo-root=/vitess/global")
 		require.NoError(t, err, "Mount Register command failed with %s", output)
 
 		output, err = vc.VtctldClient.ExecuteCommandWithOutput("Mount", "list")
@@ -110,7 +111,7 @@ func TestMigrateUnsharded(t *testing.T) {
 		require.NoError(t, err, "Mount command failed with %s\n", output)
 
 		require.Equal(t, "etcd2", gjson.Get(output, "topo_type").String())
-		require.Equal(t, "localhost:12379", gjson.Get(output, "topo_server").String())
+		require.Equal(t, etcdHostPort, gjson.Get(output, "topo_server").String())
 		require.Equal(t, "/vitess/global", gjson.Get(output, "topo_root").String())
 	})
 


### PR DESCRIPTION
## Description

The [`vreplication_migrate` workflow](https://github.com/vitessio/vitess/blob/main/.github/workflows/cluster_endtoend_vreplication_migrate.yml) which runs the [`TestMigrateUnsharded` and `TestMigrateSharded`](https://github.com/vitessio/vitess/blob/main/go/test/endtoend/vreplication/migrate_test.go) tests [has been a *little* flaky](https://github.com/vitessio/vitess/actions/workflows/cluster_endtoend_vreplication_migrate.yml). The failures that I've seen are all related to port re-use. For example, from [the most recent non-PR changes related failure](https://github.com/vitessio/vitess/actions/runs/13165249145/job/36743668214): 
```
2025-02-05T19:46:04.6078463Z F0205 19:45:45.485443   37959 grpc_server.go:305] Cannot listen on port 28192 for gRPC: listen tcp 127.0.0.1:28192: bind: address already in use
2025-02-05T19:46:04.6078885Z 
2025-02-05T19:46:04.6079010Z     cluster_test.go:661: 
2025-02-05T19:46:04.6079670Z         	Error Trace:	/home/runner/work/vitess/vitess/go/test/endtoend/vreplication/cluster_test.go:661
2025-02-05T19:46:04.6080863Z         	            				/home/runner/work/vitess/vitess/go/test/endtoend/vreplication/cluster_test.go:472
2025-02-05T19:46:04.6082094Z         	            				/home/runner/work/vitess/vitess/go/test/endtoend/vreplication/migrate_test.go:260
2025-02-05T19:46:04.6083233Z         	            				/home/runner/work/vitess/vitess/go/test/endtoend/vreplication/migrate_test.go:229
2025-02-05T19:46:04.6083746Z         	Error:      	Received unexpected error:
2025-02-05T19:46:04.6084837Z         	            	process 'extcell1-1201' timed out after 10s (err: process 'extcell1-1201' exited prematurely (err: exit status 1))
2025-02-05T19:46:04.6085392Z         	Test:       	TestMigrateSharded
```

What makes this workflow and its tests somewhat unique is that each test creates *two* Vitess clusters (each with its own etcd server). So there was  a fair amount of port re-use. So if there was any parallelism on the host or we failed to kill one of the test processes at the end we'd encounter a failure due to trying to bind to a port that's already in use.

This PR tries to address (or at least mitigate) the issue by adding some randomness to the ports used.

I re-ran the workflow 20 times here to confirm that we saw no failures, and we did not: https://github.com/vitessio/vitess/actions/runs/13186110424/job/36808474378?pr=17712

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required