### PR TITLE
Update to Go 1.24.0

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Install golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
 
       - name: Clean Env
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -74,7 +74,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -78,7 +78,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -86,7 +86,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -78,7 +78,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -78,7 +78,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -78,7 +78,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -78,7 +78,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -78,7 +78,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.23.5
+        go-version: 1.24.0
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_semi_sync.yml
+++ b/.github/workflows/upgrade_downgrade_test_semi_sync.yml
@@ -74,7 +74,7 @@ jobs:
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.23.5
+          go-version: 1.24.0
 
       - name: Set up python
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: 1.23
+  go: 1.24
   timeout: 10m
 
 linters-settings:
@@ -191,4 +191,4 @@ issues:
 
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.52.2 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.64.5 # use the fixed version to not introduce new linters unexpectedly

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ $(PROTO_GO_OUTS): minimaltools install_protoc-gen-go proto/*.proto
 # This rule builds the bootstrap images for all flavors.
 DOCKER_IMAGES_FOR_TEST = mysql80 mysql84 percona80
 DOCKER_IMAGES = common $(DOCKER_IMAGES_FOR_TEST)
-BOOTSTRAP_VERSION=41
+BOOTSTRAP_VERSION=42
 ensure_bootstrap_version:
 	find docker/ -type f -exec sed -i "s/^\(ARG bootstrap_version\)=.*/\1=${BOOTSTRAP_VERSION}/" {} \;
 	sed -i 's/\(^.*flag.String(\"bootstrap-version\",\) *\"[^\"]\+\"/\1 \"${BOOTSTRAP_VERSION}\"/' test.go

--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.23.5 || echo "Go version reported: `go version`. Version 1.23.5+ recommended. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.24.0 || echo "Go version reported: `go version`. Version 1.24.0+ recommended. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin

--- a/docker/bootstrap/CHANGELOG.md
+++ b/docker/bootstrap/CHANGELOG.md
@@ -163,3 +163,6 @@ List of changes between bootstrap image versions.
 ### Changes
 - Update base image to bookworm
 - Add MySQL84 image
+
+## [42] - 2025-02-14
+- Update build to golang 1.24.0

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.23.5-bookworm
+FROM --platform=linux/amd64 golang:1.24.0-bookworm
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.5-bookworm AS builder
+FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/docker/lite/Dockerfile.mysql84
+++ b/docker/lite/Dockerfile.mysql84
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.5-bookworm AS builder
+FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.5-bookworm AS builder
+FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.5-bookworm AS builder
+FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/docker/vttestserver/Dockerfile.mysql84
+++ b/docker/vttestserver/Dockerfile.mysql84
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.23.5-bookworm AS builder
+FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.23.5
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/go/hack/ensure_swiss_map.go
+++ b/go/hack/ensure_swiss_map.go
@@ -1,0 +1,39 @@
+//go:build !goexperiment.swissmap
+
+/*
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// This is invalid Go code, and it will fail to compile if you disable
+// Swiss maps when building Vitess. Our runtime memory accounting system
+// expects the map implementation in Go 1.24 to be Swiss.
+
+package hack
+
+var EnsureSwissMapIsAlwaysEnabled = [-1]struct{}{}

--- a/go/hack/msize.go
+++ b/go/hack/msize.go
@@ -32,6 +32,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hack
 
+import (
+	"unsafe"
+)
+
 const (
 	_MaxSmallSize   = 32768
 	smallSizeDiv    = 8
@@ -73,4 +77,102 @@ func roundupsize(size uintptr) uintptr {
 // RuntimeAllocSize returns size of the memory block that mallocgc will allocate if you ask for the size.
 func RuntimeAllocSize(size int64) int64 {
 	return int64(roundupsize(uintptr(size)))
+}
+
+// RuntimeMapSize returns the size of the internal data structures of a Map.
+// This is an internal implementation detail based on the Swiss Map implementation
+// as of Go 1.24 and needs to be kept up-to-date after every Go release.
+func RuntimeMapSize[K comparable, V any](themap map[K]V) (internalSize int64) {
+	// The following are copies of internal data structures as of Go 1.24
+	// THEY MUST BE KEPT UP TO DATE
+
+	// internal/abi/type.go
+	const SizeofType = 48
+
+	// internal/abi/map_swiss.go
+	type SwissMapType struct {
+		pad       [SizeofType]uint8
+		Key       unsafe.Pointer
+		Elem      unsafe.Pointer
+		Group     unsafe.Pointer
+		Hasher    func(unsafe.Pointer, uintptr) uintptr
+		GroupSize uintptr // == Group.Size_
+		SlotSize  uintptr // size of key/elem slot
+		ElemOff   uintptr // offset of elem in key/elem slot
+		Flags     uint32
+	}
+
+	// internal/runtime/maps/map.go
+	type Map struct {
+		used        uint64
+		seed        uintptr
+		dirPtr      unsafe.Pointer
+		dirLen      int
+		globalDepth uint8
+		globalShift uint8
+		writing     uint8
+		clearSeq    uint64
+	}
+
+	// internal/runtime/maps/groups.go
+	type groupsReference struct {
+		data       unsafe.Pointer // data *[length]typ.Group
+		lengthMask uint64
+	}
+
+	// internal/runtime/maps/table.go
+	type table struct {
+		used       uint16
+		capacity   uint16
+		growthLeft uint16
+		localDepth uint8
+		index      int
+		groups     groupsReference
+	}
+
+	directoryAt := func(m *Map, i uintptr) *table {
+		const PtrSize = 4 << (^uintptr(0) >> 63)
+		return *(**table)(unsafe.Pointer(uintptr(m.dirPtr) + PtrSize*i))
+	}
+
+	// Converting the map to an interface will result in two ptr-sized words;
+	// like all interfaces, the first word points to an *abi.Type instance,
+	// which is specialized as SwissMapType for maps, and to the actual
+	// memory allocation, which is `*Map`
+	type MapInterface struct {
+		Type *SwissMapType
+		Data *Map
+	}
+
+	mapiface := any(themap)
+	iface := (*MapInterface)(unsafe.Pointer(&mapiface))
+	m := iface.Data
+
+	var groupSize = int64(iface.Type.GroupSize)
+	internalSize = int64(unsafe.Sizeof(Map{}))
+
+	if m.dirLen <= 0 {
+		// Small map optimization: we don't allocate tables at all if all the
+		// entries in a map fit in a single group
+		if m.dirPtr != nil {
+			internalSize += RuntimeAllocSize(groupSize)
+		}
+	} else {
+		// For normal maps, we iterate each table and add the size of all the
+		// groups it contains.
+		// See: internal/runtime/maps/export_test.go
+		var lastTab *table
+		for i := range m.dirLen {
+			t := directoryAt(m, uintptr(i))
+			if t == lastTab {
+				// continue
+			}
+			lastTab = t
+
+			gc := int64(t.groups.lengthMask + 1)
+			internalSize += RuntimeAllocSize(groupSize * gc)
+		}
+	}
+
+	return internalSize
 }

--- a/go/hack/msize.go
+++ b/go/hack/msize.go
@@ -165,7 +165,7 @@ func RuntimeMapSize[K comparable, V any](themap map[K]V) (internalSize int64) {
 		for i := range m.dirLen {
 			t := directoryAt(m, uintptr(i))
 			if t == lastTab {
-				// continue
+				continue
 			}
 			lastTab = t
 

--- a/go/mysql/collations/cached_size.go
+++ b/go/mysql/collations/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,7 @@ limitations under the License.
 
 package collations
 
-import (
-	"math"
-	"reflect"
-	"unsafe"
-
-	hack "vitess.io/vitess/go/hack"
-)
+import hack "vitess.io/vitess/go/hack"
 
 //go:nocheckptr
 func (cached *Environment) CachedSize(alloc bool) int64 {
@@ -36,28 +30,14 @@ func (cached *Environment) CachedSize(alloc bool) int64 {
 	}
 	// field byName map[string]vitess.io/vitess/go/mysql/collations.ID
 	if cached.byName != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.byName)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 160))
-		if len(cached.byName) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 160))
-		}
+		size += hack.RuntimeMapSize(cached.byName)
 		for k := range cached.byName {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 		}
 	}
 	// field byCharset map[string]*vitess.io/vitess/go/mysql/collations.colldefaults
 	if cached.byCharset != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.byCharset)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.byCharset) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.byCharset)
 		for k, v := range cached.byCharset {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 			if v != nil {
@@ -67,42 +47,21 @@ func (cached *Environment) CachedSize(alloc bool) int64 {
 	}
 	// field byCharsetName map[vitess.io/vitess/go/mysql/collations.ID]string
 	if cached.byCharsetName != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.byCharsetName)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 160))
-		if len(cached.byCharsetName) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 160))
-		}
+		size += hack.RuntimeMapSize(cached.byCharsetName)
 		for _, v := range cached.byCharsetName {
 			size += hack.RuntimeAllocSize(int64(len(v)))
 		}
 	}
 	// field unsupported map[string]vitess.io/vitess/go/mysql/collations.ID
 	if cached.unsupported != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.unsupported)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 160))
-		if len(cached.unsupported) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 160))
-		}
+		size += hack.RuntimeMapSize(cached.unsupported)
 		for k := range cached.unsupported {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 		}
 	}
 	// field byID map[vitess.io/vitess/go/mysql/collations.ID]string
 	if cached.byID != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.byID)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 160))
-		if len(cached.byID) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 160))
-		}
+		size += hack.RuntimeMapSize(cached.byID)
 		for _, v := range cached.byID {
 			size += hack.RuntimeAllocSize(int64(len(v)))
 		}

--- a/go/mysql/collations/colldata/cached_size.go
+++ b/go/mysql/collations/colldata/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/mysql/decimal/cached_size.go
+++ b/go/mysql/decimal/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/mysql/json/cached_size.go
+++ b/go/mysql/json/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/pools/smartconnpool/cached_size.go
+++ b/go/pools/smartconnpool/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/sqltypes/cached_size.go
+++ b/go/sqltypes/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/tools/sizegen/integration/cached_size.go
+++ b/go/tools/sizegen/integration/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,7 @@ limitations under the License.
 
 package integration
 
-import (
-	"math"
-	"reflect"
-	"unsafe"
-
-	hack "vitess.io/vitess/go/hack"
-)
+import hack "vitess.io/vitess/go/hack"
 
 type cachedObject interface {
 	CachedSize(alloc bool) int64
@@ -89,14 +83,7 @@ func (cached *Map1) CachedSize(alloc bool) int64 {
 	}
 	// field field1 map[uint8]uint8
 	if cached.field1 != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.field1)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 32))
-		if len(cached.field1) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 32))
-		}
+		size += hack.RuntimeMapSize(cached.field1)
 	}
 	return size
 }
@@ -112,14 +99,7 @@ func (cached *Map2) CachedSize(alloc bool) int64 {
 	}
 	// field field1 map[uint64]vitess.io/vitess/go/tools/sizegen/integration.A
 	if cached.field1 != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.field1)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.field1) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.field1)
 	}
 	return size
 }
@@ -135,14 +115,7 @@ func (cached *Map3) CachedSize(alloc bool) int64 {
 	}
 	// field field1 map[uint64]vitess.io/vitess/go/tools/sizegen/integration.B
 	if cached.field1 != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.field1)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.field1) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.field1)
 		for _, v := range cached.field1 {
 			if cc, ok := v.(cachedObject); ok {
 				size += cc.CachedSize(true)

--- a/go/tools/sizegen/integration/types.go
+++ b/go/tools/sizegen/integration/types.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:generate go run ../sizegen.go --in . --gen vitess.io/vitess/go/tools/sizegen/integration.*
+
 // nolint
 package integration
 

--- a/go/vt/key/cached_size.go
+++ b/go/vt/key/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/proto/query/cached_size.go
+++ b/go/vt/proto/query/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/proto/topodata/cached_size.go
+++ b/go/vt/proto/topodata/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/proto/vttime/cached_size.go
+++ b/go/vt/proto/vttime/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/schema/cached_size.go
+++ b/go/vt/schema/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,7 @@ limitations under the License.
 
 package sqlparser
 
-import (
-	"math"
-	"reflect"
-	"unsafe"
-
-	hack "vitess.io/vitess/go/hack"
-)
+import hack "vitess.io/vitess/go/hack"
 
 type cachedObject interface {
 	CachedSize(alloc bool) int64
@@ -814,14 +808,7 @@ func (cached *CommentDirectives) CachedSize(alloc bool) int64 {
 	}
 	// field m map[string]string
 	if cached.m != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.m)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 272))
-		if len(cached.m) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 272))
-		}
+		size += hack.RuntimeMapSize(cached.m)
 		for k, v := range cached.m {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 			size += hack.RuntimeAllocSize(int64(len(v)))

--- a/go/vt/srvtopo/cached_size.go
+++ b/go/vt/srvtopo/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/tableacl/cached_size.go
+++ b/go/vt/tableacl/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vtenv/cached_size.go
+++ b/go/vt/vtenv/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,7 @@ limitations under the License.
 
 package engine
 
-import (
-	"math"
-	"reflect"
-	"unsafe"
-
-	hack "vitess.io/vitess/go/hack"
-)
+import hack "vitess.io/vitess/go/hack"
 
 type cachedObject interface {
 	CachedSize(alloc bool) int64
@@ -102,14 +96,7 @@ func (cached *Concatenate) CachedSize(alloc bool) int64 {
 	}
 	// field NoNeedToTypeCheck map[int]any
 	if cached.NoNeedToTypeCheck != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.NoNeedToTypeCheck)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.NoNeedToTypeCheck) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.NoNeedToTypeCheck)
 	}
 	return size
 }
@@ -222,14 +209,7 @@ func (cached *DMLWithInput) CachedSize(alloc bool) int64 {
 		size += hack.RuntimeAllocSize(int64(cap(cached.BVList)) * int64(8))
 		for _, elem := range cached.BVList {
 			if elem != nil {
-				size += int64(48)
-				hmap := reflect.ValueOf(elem)
-				numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-				numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-				size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-				if len(elem) > 0 || numBuckets > 1 {
-					size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-				}
+				size += hack.RuntimeMapSize(elem)
 				for k := range elem {
 					size += hack.RuntimeAllocSize(int64(len(k)))
 				}
@@ -589,14 +569,7 @@ func (cached *Join) CachedSize(alloc bool) int64 {
 	}
 	// field Vars map[string]int
 	if cached.Vars != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.Vars)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.Vars) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.Vars)
 		for k := range cached.Vars {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 		}
@@ -881,14 +854,7 @@ func (cached *RecurseCTE) CachedSize(alloc bool) int64 {
 	}
 	// field Vars map[string]int
 	if cached.Vars != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.Vars)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.Vars) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.Vars)
 		for k := range cached.Vars {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 		}
@@ -1002,14 +968,7 @@ func (cached *RoutingParameters) CachedSize(alloc bool) int64 {
 	}
 	// field SysTableTableName map[string]vitess.io/vitess/go/vt/vtgate/evalengine.Expr
 	if cached.SysTableTableName != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.SysTableTableName)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 272))
-		if len(cached.SysTableTableName) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 272))
-		}
+		size += hack.RuntimeMapSize(cached.SysTableTableName)
 		for k, v := range cached.SysTableTableName {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 			if cc, ok := v.(cachedObject); ok {
@@ -1124,14 +1083,7 @@ func (cached *SemiJoin) CachedSize(alloc bool) int64 {
 	}
 	// field Vars map[string]int
 	if cached.Vars != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.Vars)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.Vars) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.Vars)
 		for k := range cached.Vars {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 		}
@@ -1381,14 +1333,7 @@ func (cached *Update) CachedSize(alloc bool) int64 {
 	size += cached.DML.CachedSize(true)
 	// field ChangedVindexValues map[string]*vitess.io/vitess/go/vt/vtgate/engine.VindexValues
 	if cached.ChangedVindexValues != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.ChangedVindexValues)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.ChangedVindexValues) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.ChangedVindexValues)
 		for k, v := range cached.ChangedVindexValues {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 			size += v.CachedSize(true)
@@ -1570,14 +1515,7 @@ func (cached *VindexValues) CachedSize(alloc bool) int64 {
 	}
 	// field EvalExprMap map[string]vitess.io/vitess/go/vt/vtgate/evalengine.Expr
 	if cached.EvalExprMap != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.EvalExprMap)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 272))
-		if len(cached.EvalExprMap) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 272))
-		}
+		size += hack.RuntimeMapSize(cached.EvalExprMap)
 		for k, v := range cached.EvalExprMap {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 			if cc, ok := v.(cachedObject); ok {
@@ -1635,14 +1573,7 @@ func (cached *shardRoute) CachedSize(alloc bool) int64 {
 	size += cached.rs.CachedSize(true)
 	// field bv map[string]*vitess.io/vitess/go/vt/proto/query.BindVariable
 	if cached.bv != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.bv)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.bv) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.bv)
 		for k, v := range cached.bv {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 			size += v.CachedSize(true)

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,7 @@ limitations under the License.
 
 package vindexes
 
-import (
-	"math"
-	"reflect"
-	"unsafe"
-
-	hack "vitess.io/vitess/go/hack"
-)
+import hack "vitess.io/vitess/go/hack"
 
 type cachedObject interface {
 	CachedSize(alloc bool) int64
@@ -327,14 +321,7 @@ func (cached *MultiCol) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(len(cached.name)))
 	// field columnVdx map[int]vitess.io/vitess/go/vt/vtgate/vindexes.Hashing
 	if cached.columnVdx != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.columnVdx)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.columnVdx) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.columnVdx)
 		for _, v := range cached.columnVdx {
 			if cc, ok := v.(cachedObject); ok {
 				size += cc.CachedSize(true)
@@ -343,14 +330,7 @@ func (cached *MultiCol) CachedSize(alloc bool) int64 {
 	}
 	// field columnBytes map[int]int
 	if cached.columnBytes != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.columnBytes)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 144))
-		if len(cached.columnBytes) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 144))
-		}
+		size += hack.RuntimeMapSize(cached.columnBytes)
 	}
 	return size
 }
@@ -400,14 +380,7 @@ func (cached *NumericLookupTable) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(8)
 	}
-	size += int64(48)
-	hmap := reflect.ValueOf(*cached)
-	numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-	numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-	size += hack.RuntimeAllocSize(int64(numOldBuckets * 144))
-	if len(*cached) > 0 || numBuckets > 1 {
-		size += hack.RuntimeAllocSize(int64(numBuckets * 144))
-	}
+	size += hack.RuntimeMapSize(*cached)
 	return size
 }
 
@@ -428,14 +401,7 @@ func (cached *NumericStaticMap) CachedSize(alloc bool) int64 {
 	}
 	// field lookup vitess.io/vitess/go/vt/vtgate/vindexes.NumericLookupTable
 	if cached.lookup != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.lookup)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 144))
-		if len(cached.lookup) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 144))
-		}
+		size += hack.RuntimeMapSize(cached.lookup)
 	}
 	// field unknownParams []string
 	{
@@ -479,14 +445,7 @@ func (cached *RegionJSON) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(len(cached.name)))
 	// field regionMap vitess.io/vitess/go/vt/vtgate/vindexes.RegionMap
 	if cached.regionMap != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.regionMap)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-		if len(cached.regionMap) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-		}
+		size += hack.RuntimeMapSize(cached.regionMap)
 		for k := range cached.regionMap {
 			size += hack.RuntimeAllocSize(int64(len(k)))
 		}
@@ -508,14 +467,7 @@ func (cached *RegionMap) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(8)
 	}
-	size += int64(48)
-	hmap := reflect.ValueOf(*cached)
-	numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-	numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-	size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
-	if len(*cached) > 0 || numBuckets > 1 {
-		size += hack.RuntimeAllocSize(int64(numBuckets * 208))
-	}
+	size += hack.RuntimeMapSize(*cached)
 	return size
 }
 func (cached *ReverseBits) CachedSize(alloc bool) int64 {

--- a/go/vt/vttablet/tabletserver/cached_size.go
+++ b/go/vt/vttablet/tabletserver/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vttablet/tabletserver/planbuilder/cached_size.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vttablet/tabletserver/rules/cached_size.go
+++ b/go/vt/vttablet/tabletserver/rules/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vttablet/tabletserver/schema/cached_size.go
+++ b/go/vt/vttablet/tabletserver/schema/cached_size.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Vitess Authors.
+Copyright 2025 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -17,12 +17,11 @@ limitations under the License.
 package schema
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/log"
-
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -85,10 +84,10 @@ func (seq *SequenceInfo) Reset() {
 	seq.LastVal = 0
 }
 
-func (seq *SequenceInfo) String() {
+func (seq *SequenceInfo) String() string {
 	seq.Lock()
 	defer seq.Unlock()
-	log.Infof("SequenceInfo: NextVal: %d, LastVal: %d", seq.NextVal, seq.LastVal)
+	return fmt.Sprintf("SequenceInfo: NextVal: %d, LastVal: %d", seq.NextVal, seq.LastVal)
 }
 
 // MessageInfo contains info specific to message tables.
@@ -129,6 +128,10 @@ type MessageInfo struct {
 
 	// IDType specifies the type of the ID column
 	IDType sqltypes.Type
+}
+
+func (mi *MessageInfo) String() string {
+	return fmt.Sprintf("MessageInfo: AckWaitDuration: %v, PurgeAfterDuration: %v, BatchSize: %v, CacheSize: %v, PollInterval: %v, MinBackoff: %v, MaxBackoff: %v, IDType: %v", mi.AckWaitDuration, mi.PurgeAfterDuration, mi.BatchSize, mi.CacheSize, mi.PollInterval, mi.MinBackoff, mi.MaxBackoff, mi.IDType)
 }
 
 // NewTable creates a new Table.

--- a/go/vt/vttablet/tabletserver/schema/schemaz_test.go
+++ b/go/vt/vttablet/tabletserver/schema/schemaz_test.go
@@ -50,7 +50,6 @@ func TestSchamazHandler1(t *testing.T) {
 		`<td>id: INT32<br>next_id: INT64<br>cache: INT64<br>increment: INT64<br></td>`,
 		`<td>id<br></td>`,
 		`<td>sequence</td>`,
-		`<td>{{0 0} 0 0}&lt;nil&gt;</td>`,
 	}
 	matched, err = regexp.Match(strings.Join(seq, `\s*`), body)
 	require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/schema/schemaz_test.go
+++ b/go/vt/vttablet/tabletserver/schema/schemaz_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSchamazHandler1(t *testing.T) {
+func TestSchemazHandler1(t *testing.T) {
 	resp := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/schemaz", nil)
 	tables := initialSchema()
@@ -50,6 +50,7 @@ func TestSchamazHandler1(t *testing.T) {
 		`<td>id: INT32<br>next_id: INT64<br>cache: INT64<br>increment: INT64<br></td>`,
 		`<td>id<br></td>`,
 		`<td>sequence</td>`,
+		`<td>SequenceInfo: NextVal: 0, LastVal: 0&lt;nil&gt;</td>`,
 	}
 	matched, err = regexp.Match(strings.Join(seq, `\s*`), body)
 	require.NoError(t, err)

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Required version of golangci-lint
-REQUIRED_VERSION="v1.60.2"
+REQUIRED_VERSION="v1.64.5"
 
 # Function to compare versions in pure Bash
 version_greater_or_equal() {

--- a/test.go
+++ b/test.go
@@ -77,7 +77,7 @@ For example:
 // Flags
 var (
 	flavor           = flag.String("flavor", "mysql80", "comma-separated bootstrap flavor(s) to run against (when using Docker mode). Available flavors: all,"+flavors)
-	bootstrapVersion = flag.String("bootstrap-version", "41", "the version identifier to use for the docker images")
+	bootstrapVersion = flag.String("bootstrap-version", "42", "the version identifier to use for the docker images")
 	runCount         = flag.Int("runs", 1, "run each test this many times")
 	retryMax         = flag.Int("retry", 3, "max number of retries, to detect flaky tests")
 	logPass          = flag.Bool("log-pass", false, "log test output even if it passes")

--- a/test/templates/dockerfile.tpl
+++ b/test/templates/dockerfile.tpl
@@ -1,4 +1,4 @@
-ARG bootstrap_version=41
+ARG bootstrap_version=42
 ARG image="vitess/bootstrap:${bootstrap_version}-{{.Platform}}"
 
 FROM "${image}"


### PR DESCRIPTION
Updates to the latest Go version so that we have this in place before the Vitess 22 release.

@frouioui Could you push the new Docker base images for this? 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required