### PR TITLE
Fix data race in Schema Engine 

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -352,6 +352,13 @@ func (se *Engine) MakePrimary(serving bool) {
 	se.isServingPrimary = serving
 }
 
+// IsServingPrimary returns true if the tablet is currently serving as primary.
+func (se *Engine) IsServingPrimary() bool {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	return se.isServingPrimary
+}
+
 // EnableHistorian forces tracking to be on or off.
 // Only used for testing.
 func (se *Engine) EnableHistorian(enabled bool) error {
@@ -477,7 +484,7 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 	}
 
 	// On the primary tablet, we also check the data we have stored in our schema tables to see what all needs reloading.
-	shouldUseDatabase := se.isServingPrimary && se.schemaCopy
+	shouldUseDatabase := se.IsServingPrimary() && se.schemaCopy
 
 	// changedViews are the views that have changed. We can't use the same createTime logic for views because, MySQL
 	// doesn't update the create_time field for views when they are altered. This is annoying, but something we have to work around.

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -1458,7 +1458,7 @@ func TestEngineReload(t *testing.T) {
 			require.NoError(t, err)
 
 			se.SkipMetaCheck = false
-			se.lastChange.Store(987654321)
+			se.lastChange = 987654321
 
 			// Initial tables in the schema engine
 			se.tables = map[string]*Table{


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the data race seen in schema engine.
This was caused by making changes in the PR https://github.com/vitessio/vitess/pull/17855 which does not take lock on calling the `reload` method causing multiple data race.

This also reverts a change made in PR to fix partial data race https://github.com/vitessio/vitess/pull/17914

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
