### PR TITLE
Fix `vtbackup` help output

### DIFF
--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -144,18 +144,25 @@ var (
 		Long: `vtbackup is a batch command to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, vtbackup can ensure these configurable policies:
+
 	* There is always a recent backup for the shard.
+
 	* Old backups for the shard are removed.
 
 Whatever system launches vtbackup is responsible for the following:
 	- Running vtbackup with similar flags that would be used for a vttablet and
     mysqlctld in the target shard to be backed up.
+
 	- Provisioning as much disk space for vtbackup as would be given to vttablet.
     The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
 	- Running vtbackup periodically for each shard, for each backup storage location.
+
 	- Ensuring that at most one instance runs at a time for a given pair of shard
     and backup storage location.
+
 	- Retrying vtbackup if it fails.
+
 	- Alerting human operators if the failure is persistent.
 
 The process vtbackup follows to take a new backup has the following steps:

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -144,26 +144,25 @@ var (
 		Long: `vtbackup is a batch command to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, vtbackup can ensure these configurable policies:
+ * There is always a recent backup for the shard.
 
-	* There is always a recent backup for the shard.
-
-	* Old backups for the shard are removed.
+ * Old backups for the shard are removed.
 
 Whatever system launches vtbackup is responsible for the following:
-	- Running vtbackup with similar flags that would be used for a vttablet and
-    mysqlctld in the target shard to be backed up.
+ - Running vtbackup with similar flags that would be used for a vttablet and 
+   mysqlctld in the target shard to be backed up.
 
-	- Provisioning as much disk space for vtbackup as would be given to vttablet.
-    The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+ - Provisioning as much disk space for vtbackup as would be given to vttablet.
+   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
 
-	- Running vtbackup periodically for each shard, for each backup storage location.
+ - Running vtbackup periodically for each shard, for each backup storage location.
 
-	- Ensuring that at most one instance runs at a time for a given pair of shard
-    and backup storage location.
+ - Ensuring that at most one instance runs at a time for a given pair of shard
+   and backup storage location.
 
-	- Retrying vtbackup if it fails.
+ - Retrying vtbackup if it fails.
 
-	- Alerting human operators if the failure is persistent.
+ - Alerting human operators if the failure is persistent.
 
 The process vtbackup follows to take a new backup has the following steps:
  1. Restore from the most recent backup.

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -1,19 +1,25 @@
 vtbackup is a batch command to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, vtbackup can ensure these configurable policies:
-	* There is always a recent backup for the shard.
-	* Old backups for the shard are removed.
+ * There is always a recent backup for the shard.
+
+ * Old backups for the shard are removed.
 
 Whatever system launches vtbackup is responsible for the following:
-	- Running vtbackup with similar flags that would be used for a vttablet and
-    mysqlctld in the target shard to be backed up.
-	- Provisioning as much disk space for vtbackup as would be given to vttablet.
-    The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
-	- Running vtbackup periodically for each shard, for each backup storage location.
-	- Ensuring that at most one instance runs at a time for a given pair of shard
-    and backup storage location.
-	- Retrying vtbackup if it fails.
-	- Alerting human operators if the failure is persistent.
+ - Running vtbackup with similar flags that would be used for a vttablet and 
+   mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for vtbackup as would be given to vttablet.
+   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running vtbackup periodically for each shard, for each backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard
+   and backup storage location.
+
+ - Retrying vtbackup if it fails.
+
+ - Alerting human operators if the failure is persistent.
 
 The process vtbackup follows to take a new backup has the following steps:
  1. Restore from the most recent backup.
@@ -68,7 +74,7 @@ Flags:
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [{{ .Workdir }}])
+      --config-path strings                                         Paths to search for config files in. (default [/Users/florentpoinsard/Code/vitess])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -74,7 +74,7 @@ Flags:
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/florentpoinsard/Code/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [{{ .Workdir }}])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.


### PR DESCRIPTION
## Description

As described in https://github.com/vitessio/website/issues/1953, the help output of vtbackup is causing readability issues in our documentations. This PR fixes the output generated by vtbackup to be properly formatted in markdown.

A preview of the changes made to the help output can be seen on https://deploy-preview-1952--vitess.netlify.app/docs/22.0/reference/programs/vtbackup/ from PR: https://github.com/vitessio/website/pull/1952

## Related Issue(s)

- Part of https://github.com/vitessio/website/issues/1953
