### PR TITLE
test: replace `t.Errorf` and `t.Fatalf` with `assert` and `require`

### DIFF
--- a/go/cache/lru_cache_test.go
+++ b/go/cache/lru_cache_test.go
@@ -119,16 +119,16 @@ func TestCapacityIsObeyed(t *testing.T) {
 	// Check various other stats
 	l := cache.Len()
 	assert.Equal(t, size, int64(l), "cache.Len() returned bad length: %v", l)
-	
+
 	s := cache.UsedCapacity()
 	assert.Equal(t, size, s, "cache.UsedCapacity() returned bad size: %v", s)
-	
+
 	c := cache.MaxCapacity()
 	assert.Equal(t, size, c, "cache.UsedCapacity() returned bad length: %v", c)
-	
+
 	hits := cache.Hits()
 	assert.Zero(t, hits, "cache.Hits() returned hits when there should be none: %v", hits)
-	
+
 	misses := cache.Misses()
 	assert.Zero(t, misses, "cache.Misses() returned misses when there should be none: %v", misses)
 }

--- a/go/cache/lru_cache_test.go
+++ b/go/cache/lru_cache_test.go
@@ -46,11 +46,11 @@ func TestSetInsertsValue(t *testing.T) {
 
 	v, ok := cache.Get(key)
 	assert.True(t, ok)
-	assert.Equal(t, v, data, "Cache has incorrect value: expected %v, got %v", data, v)
+	assert.EqualValues(t, v, data)
 
 	values := cache.Items()
 	require.NotEmpty(t, values)
-	assert.Equal(t, key, values[0].Key, "Cache.Values() returned incorrect values: %v", values)
+	assert.Equal(t, key, values[0].Key)
 }
 
 func TestGetValueWithMultipleTypes(t *testing.T) {
@@ -61,11 +61,11 @@ func TestGetValueWithMultipleTypes(t *testing.T) {
 
 	v, ok := cache.Get("key")
 	assert.True(t, ok)
-	assert.Equal(t, data, v, "Cache has incorrect value for \"key\": expected %v, got %v", data, v)
+	assert.Equal(t, data, v)
 
 	v, ok = cache.Get(string([]byte{'k', 'e', 'y'}))
 	assert.True(t, ok)
-	assert.Equal(t, data, v, "Cache has incorrect value for []byte {'k','e','y'}: expected %v, got %v", data, v)
+	assert.Equal(t, data, v)
 }
 
 func TestSetWithOldKeyUpdatesValue(t *testing.T) {
@@ -78,7 +78,7 @@ func TestSetWithOldKeyUpdatesValue(t *testing.T) {
 
 	v, ok := cache.Get(key)
 	assert.True(t, ok)
-	assert.Equal(t, someValue, v, "Cache has incorrect value: expected %v, got %v", someValue, v)
+	assert.Equal(t, someValue, v)
 }
 
 func TestGetNonExistent(t *testing.T) {
@@ -98,7 +98,7 @@ func TestDelete(t *testing.T) {
 	cache.Delete(key)
 
 	sz := cache.UsedCapacity()
-	assert.Zero(t, sz, "cache.UsedCapacity() = %v, expected 0", sz)
+	assert.Zero(t, sz)
 
 	val, ok := cache.Get("notthere")
 	assert.False(t, ok, "Cache returned a value after deletion: val=%v", val)
@@ -115,7 +115,7 @@ func TestCapacityIsObeyed(t *testing.T) {
 	cache.Set("key2", value)
 	cache.Set("key3", value)
 	sz := cache.UsedCapacity()
-	assert.Equal(t, size, sz, "cache.UsedCapacity() = %v, expected %v", sz, size)
+	assert.EqualValues(t, size, sz)
 	// Insert one more; something should be evicted to make room.
 	cache.Set("key4", value)
 	sz, evictions := cache.UsedCapacity(), cache.Evictions()
@@ -124,19 +124,19 @@ func TestCapacityIsObeyed(t *testing.T) {
 
 	// Check various other stats
 	l := cache.Len()
-	assert.EqualValues(t, size, l, "cache.Len() returned bad length: %v", l)
+	assert.EqualValues(t, size, l)
 
 	s := cache.UsedCapacity()
-	assert.EqualValues(t, size, s, "cache.UsedCapacity() returned bad size: %v", s)
+	assert.EqualValues(t, size, s)
 
 	c := cache.MaxCapacity()
-	assert.EqualValues(t, size, c, "cache.UsedCapacity() returned bad length: %v", c)
+	assert.EqualValues(t, size, c)
 
 	hits := cache.Hits()
-	assert.Zero(t, hits, "cache.Hits() returned hits when there should be none: %v", hits)
+	assert.Zero(t, hits)
 
 	misses := cache.Misses()
-	assert.Zero(t, misses, "cache.Misses() returned misses when there should be none: %v", misses)
+	assert.Zero(t, misses)
 }
 
 func TestLRUIsEvicted(t *testing.T) {
@@ -162,11 +162,11 @@ func TestLRUIsEvicted(t *testing.T) {
 	assert.False(t, ok, "Least recently used element was not evicted: %v", v)
 
 	e := cache.Evictions()
-	assert.EqualValues(t, 1, e, "evictions: got %d, want: %d", e, 1)
+	assert.EqualValues(t, 1, e)
 
 	h := cache.Hits()
-	assert.EqualValues(t, 3, h, "hits: got %d, want: %d", h, 3)
+	assert.EqualValues(t, 3, h)
 
 	m := cache.Misses()
-	assert.EqualValues(t, 1, m, "misses: got %d, want: %d", m, 1)
+	assert.EqualValues(t, 1, m)
 }

--- a/go/cache/lru_cache_test.go
+++ b/go/cache/lru_cache_test.go
@@ -49,7 +49,7 @@ func TestSetInsertsValue(t *testing.T) {
 	assert.EqualValues(t, v, data)
 
 	values := cache.Items()
-	require.NotEmpty(t, values)
+	require.Len(t, values, 1)
 	assert.Equal(t, key, values[0].Key)
 }
 

--- a/go/event/event_test.go
+++ b/go/event/event_test.go
@@ -56,7 +56,9 @@ func TestStaticListener(t *testing.T) {
 
 	triggered := false
 	AddListener(func(testEvent1) { triggered = true })
-	AddListener(func(testEvent2) { t.Errorf("wrong listener type triggered") })
+	AddListener(func(testEvent2) { 
+		assert.Fail(t, "wrong listener type triggered") 
+	})
 	Dispatch(testEvent1{})
 	assert.True(t, triggered, "static listener failed to trigger")
 }
@@ -66,7 +68,9 @@ func TestPointerListener(t *testing.T) {
 
 	testEvent := new(testEvent2)
 	AddListener(func(ev *testEvent2) { ev.triggered = true })
-	AddListener(func(testEvent2) { t.Errorf("non-pointer listener triggered on pointer type") })
+	AddListener(func(testEvent2) { 
+		assert.Fail(t, "non-pointer listener triggered on pointer type") 
+	})
 	Dispatch(testEvent)
 	assert.True(t, testEvent.triggered, "pointer listener failed to trigger")
 }
@@ -76,7 +80,9 @@ func TestInterfaceListener(t *testing.T) {
 
 	triggered := false
 	AddListener(func(testInterface1) { triggered = true })
-	AddListener(func(testInterface2) { t.Errorf("interface listener triggered on non-matching type") })
+	AddListener(func(testInterface2) { 
+		assert.Fail(t, "interface listener triggered on non-matching type") 
+	})
 	Dispatch(testEvent1{})
 	assert.True(t, triggered, "interface listener failed to trigger")
 }
@@ -98,9 +104,7 @@ func TestMultipleListeners(t *testing.T) {
 	AddListener(func(testEvent1) { triggered2 = true })
 	Dispatch(testEvent1{})
 
-	if !triggered1 || !triggered2 {
-		t.Errorf("not all matching listeners triggered")
-	}
+	assert.True(t, triggered1 && triggered2, "not all matching listeners triggered")
 }
 
 func TestBadListenerWrongInputs(t *testing.T) {
@@ -108,9 +112,8 @@ func TestBadListenerWrongInputs(t *testing.T) {
 
 	defer func() {
 		err := recover()
-
+		assert.NotNil(t, err, "bad listener func (wrong # of inputs) failed to trigger panic")
 		if err == nil {
-			t.Errorf("bad listener func (wrong # of inputs) failed to trigger panic")
 			return
 		}
 
@@ -120,9 +123,7 @@ func TestBadListenerWrongInputs(t *testing.T) {
 		}
 
 		want := "bad listener func: listener must take exactly one input argument"
-		if got := blErr.Error(); got != want {
-			t.Errorf(`BadListenerError.Error() = "%s", want "%s"`, got, want)
-		}
+		assert.Equal(t, want, blErr.Error(), `BadListenerError.Error() = "%s", want "%s"`, blErr.Error(), want)
 	}()
 
 	AddListener(func() {})
@@ -134,9 +135,7 @@ func TestBadListenerWrongType(t *testing.T) {
 
 	defer func() {
 		err := recover()
-		if err == nil {
-			t.Errorf("bad listener type (not a func) failed to trigger panic")
-		}
+		assert.NotNil(t, err, "bad listener type (not a func) failed to trigger panic")
 
 		blErr, ok := err.(BadListenerError)
 		if !ok {
@@ -144,9 +143,7 @@ func TestBadListenerWrongType(t *testing.T) {
 		}
 
 		want := "bad listener func: listener must be a function"
-		if got := blErr.Error(); got != want {
-			t.Errorf(`BadListenerError.Error() = "%s", want "%s"`, got, want)
-		}
+		assert.Equal(t, want, blErr.Error(), `BadListenerError.Error() = "%s", want "%s"`, blErr.Error(), want)
 	}()
 
 	AddListener("this is not a function")
@@ -163,7 +160,7 @@ func TestAsynchronousDispatch(t *testing.T) {
 	select {
 	case <-triggered:
 	case <-time.After(time.Second):
-		t.Errorf("asynchronous dispatch failed to trigger listener")
+		assert.Fail(t, "asynchronous dispatch failed to trigger listener")
 	}
 }
 
@@ -204,7 +201,7 @@ func TestDispatchValueToPointerInterfaceListener(t *testing.T) {
 	clearListeners()
 
 	AddListener(func(testInterface2) {
-		t.Errorf("interface listener triggered for value dispatch")
+		assert.Fail(t, "interface listener triggered for value dispatch")
 	})
 	Dispatch(testEvent2{})
 }
@@ -230,7 +227,6 @@ func TestDispatchUpdate(t *testing.T) {
 	assert.True(t, triggered, "listener failed to trigger on DispatchUpdate()")
 
 	want := "hello"
-	if got := ev.update.(string); got != want {
-		t.Errorf("ev.update = %#v, want %#v", got, want)
-	}
+	got := ev.update.(string)
+	assert.Equal(t, want, got, "ev.update = %#v, want %#v", got, want)
 }

--- a/go/event/event_test.go
+++ b/go/event/event_test.go
@@ -56,8 +56,8 @@ func TestStaticListener(t *testing.T) {
 
 	triggered := false
 	AddListener(func(testEvent1) { triggered = true })
-	AddListener(func(testEvent2) { 
-		assert.Fail(t, "wrong listener type triggered") 
+	AddListener(func(testEvent2) {
+		assert.Fail(t, "wrong listener type triggered")
 	})
 	Dispatch(testEvent1{})
 	assert.True(t, triggered, "static listener failed to trigger")
@@ -68,8 +68,8 @@ func TestPointerListener(t *testing.T) {
 
 	testEvent := new(testEvent2)
 	AddListener(func(ev *testEvent2) { ev.triggered = true })
-	AddListener(func(testEvent2) { 
-		assert.Fail(t, "non-pointer listener triggered on pointer type") 
+	AddListener(func(testEvent2) {
+		assert.Fail(t, "non-pointer listener triggered on pointer type")
 	})
 	Dispatch(testEvent)
 	assert.True(t, testEvent.triggered, "pointer listener failed to trigger")
@@ -80,8 +80,8 @@ func TestInterfaceListener(t *testing.T) {
 
 	triggered := false
 	AddListener(func(testInterface1) { triggered = true })
-	AddListener(func(testInterface2) { 
-		assert.Fail(t, "interface listener triggered on non-matching type") 
+	AddListener(func(testInterface2) {
+		assert.Fail(t, "interface listener triggered on non-matching type")
 	})
 	Dispatch(testEvent1{})
 	assert.True(t, triggered, "interface listener failed to trigger")

--- a/go/event/event_test.go
+++ b/go/event/event_test.go
@@ -104,7 +104,8 @@ func TestMultipleListeners(t *testing.T) {
 	AddListener(func(testEvent1) { triggered2 = true })
 	Dispatch(testEvent1{})
 
-	assert.True(t, triggered1 && triggered2, "not all matching listeners triggered")
+	assert.True(t, triggered1, "listener 1 failed to trigger")
+	assert.True(t, triggered2, "listener 2 failed to trigger")
 }
 
 func TestBadListenerWrongInputs(t *testing.T) {

--- a/go/event/event_test.go
+++ b/go/event/event_test.go
@@ -124,7 +124,7 @@ func TestBadListenerWrongInputs(t *testing.T) {
 		}
 
 		want := "bad listener func: listener must take exactly one input argument"
-		assert.Equal(t, want, blErr.Error(), `BadListenerError.Error() = "%s", want "%s"`, blErr.Error(), want)
+		assert.Equal(t, want, blErr.Error())
 	}()
 
 	AddListener(func() {})
@@ -144,7 +144,7 @@ func TestBadListenerWrongType(t *testing.T) {
 		}
 
 		want := "bad listener func: listener must be a function"
-		assert.Equal(t, want, blErr.Error(), `BadListenerError.Error() = "%s", want "%s"`, blErr.Error(), want)
+		assert.Equal(t, want, blErr.Error())
 	}()
 
 	AddListener("this is not a function")
@@ -229,5 +229,5 @@ func TestDispatchUpdate(t *testing.T) {
 
 	want := "hello"
 	got := ev.update.(string)
-	assert.Equal(t, want, got, "ev.update = %#v, want %#v", got, want)
+	assert.Equal(t, want, got)
 }

--- a/go/exit/exit_test.go
+++ b/go/exit/exit_test.go
@@ -31,7 +31,7 @@ func TestReturn(t *testing.T) {
 
 		switch code := err.(type) {
 		case exitCode:
-			assert.Equal(t, exitCode(152), code, "got %v, want %v", code, 152)
+			assert.Equal(t, exitCode(152), code)
 		default:
 			panic(err)
 		}
@@ -52,7 +52,7 @@ func TestRecover(t *testing.T) {
 		Return(8235)
 	}()
 
-	assert.EqualValues(t, 8235, code, "got %v, want %v", code, 8235)
+	assert.EqualValues(t, 8235, code)
 }
 
 func TestRecoverRepanic(t *testing.T) {

--- a/go/exit/exit_test.go
+++ b/go/exit/exit_test.go
@@ -52,7 +52,7 @@ func TestRecover(t *testing.T) {
 		Return(8235)
 	}()
 
-	assert.Equal(t, 8235, code, "got %v, want %v", code, 8235)
+	assert.EqualValues(t, 8235, code, "got %v, want %v", code, 8235)
 }
 
 func TestRecoverRepanic(t *testing.T) {

--- a/go/exit/exit_test.go
+++ b/go/exit/exit_test.go
@@ -18,6 +18,8 @@ package exit
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type repanicType int
@@ -25,15 +27,11 @@ type repanicType int
 func TestReturn(t *testing.T) {
 	defer func() {
 		err := recover()
-		if err == nil {
-			t.Errorf("Return() did not panic with exit code")
-		}
+		assert.NotNil(t, err, "Return() did not panic with exit code")
 
 		switch code := err.(type) {
 		case exitCode:
-			if code != 152 {
-				t.Errorf("got %v, want %v", code, 152)
-			}
+			assert.Equal(t, exitCode(152), code, "got %v, want %v", code, 152)
 		default:
 			panic(err)
 		}
@@ -54,21 +52,20 @@ func TestRecover(t *testing.T) {
 		Return(8235)
 	}()
 
-	if code != 8235 {
-		t.Errorf("got %v, want %v", code, 8235)
-	}
+	assert.Equal(t, 8235, code, "got %v, want %v", code, 8235)
 }
 
 func TestRecoverRepanic(t *testing.T) {
 	defer func() {
 		err := recover()
-
+		assert.NotNil(t, err, "Recover() didn't re-panic an error other than exitCode")
 		if err == nil {
-			t.Errorf("Recover() didn't re-panic an error other than exitCode")
 			return
 		}
 
-		if _, ok := err.(repanicType); !ok {
+		_, ok := err.(repanicType)
+		assert.True(t, ok, "unexpected error type recovered")
+		if !ok {
 			panic(err) // something unexpected went wrong
 		}
 	}()
@@ -83,10 +80,7 @@ func TestRecoverAll(t *testing.T) {
 
 	defer func() {
 		err := recover()
-
-		if err != nil {
-			t.Errorf("RecoverAll() didn't absorb all panics")
-		}
+		assert.Nil(t, err, "RecoverAll() didn't absorb all panics")
 	}()
 
 	defer RecoverAll()

--- a/go/history/history_test.go
+++ b/go/history/history_test.go
@@ -31,12 +31,9 @@ func TestHistory(t *testing.T) {
 	}
 	want := []int{1, 0}
 	records := q.Records()
-	if want, got := len(want), len(records); want != got {
-		t.Errorf("len(records): want %v, got %v. records: %+v", want, got, q)
-	}
+	assert.Equal(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
 	for i, record := range records {
 		assert.Equal(t, want[i], record)
-
 	}
 
 	for ; i < 6; i++ {
@@ -45,12 +42,9 @@ func TestHistory(t *testing.T) {
 
 	want = []int{5, 4, 3, 2}
 	records = q.Records()
-	if want, got := len(want), len(records); want != got {
-		t.Errorf("len(records): want %v, got %v. records: %+v", want, got, q)
-	}
+	assert.Equal(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
 	for i, record := range records {
 		assert.Equal(t, want[i], record)
-
 	}
 }
 
@@ -59,32 +53,20 @@ func TestLatest(t *testing.T) {
 
 	// Add first value.
 	h.Add(mod10(1))
-	if got, want := int(h.Records()[0].(mod10)), 1; got != want {
-		t.Errorf("h.Records()[0] = %v, want %v", got, want)
-	}
-	if got, want := int(h.Latest().(mod10)), 1; got != want {
-		t.Errorf("h.Latest() = %v, want %v", got, want)
-	}
+	assert.Equal(t, 1, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 1)
+	assert.Equal(t, 1, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 1)
 
 	// Add value that isn't a "duplicate".
 	h.Add(mod10(2))
-	if got, want := int(h.Records()[0].(mod10)), 2; got != want {
-		t.Errorf("h.Records()[0] = %v, want %v", got, want)
-	}
-	if got, want := int(h.Latest().(mod10)), 2; got != want {
-		t.Errorf("h.Latest() = %v, want %v", got, want)
-	}
+	assert.Equal(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
+	assert.Equal(t, 2, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 2)
 
 	// Add value that IS a "duplicate".
 	h.Add(mod10(12))
 	// Records()[0] doesn't change.
-	if got, want := int(h.Records()[0].(mod10)), 2; got != want {
-		t.Errorf("h.Records()[0] = %v, want %v", got, want)
-	}
+	assert.Equal(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
 	// Latest() does change.
-	if got, want := int(h.Latest().(mod10)), 12; got != want {
-		t.Errorf("h.Latest() = %v, want %v", got, want)
-	}
+	assert.Equal(t, 12, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 12)
 }
 
 type duplic int
@@ -97,9 +79,7 @@ func TestIsEquivalent(t *testing.T) {
 	q := New(4)
 	q.Add(duplic(0))
 	q.Add(duplic(0))
-	if got, want := len(q.Records()), 1; got != want {
-		t.Errorf("len(q.Records())=%v, want %v", got, want)
-	}
+	assert.Equal(t, 1, len(q.Records()), "len(q.Records())=%v, want %v", len(q.Records()), 1)
 }
 
 type mod10 int

--- a/go/history/history_test.go
+++ b/go/history/history_test.go
@@ -31,7 +31,7 @@ func TestHistory(t *testing.T) {
 	}
 	want := []int{1, 0}
 	records := q.Records()
-	assert.Equal(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
+	assert.EqualValues(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
 	for i, record := range records {
 		assert.Equal(t, want[i], record)
 	}
@@ -42,7 +42,7 @@ func TestHistory(t *testing.T) {
 
 	want = []int{5, 4, 3, 2}
 	records = q.Records()
-	assert.Equal(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
+	assert.EqualValues(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
 	for i, record := range records {
 		assert.Equal(t, want[i], record)
 	}
@@ -53,20 +53,20 @@ func TestLatest(t *testing.T) {
 
 	// Add first value.
 	h.Add(mod10(1))
-	assert.Equal(t, 1, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 1)
-	assert.Equal(t, 1, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 1)
+	assert.EqualValues(t, 1, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 1)
+	assert.EqualValues(t, 1, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 1)
 
 	// Add value that isn't a "duplicate".
 	h.Add(mod10(2))
-	assert.Equal(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
-	assert.Equal(t, 2, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 2)
+	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
+	assert.EqualValues(t, 2, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 2)
 
 	// Add value that IS a "duplicate".
 	h.Add(mod10(12))
 	// Records()[0] doesn't change.
-	assert.Equal(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
+	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
 	// Latest() does change.
-	assert.Equal(t, 12, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 12)
+	assert.EqualValues(t, 12, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 12)
 }
 
 type duplic int
@@ -79,7 +79,7 @@ func TestIsEquivalent(t *testing.T) {
 	q := New(4)
 	q.Add(duplic(0))
 	q.Add(duplic(0))
-	assert.Equal(t, 1, len(q.Records()), "len(q.Records())=%v, want %v", len(q.Records()), 1)
+	assert.EqualValues(t, 1, len(q.Records()), "len(q.Records())=%v, want %v", len(q.Records()), 1)
 }
 
 type mod10 int

--- a/go/history/history_test.go
+++ b/go/history/history_test.go
@@ -53,20 +53,20 @@ func TestLatest(t *testing.T) {
 
 	// Add first value.
 	h.Add(mod10(1))
-	assert.EqualValues(t, 1, int(h.Records()[0].(mod10)))
-	assert.EqualValues(t, 1, int(h.Latest().(mod10)))
+	assert.EqualValues(t, 1, h.Records()[0].(mod10))
+	assert.EqualValues(t, 1, h.Latest().(mod10))
 
 	// Add value that isn't a "duplicate".
 	h.Add(mod10(2))
-	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)))
-	assert.EqualValues(t, 2, int(h.Latest().(mod10)))
+	assert.EqualValues(t, 2, h.Records()[0].(mod10))
+	assert.EqualValues(t, 2, h.Latest().(mod10))
 
 	// Add value that IS a "duplicate".
 	h.Add(mod10(12))
 	// Records()[0] doesn't change.
-	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)))
+	assert.EqualValues(t, 2, h.Records()[0].(mod10))
 	// Latest() does change.
-	assert.EqualValues(t, 12, int(h.Latest().(mod10)))
+	assert.EqualValues(t, 12, h.Latest().(mod10))
 }
 
 type duplic int

--- a/go/history/history_test.go
+++ b/go/history/history_test.go
@@ -58,7 +58,7 @@ func TestLatest(t *testing.T) {
 
 	// Add value that isn't a "duplicate".
 	h.Add(mod10(2))
-	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)),)
+	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)))
 	assert.EqualValues(t, 2, int(h.Latest().(mod10)))
 
 	// Add value that IS a "duplicate".

--- a/go/history/history_test.go
+++ b/go/history/history_test.go
@@ -31,7 +31,7 @@ func TestHistory(t *testing.T) {
 	}
 	want := []int{1, 0}
 	records := q.Records()
-	assert.EqualValues(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
+	assert.EqualValues(t, len(want), len(records))
 	for i, record := range records {
 		assert.Equal(t, want[i], record)
 	}
@@ -42,7 +42,7 @@ func TestHistory(t *testing.T) {
 
 	want = []int{5, 4, 3, 2}
 	records = q.Records()
-	assert.EqualValues(t, len(want), len(records), "len(records): want %v, got %v. records: %+v", len(want), len(records), q)
+	assert.EqualValues(t, len(want), len(records))
 	for i, record := range records {
 		assert.Equal(t, want[i], record)
 	}
@@ -53,20 +53,20 @@ func TestLatest(t *testing.T) {
 
 	// Add first value.
 	h.Add(mod10(1))
-	assert.EqualValues(t, 1, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 1)
-	assert.EqualValues(t, 1, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 1)
+	assert.EqualValues(t, 1, int(h.Records()[0].(mod10)))
+	assert.EqualValues(t, 1, int(h.Latest().(mod10)))
 
 	// Add value that isn't a "duplicate".
 	h.Add(mod10(2))
-	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
-	assert.EqualValues(t, 2, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 2)
+	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)),)
+	assert.EqualValues(t, 2, int(h.Latest().(mod10)))
 
 	// Add value that IS a "duplicate".
 	h.Add(mod10(12))
 	// Records()[0] doesn't change.
-	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)), "h.Records()[0] = %v, want %v", h.Records()[0], 2)
+	assert.EqualValues(t, 2, int(h.Records()[0].(mod10)))
 	// Latest() does change.
-	assert.EqualValues(t, 12, int(h.Latest().(mod10)), "h.Latest() = %v, want %v", h.Latest(), 12)
+	assert.EqualValues(t, 12, int(h.Latest().(mod10)))
 }
 
 type duplic int
@@ -79,7 +79,7 @@ func TestIsEquivalent(t *testing.T) {
 	q := New(4)
 	q.Add(duplic(0))
 	q.Add(duplic(0))
-	assert.EqualValues(t, 1, len(q.Records()), "len(q.Records())=%v, want %v", len(q.Records()), 1)
+	assert.EqualValues(t, 1, len(q.Records()))
 }
 
 type mod10 int

--- a/go/history/history_test.go
+++ b/go/history/history_test.go
@@ -79,7 +79,7 @@ func TestIsEquivalent(t *testing.T) {
 	q := New(4)
 	q.Add(duplic(0))
 	q.Add(duplic(0))
-	assert.EqualValues(t, 1, len(q.Records()))
+	assert.Len(t, q.Records(), 1)
 }
 
 type mod10 int

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -179,7 +179,7 @@ func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
 
 func TestBinlogEventQuery(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	input := binlogEvent(googleQueryEvent)
 	want := Query{

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -23,6 +23,7 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // sample event data
@@ -40,27 +41,27 @@ var (
 
 func TestBinlogEventEmptyBuf(t *testing.T) {
 	input := binlogEvent([]byte{})
-	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
+	assert.False(t, input.IsValid(), "%#v", input)
 }
 
 func TestBinlogEventGarbage(t *testing.T) {
 	input := binlogEvent(garbageEvent)
-	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
+	assert.False(t, input.IsValid(), "%#v", input)
 }
 
 func TestBinlogEventIsValid(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.True(t, input.IsValid(), "%#v.IsValid()", input)
+	assert.True(t, input.IsValid(), "%#v", input)
 }
 
 func TestBinlogEventTruncatedHeader(t *testing.T) {
 	input := binlogEvent(googleRotateEvent[:18])
-	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
+	assert.False(t, input.IsValid(), "%#v", input)
 }
 
 func TestBinlogEventTruncatedData(t *testing.T) {
 	input := binlogEvent(googleRotateEvent[:len(googleRotateEvent)-1])
-	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
+	assert.False(t, input.IsValid(), "%#v", input)
 }
 
 func TestBinlogEventType(t *testing.T) {
@@ -85,57 +86,57 @@ func TestBinlogEventServerID(t *testing.T) {
 
 func TestBinlogEventIsFormatDescription(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.True(t, input.IsFormatDescription(), "%#v.IsFormatDescription()", input)
+	assert.True(t, input.IsFormatDescription(), "%#v", input)
 }
 
 func TestBinlogEventIsNotFormatDescription(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.False(t, input.IsFormatDescription(), "%#v.IsFormatDescription()", input)
+	assert.False(t, input.IsFormatDescription(), "%#v", input)
 }
 
 func TestBinlogEventIsQuery(t *testing.T) {
 	input := binlogEvent(googleQueryEvent)
-	assert.True(t, input.IsQuery(), "%#v.IsQuery()", input)
+	assert.True(t, input.IsQuery(), "%#v", input)
 }
 
 func TestBinlogEventIsNotQuery(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsQuery(), "%#v.IsQuery()", input)
+	assert.False(t, input.IsQuery(), "%#v", input)
 }
 
 func TestBinlogEventIsIntVar(t *testing.T) {
 	input := binlogEvent(googleIntVarEvent1)
-	assert.True(t, input.IsIntVar(), "%#v.IsIntVar()", input)
+	assert.True(t, input.IsIntVar(), "%#v", input)
 }
 
 func TestBinlogEventIsNotIntVar(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsIntVar(), "%#v.IsIntVar()", input)
+	assert.False(t, input.IsIntVar(), "%#v", input)
 }
 
 func TestBinlogEventIsRotate(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.True(t, input.IsRotate(), "%#v.IsRotate()", input)
+	assert.True(t, input.IsRotate(), "%#v", input)
 }
 
 func TestBinlogEventIsNotRotate(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsRotate(), "%#v.IsRotate()", input)
+	assert.False(t, input.IsRotate(), "%#v", input)
 }
 
 func TestBinlogEventIsNotHeartbeat(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsHeartbeat(), "%#v.IsHeartbeat()", input)
+	assert.False(t, input.IsHeartbeat(), "%#v", input)
 }
 
 func TestBinlogEventIsXID(t *testing.T) {
 	input := binlogEvent(googleXIDEvent)
-	assert.True(t, input.IsXID(), "%#v.IsXID()", input)
+	assert.True(t, input.IsXID(), "%#v", input)
 }
 
 func TestBinlogEventIsNotXID(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsXID(), "%#v.IsXID()", input)
+	assert.False(t, input.IsXID(), "%#v", input)
 }
 
 func TestBinlogEventFormat(t *testing.T) {
@@ -148,7 +149,7 @@ func TestBinlogEventFormat(t *testing.T) {
 	}
 	got, err := input.Format()
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(got, want), "%#v.Format() = %v, want %v", input, got, want)
+	assert.True(t, reflect.DeepEqual(got, want), "%#v", input)
 	assert.False(t, input.IsHeartbeat())
 }
 
@@ -160,10 +161,8 @@ func TestBinlogEventFormatWrongVersion(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "format version = 5, we only support version 4"
 	_, err := input.Format()
-	assert.Error(t, err)
-	if err != nil {
-		assert.EqualValues(t, want, err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, want)
 }
 
 func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
@@ -174,10 +173,8 @@ func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "header length = 12, should be >= 19"
 	_, err := input.Format()
-	assert.Error(t, err)
-	if err != nil {
-		assert.EqualValues(t, want, err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, want)
 }
 
 func TestBinlogEventQuery(t *testing.T) {
@@ -195,7 +192,7 @@ primary key(eid, id)
 ) Engine=InnoDB`,
 	}
 	got, err := input.Query(f)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(got, want), "%#v.Query() = %v, want %v", input, got, want)
 }
 
@@ -210,41 +207,39 @@ func TestBinlogEventQueryBadLength(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "SQL query position overflows buffer (240 > 146)"
 	_, err = input.Query(f)
-	assert.Error(t, err)
-	if err != nil {
-		assert.EqualValues(t, want, err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, want)
 }
 
 func TestBinlogEventIntVar1(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	input := binlogEvent(googleIntVarEvent1)
 	wantType := byte(IntVarLastInsertID)
 	wantValue := uint64(101)
 	gotType, gotValue, err := input.IntVar(f)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wantType, gotType)
 	assert.Equal(t, wantValue, gotValue)
 }
 
 func TestBinlogEventIntVar2(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	input := binlogEvent(googleIntVarEvent2)
 	wantType := byte(IntVarInsertID)
 	wantValue := uint64(101)
 	gotType, gotValue, err := input.IntVar(f)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wantType, gotType)
 	assert.Equal(t, wantValue, gotValue)
 }
 
 func TestBinlogEventIntVarBadID(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	buf := make([]byte, len(googleIntVarEvent2))
 	copy(buf, googleIntVarEvent2)
@@ -253,10 +248,8 @@ func TestBinlogEventIntVarBadID(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "invalid IntVar ID: 3"
 	_, _, err = input.IntVar(f)
-	assert.Error(t, err)
-	if err != nil {
-		assert.Equal(t, want, err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, want)
 }
 
 func TestBinlogEventIsSemiSyncNoAckQuery(t *testing.T) {

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -65,7 +65,7 @@ func TestBinlogEventTruncatedData(t *testing.T) {
 
 func TestBinlogEventType(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.Equal(t, byte(0x04), input.Type(), "%#v.Type() = %v, want %v", input, input.Type(), 0x04)
+	assert.EqualValues(t, byte(0x04), input.Type(), "%#v.Type() = %v, want %v", input, input.Type(), 0x04)
 }
 
 func TestBinlogEventFlags(t *testing.T) {
@@ -75,12 +75,12 @@ func TestBinlogEventFlags(t *testing.T) {
 
 func TestBinlogEventTimestamp(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.Equal(t, uint32(0x53e95252), input.Timestamp(), "%#v.Timestamp() = %v, want %v", input, input.Timestamp(), 0x53e95252)
+	assert.EqualValues(t, uint32(0x53e95252), input.Timestamp(), "%#v.Timestamp() = %v, want %v", input, input.Timestamp(), 0x53e95252)
 }
 
 func TestBinlogEventServerID(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.Equal(t, uint32(62344), input.ServerID(), "%#v.ServerID() = %v, want %v", input, input.ServerID(), 62344)
+	assert.EqualValues(t, uint32(62344), input.ServerID(), "%#v.ServerID() = %v, want %v", input, input.ServerID(), 62344)
 }
 
 func TestBinlogEventIsFormatDescription(t *testing.T) {
@@ -162,7 +162,7 @@ func TestBinlogEventFormatWrongVersion(t *testing.T) {
 	_, err := input.Format()
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 
@@ -176,7 +176,7 @@ func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
 	_, err := input.Format()
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 
@@ -212,7 +212,7 @@ func TestBinlogEventQueryBadLength(t *testing.T) {
 	_, err = input.Query(f)
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 
@@ -255,7 +255,7 @@ func TestBinlogEventIntVarBadID(t *testing.T) {
 	_, _, err = input.IntVar(f)
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysql
 
 import (
-	"reflect"
 	"testing"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -66,22 +65,22 @@ func TestBinlogEventTruncatedData(t *testing.T) {
 
 func TestBinlogEventType(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.EqualValues(t, byte(0x04), input.Type())
+	assert.EqualValues(t, 0x04, input.Type())
 }
 
 func TestBinlogEventFlags(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.Equal(t, uint16(0x20), input.Flags())
+	assert.EqualValues(t, 0x20, input.Flags())
 }
 
 func TestBinlogEventTimestamp(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.EqualValues(t, uint32(0x53e95252), input.Timestamp())
+	assert.EqualValues(t, 0x53e95252, input.Timestamp())
 }
 
 func TestBinlogEventServerID(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.EqualValues(t, uint32(62344), input.ServerID())
+	assert.EqualValues(t, 62344, input.ServerID())
 }
 
 func TestBinlogEventIsFormatDescription(t *testing.T) {
@@ -149,7 +148,7 @@ func TestBinlogEventFormat(t *testing.T) {
 	}
 	got, err := input.Format()
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(got, want), "%#v", input)
+	assert.Equal(t, want, got)
 	assert.False(t, input.IsHeartbeat())
 }
 
@@ -193,12 +192,12 @@ primary key(eid, id)
 	}
 	got, err := input.Query(f)
 	require.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(got, want), "%#v.Query() = %v, want %v", input, got, want)
+	assert.Equal(t, want, got)
 }
 
 func TestBinlogEventQueryBadLength(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	buf := make([]byte, len(googleQueryEvent))
 	copy(buf, googleQueryEvent)

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -40,138 +40,87 @@ var (
 
 func TestBinlogEventEmptyBuf(t *testing.T) {
 	input := binlogEvent([]byte{})
-	want := false
-	if got := input.IsValid(); got != want {
-		t.Errorf("%#v.IsValid() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
 }
 
 func TestBinlogEventGarbage(t *testing.T) {
 	input := binlogEvent(garbageEvent)
-	want := false
-	if got := input.IsValid(); got != want {
-		t.Errorf("%#v.IsValid() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
 }
 
 func TestBinlogEventIsValid(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	want := true
-	if got := input.IsValid(); got != want {
-		t.Errorf("%#v.IsValid() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsValid(), "%#v.IsValid() = false, want true", input)
 }
 
 func TestBinlogEventTruncatedHeader(t *testing.T) {
 	input := binlogEvent(googleRotateEvent[:18])
-	want := false
-	if got := input.IsValid(); got != want {
-		t.Errorf("%#v.IsValid() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
 }
 
 func TestBinlogEventTruncatedData(t *testing.T) {
 	input := binlogEvent(googleRotateEvent[:len(googleRotateEvent)-1])
-	want := false
-	if got := input.IsValid(); got != want {
-		t.Errorf("%#v.IsValid() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
 }
 
 func TestBinlogEventType(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	want := byte(0x04)
-	if got := input.Type(); got != want {
-		t.Errorf("%#v.Type() = %v, want %v", input, got, want)
-	}
+	assert.Equal(t, byte(0x04), input.Type(), "%#v.Type() = %v, want %v", input, input.Type(), 0x04)
 }
 
 func TestBinlogEventFlags(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	want := uint16(0x20)
-	if got := input.Flags(); got != want {
-		t.Errorf("%#v.Flags() = %v, want %v", input, got, want)
-	}
+	assert.Equal(t, uint16(0x20), input.Flags(), "%#v.Flags() = %v, want %v", input, input.Flags(), 0x20)
 }
 
 func TestBinlogEventTimestamp(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	want := uint32(0x53e95252)
-	if got := input.Timestamp(); got != want {
-		t.Errorf("%#v.Timestamp() = %v, want %v", input, got, want)
-	}
+	assert.Equal(t, uint32(0x53e95252), input.Timestamp(), "%#v.Timestamp() = %v, want %v", input, input.Timestamp(), 0x53e95252)
 }
 
 func TestBinlogEventServerID(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	want := uint32(62344)
-	if got := input.ServerID(); got != want {
-		t.Errorf("%#v.ServerID() = %v, want %v", input, got, want)
-	}
+	assert.Equal(t, uint32(62344), input.ServerID(), "%#v.ServerID() = %v, want %v", input, input.ServerID(), 62344)
 }
 
 func TestBinlogEventIsFormatDescription(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	want := true
-	if got := input.IsFormatDescription(); got != want {
-		t.Errorf("%#v.IsFormatDescription() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsFormatDescription(), "%#v.IsFormatDescription() = false, want true", input)
 }
 
 func TestBinlogEventIsNotFormatDescription(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	want := false
-	if got := input.IsFormatDescription(); got != want {
-		t.Errorf("%#v.IsFormatDescription() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsFormatDescription(), "%#v.IsFormatDescription() = true, want false", input)
 }
 
 func TestBinlogEventIsQuery(t *testing.T) {
 	input := binlogEvent(googleQueryEvent)
-	want := true
-	if got := input.IsQuery(); got != want {
-		t.Errorf("%#v.IsQuery() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsQuery(), "%#v.IsQuery() = false, want true", input)
 }
 
 func TestBinlogEventIsNotQuery(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	want := false
-	if got := input.IsQuery(); got != want {
-		t.Errorf("%#v.IsQuery() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsQuery(), "%#v.IsQuery() = true, want false", input)
 }
 
 func TestBinlogEventIsIntVar(t *testing.T) {
 	input := binlogEvent(googleIntVarEvent1)
-	want := true
-	if got := input.IsIntVar(); got != want {
-		t.Errorf("%#v.IsIntVar() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsIntVar(), "%#v.IsIntVar() = false, want true", input)
 }
 
 func TestBinlogEventIsNotIntVar(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	want := false
-	if got := input.IsIntVar(); got != want {
-		t.Errorf("%#v.IsIntVar() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsIntVar(), "%#v.IsIntVar() = true, want false", input)
 }
 
 func TestBinlogEventIsRotate(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	want := true
-	if got := input.IsRotate(); got != want {
-		t.Errorf("%#v.IsRotate() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsRotate(), "%#v.IsRotate() = false, want true", input)
 }
 
 func TestBinlogEventIsNotRotate(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	want := false
-	if got := input.IsRotate(); got != want {
-		t.Errorf("%#v.IsRotate() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsRotate(), "%#v.IsRotate() = true, want false", input)
 }
 
 func TestBinlogEventIsNotHeartbeat(t *testing.T) {
@@ -181,18 +130,12 @@ func TestBinlogEventIsNotHeartbeat(t *testing.T) {
 
 func TestBinlogEventIsXID(t *testing.T) {
 	input := binlogEvent(googleXIDEvent)
-	want := true
-	if got := input.IsXID(); got != want {
-		t.Errorf("%#v.IsXID() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsXID(), "%#v.IsXID() = false, want true", input)
 }
 
 func TestBinlogEventIsNotXID(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	want := false
-	if got := input.IsXID(); got != want {
-		t.Errorf("%#v.IsXID() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsXID(), "%#v.IsXID() = true, want false", input)
 }
 
 func TestBinlogEventFormat(t *testing.T) {
@@ -207,7 +150,6 @@ func TestBinlogEventFormat(t *testing.T) {
 	assert.NoError(t, err, "unexpected error: %v", err)
 	assert.True(t, reflect.DeepEqual(got, want), "%#v.Format() = %v, want %v", input, got, want)
 	assert.False(t, input.IsHeartbeat())
-
 }
 
 func TestBinlogEventFormatWrongVersion(t *testing.T) {
@@ -218,12 +160,9 @@ func TestBinlogEventFormatWrongVersion(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "format version = 5, we only support version 4"
 	_, err := input.Format()
-	if err == nil {
-		t.Errorf("expected error, got none")
-		return
-	}
-	if got := err.Error(); got != want {
-		t.Errorf("wrong error, got %#v, want %#v", got, want)
+	assert.Error(t, err, "expected error, got none")
+	if err != nil {
+		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 
@@ -235,21 +174,15 @@ func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "header length = 12, should be >= 19"
 	_, err := input.Format()
-	if err == nil {
-		t.Errorf("expected error, got none")
-		return
-	}
-	if got := err.Error(); got != want {
-		t.Errorf("wrong error, got %#v, want %#v", got, want)
+	assert.Error(t, err, "expected error, got none")
+	if err != nil {
+		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 
 func TestBinlogEventQuery(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
 
 	input := binlogEvent(googleQueryEvent)
 	want := Query{
@@ -262,20 +195,13 @@ primary key(eid, id)
 ) Engine=InnoDB`,
 	}
 	got, err := input.Query(f)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
 	assert.True(t, reflect.DeepEqual(got, want), "%#v.Query() = %v, want %v", input, got, want)
-
 }
 
 func TestBinlogEventQueryBadLength(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
 
 	buf := make([]byte, len(googleQueryEvent))
 	copy(buf, googleQueryEvent)
@@ -284,61 +210,41 @@ func TestBinlogEventQueryBadLength(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "SQL query position overflows buffer (240 > 146)"
 	_, err = input.Query(f)
-	if err == nil {
-		t.Errorf("expected error, got none")
-		return
-	}
-	if got := err.Error(); got != want {
-		t.Errorf("wrong error, got %#v, want %#v", got, want)
+	assert.Error(t, err, "expected error, got none")
+	if err != nil {
+		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 
 func TestBinlogEventIntVar1(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
 
 	input := binlogEvent(googleIntVarEvent1)
 	wantType := byte(IntVarLastInsertID)
 	wantValue := uint64(101)
 	gotType, gotValue, err := input.IntVar(f)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
-	if gotType != wantType || gotValue != wantValue {
-		t.Errorf("%#v.IntVar() = (%#v, %#v), want (%#v, %#v)", input, gotType, gotValue, wantType, wantValue)
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.Equal(t, wantType, gotType)
+	assert.Equal(t, wantValue, gotValue)
 }
 
 func TestBinlogEventIntVar2(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
 
 	input := binlogEvent(googleIntVarEvent2)
 	wantType := byte(IntVarInsertID)
 	wantValue := uint64(101)
 	gotType, gotValue, err := input.IntVar(f)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
-	if gotType != wantType || gotValue != wantValue {
-		t.Errorf("%#v.IntVar() = (%#v, %#v), want (%#v, %#v)", input, gotType, gotValue, wantType, wantValue)
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.Equal(t, wantType, gotType)
+	assert.Equal(t, wantValue, gotValue)
 }
 
 func TestBinlogEventIntVarBadID(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	assert.NoError(t, err, "unexpected error: %v", err)
 
 	buf := make([]byte, len(googleIntVarEvent2))
 	copy(buf, googleIntVarEvent2)
@@ -347,12 +253,9 @@ func TestBinlogEventIntVarBadID(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "invalid IntVar ID: 3"
 	_, _, err = input.IntVar(f)
-	if err == nil {
-		t.Errorf("expected error, got none")
-		return
-	}
-	if got := err.Error(); got != want {
-		t.Errorf("wrong error, got %#v, want %#v", got, want)
+	assert.Error(t, err, "expected error, got none")
+	if err != nil {
+		assert.Equal(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
 	}
 }
 

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -65,22 +65,22 @@ func TestBinlogEventTruncatedData(t *testing.T) {
 
 func TestBinlogEventType(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.EqualValues(t, byte(0x04), input.Type(), "%#v.Type() = %v, want %v", input, input.Type(), 0x04)
+	assert.EqualValues(t, byte(0x04), input.Type())
 }
 
 func TestBinlogEventFlags(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.Equal(t, uint16(0x20), input.Flags(), "%#v.Flags() = %v, want %v", input, input.Flags(), 0x20)
+	assert.Equal(t, uint16(0x20), input.Flags())
 }
 
 func TestBinlogEventTimestamp(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.EqualValues(t, uint32(0x53e95252), input.Timestamp(), "%#v.Timestamp() = %v, want %v", input, input.Timestamp(), 0x53e95252)
+	assert.EqualValues(t, uint32(0x53e95252), input.Timestamp())
 }
 
 func TestBinlogEventServerID(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.EqualValues(t, uint32(62344), input.ServerID(), "%#v.ServerID() = %v, want %v", input, input.ServerID(), 62344)
+	assert.EqualValues(t, uint32(62344), input.ServerID())
 }
 
 func TestBinlogEventIsFormatDescription(t *testing.T) {
@@ -162,7 +162,7 @@ func TestBinlogEventFormatWrongVersion(t *testing.T) {
 	_, err := input.Format()
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.EqualValues(t, want, err.Error())
 	}
 }
 
@@ -176,7 +176,7 @@ func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
 	_, err := input.Format()
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.EqualValues(t, want, err.Error())
 	}
 }
 
@@ -212,7 +212,7 @@ func TestBinlogEventQueryBadLength(t *testing.T) {
 	_, err = input.Query(f)
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.EqualValues(t, want, err.Error())
 	}
 }
 
@@ -255,7 +255,7 @@ func TestBinlogEventIntVarBadID(t *testing.T) {
 	_, _, err = input.IntVar(f)
 	assert.Error(t, err, "expected error, got none")
 	if err != nil {
-		assert.EqualValues(t, want, err.Error(), "wrong error, got %#v, want %#v", err.Error(), want)
+		assert.Equal(t, want, err.Error())
 	}
 }
 

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -40,27 +40,27 @@ var (
 
 func TestBinlogEventEmptyBuf(t *testing.T) {
 	input := binlogEvent([]byte{})
-	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
+	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
 }
 
 func TestBinlogEventGarbage(t *testing.T) {
 	input := binlogEvent(garbageEvent)
-	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
+	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
 }
 
 func TestBinlogEventIsValid(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.True(t, input.IsValid(), "%#v.IsValid() = false, want true", input)
+	assert.True(t, input.IsValid(), "%#v.IsValid()", input)
 }
 
 func TestBinlogEventTruncatedHeader(t *testing.T) {
 	input := binlogEvent(googleRotateEvent[:18])
-	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
+	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
 }
 
 func TestBinlogEventTruncatedData(t *testing.T) {
 	input := binlogEvent(googleRotateEvent[:len(googleRotateEvent)-1])
-	assert.False(t, input.IsValid(), "%#v.IsValid() = true, want false", input)
+	assert.False(t, input.IsValid(), "%#v.IsValid()", input)
 }
 
 func TestBinlogEventType(t *testing.T) {
@@ -85,57 +85,57 @@ func TestBinlogEventServerID(t *testing.T) {
 
 func TestBinlogEventIsFormatDescription(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.True(t, input.IsFormatDescription(), "%#v.IsFormatDescription() = false, want true", input)
+	assert.True(t, input.IsFormatDescription(), "%#v.IsFormatDescription()", input)
 }
 
 func TestBinlogEventIsNotFormatDescription(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.False(t, input.IsFormatDescription(), "%#v.IsFormatDescription() = true, want false", input)
+	assert.False(t, input.IsFormatDescription(), "%#v.IsFormatDescription()", input)
 }
 
 func TestBinlogEventIsQuery(t *testing.T) {
 	input := binlogEvent(googleQueryEvent)
-	assert.True(t, input.IsQuery(), "%#v.IsQuery() = false, want true", input)
+	assert.True(t, input.IsQuery(), "%#v.IsQuery()", input)
 }
 
 func TestBinlogEventIsNotQuery(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsQuery(), "%#v.IsQuery() = true, want false", input)
+	assert.False(t, input.IsQuery(), "%#v.IsQuery()", input)
 }
 
 func TestBinlogEventIsIntVar(t *testing.T) {
 	input := binlogEvent(googleIntVarEvent1)
-	assert.True(t, input.IsIntVar(), "%#v.IsIntVar() = false, want true", input)
+	assert.True(t, input.IsIntVar(), "%#v.IsIntVar()", input)
 }
 
 func TestBinlogEventIsNotIntVar(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsIntVar(), "%#v.IsIntVar() = true, want false", input)
+	assert.False(t, input.IsIntVar(), "%#v.IsIntVar()", input)
 }
 
 func TestBinlogEventIsRotate(t *testing.T) {
 	input := binlogEvent(googleRotateEvent)
-	assert.True(t, input.IsRotate(), "%#v.IsRotate() = false, want true", input)
+	assert.True(t, input.IsRotate(), "%#v.IsRotate()", input)
 }
 
 func TestBinlogEventIsNotRotate(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsRotate(), "%#v.IsRotate() = true, want false", input)
+	assert.False(t, input.IsRotate(), "%#v.IsRotate()", input)
 }
 
 func TestBinlogEventIsNotHeartbeat(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsHeartbeat())
+	assert.False(t, input.IsHeartbeat(), "%#v.IsHeartbeat()", input)
 }
 
 func TestBinlogEventIsXID(t *testing.T) {
 	input := binlogEvent(googleXIDEvent)
-	assert.True(t, input.IsXID(), "%#v.IsXID() = false, want true", input)
+	assert.True(t, input.IsXID(), "%#v.IsXID()", input)
 }
 
 func TestBinlogEventIsNotXID(t *testing.T) {
 	input := binlogEvent(googleFormatEvent)
-	assert.False(t, input.IsXID(), "%#v.IsXID() = true, want false", input)
+	assert.False(t, input.IsXID(), "%#v.IsXID()", input)
 }
 
 func TestBinlogEventFormat(t *testing.T) {
@@ -147,7 +147,7 @@ func TestBinlogEventFormat(t *testing.T) {
 		HeaderSizes:   googleFormatEvent[76 : len(googleFormatEvent)-5],
 	}
 	got, err := input.Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(got, want), "%#v.Format() = %v, want %v", input, got, want)
 	assert.False(t, input.IsHeartbeat())
 }
@@ -160,7 +160,7 @@ func TestBinlogEventFormatWrongVersion(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "format version = 5, we only support version 4"
 	_, err := input.Format()
-	assert.Error(t, err, "expected error, got none")
+	assert.Error(t, err)
 	if err != nil {
 		assert.EqualValues(t, want, err.Error())
 	}
@@ -174,7 +174,7 @@ func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "header length = 12, should be >= 19"
 	_, err := input.Format()
-	assert.Error(t, err, "expected error, got none")
+	assert.Error(t, err)
 	if err != nil {
 		assert.EqualValues(t, want, err.Error())
 	}
@@ -182,7 +182,7 @@ func TestBinlogEventFormatBadHeaderLength(t *testing.T) {
 
 func TestBinlogEventQuery(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 
 	input := binlogEvent(googleQueryEvent)
 	want := Query{
@@ -195,13 +195,13 @@ primary key(eid, id)
 ) Engine=InnoDB`,
 	}
 	got, err := input.Query(f)
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(got, want), "%#v.Query() = %v, want %v", input, got, want)
 }
 
 func TestBinlogEventQueryBadLength(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 
 	buf := make([]byte, len(googleQueryEvent))
 	copy(buf, googleQueryEvent)
@@ -210,7 +210,7 @@ func TestBinlogEventQueryBadLength(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "SQL query position overflows buffer (240 > 146)"
 	_, err = input.Query(f)
-	assert.Error(t, err, "expected error, got none")
+	assert.Error(t, err)
 	if err != nil {
 		assert.EqualValues(t, want, err.Error())
 	}
@@ -218,33 +218,33 @@ func TestBinlogEventQueryBadLength(t *testing.T) {
 
 func TestBinlogEventIntVar1(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 
 	input := binlogEvent(googleIntVarEvent1)
 	wantType := byte(IntVarLastInsertID)
 	wantValue := uint64(101)
 	gotType, gotValue, err := input.IntVar(f)
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 	assert.Equal(t, wantType, gotType)
 	assert.Equal(t, wantValue, gotValue)
 }
 
 func TestBinlogEventIntVar2(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 
 	input := binlogEvent(googleIntVarEvent2)
 	wantType := byte(IntVarInsertID)
 	wantValue := uint64(101)
 	gotType, gotValue, err := input.IntVar(f)
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 	assert.Equal(t, wantType, gotType)
 	assert.Equal(t, wantValue, gotValue)
 }
 
 func TestBinlogEventIntVarBadID(t *testing.T) {
 	f, err := binlogEvent(googleFormatEvent).Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.NoError(t, err)
 
 	buf := make([]byte, len(googleIntVarEvent2))
 	copy(buf, googleIntVarEvent2)
@@ -253,7 +253,7 @@ func TestBinlogEventIntVarBadID(t *testing.T) {
 	input := binlogEvent(buf)
 	want := "invalid IntVar ID: 3"
 	_, _, err = input.IntVar(f)
-	assert.Error(t, err, "expected error, got none")
+	assert.Error(t, err)
 	if err != nil {
 		assert.Equal(t, want, err.Error())
 	}

--- a/go/mysql/binlog_event_mariadb_test.go
+++ b/go/mysql/binlog_event_mariadb_test.go
@@ -84,7 +84,7 @@ func TestMariadbStandaloneBinlogEventGTID(t *testing.T) {
 	got, hasBegin, err := input.GTID(f)
 	assert.NoError(t, err)
 	assert.False(t, hasBegin)
-	assert.EqualValues(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
+	assert.Equal(t, want, got)
 }
 
 func TestMariadbBinlogEventGTID(t *testing.T) {
@@ -96,7 +96,7 @@ func TestMariadbBinlogEventGTID(t *testing.T) {
 	got, hasBegin, err := input.GTID(f)
 	assert.NoError(t, err)
 	assert.True(t, hasBegin)
-	assert.EqualValues(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
+	assert.Equal(t, want, got)
 }
 
 func TestMariadbBinlogEventFormat(t *testing.T) {
@@ -110,7 +110,7 @@ func TestMariadbBinlogEventFormat(t *testing.T) {
 	}
 	got, err := input.Format()
 	assert.NoError(t, err)
-	assert.EqualValues(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
+	assert.Equal(t, want, got)
 }
 
 func TestMariadbBinlogEventChecksumFormat(t *testing.T) {
@@ -124,7 +124,7 @@ func TestMariadbBinlogEventChecksumFormat(t *testing.T) {
 	}
 	got, err := input.Format()
 	assert.NoError(t, err)
-	assert.EqualValues(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
+	assert.Equal(t, want, got)
 }
 
 func TestMariadbBinlogEventStripChecksum(t *testing.T) {
@@ -136,8 +136,8 @@ func TestMariadbBinlogEventStripChecksum(t *testing.T) {
 	wantChecksum := []byte{0xce, 0x49, 0x7a, 0x53}
 	gotEvent, gotChecksum, err := input.StripChecksum(f)
 	require.NoError(t, err)
-	assert.EqualValues(t, wantEvent, gotEvent)
-	assert.EqualValues(t, wantChecksum, gotChecksum)
+	assert.Equal(t, wantEvent, gotEvent)
+	assert.Equal(t, wantChecksum, gotChecksum)
 }
 
 func TestMariadbBinlogEventStripChecksumNone(t *testing.T) {
@@ -148,7 +148,7 @@ func TestMariadbBinlogEventStripChecksumNone(t *testing.T) {
 	want := input
 	gotEvent, gotChecksum, err := input.StripChecksum(f)
 	require.NoError(t, err)
-	assert.EqualValues(t, want, gotEvent)
+	assert.Equal(t, want, gotEvent)
 	assert.Nil(t, gotChecksum)
 }
 

--- a/go/mysql/binlog_event_mariadb_test.go
+++ b/go/mysql/binlog_event_mariadb_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysql
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,86 +42,61 @@ var (
 
 func TestMariadbStandaloneGTIDEventIsGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
-	want := true
-	if got := input.IsGTID(); got != want {
-		t.Errorf("%#v.IsGTID() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsGTID(), "%#v.IsGTID() = false, want true", input)
 }
 
 func TestMariadbBeginGTIDEventIsGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbBeginGTIDEvent)}
-	want := true
-	if got := input.IsGTID(); got != want {
-		t.Errorf("%#v.IsGTID() = %v, want %v", input, got, want)
-	}
+	assert.True(t, input.IsGTID(), "%#v.IsGTID() = false, want true", input)
 }
 
 func TestMariadbBinlogEventIsntGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbInsertEvent)}
-	want := false
-	if got := input.IsGTID(); got != want {
-		t.Errorf("%#v.IsGTID() = %v, want %v", input, got, want)
-	}
+	assert.False(t, input.IsGTID(), "%#v.IsGTID() = true, want false", input)
 }
 
 func TestMariadbNotBeginGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	require.NoError(t, err, "unexpected error: %v", err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
-	want := false
-	if _, got, err := input.GTID(f); got != want {
-		t.Errorf("%#v.GTID() = %v (%v), want %v", input, got, err, want)
-	}
+	_, got, err := input.GTID(f)
+	require.NoError(t, err)
+	assert.False(t, got, "%#v.GTID() = true, want false", input)
 }
 
 func TestMariadbIsBeginGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	require.NoError(t, err, "unexpected error: %v", err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbBeginGTIDEvent)}
-	want := true
-	if _, got, err := input.GTID(f); got != want {
-		t.Errorf("%#v.IsBeginGTID() = %v (%v), want %v", input, got, err, want)
-	}
+	_, got, err := input.GTID(f)
+	require.NoError(t, err)
+	assert.True(t, got, "%#v.IsBeginGTID() = false, want true", input)
 }
 
 func TestMariadbStandaloneBinlogEventGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	require.NoError(t, err, "unexpected error: %v", err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
 	want := replication.MariadbGTID{Domain: 0, Server: 62344, Sequence: 9}
 	got, hasBegin, err := input.GTID(f)
-	assert.NoError(t, err, "unexpected error: %v", err)
-	assert.False(t, hasBegin, "unexpected hasBegin")
-	assert.True(t, reflect.DeepEqual(got, want), "%#v.GTID() = %#v, want %#v", input, got, want)
-
+	assert.NoError(t, err)
+	assert.False(t, hasBegin)
+	assert.Equal(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
 }
 
 func TestMariadbBinlogEventGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
+	require.NoError(t, err, "unexpected error: %v", err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbBeginGTIDEvent)}
 	want := replication.MariadbGTID{Domain: 0, Server: 62344, Sequence: 10}
 	got, hasBegin, err := input.GTID(f)
-	assert.NoError(t, err, "unexpected error: %v", err)
-	assert.True(t, hasBegin, "unexpected !hasBegin")
-	assert.True(t, reflect.DeepEqual(got, want), "%#v.GTID() = %#v, want %#v", input, got, want)
-
+	assert.NoError(t, err)
+	assert.True(t, hasBegin)
+	assert.Equal(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
 }
 
 func TestMariadbBinlogEventFormat(t *testing.T) {
@@ -135,9 +109,8 @@ func TestMariadbBinlogEventFormat(t *testing.T) {
 		HeaderSizes:       mariadbFormatEvent[76 : len(mariadbFormatEvent)-5],
 	}
 	got, err := input.Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
-	assert.True(t, reflect.DeepEqual(got, want), "%#v.Format() = %v, want %v", input, got, want)
-
+	assert.NoError(t, err)
+	assert.Equal(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
 }
 
 func TestMariadbBinlogEventChecksumFormat(t *testing.T) {
@@ -150,38 +123,33 @@ func TestMariadbBinlogEventChecksumFormat(t *testing.T) {
 		HeaderSizes:       mariadbChecksumFormatEvent[76 : len(mariadbChecksumFormatEvent)-5],
 	}
 	got, err := input.Format()
-	assert.NoError(t, err, "unexpected error: %v", err)
-	assert.True(t, reflect.DeepEqual(got, want), "%#v.Format() = %v, want %v", input, got, want)
-
+	assert.NoError(t, err)
+	assert.Equal(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
 }
 
 func TestMariadbBinlogEventStripChecksum(t *testing.T) {
 	f, err := (mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbChecksumFormatEvent)}).Format()
-	require.NoError(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbChecksumQueryEvent)}
 	wantEvent := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbChecksumStrippedQueryEvent)}
 	wantChecksum := []byte{0xce, 0x49, 0x7a, 0x53}
 	gotEvent, gotChecksum, err := input.StripChecksum(f)
-	require.NoError(t, err, "unexpected error: %v", err)
-
-	if !reflect.DeepEqual(gotEvent, wantEvent) || !reflect.DeepEqual(gotChecksum, wantChecksum) {
-		t.Errorf("%#v.StripChecksum() = (%v, %v), want (%v, %v)", input, gotEvent, gotChecksum, wantEvent, wantChecksum)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, wantEvent, gotEvent)
+	assert.Equal(t, wantChecksum, gotChecksum)
 }
 
 func TestMariadbBinlogEventStripChecksumNone(t *testing.T) {
 	f, err := (mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbFormatEvent)}).Format()
-	require.NoError(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
 	want := input
 	gotEvent, gotChecksum, err := input.StripChecksum(f)
-	require.NoError(t, err, "unexpected error: %v", err)
-
-	if !reflect.DeepEqual(gotEvent, want) || gotChecksum != nil {
-		t.Errorf("%#v.StripChecksum() = (%v, %v), want (%v, nil)", input, gotEvent, gotChecksum, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, want, gotEvent)
+	assert.Nil(t, gotChecksum)
 }
 
 func TestMariaDBSemiSyncAck(t *testing.T) {

--- a/go/mysql/binlog_event_mariadb_test.go
+++ b/go/mysql/binlog_event_mariadb_test.go
@@ -57,7 +57,7 @@ func TestMariadbBinlogEventIsntGTID(t *testing.T) {
 
 func TestMariadbNotBeginGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	require.NoError(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
 	_, got, err := input.GTID(f)
@@ -67,7 +67,7 @@ func TestMariadbNotBeginGTID(t *testing.T) {
 
 func TestMariadbIsBeginGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	require.NoError(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbBeginGTIDEvent)}
 	_, got, err := input.GTID(f)
@@ -77,7 +77,7 @@ func TestMariadbIsBeginGTID(t *testing.T) {
 
 func TestMariadbStandaloneBinlogEventGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	require.NoError(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
 	want := replication.MariadbGTID{Domain: 0, Server: 62344, Sequence: 9}
@@ -89,7 +89,7 @@ func TestMariadbStandaloneBinlogEventGTID(t *testing.T) {
 
 func TestMariadbBinlogEventGTID(t *testing.T) {
 	f, err := binlogEvent(mariadbFormatEvent).Format()
-	require.NoError(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbBeginGTIDEvent)}
 	want := replication.MariadbGTID{Domain: 0, Server: 62344, Sequence: 10}

--- a/go/mysql/binlog_event_mariadb_test.go
+++ b/go/mysql/binlog_event_mariadb_test.go
@@ -42,17 +42,17 @@ var (
 
 func TestMariadbStandaloneGTIDEventIsGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
-	assert.True(t, input.IsGTID(), "%#v.IsGTID() = false, want true", input)
+	assert.True(t, input.IsGTID(), "%#v", input)
 }
 
 func TestMariadbBeginGTIDEventIsGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbBeginGTIDEvent)}
-	assert.True(t, input.IsGTID(), "%#v.IsGTID() = false, want true", input)
+	assert.True(t, input.IsGTID(), "%#v", input)
 }
 
 func TestMariadbBinlogEventIsntGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbInsertEvent)}
-	assert.False(t, input.IsGTID(), "%#v.IsGTID() = true, want false", input)
+	assert.False(t, input.IsGTID(), "%#v", input)
 }
 
 func TestMariadbNotBeginGTID(t *testing.T) {
@@ -62,7 +62,7 @@ func TestMariadbNotBeginGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbStandaloneGTIDEvent)}
 	_, got, err := input.GTID(f)
 	require.NoError(t, err)
-	assert.False(t, got, "%#v.GTID() = true, want false", input)
+	assert.False(t, got, "%#v", input)
 }
 
 func TestMariadbIsBeginGTID(t *testing.T) {
@@ -72,7 +72,7 @@ func TestMariadbIsBeginGTID(t *testing.T) {
 	input := mariadbBinlogEvent{binlogEvent: binlogEvent(mariadbBeginGTIDEvent)}
 	_, got, err := input.GTID(f)
 	require.NoError(t, err)
-	assert.True(t, got, "%#v.IsBeginGTID() = false, want true", input)
+	assert.True(t, got, "%#v", input)
 }
 
 func TestMariadbStandaloneBinlogEventGTID(t *testing.T) {
@@ -111,6 +111,7 @@ func TestMariadbBinlogEventFormat(t *testing.T) {
 	got, err := input.Format()
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
+
 }
 
 func TestMariadbBinlogEventChecksumFormat(t *testing.T) {

--- a/go/mysql/binlog_event_mariadb_test.go
+++ b/go/mysql/binlog_event_mariadb_test.go
@@ -84,7 +84,7 @@ func TestMariadbStandaloneBinlogEventGTID(t *testing.T) {
 	got, hasBegin, err := input.GTID(f)
 	assert.NoError(t, err)
 	assert.False(t, hasBegin)
-	assert.Equal(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
+	assert.EqualValues(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
 }
 
 func TestMariadbBinlogEventGTID(t *testing.T) {
@@ -96,7 +96,7 @@ func TestMariadbBinlogEventGTID(t *testing.T) {
 	got, hasBegin, err := input.GTID(f)
 	assert.NoError(t, err)
 	assert.True(t, hasBegin)
-	assert.Equal(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
+	assert.EqualValues(t, want, got, "%#v.GTID() = %#v, want %#v", input, got, want)
 }
 
 func TestMariadbBinlogEventFormat(t *testing.T) {
@@ -110,7 +110,7 @@ func TestMariadbBinlogEventFormat(t *testing.T) {
 	}
 	got, err := input.Format()
 	assert.NoError(t, err)
-	assert.Equal(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
+	assert.EqualValues(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
 }
 
 func TestMariadbBinlogEventChecksumFormat(t *testing.T) {
@@ -124,7 +124,7 @@ func TestMariadbBinlogEventChecksumFormat(t *testing.T) {
 	}
 	got, err := input.Format()
 	assert.NoError(t, err)
-	assert.Equal(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
+	assert.EqualValues(t, want, got, "%#v.Format() = %v, want %v", input, got, want)
 }
 
 func TestMariadbBinlogEventStripChecksum(t *testing.T) {
@@ -136,8 +136,8 @@ func TestMariadbBinlogEventStripChecksum(t *testing.T) {
 	wantChecksum := []byte{0xce, 0x49, 0x7a, 0x53}
 	gotEvent, gotChecksum, err := input.StripChecksum(f)
 	require.NoError(t, err)
-	assert.Equal(t, wantEvent, gotEvent)
-	assert.Equal(t, wantChecksum, gotChecksum)
+	assert.EqualValues(t, wantEvent, gotEvent)
+	assert.EqualValues(t, wantChecksum, gotChecksum)
 }
 
 func TestMariadbBinlogEventStripChecksumNone(t *testing.T) {
@@ -148,7 +148,7 @@ func TestMariadbBinlogEventStripChecksumNone(t *testing.T) {
 	want := input
 	gotEvent, gotChecksum, err := input.StripChecksum(f)
 	require.NoError(t, err)
-	assert.Equal(t, want, gotEvent)
+	assert.EqualValues(t, want, gotEvent)
 	assert.Nil(t, gotChecksum)
 }
 

--- a/go/pools/id_pool_test.go
+++ b/go/pools/id_pool_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 func (pool *IDPool) want(want *IDPool, t *testing.T) {
-	assert.EqualValues(t, want.maxUsed, pool.maxUsed)
-	assert.EqualValues(t, want.used, pool.used)
+	assert.Equal(t, want.maxUsed, pool.maxUsed)
+	assert.Equal(t, want.used, pool.used)
 }
 
 func TestIDPoolFirstGet(t *testing.T) {
 	pool := NewIDPool(0)
 	got := pool.Get()
-	assert.EqualValues(t, uint32(1), got)
+	assert.EqualValues(t, 1, got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 1}, t)
 }
 
@@ -40,7 +40,7 @@ func TestIDPoolSecondGet(t *testing.T) {
 	pool := NewIDPool(0)
 	pool.Get()
 	got := pool.Get()
-	assert.EqualValues(t, uint32(2), got)
+	assert.EqualValues(t, 2, got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 2}, t)
 }
 
@@ -73,7 +73,7 @@ func TestIDPoolGetFromUsedSet(t *testing.T) {
 	pool.Get()
 	pool.Put(id1)
 	got := pool.Get()
-	assert.EqualValues(t, uint32(1), got)
+	assert.EqualValues(t, 1, got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 2}, t)
 }
 

--- a/go/pools/id_pool_test.go
+++ b/go/pools/id_pool_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pools
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,7 +80,8 @@ func wantError(want string, t *testing.T) {
 	rec := recover()
 	require.NotNil(t, rec, "expected panic, but there wasn't one")
 	err, ok := rec.(error)
-	require.True(t, ok && strings.Contains(err.Error(), want), "wrong error, got '%v', want '%v'", err, want)
+	assert.True(t, ok)
+	assert.Contains(t, err.Error(), want)
 }
 
 func TestIDPoolPut0(t *testing.T) {

--- a/go/pools/id_pool_test.go
+++ b/go/pools/id_pool_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 func (pool *IDPool) want(want *IDPool, t *testing.T) {
-	assert.EqualValues(t, want.maxUsed, pool.maxUsed, "pool.maxUsed = %#v, want %#v", pool.maxUsed, want.maxUsed)
-	assert.EqualValues(t, want.used, pool.used, "pool.used = %#v, want %#v", pool.used, want.used)
+	assert.EqualValues(t, want.maxUsed, pool.maxUsed)
+	assert.EqualValues(t, want.used, pool.used)
 }
 
 func TestIDPoolFirstGet(t *testing.T) {
 	pool := NewIDPool(0)
 	got := pool.Get()
-	assert.EqualValues(t, uint32(1), got, "pool.Get() = %v, want 1", got)
+	assert.EqualValues(t, uint32(1), got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 1}, t)
 }
 
@@ -40,7 +40,7 @@ func TestIDPoolSecondGet(t *testing.T) {
 	pool := NewIDPool(0)
 	pool.Get()
 	got := pool.Get()
-	assert.EqualValues(t, uint32(2), got, "pool.Get() = %v, want 2", got)
+	assert.EqualValues(t, uint32(2), got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 2}, t)
 }
 
@@ -73,7 +73,7 @@ func TestIDPoolGetFromUsedSet(t *testing.T) {
 	pool.Get()
 	pool.Put(id1)
 	got := pool.Get()
-	assert.EqualValues(t, uint32(1), got, "pool.Get() = %v, want 1", got)
+	assert.EqualValues(t, uint32(1), got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 2}, t)
 }
 

--- a/go/pools/id_pool_test.go
+++ b/go/pools/id_pool_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 func (pool *IDPool) want(want *IDPool, t *testing.T) {
-	assert.Equal(t, want.maxUsed, pool.maxUsed, "pool.maxUsed = %#v, want %#v", pool.maxUsed, want.maxUsed)
-	assert.Equal(t, want.used, pool.used, "pool.used = %#v, want %#v", pool.used, want.used)
+	assert.EqualValues(t, want.maxUsed, pool.maxUsed, "pool.maxUsed = %#v, want %#v", pool.maxUsed, want.maxUsed)
+	assert.EqualValues(t, want.used, pool.used, "pool.used = %#v, want %#v", pool.used, want.used)
 }
 
 func TestIDPoolFirstGet(t *testing.T) {
 	pool := NewIDPool(0)
 	got := pool.Get()
-	assert.Equal(t, uint32(1), got, "pool.Get() = %v, want 1", got)
+	assert.EqualValues(t, uint32(1), got, "pool.Get() = %v, want 1", got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 1}, t)
 }
 
@@ -40,7 +40,7 @@ func TestIDPoolSecondGet(t *testing.T) {
 	pool := NewIDPool(0)
 	pool.Get()
 	got := pool.Get()
-	assert.Equal(t, uint32(2), got, "pool.Get() = %v, want 2", got)
+	assert.EqualValues(t, uint32(2), got, "pool.Get() = %v, want 2", got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 2}, t)
 }
 
@@ -73,7 +73,7 @@ func TestIDPoolGetFromUsedSet(t *testing.T) {
 	pool.Get()
 	pool.Put(id1)
 	got := pool.Get()
-	assert.Equal(t, uint32(1), got, "pool.Get() = %v, want 1", got)
+	assert.EqualValues(t, uint32(1), got, "pool.Get() = %v, want 1", got)
 	pool.want(&IDPool{used: map[uint32]bool{}, maxUsed: 2}, t)
 }
 

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -534,7 +534,7 @@ func TestCreateFail(t *testing.T) {
 
 	_, err := p.Get(ctx)
 	assert.EqualError(t, err, "Failed", "Expecting Failed, received %v", err)
-	
+
 	stats := p.StatsJSON()
 	expected := `{"Capacity": 5, "Available": 5, "Active": 0, "InUse": 0, "MaxCapacity": 5, "WaitCount": 0, "WaitTime": 0, "IdleTimeout": 1000000000, "IdleClosed": 0, "MaxLifetimeClosed": 0, "Exhausted": 0}`
 	assert.Equal(t, expected, stats)

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -608,5 +608,5 @@ func TestExpired(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 	_, err := p.Get(ctx)
 	cancel()
-	assert.EqualError(t, err, "resource pool context already expired")
+	require.EqualError(t, err, "resource pool context already expired")
 }

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -118,9 +118,7 @@ func TestOpen(t *testing.T) {
 	assert.Equal(t, 5, len(waitStarts))
 	// verify start times are monotonic increasing
 	for i := 1; i < len(waitStarts); i++ {
-		if waitStarts[i].Before(waitStarts[i-1]) {
-			t.Errorf("Expecting monotonic increasing start times")
-		}
+		assert.False(t, waitStarts[i].Before(waitStarts[i-1]), "Expecting monotonic increasing start times")
 	}
 	assert.NotZero(t, p.WaitTime())
 	assert.EqualValues(t, 5, lastID.Load())
@@ -534,9 +532,9 @@ func TestCreateFail(t *testing.T) {
 	p := NewResourcePool(FailFactory, 5, 5, time.Second, 0, logWait, nil, 0)
 	defer p.Close()
 
-	if _, err := p.Get(ctx); err.Error() != "Failed" {
-		t.Errorf("Expecting Failed, received %v", err)
-	}
+	_, err := p.Get(ctx)
+	assert.EqualError(t, err, "Failed", "Expecting Failed, received %v", err)
+	
 	stats := p.StatsJSON()
 	expected := `{"Capacity": 5, "Available": 5, "Active": 0, "InUse": 0, "MaxCapacity": 5, "WaitCount": 0, "WaitTime": 0, "IdleTimeout": 1000000000, "IdleClosed": 0, "MaxLifetimeClosed": 0, "Exhausted": 0}`
 	assert.Equal(t, expected, stats)
@@ -610,5 +608,5 @@ func TestExpired(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 	_, err := p.Get(ctx)
 	cancel()
-	require.EqualError(t, err, "resource pool context already expired")
+	assert.EqualError(t, err, "resource pool context already expired")
 }

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -181,9 +181,7 @@ func TestOpen(t *testing.T) {
 	assert.Equal(t, 5, len(state.waits))
 	// verify start times are monotonic increasing
 	for i := 1; i < len(state.waits); i++ {
-		if state.waits[i].Before(state.waits[i-1]) {
-			t.Errorf("Expecting monotonic increasing start times")
-		}
+		assert.False(t, state.waits[i].Before(state.waits[i-1]), "Expecting monotonic increasing start times")
 	}
 	assert.NotZero(t, p.Metrics.WaitTime())
 	assert.EqualValues(t, 5, state.lastID.Load())
@@ -999,9 +997,7 @@ func TestMultiSettings(t *testing.T) {
 	assert.Equal(t, 5, len(state.waits))
 	// verify start times are monotonic increasing
 	for i := 1; i < len(state.waits); i++ {
-		if state.waits[i].Before(state.waits[i-1]) {
-			t.Errorf("Expecting monotonic increasing start times")
-		}
+		assert.False(t, state.waits[i].Before(state.waits[i-1]), "Expecting monotonic increasing start times")
 	}
 	assert.NotZero(t, p.Metrics.WaitTime())
 	assert.EqualValues(t, 5, state.lastID.Load())

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -225,11 +225,11 @@ func TestIsFunctions(t *testing.T) {
 
 func TestTypeToMySQL(t *testing.T) {
 	v, f := TypeToMySQL(Bit)
-	assert.EqualValues(t, 16, int(v))
-	assert.EqualValues(t, mysqlUnsigned, int(f))
+	assert.EqualValues(t, 16, v)
+	assert.EqualValues(t, mysqlUnsigned, f)
 	v, f = TypeToMySQL(Date)
-	assert.EqualValues(t, 10, int(v))
-	assert.EqualValues(t, mysqlBinary, int(f))
+	assert.EqualValues(t, 10, v)
+	assert.EqualValues(t, mysqlBinary, f)
 }
 
 func TestMySQLToType(t *testing.T) {

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -359,7 +358,7 @@ func TestMySQLToType(t *testing.T) {
 	}}
 	for _, tcase := range testcases {
 		got, err := MySQLToType(tcase.intype, tcase.inflags)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, tcase.outtype, got)
 	}
 }

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -134,7 +134,7 @@ func TestTypeValues(t *testing.T) {
 		expected: 34 | flagIsText,
 	}}
 	for _, tcase := range testcases {
-		assert.EqualValues(t, tcase.expected, int(tcase.defined), "Type %s: %d, want: %d", tcase.defined, int(tcase.defined), tcase.expected)
+		assert.EqualValues(t, tcase.expected, int(tcase.defined))
 	}
 }
 
@@ -225,11 +225,11 @@ func TestIsFunctions(t *testing.T) {
 
 func TestTypeToMySQL(t *testing.T) {
 	v, f := TypeToMySQL(Bit)
-	assert.EqualValues(t, 16, int(v), "Bit: %d, want 16", v)
-	assert.EqualValues(t, mysqlUnsigned, int(f), "Bit flag: %x, want %x", f, mysqlUnsigned)
+	assert.EqualValues(t, 16, int(v))
+	assert.EqualValues(t, mysqlUnsigned, int(f))
 	v, f = TypeToMySQL(Date)
-	assert.EqualValues(t, 10, int(v), "Bit: %d, want 10", v)
-	assert.EqualValues(t, mysqlBinary, int(f), "Bit flag: %x, want %x", f, mysqlBinary)
+	assert.EqualValues(t, 10, int(v))
+	assert.EqualValues(t, mysqlBinary, int(f))
 }
 
 func TestMySQLToType(t *testing.T) {
@@ -360,14 +360,14 @@ func TestMySQLToType(t *testing.T) {
 	for _, tcase := range testcases {
 		got, err := MySQLToType(tcase.intype, tcase.inflags)
 		require.NoError(t, err)
-		assert.Equal(t, tcase.outtype, got, "MySQLToType(%d, %x): %v, want %v", tcase.intype, tcase.inflags, got, tcase.outtype)
+		assert.Equal(t, tcase.outtype, got)
 	}
 }
 
 func TestTypeError(t *testing.T) {
 	_, err := MySQLToType(50, 0)
 	want := "unsupported type: 50"
-	assert.EqualError(t, err, want, "MySQLToType: %v, want %s", err, want)
+	assert.EqualError(t, err, want)
 }
 
 func TestTypeEquivalenceCheck(t *testing.T) {

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -133,9 +134,7 @@ func TestTypeValues(t *testing.T) {
 		expected: 34 | flagIsText,
 	}}
 	for _, tcase := range testcases {
-		if int(tcase.defined) != tcase.expected {
-			t.Errorf("Type %s: %d, want: %d", tcase.defined, int(tcase.defined), tcase.expected)
-		}
+		assert.Equal(t, tcase.expected, int(tcase.defined), "Type %s: %d, want: %d", tcase.defined, int(tcase.defined), tcase.expected)
 	}
 }
 
@@ -181,108 +180,56 @@ func TestCategory(t *testing.T) {
 	for _, typ := range alltypes {
 		matched := false
 		if IsSigned(typ) {
-			if !IsIntegral(typ) {
-				t.Errorf("Signed type %v is not an integral", typ)
-			}
+			assert.True(t, IsIntegral(typ), "Signed type %v is not an integral", typ)
 			matched = true
 		}
 		if IsUnsigned(typ) {
-			if !IsIntegral(typ) {
-				t.Errorf("Unsigned type %v is not an integral", typ)
-			}
-			if matched {
-				t.Errorf("%v matched more than one category", typ)
-			}
+			assert.True(t, IsIntegral(typ), "Unsigned type %v is not an integral", typ)
+			assert.False(t, matched, "%v matched more than one category", typ)
 			matched = true
 		}
 		if IsFloat(typ) {
-			if matched {
-				t.Errorf("%v matched more than one category", typ)
-			}
+			assert.False(t, matched, "%v matched more than one category", typ)
 			matched = true
 		}
 		if IsQuoted(typ) {
-			if matched {
-				t.Errorf("%v matched more than one category", typ)
-			}
+			assert.False(t, matched, "%v matched more than one category", typ)
 			matched = true
 		}
 		if typ == Null || typ == Decimal || typ == Expression || typ == Bit ||
 			typ == HexNum || typ == HexVal || typ == BitNum {
-			if matched {
-				t.Errorf("%v matched more than one category", typ)
-			}
+			assert.False(t, matched, "%v matched more than one category", typ)
 			matched = true
 		}
-		if !matched {
-			t.Errorf("%v matched no category", typ)
-		}
+		assert.True(t, matched, "%v matched no category", typ)
 	}
 }
 
 func TestIsFunctions(t *testing.T) {
-	if IsIntegral(Null) {
-		t.Error("Null: IsIntegral, must be false")
-	}
-	if !IsIntegral(Int64) {
-		t.Error("Int64: !IsIntegral, must be true")
-	}
-	if IsSigned(Uint64) {
-		t.Error("Uint64: IsSigned, must be false")
-	}
-	if !IsSigned(Int64) {
-		t.Error("Int64: !IsSigned, must be true")
-	}
-	if IsUnsigned(Int64) {
-		t.Error("Int64: IsUnsigned, must be false")
-	}
-	if !IsUnsigned(Uint64) {
-		t.Error("Uint64: !IsUnsigned, must be true")
-	}
-	if IsFloat(Int64) {
-		t.Error("Int64: IsFloat, must be false")
-	}
-	if !IsFloat(Float64) {
-		t.Error("Uint64: !IsFloat, must be true")
-	}
-	if IsQuoted(Int64) {
-		t.Error("Int64: IsQuoted, must be false")
-	}
-	if !IsQuoted(Binary) {
-		t.Error("Binary: !IsQuoted, must be true")
-	}
-	if IsText(Int64) {
-		t.Error("Int64: IsText, must be false")
-	}
-	if !IsText(Char) {
-		t.Error("Char: !IsText, must be true")
-	}
-	if IsBinary(Int64) {
-		t.Error("Int64: IsBinary, must be false")
-	}
-	if !IsBinary(Binary) {
-		t.Error("Char: !IsBinary, must be true")
-	}
-	if !IsNumber(Int64) {
-		t.Error("Int64: !isNumber, must be true")
-	}
+	assert.False(t, IsIntegral(Null), "Null: IsIntegral, must be false")
+	assert.True(t, IsIntegral(Int64), "Int64: !IsIntegral, must be true")
+	assert.False(t, IsSigned(Uint64), "Uint64: IsSigned, must be false")
+	assert.True(t, IsSigned(Int64), "Int64: !IsSigned, must be true")
+	assert.False(t, IsUnsigned(Int64), "Int64: IsUnsigned, must be false")
+	assert.True(t, IsUnsigned(Uint64), "Uint64: !IsUnsigned, must be true")
+	assert.False(t, IsFloat(Int64), "Int64: IsFloat, must be false")
+	assert.True(t, IsFloat(Float64), "Uint64: !IsFloat, must be true")
+	assert.False(t, IsQuoted(Int64), "Int64: IsQuoted, must be false")
+	assert.True(t, IsQuoted(Binary), "Binary: !IsQuoted, must be true")
+	assert.False(t, IsText(Int64), "Int64: IsText, must be false")
+	assert.True(t, IsText(Char), "Char: !IsText, must be true")
+	assert.False(t, IsBinary(Int64), "Int64: IsBinary, must be false")
+	assert.True(t, IsBinary(Binary), "Char: !IsBinary, must be true")
+	assert.True(t, IsNumber(Int64), "Int64: !isNumber, must be true")
 }
 
 func TestTypeToMySQL(t *testing.T) {
 	v, f := TypeToMySQL(Bit)
-	if v != 16 {
-		t.Errorf("Bit: %d, want 16", v)
-	}
-	if f != mysqlUnsigned {
-		t.Errorf("Bit flag: %x, want %x", f, mysqlUnsigned)
-	}
+	assert.Equal(t, 16, int(v), "Bit: %d, want 16", v)
+	assert.Equal(t, mysqlUnsigned, int(f), "Bit flag: %x, want %x", f, mysqlUnsigned)
 	v, f = TypeToMySQL(Date)
-	if v != 10 {
-		t.Errorf("Bit: %d, want 10", v)
-	}
-	if f != mysqlBinary {
-		t.Errorf("Bit flag: %x, want %x", f, mysqlBinary)
-	}
+	assert.Equal(t, 10, int(v), "Bit: %d, want 10", v)
+	assert.Equal(t, mysqlBinary, int(f), "Bit flag: %x, want %x", f, mysqlBinary)
 }
 
 func TestMySQLToType(t *testing.T) {
@@ -412,42 +359,24 @@ func TestMySQLToType(t *testing.T) {
 	}}
 	for _, tcase := range testcases {
 		got, err := MySQLToType(tcase.intype, tcase.inflags)
-		if err != nil {
-			t.Error(err)
-		}
-		if got != tcase.outtype {
-			t.Errorf("MySQLToType(%d, %x): %v, want %v", tcase.intype, tcase.inflags, got, tcase.outtype)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, tcase.outtype, got, "MySQLToType(%d, %x): %v, want %v", tcase.intype, tcase.inflags, got, tcase.outtype)
 	}
 }
 
 func TestTypeError(t *testing.T) {
 	_, err := MySQLToType(50, 0)
 	want := "unsupported type: 50"
-	if err == nil || err.Error() != want {
-		t.Errorf("MySQLToType: %v, want %s", err, want)
-	}
+	assert.EqualError(t, err, want, "MySQLToType: %v, want %s", err, want)
 }
 
 func TestTypeEquivalenceCheck(t *testing.T) {
-	if !AreTypesEquivalent(Int16, Int16) {
-		t.Errorf("Int16 and Int16 are same types.")
-	}
-	if AreTypesEquivalent(Int16, Int24) {
-		t.Errorf("Int16 and Int24 are not same types.")
-	}
-	if !AreTypesEquivalent(VarChar, VarBinary) {
-		t.Errorf("VarChar in binlog and VarBinary in schema are equivalent types.")
-	}
-	if AreTypesEquivalent(VarBinary, VarChar) {
-		t.Errorf("VarBinary in binlog and VarChar in schema are not equivalent types.")
-	}
-	if !AreTypesEquivalent(Int16, Uint16) {
-		t.Errorf("Int16 in binlog and Uint16 in schema are equivalent types.")
-	}
-	if AreTypesEquivalent(Uint16, Int16) {
-		t.Errorf("Uint16 in binlog and Int16 in schema are not equivalent types.")
-	}
+	assert.True(t, AreTypesEquivalent(Int16, Int16), "Int16 and Int16 are same types.")
+	assert.False(t, AreTypesEquivalent(Int16, Int24), "Int16 and Int24 are not same types.")
+	assert.True(t, AreTypesEquivalent(VarChar, VarBinary), "VarChar in binlog and VarBinary in schema are equivalent types.")
+	assert.False(t, AreTypesEquivalent(VarBinary, VarChar), "VarBinary in binlog and VarChar in schema are not equivalent types.")
+	assert.True(t, AreTypesEquivalent(Int16, Uint16), "Int16 in binlog and Uint16 in schema are equivalent types.")
+	assert.False(t, AreTypesEquivalent(Uint16, Int16), "Uint16 in binlog and Int16 in schema are not equivalent types.")
 }
 
 func TestPrintTypeChecks(t *testing.T) {

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -134,7 +134,7 @@ func TestTypeValues(t *testing.T) {
 		expected: 34 | flagIsText,
 	}}
 	for _, tcase := range testcases {
-		assert.Equal(t, tcase.expected, int(tcase.defined), "Type %s: %d, want: %d", tcase.defined, int(tcase.defined), tcase.expected)
+		assert.EqualValues(t, tcase.expected, int(tcase.defined), "Type %s: %d, want: %d", tcase.defined, int(tcase.defined), tcase.expected)
 	}
 }
 
@@ -225,11 +225,11 @@ func TestIsFunctions(t *testing.T) {
 
 func TestTypeToMySQL(t *testing.T) {
 	v, f := TypeToMySQL(Bit)
-	assert.Equal(t, 16, int(v), "Bit: %d, want 16", v)
-	assert.Equal(t, mysqlUnsigned, int(f), "Bit flag: %x, want %x", f, mysqlUnsigned)
+	assert.EqualValues(t, 16, int(v), "Bit: %d, want 16", v)
+	assert.EqualValues(t, mysqlUnsigned, int(f), "Bit flag: %x, want %x", f, mysqlUnsigned)
 	v, f = TypeToMySQL(Date)
-	assert.Equal(t, 10, int(v), "Bit: %d, want 10", v)
-	assert.Equal(t, mysqlBinary, int(f), "Bit flag: %x, want %x", f, mysqlBinary)
+	assert.EqualValues(t, 10, int(v), "Bit: %d, want 10", v)
+	assert.EqualValues(t, mysqlBinary, int(f), "Bit flag: %x, want %x", f, mysqlBinary)
 }
 
 func TestMySQLToType(t *testing.T) {

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -147,7 +147,8 @@ func TestStatsdCounterDuration(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -172,7 +173,8 @@ func TestStatsdCountersWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -233,7 +235,8 @@ func TestStatsdCountersFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -265,7 +268,8 @@ func TestStatsdGaugesWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -294,7 +298,8 @@ func TestStatsdGaugesFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -326,7 +331,8 @@ func TestStatsdGaugesWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -351,7 +357,8 @@ func TestStatsdMultiTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -376,7 +383,8 @@ func TestStatsdTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -403,8 +411,8 @@ func TestStatsdHistogram(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
-
+			err := sb.statsdClient.Flush()
+			require.NoError(t, err)
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -376,7 +376,7 @@ func TestStatsdTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
 			if err != nil {

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -147,13 +147,10 @@ func TestStatsdCounterDuration(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := string(bytes[:n])
 			expected := "test.counter_duration_name:1.000000|ms\n"
 			assert.Equal(t, expected, result)
@@ -173,13 +170,10 @@ func TestStatsdCountersWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := strings.Split(string(bytes[:n]), "\n")
 			sort.Strings(result)
 			expected := []string{
@@ -235,13 +229,10 @@ func TestStatsdCountersFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := strings.Split(string(bytes[:n]), "\n")
 			sort.Strings(result)
 			expected := []string{
@@ -268,13 +259,10 @@ func TestStatsdGaugesWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := string(bytes[:n])
 			expected := "test.gauges_with_multiple_label_name:3|g|#label1:foo,label2:bar\n"
 			assert.Equal(t, expected, result)
@@ -298,13 +286,10 @@ func TestStatsdGaugesFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := strings.Split(string(bytes[:n]), "\n")
 			sort.Strings(result)
 			expected := []string{
@@ -331,13 +316,10 @@ func TestStatsdGaugesWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := string(bytes[:n])
 			expected := "test.gauges_with_single_label_name:1|g|#label1:bar\n"
 			assert.Equal(t, expected, result)
@@ -357,13 +339,10 @@ func TestStatsdMultiTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := string(bytes[:n])
 			expected := "test.multi_timings_name:10.000000|ms|#label1:foo,label2:bar\n"
 			assert.Equal(t, expected, result)
@@ -383,13 +362,10 @@ func TestStatsdTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			result := string(bytes[:n])
 			expected := "test.timings_name:2.000000|ms|#label1:foo\n"
 			assert.Equal(t, expected, result)
@@ -411,8 +387,7 @@ func TestStatsdHistogram(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			err := sb.statsdClient.Flush()
-			require.NoError(t, err)
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/stats"
 )
@@ -45,22 +46,18 @@ func TestStatsdCounter(t *testing.T) {
 		found = true
 		if kv.Key == name {
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			
 			result := string(bytes[:n])
 			expected := "test.counter_name:1|c\n"
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdGauge(t *testing.T) {
@@ -74,22 +71,18 @@ func TestStatsdGauge(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			
 			result := string(bytes[:n])
 			expected := "test.gauge_name:10|g\n"
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdGaugeFloat64(t *testing.T) {
@@ -103,22 +96,18 @@ func TestStatsdGaugeFloat64(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			
 			result := string(bytes[:n])
 			expected := "test.gauge_name_f64:3.14|g\n"
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdGaugeFunc(t *testing.T) {
@@ -133,22 +122,18 @@ func TestStatsdGaugeFunc(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			
 			result := string(bytes[:n])
 			expected := "test.gauge_func_name:2|g\n"
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdCounterDuration(t *testing.T) {
@@ -162,9 +147,7 @@ func TestStatsdCounterDuration(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -175,9 +158,7 @@ func TestStatsdCounterDuration(t *testing.T) {
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdCountersWithSingleLabel(t *testing.T) {
@@ -191,9 +172,7 @@ func TestStatsdCountersWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -211,9 +190,7 @@ func TestStatsdCountersWithSingleLabel(t *testing.T) {
 			}
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdCountersWithMultiLabels(t *testing.T) {
@@ -227,22 +204,18 @@ func TestStatsdCountersWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			
 			result := string(bytes[:n])
 			expected := "test.counter_with_multiple_label_name:1|c|#label1:foo,label2:bar\n"
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdCountersFuncWithMultiLabels(t *testing.T) {
@@ -260,9 +233,7 @@ func TestStatsdCountersFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -280,9 +251,7 @@ func TestStatsdCountersFuncWithMultiLabels(t *testing.T) {
 			}
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdGaugesWithMultiLabels(t *testing.T) {
@@ -296,9 +265,7 @@ func TestStatsdGaugesWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -309,9 +276,7 @@ func TestStatsdGaugesWithMultiLabels(t *testing.T) {
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdGaugesFuncWithMultiLabels(t *testing.T) {
@@ -329,9 +294,7 @@ func TestStatsdGaugesFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -349,9 +312,7 @@ func TestStatsdGaugesFuncWithMultiLabels(t *testing.T) {
 			}
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdGaugesWithSingleLabel(t *testing.T) {
@@ -365,9 +326,7 @@ func TestStatsdGaugesWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -378,9 +337,7 @@ func TestStatsdGaugesWithSingleLabel(t *testing.T) {
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdMultiTimings(t *testing.T) {
@@ -394,9 +351,7 @@ func TestStatsdMultiTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -407,9 +362,7 @@ func TestStatsdMultiTimings(t *testing.T) {
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdTimings(t *testing.T) {
@@ -423,9 +376,7 @@ func TestStatsdTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -436,9 +387,7 @@ func TestStatsdTimings(t *testing.T) {
 			assert.Equal(t, expected, result)
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestStatsdHistogram(t *testing.T) {
@@ -454,14 +403,12 @@ func TestStatsdHistogram(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			if err := sb.statsdClient.Flush(); err != nil {
-				t.Errorf("Error flushing: %s", err)
-			}
+			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			
 			result := string(bytes[:n])
 			expected := []string{
 				"test.histogram_name:2|h",
@@ -474,9 +421,7 @@ func TestStatsdHistogram(t *testing.T) {
 			}
 		}
 	})
-	if !found {
-		t.Errorf("Stat %s not found...", name)
-	}
+	assert.True(t, found, "Stat %s not found", name)
 }
 
 func TestMakeCommonTags(t *testing.T) {

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -47,11 +47,11 @@ func TestStatsdCounter(t *testing.T) {
 		if kv.Key == name {
 			sb.addExpVar(kv)
 			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
-			
+
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)
-			
+
 			result := string(bytes[:n])
 			expected := "test.counter_name:1|c\n"
 			assert.Equal(t, expected, result)
@@ -72,11 +72,11 @@ func TestStatsdGauge(t *testing.T) {
 			found = true
 			sb.addExpVar(kv)
 			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
-			
+
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)
-			
+
 			result := string(bytes[:n])
 			expected := "test.gauge_name:10|g\n"
 			assert.Equal(t, expected, result)
@@ -97,11 +97,11 @@ func TestStatsdGaugeFloat64(t *testing.T) {
 			found = true
 			sb.addExpVar(kv)
 			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
-			
+
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)
-			
+
 			result := string(bytes[:n])
 			expected := "test.gauge_name_f64:3.14|g\n"
 			assert.Equal(t, expected, result)
@@ -123,11 +123,11 @@ func TestStatsdGaugeFunc(t *testing.T) {
 			found = true
 			sb.addExpVar(kv)
 			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
-			
+
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)
-			
+
 			result := string(bytes[:n])
 			expected := "test.gauge_func_name:2|g\n"
 			assert.Equal(t, expected, result)
@@ -205,11 +205,11 @@ func TestStatsdCountersWithMultiLabels(t *testing.T) {
 			found = true
 			sb.addExpVar(kv)
 			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
-			
+
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)
-			
+
 			result := string(bytes[:n])
 			expected := "test.counter_with_multiple_label_name:1|c|#label1:foo,label2:bar\n"
 			assert.Equal(t, expected, result)
@@ -404,11 +404,11 @@ func TestStatsdHistogram(t *testing.T) {
 			found = true
 			sb.addExpVar(kv)
 			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
-			
+
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			require.NoError(t, err)
-			
+
 			result := string(bytes[:n])
 			expected := []string{
 				"test.histogram_name:2|h",

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -46,7 +46,7 @@ func TestStatsdCounter(t *testing.T) {
 		found = true
 		if kv.Key == name {
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
@@ -71,7 +71,7 @@ func TestStatsdGauge(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
@@ -96,7 +96,7 @@ func TestStatsdGaugeFloat64(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
@@ -122,7 +122,7 @@ func TestStatsdGaugeFunc(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
@@ -147,7 +147,7 @@ func TestStatsdCounterDuration(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -172,7 +172,7 @@ func TestStatsdCountersWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -204,7 +204,7 @@ func TestStatsdCountersWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
@@ -233,7 +233,7 @@ func TestStatsdCountersFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -265,7 +265,7 @@ func TestStatsdGaugesWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -294,7 +294,7 @@ func TestStatsdGaugesFuncWithMultiLabels(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -326,7 +326,7 @@ func TestStatsdGaugesWithSingleLabel(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -351,7 +351,7 @@ func TestStatsdMultiTimings(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 			bytes := make([]byte, 49152)
 			n, err := server.Read(bytes)
 			if err != nil {
@@ -403,7 +403,7 @@ func TestStatsdHistogram(t *testing.T) {
 		if kv.Key == name {
 			found = true
 			sb.addExpVar(kv)
-			require.NoError(t, sb.statsdClient.Flush(), "Error flushing")
+			assert.NoError(t, sb.statsdClient.Flush(), "Error flushing")
 
 			bytes := make([]byte, 4096)
 			n, err := server.Read(bytes)


### PR DESCRIPTION

## Description
- replace instances of t.Errorf and t.Fatalf with assert and require

## Related Issue(s)

- #15182

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
