### PR TITLE
Fix semi-sync monitor bug of expecting incorrect number of fields

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -134,7 +134,7 @@ func TestDemotePrimaryWaitingForSemiSyncUnblock(t *testing.T) {
 		<-ch
 	})
 	// Add a fake query that makes the semi-sync monitor believe that the tablet is blocked on semi-sync ACKs.
-	fakeDb.AddQuery("select variable_value from performance_schema.global_status where regexp_like(variable_name, 'Rpl_semi_sync_(source|master)_wait_sessions')", sqltypes.MakeTestResult(sqltypes.MakeTestFields("Variable_name|Value", "varchar|varchar"), "Rpl_semi_sync_source_wait_sessions|1"))
+	fakeDb.AddQuery("select variable_value from performance_schema.global_status where regexp_like(variable_name, 'Rpl_semi_sync_(source|master)_wait_sessions')", sqltypes.MakeTestResult(sqltypes.MakeTestFields("Variable_value", "varchar"), "1"))
 
 	// Verify that in the beginning the tablet is serving.
 	require.True(t, tm.QueryServiceControl.IsServing())
@@ -159,7 +159,7 @@ func TestDemotePrimaryWaitingForSemiSyncUnblock(t *testing.T) {
 	require.False(t, fakeMysqlDaemon.SuperReadOnly.Load())
 
 	// Now we unblock the semi-sync monitor.
-	fakeDb.AddQuery("select variable_value from performance_schema.global_status where regexp_like(variable_name, 'Rpl_semi_sync_(source|master)_wait_sessions')", sqltypes.MakeTestResult(sqltypes.MakeTestFields("Variable_name|Value", "varchar|varchar"), "Rpl_semi_sync_source_wait_sessions|0"))
+	fakeDb.AddQuery("select variable_value from performance_schema.global_status where regexp_like(variable_name, 'Rpl_semi_sync_(source|master)_wait_sessions')", sqltypes.MakeTestResult(sqltypes.MakeTestFields("Variable_value", "varchar"), "0"))
 	close(ch)
 
 	// This should unblock the demote primary operation eventually.

--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
@@ -18,7 +18,7 @@ package semisyncmonitor
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -205,10 +205,10 @@ func (m *Monitor) isSemiSyncBlocked(ctx context.Context) (bool, error) {
 	}
 
 	// Read the status value and check if it is non-zero.
-	if len(res.Rows) != 1 || len(res.Rows[0]) != 2 {
-		return false, errors.New("unexpected number of rows received")
+	if len(res.Rows) != 1 || len(res.Rows[0]) != 1 {
+		return false, fmt.Errorf("unexpected number of rows received - %v", res.Rows)
 	}
-	value, err := res.Rows[0][1].ToCastInt64()
+	value, err := res.Rows[0][0].ToCastInt64()
 	return value != 0, err
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the bug described in https://github.com/vitessio/vitess/issues/17938. The problem of expecting incorrect number of fields has been fixed. There is an e2e test that would have caught this bug when the semi-sync monitor was introduced in #17763, but the test doesn't run on CI and I didn't run it locally after addressing the review comments as part of which I changed the query that the semi-sync monitor was running.

This time I have ensured that the e2e test is now working as expected after the fix.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #17938 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
