### PR TITLE
Simply changing GH Actions runner

### DIFF
--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -172,7 +172,7 @@ type clusterTest struct {
 	Name, Shard, Platform              string
 	FileName                           string
 	BuildTag                           string
-	Cores16RunnerName                  string
+	RunnerName                         string
 	MemoryCheck                        bool
 	MakeTools, InstallXtraBackup       bool
 	Docker                             bool
@@ -180,7 +180,6 @@ type clusterTest struct {
 	EnableBinlogTransactionCompression bool
 	EnablePartialJSON                  bool
 	PartialKeyspace                    bool
-	Cores16                            bool
 	NeedsMinio                         bool
 }
 
@@ -269,8 +268,7 @@ func generateClusterWorkflows(list []string, tpl string) {
 			cores16Clusters := canonnizeList(clusterRequiring16CoresMachines)
 			for _, cores16Cluster := range cores16Clusters {
 				if cores16Cluster == cluster {
-					test.Cores16 = true
-					test.Cores16RunnerName = cores16RunnerName
+					test.RunnerName = cores16RunnerName
 					break
 				}
 			}

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -166,7 +166,7 @@ var (
 )
 
 type unitTest struct {
-	Name, Platform, FileName, Evalengine string
+	Name, RunsOn, Platform, FileName, Evalengine string
 }
 
 type clusterTest struct {
@@ -187,6 +187,7 @@ type clusterTest struct {
 type vitessTesterTest struct {
 	FileName string
 	Name     string
+	RunsOn   string
 	Path     string
 }
 
@@ -243,8 +244,9 @@ func canonnizeList(list []string) []string {
 func generateVitessTesterWorkflows(mp map[string]string, tpl string) {
 	for test, testPath := range mp {
 		tt := &vitessTesterTest{
-			Name: fmt.Sprintf("Vitess Tester (%v)", test),
-			Path: testPath,
+			Name:   fmt.Sprintf("Vitess Tester (%v)", test),
+			RunsOn: defaultRunnerName,
+			Path:   testPath,
 		}
 
 		templateFileName := tpl
@@ -342,6 +344,7 @@ func generateUnitTestWorkflows() {
 		for _, evalengine := range []string{"1", "0"} {
 			test := &unitTest{
 				Name:       fmt.Sprintf("Unit Test (%s%s)", evalengineToString(evalengine), platform),
+				RunsOn:     defaultRunnerName,
 				Platform:   string(platform),
 				Evalengine: evalengine,
 			}

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -34,6 +34,7 @@ const (
 	mysql84 mysqlVersion = "mysql84"
 
 	cores16RunnerName   = "gh-hosted-runners-16cores-1-24.04"
+	defaultRunnerName   = "ubuntu-24.04"
 	defaultMySQLVersion = mysql80
 )
 
@@ -264,6 +265,7 @@ func generateClusterWorkflows(list []string, tpl string) {
 				Name:     fmt.Sprintf("Cluster (%s)", cluster),
 				Shard:    cluster,
 				BuildTag: buildTag[cluster],
+				RunsOn:   defaultRunnerName,
 			}
 			cores16Clusters := canonnizeList(clusterRequiring16CoresMachines)
 			for _, cores16Cluster := range cores16Clusters {

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -33,6 +33,7 @@ const (
 	mysql80 mysqlVersion = "mysql80"
 	mysql84 mysqlVersion = "mysql84"
 
+	cores16RunnerName   = "gh-hosted-runners-16cores-1-24.04"
 	defaultMySQLVersion = mysql80
 )
 
@@ -171,6 +172,7 @@ type clusterTest struct {
 	Name, Shard, Platform              string
 	FileName                           string
 	BuildTag                           string
+	Cores16RunnerName                  string
 	MemoryCheck                        bool
 	MakeTools, InstallXtraBackup       bool
 	Docker                             bool
@@ -268,6 +270,7 @@ func generateClusterWorkflows(list []string, tpl string) {
 			for _, cores16Cluster := range cores16Clusters {
 				if cores16Cluster == cluster {
 					test.Cores16 = true
+					test.Cores16RunnerName = cores16RunnerName
 					break
 				}
 			}

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -172,7 +172,7 @@ type clusterTest struct {
 	Name, Shard, Platform              string
 	FileName                           string
 	BuildTag                           string
-	RunnerName                         string
+	RunsOn                             string
 	MemoryCheck                        bool
 	MakeTools, InstallXtraBackup       bool
 	Docker                             bool
@@ -268,7 +268,7 @@ func generateClusterWorkflows(list []string, tpl string) {
 			cores16Clusters := canonnizeList(clusterRequiring16CoresMachines)
 			for _, cores16Cluster := range cores16Clusters {
 				if cores16Cluster == cluster {
-					test.RunnerName = cores16RunnerName
+					test.RunsOn = cores16RunnerName
 					break
 				}
 			}

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,7 +15,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunnerName}}{{ .RunnerName }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunsOn}}{{ .RunsOn }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,7 +15,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}{{ .Cores16RunnerName }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunnerName}}{{ .RunnerName }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,7 +15,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1-24.04{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .Cores16}}{{ .Cores16RunnerName }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,7 +15,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunsOn}}{{ .RunsOn }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunsOn}}{{.RunsOn}}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,7 +15,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunsOn}}{{.RunsOn}}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{.RunsOn}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunnerName}}{{ .RunnerName }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunsOn}}{{ .RunsOn }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunsOn}}{{ .RunsOn }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunsOn}}{{.RunsOn}}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunsOn}}{{.RunsOn}}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{.RunsOn}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1-24.04{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .Cores16}}{{ .Cores16RunnerName }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}{{ .Cores16RunnerName }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunnerName}}{{ .RunnerName }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunnerName}}{{ .RunnerName }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunsOn}}{{ .RunsOn }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunsOn}}{{.RunsOn}}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{.RunsOn}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}{{ .Cores16RunnerName }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunnerName}}{{ .RunnerName }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .RunsOn}}{{ .RunsOn }}{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .RunsOn}}{{.RunsOn}}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: {{if .Cores16}}gh-hosted-runners-16cores-1-24.04{{else}}ubuntu-24.04{{end}}
+    runs-on: {{if .Cores16}}{{ .Cores16RunnerName }}{{else}}ubuntu-24.04{{end}}
 
     steps:
     - name: Skip CI

--- a/test/templates/cluster_vitess_tester.tpl
+++ b/test/templates/cluster_vitess_tester.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-24.04
+    runs-on: {{.RunsOn}}
 
     steps:
     - name: Skip CI

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: {{.Name}}
-    runs-on: ubuntu-24.04
+    runs-on: {{.RunsOn}}
 
     steps:
     - name: Skip CI


### PR DESCRIPTION
## Description

This small tweak to `test/ci_workflow_gen.go` makes it more straightforward for forks of `vitessio/vitess` to modify the GitHub Actions runner used for heavier CI jobs _(modify the `const cores16RunnerName`)_

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
