### PR TITLE
fix: race on storing schema engine last changed time

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -71,7 +72,7 @@ type Engine struct {
 	mu         sync.Mutex
 	isOpen     bool
 	tables     map[string]*Table
-	lastChange int64
+	lastChange atomic.Int64
 	// the position at which the schema was last loaded. it is only used in conjunction with ReloadAt
 	reloadAtPos replication.Position
 	notifierMu  sync.Mutex
@@ -319,7 +320,7 @@ func (se *Engine) closeLocked() {
 	se.conns.Close()
 
 	se.tables = make(map[string]*Table)
-	se.lastChange = 0
+	se.lastChange.Store(0)
 	se.notifiers = make(map[string]notifier)
 	se.isOpen = false
 
@@ -553,7 +554,7 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 		tbl, isInTablesMap := se.tables[tableName]
 		_, isInChangedViewMap := changedViews[tableName]
 		_, isInMismatchTableMap := mismatchTables[tableName]
-		if isInTablesMap && createTime == tbl.CreateTime && createTime < se.lastChange && !isInChangedViewMap && !isInMismatchTableMap {
+		if isInTablesMap && createTime == tbl.CreateTime && createTime < se.lastChange.Load() && !isInChangedViewMap && !isInMismatchTableMap {
 			if includeStats {
 				tbl.FileSize = fileSize
 				tbl.AllocatedSize = allocatedSize
@@ -616,7 +617,7 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 	for k, t := range changedTables {
 		se.tables[k] = t
 	}
-	se.lastChange = curTime
+	se.lastChange.Store(curTime)
 	if len(created) > 0 || len(altered) > 0 || len(dropped) > 0 {
 		log.Infof("schema engine created %v, altered %v, dropped %v", extractNamesFromTablesList(created), extractNamesFromTablesList(altered), extractNamesFromTablesList(dropped))
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -1458,7 +1458,7 @@ func TestEngineReload(t *testing.T) {
 			require.NoError(t, err)
 
 			se.SkipMetaCheck = false
-			se.lastChange = 987654321
+			se.lastChange.Store(987654321)
 
 			// Initial tables in the schema engine
 			se.tables = map[string]*Table{


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR addresses a race condition in the Schema Engine related to updating the last changed time. The issue arises because this time is updated by both:
1. A ticker that periodically reloads the schema and updates the timestamp.
1. The VStream tracker process, which also modifies this value.

Logs from CI: 
```
==================
WARNING: DATA RACE
Write at 0x00c0003d87c0 by goroutine 1861:
  vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).reload()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/schema/engine.go:619 +0x28f9
  vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).ReloadAtEx()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/schema/engine.go:393 +0x2a4
  vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).ReloadAt()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/schema/engine.go:373 +0x1e3d
  vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).parseEvent()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:550 +0x1dda
  vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).parseEvents()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:381 +0xd55
  vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).replicate()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:[211](https://github.com/vitessio/vitess/actions/runs/13694130321/job/38292683920?pr=17907#step:10:212) +0x27d
  vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).Stream()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:190 +0x2e9
  vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*uvstreamer).Stream()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go:438 +0x5e9
  vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*Engine).Stream()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/vstreamer/engine.go:280 +0x27c
  vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Tracker).process()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/schema/tracker.go:132 +0x646
  vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Tracker).Open.gowrap2()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/schema/tracker.go:86 +0x4f

Previous write at 0x00c0003d87c0 by goroutine 173:
  vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).reload()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/schema/engine.go:619 +0x28f9
  vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).Open.func2()
      /home/runner/work/vitess/vitess/go/vt/vttablet/tabletserver/schema/engine.go:275 +0x4f
  vitess.io/vitess/go/timer.(*Timer).run()
      /home/runner/work/vitess/vitess/go/timer/timer.go:111 +0x167
  vitess.io/vitess/go/timer.(*Timer).Start.gowrap2()
      /home/runner/work/vitess/vitess/go/timer/timer.go:85 +0x44
```

Backport Reason: CI failure, leads to wait time for PR to be merged.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
