### PR TITLE
VTTablet schema reload: include stats only on periodic reload, default to "base table" query for the "with sizes" query for 5.7 only

### DIFF
--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -487,7 +487,12 @@ const InnoDBTableSizes = `
 
 // baseShowTablesWithSizes is part of the Flavor interface.
 func (mysqlFlavor57) baseShowTablesWithSizes() string {
-	return TablesWithSize57
+	// For 5.7, we use the base query instead of the query with sizes. Flavor57 should only be used
+	// for unmanaged tables during import. We don't need to know the size of the tables in that case since
+	// the size information is mainly used by Online DDL.
+	// The TablesWithSize57 query can be very non-performant on some external databases, for example on Aurora with
+	// a large number of tables, it can time out often.
+	return BaseShowTables
 }
 
 // baseShowInnodbTableSizes is part of the Flavor interface.

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -1042,8 +1042,8 @@ func TestEngineReload(t *testing.T) {
 					assert.Zero(t, tbl.FileSize)
 					assert.Zero(t, tbl.AllocatedSize)
 				default:
-					assert.NotZero(t, tbl.FileSize)
-					assert.NotZero(t, tbl.AllocatedSize)
+					assert.Zero(t, tbl.FileSize)
+					assert.Zero(t, tbl.AllocatedSize)
 				}
 			})
 		}
@@ -1082,8 +1082,8 @@ func TestEngineReload(t *testing.T) {
 					assert.Zero(t, tbl.FileSize)
 					assert.Zero(t, tbl.AllocatedSize)
 				default:
-					assert.NotZero(t, tbl.FileSize)
-					assert.NotZero(t, tbl.AllocatedSize)
+					assert.Zero(t, tbl.FileSize)
+					assert.Zero(t, tbl.AllocatedSize)
 				}
 			})
 		}

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -271,7 +271,8 @@ func (se *Engine) Open() error {
 	}
 
 	se.ticks.Start(func() {
-		if err := se.Reload(ctx); err != nil {
+		// update stats on periodic reloads
+		if err := se.reload(ctx, true); err != nil {
 			log.Errorf("periodic schema reload failed: %v", err)
 		}
 	})

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -369,7 +369,7 @@ func (se *Engine) Reload(ctx context.Context) error {
 // It maintains the position at which the schema was reloaded and if the same position is provided
 // (say by multiple vstreams) it returns the cached schema. In case of a newer or empty pos it always reloads the schema
 func (se *Engine) ReloadAt(ctx context.Context, pos replication.Position) error {
-	return se.ReloadAtEx(ctx, pos, true)
+	return se.ReloadAtEx(ctx, pos, false)
 }
 
 // ReloadAtEx reloads the schema info from the db.
@@ -800,7 +800,7 @@ func (se *Engine) GetTableForPos(ctx context.Context, tableName sqlparser.Identi
 	// This also allows us to perform a just-in-time initialization of the cache if
 	// a vstreamer is the first one to access it.
 	if se.conns != nil { // Test Engines (NewEngineForTests()) don't have a conns pool
-		if err := se.reload(ctx, true); err != nil {
+		if err := se.reload(ctx, false); err != nil {
 			return nil, err
 		}
 		if st, ok := se.tables[tableNameStr]; ok {

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -29,8 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/log"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -181,9 +179,7 @@ func TestOpenAndReloadLegacy(t *testing.T) {
 
 	firstTime := true
 	notifier := func(full map[string]*Table, created, altered, dropped []*Table, _ bool) {
-		log.Infof("Notifier called, firstTime: %v, created %v, altered %v, dropped %v", firstTime, created, altered, dropped)
 		if firstTime {
-			log.Infof("Notifier called 2, firstTime: %v, created %v, altered %v, dropped %v", firstTime, created, altered, dropped)
 			firstTime = false
 			createTables := extractNamesFromTablesList(created)
 			sort.Strings(createTables)
@@ -191,7 +187,6 @@ func TestOpenAndReloadLegacy(t *testing.T) {
 			assert.Equal(t, []*Table(nil), altered)
 			assert.Equal(t, []*Table(nil), dropped)
 		} else {
-			log.Infof("Notifier called 3, firstTime: %v, created %v, altered %v, dropped %v", firstTime, created, altered, dropped)
 			assert.Equal(t, []string{"test_table_04"}, extractNamesFromTablesList(created))
 			assert.Equal(t, []string{"test_table_03"}, extractNamesFromTablesList(altered))
 			assert.Equal(t, []string{"msg"}, extractNamesFromTablesList(dropped))

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -42,7 +42,6 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/dbconfigs"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
@@ -51,6 +50,7 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 const baseShowTablesWithSizesPattern = `SELECT t\.table_name.*SUM\(i\.file_size\).*`


### PR DESCRIPTION
## Description

For a specific `MoveTables` workflow, we are seeing timeouts on reloading the schema on unmanaged tables connected to the multi-tenant Aurora cluster with a massive number of tables.

For schema reloads, we are defaulting to using the "with sizes" query instead of just the "base tables" one. The "with sizes" one is significantly slower and is only needed by `Online DDL` migrations which we don't do on the unmanaged keyspaces.

This PR changes the VReplication related schema reloads to not include file size stats. We do reload stats for the periodic reload that is done on a timer at interval defined by the `vttablet` flag `--queryserver-config-schema-reload-time`.

Vitess now only supports MySQL 5.7 for imports, since 5.7 is EOL. So for the 5.7 flavor, which is the one used for many of the Aurora and RDS imports, we will just default to the "base tables" query instead of the "with sizes" one even if `include_stats` is specified to schema reload.


## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/17856

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
