### PR TITLE
Fix vtclient vtgate missing flags (specifically --grpc_*)

### DIFF
--- a/go/cmd/vtclient/cli/vtclient.go
+++ b/go/cmd/vtclient/cli/vtclient.go
@@ -82,7 +82,7 @@ var (
 	seqChan = make(chan int, 10)
 )
 
-func init() {
+func InitializeFlags() {
 	servenv.MoveFlagsToCobraCommand(Main)
 
 	Main.Flags().StringVar(&server, "server", server, "vtgate server to connect to")

--- a/go/cmd/vtclient/cli/vtclient_test.go
+++ b/go/cmd/vtclient/cli/vtclient_test.go
@@ -127,6 +127,7 @@ func TestVtclient(t *testing.T) {
 		args := []string{"--server", vtgateAddr}
 		args = append(args, q.args...)
 
+		InitializeFlags()
 		err := Main.ParseFlags(args)
 		require.NoError(t, err)
 

--- a/go/cmd/vtclient/cli/vtclient_test.go
+++ b/go/cmd/vtclient/cli/vtclient_test.go
@@ -121,13 +121,14 @@ func TestVtclient(t *testing.T) {
 		},
 	}
 
+	// initialize the vtclient flags before running any commands
+	InitializeFlags()
 	for _, q := range queries {
 		// Run main function directly and not as external process. To achieve this,
 		// overwrite os.Args which is used by pflag.Parse().
 		args := []string{"--server", vtgateAddr}
 		args = append(args, q.args...)
 
-		InitializeFlags()
 		err := Main.ParseFlags(args)
 		require.NoError(t, err)
 

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -22,6 +22,7 @@ import (
 )
 
 func main() {
+	cli.InitializeFlags()
 	if err := cli.Main.Execute(); err != nil {
 		log.Exit(err)
 	}

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -336,7 +336,7 @@ func ParseFlagsForTests(cmd string) {
 // the given cobra command, then copies over the glog flags that otherwise
 // require manual transferring.
 func MoveFlagsToCobraCommand(cmd *cobra.Command) {
-	moveFlags(cmd.Use, cmd.Flags())
+	moveFlags(cmd.Name(), cmd.Flags())
 }
 
 // MovePersistentFlagsToCobraCommand functions exactly like MoveFlagsToCobraCommand,
@@ -347,7 +347,7 @@ func MoveFlagsToCobraCommand(cmd *cobra.Command) {
 // Useful for transferring flags to a parent command whose subcommands should
 // inherit the servenv-registered flags.
 func MovePersistentFlagsToCobraCommand(cmd *cobra.Command) {
-	moveFlags(cmd.Use, cmd.PersistentFlags())
+	moveFlags(cmd.Name(), cmd.PersistentFlags())
 }
 
 func moveFlags(name string, fs *pflag.FlagSet) {


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
- It looks like cmd.Use was accidenatlly used instead of `cmd.Name()`
- `cmd.Use` is actaully the help text, not the name of the command
- This was not allowing commands to make use of registered/available flags for their use (IE --grpc_...)

Extra:
- Since a lot of these flags are initialized by functional callback, we should not rely on go-lang `init()` as the order can change and be somewhat arbitrary
- Refactored `init()` to `initializedFlags()` and called at runtime for vtclient
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes https://github.com/vitessio/vitess/issues/17801
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
