### PR TITLE
Atomic Copy: Fix panics when the copy phase starts in some clusters

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -724,6 +724,10 @@ func (tp *TablePlan) appendFromRow(buf *bytes2.Buffer, row *querypb.Row) error {
 		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "wrong number of fields: got %d fields for %d bind locations",
 			len(tp.Fields), len(bindLocations))
 	}
+	if len(row.Lengths) < len(tp.Fields) {
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "wrong number of lengths: got %d lengths for %d fields",
+			len(row.Lengths), len(tp.Fields))
+	}
 
 	// Bind field values to locations.
 	var (

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -154,9 +154,9 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 
 			lastpk = nil
 			// pkfields are only used for logging, so that we can monitor progress.
-			pkfields = make([]*querypb.Field, len(resp.Pkfields))
-			for i, f := range resp.Pkfields {
-				pkfields[i] = f.CloneVT()
+			pkfields = make([]*querypb.Field, 0, len(resp.Pkfields))
+			for _, f := range resp.Pkfields {
+				pkfields = append(pkfields, f.CloneVT())
 			}
 
 			fieldEvent := &binlogdatapb.FieldEvent{

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -155,8 +155,8 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 			lastpk = nil
 			// pkfields are only used for logging, so that we can monitor progress.
 			pkfields = make([]*querypb.Field, len(resp.Pkfields))
-			for _, f := range resp.Pkfields {
-				pkfields = append(pkfields, f.CloneVT())
+			for i, f := range resp.Pkfields {
+				pkfields[i] = f.CloneVT()
 			}
 
 			fieldEvent := &binlogdatapb.FieldEvent{

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -84,6 +84,11 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 	defer rowsCopiedTicker.Stop()
 
 	parallelism := int(math.Max(1, float64(vc.vr.workflowConfig.ParallelInsertWorkers)))
+	// For now do not support concurrent inserts for atomic copies.
+	if parallelism > 1 {
+		parallelism = 1
+		log.Infof("Disabling concurrent inserts for atomic copies")
+	}
 	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism)
 	var copyWorkQueue *vcopierCopyWorkQueue
 


### PR DESCRIPTION
## Description

Note that this doesn't fix the [underlying issue](https://github.com/vitessio/vitess/issues/17716
) that was reported but just fixes the panic, adds debug logging and returns an error so that vttablet doesn't crash.

It does fix a bug in a list initialization, used only for logging in atomicCopy mode, that was resulting in a confusing log message.

Unable to repro the underlying issue, so we will create a new issue with details when we get more info on it.

Backporting to all supported versions to prevent the panic.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/17716

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
