### PR TITLE
Fail assignment expressions with the correct message

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -157,7 +157,10 @@ func newNormalizer(
 // It handles normalization logic based on node types.
 func (nz *normalizer) walkDown(node, _ SQLNode) bool {
 	switch node := node.(type) {
-	case *Begin, *Commit, *Rollback, *Savepoint, *SRollback, *Release, *OtherAdmin, *Analyze, *AssignmentExpr,
+	case *AssignmentExpr:
+		nz.err = vterrors.VT12001("Assignment expression")
+		return false
+	case *Begin, *Commit, *Rollback, *Savepoint, *SRollback, *Release, *OtherAdmin, *Analyze,
 		*PrepareStmt, *ExecuteStmt, *FramePoint, *ColName, TableName, *ConvertType:
 		// These statement don't need normalizing
 		return false

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1327,9 +1327,15 @@ var (
 		input: "update /* a.b */ a.b set b = 3",
 	}, {
 		input: "update a.b set d = @v := d + 7 where u = 42",
+		// Assignment expresions aren't supported, so we skip the normalizer test.
+		// We only support parsing these expressions.
+		ignoreNormalizerTest: true,
 	}, {
 		input:  "select @topic3_id:= 10103;",
 		output: "select @topic3_id := 10103 from dual",
+		// Assignment expresions aren't supported, so we skip the normalizer test.
+		// We only support parsing these expressions.
+		ignoreNormalizerTest: true,
 	}, {
 		input: "update /* list */ a set b = 3, c = 4",
 	}, {

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -230,6 +230,11 @@
     "plan": "VT12001: unsupported: Assignment expression"
   },
   {
+    "comment": "Assignment expression in on duplicate clause",
+    "query": "insert into unsharded (id) values (@val := 42)",
+    "plan": "VT12001: unsupported: Assignment expression"
+  },
+  {
     "comment": "Assignment expression in union statements",
     "query": "select @val := 42 union select 1",
     "plan": "VT12001: unsupported: Assignment expression"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
As pointed out in https://github.com/vitessio/vitess/issues/17751, we shoud be failing assignment expressions with the proper error message.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/17751

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
