### PR TITLE
Fix data race in `TestIsServingLocked`

### DIFF
--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -150,15 +150,24 @@ func TestStateManagerUnservePrimary(t *testing.T) {
 }
 
 type testDiskMonitor struct {
+	mu            sync.Mutex
 	isDiskStalled bool
 }
 
 func (t *testDiskMonitor) IsDiskStalled() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return t.isDiskStalled
 }
 
-// TestIsServingLocked tests isServingLocked() functionality.
-func TestIsServingLocked(t *testing.T) {
+func (t *testDiskMonitor) setDiskStalled(ds bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.isDiskStalled = ds
+}
+
+// TestIsServing tests IsServing() functionality.
+func TestIsServing(t *testing.T) {
 	sm := newTestStateManager()
 	defer sm.StopService()
 	tdm := &testDiskMonitor{isDiskStalled: false}
@@ -166,10 +175,10 @@ func TestIsServingLocked(t *testing.T) {
 
 	err := sm.SetServingType(topodatapb.TabletType_REPLICA, testNow, StateServing, "")
 	require.NoError(t, err)
-	require.True(t, sm.isServingLocked())
+	require.True(t, sm.IsServing())
 
-	tdm.isDiskStalled = true
-	require.False(t, sm.isServingLocked())
+	tdm.setDiskStalled(true)
+	require.False(t, sm.IsServing())
 }
 
 func TestStateManagerUnserveNonPrimary(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the data race found in `TestIsServingLocked` - 

```
==================
WARNING: DATA RACE
Read at 0x00c0007b9e8f by goroutine 13510:
  vitess.io/vitess/go/vt/vttablet/tabletserver.(*testDiskMonitor).IsDiskStalled()
      /opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletserver/state_manager_test.go:157 +0x28
  vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).isServingLocked()
      /opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletserver/state_manager.go:793 +0xe1
  vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).Broadcast()
      /opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletserver/state_manager.go:736 +0x14a
  vitess.io/vitess/go/vt/vttablet/tabletserver.(*stateManager).Broadcast-fm()
      <autogenerated>:1 +0x33
  vitess.io/vitess/go/timer.(*Timer).run()
      /opt/actions-runner/_work/vitess-private/vitess-private/go/timer/timer.go:111 +0x169
  vitess.io/vitess/go/timer.(*Timer).Start.gowrap2()
      /opt/actions-runner/_work/vitess-private/vitess-private/go/timer/timer.go:85 +0x44

Previous write at 0x00c0007b9e8f by goroutine 13509:
  vitess.io/vitess/go/vt/vttablet/tabletserver.TestIsServingLocked()
      /opt/actions-runner/_work/vitess-private/vitess-private/go/vt/vttablet/tabletserver/state_manager_test.go:171 +0x197
  testing.tRunner()
      /opt/actions-runner/_work/_tool/go/1.23.5/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/actions-runner/_work/_tool/go/1.23.5/x64/src/testing/testing.go:1743 +0x44
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
