### PR TITLE
VDiff: Fix bug with handling tables with no pks but only a unique key.

### DIFF
--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: gh-hosted-runners-16cores-1-24.04
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: gh-hosted-runners-16cores-1-24.04
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite)
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: gh-hosted-runners-16cores-1-24.04
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: gh-hosted-runners-16cores-1-24.04
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on Cluster (vreplication_basic)
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: gh-hosted-runners-16cores-1-24.04
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on Cluster (vreplication_migrate)
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: gh-hosted-runners-16cores-1-24.04
 
     steps:
     - name: Skip CI

--- a/.github/workflows/cluster_endtoend_vreplication_vtctldclient_vdiff2_movetables_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_vtctldclient_vdiff2_movetables_tz.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     timeout-minutes: 60
     name: Run endtoend tests on Cluster (vreplication_vtctldclient_vdiff2_movetables_tz)
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: gh-hosted-runners-16cores-1-24.04
 
     steps:
     - name: Skip CI

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -76,6 +76,7 @@ create table  `+"`blüb_tbl`"+` (id int, val1 varchar(20), `+"`blöb1`"+` blob, 
 create table reftable (id int, val1 varchar(20), primary key(id), key(val1));
 create table loadtest (id int, name varchar(256), primary key(id), key(name));
 create table nopk (name varchar(128), age int unsigned);
+create table ukTable (id1 int not null, id2 int not null, name varchar(20), unique key uk1(id1, id2), key uk2(id2));
 `, customerTable)
 
 	// These should always be ignored in vreplication
@@ -114,7 +115,8 @@ create table nopk (name varchar(128), age int unsigned);
     "nopk": {},
     "reftable": {
       "type": "reference"
-    }
+    },
+	"ukTable": {}
   }
 }
 `
@@ -146,6 +148,15 @@ create table nopk (name varchar(128), age int unsigned);
         }
       ]
     },
+  "ukTable": {
+      "column_vindexes": [
+        {
+          "column": "id1",
+          "name": "reverse_bits"
+        }
+      ]
+    },
+    
     "customer": {
       "column_vindexes": [
         {

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -45,8 +45,16 @@ insert into datze(id, dt2, ts1) values (6, current_timestamp, current_timestamp)
 
 insert into geom_tbl(id, g, p, ls, pg, mp, mls, mpg, gc) values(1,ST_GeomFromText("LINESTRING(0 0,1 2,2 4)"), POINT(32767, 12345678901234567890),ST_GeomFromText("LINESTRING(-1 1,32627 32678,32679 65536,1234567890123456789 489749749734.234212908)"),ST_GeomFromText("POLYGON ((1 2, 2 3, 3 4, 1 2))"), ST_GeomFromText("MULTIPOINT(0 0, 15 25, 45 65)"),ST_GeomFromText("MULTILINESTRING((12 12, 22 22), (19 19, 32 18))"),ST_GeomFromText("MULTIPOLYGON(((0 0,11 0,12 11,0 9,0 0)),((3 5,7 4,4 7,7 7,3 5)))"),ST_GeomFromText("GEOMETRYCOLLECTION(POINT(3 2),LINESTRING(0 0,1 3,2 5,3 5,4 7))"));
 
-insert into reftable (id, val1) values (1, 'a')
-insert into reftable (id, val1) values (2, 'b')
-insert into reftable (id, val1) values (3, 'c')
-insert into reftable (id, val1) values (4, 'd')
-insert into reftable (id, val1) values (5, 'e')
+insert into reftable (id, val1) values (1, 'a');
+insert into reftable (id, val1) values (2, 'b');
+insert into reftable (id, val1) values (3, 'c');
+insert into reftable (id, val1) values (4, 'd');
+insert into reftable (id, val1) values (5, 'e');
+
+insert into ukTable(id1, id2, name) values(1, 10, 'a');
+insert into ukTable(id1, id2, name) values(2, 20, 'b');
+insert into ukTable(id1, id2, name) values(3, 30, 'c');
+insert into ukTable(id1, id2, name) values(4, 40, 'd');
+insert into ukTable(id1, id2, name) values(5, 50, 'e');
+
+

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -78,7 +78,7 @@ var testCases = []*testCase{
 		sourceShards:        "0",
 		targetShards:        "-80,80-",
 		tabletBaseID:        200,
-		tables:              "customer,Lead,Lead-1,nopk",
+		tables:              "customer,Lead,Lead-1,nopk,ukTable",
 		autoRetryError:      true,
 		retryInsert:         `insert into customer(cid, name, typ) values(2005149100, 'Testy McTester', 'soho')`,
 		resume:              true,

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -944,7 +944,7 @@ func (td *tableDiffer) getSourcePKCols() error {
 		executeFetch := func(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
 			res, err := td.wd.ct.tmc.ExecuteFetchAsApp(ctx, sourceTablet.Tablet, false, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
 				Query:   []byte(query),
-				MaxRows: 1,
+				MaxRows: uint64(maxrows),
 			})
 			if err != nil {
 				return nil, vterrors.Wrapf(err, "failed to query the %s source tablet in order to get a primary key equivalent for the %s table",
@@ -958,9 +958,11 @@ func (td *tableDiffer) getSourcePKCols() error {
 				td.table.Name, topoproto.TabletAliasString(sourceTablet.Tablet.Alias))
 		}
 		if len(pkeCols) > 0 {
+			log.Infof("Using primary key equivalent columns %+v for table %s", pkeCols, td.table.Name)
 			sourceTable.PrimaryKeyColumns = pkeCols
 		} else {
 			// We use every column together as a substitute PK.
+			log.Infof("Using all columns as a substitute primary key for table %s", td.table.Name)
 			sourceTable.PrimaryKeyColumns = append(sourceTable.PrimaryKeyColumns, td.table.Columns...)
 		}
 	}

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -47,7 +47,9 @@ var (
 )
 
 const (
-	cores16RunnerName = "oracle-16cpu-64gb-x86-64"
+	oracleCloudRunner = "oracle-16cpu-64gb-x86-64"
+	githubRunner      = "gh-hosted-runners-16cores-1-24.04"
+	cores16RunnerName = githubRunner
 	defaultRunnerName = "ubuntu-24.04"
 )
 


### PR DESCRIPTION
## Description

There was a bug in the code that checks for primary key equivalents where only a single column was expected for a unique key. 

This has been fixed and the failing case added to the vdiff end to end tests.

The core functionality for PKE support was added in v19 in https://github.com/vitessio/vitess/pull/14794 and hence we backport this to supported versions.

## Related Issue(s)

fixes https://github.com/vitessio/vitess/issues/17969

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
