### PR TITLE
[release-16.0 Direct PR] VDiff: Fix logic for reconciling extra rows 

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"testing"
 
+	_flag "vitess.io/vitess/go/internal/flag"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -171,6 +173,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	_flag.ParseFlagsForTest()
 	exitCode := func() int {
 		var err error
 		tstenv, err = testenv.Init()

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -35,6 +35,8 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
+// TestReconcileExtraRows tests reconcileExtraRows() by providing different types of source and target slices and validating
+// that the matching rows are correctly identified and removed.
 func TestReconcileExtraRows(t *testing.T) {
 	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()
@@ -72,6 +74,7 @@ func TestReconcileExtraRows(t *testing.T) {
 		wantMatchingCount   int64
 		wantMismatchedCount int64
 	}
+
 	testCases := []testCase{
 		{
 			name: "no extra rows, same order",
@@ -103,15 +106,15 @@ func TestReconcileExtraRows(t *testing.T) {
 			name: "extra rows, same count of extras on both",
 			extraDiffsSource: []*RowDiff{
 				{Row: map[string]string{"1": "c1"}},
-				{Row: map[string]string{"2": "c2"}},
 				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"2": "c2"}},
 				{Row: map[string]string{"3b": "c3b"}},
 			},
 			extraDiffsTarget: []*RowDiff{
 				{Row: map[string]string{"2": "c2"}},
 				{Row: map[string]string{"4a": "c4a"}},
-				{Row: map[string]string{"1": "c1"}},
 				{Row: map[string]string{"4b": "c4b"}},
+				{Row: map[string]string{"1": "c1"}},
 			},
 			wantExtraSource: []*RowDiff{
 				{Row: map[string]string{"3a": "c3a"}},

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -35,6 +35,174 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
+func TestReconcileExtraRows(t *testing.T) {
+	vdenv := newTestVDiffEnv(t)
+	defer vdenv.close()
+	UUID := uuid.New()
+	controllerQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		vdiffTestCols,
+		vdiffTestColTypes,
+	),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
+	)
+
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
+	require.NoError(t, err)
+	wd, err := newWorkflowDiffer(ct, vdiffenv.opts)
+	require.NoError(t, err)
+
+	dr := &DiffReport{
+		TableName:            "t1",
+		ExtraRowsSourceDiffs: []*RowDiff{},
+		ExtraRowsTargetDiffs: []*RowDiff{},
+		MismatchedRowsDiffs:  nil,
+	}
+
+	type testCase struct {
+		name             string
+		maxExtras        int64
+		extraDiffsSource []*RowDiff
+		extraDiffsTarget []*RowDiff
+
+		wantExtraSource []*RowDiff
+		wantExtraTarget []*RowDiff
+
+		wantProcessedCount  int64
+		wantMatchingCount   int64
+		wantMismatchedCount int64
+	}
+	testCases := []testCase{
+		{
+			name: "no extra rows, same order",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+			},
+			wantExtraSource: []*RowDiff{},
+			wantExtraTarget: []*RowDiff{},
+		},
+		{
+			name: "no extra rows, different order",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"1": "c1"}},
+			},
+			wantExtraSource: []*RowDiff{},
+			wantExtraTarget: []*RowDiff{},
+		},
+		{
+			name: "extra rows, same count of extras on both",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"4b": "c4b"}},
+			},
+			wantExtraSource: []*RowDiff{
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			wantExtraTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"4b": "c4b"}},
+			},
+		},
+		{
+			name: "extra rows, less extras on target",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"1": "c1"}},
+			},
+			wantExtraSource: []*RowDiff{
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			wantExtraTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+			},
+		},
+		{
+			name: "extra rows, no matching rows",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"5": "c5"}},
+				{Row: map[string]string{"6": "c6"}},
+			},
+			wantExtraSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			wantExtraTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"5": "c5"}},
+				{Row: map[string]string{"6": "c6"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			maxExtras := int64(10)
+			if tc.maxExtras != 0 {
+				maxExtras = tc.maxExtras
+			}
+
+			dr.ExtraRowsSourceDiffs = tc.extraDiffsSource
+			dr.ExtraRowsTargetDiffs = tc.extraDiffsTarget
+			dr.ExtraRowsSource = int64(len(tc.extraDiffsSource))
+			dr.ExtraRowsTarget = int64(len(tc.extraDiffsTarget))
+			origExtraRowsSource := dr.ExtraRowsSource
+
+			dr.MatchingRows = 0
+			dr.MismatchedRows = dr.ExtraRowsSource
+			dr.ProcessedRows = 0
+
+			wd.reconcileExtraRows(dr, maxExtras)
+
+			// check counts
+			require.Equal(t, dr.MatchingRows, origExtraRowsSource-dr.ExtraRowsSource)
+			require.Equal(t, dr.ProcessedRows, dr.MatchingRows)
+			require.Equal(t, dr.MismatchedRows, origExtraRowsSource-dr.MatchingRows)
+			require.Equal(t, dr.ExtraRowsSource, int64(len(tc.wantExtraSource)))
+			require.Equal(t, dr.ExtraRowsTarget, int64(len(tc.wantExtraTarget)))
+
+			// check actual extra rows
+			require.EqualValues(t, dr.ExtraRowsSourceDiffs, tc.wantExtraSource)
+			require.EqualValues(t, dr.ExtraRowsTargetDiffs, tc.wantExtraTarget)
+		})
+	}
+}
+
 func TestBuildPlanSuccess(t *testing.T) {
 	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()


### PR DESCRIPTION
## Description

This PR fixes the logic in vdiff that looks at extra source and target rows, if they are found, and checks to see if there are identical rows. This can happen if there is an issue in sorting the rows usually because of different collations on the source and target.  If matches are found, it removes them from the extra rows slices. 

⚠️ CI is broken for this unsupported version. Unit tests run locally for me for the vdiff directory:

```
=== RUN   TestPerformVDiffAction
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
=== RUN   TestPerformVDiffAction/engine_not_open
=== RUN   TestPerformVDiffAction/create_with_defaults
=== NAME  TestPerformVDiffAction
    action.go:165: DBClient query: select id as id from _vt.vdiff where vdiff_uuid = '6999e83b-1270-4120-a405-ab37da7b2d70'
    action.go:193: DBClient query: insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values('', '', 'pending', '{\"picker_options\":{\"source_cell\":\"cell1,zone100_test\",\"target_cell\":\"cell1,zone100_test\"}}', '0', 'vt_vttest', '6999e83b-1270-4120-a405-ab37da7b2d70')
=== RUN   TestPerformVDiffAction/create_with_cell_alias
=== NAME  TestPerformVDiffAction
    action.go:165: DBClient query: select id as id from _vt.vdiff where vdiff_uuid = '6999e83b-1270-4120-a405-ab37da7b2d70'
    action.go:193: DBClient query: insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values('', '', 'pending', '{\"picker_options\":{\"source_cell\":\"all\",\"target_cell\":\"all\"}}', '0', 'vt_vttest', '6999e83b-1270-4120-a405-ab37da7b2d70')
=== RUN   TestPerformVDiffAction/delete_by_uuid
=== NAME  TestPerformVDiffAction
    action.go:353: DBClient query: select id as id from _vt.vdiff where vdiff_uuid = '6999e83b-1270-4120-a405-ab37da7b2d70'
    action.go:371: DBClient query: delete from vd, vdt using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        							where vd.vdiff_uuid = '6999e83b-1270-4120-a405-ab37da7b2d70'
=== RUN   TestPerformVDiffAction/delete_all
=== NAME  TestPerformVDiffAction
    action.go:326: DBClient query: select id as id from _vt.vdiff where keyspace = 'ks' and workflow = 'wf'
    action.go:371: DBClient query: delete from vd, vdt, vdl using _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        										left join _vt.vdiff_log as vdl on (vd.id = vdl.vdiff_id)
        										where vd.keyspace = 'ks' and vd.workflow = 'wf'
--- PASS: TestPerformVDiffAction (0.01s)
    --- PASS: TestPerformVDiffAction/engine_not_open (0.00s)
    --- PASS: TestPerformVDiffAction/create_with_defaults (0.00s)
    --- PASS: TestPerformVDiffAction/create_with_cell_alias (0.00s)
    --- PASS: TestPerformVDiffAction/delete_by_uuid (0.00s)
    --- PASS: TestPerformVDiffAction/delete_all (0.00s)
=== RUN   TestEngineOpen
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
=== RUN   TestEngineOpen/pending_vdiff
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
    controller.go:186: DBClient query: select * from _vt.vreplication where workflow = 'testwf' and db_name = 'vttest'
    controller.go:169: DBClient query: update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1
E0307 13:53:32.571130   25156 controller.go:138] Encountered an error for vdiff 58893899-4697-47bc-b1be-e254f9a2ff25: Short circuiting test
    controller.go:169: DBClient query: update _vt.vdiff set state = 'error', last_error = left('Short circuiting test', 1024)  where id = 1
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: error')
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'Error: Short circuiting test')
=== RUN   TestEngineOpen/started_vdiff
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
    controller.go:186: DBClient query: select * from _vt.vreplication where workflow = 'testwf' and db_name = 'vttest'
    controller.go:169: DBClient query: update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1
E0307 13:53:32.578483   25156 controller.go:138] Encountered an error for vdiff 58893899-4697-47bc-b1be-e254f9a2ff25: Short circuiting test
    controller.go:169: DBClient query: update _vt.vdiff set state = 'error', last_error = left('Short circuiting test', 1024)  where id = 1
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: error')
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'Error: Short circuiting test')
--- PASS: TestEngineOpen (0.02s)
    --- PASS: TestEngineOpen/pending_vdiff (0.01s)
    --- PASS: TestEngineOpen/started_vdiff (0.00s)
=== RUN   TestVDiff
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
    controller.go:186: DBClient query: select * from _vt.vreplication where workflow = 'testwf' and db_name = 'vttest'
    controller.go:169: DBClient query: update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: started')
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    workflow_differ.go:356: DBClient query: select table_name as table_name, table_rows as table_rows from INFORMATION_SCHEMA.TABLES where table_schema = 'vttest' and table_name in ('t1')
    workflow_differ.go:365: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    workflow_differ.go:377: DBClient query: update _vt.vdiff_table set table_rows = 1 where vdiff_id = 1 and table_name = 't1'
    workflow_differ.go:226: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    table_differ.go:697: DBClient query: update _vt.vdiff_table set state = 'started' where vdiff_id = 1 and table_name = 't1'
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'started: table \'t1\'')
    table_differ.go:163: DBClient query: select id, source, pos from _vt.vreplication where workflow = 'testwf' and db_name = 'vttest'
    table_differ.go:465: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    table_differ.go:689: DBClient query: update _vt.vdiff_table set rows_compared = 0, report = '{\"TableName\":\"t1\",\"ProcessedRows\":0,\"MatchingRows\":0,\"MismatchedRows\":0,\"ExtraRowsSource\":0,\"ExtraRowsTarget\":0}' where vdiff_id = 1 and table_name = 't1'
    table_differ.go:717: DBClient query: update _vt.vdiff_table set state = 'completed', rows_compared = 0, report = '{\"TableName\":\"t1\",\"ProcessedRows\":0,\"MatchingRows\":0,\"MismatchedRows\":0,\"ExtraRowsSource\":0,\"ExtraRowsTarget\":0}' where vdiff_id = 1 and table_name = 't1'
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'completed: table \'t1\'')
    table_differ.go:697: DBClient query: update _vt.vdiff_table set state = 'completed' where vdiff_id = 1 and table_name = 't1'
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'completed: table \'t1\'')
    workflow_differ.go:256: DBClient query: select table_name as table_name from _vt.vdiff_table where vdiff_id = 1 and state != 'completed'
    controller.go:169: DBClient query: update _vt.vdiff set state = 'completed', last_error = left('', 1024) , completed_at = utc_timestamp() where id = 1
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: completed')
--- PASS: TestVDiff (0.03s)
=== RUN   TestEngineRetryErroredVDiffs
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
=== RUN   TestEngineRetryErroredVDiffs/nothing_to_retry
=== NAME  TestEngineRetryErroredVDiffs
    engine.go:292: DBClient query: select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true'
=== RUN   TestEngineRetryErroredVDiffs/non-ephemeral_error
=== NAME  TestEngineRetryErroredVDiffs
    engine.go:292: DBClient query: select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true'
=== RUN   TestEngineRetryErroredVDiffs/ephemeral_error
=== NAME  TestEngineRetryErroredVDiffs
    engine.go:292: DBClient query: select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true'
    engine.go:346: DBClient query: update _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) set vd.state = 'pending',
        					vd.last_error = '', vdt.state = 'pending' where vd.id = 1 and (vd.state = 'error' or vdt.state = 'error')
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
    controller.go:186: DBClient query: select * from _vt.vreplication where workflow = 'testwf' and db_name = 'vttest'
    controller.go:169: DBClient query: update _vt.vdiff set state = 'started', last_error = left('', 1024) , started_at = utc_timestamp() where id = 1
E0307 13:53:32.619871   25156 controller.go:138] Encountered an error for vdiff 2a0e1fae-62ed-42e6-b01b-7891d1158d72: Short circuiting test
    controller.go:169: DBClient query: update _vt.vdiff set state = 'error', last_error = left('Short circuiting test', 1024)  where id = 1
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: error')
    utils.go:75: DBClient query: insert into _vt.vdiff_log(vdiff_id, message) values (1, 'Error: Short circuiting test')
--- PASS: TestEngineRetryErroredVDiffs (0.01s)
    --- PASS: TestEngineRetryErroredVDiffs/nothing_to_retry (0.00s)
    --- PASS: TestEngineRetryErroredVDiffs/non-ephemeral_error (0.00s)
    --- PASS: TestEngineRetryErroredVDiffs/ephemeral_error (0.00s)
=== RUN   TestReconcileExtraRows
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
=== RUN   TestReconcileExtraRows/no_extra_rows,_same_order
E0307 13:53:32.626332   25156 controller.go:124] Encountered an error getting vdiff record for 48d2866e-6ef7-4974-9812-02be585de2c9: no vdiff found for id 1 on tablet cell:"cell1" uid:100
=== RUN   TestReconcileExtraRows/no_extra_rows,_different_order
=== RUN   TestReconcileExtraRows/extra_rows,_same_count_of_extras_on_both
=== RUN   TestReconcileExtraRows/extra_rows,_less_extras_on_target
=== RUN   TestReconcileExtraRows/extra_rows,_no_matching_rows
--- PASS: TestReconcileExtraRows (0.01s)
    --- PASS: TestReconcileExtraRows/no_extra_rows,_same_order (0.00s)
    --- PASS: TestReconcileExtraRows/no_extra_rows,_different_order (0.00s)
    --- PASS: TestReconcileExtraRows/extra_rows,_same_count_of_extras_on_both (0.00s)
    --- PASS: TestReconcileExtraRows/extra_rows,_less_extras_on_target (0.00s)
    --- PASS: TestReconcileExtraRows/extra_rows,_no_matching_rows (0.00s)
=== RUN   TestBuildPlanSuccess
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
=== RUN   TestBuildPlanSuccess/#00
=== NAME  TestBuildPlanSuccess
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
E0307 13:53:32.639386   25156 controller.go:124] Encountered an error getting vdiff record for 1112c415-f7b4-4bc8-979a-331bb1877ea6: no vdiff found for id 1 on tablet cell:"cell1" uid:100
=== NAME  TestBuildPlanSuccess/#00
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/-80
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_*_from_t1
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_c2,_c1_from_t1
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_c0_as_c1,_c2_from_t2
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_c1,_textcol_from_nonpktext
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'nonpktext'
=== RUN   TestBuildPlanSuccess/select_textcol,_c1_from_nonpktext
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'nonpktext'
=== RUN   TestBuildPlanSuccess/select_textcol,_c2_from_pktext
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'pktext'
=== RUN   TestBuildPlanSuccess/select_c2,_textcol_from_pktext
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'pktext'
=== RUN   TestBuildPlanSuccess/select_c2,_a+b_as_textcol_from_pktext
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'pktext'
=== RUN   TestBuildPlanSuccess/#01
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'multipk'
=== RUN   TestBuildPlanSuccess/select_*_from_t1_where_in_keyrange('-80')
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_*_from_t1_where_c2_=_2_and_in_keyrange('-80')
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_*_from_t1_where_in_keyrange('-80')_and_c2_=_2
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_*_from_t1_where_c2_=_2_and_c1_=_1_and_in_keyrange('-80')
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_*_from_t1_where_(c2_=_2_and_in_keyrange('-80'))
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_*_from_t1_group_by_c1
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
=== RUN   TestBuildPlanSuccess/select_c1,_c2,_count(*)_as_c3,_sum(c4)_as_c4_from_t1_group_by_c1
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'aggr'
=== RUN   TestBuildPlanSuccess/#02
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 'datze'
--- PASS: TestBuildPlanSuccess (0.01s)
    --- PASS: TestBuildPlanSuccess/#00 (0.00s)
    --- PASS: TestBuildPlanSuccess/-80 (0.00s)
    --- PASS: TestBuildPlanSuccess/select_*_from_t1 (0.00s)
    --- PASS: TestBuildPlanSuccess/select_c2,_c1_from_t1 (0.00s)
    --- PASS: TestBuildPlanSuccess/select_c0_as_c1,_c2_from_t2 (0.00s)
    --- PASS: TestBuildPlanSuccess/select_c1,_textcol_from_nonpktext (0.00s)
    --- PASS: TestBuildPlanSuccess/select_textcol,_c1_from_nonpktext (0.00s)
    --- PASS: TestBuildPlanSuccess/select_textcol,_c2_from_pktext (0.00s)
    --- PASS: TestBuildPlanSuccess/select_c2,_textcol_from_pktext (0.00s)
    --- PASS: TestBuildPlanSuccess/select_c2,_a+b_as_textcol_from_pktext (0.00s)
    --- PASS: TestBuildPlanSuccess/#01 (0.00s)
    --- PASS: TestBuildPlanSuccess/select_*_from_t1_where_in_keyrange('-80') (0.00s)
    --- PASS: TestBuildPlanSuccess/select_*_from_t1_where_c2_=_2_and_in_keyrange('-80') (0.00s)
    --- PASS: TestBuildPlanSuccess/select_*_from_t1_where_in_keyrange('-80')_and_c2_=_2 (0.00s)
    --- PASS: TestBuildPlanSuccess/select_*_from_t1_where_c2_=_2_and_c1_=_1_and_in_keyrange('-80') (0.00s)
    --- PASS: TestBuildPlanSuccess/select_*_from_t1_where_(c2_=_2_and_in_keyrange('-80')) (0.00s)
    --- PASS: TestBuildPlanSuccess/select_*_from_t1_group_by_c1 (0.00s)
    --- PASS: TestBuildPlanSuccess/select_c1,_c2,_count(*)_as_c3,_sum(c4)_as_c4_from_t1_group_by_c1 (0.00s)
    --- PASS: TestBuildPlanSuccess/#02 (0.00s)
=== RUN   TestBuildPlanInclude
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't2'
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
E0307 13:53:32.649884   25156 controller.go:124] Encountered an error getting vdiff record for d7972ff1-edb6-4eca-9fcb-7e611555b801: no vdiff found for id 1 on tablet cell:"cell1" uid:100
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't2'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't3'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't2'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't3'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't4'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't2'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't3'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't4'
--- PASS: TestBuildPlanInclude (0.01s)
=== RUN   TestBuildPlanFailure
    engine.go:281: DBClient query: select * from _vt.vdiff where state in ('started','pending')
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    engine.go:303: DBClient query: select * from _vt.vdiff where id = 1
E0307 13:53:32.658099   25156 controller.go:124] Encountered an error getting vdiff record for 2b4b10bc-1aff-49ea-ab8d-b91280f73726: no vdiff found for id 1 on tablet cell:"cell1" uid:100
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
    workflow_differ.go:326: DBClient query: select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
        						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
        						where vdt.vdiff_id = 1 and vdt.table_name = 't1'
--- PASS: TestBuildPlanFailure (0.01s)
PASS
ok  	vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff	5.591s
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
