### PR TITLE
Multi-tenant workflow SwitchWrites: Don't add denied tables on cancelMigration()

### DIFF
--- a/go/vt/topotools/mirror_rules.go
+++ b/go/vt/topotools/mirror_rules.go
@@ -55,7 +55,7 @@ func GetMirrorRules(ctx context.Context, ts *topo.Server) (map[string]map[string
 // SaveMirrorRules converts a mapping of fromTable=>[]toTables into a
 // vschemapb.MirrorRules protobuf message and saves it in the topology.
 func SaveMirrorRules(ctx context.Context, ts *topo.Server, rules map[string]map[string]float32) error {
-	log.Infof("Saving mirror rules %v\n", rules)
+	log.V(2).Infof("Saving mirror rules %v\n", rules)
 
 	rrs := &vschemapb.MirrorRules{Rules: make([]*vschemapb.MirrorRule, 0)}
 	for fromTable, mrs := range rules {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2977,7 +2977,6 @@ func (s *Server) switchWrites(ctx context.Context, req *vtctldatapb.WorkflowSwit
 				time.Sleep(lockTablesCycleDelay)
 			}
 		}
-
 		// Get the source positions now that writes are stopped, the streams were stopped (e.g.
 		// intra-keyspace materializations that write on the source), and we know for certain
 		// that any in progress writes are done.

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1156,7 +1156,7 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 		// for forensics in case of failures.
 		ts.Logger().Infof("In Cancel migration: original context invalid: %s", ctx.Err())
 	}
-
+	log.Infof("cancelMigration (%v): starting", ts.WorkflowName())
 	// We create a new context while canceling the migration, so that we are independent of the original
 	// context being canceled prior to or during the cancel operation itself.
 	// First we create a copy of the parent context, so that we maintain the locks, but which cannot be
@@ -1168,20 +1168,29 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 	defer cmCancel()
 
 	if ts.MigrationType() == binlogdatapb.MigrationType_TABLES {
-		err = ts.switchDeniedTables(cmCtx, true /* revert */)
+		if !ts.IsMultiTenantMigration() {
+			log.Infof("cancelMigration (%v): switching denied tables to target", ts.WorkflowName())
+			err = ts.switchDeniedTables(cmCtx, true /* revert */)
+		} else {
+			log.Infof("cancelMigration (%v): multi-tenant, not switching denied tables to target", ts.WorkflowName())
+		}
 	} else {
+		log.Infof("cancelMigration (%v): allowing writes on source shards", ts.WorkflowName())
 		err = ts.changeShardsAccess(cmCtx, ts.SourceKeyspaceName(), ts.SourceShards(), allowWrites)
 	}
 	if err != nil {
+		log.Infof("Cancel migration failed for %v: could not revert denied tables / shard access: %v", ts.WorkflowName(), err)
 		cancelErrs.RecordError(fmt.Errorf("could not revert denied tables / shard access: %v", err))
 		ts.Logger().Errorf("Cancel migration failed: could not revert denied tables / shard access: %v", err)
 	}
 
 	if err := sm.CancelStreamMigrations(cmCtx); err != nil {
+		log.Infof("Cancel migration failed for %v: could not cancel stream migrations: %v", ts.WorkflowName(), err)
 		cancelErrs.RecordError(fmt.Errorf("could not cancel stream migrations: %v", err))
 		ts.Logger().Errorf("Cancel migration failed: could not cancel stream migrations: %v", err)
 	}
 
+	log.Infof("cancelMigration (%s): restarting vreplication workflows", ts.WorkflowName())
 	err = ts.ForAllTargets(func(target *MigrationTarget) error {
 		query := fmt.Sprintf("update _vt.vreplication set state='Running', message='' where db_name=%s and workflow=%s",
 			encodeString(target.GetPrimary().DbName()), encodeString(ts.WorkflowName()))
@@ -1189,18 +1198,24 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 		return err
 	})
 	if err != nil {
+		log.Infof("Cancel migration failed for %v: could not restart vreplication: %v", ts.WorkflowName(), err)
 		cancelErrs.RecordError(fmt.Errorf("could not restart vreplication: %v", err))
 		ts.Logger().Errorf("Cancel migration failed: could not restart vreplication: %v", err)
 	}
 
+	log.Infof("cancelMigration (%v): deleting reverse vreplication workflows", ts.WorkflowName())
 	if err := ts.deleteReverseVReplication(cmCtx); err != nil {
+		log.Infof("Cancel migration failed for %v: could not delete reverse vreplication streams: %v", ts.WorkflowName(), err)
 		cancelErrs.RecordError(fmt.Errorf("could not delete reverse vreplication streams: %v", err))
 		ts.Logger().Errorf("Cancel migration failed: could not delete reverse vreplication streams: %v", err)
 	}
 
 	if cancelErrs.HasErrors() {
+		log.Infof("Cancel migration failed for %v, manual cleanup work may be necessary: %v", ts.WorkflowName(), cancelErrs.AggrError(vterrors.Aggregate))
 		return vterrors.Wrap(cancelErrs.AggrError(vterrors.Aggregate), "cancel migration failed, manual cleanup work may be necessary")
 	}
+
+	log.Infof("cancelMigration (%v): completed", ts.WorkflowName())
 	return nil
 }
 

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1154,7 +1154,7 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 	if ctx.Err() != nil {
 		// Even though we create a new context later on we still record any context error:
 		// for forensics in case of failures.
-		ts.Logger().Infof("In Cancel migration: original context invalid: %s", ctx.Err())
+		ts.Logger().Infof("cancelMigration (%v): original context invalid: %s", ts.WorkflowName(), ctx.Err())
 	}
 	ts.Logger().Infof("cancelMigration (%v): starting", ts.WorkflowName())
 	// We create a new context while canceling the migration, so that we are independent of the original
@@ -1169,10 +1169,10 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 
 	if ts.MigrationType() == binlogdatapb.MigrationType_TABLES {
 		if !ts.IsMultiTenantMigration() {
-			ts.Logger().Infof("cancelMigration (%v): switching denied tables to target", ts.WorkflowName())
+			ts.Logger().Infof("cancelMigration (%v): adding denied tables to target", ts.WorkflowName())
 			err = ts.switchDeniedTables(cmCtx, true /* revert */)
 		} else {
-			ts.Logger().Infof("cancelMigration (%v): multi-tenant, not switching denied tables to target", ts.WorkflowName())
+			ts.Logger().Infof("cancelMigration (%v): multi-tenant, not adding denied tables to target", ts.WorkflowName())
 		}
 	} else {
 		ts.Logger().Infof("cancelMigration (%v): allowing writes on source shards", ts.WorkflowName())
@@ -1180,15 +1180,15 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 	}
 	if err != nil {
 		cancelErrs.RecordError(fmt.Errorf("could not revert denied tables / shard access: %v", err))
-		ts.Logger().Errorf("Cancel migration failed: could not revert denied tables / shard access: %v", err)
+		ts.Logger().Errorf("Cancel migration failed (%v): could not revert denied tables / shard access: %v", ts.WorkflowName(), err)
 	}
 
 	if err := sm.CancelStreamMigrations(cmCtx); err != nil {
 		cancelErrs.RecordError(fmt.Errorf("could not cancel stream migrations: %v", err))
-		ts.Logger().Errorf("Cancel migration failed: could not cancel stream migrations: %v", err)
+		ts.Logger().Errorf("Cancel migration failed (%v): could not cancel stream migrations: %v", ts.WorkflowName(), err)
 	}
 
-	ts.Logger().Infof("cancelMigration (%s): restarting vreplication workflows", ts.WorkflowName())
+	ts.Logger().Infof("cancelMigration (%v): restarting vreplication workflows", ts.WorkflowName())
 	err = ts.ForAllTargets(func(target *MigrationTarget) error {
 		query := fmt.Sprintf("update _vt.vreplication set state='Running', message='' where db_name=%s and workflow=%s",
 			encodeString(target.GetPrimary().DbName()), encodeString(ts.WorkflowName()))
@@ -1197,13 +1197,13 @@ func (ts *trafficSwitcher) cancelMigration(ctx context.Context, sm *StreamMigrat
 	})
 	if err != nil {
 		cancelErrs.RecordError(fmt.Errorf("could not restart vreplication: %v", err))
-		ts.Logger().Errorf("Cancel migration failed: could not restart vreplication: %v", err)
+		ts.Logger().Errorf("Cancel migration failed (%v): could not restart vreplication: %v", ts.WorkflowName(), err)
 	}
 
 	ts.Logger().Infof("cancelMigration (%v): deleting reverse vreplication workflows", ts.WorkflowName())
 	if err := ts.deleteReverseVReplication(cmCtx); err != nil {
 		cancelErrs.RecordError(fmt.Errorf("could not delete reverse vreplication streams: %v", err))
-		ts.Logger().Errorf("Cancel migration failed: could not delete reverse vreplication streams: %v", err)
+		ts.Logger().Errorf("Cancel migration failed (%v): could not delete reverse vreplication streams: %v", ts.WorkflowName(), err)
 	}
 
 	if cancelErrs.HasErrors() {

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -115,7 +115,6 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 	}
 	blpStats.WorkflowConfig = workflowConfig.String()
 	ct.sourceTablet.Store(&topodatapb.TabletAlias{})
-	log.Infof("creating controller with cell: %v, tabletTypes: %v, and params: %v", cell, tabletTypesStr, params)
 
 	id, err := strconv.ParseInt(params["id"], 10, 32)
 	if err != nil {
@@ -123,6 +122,8 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 	}
 	ct.id = int32(id)
 	ct.workflow = params["workflow"]
+	log.Infof("creating controller with id: %v, name: %v, cell: %v, tabletTypes: %v", ct.id, ct.workflow, cell, tabletTypesStr)
+
 	ct.lastWorkflowError = vterrors.NewLastError(fmt.Sprintf("VReplication controller %d for workflow %q", ct.id, ct.workflow), workflowConfig.MaxTimeToRetryError)
 
 	state := params["state"]

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -125,7 +125,8 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 		settings.StopPos = pausePos
 		saveStop = false
 	}
-	log.Infof("Starting VReplication player id: %v, startPos: %v, stop: %v, filter: %+v",
+	log.Infof("Starting VReplication player id: %v, name: %v, startPos: %v, stop: %v", vr.id, vr.WorkflowName, settings.StartPos, settings.StopPos)
+	log.V(2).Infof("Starting VReplication player id: %v, startPos: %v, stop: %v, filter: %+v",
 		vr.id, settings.StartPos, settings.StopPos, vr.source.Filter)
 	queryFunc := func(ctx context.Context, sql string) (*sqltypes.Result, error) {
 		return vr.dbClient.ExecuteWithRetry(ctx, sql)
@@ -266,7 +267,7 @@ func (vp *vplayer) updateFKCheck(ctx context.Context, flags2 uint32) error {
 // one. This allows for the apply thread to catch up more quickly if
 // a backlog builds up.
 func (vp *vplayer) fetchAndApply(ctx context.Context) (err error) {
-	log.Infof("Starting VReplication player id: %v, startPos: %v, stop: %v, filter: %v", vp.vr.id, vp.startPos, vp.stopPos, vp.vr.source)
+	log.Infof("Starting VReplication player id: %v, name: %v, startPos: %v, stop: %v", vp.vr.id, vp.vr.WorkflowName, vp.startPos, vp.stopPos)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
## Description

Currently when a multi-tenant SwitchWrites times out and `cancelMigration()` is called, we also add denied tables to the target keyspace's shard control. This is clearly incorrect behaviour since other tenants could be already migrated and live on the target keyspace.

This PR:

* changes this behaviour and no longer adds the denied tables to the target
* adds a lot of logs in cancelMigration(). Currently the logs are sent to the caller and not in the normal `vtctld` logs
* reduces the verbosity of logs where the entire binlogsource filter was being printed making the logs very noisy

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17794

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
