### PR TITLE
Fix a potential connection pool leak.

### DIFF
--- a/go/pools/smartconnpool/stack.go
+++ b/go/pools/smartconnpool/stack.go
@@ -51,6 +51,7 @@ func (s *connStack[C]) Pop() (*Pooled[C], bool) {
 
 		newHead := oldHead.next.Load()
 		if s.top.CompareAndSwap(oldHead, popCount, newHead, popCount+1) {
+			oldHead.next.Store(nil)
 			return oldHead, true
 		}
 		runtime.Gosched()

--- a/go/pools/smartconnpool/stack_test.go
+++ b/go/pools/smartconnpool/stack_test.go
@@ -1,0 +1,26 @@
+package smartconnpool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testPooled struct {
+	Connection
+}
+
+func TestStackPop(t *testing.T) {
+	s := &connStack[testPooled]{}
+
+	first := &Pooled[testPooled]{}
+	s.Push(first)
+
+	second := &Pooled[testPooled]{}
+	s.Push(second)
+
+	c, ok := s.Pop()
+	assert.True(t, ok)
+
+	assert.Nil(t, c.next.Load())
+}


### PR DESCRIPTION
## Description

After upgrading to v19, we noticed a constant growth in memory usage in one of our keyspaces.
Looking at a heap profile, we noticed that the majority of this additional memory usage came from `bufio.NewReaderSize`, which was called as part of `mysql.newConn`.

@danieljoos and I believe we were able to trace this back to the new connection pool, when reserved connections are employed in a keyspace. We use reserved connections implicitly in this keyspace, to support `GET_LOCK()` queries.

`Pooled[C]` structs keep a pointer to the `next` connection in the stack. This pointer was only reset when a connection was returned to a connection stack, but not cleared when the connection was taken out of a stack. If a reserved connection `A` was pointing to a connection that was turned into a reserved connection `B`, that pointer from `A` to `B` would prevent `B` from being garbage collected for as long as `A` was still alive.

We're not absolutely sure that this is the root cause of the memory leak, but it seems like a plausible explanation, and the fix for it seems to make sense even if this is not the root cause. It's unclear why we wouldn't eventually see a reduction in memory usage once the connections do get cleaned up.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17808

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
