### PR TITLE
Fix how we generate `vtclient` CLI docs

### DIFF
--- a/go/cmd/vtclient/docgen/main.go
+++ b/go/cmd/vtclient/docgen/main.go
@@ -24,6 +24,8 @@ import (
 )
 
 func main() {
+	cli.InitializeFlags()
+
 	var dir string
 	cmd := cobra.Command{
 		Use: "docgen [-d <dir>]",


### PR DESCRIPTION
## Description

The generation of the CLI documentation for `vtclient` broke after https://github.com/vitessio/vitess/pull/17800. The flags were not initialized correctly, leading to the doc gen to generate an empty list of flags.

This can be tested with
```
$ go run ./go/cmd/vtclient/docgen/main.go
$ less doc/_index.md
```
