### PR TITLE
Chore: use new range for loops

### DIFF
--- a/go/cmd/rulesctl/cmd/explain.go
+++ b/go/cmd/rulesctl/cmd/explain.go
@@ -40,7 +40,7 @@ fails selects."
 
 The list of valid plan types that can be used follows:
 `)
-	for i := 0; i < int(planbuilder.NumPlans); i++ {
+	for i := range int(planbuilder.NumPlans) {
 		fmt.Printf("  - %v\n", planbuilder.PlanType(i).String())
 	}
 }

--- a/go/cmd/vtclient/cli/vtclient.go
+++ b/go/cmd/vtclient/cli/vtclient.go
@@ -220,7 +220,7 @@ func execMulti(ctx context.Context, db *sql.DB, sql string) (*results, error) {
 	isThrottled := qps > 0
 
 	start := time.Now()
-	for i := 0; i < parallel; i++ {
+	for range parallel {
 		wg.Add(1)
 
 		go func() {
@@ -232,7 +232,7 @@ func execMulti(ctx context.Context, db *sql.DB, sql string) (*results, error) {
 				ticker = time.NewTicker(tickDuration)
 			}
 
-			for j := 0; j < count; j++ {
+			for range count {
 				var qr *results
 				var err error
 				if isDML {

--- a/go/fileutil/wildcards.go
+++ b/go/fileutil/wildcards.go
@@ -21,13 +21,12 @@ package fileutil
 // where we detect a bad pattern, we return 'true', and let the path.Match
 // function find it.
 func HasWildcard(path string) bool {
-	for i := 0; i < len(path); i++ {
+	for i := range len(path) {
 		switch path[i] {
 		case '\\':
 			if i+1 >= len(path) {
 				return true
 			}
-			i++
 		case '*', '?', '[':
 			return true
 		}

--- a/go/history/history.go
+++ b/go/history/history.go
@@ -82,7 +82,7 @@ func (history *History) Records() []any {
 	records = append(records, history.records[:history.next]...)
 
 	// In place reverse.
-	for i := 0; i < history.length/2; i++ {
+	for i := range history.length / 2 {
 		records[i], records[history.length-i-1] = records[history.length-i-1], records[i]
 	}
 

--- a/go/mysql/binlog_event_rbr.go
+++ b/go/mysql/binlog_event_rbr.go
@@ -327,7 +327,7 @@ func (ev binlogEvent) Rows(f BinlogFormat, tm *TableMap) (Rows, error) {
 
 	// For PartialUpdateRowsEvents, we need to know how many JSON columns there are.
 	if ev.Type() == ePartialUpdateRowsEvent {
-		for c := 0; c < int(columnCount); c++ {
+		for c := range int(columnCount) {
 			if tm.Types[c] == binlog.TypeJSON {
 				numJSONColumns++
 			}
@@ -345,7 +345,7 @@ func (ev binlogEvent) Rows(f BinlogFormat, tm *TableMap) (Rows, error) {
 			// Get the identify values.
 			startPos := pos
 			valueIndex := 0
-			for c := 0; c < int(columnCount); c++ {
+			for c := range int(columnCount) {
 				if !result.IdentifyColumns.Bit(c) {
 					// This column is not represented.
 					continue
@@ -386,7 +386,7 @@ func (ev binlogEvent) Rows(f BinlogFormat, tm *TableMap) (Rows, error) {
 			// Get the values.
 			startPos := pos
 			valueIndex := 0
-			for c := 0; c < int(columnCount); c++ {
+			for c := range int(columnCount) {
 				if !result.DataColumns.Bit(c) {
 					// This column is not represented.
 					continue
@@ -426,7 +426,7 @@ func (rs *Rows) StringValuesForTests(tm *TableMap, rowIndex int) ([]string, erro
 	jsonIndex := 0
 	data := rs.Rows[rowIndex].Data
 	pos := 0
-	for c := 0; c < rs.DataColumns.Count(); c++ {
+	for c := range rs.DataColumns.Count() {
 		if !rs.DataColumns.Bit(c) {
 			continue
 		}
@@ -470,7 +470,7 @@ func (rs *Rows) StringIdentifiesForTests(tm *TableMap, rowIndex int) ([]string, 
 	valueIndex := 0
 	data := rs.Rows[rowIndex].Identify
 	pos := 0
-	for c := 0; c < rs.IdentifyColumns.Count(); c++ {
+	for c := range rs.IdentifyColumns.Count() {
 		if !rs.IdentifyColumns.Bit(c) {
 			continue
 		}

--- a/go/mysql/collations/colldata/multibyte.go
+++ b/go/mysql/collations/colldata/multibyte.go
@@ -55,7 +55,7 @@ func (c *Collation_multibyte) Collate(left, right []byte, isPrefix bool) int {
 	cmpLen := min(len(left), len(right))
 	cs := c.charset
 	sortOrder := c.sort
-	for i := 0; i < cmpLen; i++ {
+	for i := range cmpLen {
 		sortL, sortR := left[i], right[i]
 		if sortL > 127 {
 			if sortL != sortR {

--- a/go/mysql/collations/colldata/wildcard_test.go
+++ b/go/mysql/collations/colldata/wildcard_test.go
@@ -382,7 +382,7 @@ func BenchmarkWildcardMatching(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 
-		for n := 0; n < b.N; n++ {
+		for range b.N {
 			for _, bb := range patterns {
 				_ = bb.m1.Match(bb.input)
 			}
@@ -393,7 +393,7 @@ func BenchmarkWildcardMatching(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 
-		for n := 0; n < b.N; n++ {
+		for range b.N {
 			for _, bb := range patterns {
 				_ = bb.m2.Match(bb.input)
 			}

--- a/go/mysql/collations/tools/makecolldata/codegen/codegen.go
+++ b/go/mysql/collations/tools/makecolldata/codegen/codegen.go
@@ -164,7 +164,7 @@ func (g *Generator) gatherPackages(tt reflect.Type) {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Ptr, reflect.Slice:
 		g.gatherPackages(tt.Elem())
 	case reflect.Struct:
-		for i := 0; i < tt.NumField(); i++ {
+		for i := range tt.NumField() {
 			g.gatherPackages(tt.Field(i).Type)
 		}
 	}

--- a/go/mysql/collations/vindex/collate/collate.go
+++ b/go/mysql/collations/vindex/collate/collate.go
@@ -39,7 +39,7 @@ func (c *Hasher) Hash(str []byte) []byte {
 	var pos int
 
 	for c.iter.Next() {
-		for n := 0; n < c.iter.N; n++ {
+		for n := range c.iter.N {
 			if w := c.iter.Elems[n].Primary(); w > 0 {
 				if w <= 0x7FFF {
 					if len(scratch)-pos < 2 {

--- a/go/mysql/datetime/parse.go
+++ b/go/mysql/datetime/parse.go
@@ -82,7 +82,7 @@ func parsetimeSeconds(tp *timeparts, in string) (string, TimeState) {
 func parsetimeAny(tp *timeparts, in string) (out string, state TimeState) {
 	orig := in
 	var ok bool
-	for i := 0; i < len(in); i++ {
+	for i := range len(in) {
 		switch r := in[i]; {
 		case isSpace(r):
 			tp.day, in, ok = getnum(in, false)

--- a/go/mysql/endtoend/replication_test.go
+++ b/go/mysql/endtoend/replication_test.go
@@ -1051,7 +1051,7 @@ func valuesForTests(t *testing.T, rs *mysql.Rows, tm *mysql.TableMap, rowIndex i
 	valueIndex := 0
 	data := rs.Rows[rowIndex].Data
 	pos := 0
-	for c := 0; c < rs.DataColumns.Count(); c++ {
+	for c := range rs.DataColumns.Count() {
 		if !rs.DataColumns.Bit(c) {
 			continue
 		}

--- a/go/mysql/icuregex/internal/utrie/utrie2.go
+++ b/go/mysql/icuregex/internal/utrie/utrie2.go
@@ -193,7 +193,7 @@ func (t *UTrie2) enumEitherTrie(start, limit rune, enumValue EnumValue, enumRang
 					}
 					c += dataBlockLength
 				} else {
-					for j := 0; j < dataBlockLength; j++ {
+					for j := range dataBlockLength {
 						var value uint32
 						if data32 != nil {
 							value = data32[block+j]

--- a/go/mysql/json/json_path.go
+++ b/go/mysql/json/json_path.go
@@ -373,7 +373,7 @@ func stepRoot(p *PathParser, in []byte) ([]byte, error) {
 }
 
 func trim(in []byte) ([]byte, int) {
-	for n := 0; n < len(in); n++ {
+	for n := range len(in) {
 		switch in[n] {
 		case ' ', '\t', '\n':
 		default:

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -757,7 +757,7 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 		warnings: warningCount,
 	}
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		kontinue := sConn.handleNextCommand(&handler)
 		require.True(t, kontinue, "error handling command: %d", i)
 

--- a/go/mysql/replication/mysql56_gtid_set_test.go
+++ b/go/mysql/replication/mysql56_gtid_set_test.go
@@ -698,7 +698,7 @@ func BenchmarkMySQL56GTIDParsing(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for range b.N {
 		for _, input := range Inputs {
 			_, _ = ParseMysql56GTIDSet(input)
 		}

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -66,7 +66,7 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 
 	// Read column headers. One packet per column.
 	// Build the fields.
-	for i := 0; i < colNumber; i++ {
+	for i := range colNumber {
 		fieldsPointers[i] = &fields[i]
 		if err := c.readColumnDefinition(fieldsPointers[i], i); err != nil {
 			return err

--- a/go/pools/numbered_test.go
+++ b/go/pools/numbered_test.go
@@ -87,7 +87,7 @@ func BenchmarkRegisterUnregister(b *testing.B) {
 	p := NewNumbered()
 	id := int64(1)
 	val := "foobarbazdummyval"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p.Register(id, val)
 		p.Unregister(id, "some reason")
 	}

--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -117,7 +117,7 @@ func NewResourcePool(factory Factory, capacity, maxCap int, idleTimeout time.Dur
 	rp.idleTimeout.Store(idleTimeout.Nanoseconds())
 	rp.maxLifetime.Store(maxLifetime.Nanoseconds())
 
-	for i := 0; i < capacity; i++ {
+	for range capacity {
 		rp.resources <- resourceWrapper{}
 	}
 
@@ -153,7 +153,7 @@ func (rp *ResourcePool) closeIdleResources() {
 	available := int(rp.Available())
 	idleTimeout := rp.IdleTimeout()
 
-	for i := 0; i < available; i++ {
+	for range available {
 		var wrapper resourceWrapper
 		select {
 		case wrapper = <-rp.resources:
@@ -311,7 +311,7 @@ func (rp *ResourcePool) SetCapacity(capacity int) error {
 	// Otherwise, if the required capacity is more than the current capacity,
 	// then we just add empty resource to the channel.
 	if capacity < oldcap {
-		for i := 0; i < oldcap-capacity; i++ {
+		for range oldcap - capacity {
 			wrapper := <-rp.resources
 			if wrapper.resource != nil {
 				wrapper.resource.Close()
@@ -320,7 +320,7 @@ func (rp *ResourcePool) SetCapacity(capacity int) error {
 			rp.available.Add(-1)
 		}
 	} else {
-		for i := 0; i < capacity-oldcap; i++ {
+		for range capacity - oldcap {
 			rp.resources <- resourceWrapper{}
 			rp.available.Add(1)
 		}

--- a/go/pools/rpc_pool_test.go
+++ b/go/pools/rpc_pool_test.go
@@ -76,7 +76,7 @@ func TestRPCPool(t *testing.T) {
 }
 
 func BenchmarkRPCPoolAllocs(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		NewRPCPool(1000, 0, nil)
 		// p.Close()
 	}

--- a/go/pools/smartconnpool/benchmarking/legacy/resource_pool.go
+++ b/go/pools/smartconnpool/benchmarking/legacy/resource_pool.go
@@ -153,7 +153,7 @@ func NewResourcePool(factory Factory, capacity, maxCap int, idleTimeout time.Dur
 	rp.idleTimeout.Store(idleTimeout.Nanoseconds())
 	rp.maxLifetime.Store(maxLifetime.Nanoseconds())
 
-	for i := 0; i < capacity; i++ {
+	for range capacity {
 		rp.resources <- resourceWrapper{}
 	}
 
@@ -189,7 +189,7 @@ func (rp *ResourcePool) closeIdleResources() {
 	available := int(rp.Available())
 	idleTimeout := rp.IdleTimeout()
 
-	for i := 0; i < available; i++ {
+	for range available {
 		var wrapper resourceWrapper
 		var origPool bool
 		select {
@@ -463,7 +463,7 @@ func (rp *ResourcePool) SetCapacity(capacity int) error {
 	// Otherwise, if the required capacity is more than the current capacity,
 	// then we just add empty resource to the channel.
 	if capacity < oldcap {
-		for i := 0; i < oldcap-capacity; i++ {
+		for range oldcap - capacity {
 			var wrapper resourceWrapper
 			select {
 			case wrapper = <-rp.resources:
@@ -476,7 +476,7 @@ func (rp *ResourcePool) SetCapacity(capacity int) error {
 			rp.available.Add(-1)
 		}
 	} else {
-		for i := 0; i < capacity-oldcap; i++ {
+		for range capacity - oldcap {
 			rp.resources <- resourceWrapper{}
 			rp.available.Add(1)
 		}

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -136,7 +136,7 @@ func TestOpen(t *testing.T) {
 	var err error
 
 	// Test Get
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if i%2 == 0 {
 			r, err = p.Get(ctx, nil)
 		} else {
@@ -155,7 +155,7 @@ func TestOpen(t *testing.T) {
 	// Test that Get waits
 	done := make(chan struct{})
 	go func() {
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			if i%2 == 0 {
 				r, err = p.Get(ctx, nil)
 			} else {
@@ -164,12 +164,12 @@ func TestOpen(t *testing.T) {
 			require.NoError(t, err)
 			resources[i] = r
 		}
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			p.put(resources[i])
 		}
 		close(done)
 	}()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		// block until we have a client wait for a connection, then offer it
 		for p.wait.waiting() == 0 {
 			time.Sleep(time.Millisecond)
@@ -196,7 +196,7 @@ func TestOpen(t *testing.T) {
 	assert.EqualValues(t, 5, state.open.Load())
 	assert.EqualValues(t, 6, state.lastID.Load())
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if i%2 == 0 {
 			r, err = p.Get(ctx, nil)
 		} else {
@@ -205,7 +205,7 @@ func TestOpen(t *testing.T) {
 		require.NoError(t, err)
 		resources[i] = r
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		p.put(resources[i])
 	}
 	assert.EqualValues(t, 5, state.open.Load())
@@ -224,7 +224,7 @@ func TestOpen(t *testing.T) {
 	assert.EqualValues(t, 6, p.Capacity())
 	assert.EqualValues(t, 6, p.Available())
 
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		if i%2 == 0 {
 			r, err = p.Get(ctx, nil)
 		} else {
@@ -233,7 +233,7 @@ func TestOpen(t *testing.T) {
 		require.NoError(t, err)
 		resources[i] = r
 	}
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		p.put(resources[i])
 	}
 	assert.EqualValues(t, 6, state.open.Load())
@@ -258,7 +258,7 @@ func TestShrinking(t *testing.T) {
 
 	var resources [10]*Pooled[*TestConn]
 	// Leave one empty slot in the pool
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		var r *Pooled[*TestConn]
 		var err error
 		if i%2 == 0 {
@@ -287,7 +287,7 @@ func TestShrinking(t *testing.T) {
 		"IdleClosed":        0,
 		"MaxLifetimeClosed": 0,
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		time.Sleep(10 * time.Millisecond)
 		stats := p.StatsJSON()
 		if reflect.DeepEqual(expected, stats) {
@@ -302,7 +302,7 @@ func TestShrinking(t *testing.T) {
 	p.put(resources[3])
 	<-done
 	// Return the rest of the resources
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		p.put(resources[i])
 	}
 	stats := p.StatsJSON()
@@ -323,7 +323,7 @@ func TestShrinking(t *testing.T) {
 	// Ensure no deadlock if SetCapacity is called after we start
 	// waiting for a resource
 	var err error
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		var r *Pooled[*TestConn]
 		if i%2 == 0 {
 			r, err = p.Get(ctx, nil)
@@ -350,7 +350,7 @@ func TestShrinking(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// This should not hang
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		p.put(resources[i])
 	}
 	<-done
@@ -364,7 +364,7 @@ func TestShrinking(t *testing.T) {
 	// Test race condition of SetCapacity with itself
 	err = p.SetCapacity(ctx, 3)
 	require.NoError(t, err)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		var r *Pooled[*TestConn]
 		var err error
 		if i%2 == 0 {
@@ -397,7 +397,7 @@ func TestShrinking(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// This should not hang
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		p.put(resources[i])
 	}
 	<-done
@@ -421,7 +421,7 @@ func TestClosing(t *testing.T) {
 	}).Open(newConnector(&state), nil)
 
 	var resources [10]*Pooled[*TestConn]
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		var r *Pooled[*TestConn]
 		var err error
 		if i%2 == 0 {
@@ -455,7 +455,7 @@ func TestClosing(t *testing.T) {
 	assert.Equal(t, expected, stats)
 
 	// Put is allowed when closing
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		p.put(resources[i])
 	}
 
@@ -495,7 +495,7 @@ func TestReopen(t *testing.T) {
 	})
 
 	var resources [10]*Pooled[*TestConn]
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		var r *Pooled[*TestConn]
 		var err error
 		if i%2 == 0 {
@@ -525,7 +525,7 @@ func TestReopen(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	assert.Truef(t, refreshed.Load(), "did not refresh")
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		p.put(resources[i])
 	}
 	time.Sleep(50 * time.Millisecond)
@@ -557,7 +557,7 @@ func TestUserClosing(t *testing.T) {
 	}).Open(newConnector(&state), nil)
 
 	var resources [5]*Pooled[*TestConn]
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		var err error
 		resources[i], err = p.Get(ctx, nil)
 		require.NoError(t, err)
@@ -600,7 +600,7 @@ func TestIdleTimeout(t *testing.T) {
 		defer p.Close()
 
 		var conns []*Pooled[*TestConn]
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			r, err := p.Get(ctx, setting)
 			require.NoError(t, err)
 			assert.EqualValues(t, i+1, state.open.Load())
@@ -742,7 +742,7 @@ func TestExtendedLifetimeTimeout(t *testing.T) {
 
 	// maxLifetime > 0
 	config.MaxLifetime = 10 * time.Millisecond
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		p = NewPool(config).Open(connector, nil)
 		assert.LessOrEqual(t, config.MaxLifetime, p.extendedMaxLifetime())
 		assert.Greater(t, 2*config.MaxLifetime, p.extendedMaxLifetime())
@@ -766,7 +766,7 @@ func TestMaxIdleCount(t *testing.T) {
 		defer p.Close()
 
 		var conns []*Pooled[*TestConn]
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			r, err := p.Get(ctx, setting)
 			require.NoError(t, err)
 			assert.EqualValues(t, i+1, state.open.Load())
@@ -869,7 +869,7 @@ func TestSlowCreateFail(t *testing.T) {
 
 		state.chaos.failConnect = true
 
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			go func() {
 				conn, _ := p.Get(ctx, setting)
 				ch <- conn
@@ -964,7 +964,7 @@ func TestMultiSettings(t *testing.T) {
 	settings := []*Setting{nil, sFoo, sBar, sBar, sFoo}
 
 	// Test Get
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		r, err = p.Get(ctx, settings[i])
 		require.NoError(t, err)
 		resources[i] = r
@@ -979,17 +979,17 @@ func TestMultiSettings(t *testing.T) {
 	// Test that Get waits
 	ch := make(chan bool)
 	go func() {
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			r, err = p.Get(ctx, settings[i])
 			require.NoError(t, err)
 			resources[i] = r
 		}
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			p.put(resources[i])
 		}
 		ch <- true
 	}()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		// Sleep to ensure the goroutine waits
 		time.Sleep(10 * time.Millisecond)
 		p.put(resources[i])
@@ -1030,7 +1030,7 @@ func TestMultiSettingsWithReset(t *testing.T) {
 	settings := []*Setting{nil, sFoo, sBar, sBar, sFoo}
 
 	// Test Get
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		r, err = p.Get(ctx, settings[i])
 		require.NoError(t, err)
 		resources[i] = r
@@ -1040,12 +1040,12 @@ func TestMultiSettingsWithReset(t *testing.T) {
 	}
 
 	// Put all of them back
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		p.put(resources[i])
 	}
 
 	// Getting all with same setting.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		r, err = p.Get(ctx, settings[1]) // {foo}
 		require.NoError(t, err)
 		assert.Truef(t, r.Conn.setting == settings[1], "setting was not properly applied")
@@ -1056,7 +1056,7 @@ func TestMultiSettingsWithReset(t *testing.T) {
 	assert.EqualValues(t, 5, state.lastID.Load())
 	assert.EqualValues(t, 5, state.open.Load())
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		p.put(resources[i])
 	}
 
@@ -1083,7 +1083,7 @@ func TestApplySettingsFailure(t *testing.T) {
 
 	settings := []*Setting{nil, sFoo, sBar, sBar, sFoo}
 	// get the resource and mark for failure
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		r, err = p.Get(ctx, settings[i])
 		require.NoError(t, err)
 		r.Conn.failApply = true
@@ -1102,7 +1102,7 @@ func TestApplySettingsFailure(t *testing.T) {
 	// Otherwise, will fail to get the resource.
 	var failCount int
 	resources = nil
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		r, err = p.Get(ctx, settings[1])
 		if err != nil {
 			failCount++
@@ -1119,7 +1119,7 @@ func TestApplySettingsFailure(t *testing.T) {
 
 	// should be able to get all the resource with no setting
 	resources = nil
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		r, err = p.Get(ctx, nil)
 		require.NoError(t, err)
 		resources = append(resources, r)
@@ -1143,7 +1143,7 @@ func TestGetSpike(t *testing.T) {
 	var resources [10]*Pooled[*TestConn]
 
 	// Ensure we have a pool with 5 available resources
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		r, err := p.Get(ctx, nil)
 
 		require.NoError(t, err)
@@ -1156,7 +1156,7 @@ func TestGetSpike(t *testing.T) {
 		assert.EqualValues(t, i+1, state.open.Load())
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		p.put(resources[i])
 	}
 
@@ -1164,7 +1164,7 @@ func TestGetSpike(t *testing.T) {
 	assert.EqualValues(t, 5, p.Active())
 	assert.EqualValues(t, 0, p.InUse())
 
-	for i := 0; i < 2000; i++ {
+	for range 2000 {
 		wg := sync.WaitGroup{}
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -1172,7 +1172,7 @@ func TestGetSpike(t *testing.T) {
 
 		errs := make(chan error, 80)
 
-		for j := 0; j < 80; j++ {
+		for range 80 {
 			wg.Add(1)
 
 			go func() {

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -79,11 +79,11 @@ func TestStackRace(t *testing.T) {
 	var stack connStack[*StressConn]
 	var done atomic.Bool
 
-	for c := 0; c < Count; c++ {
+	for range Count {
 		stack.Push(&Pooled[*StressConn]{Conn: &StressConn{}})
 	}
 
-	for i := 0; i < Procs; i++ {
+	for i := range Procs {
 		wg.Add(1)
 		go func(tid int32) {
 			defer wg.Done()
@@ -108,7 +108,7 @@ func TestStackRace(t *testing.T) {
 	done.Store(true)
 	wg.Wait()
 
-	for c := 0; c < Count; c++ {
+	for range Count {
 		conn, ok := stack.Pop()
 		require.NotNil(t, conn)
 		require.True(t, ok)
@@ -130,7 +130,7 @@ func TestStress(t *testing.T) {
 	var wg errgroup.Group
 	var stop atomic.Bool
 
-	for p := 0; p < P; p++ {
+	for p := range P {
 		tid := int32(p + 1)
 		wg.Go(func() error {
 			ctx := context.Background()

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -36,7 +36,7 @@ func TestWaitlistExpireWithMultipleWaiters(t *testing.T) {
 	waiterCount := 2
 	expireCount := atomic.Int32{}
 
-	for i := 0; i < waiterCount; i++ {
+	for range waiterCount {
 		go func() {
 			_, err := wait.waitForConn(ctx, nil)
 			if err != nil {

--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -35,7 +35,7 @@ func WriteEscapeID(buf *strings.Builder, in string) {
 	buf.Grow(4 + len(in))
 
 	buf.WriteByte('`')
-	for i := 0; i < len(in); i++ {
+	for i := range len(in) {
 		buf.WriteByte(in[i])
 		if in[i] == '`' {
 			buf.WriteByte('`')
@@ -93,7 +93,7 @@ func UnescapeID(in string) (string, error) {
 	var buf strings.Builder
 	buf.Grow(len(in))
 
-	for i := 0; i < len(in); i++ {
+	for i := range len(in) {
 		buf.WriteByte(in[i])
 
 		if i < len(in)-1 && in[i] == '`' {

--- a/go/sqlescape/ids_test.go
+++ b/go/sqlescape/ids_test.go
@@ -225,7 +225,7 @@ func BenchmarkEscapeID(b *testing.B) {
 			name = "long"
 		}
 		b.Run(name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				scratch = EscapeID(tc)
 			}
 		})

--- a/go/sqltypes/marshal.go
+++ b/go/sqltypes/marshal.go
@@ -182,7 +182,7 @@ func MarshalResult(v any) (*Result, error) {
 		fields = append(fields, sqlField)
 	}
 
-	for i := 0; i < val.Len(); i++ {
+	for i := range val.Len() {
 		// TODO: handle case where val is a slice of non-pointer objects.
 		v := val.Index(i).Elem()
 		row, err := marshalRow(v, fields, exportedStructFields)

--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -425,7 +425,7 @@ func safeJoinLabels(labels []string, combinedLabels []bool) string {
 func appendSafeLabel(b *strings.Builder, label string) {
 	// first quickly check if there are any periods to be replaced
 	found := false
-	for i := 0; i < len(label); i++ {
+	for i := range len(label) {
 		if label[i] == '.' {
 			found = true
 			break
@@ -438,7 +438,7 @@ func appendSafeLabel(b *strings.Builder, label string) {
 		return
 	}
 
-	for i := 0; i < len(label); i++ {
+	for i := range len(label) {
 		if label[i] == '.' {
 			b.WriteByte('_')
 		} else {

--- a/go/stats/export_test.go
+++ b/go/stats/export_test.go
@@ -249,13 +249,13 @@ func BenchmarkSafeJoinLabels(b *testing.B) {
 	combined := [5]bool{true, true, true, true, true}
 	b.Run("no combined", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = safeJoinLabels(labels[:], nil)
 		}
 	})
 	b.Run("combined", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = safeJoinLabels(labels[:], combined[:])
 		}
 	})

--- a/go/stats/prometheusbackend/prometheusbackend_test.go
+++ b/go/stats/prometheusbackend/prometheusbackend_test.go
@@ -262,7 +262,7 @@ func checkHandlerForMetricWithMultiLabels(t *testing.T, metric string, labels []
 	response := testMetricsHandler(t)
 
 	kvPairs := make([]string, 0)
-	for i := 0; i < len(labels); i++ {
+	for i := range len(labels) {
 		kvPairs = append(kvPairs, fmt.Sprintf("%s=\"%s\"", labels[i], labelValues[i]))
 	}
 

--- a/go/stats/ring.go
+++ b/go/stats/ring.go
@@ -38,7 +38,7 @@ func (ri *RingInt64) Add(val int64) {
 
 func (ri *RingInt64) Values() (values []int64) {
 	values = make([]int64, len(ri.values))
-	for i := 0; i < len(ri.values); i++ {
+	for i := range len(ri.values) {
 		values[i] = ri.values[(ri.position+i)%cap(ri.values)]
 	}
 	return values

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -186,7 +186,7 @@ func TestChannel(t *testing.T) {
 	if len(got) != len(want) {
 		t.Errorf("Bad results length: got %d, want %d", len(got), len(want))
 	} else {
-		for i := 0; i < len(want); i++ {
+		for i := range len(want) {
 			if want[i]+"\n" != got[i] {
 				t.Errorf("Unexpected result in log: got %q, want %q", got[i], want[i]+"\n")
 			}

--- a/go/sync2/consolidator_test.go
+++ b/go/sync2/consolidator_test.go
@@ -33,7 +33,7 @@ func TestAddWaiterCount(t *testing.T) {
 
 	var concurrent = 1000
 
-	for i := 0; i < concurrent; i++ {
+	for range concurrent {
 		wgAdd.Add(1)
 		wgSub.Add(1)
 		go func() {

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1211,7 +1211,7 @@ func ReadRowsFromReplica(t *testing.T, replicaIndex int) (msgs []string) {
 func FlushBinaryLogsOnReplica(t *testing.T, replicaIndex int, count int) {
 	replica := getReplica(t, replicaIndex)
 	query := "flush binary logs"
-	for i := 0; i < count; i++ {
+	for range count {
 		_, err := replica.VttabletProcess.QueryTablet(query, keyspaceName, true)
 		require.NoError(t, err)
 	}

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -437,7 +437,7 @@ func (cluster *LocalProcessCluster) AddShard(keyspaceName string, shardName stri
 	}
 	log.Infof("Starting shard: %v", shardName)
 	var mysqlctlProcessList []*exec.Cmd
-	for i := 0; i < totalTabletsRequired; i++ {
+	for i := range totalTabletsRequired {
 		// instantiate vttablet object with reserved ports
 		tabletUID := cluster.GetAndReserveTabletUID()
 		tablet := &Vttablet{
@@ -564,7 +564,7 @@ func (cluster *LocalProcessCluster) StartKeyspaceLegacy(keyspace Keyspace, shard
 		}
 		log.Infof("Starting shard: %v", shardName)
 		mysqlctlProcessList = []*exec.Cmd{}
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := cluster.GetAndReserveTabletUID()
 			tablet := &Vttablet{

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -564,7 +564,7 @@ func executeQuery(dbConn *mysql.Conn, query string) (*sqltypes.Result, error) {
 	)
 	retries := 10
 	retryDelay := 1 * time.Second
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		if i > 0 {
 			// We only audit from 2nd attempt and onwards, otherwise this is just too verbose.
 			log.Infof("Executing query %s (attempt %d of %d)", query, (i + 1), retries)
@@ -584,7 +584,7 @@ func executeQuery(dbConn *mysql.Conn, query string) (*sqltypes.Result, error) {
 func executeMultiQuery(dbConn *mysql.Conn, query string) (err error) {
 	retries := 10
 	retryDelay := 1 * time.Second
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		if i > 0 {
 			// We only audit from 2nd attempt and onwards, otherwise this is just too verbose.
 			log.Infof("Executing query %s (attempt %d of %d)", query, (i + 1), retries)

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -82,7 +82,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 			Name: shardName,
 		}
 		var mysqlCtlProcessList []*exec.Cmd
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := clusterInstance.GetAndReserveTabletUID()
 			tablet := &cluster.Vttablet{

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -87,7 +87,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) error {
 		shard := &cluster.Shard{
 			Name: shardName,
 		}
-		for i := 0; i < totalTabletsRequired; i++ {
+		for i := range totalTabletsRequired {
 			// instantiate vttablet object with reserved ports
 			tabletUID := clusterInstance.GetAndReserveTabletUID()
 			tablet := &cluster.Vttablet{

--- a/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
+++ b/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
@@ -569,7 +569,7 @@ func runMultipleConnections(ctx context.Context, t *testing.T) {
 
 	log.Infof("Running multiple connections: maxConcurrency=%v, sleep interval=%v", maxConcurrency, sleepInterval)
 	var wg sync.WaitGroup
-	for i := 0; i < maxConcurrency; i++ {
+	for range maxConcurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -591,13 +591,13 @@ func initTable(t *testing.T) {
 
 	appliedDMLStart := totalAppliedDML.Load()
 
-	for i := 0; i < maxTableRows/2; i++ {
+	for range maxTableRows / 2 {
 		generateInsert(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateUpdate(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateDelete(t, conn)
 	}
 	appliedDMLEnd := totalAppliedDML.Load()

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -859,7 +859,7 @@ func testRevert(t *testing.T) {
 	// If they fail, it has nothing to do with revert.
 	// We run these tests because we expect their functionality to work in the next step.
 	var alterHints []string
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		testName := fmt.Sprintf("online ALTER TABLE %d", i)
 		hint := fmt.Sprintf("hint-alter-%d", i)
 		alterHints = append(alterHints, hint)
@@ -1404,7 +1404,7 @@ func runMultipleConnections(ctx context.Context, t *testing.T) {
 	require.True(t, checkTable(t, tableName, true))
 	var done int64
 	var wg sync.WaitGroup
-	for i := 0; i < maxConcurrency; i++ {
+	for range maxConcurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1431,13 +1431,13 @@ func initTable(t *testing.T) {
 	_, err = conn.ExecuteFetch(truncateStatement, 1000, true)
 	require.Nil(t, err)
 
-	for i := 0; i < maxTableRows/2; i++ {
+	for range maxTableRows / 2 {
 		generateInsert(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateUpdate(t, conn)
 	}
-	for i := 0; i < maxTableRows/4; i++ {
+	for range maxTableRows / 4 {
 		generateDelete(t, conn)
 	}
 }

--- a/test.go
+++ b/test.go
@@ -385,7 +385,7 @@ func main() {
 	if *runCount > 1 {
 		var dup []*Test
 		for _, t := range tests {
-			for i := 0; i < *runCount; i++ {
+			for i := range *runCount {
 				// Make a copy, since they're pointers.
 				test := *t
 				test.runIndex = i
@@ -479,7 +479,7 @@ func main() {
 	}()
 
 	// Start the requested number of parallel runners.
-	for i := 0; i < *parallel; i++ {
+	for range *parallel {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION


## Description

- Updates our codebase to use new integer range syntax for cleaner and more idiomatic loops. This replaces traditional counter loops ```for i := 0; i < n; i++``` with the more concise for `i := range n` syntax where applicable. This change improves code readability while maintaining the same functionality.

## Related Issue(s)

- #15193

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
