### PR TITLE
Remove deprecated `--disable_active_reparents` flag

### DIFF
--- a/changelog/22.0/22.0.0/summary.md
+++ b/changelog/22.0/22.0.0/summary.md
@@ -46,6 +46,7 @@ These are the RPC changes made in this release -
 #### <a id="vttablet-flags"/>Deprecated VTTablet Flags</a>
 
 - `twopc_enable` flag is deprecated. Usage of TwoPC commit will be determined by the `transaction_mode` set on VTGate via flag or session variable.
+- `--disable_active_reparents` flag that was previously deprecated, has now been removed.
 
 #### <a id="ghost-ptosc"/>Removing gh-ost and pt-osc Online DDL strategies</a>
 

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -150,7 +150,6 @@ exec $VTROOT/bin/vttablet \
   --tablet-path $alias \
   --tablet_hostname "$vthost" \
   --health_check_interval 5s \
-  --disable_active_reparents=true \
   --port $web_port \
   --grpc_port $grpc_port \
   --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \

--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -71,7 +71,7 @@ func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tabl
 	if UseXb {
 		replicaTabletArgs = append(replicaTabletArgs, XbArgs...)
 	}
-	replicaTabletArgs = append(replicaTabletArgs, "--disable_active_reparents",
+	replicaTabletArgs = append(replicaTabletArgs,
 		"--enable_replication_reporter=false",
 		"--init_tablet_type", "replica",
 		"--init_keyspace", restoreKSName,

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -65,7 +65,6 @@ func TestTabletReshuffle(t *testing.T) {
 		"--lock_tables_timeout", "5s",
 		"--mycnf_server_id", fmt.Sprintf("%d", rTablet.TabletUID),
 		"--db_socket", fmt.Sprintf("%s/mysql.sock", primaryTablet.VttabletProcess.Directory),
-		"--disable_active_reparents",
 		"--enable_replication_reporter=false",
 	}
 	defer func() { clusterInstance.VtTabletExtraArgs = []string{} }()

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -109,7 +109,6 @@ func TestMain(m *testing.M) {
 			"--enable_replication_reporter",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", onDemandHeartbeatDuration.String(),
-			"--disable_active_reparents",
 		}
 
 		// Start keyspace

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -134,7 +134,6 @@ func createVttablets(clusterInstance *cluster.LocalProcessCluster, cellInfos []*
 	}
 	clusterInstance.VtTabletExtraArgs = []string{
 		"--lock_tables_timeout", "5s",
-		"--disable_active_reparents",
 	}
 	// Initialize Cluster
 	shard0.Vttablets = tablets
@@ -813,7 +812,6 @@ func SetupNewClusterSemiSync(t *testing.T) *VTOrcClusterInfo {
 
 	clusterInstance.VtTabletExtraArgs = []string{
 		"--lock_tables_timeout", "5s",
-		"--disable_active_reparents",
 	}
 
 	// Initialize Cluster
@@ -888,7 +886,6 @@ func AddSemiSyncKeyspace(t *testing.T, clusterInfo *VTOrcClusterInfo) {
 	}()
 	clusterInfo.ClusterInstance.VtTabletExtraArgs = []string{
 		"--lock_tables_timeout", "5s",
-		"--disable_active_reparents",
 	}
 
 	// Initialize Cluster

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -133,9 +133,6 @@ func init() {
 	for _, cmd := range []string{"vtctld", "vtctldclient"} {
 		servenv.OnParseFor(cmd, registerReparentFlags)
 	}
-	for _, cmd := range []string{"vtcombo", "vttablet", "vttestserver"} {
-		servenv.OnParseFor(cmd, registerDeprecatedReparentFlags)
-	}
 	for _, cmd := range []string{"mysqlctl", "mysqlctld", "vtcombo", "vttablet", "vttestserver"} {
 		servenv.OnParseFor(cmd, registerPoolFlags)
 	}
@@ -150,11 +147,6 @@ func registerMySQLDFlags(fs *pflag.FlagSet) {
 
 func registerReparentFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&DisableActiveReparents, "disable_active_reparents", DisableActiveReparents, "if set, do not allow active reparents. Use this to protect a cluster using external reparents.")
-}
-
-func registerDeprecatedReparentFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&DisableActiveReparents, "disable_active_reparents", DisableActiveReparents, "if set, do not allow active reparents. Use this to protect a cluster using external reparents.")
-	fs.MarkDeprecated("disable_active_reparents", "Use --unmanaged flag instead for unmanaged tablets.")
 }
 
 func registerPoolFlags(fs *pflag.FlagSet) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR deletes the flag deprecated in #14871.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#17734

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
