### PR TITLE
`vtorc`: store cells in backend and periodically refresh

### DIFF
--- a/go/vt/vtorc/db/generate_base.go
+++ b/go/vt/vtorc/db/generate_base.go
@@ -29,9 +29,10 @@ var TableNames = []string{
 	"global_recovery_disable",
 	"topology_recovery_steps",
 	"database_instance_stale_binlog_coordinates",
-	"vitess_tablet",
+	"vitess_cell",
 	"vitess_keyspace",
 	"vitess_shard",
+	"vitess_tablet",
 }
 
 // vtorcBackend is a list of SQL statements required to build the vtorc backend
@@ -305,6 +306,14 @@ CREATE TABLE vitess_shard (
 	primary_alias varchar(512) NOT NULL,
 	primary_timestamp varchar(512) NOT NULL,
 	PRIMARY KEY (keyspace, shard)
+)`,
+	`
+DROP TABLE IF EXISTS vitess_cell
+`,
+	`
+CREATE TABLE vitess_cell (
+	cell varchar(128) NOT NULL,
+	PRIMARY KEY (cell)
 )`,
 	`
 CREATE INDEX source_host_port_idx_database_instance_database_instance on database_instance (source_host, source_port)

--- a/go/vt/vtorc/inst/cell_dao.go
+++ b/go/vt/vtorc/inst/cell_dao.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inst
+
+import (
+	"vitess.io/vitess/go/vt/external/golib/sqlutils"
+	"vitess.io/vitess/go/vt/vtorc/db"
+)
+
+// ReadCells reads all the vitess cell names.
+func ReadCells() ([]string, error) {
+	cells := make([]string, 0)
+	query := `SELECT cell FROM vitess_cell`
+	err := db.QueryVTOrc(query, nil, func(row sqlutils.RowMap) error {
+		cells = append(cells, row.GetString("cell"))
+		return nil
+	})
+	return cells, err
+}
+
+// SaveCell saves the keyspace record against the keyspace name.
+func SaveCell(cell string) error {
+	_, err := db.ExecVTOrc(`REPLACE INTO vitess_cell (cell) VALUES(?)`, cell)
+	return err
+}
+
+// DeleteCell deletes a cell.
+func DeleteCell(cell string) (err error) {
+	_, err = db.ExecVTOrc(`DELETE FROM vitess_cell WHERE cell = ?`, cell)
+	return err
+}

--- a/go/vt/vtorc/inst/cell_dao_test.go
+++ b/go/vt/vtorc/inst/cell_dao_test.go
@@ -24,7 +24,7 @@ import (
 	"vitess.io/vitess/go/vt/vtorc/db"
 )
 
-func TestSaveAndReadCells(t *testing.T) {
+func TestSaveReadAndDeleteCells(t *testing.T) {
 	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
 	defer func() {
 		db.ClearVTOrcDatabase()
@@ -36,4 +36,9 @@ func TestSaveAndReadCells(t *testing.T) {
 	cellsRead, err := ReadCells()
 	require.NoError(t, err)
 	require.Equal(t, cells, cellsRead)
+
+	require.NoError(t, DeleteCell("zone3"))
+	cellsRead, err = ReadCells()
+	require.NoError(t, err)
+	require.Equal(t, []string{"zone1", "zone2"}, cellsRead)
 }

--- a/go/vt/vtorc/inst/cell_dao_test.go
+++ b/go/vt/vtorc/inst/cell_dao_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inst
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vtorc/db"
+)
+
+func TestSaveAndReadCells(t *testing.T) {
+	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
+	defer func() {
+		db.ClearVTOrcDatabase()
+	}()
+	cells := []string{"zone1", "zone2", "zone3"}
+	for _, cell := range cells {
+		require.NoError(t, SaveCell(cell))
+	}
+	cellsRead, err := ReadCells()
+	require.NoError(t, err)
+	require.Equal(t, cells, cellsRead)
+}

--- a/go/vt/vtorc/inst/cell_dao_test.go
+++ b/go/vt/vtorc/inst/cell_dao_test.go
@@ -25,10 +25,9 @@ import (
 )
 
 func TestSaveReadAndDeleteCells(t *testing.T) {
-	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
-	defer func() {
-		db.ClearVTOrcDatabase()
-	}()
+	db.ClearVTOrcDatabase()
+	defer db.ClearVTOrcDatabase()
+
 	cells := []string{"zone1", "zone2", "zone3"}
 	for _, cell := range cells {
 		require.NoError(t, SaveCell(cell))

--- a/go/vt/vtorc/logic/cell_discovery.go
+++ b/go/vt/vtorc/logic/cell_discovery.go
@@ -49,17 +49,18 @@ func refreshCells(cells []string) (err error) {
 	for _, cell := range cells {
 		err = inst.SaveCell(cell)
 		if err != nil {
-			log.Errorf("Failed to save cell %q: %+v", cell, err)
+			log.Errorf("Failed to save cell %s: %+v", cell, err)
 			return err
 		}
 		updated[cell] = true
 	}
 
-	// read all saved cells. the values should not
-	// be changing because we are holding a lock.
+	// read all saved cells. the values should not be changing
+	// because we are holding a lock and updates originate
+	// from this func only.
 	cells, err = inst.ReadCells()
 	if err != nil {
-		log.Errorf("Failed to read cells: %+v", err)
+		log.Errorf("Failed to read all cells: %+v", err)
 		return err
 	}
 
@@ -68,9 +69,9 @@ func refreshCells(cells []string) (err error) {
 		if updated[cell] {
 			continue
 		}
-		log.Infof("Forgetting stale cell %q", cell)
+		log.Infof("Forgetting stale cell %s", cell)
 		if err = inst.DeleteCell(cell); err != nil {
-			log.Errorf("Failed to delete cell %q: %+v", cell, err)
+			log.Errorf("Failed to delete cell %s: %+v", cell, err)
 		}
 	}
 	return nil

--- a/go/vt/vtorc/logic/cell_discovery.go
+++ b/go/vt/vtorc/logic/cell_discovery.go
@@ -49,7 +49,7 @@ func refreshCells(cells []string) (err error) {
 	for _, cell := range cells {
 		err = inst.SaveCell(cell)
 		if err != nil {
-			log.Error(err)
+			log.Errorf("Failed to save cell %q: %+v", cell, err)
 			return err
 		}
 		updated[cell] = true
@@ -59,6 +59,7 @@ func refreshCells(cells []string) (err error) {
 	// be changing because we are holding a lock.
 	cells, err = inst.ReadCells()
 	if err != nil {
+		log.Errorf("Failed to read cells: %+v", err)
 		return err
 	}
 
@@ -69,7 +70,7 @@ func refreshCells(cells []string) (err error) {
 		}
 		log.Infof("Forgetting stale cell %q", cell)
 		if err = inst.DeleteCell(cell); err != nil {
-			return err
+			log.Errorf("Failed to delete cell %q: %+v", cell, err)
 		}
 	}
 	return nil

--- a/go/vt/vtorc/logic/cell_discovery.go
+++ b/go/vt/vtorc/logic/cell_discovery.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"context"
+	"sync"
+
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtorc/inst"
+)
+
+var refreshCellsMu sync.Mutex
+
+// RefreshCells refreshes the list of cells.
+func RefreshCells(ctx context.Context) error {
+	cellsCtx, cellsCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+	defer cellsCancel()
+	cells, err := ts.GetKnownCells(cellsCtx)
+	if err != nil {
+		return err
+	}
+	return refreshCells(cells)
+}
+
+// refreshCells saves a slice of cells and removes
+// stale cells that were not updated.
+func refreshCells(cells []string) (err error) {
+	refreshCellsMu.Lock()
+	defer refreshCellsMu.Unlock()
+
+	// save cells.
+	updated := make(map[string]bool)
+	for _, cell := range cells {
+		err = inst.SaveCell(cell)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		updated[cell] = true
+	}
+
+	// read all saved cells. the values should not
+	// be changing because we are holding a lock.
+	cells, err = inst.ReadCells()
+	if err != nil {
+		return err
+	}
+
+	// delete cells that are stale.
+	for _, cell := range cells {
+		if updated[cell] {
+			continue
+		}
+		log.Infof("Forgetting stale cell %q", cell)
+		if err = inst.DeleteCell(cell); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/vt/vtorc/logic/cell_discovery_test.go
+++ b/go/vt/vtorc/logic/cell_discovery_test.go
@@ -45,7 +45,7 @@ func TestRefreshCells(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cells, cellsRead)
 
-	require.NoError(t, ts.DeleteCellInfo(context.Background(), "zone3", true))
+	require.NoError(t, ts.DeleteCellInfo(ctx, "zone3", true))
 	require.NoError(t, RefreshCells(ctx))
 	cellsRead, err = inst.ReadCells()
 	require.NoError(t, err)

--- a/go/vt/vtorc/logic/cell_discovery_test.go
+++ b/go/vt/vtorc/logic/cell_discovery_test.go
@@ -45,8 +45,13 @@ func TestRefreshCells(t *testing.T) {
 	ts = memorytopo.NewServer(ctx, cells...)
 
 	require.NoError(t, RefreshCells(ctx))
-
 	cellsRead, err := inst.ReadCells()
 	require.NoError(t, err)
 	require.Equal(t, cells, cellsRead)
+
+	require.NoError(t, ts.DeleteCellInfo(context.Background(), "zone3", true))
+	require.NoError(t, RefreshCells(ctx))
+	cellsRead, err = inst.ReadCells()
+	require.NoError(t, err)
+	require.Equal(t, cells[:2], cellsRead)
 }

--- a/go/vt/vtorc/logic/cell_discovery_test.go
+++ b/go/vt/vtorc/logic/cell_discovery_test.go
@@ -27,7 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/vtorc/inst"
 )
 
-func TestRefreshAllCells(t *testing.T) {
+func TestRefreshCells(t *testing.T) {
 	// Store the old flags and restore on test completion
 	oldTs := ts
 	defer func() {

--- a/go/vt/vtorc/logic/cell_discovery_test.go
+++ b/go/vt/vtorc/logic/cell_discovery_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vtorc/db"
+	"vitess.io/vitess/go/vt/vtorc/inst"
+)
+
+func TestRefreshAllCells(t *testing.T) {
+	// Store the old flags and restore on test completion
+	oldTs := ts
+	defer func() {
+		ts = oldTs
+	}()
+
+	db.ClearVTOrcDatabase()
+	defer func() {
+		db.ClearVTOrcDatabase()
+	}()
+
+	cells := []string{"zone1", "zone2", "zone3"}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts = memorytopo.NewServer(ctx, cells...)
+
+	require.NoError(t, RefreshCells(ctx))
+
+	cellsRead, err := inst.ReadCells()
+	require.NoError(t, err)
+	require.Equal(t, cells, cellsRead)
+}

--- a/go/vt/vtorc/logic/cell_discovery_test.go
+++ b/go/vt/vtorc/logic/cell_discovery_test.go
@@ -28,15 +28,11 @@ import (
 )
 
 func TestRefreshCells(t *testing.T) {
-	// Store the old flags and restore on test completion
+	db.ClearVTOrcDatabase()
 	oldTs := ts
 	defer func() {
-		ts = oldTs
-	}()
-
-	db.ClearVTOrcDatabase()
-	defer func() {
 		db.ClearVTOrcDatabase()
+		ts = oldTs
 	}()
 
 	cells := []string{"zone1", "zone2", "zone3"}

--- a/go/vt/vtorc/logic/cell_discovery_test.go
+++ b/go/vt/vtorc/logic/cell_discovery_test.go
@@ -53,5 +53,5 @@ func TestRefreshCells(t *testing.T) {
 	require.NoError(t, RefreshCells(ctx))
 	cellsRead, err = inst.ReadCells()
 	require.NoError(t, err)
-	require.Equal(t, cells[:2], cellsRead)
+	require.Equal(t, []string{"zone1", "zone2"}, cellsRead)
 }

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -237,7 +237,12 @@ func refreshTabletInfoOfShard(ctx context.Context, keyspace, shard string) {
 }
 
 func refreshTabletsInKeyspaceShard(ctx context.Context, keyspace, shard string, loader func(tabletAlias string), forceRefresh bool, tabletsToIgnore []string) {
-	tablets, err := ts.GetTabletsByShard(ctx, keyspace, shard)
+	cells, err := inst.ReadCells()
+	if err != nil {
+		log.Errorf("Error fetching cells: %v", err)
+		return
+	}
+	tablets, err := ts.GetTabletsByShardCell(ctx, keyspace, shard, cells)
 	if err != nil {
 		log.Errorf("Error fetching tablets for keyspace/shard %v/%v: %v", keyspace, shard, err)
 		return

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -181,12 +181,13 @@ func refreshAllTablets(ctx context.Context) error {
 
 // refreshTabletsUsing refreshes tablets using a provided loader.
 func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), forceRefresh bool) error {
-	// Get all cells.
-	ctx, cancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
-	defer cancel()
-	cells, err := ts.GetKnownCells(ctx)
+	cells, err := inst.ReadCells()
 	if err != nil {
 		return err
+	}
+	if len(cells) == 0 {
+		log.Error("Found no cells")
+		return nil
 	}
 
 	// Get all tablets from all cells.

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -321,6 +321,11 @@ func refreshAllInformation(ctx context.Context) error {
 	// Create an errgroup
 	eg, ctx := errgroup.WithContext(ctx)
 
+	// Refresh all cells.
+	eg.Go(func() error {
+		return RefreshCells(ctx)
+	})
+
 	// Refresh all keyspace information.
 	eg.Go(func() error {
 		return RefreshAllKeyspacesAndShards(ctx)


### PR DESCRIPTION
## Description

This PR causes VTOrc to store a list of known cells in the backend and refresh them during the usual topo tick. This is called first  by `OpenTabletDiscovery(...)` _(via `refreshAllInformation(...)`)_ and later on a ticker loop _(default every `15s`)_. I think a small amount of drift in what cells are alive will be ok, for example if a shard refresh happens right after a cell is added/removed _(cc @GuptaManan100?)_

Today the list of cells is refreshed [every time time `refreshTabletsUsing(...)` is called](https://github.com/vitessio/vitess/blob/main/go/vt/vtorc/logic/tablet_discovery.go#L182-L215), which can be more frequent than the ticker interval

This should reduce global topo reads while adding some resilence if `ts.GetKnownCells(...)` fails temporarily

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17330

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
