### PR TITLE
`operator.yaml`: pass on the `sidecarDbName` when creating a keyspace

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -4422,6 +4422,8 @@ spec:
                         maxItems: 2
                         minItems: 1
                         type: array
+                      sidecarDbName:
+                        type: string
                       turndownPolicy:
                         enum:
                           - RequireIdle
@@ -6239,6 +6241,8 @@ spec:
                   maxItems: 2
                   minItems: 1
                   type: array
+                sidecarDbName:
+                  type: string
                 topologyReconciliation:
                   properties:
                     pruneCells:


### PR DESCRIPTION
## Description

This is a follow up of the work done by @mcrauwel on https://github.com/planetscale/vitess-operator/pull/662. The CRDs are changing, and this PR makes sure the changes are reported on the vtop examples in the vitessio/vitess repository.