### PR TITLE
Fix flakiness in throttler's `TestDormant`

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler_test.go
@@ -1648,7 +1648,7 @@ func TestDormant(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				require.FailNow(t, "context expired before testing completed")
-			case <-time.After(throttler.dormantPeriod):
+			case <-time.After(throttler.dormantPeriod + 2*recentCheckRateLimiterInterval):
 				assert.True(t, throttler.isDormant())
 			}
 		}()


### PR DESCRIPTION

## Description

We've seen some flakiness in `TestDormant`. This unit test runs the throttler, issues some checks, then waits a "dormant period" amount of time, then checks the throttler to see that it's dormant. While this passes consistently on local dev envs, it sometimes fails in GitHub CI due to slow runners. There's a potential for a race condition on slow runners, where the throttler is still not fast enough to enter the dormant period. The fix here is to add two "check intervals", which means extra two seconds, before checking that the throttler is dormant. This should be good enough: on one hand should add enough time for the throttler to turn dormant, on the other hand we still don't waste too much test time, and we do validate that the throttler ends up turning dormant (the precise timing is not very important even in prod envs).


## Related Issue(s)

None linked. There's been a few failed CI jobs.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
