### PR TITLE
Experimental: vreplication local timezone

### DIFF
--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -289,6 +289,12 @@ func (v *VRepl) generateFilterQuery() error {
 		case targetCol.Type() == "json": // we already know the source col is not JSON, per the above `case` condition
 			// Convert any type to JSON: encode the type as utf8mb4 text
 			sb.WriteString(fmt.Sprintf("convert(%s using utf8mb4)", escapeName(name)))
+		case sourceCol.Type() == "timestamp":
+			sb.WriteString(fmt.Sprintf("IF(%s='0000-00-00 00:00:00', '0000-00-00 00:00:00', CONVERT_TZ(%s, '+00:00', @@global.time_zone))", escapeName(name), escapeName(name)))
+		// case targetCol.Type() == "timestamp":
+		// 	sb.WriteString(fmt.Sprintf("CONVERT_TZ(%s, '+00:00', @@global.time_zone)", escapeName(name)))
+		// case targetCol.Type() == "datetime":
+		// 	sb.WriteString(fmt.Sprintf("CONVERT_TZ(%s, '+00:00', @@global.time_zone)", escapeName(name)))
 		case sourceCol.IsTextual():
 			// Check source and target charset/encoding. If needed, create
 			// a binlogdatapb.CharsetConversion entry (later written to vreplication)

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -211,11 +211,6 @@ func setDBClientSettings(dbClient binlogplayer.DBClient, workflowConfig *vttable
 		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "vreplication controller: workflowConfig is nil")
 	}
 	const maxRows = 10000
-	// Timestamp fields from binlogs are always sent as UTC.
-	// So, we should set the timezone to be UTC for those values to be correctly inserted.
-	if _, err := dbClient.ExecuteFetch("set @@session.time_zone = '+00:00'", maxRows); err != nil {
-		return err
-	}
 	// Tables may have varying character sets. To ship the bits without interpreting them
 	// we set the character set to be binary.
 	if _, err := dbClient.ExecuteFetch("set names 'binary'", maxRows); err != nil {


### PR DESCRIPTION

## Description

Experimental PR. Today we enforce UTC timezone in vreplication. We wish to see whether and how this can be removed. A bit of context: https://github.com/vitessio/vitess/issues/17860

## Related Issue(s)

-

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
