### PR TITLE
go/vt/vtgate: take routing rules into account for traffic mirroring

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/rewriters.go
+++ b/go/vt/vtgate/planbuilder/operators/rewriters.go
@@ -50,9 +50,7 @@ type (
 	VisitRule bool
 )
 
-var (
-	NoRewrite *ApplyResult = nil
-)
+var NoRewrite *ApplyResult = nil
 
 const (
 	VisitChildren VisitRule = true

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -349,7 +349,19 @@ func findVSchemaTableAndCreateRoute(
 	tableName sqlparser.TableName,
 	planAlternates bool,
 ) *Route {
-	vschemaTable, _, _, tabletType, target, err := ctx.VSchema.FindTableOrVindex(tableName)
+	var (
+		vschemaTable *vindexes.BaseTable
+		tabletType   topodatapb.TabletType
+		target       key.Destination
+		err          error
+	)
+
+	if ctx.IsMirrored() {
+		vschemaTable, _, tabletType, target, err = ctx.VSchema.FindTable(tableName)
+	} else {
+		vschemaTable, _, _, tabletType, target, err = ctx.VSchema.FindTableOrVindex(tableName)
+	}
+
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -60,7 +60,6 @@ func optimizeJoin(ctx *plancontext.PlanningContext, op *Join) (Operator, *ApplyR
 }
 
 func optimizeQueryGraph(ctx *plancontext.PlanningContext, op *QueryGraph) (result Operator, changed *ApplyResult) {
-
 	switch {
 	case ctx.PlannerVersion == querypb.ExecuteOptions_Gen4Left2Right:
 		result = leftToRightSolve(ctx, op)

--- a/go/vt/vtgate/planbuilder/testdata/mirror_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/mirror_cases.json
@@ -41,6 +41,88 @@
     }
   },
   {
+    "comment": "select from source of unsharded, qualified, table mirrored to unsharded table with routing rules",
+    "query": "select t4.id from unsharded_src1.t4 where t4.id = 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select t4.id from unsharded_src1.t4 where t4.id = 1",
+      "Instructions": {
+        "OperatorType": "Mirror",
+        "Variant": "PercentBased",
+        "Percent": 10,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_src1",
+              "Sharded": false
+            },
+            "FieldQuery": "select t4.id from t4 where 1 != 1",
+            "Query": "select t4.id from t4 where t4.id = 1",
+            "Table": "t4"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_dst1",
+              "Sharded": false
+            },
+            "FieldQuery": "select t4.id from t4 where 1 != 1",
+            "Query": "select t4.id from t4 where t4.id = 1",
+            "Table": "t4"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "unsharded_dst1.t4",
+        "unsharded_src1.t4"
+      ]
+    }
+  },
+  {
+    "comment": "select from destination of unsharded, qualified, table mirrored to unsharded table with routing rules",
+    "query": "select t4.id from unsharded_dst1.t4 where t4.id = 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select t4.id from unsharded_dst1.t4 where t4.id = 1",
+      "Instructions": {
+        "OperatorType": "Mirror",
+        "Variant": "PercentBased",
+        "Percent": 10,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_src1",
+              "Sharded": false
+            },
+            "FieldQuery": "select t4.id from t4 where 1 != 1",
+            "Query": "select t4.id from t4 where t4.id = 1",
+            "Table": "t4"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "unsharded_dst1",
+              "Sharded": false
+            },
+            "FieldQuery": "select t4.id from t4 where 1 != 1",
+            "Query": "select t4.id from t4 where t4.id = 1",
+            "Table": "t4"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "unsharded_dst1.t4",
+        "unsharded_src1.t4"
+      ]
+    }
+  },
+  {
     "comment": "select unsharded, qualified, table mirrored to unsharded table with zero percentage",
     "query": "select t3.id from unsharded_src1.t3 where t3.id = 1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/mirror_schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/mirror_schema.json
@@ -45,6 +45,69 @@
         "from_table": "unsharded_src1.t3",
         "to_table": "unsharded_dst1.t2",
         "percent": 0
+      },
+      {
+        "from_table": "unsharded_src1.t4",
+        "to_table": "unsharded_dst1.t4",
+        "percent": 10
+      }
+    ]
+  },
+  "routing_rules": {
+    "rules": [
+      {
+        "from_table": "t4",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "t4@replica",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "t4@rdonly",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "unsharded_src1.t4",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "unsharded_src1.t4@replica",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "unsharded_src1.t4@rdonly",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "unsharded_dst1.t4",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "unsharded_dst1.t4@replica",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
+      },
+      {
+        "from_table": "unsharded_dst1.t4@rdonly",
+        "to_tables": [
+          "unsharded_src1.t4"
+        ]
       }
     ]
   },

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -554,7 +554,11 @@ func (etc *earlyTableCollector) createTable(
 		return nil, err
 	}
 
-	mr, err := etc.si.FindMirrorRule(t)
+	tblName := t
+	if tbl != nil && tbl.Keyspace != nil {
+		tblName = tbl.GetTableName()
+	}
+	mr, err := etc.si.FindMirrorRule(tblName)
 	if err != nil {
 		// Mirroring is best effort. If we get an error while mirroring, keep going
 		// as if mirroring was disabled. We don't want to interrupt production work


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Traffic mirroring is currently broken because it is not properly taking routing rules into account. 

Given the following mirror rules and routing rules.

*Mirror rules*

```json
{
  "rules": [
    {
      "from_table": "commerce.corder@replica",
      "to_table": "customer.corder",
      "percent": 100
    },
    {
      "from_table": "commerce.corder@rdonly",
      "to_table": "customer.corder",
      "percent": 100
    },
    {
      "from_table": "commerce.corder",
      "to_table": "customer.corder",
      "percent": 100
    }
  ]
}
```

*Routing rules*

```json
{
  "rules": [
    {
      "from_table": "commerce.corder",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "commerce.corder@rdonly",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "corder@rdonly",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "customer.corder@replica",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "commerce.corder@replica",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "corder",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "corder@replica",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "customer.corder",
      "to_tables": [
        "commerce.corder"
      ]
    },
    {
      "from_table": "customer.corder@rdonly",
      "to_tables": [
        "commerce.corder"
      ]
    }
  ]
}
```

There are two flaws:

* When querying from `commerce.corder`, we seed operators with mirror source `commerce.corder` and mirror target `customer.corder`. That's good, but then later in planning we replace the mirror target with its routing rule destination `commerce.corder`. This results in mirroring back to `commerce.corder`.
* When querying from `corder` or `customer.corder`, we seed only from mirror source `commerce.corder`. This results in no mirroring.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes https://github.com/vitessio/vitess/issues/17951.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
