### PR TITLE
Add support for hashed caching sha2 passwords

### DIFF
--- a/go/mysql/auth_server.go
+++ b/go/mysql/auth_server.go
@@ -277,10 +277,10 @@ func ScrambleMysqlNativePassword(salt, password []byte) []byte {
 	return scramble
 }
 
-// DecodeMysqlNativePasswordHex decodes the standard format used by MySQL
+// DecodePasswordHex decodes the standard format used by MySQL
 // for 4.1 style password hashes. It drops the optionally leading * before
 // decoding the rest as a hex encoded string.
-func DecodeMysqlNativePasswordHex(hexEncodedPassword string) ([]byte, error) {
+func DecodePasswordHex(hexEncodedPassword string) ([]byte, error) {
 	if hexEncodedPassword[0] == '*' {
 		hexEncodedPassword = hexEncodedPassword[1:]
 	}
@@ -294,7 +294,7 @@ func DecodeMysqlNativePasswordHex(hexEncodedPassword string) ([]byte, error) {
 //
 // All values here are non encoded byte slices, so if you store for example the double
 // SHA1 of the password as hex encoded characters, you need to decode that first.
-// See DecodeMysqlNativePasswordHex for a decoding helper for the standard encoding
+// See DecodePasswordHex for a decoding helper for the standard encoding
 // format of this hash used by MySQL.
 func VerifyHashedMysqlNativePassword(reply, salt, hashedNativePassword []byte) bool {
 	if len(reply) == 0 || len(hashedNativePassword) == 0 {

--- a/go/mysql/auth_server_test.go
+++ b/go/mysql/auth_server_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVerifyHashedMysqlNativePassword(t *testing.T) {
+func TestVerifyHashedCachingSha2Password(t *testing.T) {
 	salt := []byte{10, 47, 74, 111, 75, 73, 34, 48, 88, 76, 114, 74, 37, 13, 3, 80, 82, 2, 23, 21}
 	password := "secret"
 
-	// Double SHA1 of "secret"
+	// Double SHA2 of "secret"
 	passwordHash := []byte{0x38, 0x81, 0x21, 0x9d, 0x08, 0x7d, 0xd9, 0xc6, 0x34, 0x37, 0x3f, 0xd3,
 		0x3d, 0xfa, 0x33, 0xa2, 0xcb, 0x6b, 0xfc, 0x6c, 0x52, 0x0b, 0x64, 0xb8,
 		0xbb, 0x60, 0xef, 0x2c, 0xeb, 0x53, 0x4a, 0xe7}
@@ -39,7 +39,7 @@ func TestVerifyHashedMysqlNativePassword(t *testing.T) {
 	assert.False(t, VerifyHashedCachingSha2Password(reply, salt, passwordHash), "password hash match")
 }
 
-func TestVerifyHashedCachingSha2Password(t *testing.T) {
+func TestVerifyHashedMysqlNativePassword(t *testing.T) {
 	salt := []byte{10, 47, 74, 111, 75, 73, 34, 48, 88, 76, 114, 74, 37, 13, 3, 80, 82, 2, 23, 21}
 	password := "secret"
 

--- a/go/mysql/vault/auth_server_vault.go
+++ b/go/mysql/vault/auth_server_vault.go
@@ -164,7 +164,7 @@ func (a *AuthServerVault) UserEntryWithHash(conn *mysql.Conn, salt []byte, user 
 
 	for _, entry := range userEntries {
 		if entry.MysqlNativePassword != "" {
-			hash, err := mysql.DecodeMysqlNativePasswordHex(entry.MysqlNativePassword)
+			hash, err := mysql.DecodePasswordHex(entry.MysqlNativePassword)
 			if err != nil {
 				return &mysql.StaticUserData{Username: entry.UserData, Groups: entry.Groups}, sqlerror.NewSQLErrorf(sqlerror.ERAccessDeniedError, sqlerror.SSAccessDeniedError, "Access denied for user '%v'", user)
 			}


### PR DESCRIPTION
This allows for storing already hashed caching sha2 passwords for authentication. This way you can use the new authentication method without needing the password to be in plain text.

## Related Issue(s)

Fixes #17947 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required