### PR TITLE
Throttler: reduce regexp/string allocations by pre-computing pascal case

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/base/metric_name.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/metric_name.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"vitess.io/vitess/go/textutil"
 )
 
 // MetricName is a formalized name for a metric, such as "lag" or "threads_running". A metric name
@@ -77,6 +79,14 @@ func (metric MetricName) DefaultScope() Scope {
 	return SelfScope
 }
 
+// Pascal case representation of this name, e.g. "ThreadsRunning"
+func (metric MetricName) Pascal() string {
+	if pascal, ok := pascalMetricNames[metric]; ok {
+		return pascal
+	}
+	return textutil.PascalCase(metric.String())
+}
+
 func (metric MetricName) String() string {
 	return string(metric)
 }
@@ -113,6 +123,7 @@ var (
 	// - no textual parsing is needed in the critical path
 	// - we can easily check if a metric name is valid
 	aggregatedMetricNames = make(map[string]AggregatedMetricName)
+	pascalMetricNames     = make(map[MetricName]string)
 )
 
 // DisaggregateMetricName splits a metric name into its scope name and metric name

--- a/go/vt/vttablet/tabletserver/throttle/base/metric_name_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/metric_name_test.go
@@ -261,6 +261,7 @@ func TestKnownMetricNamesPascalCase(t *testing.T) {
 		t.Run(metricName.String(), func(t *testing.T) {
 			expect, ok := expectCases[metricName]
 			require.True(t, ok)
+			assert.Equal(t, expect, metricName.Pascal())
 			assert.Equal(t, expect, textutil.PascalCase(metricName.String()))
 		})
 	}

--- a/go/vt/vttablet/tabletserver/throttle/base/metric_scope.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/metric_scope.go
@@ -30,6 +30,18 @@ const (
 	SelfScope      Scope = "self"
 )
 
+var (
+	pascalScopeNames = map[Scope]string{
+		UndefinedScope: "",
+		ShardScope:     "Shard",
+		SelfScope:      "Self",
+	}
+)
+
+func (s Scope) Pascal() string {
+	return pascalScopeNames[s]
+}
+
 func (s Scope) String() string {
 	return string(s)
 }

--- a/go/vt/vttablet/tabletserver/throttle/base/metric_scope_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/metric_scope_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestKScopePascalCase(t *testing.T) {
+func TestScopePascalCase(t *testing.T) {
 	expectCases := map[Scope]string{
 		UndefinedScope: "",
 		ShardScope:     "Shard",

--- a/go/vt/vttablet/tabletserver/throttle/base/metric_scope_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/metric_scope_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKScopePascalCase(t *testing.T) {
+	expectCases := map[Scope]string{
+		UndefinedScope: "",
+		ShardScope:     "Shard",
+		SelfScope:      "Self",
+	}
+	for scope, expect := range expectCases {
+		t.Run(scope.String(), func(t *testing.T) {
+			pascal := scope.Pascal()
+			assert.Equal(t, expect, pascal)
+		})
+	}
+}

--- a/go/vt/vttablet/tabletserver/throttle/base/self_metric.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/self_metric.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
@@ -48,6 +49,7 @@ var (
 func registerSelfMetric(selfMetric SelfMetric) SelfMetric {
 	RegisteredSelfMetrics[selfMetric.Name()] = selfMetric
 	KnownMetricNames = append(KnownMetricNames, selfMetric.Name())
+	pascalMetricNames[selfMetric.Name()] = textutil.PascalCase(selfMetric.Name().String())
 	aggregatedMetricNames[selfMetric.Name().String()] = AggregatedMetricName{
 		Scope:  selfMetric.DefaultScope(),
 		Metric: selfMetric.Name(),

--- a/go/vt/vttablet/tabletserver/throttle/check.go
+++ b/go/vt/vttablet/tabletserver/throttle/check.go
@@ -47,7 +47,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/stats"
-	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/base"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
 
@@ -175,9 +174,9 @@ func (check *ThrottlerCheck) Check(ctx context.Context, appName string, scope ba
 					// Out of abundance of caution, we will protect against such a scenario.
 					return
 				}
-				stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheck%s%sTotal", textutil.PascalCase(metricScope.String()), textutil.PascalCase(metricName.String())), "").Add(1)
+				stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheck%s%sTotal", metricScope.Pascal(), metricName.Pascal()), "").Add(1)
 				if !metricCheckResult.IsOK() {
-					stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheck%s%sError", textutil.PascalCase(metricScope.String()), textutil.PascalCase(metricName.String())), "").Add(1)
+					stats.GetOrNewCounter(fmt.Sprintf("ThrottlerCheck%s%sError", metricScope.Pascal(), metricName.Pascal()), "").Add(1)
 				}
 			}(metricCheckResult)
 		}
@@ -232,7 +231,7 @@ func (check *ThrottlerCheck) localCheck(ctx context.Context, aggregatedMetricNam
 		check.throttler.markMetricHealthy(aggregatedMetricName)
 	}
 	if timeSinceHealthy, found := check.throttler.timeSinceMetricHealthy(aggregatedMetricName); found {
-		go stats.GetOrNewGauge(fmt.Sprintf("ThrottlerCheck%sSecondsSinceHealthy", textutil.PascalCase(scope.String())), fmt.Sprintf("seconds since last healthy check for %v", scope)).Set(int64(timeSinceHealthy.Seconds()))
+		go stats.GetOrNewGauge(fmt.Sprintf("ThrottlerCheck%sSecondsSinceHealthy", scope.Pascal()), fmt.Sprintf("seconds since last healthy check for %v", scope)).Set(int64(timeSinceHealthy.Seconds()))
 	}
 
 	return checkResult
@@ -244,7 +243,7 @@ func (check *ThrottlerCheck) reportAggregated(aggregatedMetricName string, metri
 		return
 	}
 	if value, err := metricResult.Get(); err == nil {
-		stats.GetOrNewGaugeFloat64(fmt.Sprintf("ThrottlerAggregated%s%s", textutil.PascalCase(scope.String()), textutil.PascalCase(metricName.String())), fmt.Sprintf("aggregated value for %v", scope)).Set(value)
+		stats.GetOrNewGaugeFloat64(fmt.Sprintf("ThrottlerAggregated%s%s", scope.Pascal(), metricName.Pascal()), fmt.Sprintf("aggregated value for %v", scope)).Set(value)
 	}
 }
 


### PR DESCRIPTION

## Description

General memory/allocation optimization: for purposes of gauge export, the throttler dynamically computes debug/var names, and turns metric and scope names into pascal case.

The way it's done right now is wasteful since the name is computed via regexp/string manipulation every single time. This PR pre-computes the metric pascal case for all metrics and scopes.

## Related Issue(s)

-

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
