### PR TITLE
`vtorc`: add stats to shard locks and instance discovery

### DIFF
--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -23,7 +23,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -45,11 +44,10 @@ import (
 )
 
 var (
-	ts                *topo.Server
-	tmc               tmclient.TabletManagerClient
-	clustersToWatch   []string
-	shutdownWaitTime  = 30 * time.Second
-	shardsLockCounter int32
+	ts               *topo.Server
+	tmc              tmclient.TabletManagerClient
+	clustersToWatch  []string
+	shutdownWaitTime = 30 * time.Second
 	// shardsToWatch is a map storing the shards for a given keyspace that need to be watched.
 	// We store the key range for all the shards that we want to watch.
 	// This is populated by parsing `--clusters_to_watch` flag.
@@ -347,35 +345,6 @@ func refreshTablets(tablets []*topo.TabletInfo, query string, args []any, loader
 			log.Error(err)
 		}
 	}
-}
-
-func getLockAction(analysedInstance string, code inst.AnalysisCode) string {
-	return fmt.Sprintf("VTOrc Recovery for %v on %v", code, analysedInstance)
-}
-
-// LockShard locks the keyspace-shard preventing others from performing conflicting actions.
-func LockShard(ctx context.Context, keyspace, shard, lockAction string) (context.Context, func(*error), error) {
-	if keyspace == "" {
-		return nil, nil, errors.New("can't lock shard: keyspace is unspecified")
-	}
-	if shard == "" {
-		return nil, nil, errors.New("can't lock shard: shard name is unspecified")
-	}
-	val := atomic.LoadInt32(&hasReceivedSIGTERM)
-	if val > 0 {
-		return nil, nil, errors.New("can't lock shard: SIGTERM received")
-	}
-
-	atomic.AddInt32(&shardsLockCounter, 1)
-	ctx, unlock, err := ts.TryLockShard(ctx, keyspace, shard, lockAction)
-	if err != nil {
-		atomic.AddInt32(&shardsLockCounter, -1)
-		return nil, nil, err
-	}
-	return ctx, func(e *error) {
-		defer atomic.AddInt32(&shardsLockCounter, -1)
-		unlock(e)
-	}, nil
 }
 
 // tabletUndoDemotePrimary calls the said RPC for the given tablet.

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -58,6 +58,9 @@ var (
 	discoveryRecentCountGauge          = stats.NewGauge("DiscoveriesRecentCount", "Number of recent discoveries")
 	discoveryWorkersGauge              = stats.NewGauge("DiscoveryWorkers", "Number of discovery workers")
 	discoveryWorkersActiveGauge        = stats.NewGauge("DiscoveryWorkersActive", "Number of discovery workers actively discovering tablets")
+
+	discoverInstanceTimingsActions = []string{"Backend", "Instance", "Other"}
+	discoverInstanceTimings        = stats.NewTimings("DiscoverInstanceTimings", "Timings for instance discovery actions", "Action", discoverInstanceTimingsActions...)
 )
 
 var discoveryMetrics = collection.CreateOrReturnCollection(DiscoveryMetricsName)
@@ -95,7 +98,7 @@ func closeVTOrc() {
 func waitForLocksRelease() {
 	timeout := time.After(shutdownWaitTime)
 	for {
-		count := atomic.LoadInt32(&shardsLockCounter)
+		count := atomic.LoadInt64(&shardsLockCounter)
 		if count == 0 {
 			break
 		}
@@ -192,6 +195,11 @@ func DiscoverInstance(tabletAlias string, forceDiscovery bool) {
 	totalLatency := latency.Elapsed("total")
 	backendLatency := latency.Elapsed("backend")
 	instanceLatency := latency.Elapsed("instance")
+	otherLatency := totalLatency - (backendLatency + instanceLatency)
+
+	discoverInstanceTimings.Add("Backend", backendLatency)
+	discoverInstanceTimings.Add("Instance", instanceLatency)
+	discoverInstanceTimings.Add("Other", otherLatency)
 
 	if forceDiscovery {
 		log.Infof("Force discovered - %+v, err - %v", instance, err)

--- a/go/vt/vtorc/logic/vtorc_test.go
+++ b/go/vt/vtorc/logic/vtorc_test.go
@@ -29,10 +29,10 @@ func TestWaitForLocksRelease(t *testing.T) {
 
 	t.Run("Timeout from shutdownWaitTime", func(t *testing.T) {
 		// Increment shardsLockCounter to simulate locking of a shard
-		atomic.AddInt32(&shardsLockCounter, +1)
+		atomic.AddInt64(&shardsLockCounter, +1)
 		defer func() {
 			// Restore the initial value
-			atomic.StoreInt32(&shardsLockCounter, 0)
+			atomic.StoreInt64(&shardsLockCounter, 0)
 		}()
 		shutdownWaitTime = 200 * time.Millisecond
 		timeSpent := waitForLocksReleaseAndGetTimeWaitedFor()
@@ -42,12 +42,12 @@ func TestWaitForLocksRelease(t *testing.T) {
 
 	t.Run("Successful wait for locks release", func(t *testing.T) {
 		// Increment shardsLockCounter to simulate locking of a shard
-		atomic.AddInt32(&shardsLockCounter, +1)
+		atomic.AddInt64(&shardsLockCounter, +1)
 		shutdownWaitTime = 500 * time.Millisecond
 		// Release the locks after 200 milliseconds
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			atomic.StoreInt32(&shardsLockCounter, 0)
+			atomic.StoreInt64(&shardsLockCounter, 0)
 		}()
 		timeSpent := waitForLocksReleaseAndGetTimeWaitedFor()
 		assert.Greater(t, timeSpent, 100*time.Millisecond, "waitForLocksRelease should wait for the locks and not return early")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR adds stats to shard locks and `DiscoverInstance` in VTOrc 

Also `logic.LockShard(...)` was moved to `go/vt/vtorc/logic/topology_recovery.go` because it's not related to tablet discovery and is only called in `topology_recovery.go`

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17330

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
