### PR TITLE
Pass through predicates when trying to merge apply join.

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5452,11 +5452,11 @@
   },
   {
     "comment": "Joining with a subquery that uses an aggregate column and an `EqualUnique` route with additional subquery can be merged together",
-    "query": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.col NOT IN (SELECT col FROM user WHERE user.user_id = 5)) other ON other.maxt = music.id",
+    "query": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.col NOT IN (SELECT col FROM user WHERE user.id = 5)) other ON other.maxt = music.id",
     "plan": {
       "Type": "Passthrough",
       "QueryType": "SELECT",
-      "Original": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.col NOT IN (SELECT col FROM user WHERE user.user_id = 5)) other ON other.maxt = music.id",
+      "Original": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.col NOT IN (SELECT col FROM user WHERE user.id = 5)) other ON other.maxt = music.id",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "EqualUnique",
@@ -5465,7 +5465,7 @@
           "Sharded": true
         },
         "FieldQuery": "select music.id from (select max(id) as maxt from music where 1 != 1) as other, music where 1 != 1",
-        "Query": "select music.id from (select max(id) as maxt from music where music.user_id = 5 and music.foobar not in (select foobar from music_extra where music_extra.user_id = 5)) as other, music where other.maxt = music.id",
+        "Query": "select music.id from (select max(id) as maxt from music where music.user_id = 5 and music.col not in (select col from `user` where `user`.id = 5)) as other, music where other.maxt = music.id",
         "Table": "music",
         "Values": [
           "5"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5452,11 +5452,11 @@
   },
   {
     "comment": "Joining with a subquery that uses an aggregate column and an `EqualUnique` route with additional subquery can be merged together",
-    "query": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.foobar NOT IN (SELECT foobar FROM music_extra WHERE music_extra.user_id = 5)) other ON other.maxt = music.id",
+    "query": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.col NOT IN (SELECT col FROM user WHERE user.user_id = 5)) other ON other.maxt = music.id",
     "plan": {
       "Type": "Passthrough",
       "QueryType": "SELECT",
-      "Original": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.foobar NOT IN (SELECT foobar FROM music_extra WHERE music_extra.user_id = 5)) other ON other.maxt = music.id",
+      "Original": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.col NOT IN (SELECT col FROM user WHERE user.user_id = 5)) other ON other.maxt = music.id",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "EqualUnique",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5451,6 +5451,33 @@
     }
   },
   {
+    "comment": "Joining with a subquery that uses an aggregate column and an `EqualUnique` route with additional subquery can be merged together",
+    "query": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.foobar NOT IN (SELECT foobar FROM music_extra WHERE music_extra.user_id = 5)) other ON other.maxt = music.id",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT music.id FROM music INNER JOIN (SELECT MAX(id) as maxt FROM music WHERE music.user_id = 5 AND music.foobar NOT IN (SELECT foobar FROM music_extra WHERE music_extra.user_id = 5)) other ON other.maxt = music.id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id from (select max(id) as maxt from music where 1 != 1) as other, music where 1 != 1",
+        "Query": "select music.id from (select max(id) as maxt from music where music.user_id = 5 and music.foobar not in (select foobar from music_extra where music_extra.user_id = 5)) as other, music where other.maxt = music.id",
+        "Table": "music",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music"
+      ]
+    }
+  },
+  {
     "comment": "Joining with a subquery that uses an `EqualUnique` route can be merged",
     "query": "SELECT music.id FROM music INNER JOIN (SELECT id FROM music WHERE music.user_id = 5) other ON other.id = music.id",
     "plan": {


### PR DESCRIPTION
## Description

This prevents the query planner from breaking up joins that can be passed through to a specific shard.

## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/17867

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
