### PR TITLE
Rebuild `SrvKeyspace` and `SrvVSchema` during vtgate init if required

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -360,7 +360,7 @@ func Init(
 	}
 
 	// executor sets a watch on SrvVSchema, so let's rebuild these before creating it
-	if err := rebuildTopoGraphs(ctx, serv, cell, keyspaces); err != nil {
+	if err := rebuildTopoGraphs(ctx, ts, cell, keyspaces); err != nil {
 		log.Fatalf("rebuildTopoGraphs failed: %v", err)
 	}
 
@@ -423,12 +423,7 @@ func Init(
 	return vtgateInst
 }
 
-func rebuildTopoGraphs(ctx context.Context, serv srvtopo.Server, cell string, keyspaces []string) error {
-	topoServer, err := serv.GetTopoServer()
-	if err != nil {
-		return vterrors.Wrap(err, "error reading topo server")
-	}
-
+func rebuildTopoGraphs(ctx context.Context, topoServer *topo.Server, cell string, keyspaces []string) error {
 	for _, ks := range keyspaces {
 		_, err := topoServer.GetSrvKeyspace(ctx, cell, ks)
 		switch {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Right now, `SrvKeyspace` and `SrvVSchema` for a cell are built only if a tablet for that keyspace/shard is deployed into that cell. This breaks migration architectures where you might deploy vtgates in all cells, but unmanaged tablets for the source database in only a subset of cells. What happens when you try to SwitchTraffic is that vtgates in cells without tablets will not be able to route traffic to a primary in a different cell.
In order to workaround this, people have been manually running RebuildKeyspaceGraph and RebuildVSchemaGraph commands.

The proposal is to make this part of vtgate initialization. If a vtgate is deployed in a cell, then it is fair to assume that it is intended to serve traffic. Hence, we can go ahead and build the SrvKeyspace and SrvVSchema for the keyspaces it watches.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #17909 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
