### PR TITLE
sqltypes: move datetime handling to Value method

### DIFF
--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -26,11 +26,13 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/encoding/protowire"
 
 	"vitess.io/vitess/go/bytes2"
 	"vitess.io/vitess/go/hack"
+	"vitess.io/vitess/go/mysql/datetime"
 	"vitess.io/vitess/go/mysql/decimal"
 	"vitess.io/vitess/go/mysql/fastparse"
 	"vitess.io/vitess/go/mysql/format"
@@ -433,6 +435,78 @@ func (v Value) String() string {
 		return fmt.Sprintf("%v(%q)", Type(v.typ), v.val)
 	}
 	return fmt.Sprintf("%v(%s)", Type(v.typ), v.val)
+}
+
+// ToTime returns the value as a time.Time in UTC.
+// NULL values are returned as zero time.
+func (v Value) ToTime() (time.Time, error) {
+	return v.ToTimeInLocation(time.UTC)
+}
+
+// ToTimeInLocation returns the value as a time.Time in the provided location.
+// NULL values are returned as zero time.
+func (v Value) ToTimeInLocation(loc *time.Location) (time.Time, error) {
+	if v.Type() == Null {
+		return time.Time{}, nil
+	}
+	switch v.Type() {
+	case Datetime, Timestamp:
+		return datetimeToTime(v, loc)
+	case Date:
+		return dateToTime(v, loc)
+	default:
+		return time.Time{}, ErrIncompatibleTypeCast
+	}
+}
+
+// ErrInvalidTime is returned when we fail to parse a datetime
+// string from MySQL. This should never happen unless things are
+// seriously messed up.
+var ErrInvalidTime = errors.New("invalid MySQL time string")
+
+func datetimeToTime(v Value, loc *time.Location) (time.Time, error) {
+	if v.IsNull() {
+		return time.Time{}, nil
+	}
+	// Valid format string offsets for a DATETIME
+	//  |DATETIME          |19+
+	//  |------------------|------|
+	// "2006-01-02 15:04:05.999999"
+	dt, _, ok := datetime.ParseDateTime(v.ToString(), -1)
+	if !ok {
+		return time.Time{}, ErrInvalidTime
+	}
+	if dt.IsZero() {
+		return time.Time{}, nil
+	}
+
+	if loc == nil {
+		loc = time.UTC
+	}
+	return time.Date(dt.Date.Year(), time.Month(dt.Date.Month()), dt.Date.Day(),
+		dt.Time.Hour(), dt.Time.Minute(), dt.Time.Second(), dt.Time.Nanosecond(), loc), nil
+}
+
+func dateToTime(v Value, loc *time.Location) (time.Time, error) {
+	if v.IsNull() {
+		return time.Time{}, nil
+	}
+	// Valid format string offsets for a DATE
+	//  |DATE     |10
+	//  |---------|
+	// "2006-01-02 00:00:00.000000"
+	d, ok := datetime.ParseDate(v.ToString())
+	if !ok {
+		return time.Time{}, ErrInvalidTime
+	}
+	if d.IsZero() {
+		return time.Time{}, nil
+	}
+
+	if loc == nil {
+		loc = time.UTC
+	}
+	return time.Date(d.Year(), time.Month(d.Month()), d.Day(), 0, 0, 0, 0, loc), nil
 }
 
 // EncodeSQL encodes the value into an SQL statement. Can be binary.

--- a/go/vt/vitessdriver/convert.go
+++ b/go/vt/vitessdriver/convert.go
@@ -18,11 +18,9 @@ package vitessdriver
 
 import (
 	"database/sql/driver"
-	"errors"
 	"fmt"
 	"time"
 
-	"vitess.io/vitess/go/mysql/datetime"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -45,66 +43,14 @@ func (cv *converter) ToNative(v sqltypes.Value) (any, error) {
 		return v.ToUint64()
 	case v.IsFloat():
 		return v.ToFloat64()
-	case v.Type() == sqltypes.Datetime, v.Type() == sqltypes.Timestamp:
-		return cv.datetimeToTime(v)
-	case v.Type() == sqltypes.Date:
-		return cv.dateToTime(v)
+	case v.Type() == sqltypes.Datetime, v.Type() == sqltypes.Timestamp, v.Type() == sqltypes.Date:
+		return v.ToTimeInLocation(cv.location)
 	case v.IsQuoted() || v.Type() == sqltypes.Bit || v.Type() == sqltypes.Decimal:
 		out, err = v.ToBytes()
 	case v.Type() == sqltypes.Expression:
 		err = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v cannot be converted to a go type", v)
 	}
 	return out, err
-}
-
-// ErrInvalidTime is returned when we fail to parse a datetime
-// string from MySQL. This should never happen unless things are
-// seriously messed up.
-var ErrInvalidTime = errors.New("invalid MySQL time string")
-
-func (cv *converter) datetimeToTime(v sqltypes.Value) (time.Time, error) {
-	if v.IsNull() {
-		return time.Time{}, nil
-	}
-	// Valid format string offsets for a DATETIME
-	//  |DATETIME          |19+
-	//  |------------------|------|
-	// "2006-01-02 15:04:05.999999"
-	dt, _, ok := datetime.ParseDateTime(v.ToString(), -1)
-	if !ok {
-		return time.Time{}, ErrInvalidTime
-	}
-	if dt.IsZero() {
-		return time.Time{}, nil
-	}
-	loc := cv.location
-	if loc == nil {
-		loc = time.UTC
-	}
-	return time.Date(dt.Date.Year(), time.Month(dt.Date.Month()), dt.Date.Day(),
-		dt.Time.Hour(), dt.Time.Minute(), dt.Time.Second(), dt.Time.Nanosecond(), loc), nil
-}
-
-func (cv *converter) dateToTime(v sqltypes.Value) (time.Time, error) {
-	if v.IsNull() {
-		return time.Time{}, nil
-	}
-	// Valid format string offsets for a DATE
-	//  |DATE     |10
-	//  |---------|
-	// "2006-01-02 00:00:00.000000"
-	d, ok := datetime.ParseDate(v.ToString())
-	if !ok {
-		return time.Time{}, ErrInvalidTime
-	}
-	if d.IsZero() {
-		return time.Time{}, nil
-	}
-	loc := cv.location
-	if loc == nil {
-		loc = time.UTC
-	}
-	return time.Date(d.Year(), time.Month(d.Month()), d.Day(), 0, 0, 0, 0, loc), nil
 }
 
 func (cv *converter) BuildBindVariable(v any) (*querypb.BindVariable, error) {


### PR DESCRIPTION
## Description

This reverts the move from sqltypes to vitessdriver in https://github.com/vitessio/vitess/pull/17582, but continues using the new datetime package. I'm using ToTime for conversion in #17222, and simplifies type conversions as part of the public api. Since all other native types are convertible via methods in sqltypes, it seems logical that datetimes should also be available there, even if vitess isn't natively using them.

cc @dbussink 

## Related Issue(s)
- https://github.com/vitessio/vitess/pull/17582
- #17222 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
