### PR TITLE
`vtorc`: remove duplicate instance read from backend

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -204,7 +204,7 @@ func ReadTopologyInstanceBufferable(tabletAlias string, latency *stopwatch.Named
 		goto Cleanup
 	}
 
-	fs, err = fullStatus(tabletAlias)
+	fs, err = fullStatus(tablet)
 	if err != nil {
 		goto Cleanup
 	}

--- a/go/vt/vtorc/inst/tablet_dao.go
+++ b/go/vt/vtorc/inst/tablet_dao.go
@@ -44,11 +44,7 @@ func InitializeTMC() tmclient.TabletManagerClient {
 }
 
 // fullStatus gets the full status of the MySQL running in vttablet.
-func fullStatus(tabletAlias string) (*replicationdatapb.FullStatus, error) {
-	tablet, err := ReadTablet(tabletAlias)
-	if err != nil {
-		return nil, err
-	}
+func fullStatus(tablet *topodatapb.Tablet) (*replicationdatapb.FullStatus, error) {
 	tmcCtx, tmcCancel := context.WithTimeout(context.Background(), topo.RemoteOperationTimeout)
 	defer tmcCancel()
 	return tmc.FullStatus(tmcCtx, tablet)


### PR DESCRIPTION
## Description

This PR prevents a duplicate read of an instance in `inst.ReadTopologyInstanceBufferable(...)`, which is a pretty hot-path func

<img width="800" alt="Screenshot 2025-02-20 at 20 05 03 copy" src="https://github.com/user-attachments/assets/ef362a8f-ca49-4cd1-86d7-64f636434db8" />

[Immediately before `fullStatus(...)` is called we call `inst.ReadTablet(...)`](https://github.com/vitessio/vitess/blob/45b588272166308174a20496294fd6fa145b091e/go/vt/vtorc/inst/instance_dao.go#L196) and today `fullStatus(...)` immediately does the same `inst.ReadTablet(...)` read again

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17330

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
