### PR TITLE
[Feature]: Sort results of getTablets for consistency in output/readability

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -2326,6 +2326,10 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 			tablets = append(tablets, ti.Tablet)
 		}
 
+		// Sort the list of tablets alphabetically by alias to improve readability of output.
+		sort.Slice(tablets, func(i, j int) bool {
+			return topoproto.TabletAliasString(tablets[i].Alias) < topoproto.TabletAliasString(tablets[j].Alias)
+		})
 		return &vtctldatapb.GetTabletsResponse{Tablets: tablets}, nil
 	}
 
@@ -2414,6 +2418,10 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 
 		adjustedTablets[i] = ti.Tablet
 	}
+	// Sort the list of tablets alphabetically by alias to improve readability of output.
+	sort.Slice(adjustedTablets, func(i, j int) bool {
+		return topoproto.TabletAliasString(adjustedTablets[i].Alias) < topoproto.TabletAliasString(adjustedTablets[j].Alias)
+	})
 
 	return &vtctldatapb.GetTabletsResponse{
 		Tablets: adjustedTablets,

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -4605,7 +4605,7 @@ func TestDeleteTablets(t *testing.T) {
 
 				resp, err := vtctld.GetTablets(ctx, &vtctldatapb.GetTabletsRequest{})
 				assert.NoError(t, err, "cannot look up tablets from topo after issuing DeleteTablets request")
-				testutil.AssertSameTablets(t, tt.expectedRemainingTablets, resp.Tablets)
+				utils.MustMatch(t, tt.expectedRemainingTablets, resp.Tablets)
 			}
 
 			// Run the test
@@ -13338,7 +13338,7 @@ func TestTabletExternallyReparented(t *testing.T) {
 
 					resp, err := vtctld.GetTablets(ctx, &vtctldatapb.GetTabletsRequest{})
 					require.NoError(t, err, "cannot get all tablets in the topo")
-					testutil.AssertSameTablets(t, tt.expectedTopo, resp.Tablets)
+					utils.MustMatch(t, tt.expectedTopo, resp.Tablets)
 				}()
 			}
 

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -8277,7 +8277,7 @@ func TestGetTablets(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			testutil.AssertSameTablets(t, tt.expected, resp.Tablets)
+			utils.MustMatch(t, tt.expected, resp.Tablets)
 		})
 	}
 }

--- a/go/vt/vtctl/grpcvtctldserver/testutil/proto_compare.go
+++ b/go/vt/vtctl/grpcvtctldserver/testutil/proto_compare.go
@@ -18,15 +18,12 @@ package testutil
 
 import (
 	"encoding/json"
-	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/test/utils"
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 )
 
@@ -105,16 +102,6 @@ func AssertPlannedReparentShardResponsesEqual(t *testing.T, expected *vtctldatap
 	actual = actual.CloneVT()
 	actual.Events = nil
 
-	utils.MustMatch(t, expected, actual)
-}
-
-func AssertSameTablets(t *testing.T, expected, actual []*topodatapb.Tablet) {
-	sort.Slice(expected, func(i, j int) bool {
-		return fmt.Sprintf("%v", expected[i]) < fmt.Sprintf("%v", expected[j])
-	})
-	sort.Slice(actual, func(i, j int) bool {
-		return fmt.Sprintf("%v", actual[i]) < fmt.Sprintf("%v", actual[j])
-	})
 	utils.MustMatch(t, expected, actual)
 }
 


### PR DESCRIPTION
## Description
This sorts the results of GetTablets (which for my current use case, will sort the output of [ListShardTablets](https://vitess.io/docs/archive/12.0/reference/programs/vtctl/shards/#listshardtablets)) and allow it to be consistently grokkable due to it's deterministic ordering.

To test this change, I first modified the `TestGetTablets` unit test under server_test.go from calling `testutil.AssertSameTablets(t, tt.expected, resp.Tablets)`, which first sorts the expected and actual, to `			utils.MustMatch(t, tt.expected, resp.Tablets)`, the call made under the hood after sorting in `AssertSameTablets`. I got the following running `go test` with just that test change:

<details>

```
--- FAIL: TestGetTablets (0.02s)
    --- FAIL: TestGetTablets/cells_filter (0.00s)
panic: interface conversion: interface {} is []string, not string [recovered]
	panic: interface conversion: interface {} is []string, not string

goroutine 467 [running]:
testing.tRunner.func1.2({0x1062f4160, 0x1400131a810})
	/Users/lmorduchowicz/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1632 +0x1bc
testing.tRunner.func1()
	/Users/lmorduchowicz/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1635 +0x334
panic({0x1062f4160?, 0x1400131a810?})
	/Users/lmorduchowicz/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/runtime/panic.go:785 +0x124
github.com/stretchr/testify/assert.messageFromMsgAndArgs({0x1400110be28?, 0x10650d520?, 0x2?})
	/Users/lmorduchowicz/go/pkg/mod/github.com/stretchr/testify@v1.10.0/assert/assertions.go:298 +0x100
github.com/stretchr/testify/assert.Fail({0x10654ce80, 0x14000ec01a0}, {0x105bda086, 0x13}, {0x1400110be28, 0x2, 0x2})
	/Users/lmorduchowicz/go/pkg/mod/github.com/stretchr/testify@v1.10.0/assert/assertions.go:364 +0x1ac
github.com/stretchr/testify/assert.FailNow({0x10654ce80, 0x14000ec01a0}, {0x105bda086, 0x13}, {0x1400110be28, 0x2, 0x2})
	/Users/lmorduchowicz/go/pkg/mod/github.com/stretchr/testify@v1.10.0/assert/assertions.go:331 +0x8c
github.com/stretchr/testify/require.FailNow({0x106557f50, 0x14000ec01a0}, {0x105bda086, 0x13}, {0x1400110be28, 0x2, 0x2})
	/Users/lmorduchowicz/go/pkg/mod/github.com/stretchr/testify@v1.10.0/require/require.go:516 +0xac
vitess.io/vitess/go/test/utils.MustMatchFn.func3(0x14000ec01a0, {0x10621a520, 0x140013106a8}, {0x10621a520, 0x140013106c0}, {0x0, 0x0, 0x0})
	/Users/lmorduchowicz/go/src/vitess2/vitess/go/test/utils/diff.go:71 +0xf4
vitess.io/vitess/go/vt/vtctl/grpcvtctldserver.TestGetTablets.func1(0x14000ec01a0)
	/Users/lmorduchowicz/go/src/vitess2/vitess/go/vt/vtctl/grpcvtctldserver/server_test.go:8280 +0x368
testing.tRunner(0x14000ec01a0, 0x14000eae090)
	/Users/lmorduchowicz/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1690 +0xe4
created by testing.(*T).Run in goroutine 208
	/Users/lmorduchowicz/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1743 +0x314
exit status 2
FAIL	vitess.io/vitess/go/vt/vtctl/grpcvtctldserver	1.047s
```
</details>


After implementing the actual code changes in `server.go`, I get:
<details>

```


--- PASS: TestGetTablets (0.01s)
    --- PASS: TestGetTablets/no_tablets (0.00s)
    --- PASS: TestGetTablets/cells_filter_with_single_error_is_fatal_in_strict_mode (0.00s)
    --- PASS: TestGetTablets/tablet_alias_filter_with_none_found (0.00s)
    --- PASS: TestGetTablets/in_nonstrict_mode_if_all_cells_fail_the_request_fails (0.00s)
    --- PASS: TestGetTablets/tablet_type_filter (0.00s)
    --- PASS: TestGetTablets/tablet_alias_filtering (0.00s)
    --- PASS: TestGetTablets/keyspace_and_shard_filter_-_error (0.00s)
    --- PASS: TestGetTablets/cells_filter (0.00s)
    --- PASS: TestGetTablets/stale_primary (0.00s)
    --- PASS: TestGetTablets/cells_filter_with_single_error_is_nonfatal (0.00s)
    --- PASS: TestGetTablets/keyspace,_shard,_and_tablet_type_filter (0.00s)
    --- PASS: TestGetTablets/keyspace_and_shard_filter_-_stale_primary (0.00s)
    --- PASS: TestGetTablets/keyspace_filter (0.00s)
    --- PASS: TestGetTablets/keyspace_and_shard_filter (0.00s)
    --- PASS: TestGetTablets/multiple_cells_with_one_timing_out_and_strict_true (2.00s)
    --- PASS: TestGetTablets/multiple_cells_with_one_timing_out_and_strict_false (2.00s)
```
</details>


## Related Issue(s)
This is the related issue: https://github.com/vitessio/vitess/issues/17744

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes
I don't believe this has any special properties with regards to deployments
