### PR TITLE
Clear `demotePrimaryStalled` field after the function ends

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -551,13 +551,11 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 			buf := make([]byte, 1<<16) // 64 KB buffer size
 			stackSize := runtime.Stack(buf, true)
 			log.Errorf("Stack trace:\n%s", string(buf[:stackSize]))
-			// This select is only to handle the race, where we start to set the demote primary stalled
+			// This condition check is only to handle the race, where we start to set the demote primary stalled
 			// but then the function finishes. So, after we set demote primary stalled, we check if the
 			// function has finished and if it has, we clear the demote primary stalled.
-			select {
-			case <-finishCtx.Done():
+			if finishCtx.Err() != nil {
 				tm.QueryServiceControl.ClearDemotePrimaryStalled()
-			default:
 			}
 		}
 	}()

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -50,7 +50,7 @@ func TestWaitForGrantsToHaveApplied(t *testing.T) {
 
 type demotePrimaryStallQS struct {
 	tabletserver.Controller
-	waitTime       time.Duration
+	qsWaitChan     chan any
 	primaryStalled atomic.Bool
 }
 
@@ -58,8 +58,12 @@ func (d *demotePrimaryStallQS) SetDemotePrimaryStalled() {
 	d.primaryStalled.Store(true)
 }
 
+func (d *demotePrimaryStallQS) ClearDemotePrimaryStalled() {
+	d.primaryStalled.Store(false)
+}
+
 func (d *demotePrimaryStallQS) IsServing() bool {
-	time.Sleep(d.waitTime)
+	<-d.qsWaitChan
 	return false
 }
 
@@ -74,7 +78,7 @@ func TestDemotePrimaryStalled(t *testing.T) {
 
 	// Create a fake query service control to intercept calls from DemotePrimary function.
 	qsc := &demotePrimaryStallQS{
-		waitTime: 2 * time.Second,
+		qsWaitChan: make(chan any),
 	}
 	// Create a tablet manager with a replica type tablet.
 	tm := &TabletManager{
@@ -88,8 +92,20 @@ func TestDemotePrimaryStalled(t *testing.T) {
 		QueryServiceControl: qsc,
 	}
 
-	// We make IsServing stall for over 2 seconds, which is longer than 10 * remote operation timeout.
+	go func() {
+		tm.demotePrimary(context.Background(), false)
+	}()
+	// We make IsServing stall by making it wait on a channel.
 	// This should cause the demote primary operation to be stalled.
-	tm.demotePrimary(context.Background(), false)
-	require.True(t, qsc.primaryStalled.Load())
+	require.Eventually(t, func() bool {
+		return qsc.primaryStalled.Load()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Unblock the DemotePrimary call by closing the channel.
+	close(qsc.qsWaitChan)
+
+	// Eventually demote primary will succeed, and we want the stalled field to be cleared.
+	require.Eventually(t, func() bool {
+		return !qsc.primaryStalled.Load()
+	}, 5*time.Second, 100*time.Millisecond)
 }

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -54,12 +54,8 @@ type demotePrimaryStallQS struct {
 	primaryStalled atomic.Bool
 }
 
-func (d *demotePrimaryStallQS) SetDemotePrimaryStalled() {
-	d.primaryStalled.Store(true)
-}
-
-func (d *demotePrimaryStallQS) ClearDemotePrimaryStalled() {
-	d.primaryStalled.Store(false)
+func (d *demotePrimaryStallQS) SetDemotePrimaryStalled(val bool) {
+	d.primaryStalled.Store(val)
 }
 
 func (d *demotePrimaryStallQS) IsServing() bool {

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -120,11 +120,8 @@ type Controller interface {
 	// WaitForPreparedTwoPCTransactions waits for all prepared transactions to be resolved.
 	WaitForPreparedTwoPCTransactions(ctx context.Context) error
 
-	// SetDemotePrimaryStalled marks that demote primary is stalled in the state manager.
-	SetDemotePrimaryStalled()
-
-	// ClearDemotePrimaryStalled clears the demote primary stalled field in the state manager.
-	ClearDemotePrimaryStalled()
+	// SetDemotePrimaryStalled sets the demote primary stalled field to the provided value in the state manager.
+	SetDemotePrimaryStalled(val bool)
 
 	// IsDiskStalled returns if the disk is stalled.
 	IsDiskStalled() bool

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -123,6 +123,9 @@ type Controller interface {
 	// SetDemotePrimaryStalled marks that demote primary is stalled in the state manager.
 	SetDemotePrimaryStalled()
 
+	// ClearDemotePrimaryStalled clears the demote primary stalled field in the state manager.
+	ClearDemotePrimaryStalled()
+
 	// IsDiskStalled returns if the disk is stalled.
 	IsDiskStalled() bool
 }

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -769,6 +769,14 @@ func (tsv *TabletServer) SetDemotePrimaryStalled() {
 	tsv.BroadcastHealth()
 }
 
+// ClearDemotePrimaryStalled clears the demote primary stalled field in the state manager.
+func (tsv *TabletServer) ClearDemotePrimaryStalled() {
+	tsv.sm.mu.Lock()
+	tsv.sm.demotePrimaryStalled = false
+	tsv.sm.mu.Unlock()
+	tsv.BroadcastHealth()
+}
+
 // IsDiskStalled returns if the disk is stalled or not.
 func (tsv *TabletServer) IsDiskStalled() bool {
 	return tsv.sm.diskHealthMonitor.IsDiskStalled()

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -761,18 +761,10 @@ func (tsv *TabletServer) WaitForPreparedTwoPCTransactions(ctx context.Context) e
 	}
 }
 
-// SetDemotePrimaryStalled marks that demote primary is stalled in the state manager.
-func (tsv *TabletServer) SetDemotePrimaryStalled() {
+// SetDemotePrimaryStalled sets the demote primary stalled field to the provided value in the state manager.
+func (tsv *TabletServer) SetDemotePrimaryStalled(val bool) {
 	tsv.sm.mu.Lock()
-	tsv.sm.demotePrimaryStalled = true
-	tsv.sm.mu.Unlock()
-	tsv.BroadcastHealth()
-}
-
-// ClearDemotePrimaryStalled clears the demote primary stalled field in the state manager.
-func (tsv *TabletServer) ClearDemotePrimaryStalled() {
-	tsv.sm.mu.Lock()
-	tsv.sm.demotePrimaryStalled = false
+	tsv.sm.demotePrimaryStalled = val
 	tsv.sm.mu.Unlock()
 	tsv.BroadcastHealth()
 }

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -275,13 +275,8 @@ func (tqsc *Controller) WaitForPreparedTwoPCTransactions(context.Context) error 
 }
 
 // SetDemotePrimaryStalled is part of the tabletserver.Controller interface
-func (tqsc *Controller) SetDemotePrimaryStalled() {
+func (tqsc *Controller) SetDemotePrimaryStalled(bool) {
 	tqsc.MethodCalled["SetDemotePrimaryStalled"] = true
-}
-
-// ClearDemotePrimaryStalled is part of the tabletserver.Controller interface
-func (tqsc *Controller) ClearDemotePrimaryStalled() {
-	tqsc.MethodCalled["ClearDemotePrimaryStalled"] = true
 }
 
 // IsDiskStalled is part of the tabletserver.Controller interface

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -279,6 +279,11 @@ func (tqsc *Controller) SetDemotePrimaryStalled() {
 	tqsc.MethodCalled["SetDemotePrimaryStalled"] = true
 }
 
+// ClearDemotePrimaryStalled is part of the tabletserver.Controller interface
+func (tqsc *Controller) ClearDemotePrimaryStalled() {
+	tqsc.MethodCalled["ClearDemotePrimaryStalled"] = true
+}
+
 // IsDiskStalled is part of the tabletserver.Controller interface
 func (tqsc *Controller) IsDiskStalled() bool {
 	tqsc.MethodCalled["IsDiskStalled"] = true


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue pointed out in https://github.com/vitessio/vitess/issues/17822 by clearing the demote primary stalled field after the function finishes.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/17822

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
