### PR TITLE
`vtorc`: use `REPLACE INTO` in `node_health` table update

### DIFF
--- a/go/vt/vtorc/process/health.go
+++ b/go/vt/vtorc/process/health.go
@@ -35,12 +35,7 @@ var ThisNodeHealth = &NodeHealth{}
 
 // writeHealthToDatabase writes to the database and returns if it was successful.
 func writeHealthToDatabase() bool {
-	_, err := db.ExecVTOrc("DELETE FROM node_health")
-	if err != nil {
-		log.Error(err)
-		return false
-	}
-	sqlResult, err := db.ExecVTOrc(`INSERT
+	sqlResult, err := db.ExecVTOrc(`REPLACE
 		INTO node_health (
 			last_seen_active
 		) VALUES (


### PR DESCRIPTION
## Description

This PR updates the code that updates the `node_health` sqlite3 table in VTOrc to use a single `REPLACE INTO` vs a `DELETE FROM` + `INSERT INTO`

I believe in the end both approaches achieve a 1-row table, but the `REPLACE INTO` approach is more efficient

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17330

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
