### PR TITLE
VReplication Atomic Copy Workflows: fix bugs around concurrent inserts

### DIFF
--- a/go/test/endtoend/vreplication/fk_ext_test.go
+++ b/go/test/endtoend/vreplication/fk_ext_test.go
@@ -86,7 +86,10 @@ func TestFKExt(t *testing.T) {
 	setSidecarDBName("_vt")
 
 	// Ensure that there are multiple copy phase cycles per table.
-	extraVTTabletArgs = append(extraVTTabletArgs, "--vstream_packet_size=256", "--queryserver-config-schema-change-signal")
+	extraVTTabletArgs = append(extraVTTabletArgs,
+		"--vstream_packet_size=256",
+		"--queryserver-config-schema-change-signal",
+		parallelInsertWorkers)
 	extraVTGateArgs = append(extraVTGateArgs, "--schema_change_signal=true", "--planner-version", "Gen4")
 	defer func() { extraVTTabletArgs = nil }()
 	initFKExtConfig(t)

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -43,7 +43,6 @@ func TestFKWorkflow(t *testing.T) {
 	extraVTTabletArgs = []string{
 		// Ensure that there are multiple copy phase cycles per table.
 		"--vstream_packet_size=256",
-		parallelInsertWorkers,
 	}
 	defer func() { extraVTTabletArgs = nil }()
 

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -39,9 +39,11 @@ const testWorkflowFlavor = workflowFlavorVtctld
 // It inserts initial data, then simulates load. We insert both child rows with foreign keys and those without,
 // i.e. with foreign_key_checks=0.
 func TestFKWorkflow(t *testing.T) {
+	setSidecarDBName("_vt")
 	extraVTTabletArgs = []string{
 		// Ensure that there are multiple copy phase cycles per table.
 		"--vstream_packet_size=256",
+		parallelInsertWorkers,
 	}
 	defer func() { extraVTTabletArgs = nil }()
 
@@ -128,11 +130,14 @@ func TestFKWorkflow(t *testing.T) {
 	vtgateConn, closeConn := getVTGateConn()
 	defer closeConn()
 
-	t11Count := getRowCount(t, vtgateConn, "t11")
-	t12Count := getRowCount(t, vtgateConn, "t12")
-	require.Greater(t, t11Count, 1)
-	require.Greater(t, t12Count, 1)
-	require.Equal(t, t11Count, t12Count)
+	if withLoad {
+		t11Count := getRowCount(t, vtgateConn, "t11")
+		t12Count := getRowCount(t, vtgateConn, "t12")
+		require.Greater(t, t11Count, 1)
+		require.Greater(t, t12Count, 1)
+		require.Equal(t, t11Count, t12Count)
+	}
+
 }
 
 func insertInitialFKData(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -201,11 +201,10 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		// Prepare a vcopierCopyTask for the current batch of work.
 		currCh := make(chan *vcopierCopyTaskResult, 1)
 
-		resp2 := resp
 		if parallelism > 1 {
-			resp2 = resp.CloneVT()
+			resp = resp.CloneVT()
 		}
-		currT := newVCopierCopyTask(newVCopierCopyTaskArgs(resp2.Rows, resp2.Lastpk))
+		currT := newVCopierCopyTask(newVCopierCopyTaskArgs(resp.Rows, resp.Lastpk))
 
 		// Send result to the global resultCh and currCh. resultCh is used by
 		// the loop to return results to VStreamRows. currCh will be used to

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -84,11 +84,7 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 	defer rowsCopiedTicker.Stop()
 
 	parallelism := int(math.Max(1, float64(vc.vr.workflowConfig.ParallelInsertWorkers)))
-	// For now do not support concurrent inserts for atomic copies.
-	if parallelism > 1 {
-		parallelism = 1
-		log.Infof("Disabling concurrent inserts for atomic copies")
-	}
+
 	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism)
 	var copyWorkQueue *vcopierCopyWorkQueue
 
@@ -115,7 +111,6 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 			resp.TableName, len(resp.Fields), len(resp.Rows), resp.Gtid, resp.Lastpk)
 		tableName := resp.TableName
 		gtid = resp.Gtid
-
 		updateRowsCopied := func() error {
 			updateRowsQuery := binlogplayer.GenerateUpdateRowsCopied(vc.vr.id, vc.vr.stats.CopyRowCount.Get())
 			_, err := vc.vr.dbClient.Execute(updateRowsQuery)
@@ -205,7 +200,12 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		log.Infof("copying table %s with lastpk %v", tableName, lastpkbv)
 		// Prepare a vcopierCopyTask for the current batch of work.
 		currCh := make(chan *vcopierCopyTaskResult, 1)
-		currT := newVCopierCopyTask(newVCopierCopyTaskArgs(resp.Rows, resp.Lastpk))
+
+		resp2 := resp
+		if parallelism > 1 {
+			resp2 = resp.CloneVT()
+		}
+		currT := newVCopierCopyTask(newVCopierCopyTaskArgs(resp2.Rows, resp2.Lastpk))
 
 		// Send result to the global resultCh and currCh. resultCh is used by
 		// the loop to return results to VStreamRows. currCh will be used to
@@ -292,11 +292,11 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		log.Infof("Copy of %v stopped", state.currentTableName)
 		return fmt.Errorf("CopyAll was interrupted due to context expiration")
 	default:
-		if err := vc.deleteCopyState(state.currentTableName); err != nil {
-			return err
-		}
 		if copyWorkQueue != nil {
 			copyWorkQueue.close()
+		}
+		if err := vc.deleteCopyState(state.currentTableName); err != nil {
+			return err
 		}
 		if err := vc.updatePos(ctx, gtid); err != nil {
 			return err


### PR DESCRIPTION
## Description

Setting `--vreplication-parallel-insert-workers` greater than 1, had not been tested earlier for atomic copies. When a user attempted to do it, it caused a panic in `vttablet`. There were two fixes needed here:

1. The response needed to be cloned before passing it to the concurrent workers. This had been done for regular workflows but was missed in the atomic copy case.
2. The copy state for the last table was deleted incorrectly before the queue was closed (and all concurrent workers had stopped inserting). 

In addition the `TestFKWorkflow` e2e test has been changed to test with concurrent inserts. 

## Related Issue(s)

Fixes #17716 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
