### PR TITLE
vtadmin: allow cluster IDs with underscores by sanitizing resolver scheme

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -1324,6 +1324,7 @@ func (cluster *LocalProcessCluster) NewVTAdminProcess() {
 		Binary:         "vtadmin",
 		Port:           cluster.GetAndReservePort(),
 		LogDir:         cluster.TmpDirectory,
+		ClusterID:      "local",
 		VtGateGrpcPort: cluster.VtgateProcess.GrpcPort,
 		VtGateWebPort:  cluster.VtgateProcess.Port,
 		VtctldWebPort:  cluster.VtctldProcess.Port,

--- a/go/test/endtoend/cluster/vtadmin_process.go
+++ b/go/test/endtoend/cluster/vtadmin_process.go
@@ -95,6 +95,11 @@ func (vp *VtAdminProcess) Setup() (err error) {
 		return err
 	}
 
+	// Only allow override if explicitly set by tests; default cluster ID is "local".
+	clusterID := "local"
+	if vp.ClusterID != "" {
+		clusterID = vp.ClusterID
+	}
 	vp.proc = exec.Command(
 		vp.Binary,
 		"--addr", vp.Address(),
@@ -107,18 +112,8 @@ func (vp *VtAdminProcess) Setup() (err error) {
 		"--rbac",
 		"--rbac-config", rbacFile,
 		"--cluster", fmt.Sprintf(`id=%s,name=%s,discovery=staticfile,discovery-staticfile-path=%s,tablet-fqdn-tmpl=http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }},schema-cache-default-expiration=1m`,
-			func() string {
-				if vp.ClusterID != "" {
-					return vp.ClusterID
-				}
-				return "local"
-			}(),
-			func() string {
-				if vp.ClusterID != "" {
-					return vp.ClusterID
-				}
-				return "local"
-			}(),
+			clusterID,
+			clusterID,
 			discoveryFile),
 	)
 

--- a/go/test/endtoend/vtadmin/main_test.go
+++ b/go/test/endtoend/vtadmin/main_test.go
@@ -79,6 +79,9 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.NewVTAdminProcess()
+		// Override the default cluster ID to include an underscore to
+		// exercise the gRPC name resolver handling of non-RFC3986 schemes.
+		clusterInstance.VtadminProcess.ClusterID = "local_test"
 		err = clusterInstance.VtadminProcess.Setup()
 		if err != nil {
 			return 1

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -48,18 +48,27 @@ import (
 const logPrefix = "[vtadmin.cluster.resolver]"
 
 type builder struct {
+	// scheme is the URL scheme that gRPC will use to match this resolver.
+	// Historically, vtadmin used the cluster ID as the scheme, but cluster
+	// IDs may contain characters (e.g. underscores) that are not valid in a
+	// URL scheme per RFC 3986. The scheme field is derived from the cluster
+	// ID via a sanitization function that strips or replaces invalid
+	// characters.
 	scheme string
-	opts   Options
+	// clusterID is the original cluster identifier for this builder.
+	clusterID string
+	opts      Options
 
 	// for debug.Debuggable
 	m         sync.Mutex
 	resolvers []*resolver
 }
 
-// DialAddr returns the dial address for a resolver scheme and component.
+// DialAddr returns the dial address for a gRPC resolver and component.
 //
 // VtctldClientProxy and VTGateProxy should use this to ensure their Dial calls
-// use their respective discovery resolvers.
+// use their respective discovery resolvers. The resolver's scheme should be
+// safe for use in a URI (see the notes on builder.scheme).
 func DialAddr(resolver grpcresolver.Builder, component string) string {
 	return fmt.Sprintf("%s://%s/", resolver.Scheme(), component)
 }
@@ -145,11 +154,48 @@ type Options struct {
 // "{clusterID}://{vtctld|vtgate}/". Other target URL hosts will cause an error.
 // To ensure the dial address conforms to this constraint, use this package's
 // DialAddr function.
-func (opts *Options) NewBuilder(scheme string) grpcresolver.Builder {
+// NewBuilder returns a gRPC resolver.Builder for the given cluster ID.
+//
+// Historically, we used the cluster ID directly as the scheme in the dial
+// target address (e.g. "{clusterID}://vtctld"), but gRPC requires schemes
+// to conform to RFC 3986 and underscores are not a permitted character.
+// To avoid invalid URL schemes, we sanitize the cluster ID into a safe scheme
+// and stash the original cluster ID for use in debug output.
+func (opts *Options) NewBuilder(clusterID string) grpcresolver.Builder {
 	return &builder{
-		scheme: scheme,
-		opts:   *opts,
+		scheme:    sanitizeScheme(clusterID),
+		clusterID: clusterID,
+		opts:      *opts,
 	}
+}
+
+// sanitizeScheme returns a string derived from the input that is safe to use
+// as a URL scheme per RFC 3986: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ).
+// Any runes outside of this set are replaced with '-' characters. If the first
+// character is not a letter, we prefix it with 'x' to make a valid scheme.
+func sanitizeScheme(id string) string {
+	if id == "" {
+		return "vtadmin"
+	}
+	out := strings.Builder{}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '+', r == '-', r == '.':
+			out.WriteRune(r)
+		default:
+			// replace anything else (e.g. '_') with '-'
+			out.WriteRune('-')
+		}
+	}
+	s := out.String()
+	// A URL scheme must start with a letter.
+	if s != "" {
+		first := s[0]
+		if !(first >= 'a' && first <= 'z') && !(first >= 'A' && first <= 'Z') {
+			s = "x" + s
+		}
+	}
+	return s
 }
 
 var defaultBackoffConfig = grpcbackoff.DefaultConfig
@@ -232,8 +278,9 @@ func (b *builder) build(target grpcresolver.Target, cc grpcresolver.ClientConn, 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	r := &resolver{
-		component:       target.URL.Host,
-		cluster:         target.URL.Scheme,
+		component: target.URL.Host,
+		// use the original cluster ID (not the sanitized scheme) for debugging/logging
+		cluster:         b.clusterID,
 		discoverAddrs:   fn,
 		backoffStrategy: backoff.Get(b.opts.BackoffStrategy, b.opts.BackoffConfig),
 		opts:            b.opts,

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -43,6 +43,18 @@ type mockClientConn struct {
 	cancel context.CancelFunc
 }
 
+func TestSanitizeScheme(t *testing.T) {
+	t.Parallel()
+	// 'plain' cluster IDs that are already valid schemes are unchanged
+	assert.Equal(t, "local", sanitizeScheme("local"))
+	// underscores and other invalid characters are replaced with '-' to
+	// produce a valid scheme
+	assert.Equal(t, "local-test", sanitizeScheme("local_test"))
+	// schemes must start with a letter; if the cluster ID starts with a digit,
+	// we prepend an 'x' to make it valid.
+	assert.Equal(t, "x1cluster", sanitizeScheme("1cluster"))
+}
+
 func newMockClientConn(minExpectedCalls int) *mockClientConn {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &mockClientConn{


### PR DESCRIPTION
## Description

vtadmin’s discovery resolver was treating the cluster ID as the URL scheme when dialing vtgate and vtctld, which breaks if the cluster ID contains characters that are not valid in a URI scheme (e.g. `_`). This manifested as vtadmin-api failing to connect to vtgate/vtctld when a cluster ID such as `local_test` was used.

This change introduces a small `sanitizeScheme` helper in the vtadmin cluster resolver to strip or replace invalid characters and ensure the scheme starts with a letter. The resolver now keeps the original cluster ID around for logging/debugging but advertises the sanitized scheme to gRPC. vtctldclient and vtsql continue to use the original cluster ID.

To exercise this path an end‐to‐end vtadmin test now overrides its cluster ID to `local_test`, and a unit test was added to verify `sanitizeScheme` behavior.

## Related Issue(s)

Fixes #15721

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

No special deployment steps are required beyond rolling out an updated vtadmin-api. Existing clusters can now safely use IDs containing underscores.

---

This PR was generated by an AI system in collaboration with maintainers @rbranson, @GuptaManan100, @rohit-nayak-ps, @systay.