### PR TITLE
Fix vtcombo parsing flags incorrectly

### DIFF
--- a/go/cmd/vtcombo/cli/main.go
+++ b/go/cmd/vtcombo/cli/main.go
@@ -126,15 +126,6 @@ func init() {
 	// user know about this flag.
 	Main.Flags().MarkHidden("tablet_protocol")
 
-	var err error
-	env, err = vtenv.New(vtenv.Options{
-		MySQLServerVersion: servenv.MySQLServerVersion(),
-		TruncateUILen:      servenv.TruncateUILen,
-		TruncateErrLen:     servenv.TruncateErrLen,
-	})
-	if err != nil {
-		log.Fatalf("unable to initialize env: %v", err)
-	}
 	srvTopoCounts = stats.NewCountersWithSingleLabel("ResilientSrvTopoServer", "Resilient srvtopo server operations", "type")
 }
 
@@ -187,6 +178,15 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	cmd.Flags().Set("cell", tpb.Cells[0])
 	if f := cmd.Flags().Lookup("log_dir"); f != nil && !f.Changed {
 		cmd.Flags().Set("log_dir", "$VTDATAROOT/tmp")
+	}
+
+	env, err = vtenv.New(vtenv.Options{
+		MySQLServerVersion: servenv.MySQLServerVersion(),
+		TruncateUILen:      servenv.TruncateUILen,
+		TruncateErrLen:     servenv.TruncateErrLen,
+	})
+	if err != nil {
+		log.Fatalf("unable to initialize env: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(cmd.Context())


### PR DESCRIPTION
Inside vtcombo we were setting up the vtenv too early in `init()`. This leads to reading the MySQL version number before it actually is set from the given flags, ignoring the passed in option.

This moves it into the `run` function which is the appropriate place.

We do a similar fix for `vtctldclient` by making sure we initialize the vtenv inside the pre-run command instead of in the `init()` to avoid a potentially similar problem.

Don't know how to really test this further except for the manual testing I have done. There's nothing around tests that end up invoking the binary itself, which is needed to uncover this problem. 

Should we backport this fix?

## Related Issue(s)

Fixes #17645

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required