### PR TITLE
`schemadiff`: explicit `ALGORITHM=INSTANT` counts as instant-able

### DIFF
--- a/go/vt/schemadiff/capability.go
+++ b/go/vt/schemadiff/capability.go
@@ -1,7 +1,6 @@
 package schemadiff
 
 import (
-	"fmt"
 	"strings"
 
 	"vitess.io/vitess/go/mysql/capabilities"
@@ -15,7 +14,6 @@ const (
 // alterOptionAvailableViaInstantDDL checks if the specific alter option is eligible to run via ALGORITHM=INSTANT
 // reference: https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html
 func alterOptionCapableOfInstantDDL(alterOption sqlparser.AlterOption, createTable *sqlparser.CreateTable, capableOf capabilities.CapableOf) (bool, error) {
-	fmt.Println("alterOptionCapableOfInstantDDL: ", sqlparser.String(alterOption))
 	// A table with FULLTEXT index won't support adding/removing columns instantly.
 	tableHasFulltextIndex := false
 	for _, key := range createTable.TableSpec.Indexes {

--- a/go/vt/schemadiff/capability.go
+++ b/go/vt/schemadiff/capability.go
@@ -1,6 +1,7 @@
 package schemadiff
 
 import (
+	"fmt"
 	"strings"
 
 	"vitess.io/vitess/go/mysql/capabilities"
@@ -14,6 +15,7 @@ const (
 // alterOptionAvailableViaInstantDDL checks if the specific alter option is eligible to run via ALGORITHM=INSTANT
 // reference: https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html
 func alterOptionCapableOfInstantDDL(alterOption sqlparser.AlterOption, createTable *sqlparser.CreateTable, capableOf capabilities.CapableOf) (bool, error) {
+	fmt.Println("alterOptionCapableOfInstantDDL: ", sqlparser.String(alterOption))
 	// A table with FULLTEXT index won't support adding/removing columns instantly.
 	tableHasFulltextIndex := false
 	for _, key := range createTable.TableSpec.Indexes {
@@ -223,6 +225,9 @@ func alterOptionCapableOfInstantDDL(alterOption sqlparser.AlterOption, createTab
 			return capableOf(capabilities.InstantChangeColumnVisibilityCapability)
 		}
 		return false, nil
+	case sqlparser.AlgorithmValue:
+		// We accept an explicit ALGORITHM=INSTANT option.
+		return strings.EqualFold(string(opt), sqlparser.InstantStr), nil
 	default:
 		return false, nil
 	}

--- a/go/vt/schemadiff/capability_test.go
+++ b/go/vt/schemadiff/capability_test.go
@@ -345,6 +345,18 @@ func TestAlterTableCapableOfInstantDDL(t *testing.T) {
 			alter:                     "alter table t1 alter column i1 drop default",
 			expectCapableOfInstantDDL: true,
 		},
+		{
+			name:                      "add column with explicit ALGORITHM=instant",
+			create:                    "create table t1 (id int, i1 int)",
+			alter:                     "alter table t1 add column i2 int, algorithm=instant",
+			expectCapableOfInstantDDL: true,
+		},
+		{
+			name:                      "add column with explicit ALGORITHM=INSTANT",
+			create:                    "create table t1 (id int, i1 int)",
+			alter:                     "alter table t1 add column i2 int, algorithm=INSTANT",
+			expectCapableOfInstantDDL: true,
+		},
 	}
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {

--- a/go/vt/schemadiff/capability_test.go
+++ b/go/vt/schemadiff/capability_test.go
@@ -357,6 +357,12 @@ func TestAlterTableCapableOfInstantDDL(t *testing.T) {
 			alter:                     "alter table t1 add column i2 int, algorithm=INSTANT",
 			expectCapableOfInstantDDL: true,
 		},
+		{
+			name:                      "reject if ALGORITHM=COPY",
+			create:                    "create table t1 (id int, i1 int)",
+			alter:                     "alter table t1 add column i2 int, algorithm=COPY",
+			expectCapableOfInstantDDL: false,
+		},
 	}
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/17941, see description in issue.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17941

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
