### PR TITLE
bugfix: support subqueries inside subqueries when merging

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1316,10 +1316,10 @@
   },
   {
     "comment": "Subquery inside subquery #1",
-    "query": "select 1, (select 2, (select 3, foo from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
+    "query": "select (select (select col from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select 1, (select 2, (select 3, foo from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
+      "Original": "select (select (select col from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "EqualUnique",
@@ -1327,8 +1327,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select 1, (select 2, (select 3, foo from `user` where 1 != 1) from `user` where 1 != 1) from `user` where 1 != 1",
-        "Query": "select 1, (select 2, (select 3, foo from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
+        "FieldQuery": "select (select (select col from `user` where 1 != 1) from `user` where 1 != 1) from `user` where 1 != 1",
+        "Query": "select (select (select col from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
         "Table": "`user`",
         "Values": [
           "1"
@@ -1338,15 +1338,14 @@
       "TablesUsed": [
         "user.user"
       ]
-    },
-    "skip_e2e": true
+    }
   },
   {
     "comment": "Subquery inside subquery #2",
-    "query": "select 1 from `user` where id = 1 and foo = (select (select 3, foo from `user` where id = 1) from `user` where id = 1)",
+    "query": "select 1 from `user` where id = 1 and 1 = (select (select intcol from `user` where id = 1) from `user` where id = 1)",
     "plan": {
       "QueryType": "SELECT",
-      "Original": "select 1 from `user` where id = 1 and foo = (select (select 3, foo from `user` where id = 1) from `user` where id = 1)",
+      "Original": "select 1 from `user` where id = 1 and 1 = (select (select intcol from `user` where id = 1) from `user` where id = 1)",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "EqualUnique",
@@ -1355,7 +1354,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 1 from `user` where 1 != 1",
-        "Query": "select 1 from `user` where id = 1 and foo = (select (select 3, foo from `user` where id = 1) from `user` where id = 1)",
+        "Query": "select 1 from `user` where id = 1 and 1 = (select (select intcol from `user` where id = 1) from `user` where id = 1)",
         "Table": "`user`",
         "Values": [
           "1"
@@ -1365,8 +1364,7 @@
       "TablesUsed": [
         "user.user"
       ]
-    },
-    "skip_e2e": true
+    }
   },
   {
     "comment": "Multiple parenthesized expressions",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1315,6 +1315,60 @@
     "skip_e2e": true
   },
   {
+    "comment": "Subquery inside subquery #1",
+    "query": "select 1, (select 2, (select 3, foo from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1, (select 2, (select 3, foo from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1, (select 2, (select 3, foo from `user` where 1 != 1) from `user` where 1 != 1) from `user` where 1 != 1",
+        "Query": "select 1, (select 2, (select 3, foo from `user` where id = 1) from `user` where id = 1) from `user` where id = 1",
+        "Table": "`user`",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "Subquery inside subquery #2",
+    "query": "select 1 from `user` where id = 1 and foo = (select (select 3, foo from `user` where id = 1) from `user` where id = 1)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from `user` where id = 1 and foo = (select (select 3, foo from `user` where id = 1) from `user` where id = 1)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from `user` where 1 != 1",
+        "Query": "select 1 from `user` where id = 1 and foo = (select (select 3, foo from `user` where id = 1) from `user` where id = 1)",
+        "Table": "`user`",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
     "comment": "Multiple parenthesized expressions",
     "query": "select * from user where (id = 4 and name ='abc') limit 5",
     "plan": {


### PR DESCRIPTION
## Description
Subqueries inside subqueries were not handled well if they could all be merged into a single query.

## Related Issue(s)
Fixes #17775


## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
