### PR TITLE
`vtorc`: cleanup discover queue, add concurrency flag

### DIFF
--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -32,7 +32,7 @@ Flags:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.
-      --discovery-max-concurrency int                               Number of workers for used for tablet discovery (default 300)
+      --discovery-max-concurrency int                               Number of workers used for tablet discovery (default 300)
       --emit_stats                                                  If set, emit stats to push-based monitoring and stats backends
       --enable-primary-disk-stalled-recovery                        Whether VTOrc should detect a stalled disk on the primary and failover
       --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -32,6 +32,7 @@ Flags:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.
+      --discovery-max-concurrency int                               Number of workers for used for tablet discovery (default 300)
       --emit_stats                                                  If set, emit stats to push-based monitoring and stats backends
       --enable-primary-disk-stalled-recovery                        Whether VTOrc should detect a stalled disk on the primary and failover
       --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -32,7 +32,7 @@ Flags:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.
-      --discovery-max-concurrency int                               Number of workers used for tablet discovery (default 300)
+      --discovery-workers int                                       Number of workers used for tablet discovery (default 300)
       --emit_stats                                                  If set, emit stats to push-based monitoring and stats backends
       --enable-primary-disk-stalled-recovery                        Whether VTOrc should detect a stalled disk on the primary and failover
       --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -62,7 +62,7 @@ var (
 		viperutil.Options[int]{
 			FlagName: "discovery-max-concurrency",
 			Default:  300,
-			Dynamic:  true,
+			Dynamic:  false,
 		},
 	)
 

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -57,10 +57,10 @@ var (
 		},
 	)
 
-	discoveryMaxConcurrency = viperutil.Configure(
-		"discovery-max-concurrency",
+	discoveryWorkers = viperutil.Configure(
+		"discovery-workers",
 		viperutil.Options[int]{
-			FlagName: "discovery-max-concurrency",
+			FlagName: "discovery-workers",
 			Default:  300,
 			Dynamic:  false,
 		},
@@ -199,7 +199,7 @@ func init() {
 
 // registerFlags registers the flags required by VTOrc
 func registerFlags(fs *pflag.FlagSet) {
-	fs.Int("discovery-max-concurrency", discoveryMaxConcurrency.Default(), "Number of workers used for tablet discovery")
+	fs.Int("discovery-workers", discoveryWorkers.Default(), "Number of workers used for tablet discovery")
 	fs.String("sqlite-data-file", sqliteDataFile.Default(), "SQLite Datafile to use as VTOrc's database")
 	fs.Duration("instance-poll-time", instancePollTime.Default(), "Timer duration on which VTOrc refreshes MySQL information")
 	fs.Duration("snapshot-topology-interval", snapshotTopologyInterval.Default(), "Timer duration on which VTOrc takes a snapshot of the current MySQL information it has in the database. Should be in multiple of hours")
@@ -220,7 +220,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	viperutil.BindFlags(fs,
 		instancePollTime,
 		preventCrossCellFailover,
-		discoveryMaxConcurrency,
+		discoveryWorkers,
 		sqliteDataFile,
 		snapshotTopologyInterval,
 		reasonableReplicationLag,
@@ -258,9 +258,9 @@ func GetPreventCrossCellFailover() bool {
 	return preventCrossCellFailover.Get()
 }
 
-// GetDiscoveryMaxConcurrency is a getter function.
-func GetDiscoveryMaxConcurrency() uint {
-	return uint(discoveryMaxConcurrency.Get())
+// GetDiscoveryWorkers is a getter function.
+func GetDiscoveryWorkers() uint {
+	return uint(discoveryWorkers.Get())
 }
 
 // GetSQLiteDataFile is a getter function.

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -199,7 +199,7 @@ func init() {
 
 // registerFlags registers the flags required by VTOrc
 func registerFlags(fs *pflag.FlagSet) {
-	fs.Int("discovery-max-concurrency", discoveryMaxConcurrency.Default(), "Number of goroutines doing tablet discovery")
+	fs.Int("discovery-max-concurrency", discoveryMaxConcurrency.Default(), "Number of workers for used for tablet discovery")
 	fs.String("sqlite-data-file", sqliteDataFile.Default(), "SQLite Datafile to use as VTOrc's database")
 	fs.Duration("instance-poll-time", instancePollTime.Default(), "Timer duration on which VTOrc refreshes MySQL information")
 	fs.Duration("snapshot-topology-interval", snapshotTopologyInterval.Default(), "Timer duration on which VTOrc takes a snapshot of the current MySQL information it has in the database. Should be in multiple of hours")

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -199,7 +199,7 @@ func init() {
 
 // registerFlags registers the flags required by VTOrc
 func registerFlags(fs *pflag.FlagSet) {
-	fs.Int("discovery-max-concurrency", discoveryMaxConcurrency.Default(), "Number of workers for used for tablet discovery")
+	fs.Int("discovery-max-concurrency", discoveryMaxConcurrency.Default(), "Number of workers used for tablet discovery")
 	fs.String("sqlite-data-file", sqliteDataFile.Default(), "SQLite Datafile to use as VTOrc's database")
 	fs.Duration("instance-poll-time", instancePollTime.Default(), "Timer duration on which VTOrc refreshes MySQL information")
 	fs.Duration("snapshot-topology-interval", snapshotTopologyInterval.Default(), "Timer duration on which VTOrc takes a snapshot of the current MySQL information it has in the database. Should be in multiple of hours")

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -72,7 +72,7 @@ func (q *Queue) QueueLen() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	return len(q.queue) + len(q.enqueued)
+	return len(q.enqueued)
 }
 
 // Push enqueues a key if it is not on a queue and is not being

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -39,7 +39,7 @@ type queueItem struct {
 	Key      string
 }
 
-// Queue is an implementation of discovery.Queue.
+// Queue is an ordered queue with deduplication.
 type Queue struct {
 	mu       sync.Mutex
 	enqueued map[string]struct{}

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -60,9 +60,8 @@ func (q *Queue) setKeyCheckEnqueued(key string) (alreadyEnqueued bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	if _, found := q.enqueued[key]; found {
-		alreadyEnqueued = true
-	} else {
+	_, alreadyEnqueued = q.enqueued[key]
+	if !alreadyEnqueued {
 		q.enqueued[key] = struct{}{}
 	}
 	return alreadyEnqueued

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -43,7 +43,6 @@ type queueItem struct {
 type Queue struct {
 	sync.Mutex
 	enqueued map[string]struct{}
-	nowFunc  func() time.Time
 	queue    chan queueItem
 }
 
@@ -51,7 +50,6 @@ type Queue struct {
 func NewQueue() *Queue {
 	return &Queue{
 		enqueued: make(map[string]struct{}),
-		nowFunc:  func() time.Time { return time.Now() },
 		queue:    make(chan queueItem, config.DiscoveryQueueCapacity),
 	}
 }
@@ -75,7 +73,7 @@ func (q *Queue) Push(key string) {
 	}
 	q.enqueued[key] = struct{}{}
 	q.queue <- queueItem{
-		CreatedAt: q.nowFunc(),
+		CreatedAt: time.Now(),
 		Key:       key,
 	}
 }

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -70,7 +70,10 @@ func (q *Queue) setKeyCheckEnqueued(key string) (alreadyEnqueued bool) {
 
 // QueueLen returns the length of the queue.
 func (q *Queue) QueueLen() int {
-	return len(q.queue)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	return len(q.queue) + len(q.enqueued)
 }
 
 // Push enqueues a key if it is not on a queue and is not being

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -71,7 +71,7 @@ func (q *Queue) Consume() string {
 
 	timeOnQueue := time.Since(item.CreatedAt)
 	if timeOnQueue > config.GetInstancePollTime() {
-		log.Warningf("key %v spent %.4fs waiting on a discoveryQueue", item.Key, timeOnQueue.Seconds())
+		log.Warningf("key %v spent %.4fs waiting on a discovery queue", item.Key, timeOnQueue.Seconds())
 	}
 
 	return item.Key

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -17,7 +17,7 @@
 /*
 
 package discovery manages a queue of discovery requests: an ordered
-queue.
+queue with no duplicates.
 
 push() operation never blocks while pop() blocks on an empty queue.
 

--- a/go/vt/vtorc/discovery/queue.go
+++ b/go/vt/vtorc/discovery/queue.go
@@ -34,8 +34,8 @@ import (
 
 // queueItem represents an item in the discovery.Queue.
 type queueItem struct {
-	CreatedAt time.Time
-	Key       string
+	PushedAt time.Time
+	Key      string
 }
 
 // Queue is an implementation of discovery.Queue.
@@ -59,8 +59,8 @@ func (q *Queue) QueueLen() int {
 // processed; silently returns otherwise.
 func (q *Queue) Push(key string) {
 	q.queue <- queueItem{
-		CreatedAt: time.Now(),
-		Key:       key,
+		PushedAt: time.Now(),
+		Key:      key,
 	}
 }
 
@@ -69,7 +69,7 @@ func (q *Queue) Push(key string) {
 func (q *Queue) Consume() string {
 	item := <-q.queue
 
-	timeOnQueue := time.Since(item.CreatedAt)
+	timeOnQueue := time.Since(item.PushedAt)
 	if timeOnQueue > config.GetInstancePollTime() {
 		log.Warningf("key %v spent %.4fs waiting on a discovery queue", item.Key, timeOnQueue.Seconds())
 	}

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -29,8 +29,22 @@ func TestQueue(t *testing.T) {
 	// Push
 	q.Push(t.Name())
 	require.Equal(t, 1, q.QueueLen())
+	_, found := q.enqueued.Load(t.Name())
+	require.True(t, found)
+
+	// Push duplicate
+	q.Push(t.Name())
+	require.Equal(t, 1, q.QueueLen())
 
 	// Consume
 	require.Equal(t, t.Name(), q.Consume())
 	require.Zero(t, q.QueueLen())
+	_, found = q.enqueued.Load(t.Name())
+	require.True(t, found)
+
+	// Release
+	q.Release(t.Name())
+	require.Zero(t, q.QueueLen())
+	_, found = q.enqueued.Load(t.Name())
+	require.False(t, found)
 }

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -29,17 +29,17 @@ func TestQueue(t *testing.T) {
 
 	// Push
 	q.Push(t.Name())
-	require.Equal(t, 1, q.QueueLen())
+	require.Equal(t, 2, q.QueueLen())
 	_, found := q.enqueued[t.Name()]
 	require.True(t, found)
 
 	// Push duplicate
 	q.Push(t.Name())
-	require.Equal(t, 1, q.QueueLen())
+	require.Equal(t, 2, q.QueueLen())
 
 	// Consume
 	require.Equal(t, t.Name(), q.Consume())
-	require.Zero(t, q.QueueLen())
+	require.Equal(t, 1, q.QueueLen())
 	_, found = q.enqueued[t.Name()]
 	require.True(t, found)
 

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -1,0 +1,43 @@
+package discovery
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+	now := time.Now()
+	q := NewQueue()
+	q.nowFunc = func() time.Time { return now }
+	require.Zero(t, q.QueueLen())
+
+	// Push
+	q.Push(t.Name())
+	require.Equal(t, 2, q.QueueLen())
+
+	// Consume
+	require.Equal(t, t.Name(), q.Consume())
+	require.Zero(t, q.QueueLen())
+}
+
+func BenchmarkQueues(b *testing.B) {
+	tests := []struct {
+		name string
+		q    Queue
+	}{
+		{"LegacyQueue", CreateQueue("test")},
+		{"QueueV2", NewQueue()},
+	}
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				test.q.Push(strconv.Itoa(i))
+				test.q.QueueLen()
+				test.q.Release(test.q.Consume())
+			}
+		})
+	}
+}

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -71,7 +71,8 @@ func BenchmarkQueues(b *testing.B) {
 				for i := 0; i < 1000; i++ {
 					q.Push(b.Name() + strconv.Itoa(i))
 				}
-				for q.QueueLen() > 0 {
+				q.QueueLen()
+				for i := 0; i < 1000; i++ {
 					q.Release(q.Consume())
 				}
 			}

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -29,8 +29,12 @@ func TestQueue(t *testing.T) {
 	// Push
 	q.Push(t.Name())
 	require.Equal(t, 2, q.QueueLen())
+	_, found := q.enqueued[t.Name()]
+	require.True(t, found)
 
 	// Consume
 	require.Equal(t, t.Name(), q.Consume())
 	require.Zero(t, q.QueueLen())
+	_, found = q.enqueued[t.Name()]
+	require.False(t, found)
 }

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -28,13 +28,9 @@ func TestQueue(t *testing.T) {
 
 	// Push
 	q.Push(t.Name())
-	require.Equal(t, 2, q.QueueLen())
-	_, found := q.enqueued[t.Name()]
-	require.True(t, found)
+	require.Equal(t, 1, q.QueueLen())
 
 	// Consume
 	require.Equal(t, t.Name(), q.Consume())
 	require.Zero(t, q.QueueLen())
-	_, found = q.enqueued[t.Name()]
-	require.False(t, found)
 }

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -17,17 +17,13 @@ limitations under the License.
 package discovery
 
 import (
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestQueue(t *testing.T) {
-	now := time.Now()
 	q := NewQueue()
-	q.nowFunc = func() time.Time { return now }
 	require.Zero(t, q.QueueLen())
 
 	// Push
@@ -37,23 +33,4 @@ func TestQueue(t *testing.T) {
 	// Consume
 	require.Equal(t, t.Name(), q.Consume())
 	require.Zero(t, q.QueueLen())
-}
-
-func BenchmarkQueues(b *testing.B) {
-	tests := []struct {
-		name string
-		q    Queue
-	}{
-		{"LegacyQueue", CreateQueue("test")},
-		{"QueueV2", NewQueue()},
-	}
-	for _, test := range tests {
-		b.Run(test.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				test.q.Push(strconv.Itoa(i))
-				test.q.QueueLen()
-				test.q.Release(test.q.Consume())
-			}
-		})
-	}
 }

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -29,13 +29,13 @@ func TestQueue(t *testing.T) {
 
 	// Push
 	q.Push(t.Name())
-	require.Equal(t, 2, q.QueueLen())
+	require.Equal(t, 1, q.QueueLen())
 	_, found := q.enqueued[t.Name()]
 	require.True(t, found)
 
 	// Push duplicate
 	q.Push(t.Name())
-	require.Equal(t, 2, q.QueueLen())
+	require.Equal(t, 1, q.QueueLen())
 
 	// Consume
 	require.Equal(t, t.Name(), q.Consume())

--- a/go/vt/vtorc/discovery/queue_test.go
+++ b/go/vt/vtorc/discovery/queue_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package discovery
 
 import (

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -110,7 +110,7 @@ func waitForLocksRelease() {
 func handleDiscoveryRequests() {
 	discoveryQueue = discovery.NewQueue()
 	// create a pool of discovery workers
-	for i := uint(0); i < config.GetDiscoveryMaxConcurrency(); i++ {
+	for i := uint(0); i < config.GetDiscoveryWorkers(); i++ {
 		go func() {
 			for {
 				tabletAlias := discoveryQueue.Consume()

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -110,7 +110,7 @@ func waitForLocksRelease() {
 func handleDiscoveryRequests() {
 	discoveryQueue = discovery.NewQueue()
 	// create a pool of discovery workers
-	for i := uint(0); i < config.DiscoveryMaxConcurrency; i++ {
+	for i := uint(0); i < config.GetDiscoveryMaxConcurrency(); i++ {
 		go func() {
 			for {
 				tabletAlias := discoveryQueue.Consume()

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -115,6 +115,7 @@ func handleDiscoveryRequests() {
 			for {
 				tabletAlias := discoveryQueue.Consume()
 				DiscoverInstance(tabletAlias, false /* forceDiscovery */)
+				discoveryQueue.Release(tabletAlias)
 			}
 		}()
 	}

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -108,14 +108,13 @@ func waitForLocksRelease() {
 // handleDiscoveryRequests iterates the discoveryQueue channel and calls upon
 // instance discovery per entry.
 func handleDiscoveryRequests() {
-	discoveryQueue = discovery.CreateQueue("DEFAULT")
+	discoveryQueue = discovery.NewQueue()
 	// create a pool of discovery workers
 	for i := uint(0); i < config.DiscoveryMaxConcurrency; i++ {
 		go func() {
 			for {
 				tabletAlias := discoveryQueue.Consume()
 				DiscoverInstance(tabletAlias, false /* forceDiscovery */)
-				discoveryQueue.Release(tabletAlias)
 			}
 		}()
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR cleans up the VTOrc discover queue code, mainly by removing all locking from `.Consume()`; this was achieved by adding `type queueItem struct` and pushing this to the channel instead, with the key and `time.Time` included. Previously this `time.Time` was stored in a `map` with mutex locks

The `.QueueLen()` now returns just the `len()` of the queue channel. Before this metric would include the length of the channel plus all that are "in processing" _(between `.Consume()` and `.Release()`)_, which I'm unsure is necessary. Simplifying this removed the need for a lock in `.QueueLen()`

Finally, the `--discovery-workers` flag was added to control how many workers consume the discovery queue

Benchmark:
```bash
tvaillancourt@tvailla-ltmawfe vitess % go test -v -bench=. ./go/vt/vtorc/discovery/...
=== RUN   TestQueue
--- PASS: TestQueue (0.00s)
goos: darwin
goarch: arm64
pkg: vitess.io/vitess/go/vt/vtorc/discovery
cpu: Apple M3 Max
BenchmarkQueues
BenchmarkQueues/New
BenchmarkQueues/New-14         	    4726	    244573 ns/op
BenchmarkQueues/Legacy
BenchmarkQueues/Legacy-14      	    3610	    338468 ns/op
PASS
ok  	vitess.io/vitess/go/vt/vtorc/discovery	3.923s
```
_NOTE: `New` == this PR, `Legacy` == current queue_

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17330

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
