### PR TITLE
Add more vstream metrics for vstream manager

### DIFF
--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -397,7 +397,7 @@ func (vs *vstream) startOneStream(ctx context.Context, sgtid *binlogdatapb.Shard
 		defer vs.wg.Done()
 
 		labelValues := []string{sgtid.Keyspace, sgtid.Shard, vs.tabletType.String()}
-		vs.vsm.vstreamsEndedWithErrors.Add(labelValues, 0)
+		vs.vsm.vstreamsEndedWithErrors.Reset(labelValues)
 		vs.vsm.vstreamsCreated.Add(labelValues, 1)
 		vs.vsm.vstreamsCount.Add(labelValues, 1)
 

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -397,7 +397,8 @@ func (vs *vstream) startOneStream(ctx context.Context, sgtid *binlogdatapb.Shard
 		defer vs.wg.Done()
 
 		labelValues := []string{sgtid.Keyspace, sgtid.Shard, vs.tabletType.String()}
-		vs.vsm.vstreamsEndedWithErrors.Reset(labelValues)
+		// Initialize vstreamsEndedWithErrors metric to zero.
+		vs.vsm.vstreamsEndedWithErrors.Add(labelValues, 0)
 		vs.vsm.vstreamsCreated.Add(labelValues, 1)
 		vs.vsm.vstreamsCount.Add(labelValues, 1)
 

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -456,7 +456,7 @@ func TestVStreamsMetricsErrors(t *testing.T) {
 		})
 
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
-			t.Errorf("vstream end: %v, must contain %v", err.Error(), wantErr)
+			require.ErrorContains(t, err, wantErr)
 		}
 		close(done)
 	}()
@@ -468,7 +468,7 @@ func TestVStreamsMetricsErrors(t *testing.T) {
 
 	wantVStreamsEndedWithErrors := make(map[string]int64)
 	wantVStreamsEndedWithErrors[expectedLabels1] = 1
-	wantVStreamsEndedWithErrors[expectedLabels2] = 1
+	wantVStreamsEndedWithErrors[expectedLabels2] = 0
 	assert.Equal(t, wantVStreamsEndedWithErrors, vsm.vstreamsEndedWithErrors.Counts(), "vstreamsEndedWithErrors matches")
 }
 

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -346,6 +346,9 @@ func TestVStreamsMetrics(t *testing.T) {
 	vsm := newTestVStreamManager(ctx, hc, st, cell)
 	vsm.vstreamsCreated.ResetAll()
 	vsm.vstreamsLag.ResetAll()
+	vsm.vstreamsCount.ResetAll()
+	vsm.vstreamsEventsStreamed.ResetAll()
+	vsm.vstreamsEndedWithErrors.ResetAll()
 	hostname1 := "host1"
 	hostname2 := "host2"
 	sbc0 := hc.AddTestTablet(cell, hostname1, 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
@@ -420,6 +423,9 @@ func TestVStreamsMetricsErrors(t *testing.T) {
 	vsm := newTestVStreamManager(ctx, hc, st, cell)
 	vsm.vstreamsCreated.ResetAll()
 	vsm.vstreamsLag.ResetAll()
+	vsm.vstreamsCount.ResetAll()
+	vsm.vstreamsEventsStreamed.ResetAll()
+	vsm.vstreamsEndedWithErrors.ResetAll()
 	hostname1 := "host1"
 	hostname2 := "host2"
 	sbc0 := hc.AddTestTablet(cell, hostname1, 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -335,7 +335,7 @@ func TestVStreamMulti(t *testing.T) {
 	}
 }
 
-func TestVStreamsCreatedAndLagMetrics(t *testing.T) {
+func TestVStreamsMetrics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cell := "aa"
@@ -346,9 +346,11 @@ func TestVStreamsCreatedAndLagMetrics(t *testing.T) {
 	vsm := newTestVStreamManager(ctx, hc, st, cell)
 	vsm.vstreamsCreated.ResetAll()
 	vsm.vstreamsLag.ResetAll()
-	sbc0 := hc.AddTestTablet(cell, "1.1.1.1", 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	hostname1 := "host1"
+	hostname2 := "host2"
+	sbc0 := hc.AddTestTablet(cell, hostname1, 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	addTabletToSandboxTopo(t, ctx, st, ks, "-20", sbc0.Tablet())
-	sbc1 := hc.AddTestTablet(cell, "1.1.1.1", 1002, ks, "20-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc1 := hc.AddTestTablet(cell, hostname2, 1002, ks, "20-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	addTabletToSandboxTopo(t, ctx, st, ks, "20-40", sbc1.Tablet())
 
 	send0 := []*binlogdatapb.VEvent{
@@ -377,15 +379,96 @@ func TestVStreamsCreatedAndLagMetrics(t *testing.T) {
 	ch := startVStream(ctx, t, vsm, vgtid, nil)
 	<-ch
 	<-ch
+	expectedLabels1Prefix := "TestVStream.-20.PRIMARY"
+	expectedLabels2Prefix := "TestVStream.20-40.PRIMARY"
+	expectedLabels1 := expectedLabels1Prefix + "." + hostname1
+	expectedLabels2 := expectedLabels2Prefix + "." + hostname2
 	wantVStreamsCreated := make(map[string]int64)
-	wantVStreamsCreated["TestVStream.-20.PRIMARY"] = 1
-	wantVStreamsCreated["TestVStream.20-40.PRIMARY"] = 1
+	wantVStreamsCreated[expectedLabels1] = 1
+	wantVStreamsCreated[expectedLabels2] = 1
 	assert.Equal(t, wantVStreamsCreated, vsm.vstreamsCreated.Counts(), "vstreamsCreated matches")
 
 	wantVStreamsLag := make(map[string]int64)
-	wantVStreamsLag["TestVStream.-20.PRIMARY"] = 5
-	wantVStreamsLag["TestVStream.20-40.PRIMARY"] = 7
+	wantVStreamsLag[expectedLabels1] = 5
+	wantVStreamsLag[expectedLabels2] = 7
 	assert.Equal(t, wantVStreamsLag, vsm.vstreamsLag.Counts(), "vstreamsLag matches")
+
+	wantVStreamsCount := make(map[string]int64)
+	wantVStreamsCount[expectedLabels1] = 1
+	wantVStreamsCount[expectedLabels2] = 1
+	assert.Equal(t, wantVStreamsCount, vsm.vstreamsCount.Counts(), "vstreamsCount matches")
+
+	wantVStreamsEventsStreamed := make(map[string]int64)
+	wantVStreamsEventsStreamed[expectedLabels1] = 2
+	wantVStreamsEventsStreamed[expectedLabels2] = 2
+	assert.Equal(t, wantVStreamsEventsStreamed, vsm.vstreamsEventsStreamed.Counts(), "vstreamsEventsStreamed matches")
+
+	wantVStreamsEndedWithErrors := make(map[string]int64)
+	wantVStreamsEndedWithErrors[expectedLabels1Prefix] = 0
+	wantVStreamsEndedWithErrors[expectedLabels2Prefix] = 0
+	assert.Equal(t, wantVStreamsEndedWithErrors, vsm.vstreamsEndedWithErrors.Counts(), "vstreamsEndedWithErrors matches")
+}
+
+func TestVStreamsMetricsErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cell := "aa"
+	ks := "TestVStream"
+	_ = createSandbox(ks)
+	hc := discovery.NewFakeHealthCheck(nil)
+	st := getSandboxTopo(ctx, cell, ks, []string{"-20", "20-40"})
+	vsm := newTestVStreamManager(ctx, hc, st, cell)
+	vsm.vstreamsCreated.ResetAll()
+	vsm.vstreamsLag.ResetAll()
+	hostname1 := "host1"
+	hostname2 := "host2"
+	sbc0 := hc.AddTestTablet(cell, hostname1, 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	addTabletToSandboxTopo(t, ctx, st, ks, "-20", sbc0.Tablet())
+	sbc1 := hc.AddTestTablet(cell, hostname2, 1002, ks, "20-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	addTabletToSandboxTopo(t, ctx, st, ks, "20-40", sbc1.Tablet())
+
+	const wantErr = "Invalid arg message"
+	sbc0.AddVStreamEvents(nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, wantErr))
+
+	send1 := []*binlogdatapb.VEvent{
+		{Type: binlogdatapb.VEventType_GTID, Gtid: "gtid02"},
+		{Type: binlogdatapb.VEventType_COMMIT, Timestamp: 10, CurrentTime: 17 * 1e9},
+	}
+	sbc1.AddVStreamEvents(send1, nil)
+
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: ks,
+			Shard:    "-20",
+			Gtid:     "pos",
+		}, {
+			Keyspace: ks,
+			Shard:    "20-40",
+			Gtid:     "pos",
+		}},
+	}
+	ch := make(chan *binlogdatapb.VStreamResponse)
+	done := make(chan struct{})
+	go func() {
+		err := vsm.VStream(ctx, topodatapb.TabletType_PRIMARY, vgtid, nil, &vtgatepb.VStreamFlags{}, func(events []*binlogdatapb.VEvent) error {
+			ch <- &binlogdatapb.VStreamResponse{Events: events}
+			return nil
+		})
+
+		if err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("vstream end: %v, must contain %v", err.Error(), wantErr)
+		}
+		close(done)
+	}()
+	<-done
+
+	expectedLabels1 := "TestVStream.-20.PRIMARY"
+	expectedLabels2 := "TestVStream.20-40.PRIMARY"
+
+	wantVStreamsEndedWithErrors := make(map[string]int64)
+	wantVStreamsEndedWithErrors[expectedLabels1] = 1
+	wantVStreamsEndedWithErrors[expectedLabels2] = 1
+	assert.Equal(t, wantVStreamsEndedWithErrors, vsm.vstreamsEndedWithErrors.Counts(), "vstreamsEndedWithErrors matches")
 }
 
 func TestVStreamRetriableErrors(t *testing.T) {

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -349,11 +349,9 @@ func TestVStreamsMetrics(t *testing.T) {
 	vsm.vstreamsCount.ResetAll()
 	vsm.vstreamsEventsStreamed.ResetAll()
 	vsm.vstreamsEndedWithErrors.ResetAll()
-	hostname1 := "host1"
-	hostname2 := "host2"
-	sbc0 := hc.AddTestTablet(cell, hostname1, 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc0 := hc.AddTestTablet(cell, "1.1.1.1", 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	addTabletToSandboxTopo(t, ctx, st, ks, "-20", sbc0.Tablet())
-	sbc1 := hc.AddTestTablet(cell, hostname2, 1002, ks, "20-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc1 := hc.AddTestTablet(cell, "1.1.1.2", 1002, ks, "20-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	addTabletToSandboxTopo(t, ctx, st, ks, "20-40", sbc1.Tablet())
 
 	send0 := []*binlogdatapb.VEvent{
@@ -382,10 +380,8 @@ func TestVStreamsMetrics(t *testing.T) {
 	ch := startVStream(ctx, t, vsm, vgtid, nil)
 	<-ch
 	<-ch
-	expectedLabels1Prefix := "TestVStream.-20.PRIMARY"
-	expectedLabels2Prefix := "TestVStream.20-40.PRIMARY"
-	expectedLabels1 := expectedLabels1Prefix + "." + hostname1
-	expectedLabels2 := expectedLabels2Prefix + "." + hostname2
+	expectedLabels1 := "TestVStream.-20.PRIMARY"
+	expectedLabels2 := "TestVStream.20-40.PRIMARY"
 	wantVStreamsCreated := make(map[string]int64)
 	wantVStreamsCreated[expectedLabels1] = 1
 	wantVStreamsCreated[expectedLabels2] = 1
@@ -407,8 +403,8 @@ func TestVStreamsMetrics(t *testing.T) {
 	assert.Equal(t, wantVStreamsEventsStreamed, vsm.vstreamsEventsStreamed.Counts(), "vstreamsEventsStreamed matches")
 
 	wantVStreamsEndedWithErrors := make(map[string]int64)
-	wantVStreamsEndedWithErrors[expectedLabels1Prefix] = 0
-	wantVStreamsEndedWithErrors[expectedLabels2Prefix] = 0
+	wantVStreamsEndedWithErrors[expectedLabels1] = 0
+	wantVStreamsEndedWithErrors[expectedLabels2] = 0
 	assert.Equal(t, wantVStreamsEndedWithErrors, vsm.vstreamsEndedWithErrors.Counts(), "vstreamsEndedWithErrors matches")
 }
 
@@ -426,11 +422,9 @@ func TestVStreamsMetricsErrors(t *testing.T) {
 	vsm.vstreamsCount.ResetAll()
 	vsm.vstreamsEventsStreamed.ResetAll()
 	vsm.vstreamsEndedWithErrors.ResetAll()
-	hostname1 := "host1"
-	hostname2 := "host2"
-	sbc0 := hc.AddTestTablet(cell, hostname1, 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc0 := hc.AddTestTablet(cell, "1.1.1.1", 1001, ks, "-20", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	addTabletToSandboxTopo(t, ctx, st, ks, "-20", sbc0.Tablet())
-	sbc1 := hc.AddTestTablet(cell, hostname2, 1002, ks, "20-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc1 := hc.AddTestTablet(cell, "1.1.1.2", 1002, ks, "20-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	addTabletToSandboxTopo(t, ctx, st, ks, "20-40", sbc1.Tablet())
 
 	const wantErr = "Invalid arg message"

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -466,6 +466,7 @@ func TestVStreamsMetricsErrors(t *testing.T) {
 		}
 		close(done)
 	}()
+	<-ch
 	<-done
 
 	expectedLabels1 := "TestVStream.-20.PRIMARY"


### PR DESCRIPTION
## Description

Add more metrics for vstreams on vtgates.

Inspired partially by the [tablet vstream metrics](https://github.com/vitessio/vitess/blob/main/go/vt/vttablet/tabletserver/vstreamer/engine.go#L131-L147). Let me know if you think I should include any others. Once we are decided on the metrics list, I will put out docs PR.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

  - Fixes: https://github.com/vitessio/vitess/issues/17859



## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation: https://github.com/vitessio/website/pull/1948
