### PR TITLE
VReplication: Support excluding lagging tablets and use this in vstream manager

### DIFF
--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -720,6 +720,7 @@ func TestPickNonLaggingTablets(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
 	defer cancel()
+
 	var pickedPrimary, pickedLaggingReplica, pickedNonLaggingReplica int
 	for i := 0; i < numTestIterations; i++ {
 		tablet, err := tp.PickForStreaming(ctx)
@@ -734,9 +735,9 @@ func TestPickNonLaggingTablets(t *testing.T) {
 			pickedNonLaggingReplica++
 		}
 	}
-	assert.Zero(t, pickedPrimary)
-	assert.Zero(t, pickedLaggingReplica)
-	assert.Equal(t, numTestIterations, pickedNonLaggingReplica)
+	require.Zero(t, pickedPrimary)
+	require.Zero(t, pickedLaggingReplica)
+	require.Equal(t, numTestIterations, pickedNonLaggingReplica)
 }
 
 type pickerTestEnv struct {

--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -685,6 +685,60 @@ func TestPickNonServingTablets(t *testing.T) {
 	assert.True(t, picked3)
 }
 
+// TestPickNonLaggingTablets validates that lagging tablets are excluded when the
+// ExcludeTabletsWithMaxReplicationLag option is set.
+func TestPickNonLaggingTablets(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	cells := []string{"cell1"}
+	defaultCell := cells[0]
+	tabletTypes := "replica"
+	options := TabletPickerOptions{
+		ExcludeTabletsWithMaxReplicationLag: lowReplicationLag.Default(),
+	}
+	replLag := options.ExcludeTabletsWithMaxReplicationLag + (5 * time.Second)
+	te := newPickerTestEnv(t, ctx, cells)
+
+	// Tablet should not be selected as we only want replicas.
+	primaryTablet := addTablet(ctx, te, 100, topodatapb.TabletType_PRIMARY, defaultCell, true, true)
+	defer deleteTablet(t, te, primaryTablet)
+
+	// Tablet should not be selected as it is lagging.
+	laggingReplicaTablet := addTabletWithLag(ctx, te, 200, topodatapb.TabletType_REPLICA, defaultCell, true, true, uint32(replLag.Seconds()))
+	defer deleteTablet(t, te, laggingReplicaTablet)
+
+	// Tablet should be selected because it's a non-lagging replica.
+	nonLaggingReplicaTablet := addTablet(ctx, te, 300, topodatapb.TabletType_REPLICA, defaultCell, true, true)
+	defer deleteTablet(t, te, nonLaggingReplicaTablet)
+
+	_, err := te.topoServ.UpdateShardFields(ctx, te.keyspace, te.shard, func(si *topo.ShardInfo) error {
+		si.PrimaryAlias = primaryTablet.Alias
+		return nil
+	})
+	require.NoError(t, err)
+
+	tp, err := NewTabletPicker(ctx, te.topoServ, cells, defaultCell, te.keyspace, te.shard, tabletTypes, options)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+	var pickedPrimary, pickedLaggingReplica, pickedNonLaggingReplica int
+	for i := 0; i < numTestIterations; i++ {
+		tablet, err := tp.PickForStreaming(ctx)
+		require.NoError(t, err)
+		if proto.Equal(tablet, primaryTablet) {
+			pickedPrimary++
+		}
+		if proto.Equal(tablet, laggingReplicaTablet) {
+			pickedLaggingReplica++
+		}
+		if proto.Equal(tablet, nonLaggingReplicaTablet) {
+			pickedNonLaggingReplica++
+		}
+	}
+	assert.Zero(t, pickedPrimary)
+	assert.Zero(t, pickedLaggingReplica)
+	assert.Equal(t, numTestIterations, pickedNonLaggingReplica)
+}
+
 type pickerTestEnv struct {
 	t        *testing.T
 	keyspace string
@@ -720,6 +774,10 @@ func newPickerTestEnv(t *testing.T, ctx context.Context, cells []string, extraCe
 }
 
 func addTablet(ctx context.Context, te *pickerTestEnv, id int, tabletType topodatapb.TabletType, cell string, serving, healthy bool) *topodatapb.Tablet {
+	return addTabletWithLag(ctx, te, id, tabletType, cell, serving, healthy, 0)
+}
+
+func addTabletWithLag(ctx context.Context, te *pickerTestEnv, id int, tabletType topodatapb.TabletType, cell string, serving, healthy bool, replLagSecs uint32) *topodatapb.Tablet {
 	tablet := &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: cell,
@@ -748,6 +806,7 @@ func addTablet(ctx context.Context, te *pickerTestEnv, id int, tabletType topoda
 	if healthy {
 		shr.RealtimeStats.HealthError = ""
 	}
+	shr.RealtimeStats.ReplicationLagSeconds = replLagSecs
 
 	_ = createFixedHealthConn(tablet, shr)
 

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -194,6 +194,10 @@ func (vsm *vstreamManager) VStream(ctx context.Context, tabletType topodatapb.Ta
 		tabletPickerOptions: discovery.TabletPickerOptions{
 			CellPreference: flags.GetCellPreference(),
 			TabletOrder:    flags.GetTabletOrder(),
+			// This is NOT configurable via the API because we check the
+			// discovery.GetLowReplicationLag().Seconds() value in the tablet
+			// health stream.
+			ExcludeTabletsWithMaxReplicationLag: discovery.GetLowReplicationLag(),
 		},
 		flags: flags,
 	}


### PR DESCRIPTION
## Description

This PR adds support in the [TabletPicker](https://vitess.io/docs/reference/vreplication/tablet_selection/) for excluding tablets that have MySQL replication lag higher than a given maximum value. It then uses this new support in the VTGate vstream manager to exclude candidates that would immediately [fail when we start the health check stream from the selected tablet](https://github.com/vitessio/vitess/blob/2118bc35d4711f2070b3dd1ae2d14decc28ca060/go/vt/vtgate/vstream_manager.go#L582-L584).

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/17833

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required