### PR TITLE
Remove unused code from go/acl

### DIFF
--- a/go/acl/acl.go
+++ b/go/acl/acl.go
@@ -64,9 +64,6 @@ var (
 // Policy defines the interface that needs to be satisfied by
 // ACL policy implementors.
 type Policy interface {
-	// CheckAccessActor can be called to verify if an actor
-	// has access to the role.
-	CheckAccessActor(actor, role string) error
 	// CheckAccessHTTP can be called to verify if an actor in
 	// the http request has access to the role.
 	CheckAccessHTTP(req *http.Request, role string) error
@@ -99,16 +96,6 @@ func savePolicy() {
 	}
 	log.Warningf("security_policy %q not found; using fallback policy (deny-all)", securityPolicy)
 	currentPolicy = denyAllPolicy{}
-}
-
-// CheckAccessActor uses the current security policy to
-// verify if an actor has access to the role.
-func CheckAccessActor(actor, role string) error {
-	once.Do(savePolicy)
-	if currentPolicy != nil {
-		return currentPolicy.CheckAccessActor(actor, role)
-	}
-	return nil
 }
 
 // CheckAccessHTTP uses the current security policy to

--- a/go/acl/acl_test.go
+++ b/go/acl/acl_test.go
@@ -31,13 +31,6 @@ import (
 
 type TestPolicy struct{}
 
-func (tp TestPolicy) CheckAccessActor(actor, role string) error {
-	if role == ADMIN {
-		return errors.New("not allowed")
-	}
-	return nil
-}
-
 func (tp TestPolicy) CheckAccessHTTP(req *http.Request, role string) error {
 	if role == ADMIN {
 		return errors.New("not allowed")
@@ -55,17 +48,8 @@ func init() {
 
 func TestSimplePolicy(t *testing.T) {
 	currentPolicy = policies["test"]
-	err := CheckAccessActor("", ADMIN)
 	want := "not allowed"
-	assert.Equalf(t, err.Error(), want, "got %v, want %s", err, want)
-
-	err = CheckAccessActor("", DEBUGGING)
-	assert.Equalf(t, err, nil, "got %v, want no error", err)
-
-	err = CheckAccessActor("", MONITORING)
-	assert.Equalf(t, err, nil, "got %v, want no error", err)
-
-	err = CheckAccessHTTP(nil, ADMIN)
+	err := CheckAccessHTTP(nil, ADMIN)
 	assert.Equalf(t, err.Error(), want, "got %v, want %s", err, want)
 
 	err = CheckAccessHTTP(nil, DEBUGGING)
@@ -77,16 +61,7 @@ func TestSimplePolicy(t *testing.T) {
 
 func TestEmptyPolicy(t *testing.T) {
 	currentPolicy = nil
-	err := CheckAccessActor("", ADMIN)
-	assert.Equalf(t, err, nil, "got %v, want no error", err)
-
-	err = CheckAccessActor("", DEBUGGING)
-	assert.Equalf(t, err, nil, "got %v, want no error", err)
-
-	err = CheckAccessActor("", MONITORING)
-	assert.Equalf(t, err, nil, "got %v, want no error", err)
-
-	err = CheckAccessHTTP(nil, ADMIN)
+	err := CheckAccessHTTP(nil, ADMIN)
 	assert.Equalf(t, err, nil, "got %v, want no error", err)
 
 	err = CheckAccessHTTP(nil, DEBUGGING)

--- a/go/acl/deny_all_policy.go
+++ b/go/acl/deny_all_policy.go
@@ -26,11 +26,6 @@ var errDenyAll = errors.New("not allowed: deny-all security_policy enforced")
 // denyAllPolicy rejects all access.
 type denyAllPolicy struct{}
 
-// CheckAccessActor disallows all actor access.
-func (denyAllPolicy) CheckAccessActor(actor, role string) error {
-	return errDenyAll
-}
-
 // CheckAccessHTTP disallows all HTTP access.
 func (denyAllPolicy) CheckAccessHTTP(req *http.Request, role string) error {
 	return errDenyAll

--- a/go/acl/deny_all_policy_test.go
+++ b/go/acl/deny_all_policy_test.go
@@ -26,16 +26,7 @@ func TestDenyAllPolicy(t *testing.T) {
 	testDenyAllPolicy := denyAllPolicy{}
 
 	want := errDenyAll
-	err := testDenyAllPolicy.CheckAccessActor("", ADMIN)
-	assert.Equalf(t, err, want, "got %v; want %v", err, want)
-
-	err = testDenyAllPolicy.CheckAccessActor("", DEBUGGING)
-	assert.Equalf(t, err, want, "got %v; want %v", err, want)
-
-	err = testDenyAllPolicy.CheckAccessActor("", MONITORING)
-	assert.Equalf(t, err, want, "got %v; want %v", err, want)
-
-	err = testDenyAllPolicy.CheckAccessHTTP(nil, ADMIN)
+	err := testDenyAllPolicy.CheckAccessHTTP(nil, ADMIN)
 	assert.Equalf(t, err, want, "got %v; want %v", err, want)
 
 	err = testDenyAllPolicy.CheckAccessHTTP(nil, DEBUGGING)

--- a/go/acl/read_only_policy.go
+++ b/go/acl/read_only_policy.go
@@ -27,16 +27,6 @@ var errReadOnly = errors.New("not allowed: read-only security_policy enforced")
 // while denying any other roles (e.g. ADMIN) for everyone.
 type readOnlyPolicy struct{}
 
-// CheckAccessActor disallows all actor access.
-func (readOnlyPolicy) CheckAccessActor(actor, role string) error {
-	switch role {
-	case DEBUGGING, MONITORING:
-		return nil
-	default:
-		return errReadOnly
-	}
-}
-
 // CheckAccessHTTP disallows all HTTP access.
 func (readOnlyPolicy) CheckAccessHTTP(req *http.Request, role string) error {
 	switch role {

--- a/go/acl/read_only_policy_test.go
+++ b/go/acl/read_only_policy_test.go
@@ -26,16 +26,7 @@ func TestReadOnlyPolicy(t *testing.T) {
 	testReadOnlyPolicy := readOnlyPolicy{}
 
 	want := errReadOnly
-	err := testReadOnlyPolicy.CheckAccessActor("", ADMIN)
-	assert.Equalf(t, err, want, "got %v; want %v", err, want)
-
-	err = testReadOnlyPolicy.CheckAccessActor("", DEBUGGING)
-	assert.Equalf(t, err, nil, "got %v; want no error", err)
-
-	err = testReadOnlyPolicy.CheckAccessActor("", MONITORING)
-	assert.Equalf(t, err, nil, "got %v; want no error", err)
-
-	err = testReadOnlyPolicy.CheckAccessHTTP(nil, ADMIN)
+	err := testReadOnlyPolicy.CheckAccessHTTP(nil, ADMIN)
 	assert.Equalf(t, err, want, "got %v; want %v", err, want)
 
 	err = testReadOnlyPolicy.CheckAccessHTTP(nil, DEBUGGING)


### PR DESCRIPTION
This removes the unused code found by deadcode in the go/acl package.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
