### PR TITLE
evalengine: normalize types during compilation

### DIFF
--- a/go/vt/vtgate/evalengine/expr_bvar.go
+++ b/go/vt/vtgate/evalengine/expr_bvar.go
@@ -125,10 +125,13 @@ func (bvar *BindVariable) compile(c *compiler) (ctype, error) {
 
 	switch tt := typ.Type; {
 	case sqltypes.IsSigned(tt):
+		typ.Type = sqltypes.Int64
 		c.asm.PushBVar_i(bvar.Key)
 	case sqltypes.IsUnsigned(tt):
+		typ.Type = sqltypes.Uint64
 		c.asm.PushBVar_u(bvar.Key)
 	case sqltypes.IsFloat(tt):
+		typ.Type = sqltypes.Float64
 		c.asm.PushBVar_f(bvar.Key)
 	case sqltypes.IsDecimal(tt):
 		c.asm.PushBVar_d(bvar.Key)
@@ -146,9 +149,11 @@ func (bvar *BindVariable) compile(c *compiler) (ctype, error) {
 			typ.Type = sqltypes.VarBinary
 			typ.Flag |= flagBit
 		} else {
+			typ.Type = sqltypes.VarChar
 			c.asm.PushBVar_text(bvar.Key, typ.Col)
 		}
 	case sqltypes.IsBinary(tt):
+		typ.Type = sqltypes.VarBinary
 		c.asm.PushBVar_bin(bvar.Key)
 	case sqltypes.IsNull(tt):
 		c.asm.PushNull()

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -452,3 +452,19 @@ func TestCardinalityWithBindVariables(t *testing.T) {
 		})
 	}
 }
+
+func TestBindVarType(t *testing.T) {
+	lhs := sqlparser.NewTypedArgument("lhs", sqltypes.Int32)
+	rhs := sqlparser.NewTypedArgument("rhs", sqltypes.Int64)
+	venv := vtenv.NewTestEnv()
+	cmp := &sqlparser.ComparisonExpr{
+		Operator: sqlparser.EqualOp,
+		Left:     lhs,
+		Right:    rhs,
+	}
+	_, err := Translate(cmp, &Config{
+		Collation:   venv.CollationEnv().DefaultConnectionCharset(),
+		Environment: venv,
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Description
The evalengine compiler does not operate on arbitrary width types: once
a value is evaluated into the compiler stack, its type is fixed to the
widest possible for the representation (e.g. all signed values are
promoted to INT64, all unsigned values to UINT64, etc).

The BindVariable code was not taking this into account when evaluating
and pushing the value of a bind variable into the evaluation stack. A
bind variable with type INT32 was being pushed into the stack as an
INT64, but it kept its original type when statically typing the rest of
the stack, so it caused bad compilation.

## Related Issue(s)
Fixes #17888

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required