### PR TITLE
Use `vtbackup` in scheduled backups

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -7,6 +7,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /tmp
+            type: Directory
   images:
     vtctld: vitess/lite:latest
     vtadmin: vitess/vtadmin:latest
@@ -15,7 +22,7 @@ spec:
     vtbackup: vitess/lite:latest
     vtorc: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.40
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.14.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -3,6 +3,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /tmp
+            type: Directory
   images:
     vtctld: vitess/lite:latest
     vtadmin: vitess/vtadmin:latest

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -3,6 +3,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /tmp
+            type: Directory
   images:
     vtctld: vitess/lite:latest
     vtadmin: vitess/vtadmin:latest

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -3,6 +3,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /tmp
+            type: Directory
   images:
     vtctld: vitess/lite:latest
     vtadmin: vitess/vtadmin:latest

--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -11,8 +11,8 @@ spec:
             path: /tmp
             type: Directory
     schedules:
-      - name: "every-minute-customer"
-        schedule: "* * * * *"
+      - name: "commerce"
+        schedule: "*/2 * * * *"
         resources:
           requests:
             cpu: 100m
@@ -23,27 +23,27 @@ spec:
         failedJobsHistoryLimit: 3
         jobTimeoutMinute: 5
         strategies:
-          - name: BackupShard
-            keyspace: "customer"
-            shard: "-80"
-          - name: BackupShard
-            keyspace: "customer"
-            shard: "80-"
-      - name: "every-minute-commerce"
-        schedule: "* * * * *"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 1024Mi
-          limits:
-            memory: 1024Mi
-        successfulJobsHistoryLimit: 2
-        failedJobsHistoryLimit: 3
-        jobTimeoutMinute: 5
-        strategies:
-          - name: BackupShard
+          - name: commerce_x
             keyspace: "commerce"
             shard: "-"
+      - name: "customer"
+        schedule: "*/2 * * * *"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1024Mi
+          limits:
+            memory: 1024Mi
+        successfulJobsHistoryLimit: 2
+        failedJobsHistoryLimit: 3
+        jobTimeoutMinute: 5
+        strategies:
+          - name: customer_80-x
+            keyspace: "customer"
+            shard: "80-"
+          - name: customer_x-80
+            keyspace: "customer"
+            shard: "-80"
   images:
     vtctld: vitess/lite:latest
     vtadmin: vitess/vtadmin:latest

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -416,6 +416,7 @@ spec:
                 cluster:
                   type: string
                 concurrencyPolicy:
+                  default: Forbid
                   enum:
                     - Allow
                     - Forbid
@@ -491,8 +492,6 @@ spec:
                         example: commerce
                         type: string
                       name:
-                        enum:
-                          - BackupShard
                         type: string
                       shard:
                         example: '-'
@@ -542,6 +541,11 @@ spec:
                 lastScheduledTime:
                   format: date-time
                   type: string
+                lastScheduledTimes:
+                  additionalProperties:
+                    format: date-time
+                    type: string
+                  type: object
               type: object
           type: object
       served: true
@@ -2028,6 +2032,7 @@ spec:
                               type: string
                             type: object
                           concurrencyPolicy:
+                            default: Forbid
                             enum:
                               - Allow
                               - Forbid
@@ -2099,8 +2104,6 @@ spec:
                                   example: commerce
                                   type: string
                                 name:
-                                  enum:
-                                    - BackupShard
                                   type: string
                                 shard:
                                   example: '-'
@@ -7695,7 +7698,8 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:latest
+          image: docker.io/planetscale/vitess-operator:latest
+          imagePullPolicy: Never
           name: vitess-operator
           resources:
             limits:

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -7698,8 +7698,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: docker.io/planetscale/vitess-operator:latest
-          imagePullPolicy: Never
+          image: planetscale/vitess-operator:latest
           name: vitess-operator
           resources:
             limits:


### PR DESCRIPTION
This Pull Request brings the changes made in https://github.com/planetscale/vitess-operator/pull/658 to the Vitess' examples. The operator manifest has changed with the new CRD definition, and the 101 through 306 steps now include a backup location.