### PR TITLE
Allow build git envs to be set in `docker/lite`

### DIFF
--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -17,6 +17,15 @@ FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
+# Allows docker builds to set the BUILD_TIME
+ARG BUILD_TIME
+
 WORKDIR /vt/src/vitess.io/vitess
 
 # Create vitess user

--- a/docker/lite/Dockerfile.mysql84
+++ b/docker/lite/Dockerfile.mysql84
@@ -17,6 +17,15 @@ FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
+# Allows docker builds to set the BUILD_TIME
+ARG BUILD_TIME
+
 WORKDIR /vt/src/vitess.io/vitess
 
 # Create vitess user

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -17,6 +17,15 @@ FROM --platform=linux/amd64 golang:1.24.0-bookworm AS builder
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER
 
+# Allows docker builds to set the BUILD_GIT_BRANCH
+ARG BUILD_GIT_BRANCH
+
+# Allows docker builds to set the BUILD_GIT_REV
+ARG BUILD_GIT_REV
+
+# Allows docker builds to set the BUILD_TIME
+ARG BUILD_TIME
+
 WORKDIR /vt/src/vitess.io/vitess
 
 # Create vitess user


### PR DESCRIPTION
## Description

This PR is a repeat of https://github.com/vitessio/vitess/pull/11968, but for the `docker/lite` container

TL;DR: allow `BUILD_NUMBER`, `BUILD_GIT_BRANCH`, `BUILD_GIT_REV` and `BUILD_TIME` to be set at docker build time, so metrics like `vtgate_build_information{}`/etc get the correct info

This is read from: https://github.com/vitessio/vitess/blob/main/tools/build_version_flags.sh#L31-L34. The `DEFAULT_` fallbacks are sometimes not desired, for example `BUILD_GIT_BRANCH` is often `HEAD`, not the real branch

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
