### PR TITLE
Remove deprecated items before `v22.0.0`

### DIFF
--- a/changelog/22.0/22.0.0/changelog.md
+++ b/changelog/22.0/22.0.0/changelog.md
@@ -1,5 +1,0 @@
-# Changelog of Vitess v22.0.0
-
-### Enhancement 
-#### Cluster management
- * Prefer not promoting replicas that are taking backups [#16997](https://github.com/vitessio/vitess/pull/16997)

--- a/changelog/22.0/22.0.0/summary.md
+++ b/changelog/22.0/22.0.0/summary.md
@@ -30,13 +30,18 @@
 
 ## <a id="major-changes"/>Major Changes</a>
 
-### <a id="rpc-changes"/>RPC Changes</a>
-
-These are the RPC changes made in this release - 
-
-1. `GetTransactionInfo` RPC has been added to both `VtctldServer`, and `TabletManagerClient` interface. These RPCs are used to facilitate the users in reading the state of an unresolved distributed transaction. This can be useful in debugging what went wrong and how to fix the problem.
-
 ### <a id="deprecations-and-deletions"/>Deprecations and Deletions</a>
+
+#### <a id="deletions"/>Deleted Metrics</a>
+
+| Component  |      Metric Name      | Was Deprecated In |                           PR                            |
+|------------|:---------------------:|:-----------------:|:-------------------------------------------------------:|
+| `vttablet` |  `QueryCacheLength`   |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
+| `vttablet` |   `QueryCacheSize`    |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
+| `vttablet` | `QueryCacheCapacity`  |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
+| `vttablet` | `QueryCacheEvictions` |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
+| `vttablet` |   `QueryCacheHits`    |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
+| `vttablet` |  `QueryCacheMisses`   |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
 
 #### <a id="vttablet-flags"/>Deprecated VTTablet Flags</a>
 
@@ -56,6 +61,12 @@ The use of `gh-ost` and `pt-osc` as strategies as follows, yields an error:
 $ vtctldclient ApplySchema --ddl-strategy="gh-ost" ...
 $ vtctldclient ApplySchema --ddl-strategy="pt-osc" ...
 ```
+
+### <a id="rpc-changes"/>RPC Changes</a>
+
+These are the RPC changes made in this release -
+
+1. `GetTransactionInfo` RPC has been added to both `VtctldServer`, and `TabletManagerClient` interface. These RPCs are used to facilitate the users in reading the state of an unresolved distributed transaction. This can be useful in debugging what went wrong and how to fix the problem.
 
 ### <a id="vtgate-metrics"/>VTGate Metrics
 

--- a/changelog/22.0/22.0.0/summary.md
+++ b/changelog/22.0/22.0.0/summary.md
@@ -3,12 +3,15 @@
 ### Table of Contents
 
 - **[Major Changes](#major-changes)**
-  - **[Deprecations and Deletions](#deprecations-and-deletions)**
+  - **[Deletions](#deletions)**
+    - [Metrics](#deleted-metrics)
+    - [CLI Flags](#deleted-cli-flags)
+    - [gh-ost and pt-osc Online DDL strategies](#deleted-ghost-ptosc)
+  - **[Deprecations](#deprecations)**
     - [Deprecated VTGate Metrics](#vtgate-metrics)
     - [Deprecated VTTablet Flags](#vttablet-flags)
-    - [Removing gh-ost and pt-osc Online DDL strategies](#ghost-ptosc)
   - **[RPC Changes](#rpc-changes)**
-  - **[VTGate Metrics]**(#vtgate-metrics)
+  - **[VTGate Metrics](#vtgate-metrics)**
   - **[Prefer not promoting a replica that is currently taking a backup](#reparents-prefer-not-backing-up)**
   - **[VTOrc Config File Changes](#vtorc-config-file-changes)**
   - **[VTGate Config File Changes](#vtgate-config-file-changes)**
@@ -30,11 +33,11 @@
 
 ## <a id="major-changes"/>Major Changes</a>
 
-### <a id="deprecations-and-deletions"/>Deprecations and Deletions</a>
+### <a id="deletions"/>Deletions</a>
 
-#### <a id="deletions"/>Deleted Metrics</a>
+#### <a id="deleted-metrics"/>Metrics</a>
 
-| Component  |      Metric Name      | Was Deprecated In |                           PR                            |
+| Component  |      Metric Name      | Was Deprecated In |                     Deprecation PR                      |
 |------------|:---------------------:|:-----------------:|:-------------------------------------------------------:|
 | `vttablet` |  `QueryCacheLength`   |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
 | `vttablet` |   `QueryCacheSize`    |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
@@ -43,11 +46,13 @@
 | `vttablet` |   `QueryCacheHits`    |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
 | `vttablet` |  `QueryCacheMisses`   |     `v21.0.0`     | [#16289](https://github.com/vitessio/vitess/pull/16289) |
 
-#### <a id="vttablet-flags"/>Deprecated VTTablet Flags</a>
+#### <a id="deleted-cli-flags">CLI Flags</a>
 
-- `twopc_enable` flag is deprecated. Usage of TwoPC commit will be determined by the `transaction_mode` set on VTGate via flag or session variable.
+| Component  |             Flag Name              | Was Deprecated In |                     Deprecation PR                      |
+|------------|:----------------------------------:|:-----------------:|:-------------------------------------------------------:|
+| `vttablet` | `queryserver-enable-settings-pool` |     `v21.0.0`     | [#16280](https://github.com/vitessio/vitess/pull/16280) |
 
-#### <a id="ghost-ptosc"/>Removing gh-ost and pt-osc Online DDL strategies</a>
+#### <a id="deleted-ghost-ptosc"/>gh-ost and pt-osc Online DDL strategies</a>
 
 Vitess no longer recognizes the `gh-ost` and `pt-osc` (`pt-online-schema-change`) Online DDL strategies. The `vitess` strategy is the recommended way to make schema changes at scale. `mysql` and `direct` strategies continue to be supported.
 
@@ -61,6 +66,12 @@ The use of `gh-ost` and `pt-osc` as strategies as follows, yields an error:
 $ vtctldclient ApplySchema --ddl-strategy="gh-ost" ...
 $ vtctldclient ApplySchema --ddl-strategy="pt-osc" ...
 ```
+
+### <a id="deprecations"/>Deprecations</a>
+
+#### <a id="vttablet-flags"/>Deprecated VTTablet Flags</a>
+
+- `twopc_enable` flag is deprecated. Usage of TwoPC commit will be determined by the `transaction_mode` set on VTGate via flag or session variable.
 
 ### <a id="rpc-changes"/>RPC Changes</a>
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -189,7 +189,6 @@ type QueryEngine struct {
 	// Note: queryErrorCountsWithCode is similar to queryErrorCounts except it contains error code as an additional dimension
 	queryCounts, queryCountsWithTabletType, queryTimes, queryErrorCounts, queryErrorCountsWithCode, queryRowsAffected, queryRowsReturned, queryTextCharsProcessed *stats.CountersWithMultiLabels
 	queryEnginePlanCacheHits, queryEnginePlanCacheMisses                                                                                                          *stats.CounterFunc
-	queryCacheHitsDeprecated, queryCacheMissesDeprecated                                                                                                          *stats.CounterFunc
 
 	// stats flags
 	enablePerWorkloadTableMetrics bool
@@ -273,50 +272,26 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	env.Exporter().NewGaugeFunc("StreamBufferSize", "Query engine stream buffer size", qe.streamBufferSize.Load)
 	env.Exporter().NewCounterFunc("TableACLExemptCount", "Query engine table ACL exempt count", qe.tableaclExemptCount.Load)
 
-	// QueryCacheLength is deprecated in v21 and will be removed in >=v22. This metric is replaced by QueryEnginePlanCacheLength.
-	env.Exporter().NewGaugeFunc("QueryCacheLength", "Query engine query plan cache length (deprecated: please use QueryEnginePlanCacheLength)", func() int64 {
-		return int64(qe.plans.Len())
-	})
 	env.Exporter().NewGaugeFunc("QueryEnginePlanCacheLength", "Query engine query plan cache length", func() int64 {
 		return int64(qe.plans.Len())
 	})
 
-	// QueryCacheSize is deprecated in v21 and will be removed in >=v22. This metric is replaced QueryEnginePlanCacheSize.
-	env.Exporter().NewGaugeFunc("QueryCacheSize", "Query engine query plan cache size (deprecated: please use QueryEnginePlanCacheSize)", func() int64 {
-		return int64(qe.plans.UsedCapacity())
-	})
 	env.Exporter().NewGaugeFunc("QueryEnginePlanCacheSize", "Query engine query plan cache size", func() int64 {
 		return int64(qe.plans.UsedCapacity())
 	})
 
-	// QueryCacheCapacity is deprecated in v21 and will be removed in >=v22. This metric is replaced by QueryEnginePlanCacheCapacity.
-	env.Exporter().NewGaugeFunc("QueryCacheCapacity", "Query engine query plan cache capacity (deprecated: please use QueryEnginePlanCacheCapacity)", func() int64 {
-		return int64(qe.plans.MaxCapacity())
-	})
 	env.Exporter().NewGaugeFunc("QueryEnginePlanCacheCapacity", "Query engine query plan cache capacity", func() int64 {
 		return int64(qe.plans.MaxCapacity())
 	})
 
-	// QueryCacheEvictions is deprecated in v21 and will be removed in >=v22. This metric is replaced by QueryEnginePlanCacheEvictions.
-	env.Exporter().NewCounterFunc("QueryCacheEvictions", "Query engine query plan cache evictions (deprecated: please use QueryEnginePlanCacheEvictions)", func() int64 {
-		return qe.plans.Metrics.Evicted()
-	})
 	env.Exporter().NewCounterFunc("QueryEnginePlanCacheEvictions", "Query engine query plan cache evictions", func() int64 {
 		return qe.plans.Metrics.Evicted()
 	})
 
-	// QueryCacheHits is deprecated in v21 and will be removed in >=v22. This metric is replaced by QueryEnginePlanCacheHits.
-	qe.queryCacheHitsDeprecated = env.Exporter().NewCounterFunc("QueryCacheHits", "Query engine query plan cache hits (deprecated: please use QueryEnginePlanCacheHits)", func() int64 {
-		return qe.plans.Metrics.Hits()
-	})
 	qe.queryEnginePlanCacheHits = env.Exporter().NewCounterFunc("QueryEnginePlanCacheHits", "Query engine query plan cache hits", func() int64 {
 		return qe.plans.Metrics.Hits()
 	})
 
-	// QueryCacheMisses is deprecated in v21 and will be removed in >=v22. This metric is replaced by QueryEnginePlanCacheMisses.
-	qe.queryCacheMissesDeprecated = env.Exporter().NewCounterFunc("QueryCacheMisses", "Query engine query plan cache misses (deprecated: please use QueryEnginePlanCacheMisses)", func() int64 {
-		return qe.plans.Metrics.Misses()
-	})
 	qe.queryEnginePlanCacheMisses = env.Exporter().NewCounterFunc("QueryEnginePlanCacheMisses", "Query engine query plan cache misses", func() int64 {
 		return qe.plans.Metrics.Misses()
 	})

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -199,8 +199,6 @@ func TestQueryPlanCache(t *testing.T) {
 
 	initialHits := qe.queryEnginePlanCacheHits.Get()
 	initialMisses := qe.queryEnginePlanCacheMisses.Get()
-	initialHitsDeprecated := qe.queryCacheHitsDeprecated.Get()
-	initialMissesDeprecated := qe.queryCacheMissesDeprecated.Get()
 
 	firstPlan, err := qe.GetPlan(ctx, logStats, firstQuery, false)
 	require.NoError(t, err)
@@ -211,9 +209,6 @@ func TestQueryPlanCache(t *testing.T) {
 	require.Equal(t, int64(0), qe.queryEnginePlanCacheHits.Get()-initialHits)
 	require.Equal(t, int64(1), qe.queryEnginePlanCacheMisses.Get()-initialMisses)
 
-	require.Equal(t, int64(0), qe.queryCacheHitsDeprecated.Get()-initialHitsDeprecated)
-	require.Equal(t, int64(1), qe.queryCacheMissesDeprecated.Get()-initialMissesDeprecated)
-
 	secondPlan, err := qe.GetPlan(ctx, logStats, firstQuery, false)
 	require.NoError(t, err)
 	require.NotNil(t, secondPlan, "plan should not be nil")
@@ -222,9 +217,6 @@ func TestQueryPlanCache(t *testing.T) {
 
 	require.Equal(t, int64(1), qe.queryEnginePlanCacheHits.Get()-initialHits)
 	require.Equal(t, int64(1), qe.queryEnginePlanCacheMisses.Get()-initialMisses)
-
-	require.Equal(t, int64(1), qe.queryCacheHitsDeprecated.Get()-initialHitsDeprecated)
-	require.Equal(t, int64(1), qe.queryCacheMissesDeprecated.Get()-initialMissesDeprecated)
 
 	qe.ClearQueryPlanCache()
 }

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -209,8 +209,6 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&enableReplicationReporter, "enable_replication_reporter", false, "Use polling to track replication lag.")
 	fs.BoolVar(&currentConfig.EnableOnlineDDL, "queryserver_enable_online_ddl", true, "Enable online DDL.")
 	fs.BoolVar(&currentConfig.SanitizeLogMessages, "sanitize_log_messages", false, "Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.")
-	_ = fs.Bool("queryserver-enable-settings-pool", true, "Enable pooling of connections with modified system settings")
-	_ = fs.MarkDeprecated("queryserver-enable-settings-pool", "New pool implementation does it internally and at the api level this has been enabled since v17")
 
 	fs.Int64Var(&currentConfig.RowStreamer.MaxInnoDBTrxHistLen, "vreplication_copy_phase_max_innodb_history_list_length", 1000000, "The maximum InnoDB transaction history that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet.")
 	fs.Int64Var(&currentConfig.RowStreamer.MaxMySQLReplLagSecs, "vreplication_copy_phase_max_mysql_replication_lag", 43200, "The maximum MySQL replication lag (in seconds) that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet.")


### PR DESCRIPTION
## Description

This PR removes deprecated items (metrics, flags, etc) ahead of the `v22.0.0` release.

## Related Issue(s)

- Closes https://github.com/vitessio/vitess/issues/17734
