### PR TITLE
Propagate CallerID through vtctld OnlineDDL RPCs

### DIFF
--- a/go/cmd/vtctldclient/command/onlineddl.go
+++ b/go/cmd/vtctldclient/command/onlineddl.go
@@ -33,6 +33,7 @@ import (
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/proto/vttime"
 )
 
@@ -150,9 +151,14 @@ func commandOnlineDDLCancel(cmd *cobra.Command, args []string) error {
 	}
 	cli.FinishedParsing(cmd)
 
+	var cid *vtrpcpb.CallerID
+	if applySchemaOptions.CallerID != "" {
+		cid = &vtrpcpb.CallerID{Principal: applySchemaOptions.CallerID}
+	}
 	resp, err := client.CancelSchemaMigration(commandCtx, &vtctldatapb.CancelSchemaMigrationRequest{
 		Keyspace: keyspace,
 		Uuid:     uuid,
+		CallerId: cid,
 	})
 	if err != nil {
 		return err
@@ -174,9 +180,14 @@ func commandOnlineDDLCleanup(cmd *cobra.Command, args []string) error {
 	}
 	cli.FinishedParsing(cmd)
 
+	var cid *vtrpcpb.CallerID
+	if applySchemaOptions.CallerID != "" {
+		cid = &vtrpcpb.CallerID{Principal: applySchemaOptions.CallerID}
+	}
 	resp, err := client.CleanupSchemaMigration(commandCtx, &vtctldatapb.CleanupSchemaMigrationRequest{
 		Keyspace: keyspace,
 		Uuid:     uuid,
+		CallerId: cid,
 	})
 	if err != nil {
 		return err
@@ -197,10 +208,14 @@ func commandOnlineDDLForceCutOver(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	cli.FinishedParsing(cmd)
-
+	var cid *vtrpcpb.CallerID
+	if applySchemaOptions.CallerID != "" {
+		cid = &vtrpcpb.CallerID{Principal: applySchemaOptions.CallerID}
+	}
 	resp, err := client.ForceCutOverSchemaMigration(commandCtx, &vtctldatapb.ForceCutOverSchemaMigrationRequest{
 		Keyspace: keyspace,
 		Uuid:     uuid,
+		CallerId: cid,
 	})
 	if err != nil {
 		return err
@@ -221,10 +236,14 @@ func commandOnlineDDLComplete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	cli.FinishedParsing(cmd)
-
+	var cid *vtrpcpb.CallerID
+	if applySchemaOptions.CallerID != "" {
+		cid = &vtrpcpb.CallerID{Principal: applySchemaOptions.CallerID}
+	}
 	resp, err := client.CompleteSchemaMigration(commandCtx, &vtctldatapb.CompleteSchemaMigrationRequest{
 		Keyspace: keyspace,
 		Uuid:     uuid,
+		CallerId: cid,
 	})
 	if err != nil {
 		return err
@@ -245,10 +264,14 @@ func commandOnlineDDLLaunch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	cli.FinishedParsing(cmd)
-
+	var cid *vtrpcpb.CallerID
+	if applySchemaOptions.CallerID != "" {
+		cid = &vtrpcpb.CallerID{Principal: applySchemaOptions.CallerID}
+	}
 	resp, err := client.LaunchSchemaMigration(commandCtx, &vtctldatapb.LaunchSchemaMigrationRequest{
 		Keyspace: keyspace,
 		Uuid:     uuid,
+		CallerId: cid,
 	})
 	if err != nil {
 		return err
@@ -271,10 +294,14 @@ func commandOnlineDDLRetry(cmd *cobra.Command, args []string) error {
 	}
 
 	cli.FinishedParsing(cmd)
-
+	var cid *vtrpcpb.CallerID
+	if applySchemaOptions.CallerID != "" {
+		cid = &vtrpcpb.CallerID{Principal: applySchemaOptions.CallerID}
+	}
 	resp, err := client.RetrySchemaMigration(commandCtx, &vtctldatapb.RetrySchemaMigrationRequest{
 		Keyspace: keyspace,
 		Uuid:     uuid,
+		CallerId: cid,
 	})
 	if err != nil {
 		return err
@@ -417,6 +444,8 @@ func commandOnlineDDLShow(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
+	OnlineDDL.Flags().StringVar(&applySchemaOptions.CallerID, "caller-id", "", "Effective caller ID used for the operation and should map to an ACL name which grants this identity the necessary permissions to perform the operation (this is only necessary when strict table ACLs are used).")
+
 	OnlineDDL.AddCommand(OnlineDDLCancel)
 	OnlineDDL.AddCommand(OnlineDDLCleanup)
 	OnlineDDL.AddCommand(OnlineDDLComplete)

--- a/go/vt/proto/vtctldata/vtctldata.pb.go
+++ b/go/vt/proto/vtctldata/vtctldata.pb.go
@@ -2534,11 +2534,12 @@ func (x *BackupShardRequest) GetIncrementalFromPos() string {
 }
 
 type CancelSchemaMigrationRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Keyspace      string                 `protobuf:"bytes,1,opt,name=keyspace,proto3" json:"keyspace,omitempty"`
-	Uuid          string                 `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+   state         protoimpl.MessageState `protogen:"open.v1"`
+   Keyspace      string                 `protobuf:"bytes,1,opt,name=keyspace,proto3" json:"keyspace,omitempty"`
+   Uuid          string                 `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	CallerId      *vtrpc.CallerID       `protobuf:"bytes,3,opt,name=caller_id,json=callerId,proto3" json:"caller_id,omitempty"`
+   unknownFields protoimpl.UnknownFields
+   sizeCache     protoimpl.SizeCache
 }
 
 func (x *CancelSchemaMigrationRequest) Reset() {
@@ -2578,11 +2579,19 @@ func (x *CancelSchemaMigrationRequest) GetKeyspace() string {
 	return ""
 }
 
+
 func (x *CancelSchemaMigrationRequest) GetUuid() string {
 	if x != nil {
 		return x.Uuid
 	}
 	return ""
+}
+
+	func (x *CancelSchemaMigrationRequest) GetCallerId() *vtrpc.CallerID {
+	if x != nil {
+		return x.CallerId
+	}
+	return nil
 }
 
 type CancelSchemaMigrationResponse struct {
@@ -2995,6 +3004,7 @@ type CleanupSchemaMigrationRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Keyspace      string                 `protobuf:"bytes,1,opt,name=keyspace,proto3" json:"keyspace,omitempty"`
 	Uuid          string                 `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	CallerId      *vtrpc.CallerID       `protobuf:"bytes,3,opt,name=caller_id,json=callerId,proto3" json:"caller_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3034,6 +3044,13 @@ func (x *CleanupSchemaMigrationRequest) GetKeyspace() string {
 		return x.Keyspace
 	}
 	return ""
+}
+
+	func (x *CleanupSchemaMigrationRequest) GetCallerId() *vtrpc.CallerID {
+	if x != nil {
+		return x.CallerId
+	}
+	return nil
 }
 
 func (x *CleanupSchemaMigrationRequest) GetUuid() string {
@@ -3091,6 +3108,7 @@ type CompleteSchemaMigrationRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Keyspace      string                 `protobuf:"bytes,1,opt,name=keyspace,proto3" json:"keyspace,omitempty"`
 	Uuid          string                 `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	CallerId      *vtrpc.CallerID       `protobuf:"bytes,3,opt,name=caller_id,json=callerId,proto3" json:"caller_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3137,6 +3155,13 @@ func (x *CompleteSchemaMigrationRequest) GetUuid() string {
 		return x.Uuid
 	}
 	return ""
+}
+
+	func (x *CompleteSchemaMigrationRequest) GetCallerId() *vtrpc.CallerID {
+	if x != nil {
+		return x.CallerId
+	}
+	return nil
 }
 
 type CompleteSchemaMigrationResponse struct {
@@ -4927,6 +4952,7 @@ type ForceCutOverSchemaMigrationRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Keyspace      string                 `protobuf:"bytes,1,opt,name=keyspace,proto3" json:"keyspace,omitempty"`
 	Uuid          string                 `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	CallerId      *vtrpc.CallerID       `protobuf:"bytes,3,opt,name=caller_id,json=callerId,proto3" json:"caller_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4973,6 +4999,13 @@ func (x *ForceCutOverSchemaMigrationRequest) GetUuid() string {
 		return x.Uuid
 	}
 	return ""
+}
+
+	func (x *ForceCutOverSchemaMigrationRequest) GetCallerId() *vtrpc.CallerID {
+	if x != nil {
+		return x.CallerId
+	}
+	return nil
 }
 
 type ForceCutOverSchemaMigrationResponse struct {
@@ -8327,6 +8360,7 @@ type LaunchSchemaMigrationRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Keyspace      string                 `protobuf:"bytes,1,opt,name=keyspace,proto3" json:"keyspace,omitempty"`
 	Uuid          string                 `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	CallerId      *vtrpc.CallerID       `protobuf:"bytes,3,opt,name=caller_id,json=callerId,proto3" json:"caller_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8373,6 +8407,13 @@ func (x *LaunchSchemaMigrationRequest) GetUuid() string {
 		return x.Uuid
 	}
 	return ""
+}
+
+	func (x *LaunchSchemaMigrationRequest) GetCallerId() *vtrpc.CallerID {
+	if x != nil {
+		return x.CallerId
+	}
+	return nil
 }
 
 type LaunchSchemaMigrationResponse struct {
@@ -11767,6 +11808,7 @@ type RetrySchemaMigrationRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Keyspace      string                 `protobuf:"bytes,1,opt,name=keyspace,proto3" json:"keyspace,omitempty"`
 	Uuid          string                 `protobuf:"bytes,2,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	CallerId      *vtrpc.CallerID       `protobuf:"bytes,3,opt,name=caller_id,json=callerId,proto3" json:"caller_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -11813,6 +11855,13 @@ func (x *RetrySchemaMigrationRequest) GetUuid() string {
 		return x.Uuid
 	}
 	return ""
+}
+
+	func (x *RetrySchemaMigrationRequest) GetCallerId() *vtrpc.CallerID {
+	if x != nil {
+		return x.CallerId
+	}
+	return nil
 }
 
 type RetrySchemaMigrationResponse struct {

--- a/go/vt/proto/vtctldata/vtctldata_vtproto.pb.go
+++ b/go/vt/proto/vtctldata/vtctldata_vtproto.pb.go
@@ -877,6 +877,9 @@ func (m *CancelSchemaMigrationRequest) CloneVT() *CancelSchemaMigrationRequest {
 	r := new(CancelSchemaMigrationRequest)
 	r.Keyspace = m.Keyspace
 	r.Uuid = m.Uuid
+	if m.CallerId != nil {
+		r.CallerId = m.CallerId.CloneVT()
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1050,6 +1053,9 @@ func (m *CleanupSchemaMigrationRequest) CloneVT() *CleanupSchemaMigrationRequest
 	r := new(CleanupSchemaMigrationRequest)
 	r.Keyspace = m.Keyspace
 	r.Uuid = m.Uuid
+	if m.CallerId != nil {
+		r.CallerId = m.CallerId.CloneVT()
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1091,6 +1097,9 @@ func (m *CompleteSchemaMigrationRequest) CloneVT() *CompleteSchemaMigrationReque
 	r := new(CompleteSchemaMigrationRequest)
 	r.Keyspace = m.Keyspace
 	r.Uuid = m.Uuid
+	if m.CallerId != nil {
+		r.CallerId = m.CallerId.CloneVT()
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1727,6 +1736,9 @@ func (m *ForceCutOverSchemaMigrationRequest) CloneVT() *ForceCutOverSchemaMigrat
 	r := new(ForceCutOverSchemaMigrationRequest)
 	r.Keyspace = m.Keyspace
 	r.Uuid = m.Uuid
+	if m.CallerId != nil {
+		r.CallerId = m.CallerId.CloneVT()
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -3066,6 +3078,9 @@ func (m *LaunchSchemaMigrationRequest) CloneVT() *LaunchSchemaMigrationRequest {
 	r := new(LaunchSchemaMigrationRequest)
 	r.Keyspace = m.Keyspace
 	r.Uuid = m.Uuid
+	if m.CallerId != nil {
+		r.CallerId = m.CallerId.CloneVT()
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -4267,6 +4282,9 @@ func (m *RetrySchemaMigrationRequest) CloneVT() *RetrySchemaMigrationRequest {
 	r := new(RetrySchemaMigrationRequest)
 	r.Keyspace = m.Keyspace
 	r.Uuid = m.Uuid
+	if m.CallerId != nil {
+		r.CallerId = m.CallerId.CloneVT()
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -8723,6 +8741,16 @@ func (m *CancelSchemaMigrationRequest) MarshalToSizedBufferVT(dAtA []byte) (int,
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.CallerId != nil {
+		size, err := m.CallerId.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.Uuid) > 0 {
 		i -= len(m.Uuid)
 		copy(dAtA[i:], m.Uuid)
@@ -9214,6 +9242,16 @@ func (m *CleanupSchemaMigrationRequest) MarshalToSizedBufferVT(dAtA []byte) (int
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.CallerId != nil {
+		size, err := m.CallerId.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.Uuid) > 0 {
 		i -= len(m.Uuid)
 		copy(dAtA[i:], m.Uuid)
@@ -9310,6 +9348,16 @@ func (m *CompleteSchemaMigrationRequest) MarshalToSizedBufferVT(dAtA []byte) (in
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.CallerId != nil {
+		size, err := m.CallerId.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.Uuid) > 0 {
 		i -= len(m.Uuid)
@@ -11047,6 +11095,16 @@ func (m *ForceCutOverSchemaMigrationRequest) MarshalToSizedBufferVT(dAtA []byte)
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.CallerId != nil {
+		size, err := m.CallerId.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.Uuid) > 0 {
 		i -= len(m.Uuid)
@@ -14352,6 +14410,16 @@ func (m *LaunchSchemaMigrationRequest) MarshalToSizedBufferVT(dAtA []byte) (int,
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.CallerId != nil {
+		size, err := m.CallerId.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.Uuid) > 0 {
 		i -= len(m.Uuid)
@@ -17714,6 +17782,16 @@ func (m *RetrySchemaMigrationRequest) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.CallerId != nil {
+		size, err := m.CallerId.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.Uuid) > 0 {
 		i -= len(m.Uuid)
@@ -23284,6 +23362,10 @@ func (m *CancelSchemaMigrationRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.CallerId != nil {
+		l = m.CallerId.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -23458,6 +23540,10 @@ func (m *CleanupSchemaMigrationRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.CallerId != nil {
+		l = m.CallerId.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -23492,6 +23578,10 @@ func (m *CompleteSchemaMigrationRequest) SizeVT() (n int) {
 	}
 	l = len(m.Uuid)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CallerId != nil {
+		l = m.CallerId.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -24110,6 +24200,10 @@ func (m *ForceCutOverSchemaMigrationRequest) SizeVT() (n int) {
 	}
 	l = len(m.Uuid)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CallerId != nil {
+		l = m.CallerId.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -25323,6 +25417,10 @@ func (m *LaunchSchemaMigrationRequest) SizeVT() (n int) {
 	}
 	l = len(m.Uuid)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CallerId != nil {
+		l = m.CallerId.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -26576,6 +26674,10 @@ func (m *RetrySchemaMigrationRequest) SizeVT() (n int) {
 	}
 	l = len(m.Uuid)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CallerId != nil {
+		l = m.CallerId.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -35941,6 +36043,42 @@ func (m *CancelSchemaMigrationRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Uuid = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CallerId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CallerId == nil {
+				m.CallerId = &vtrpc.CallerID{}
+			}
+			if err := m.CallerId.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -37342,6 +37480,42 @@ func (m *CleanupSchemaMigrationRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Uuid = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CallerId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CallerId == nil {
+				m.CallerId = &vtrpc.CallerID{}
+			}
+			if err := m.CallerId.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -37620,6 +37794,42 @@ func (m *CompleteSchemaMigrationRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Uuid = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CallerId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CallerId == nil {
+				m.CallerId = &vtrpc.CallerID{}
+			}
+			if err := m.CallerId.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -41576,6 +41786,42 @@ func (m *ForceCutOverSchemaMigrationRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Uuid = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CallerId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CallerId == nil {
+				m.CallerId = &vtrpc.CallerID{}
+			}
+			if err := m.CallerId.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -49131,6 +49377,42 @@ func (m *LaunchSchemaMigrationRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Uuid = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CallerId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CallerId == nil {
+				m.CallerId = &vtrpc.CallerID{}
+			}
+			if err := m.CallerId.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -57133,6 +57415,42 @@ func (m *RetrySchemaMigrationRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Uuid = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CallerId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CallerId == nil {
+				m.CallerId = &vtrpc.CallerID{}
+			}
+			if err := m.CallerId.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -575,6 +575,7 @@ func (s *VtctldServer) CancelSchemaMigration(ctx context.Context, req *vtctldata
 		Keyspace:            req.Keyspace,
 		Sql:                 []string{query},
 		WaitReplicasTimeout: protoutil.DurationToProto(DefaultWaitReplicasTimeout),
+		CallerId:            req.CallerId,
 	})
 	if err != nil {
 		return nil, err
@@ -794,6 +795,7 @@ func (s *VtctldServer) CleanupSchemaMigration(ctx context.Context, req *vtctldat
 		Keyspace:            req.Keyspace,
 		Sql:                 []string{query},
 		WaitReplicasTimeout: protoutil.DurationToProto(DefaultWaitReplicasTimeout),
+		CallerId:            req.CallerId,
 	})
 	if err != nil {
 		return nil, err
@@ -825,6 +827,7 @@ func (s *VtctldServer) ForceCutOverSchemaMigration(ctx context.Context, req *vtc
 		Keyspace:            req.Keyspace,
 		Sql:                 []string{query},
 		WaitReplicasTimeout: protoutil.DurationToProto(DefaultWaitReplicasTimeout),
+		CallerId:            req.CallerId,
 	})
 	if err != nil {
 		return nil, err
@@ -856,6 +859,7 @@ func (s *VtctldServer) CompleteSchemaMigration(ctx context.Context, req *vtctlda
 		Keyspace:            req.Keyspace,
 		Sql:                 []string{query},
 		WaitReplicasTimeout: protoutil.DurationToProto(DefaultWaitReplicasTimeout),
+		CallerId:            req.CallerId,
 	})
 	if err != nil {
 		return nil, err
@@ -3012,6 +3016,7 @@ func (s *VtctldServer) LaunchSchemaMigration(ctx context.Context, req *vtctldata
 		Keyspace:            req.Keyspace,
 		Sql:                 []string{query},
 		WaitReplicasTimeout: protoutil.DurationToProto(DefaultWaitReplicasTimeout),
+		CallerId:            req.CallerId,
 	})
 	if err != nil {
 		return nil, err
@@ -3794,6 +3799,7 @@ func (s *VtctldServer) RetrySchemaMigration(ctx context.Context, req *vtctldatap
 		Keyspace:            req.Keyspace,
 		Sql:                 []string{query},
 		WaitReplicasTimeout: protoutil.DurationToProto(DefaultWaitReplicasTimeout),
+		CallerId:            req.CallerId,
 	})
 	if err != nil {
 		return nil, err

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -53,6 +53,9 @@ import (
 	"vitess.io/vitess/go/vt/vtctl/schematools"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
+	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vttablet/tmclienttest"
 
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
@@ -1260,13 +1263,26 @@ func TestBackupShard(t *testing.T) {
 	}
 }
 
+// requireCallerIDTMClient wraps the testutil TabletManagerClient and rejects ExecuteQuery calls
+// that do not have an effective caller id in their context, simulating strict table ACLs.
+type requireCallerIDTMClient struct {
+	*testutil.TabletManagerClient
+}
+// ExecuteQuery implements the tmclient.TabletManagerClient interface for requireCallerIDTMClient.
+func (tc *requireCallerIDTMClient) ExecuteQuery(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.ExecuteQueryRequest) (*querypb.QueryResult, error) {
+	if callerid.EffectiveCallerIDFromContext(ctx) == nil {
+		return nil, vterrors.Errorf(vtrpc.Code_UNAUTHENTICATED, "missing caller id")
+	}
+	return tc.TabletManagerClient.ExecuteQuery(ctx, tablet, req)
+}
+
 func TestCancelSchemaMigration(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name      string
 		tablets   []*topodatapb.Tablet
-		tmc       *testutil.TabletManagerClient
+		tmc       tmclient.TabletManagerClient
 		req       *vtctldatapb.CancelSchemaMigrationRequest
 		expected  *vtctldatapb.CancelSchemaMigrationResponse
 		shouldErr bool
@@ -1322,13 +1338,31 @@ func TestCancelSchemaMigration(t *testing.T) {
 				Keyspace: "ks",
 				Uuid:     "abc",
 			},
-			expected: &vtctldatapb.CancelSchemaMigrationResponse{
-				RowsAffectedByShard: map[string]uint64{
-					"-80": 1,
-					"80-": 0,
-				},
+		expected: &vtctldatapb.CancelSchemaMigrationResponse{
+			RowsAffectedByShard: map[string]uint64{
+				"-80": 1,
+				"80-": 0,
 			},
 		},
+	},
+	{
+		name: "strict ACL requires caller id",
+		tablets: []*topodatapb.Tablet{
+			{Keyspace: "ks", Shard: "0", Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}, Type: topodatapb.TabletType_PRIMARY},
+		},
+		tmc: &requireCallerIDTMClient{TabletManagerClient: &testutil.TabletManagerClient{
+			ExecuteQueryResults: map[string]struct{Response *querypb.QueryResult; Error error}{
+				"zone1-0000000100": {Response: &querypb.QueryResult{RowsAffected: 1}},
+			},
+			PrimaryPositionResults: map[string]struct{Position string; Error error}{
+				"zone1-0000000100": {},
+			},
+			ReloadSchemaResults: map[string]error{"zone1-0000000100": nil},
+		}},
+		req: &vtctldatapb.CancelSchemaMigrationRequest{Keyspace: "ks", Uuid: "abc", CallerId: &vtrpc.CallerID{Principal: "strict"}},
+		expected: &vtctldatapb.CancelSchemaMigrationResponse{RowsAffectedByShard: map[string]uint64{"0": 1}},
+		shouldErr: false,
+	},
 		{
 			name: "no shard primary",
 			tablets: []*topodatapb.Tablet{

--- a/proto/vtctldata.proto
+++ b/proto/vtctldata.proto
@@ -491,6 +491,9 @@ message BackupShardRequest {
 message CancelSchemaMigrationRequest {
   string keyspace = 1;
   string uuid = 2;
+  // caller_id identifies the caller. This is the effective caller ID,
+  // set by the application to further identify the caller. This is needed when strict table ACLs are enforced on the tablets.
+  vtrpc.CallerID caller_id = 3;
 }
 
 message CancelSchemaMigrationResponse {
@@ -541,6 +544,9 @@ message CheckThrottlerResponse {
 message CleanupSchemaMigrationRequest {
   string keyspace = 1;
   string uuid = 2;
+  // caller_id identifies the caller. This is the effective caller ID,
+  // set by the application to further identify the caller.
+  vtrpc.CallerID caller_id = 3;
 }
 
 message CleanupSchemaMigrationResponse {
@@ -550,6 +556,9 @@ message CleanupSchemaMigrationResponse {
 message CompleteSchemaMigrationRequest {
   string keyspace = 1;
   string uuid = 2;
+  // caller_id identifies the caller. This is the effective caller ID,
+  // set by the application to further identify the caller.
+  vtrpc.CallerID caller_id = 3;
 }
 
 message CompleteSchemaMigrationResponse {
@@ -822,6 +831,9 @@ message FindAllShardsInKeyspaceResponse {
 message ForceCutOverSchemaMigrationRequest {
   string keyspace = 1;
   string uuid = 2;
+  // caller_id identifies the caller. This is the effective caller ID,
+  // set by the application to further identify the caller.
+  vtrpc.CallerID caller_id = 3;
 }
 
 message ForceCutOverSchemaMigrationResponse {
@@ -1225,6 +1237,9 @@ message InitShardPrimaryResponse {
 message LaunchSchemaMigrationRequest {
   string keyspace = 1;
   string uuid = 2;
+  // caller_id identifies the caller. This is the effective caller ID,
+  // set by the application to further identify the caller.
+  vtrpc.CallerID caller_id = 3;
 }
 
 message LaunchSchemaMigrationResponse {
@@ -1672,6 +1687,9 @@ message RestoreFromBackupResponse {
 message RetrySchemaMigrationRequest {
   string keyspace = 1;
   string uuid = 2;
+  // caller_id identifies the caller. This is the effective caller ID,
+  // set by the application to further identify the caller.
+  vtrpc.CallerID caller_id = 3;
 }
 
 message RetrySchemaMigrationResponse {


### PR DESCRIPTION
## Description

Fixes an issue where `vtctldclient OnlineDDL` commands would fail under strict table ACLs with `missing caller id`. This exposed that `OnlineDDL` subcommands were not supplying a caller ID on the RPCs that ultimately call `TabletManager.ExecuteQuery`, whereas the existing `ApplySchema` path already supported `--caller-id`.

To address this, I:

* Added a `caller_id` field to the relevant Online DDL RPC request protos (`CancelSchemaMigrationRequest`, `CleanupSchemaMigrationRequest`, `CompleteSchemaMigrationRequest`, `ForceCutOverSchemaMigrationRequest`, `LaunchSchemaMigrationRequest`, `RetrySchemaMigrationRequest`) and regenerated the associated Go structs/marshalers.
* Threaded `CallerId` through the vtctld gRPC server implementations of these RPCs into the existing `ApplySchemaRequest`.
* Extended the `vtctldclient OnlineDDL` command to accept a top-level `--caller-id` flag (reusing `applySchemaOptions.CallerID`) and populate the new proto field.
* Added a new end-to-end unit test to `TestCancelSchemaMigration` which wraps the fake TMClient to require an effective caller ID on the context. Without the proto and server changes this test fails; with this change it succeeds.

All touched packages (`go/cmd/vtctldclient/command`, `go/vt/vtctl/grpcvtctldserver`) build and their tests pass.

## Related Issue(s)

Fixes #17138.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Clusters that enforce strict table ACLs can now use `vtctldclient OnlineDDL ... --caller-id <principal>` so online DDL subcommands run with an effective caller ID. Existing deployments not using strict ACLs are unaffected.