### PR TITLE
Small planner refactoring

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -142,7 +142,7 @@ func (qb *queryBuilder) addPredicate(expr sqlparser.Expr) {
 		addPred = sel.AddWhere
 		qb.stmt = sel
 	default:
-		panic(fmt.Sprintf("cant add WHERE to %T", qb.stmt))
+		panic(fmt.Sprintf("cant add WHERE to %T, %s", qb.stmt, sqlparser.String(expr)))
 	}
 
 	for _, exp := range sqlparser.SplitAndExpression(nil, expr) {

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -100,20 +100,6 @@ func (f *Filter) GetOrdering(ctx *plancontext.PlanningContext) []OrderBy {
 	return f.Source.GetOrdering(ctx)
 }
 
-func (f *Filter) Compact(*plancontext.PlanningContext) (Operator, *ApplyResult) {
-	if len(f.Predicates) == 0 {
-		return f.Source, Rewrote("filter with no predicates removed")
-	}
-
-	other, isFilter := f.Source.(*Filter)
-	if !isFilter {
-		return f, NoRewrite
-	}
-	f.Source = other.Source
-	f.Predicates = append(f.Predicates, other.Predicates...)
-	return f, Rewrote("two filters merged into one")
-}
-
 func (f *Filter) planOffsets(ctx *plancontext.PlanningContext) Operator {
 	cfg := &evalengine.Config{
 		ResolveType: ctx.TypeForExpr,

--- a/go/vt/vtgate/planbuilder/operators/helpers.go
+++ b/go/vt/vtgate/planbuilder/operators/helpers.go
@@ -29,6 +29,7 @@ import (
 
 type compactable interface {
 	// Compact implement this interface for operators that have easy to see optimisations
+	// This is run after the normal planning phase and is used to optimise the operator tree
 	Compact(ctx *plancontext.PlanningContext) (Operator, *ApplyResult)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/join.go
+++ b/go/vt/vtgate/planbuilder/operators/join.go
@@ -49,16 +49,16 @@ func (j *Join) GetOrdering(*plancontext.PlanningContext) []OrderBy {
 	return nil
 }
 
-func (j *Join) Compact(ctx *plancontext.PlanningContext) (Operator, *ApplyResult) {
+func (j *Join) tryCompact(ctx *plancontext.PlanningContext) Operator {
 	if !j.JoinType.IsCommutative() {
 		// if we can't move tables around, we can't merge these inputs
-		return j, NoRewrite
+		return nil
 	}
 
 	lqg, lok := j.LHS.(*QueryGraph)
 	rqg, rok := j.RHS.(*QueryGraph)
 	if !lok || !rok {
-		return j, NoRewrite
+		return nil
 	}
 
 	newOp := &QueryGraph{
@@ -69,7 +69,7 @@ func (j *Join) Compact(ctx *plancontext.PlanningContext) (Operator, *ApplyResult
 	if j.Predicate != nil {
 		newOp.collectPredicate(ctx, j.Predicate)
 	}
-	return newOp, Rewrote("merge querygraphs into a single one")
+	return newOp
 }
 
 func createStraightJoin(ctx *plancontext.PlanningContext, join *sqlparser.JoinTableExpr, lhs, rhs Operator) Operator {

--- a/go/vt/vtgate/planbuilder/operators/plan_query.go
+++ b/go/vt/vtgate/planbuilder/operators/plan_query.go
@@ -70,7 +70,6 @@ func PlanQuery(ctx *plancontext.PlanningContext, stmt sqlparser.Statement) (resu
 		fmt.Println(ToTree(op))
 	}
 
-	op = compact(ctx, op)
 	checkValid(op)
 	op = planQuery(ctx, op)
 

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -518,7 +518,7 @@ func (p *Projection) Compact(ctx *plancontext.PlanningContext) (Operator, *Apply
 
 func (p *Projection) compactWithJoin(ctx *plancontext.PlanningContext, join *ApplyJoin) (Operator, *ApplyResult) {
 	ap, err := p.GetAliasedProjections()
-	if err != nil {
+	if err != nil || len(join.Columns) == 0 {
 		return p, NoRewrite
 	}
 
@@ -528,9 +528,6 @@ func (p *Projection) compactWithJoin(ctx *plancontext.PlanningContext, join *App
 		switch colInfo := col.Info.(type) {
 		case Offset:
 			if col.Original.As.NotEmpty() {
-				return p, NoRewrite
-			}
-			if len(join.Columns) == 0 {
 				return p, NoRewrite
 			}
 			newColumns = append(newColumns, join.Columns[colInfo])

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -488,29 +488,28 @@ func (p *Projection) ShortDescription() string {
 	return strings.Join(result, ", ")
 }
 
-func (p *Projection) Compact(ctx *plancontext.PlanningContext) (Operator, *ApplyResult) {
+func (p *Projection) isNeeded() bool {
 	ap, err := p.GetAliasedProjections()
 	if err != nil {
-		return p, NoRewrite
+		return true // we don't know enough about the columns to make a decision
 	}
 
-	// for projections that are not derived tables, we can check if it is safe to remove or not
-	needed := false
 	for i, projection := range ap {
 		e, ok := projection.Info.(Offset)
 		if !ok || int(e) != i || projection.Original.As.NotEmpty() {
-			needed = true
-			break
+			return true
 		}
 	}
 
-	if !needed {
+	return false
+}
+
+func (p *Projection) Compact(ctx *plancontext.PlanningContext) (Operator, *ApplyResult) {
+	if !p.isNeeded() {
 		return p.Source, Rewrote("removed projection only passing through the input")
 	}
 
 	switch src := p.Source.(type) {
-	case *Route:
-		return p.compactWithRoute(ctx, src)
 	case *ApplyJoin:
 		return p.compactWithJoin(ctx, src)
 	}
@@ -529,6 +528,9 @@ func (p *Projection) compactWithJoin(ctx *plancontext.PlanningContext, join *App
 		switch colInfo := col.Info.(type) {
 		case Offset:
 			if col.Original.As.NotEmpty() {
+				return p, NoRewrite
+			}
+			if len(join.Columns) == 0 {
 				return p, NoRewrite
 			}
 			newColumns = append(newColumns, join.Columns[colInfo])
@@ -553,27 +555,6 @@ func (p *Projection) compactWithJoin(ctx *plancontext.PlanningContext, join *App
 	join.Columns = newColumns
 	join.JoinColumns = newColumnsAST
 	return join, Rewrote("remove projection from before join")
-}
-
-func (p *Projection) compactWithRoute(ctx *plancontext.PlanningContext, rb *Route) (Operator, *ApplyResult) {
-	ap, err := p.GetAliasedProjections()
-	if err != nil {
-		return p, NoRewrite
-	}
-
-	for i, col := range ap {
-		offset, ok := col.Info.(Offset)
-		if !ok || int(offset) != i {
-			return p, NoRewrite
-		}
-	}
-	columns := rb.GetColumns(ctx)
-
-	if len(columns) == len(ap) {
-		return rb, Rewrote("remove projection from before route")
-	}
-	rb.ResultColumns = len(columns)
-	return rb, NoRewrite
 }
 
 // needsEvaluation finds the expression given by this argument and checks if the inside and outside expressions match

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -53,6 +53,9 @@ func pushDerived(ctx *plancontext.PlanningContext, op *Horizon) (Operator, *Appl
 }
 
 func optimizeJoin(ctx *plancontext.PlanningContext, op *Join) (Operator, *ApplyResult) {
+	if newOp := op.tryCompact(ctx); newOp != nil {
+		return newOp, Rewrote("merged query graphs")
+	}
 	return mergeOrJoin(ctx, op.LHS, op.RHS, sqlparser.SplitAndExpression(nil, op.Predicate), op.JoinType)
 }
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -378,7 +378,7 @@ func (s *planTestSuite) TestOneWithTPCHVSchema() {
 	defer reset()
 
 	env := vtenv.NewTestEnv()
-	vschema := loadSchema(s.T(), "vschemas/schema.json", true)
+	vschema := loadSchema(s.T(), "vschemas/tpch_schema.json", true)
 	vw, err := vschemawrapper.NewVschemaWrapper(env, vschema, TestBuilder)
 	require.NoError(s.T(), err)
 


### PR DESCRIPTION
## Description
Move most of the code in `Compact` implementations to run as normal push down rewriters instead.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
