### PR TITLE
Remove direct usage of archived github.com/pkg/errors (#17933)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/pires/go-proxyproto v0.8.0
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a
 	github.com/planetscale/vtprotobuf v0.6.1-0.20241121165744-79df5c4772f2
 	github.com/prometheus/client_golang v1.20.5

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -63,8 +63,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/test/endtoend/encryption"
 
@@ -305,7 +303,7 @@ func clusterSetUp(t *testing.T) (int, error) {
 
 	// Start topo server
 	if err := clusterInstance.StartTopo(); err != nil {
-		return 1, errors.Wrap(err, "unable to start topo")
+		return 1, fmt.Errorf("unable to start topo %w", err)
 	}
 
 	// create all certs
@@ -391,7 +389,7 @@ func clusterSetUp(t *testing.T) (int, error) {
 	for _, proc := range mysqlProcesses {
 		err := proc.Wait()
 		if err != nil {
-			return 1, errors.Wrap(err, "unable to wait on mysql process")
+			return 1, fmt.Errorf("unable to wait on mysql process %w", err)
 		}
 	}
 	return 0, nil


### PR DESCRIPTION
## Description

github.com/pkg/errors is archived and unmaintained with preference for using standard packages for error handling.

## Related Issue(s)

#17933 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes


