### PR TITLE
Add stats for shards watched by VTOrc, purge stale shards

### DIFF
--- a/go/vt/vtorc/inst/shard_dao.go
+++ b/go/vt/vtorc/inst/shard_dao.go
@@ -29,6 +29,30 @@ import (
 // ErrShardNotFound is a fixed error message used when a shard is not found in the database.
 var ErrShardNotFound = errors.New("shard not found")
 
+// ReadShardNames reads the names of vitess shards for a single keyspace.
+func ReadShardNames(keyspaceName string) (shardNames []string, err error) {
+	shardNames = make([]string, 0)
+	query := `select shard from vitess_shard where keyspace = ?`
+	args := sqlutils.Args(keyspaceName)
+	err = db.QueryVTOrc(query, args, func(row sqlutils.RowMap) error {
+		shardNames = append(shardNames, row.GetString("shard"))
+		return nil
+	})
+	return shardNames, err
+}
+
+// ReadAllShardNames reads the names of all vitess shards by keyspace.
+func ReadAllShardNames() (shardNames map[string][]string, err error) {
+	shardNames = make(map[string][]string)
+	query := `select keyspace, shard from vitess_shard`
+	err = db.QueryVTOrc(query, nil, func(row sqlutils.RowMap) error {
+		ks := row.GetString("keyspace")
+		shardNames[ks] = append(shardNames[ks], row.GetString("shard"))
+		return nil
+	})
+	return shardNames, err
+}
+
 // ReadShardPrimaryInformation reads the vitess shard record and gets the shard primary alias and timestamp.
 func ReadShardPrimaryInformation(keyspaceName, shardName string) (primaryAlias string, primaryTimestamp string, err error) {
 	if err = topo.ValidateKeyspaceName(keyspaceName); err != nil {
@@ -94,4 +118,17 @@ func getShardPrimaryTermStartTimeString(shard *topo.ShardInfo) string {
 		return ""
 	}
 	return protoutil.TimeFromProto(shard.PrimaryTermStartTime).UTC().String()
+}
+
+// DeleteShard deletes a shard using a keyspace and shard name.
+func DeleteShard(keyspace, shard string) error {
+	_, err := db.ExecVTOrc(`DELETE FROM
+			vitess_shard
+		WHERE
+			keyspace = ?
+			AND shard = ?`,
+		keyspace,
+		shard,
+	)
+	return err
 }

--- a/go/vt/vtorc/inst/shard_dao_test.go
+++ b/go/vt/vtorc/inst/shard_dao_test.go
@@ -108,6 +108,12 @@ func TestSaveReadAndDeleteShard(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, []string{tt.shardName}, shardNames)
 
+			// ReadAllShardNames
+			allShardNames, err := ReadAllShardNames()
+			ksShards, found := allShardNames[tt.keyspaceName]
+			require.True(t, found)
+			require.Equal(t, []string{tt.shardName}, ksShards)
+
 			// DeleteShard
 			require.NoError(t, DeleteShard(tt.keyspaceName, tt.shardName))
 			_, _, err = ReadShardPrimaryInformation(tt.keyspaceName, tt.shardName)

--- a/go/vt/vtorc/inst/shard_dao_test.go
+++ b/go/vt/vtorc/inst/shard_dao_test.go
@@ -110,6 +110,7 @@ func TestSaveReadAndDeleteShard(t *testing.T) {
 
 			// ReadAllShardNames
 			allShardNames, err := ReadAllShardNames()
+			require.NoError(t, err)
 			ksShards, found := allShardNames[tt.keyspaceName]
 			require.True(t, found)
 			require.Equal(t, []string{tt.shardName}, ksShards)

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -22,14 +22,43 @@ import (
 
 	"golang.org/x/exp/maps"
 
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
-
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtorc/inst"
 )
 
+var statsShardsWatched = stats.NewGaugesFuncWithMultiLabels("ShardsWatched",
+	"Keyspace/shards currently watched",
+	[]string{"Keyspace", "Shard"},
+	getShardsWatchedStats)
+
+// getShardsWatchedStats returns the keyspace/shards watched in a format for stats.
+func getShardsWatchedStats() map[string]int64 {
+	shardsWatched := make(map[string]int64)
+	allShardNames, err := inst.ReadAllShardNames()
+	if err != nil {
+		log.Errorf("Failed to read all shard names: %+v", err)
+		return shardsWatched
+	}
+	for ks, shards := range allShardNames {
+		for _, shard := range shards {
+			shardsWatched[ks+"."+shard] = 1
+		}
+	}
+	return shardsWatched
+}
+
+// refreshAllKeyspacesAndShardsMu ensures RefreshAllKeyspacesAndShards
+// is not executed concurrently.
+var refreshAllKeyspacesAndShardsMu sync.Mutex
+
 // RefreshAllKeyspacesAndShards reloads the keyspace and shard information for the keyspaces that vtorc is concerned with.
 func RefreshAllKeyspacesAndShards(ctx context.Context) error {
+	refreshAllKeyspacesAndShardsMu.Lock()
+	defer refreshAllKeyspacesAndShardsMu.Unlock()
+
 	var keyspaces []string
 	if len(shardsToWatch) == 0 { // all known keyspaces
 		ctx, cancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
@@ -109,6 +138,7 @@ func refreshKeyspaceHelper(ctx context.Context, keyspaceName string) error {
 
 // refreshAllShards refreshes all the shard records in the given keyspace.
 func refreshAllShards(ctx context.Context, keyspaceName string) error {
+	// get all shards for keyspace name.
 	shardInfos, err := ts.FindAllShardsInKeyspace(ctx, keyspaceName, &topo.FindAllShardsInKeyspaceOptions{
 		// Fetch shard records concurrently to speed up discovery. A typical
 		// Vitess cluster will have 1-3 vtorc instances deployed, so there is
@@ -119,13 +149,35 @@ func refreshAllShards(ctx context.Context, keyspaceName string) error {
 		log.Error(err)
 		return err
 	}
+	savedShards := make(map[string]bool, len(shardInfos))
 	for _, shardInfo := range shardInfos {
 		err = inst.SaveShard(shardInfo)
 		if err != nil {
 			log.Error(err)
 			return err
 		}
+		savedShards[shardInfo.ShardName()] = true
 	}
+
+	// delete shards that were not returned by ts.FindAllShardsInKeyspace(...),
+	// indicating they are stale.
+	shards, err := inst.ReadShardNames(keyspaceName)
+	if err != nil {
+		return err
+	}
+	for _, shard := range shards {
+		if savedShards[shard] {
+			continue
+		}
+		shardName := topoproto.KeyspaceShardString(keyspaceName, shard)
+		log.Infof("Forgetting shard: %s", shardName)
+		err = inst.DeleteShard(keyspaceName, shard)
+		if err != nil {
+			log.Errorf("Failed to delete shard %s: %+v", shardName, err)
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -170,6 +170,8 @@ func refreshAllShards(ctx context.Context, keyspaceName string) error {
 		log.Error(err)
 		return err
 	}
+
+	// save shards that should be watched.
 	savedShards := make(map[string]bool, len(shardInfos))
 	for _, shardInfo := range shardInfos {
 		if !shouldWatchShard(shardInfo) {
@@ -182,10 +184,10 @@ func refreshAllShards(ctx context.Context, keyspaceName string) error {
 		savedShards[shardInfo.ShardName()] = true
 	}
 
-	// delete shards that were not returned by ts.FindAllShardsInKeyspace(...),
-	// indicating they are stale.
+	// delete shards that were not saved, indicating they are stale.
 	shards, err := inst.ReadShardNames(keyspaceName)
 	if err != nil {
+		log.Error(err)
 		return err
 	}
 	for _, shard := range shards {

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -179,20 +179,19 @@ func refreshAllShards(ctx context.Context, keyspaceName string) error {
 	}
 	savedShards := make(map[string]bool, len(shardInfos))
 	for _, shardInfo := range shardInfos {
-		shardName := shardInfo.ShardName()
-		shouldRefresh, err := shouldWatchShard(shardInfo)
+		shouldWatchShard, err := shouldWatchShard(shardInfo)
 		if err != nil {
 			log.Error(err)
 			return err
 		}
-		if !shouldRefresh {
+		if !shouldWatchShard {
 			continue
 		}
 		if err = inst.SaveShard(shardInfo); err != nil {
 			log.Error(err)
 			return err
 		}
-		savedShards[shardName] = true
+		savedShards[shardInfo.ShardName()] = true
 	}
 
 	// delete shards that were not returned by ts.FindAllShardsInKeyspace(...),

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -123,8 +123,8 @@ func shouldWatchShard(shard *topo.ShardInfo) bool {
 
 	shardRanges, err := key.ParseShardingSpec(shard.ShardName())
 	if err != nil {
-		// This should never happen because we parse shard
-		// names when building shardsToWatch.
+		// This parse should never fail because we get the shard names
+		// from the topo using ts.FindAllShardsInKeyspace().
 		log.Error(err)
 		return false
 	}

--- a/go/vt/vtorc/logic/keyspace_shard_discovery.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery.go
@@ -109,19 +109,19 @@ func RefreshKeyspaceAndShard(keyspaceName string, shardName string) error {
 	return refreshShard(keyspaceName, shardName)
 }
 
-// shouldRefreshShard returns true if a shard is within the shardsToWatch
+// shouldWatchShard returns true if a shard is within the shardsToWatch
 // ranges for it's keyspace.
-func shouldRefreshShard(keyspace, shardName string) (bool, error) {
+func shouldWatchShard(shard *topo.ShardInfo) (bool, error) {
 	if len(shardsToWatch) == 0 {
 		return true, nil
 	}
 
-	watchRanges, found := shardsToWatch[keyspace]
+	watchRanges, found := shardsToWatch[shard.Keyspace()]
 	if !found {
 		return false, nil
 	}
 
-	shardRanges, err := key.ParseShardingSpec(shardName)
+	shardRanges, err := key.ParseShardingSpec(shard.ShardName())
 	if err != nil {
 		return false, err
 	}
@@ -180,7 +180,7 @@ func refreshAllShards(ctx context.Context, keyspaceName string) error {
 	savedShards := make(map[string]bool, len(shardInfos))
 	for _, shardInfo := range shardInfos {
 		shardName := shardInfo.ShardName()
-		shouldRefresh, err := shouldRefreshShard(keyspaceName, shardName)
+		shouldRefresh, err := shouldWatchShard(shardInfo)
 		if err != nil {
 			log.Error(err)
 			return err

--- a/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
@@ -352,7 +352,7 @@ func TestRefreshAllShards(t *testing.T) {
 	require.Equal(t, []string{"-40", "40-80", "80-c0"}, shardNames)
 
 	// test clustersToWatch filters what shards are saved
-	clustersToWatch = []string{"ks1/-40", "ks1/40-80"}
+	clustersToWatch = []string{"ks1/-80"}
 	require.NoError(t, initializeShardsToWatch())
 	require.NoError(t, refreshAllShards(ctx, "ks1"))
 	shardNames, err = inst.ReadShardNames("ks1")

--- a/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
@@ -56,11 +56,9 @@ func TestRefreshAllKeyspaces(t *testing.T) {
 	// Store the old flags and restore on test completion
 	oldTs := ts
 	oldClustersToWatch := clustersToWatch
-	oldShardsToWatch := shardsToWatch
 	defer func() {
 		ts = oldTs
 		clustersToWatch = oldClustersToWatch
-		shardsToWatch = oldShardsToWatch
 	}()
 
 	db.ClearVTOrcDatabase()
@@ -317,11 +315,9 @@ func verifyPrimaryAlias(t *testing.T, keyspaceName, shardName string, primaryAli
 func TestRefreshAllShards(t *testing.T) {
 	// Store the old flags and restore on test completion
 	oldClustersToWatch := clustersToWatch
-	oldShardsToWatch := shardsToWatch
 	oldTs := ts
 	defer func() {
 		clustersToWatch = oldClustersToWatch
-		shardsToWatch = oldShardsToWatch
 		ts = oldTs
 		db.ClearVTOrcDatabase()
 	}()

--- a/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
@@ -326,17 +326,18 @@ func TestRefreshAllShards(t *testing.T) {
 		KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
 		DurabilityPolicy: policy.DurabilityNone,
 	}))
+
 	shards := []string{"-80", "80-"}
 	for _, shard := range shards {
 		require.NoError(t, ts.CreateShard(ctx, "ks1", shard))
 	}
-	require.NoError(t, refreshAllShards(context.Background(), "ks1"))
+	require.NoError(t, refreshAllShards(ctx, "ks1"))
 	shardNames, err := inst.ReadShardNames("ks1")
 	require.NoError(t, err)
 	require.Equal(t, []string{"-80", "80-"}, shardNames)
 
 	require.NoError(t, ts.DeleteShard(ctx, "ks1", "80-"))
-	require.NoError(t, refreshAllShards(context.Background(), "ks1"))
+	require.NoError(t, refreshAllShards(ctx, "ks1"))
 	shardNames, err = inst.ReadShardNames("ks1")
 	require.NoError(t, err)
 	require.Equal(t, []string{"-80"}, shardNames)

--- a/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
+++ b/go/vt/vtorc/logic/keyspace_shard_discovery_test.go
@@ -329,16 +329,13 @@ func TestRefreshAllShards(t *testing.T) {
 	ctx := context.Background()
 	ts = memorytopo.NewServer(ctx, "zone1")
 	require.NoError(t, initializeShardsToWatch())
-	require.NoError(t, ts.CreateKeyspace(ctx, "ks1", &topodatapb.Keyspace{
-		KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
-		DurabilityPolicy: policy.DurabilityNone,
-	}))
-
-	// test shard refresh
+	require.NoError(t, ts.CreateKeyspace(ctx, "ks1", keyspaceDurabilityNone))
 	shards := []string{"-40", "40-80", "80-c0", "c0-"}
 	for _, shard := range shards {
 		require.NoError(t, ts.CreateShard(ctx, "ks1", shard))
 	}
+
+	// test shard refresh
 	require.NoError(t, refreshAllShards(ctx, "ks1"))
 	shardNames, err := inst.ReadShardNames("ks1")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR adds stats for what keyspace/shards are being watched by VTOrc, populated using the backend database

While adding this support I noticed records are never deleted from the backend `vitess_shard` table, so I added support for stale records to be deleted in a similar way to tablets: by recording what was successfully "saved" in the latest polling and removing anything that was not in that list

Finally, shards that do not meet the `--clusters_to_watch` key-ranges will not be saved to the backend. Currently all shards of a keyspace are stored

## Related Issue(s)

Closes https://github.com/vitessio/vitess/issues/17816

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
