### PR TITLE
smartconnpool: Better handling for idle expiration

### DIFF
--- a/go/pools/smartconnpool/connection.go
+++ b/go/pools/smartconnpool/connection.go
@@ -19,7 +19,6 @@ package smartconnpool
 import (
 	"context"
 	"sync/atomic"
-	"time"
 )
 
 type Connection interface {
@@ -33,8 +32,8 @@ type Connection interface {
 
 type Pooled[C Connection] struct {
 	next        atomic.Pointer[Pooled[C]]
-	timeCreated time.Time
-	timeUsed    time.Time
+	timeCreated timestamp
+	timeUsed    timestamp
 	pool        *ConnPool[C]
 
 	Conn C

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -200,7 +200,7 @@ func (pool *ConnPool[C]) open() {
 
 	// The expire worker takes care of removing from the waiter list any clients whose
 	// context has been cancelled.
-	pool.runWorker(pool.close, 100*time.Millisecond, func(now time.Time) bool {
+	pool.runWorker(pool.close, 100*time.Millisecond, func(_ time.Time) bool {
 		maybeStarving := pool.wait.expire(false)
 
 		// Do not allow connections to starve; if there's waiters in the queue

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -459,10 +459,12 @@ func (pool *ConnPool[C]) pop(stack *connStack[C]) *Pooled[C] {
 
 func (pool *ConnPool[C]) tryReturnAnyConn() bool {
 	if conn := pool.pop(&pool.clean); conn != nil {
+		conn.timeUsed.update()
 		return pool.tryReturnConn(conn)
 	}
 	for u := 0; u <= stackMask; u++ {
 		if conn := pool.pop(&pool.settings[u]); conn != nil {
+			conn.timeUsed.update()
 			return pool.tryReturnConn(conn)
 		}
 	}

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -619,8 +619,23 @@ func TestIdleTimeout(t *testing.T) {
 			p.put(conn)
 		}
 
+		// wait again; the connections will timeout inside the pool, but we'll only notice
+		// when trying to pop them again
+		time.Sleep(1 * time.Second)
+
+		for i := 0; i < 5; i++ {
+			r, err := p.Get(ctx, setting)
+			require.NoError(t, err)
+
+			p.put(r)
+		}
+
 		for _, closed := range closers {
-			<-closed
+			select {
+			case <-closed:
+			default:
+				t.Fatalf("Connections remain open after 1 second")
+			}
 		}
 
 		// no need to assert anything: all the connections in the pool should are idle-closed

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -619,16 +619,7 @@ func TestIdleTimeout(t *testing.T) {
 			p.put(conn)
 		}
 
-		// wait again; the connections will timeout inside the pool, but we'll only notice
-		// when trying to pop them again
 		time.Sleep(1 * time.Second)
-
-		for i := 0; i < 5; i++ {
-			r, err := p.Get(ctx, setting)
-			require.NoError(t, err)
-
-			p.put(r)
-		}
 
 		for _, closed := range closers {
 			select {

--- a/go/pools/smartconnpool/stack.go
+++ b/go/pools/smartconnpool/stack.go
@@ -54,6 +54,11 @@ func (s *connStack[C]) Pop() (*Pooled[C], bool) {
 	}
 }
 
+func (s *connStack[C]) Peek() *Pooled[C] {
+	top, _ := s.top.Load()
+	return top
+}
+
 func (s *connStack[C]) PopAll(out []*Pooled[C]) []*Pooled[C] {
 	var oldHead *Pooled[C]
 

--- a/go/pools/smartconnpool/stack.go
+++ b/go/pools/smartconnpool/stack.go
@@ -25,6 +25,9 @@ import (
 // connStack is a lock-free stack for Connection objects. It is safe to
 // use from several goroutines.
 type connStack[C Connection] struct {
+	// top is a pointer to the top node on the stack and to an increasing
+	// counter of pop operations, to prevent A-B-A races.
+	// See: https://en.wikipedia.org/wiki/ABA_problem
 	top atomic2.PointerAndUint64[Pooled[C]]
 }
 
@@ -57,26 +60,4 @@ func (s *connStack[C]) Pop() (*Pooled[C], bool) {
 func (s *connStack[C]) Peek() *Pooled[C] {
 	top, _ := s.top.Load()
 	return top
-}
-
-func (s *connStack[C]) PopAll(out []*Pooled[C]) []*Pooled[C] {
-	var oldHead *Pooled[C]
-
-	for {
-		var popCount uint64
-		oldHead, popCount = s.top.Load()
-		if oldHead == nil {
-			return out
-		}
-		if s.top.CompareAndSwap(oldHead, popCount, nil, popCount+1) {
-			break
-		}
-		runtime.Gosched()
-	}
-
-	for oldHead != nil {
-		out = append(out, oldHead)
-		oldHead = oldHead.next.Load()
-	}
-	return out
 }

--- a/go/pools/smartconnpool/timestamp.go
+++ b/go/pools/smartconnpool/timestamp.go
@@ -8,37 +8,62 @@ import (
 
 var monotonicRoot = time.Now()
 
+// timestamp is a monotonic point in time, stored as a number of
+// nanoseconds since the monotonic root. This type is only 8 bytes
+// and hence can always be accessed atomically
 type timestamp struct {
 	nano atomic.Int64
 }
 
+// timestampExpired is a special value that means this timestamp is now past
+// an arbitrary expiration point, and hence doesn't need to store
 const timestampExpired = math.MaxInt64
+
+// timestampBusy is a special value that means this timestamp no longer
+// tracks an expiration point
 const timestampBusy = math.MinInt64
 
-func (t *timestamp) update() {
-	t.nano.Store(int64(monotonicNow()))
-}
-
+// monotonicNow returns the current monotonic time as a time.Duration.
+// This is a very efficient operation because time.Since performs direct
+// substraction of monotonic times without considering the wall clock times.
 func monotonicNow() time.Duration {
 	return time.Since(monotonicRoot)
 }
 
+// monotonicFromTime converts a wall-clock time from time.Now into a
+// monotonic timestamp.
+// This is a very efficient operation because time.(*Time).Sub performs direct
+// substraction of monotonic times without considering the wall clock times.
 func monotonicFromTime(now time.Time) time.Duration {
 	return now.Sub(monotonicRoot)
 }
 
+// set sets this timestamp to the given monotonic value
 func (t *timestamp) set(mono time.Duration) {
 	t.nano.Store(int64(mono))
 }
 
+// get returns the monotonic time of this timestamp as the number of nanoseconds
+// since the monotonic root.
 func (t *timestamp) get() time.Duration {
 	return time.Duration(t.nano.Load())
 }
 
+// elapsed returns the number of nanoseconds that have passed since
+// this timestamp was updated
 func (t *timestamp) elapsed() time.Duration {
 	return monotonicNow() - t.get()
 }
 
+// update sets this timestamp's value to the current monotonic time
+func (t *timestamp) update() {
+	t.nano.Store(int64(monotonicNow()))
+}
+
+// borrow attempts to borrow this timestamp atomically.
+// It only succeeds if we can ensure that nobody else has marked
+// this timestamp as expired. When succeeded, the timestamp
+// is cleared as "busy" as it no longer tracks an expiration point.
 func (t *timestamp) borrow() bool {
 	stamp := t.nano.Load()
 	switch stamp {
@@ -51,6 +76,9 @@ func (t *timestamp) borrow() bool {
 	}
 }
 
+// expired attempts to atomically expire this timestamp.
+// It only succeeds if we can ensure the timestamp hasn't been
+// concurrently expired or borrowed.
 func (t *timestamp) expired(now time.Duration, timeout time.Duration) bool {
 	stamp := t.nano.Load()
 	if stamp == timestampExpired {

--- a/go/pools/smartconnpool/timestamp.go
+++ b/go/pools/smartconnpool/timestamp.go
@@ -1,0 +1,66 @@
+package smartconnpool
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+)
+
+var monotonicRoot = time.Now()
+
+type timestamp struct {
+	nano atomic.Int64
+}
+
+const timestampExpired = math.MaxInt64
+const timestampBusy = math.MinInt64
+
+func (t *timestamp) update() {
+	t.nano.Store(int64(monotonicNow()))
+}
+
+func monotonicNow() time.Duration {
+	return time.Since(monotonicRoot)
+}
+
+func monotonicFromTime(now time.Time) time.Duration {
+	return now.Sub(monotonicRoot)
+}
+
+func (t *timestamp) set(mono time.Duration) {
+	t.nano.Store(int64(mono))
+}
+
+func (t *timestamp) get() time.Duration {
+	return time.Duration(t.nano.Load())
+}
+
+func (t *timestamp) elapsed() time.Duration {
+	return monotonicNow() - t.get()
+}
+
+func (t *timestamp) borrow() bool {
+	stamp := t.nano.Load()
+	switch stamp {
+	case timestampExpired:
+		return false
+	case timestampBusy:
+		panic("timestampBusy when borrowing a time")
+	default:
+		return t.nano.CompareAndSwap(stamp, timestampBusy)
+	}
+}
+
+func (t *timestamp) expired(now time.Duration, timeout time.Duration) bool {
+	stamp := t.nano.Load()
+	if stamp == timestampExpired {
+		return false
+	}
+	if stamp == timestampBusy {
+		return false
+	}
+	if now-time.Duration(stamp) > timeout {
+		return t.nano.CompareAndSwap(stamp, timestampExpired)
+	}
+	return false
+}


### PR DESCRIPTION
## Description

We've had a report of a performance regression when migrating from an old Vitess version to a newer version that contains the new smart connection pool implementation. The system in question has inconsistent (spiky) load patterns _and_ quite stringent idle timeouts for connections.

Our assumption here is that the regression is caused by a combination of two factors: the new connection pool provides connections in a LIFO pattern (where the most recently returned to the pool is returned to the client on subsequent gets). This is as opposed to the old pool, which was FIFO, meaning that the pool would constantly cycle through all the available connections. In systems that are not at full capacity, the LIFO connection pool will continuously re-use a small subset of all the open connections. This improves performance in `mysqld`, because of data locality, but causes the connections idling in the pool to eventually hit their max idle timeout and be closed by the background worker.

In this situation, where the delta between requests/second during normal operation and peak operation is sufficiently large, we end up with a very expensive "background stall" in the background worker that is closing idle connections, because a large group of connections can expire at once. Even when the delta is not particularly big, the stringent idle timeout for the connections causes the background worker to trigger very frequently, and because the way it is implemented, these triggers cause a micro-stall.

We believe that improving the way the background worker for idle connections works can get rid of all these stalls.

The issue with the current implementation is that _it pops all the connections from each stack on each idle check_. Once all the connections have been popped, the worker iterates the list of connections and returns the ones that are not idle to the stack in reverse order (so the resulting stack has the same order as before popping it). In retrospect, this is not a good implementation and periodically popping the whole connection stack will obviously lead to micro-stalls in busy systems with stringent timeouts, as incoming requests are very likely to collide with the idle checks in the background, encountering an empty stack and having to fall back to the slower path in the wait queue.

The proposed implementation in this PR fixes the issue as follows:

1. I've implemented a new `timestamp` type that stores monotonic time points in just 8 bytes. This now replaces the `time.Time` timestamps (24 bytes) that we were using to track idle expiration dates in the pooled connections. Besides the significant memory savings, the key advantage of this timestamp is that it can be updated atomically. See the implementation in `timestamp.go`.
2. I've updated the background worker to, instead of popping all the connections in each stack, do a best-effort read-only iteration of the stack and mark all the idle connections as being idle by atomically updating their timestamps. Each connection that is marked as idle is then closed in the background worker, but it is NOT removed from the stack.
3. The client getter code is now aware that connections from the stack can carry an "idle expired" timestamp, so before returning them to the user we attempt to atomically update the timestamp as "busy". Any connections that we acquire with already expired timestamps are simply ignored, as they are being handled in the background thread.

This removes all the micro and macro stalls caused by the background worker, as the idle expiration algorithm is now wait-free: the background worker does a best-effort expiry of connections without actually contending on the connection stack, and the foreground clients cooperate with the expiration by ignoring any expired connections that are popped from a stack. The expensive close operation always happens in the background. A fixed amount of overhead is added to certain `Get` cases because now popping a connection from a stack can spuriously fail (when the popped connection is expired), and must be retried. Retrying the pop is an extremely cheap operation, so I believe this won't have an effect in the p99 of the requests, and it will certainly be a no-op in connection pools without idle timeouts, where the popped connections can never be expired.

An improvement on top of this implementation which I've discarded is upgrading the background worker to also do best-effort eviction of stale connections in the stacks. I'm opting not to pursue this because the semantics of removing nodes from the _middle_ of the atomic stack are non-obvious, and they will cause contention even if we get them right. I think having the clients cooperate by ignoring expired connections is by far the most elegant and safest approach.

cc @harshit-gangal @deepthi 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
