### PR TITLE
check always-on heartbeat config before on-demand

### DIFF
--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -98,15 +98,15 @@ func newHeartbeatWriter(env tabletenv.Env, alias *topodatapb.TabletAlias) *heart
 	configType := HeartbeatConfigTypeNone
 	onDemandDuration := defaultOnDemandDuration
 	switch {
+	case config.ReplicationTracker.Mode == tabletenv.Heartbeat:
+		configType = HeartbeatConfigTypeAlways
+		onDemandDuration = 0
 	case config.ReplicationTracker.HeartbeatOnDemand > 0:
 		configType = HeartbeatConfigTypeOnDemand
 		onDemandDuration = config.ReplicationTracker.HeartbeatOnDemand
 		if onDemandDuration < minimalOnDemandDuration {
 			onDemandDuration = minimalOnDemandDuration
 		}
-	case config.ReplicationTracker.Mode == tabletenv.Heartbeat:
-		configType = HeartbeatConfigTypeAlways
-		onDemandDuration = 0
 	}
 	heartbeatInterval := config.ReplicationTracker.HeartbeatInterval
 	if heartbeatInterval == 0 {


### PR DESCRIPTION
## Description
Change the order in which we check the config for heartbeats.
Tested manually using the local example.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #17828 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
