### PR TITLE
Upgrade golangci-lint to v1.64.5 for Go 1.24.0 Compatibility

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Install golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
 
       - name: Clean Env
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -191,4 +191,4 @@ issues:
 
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.52.2 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.64.5 # use the fixed version to not introduce new linters unexpectedly

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Required version of golangci-lint
-REQUIRED_VERSION="v1.60.2"
+REQUIRED_VERSION="v1.64.5"
 
 # Function to compare versions in pure Bash
 version_greater_or_equal() {


### PR DESCRIPTION
## Description
This pull request updates golangci-lint to version 1.64.5 to ensure full compatibility with Go 1.24.0. The upgrade leverages Go 1.24’s new go tool support, enhancing the management of development tools.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
