### PR TITLE
v19 EOL: Remove v19 from Golang Update Version CI workflow

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-21.0, release-20.0, release-19.0 ]
+        branch: [ main, release-21.0, release-20.0 ]
     name: Update Golang Version
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION

## Description

Removed the v19 branch from the golang upgrade CI workflow.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
