### PR TITLE
`vtorc`: add index for `inst.ReadInstanceClusterAttributes` table scan

### DIFF
--- a/go/vt/vtorc/db/generate_base.go
+++ b/go/vt/vtorc/db/generate_base.go
@@ -116,6 +116,9 @@ CREATE INDEX last_checked_idx_database_instance ON database_instance(last_checke
 CREATE INDEX last_seen_idx_database_instance ON database_instance(last_seen)
 	`,
 	`
+CREATE INDEX hostname_port_database_instance ON database_instance(hostname, port)
+	`,
+	`
 DROP TABLE IF EXISTS audit
 `,
 	`


### PR DESCRIPTION
## Description

This PR adds an index for `(hostname, port)` on the VTOrc `database_instance` table to avoid an expensive full table scan caused by `inst.ReadInstanceClusterAttributes` [looking for rows by `hostname` and `port`](https://github.com/slackhq/vitess/blob/main/go/vt/vtorc/inst/instance_dao.go#L488-L491)

In the future I'd like to do something smarter as discussed in https://github.com/vitessio/vitess/pull/17843, but for now this index performs much better than not-having it

#### Before w/2000~ tablets (18% of profile time)

![Screenshot 2025-02-20 at 17 58 58](https://github.com/user-attachments/assets/9ae90b8f-ae5d-4e5f-947d-26192e3aff56)

#### After w/2000~ tablets (2.6% of profile time)

![Screenshot 2025-02-20 at 17 59 18](https://github.com/user-attachments/assets/18ad7d42-02a2-40d5-9c15-071a29c7d49f)

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17330

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
