### PR TITLE
pool: reopen connection closed by idle timeout

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -503,8 +503,8 @@ func (pool *ConnPool[C]) connReopen(ctx context.Context, dbconn *Pooled[C], now 
 		return err
 	}
 
-	if dbconn.Conn.Setting() != nil {
-		err = dbconn.Conn.ApplySetting(ctx, dbconn.Conn.Setting())
+	if setting := dbconn.Conn.Setting(); setting != nil {
+		err = dbconn.Conn.ApplySetting(ctx, setting)
 		if err != nil {
 			dbconn.Close()
 			return err
@@ -772,7 +772,7 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 			if conn.timeUsed.expired(mono, timeout) {
 				pool.Metrics.idleClosed.Add(1)
 				conn.Close()
-				if err := pool.connReopen(context.Background(), conn, monotonicNow()); err != nil {
+				if err := pool.connReopen(context.Background(), conn, mono); err != nil {
 					pool.closedConn()
 				}
 			}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR complements the earlier change made in https://github.com/vitessio/vitess/pull/17757 by further refining the connection pool’s idle timeout behavior.

This implementation reduces connection churn. Instead of simply closing idle connections, they will now be closed and immediately reopened. This ensures that connections remain fresh and available, preventing unnecessary delays caused by frequent connection creation during traffic spikes.

Backport Reason: The previous iteration of this change was backported, so this update should be backported as well to maintain consistency and ensure the improvements apply across all relevant versions.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes https://github.com/vitessio/vitess/issues/17819

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
