### PR TITLE
nit: move new `const`s to own section

### DIFF
--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -33,8 +33,6 @@ const (
 	mysql80 mysqlVersion = "mysql80"
 	mysql84 mysqlVersion = "mysql84"
 
-	cores16RunnerName   = "gh-hosted-runners-16cores-1-24.04"
-	defaultRunnerName   = "ubuntu-24.04"
 	defaultMySQLVersion = mysql80
 )
 
@@ -46,6 +44,11 @@ var (
 
 var (
 	unitTestDatabases = []mysqlVersion{mysql57, mysql80, mysql84}
+)
+
+const (
+	cores16RunnerName = "gh-hosted-runners-16cores-1-24.04"
+	defaultRunnerName = "ubuntu-24.04"
 )
 
 const (


### PR DESCRIPTION
## Description

This PR fixes a minor nit introduced by my PR https://github.com/vitessio/vitess/pull/17788

I didn't realize `test/ci_workflow_gen.go` had `const`/`var`s grouped by purpose, and I dumped my new consts in a group of `const` for MySQL versions. This PR moves the new `const`s to a new section

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
