### PR TITLE
[release-21.0] DML test fix for duplicate column value 

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/main_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/main_test.go
@@ -131,7 +131,7 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 		_, _ = utils.ExecAllowError(t, mcmp.VtConn, "set workload = oltp")
 
 		tables := []string{
-			"s_tbl", "num_vdx_tbl", "user_tbl", "order_tbl", "oevent_tbl", "oextra_tbl",
+			"s_tbl", "num_vdx_tbl", "col_vdx_tbl", "user_tbl", "order_tbl", "oevent_tbl", "oextra_tbl",
 			"auto_tbl", "oid_vdx_tbl", "unq_idx", "nonunq_idx", "u_tbl", "mixed_tbl", "lkp_map_idx", "j_tbl", "j_utbl",
 		}
 		for _, table := range tables {

--- a/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
@@ -2,6 +2,8 @@ create table s_tbl
 (
     id  bigint,
     num bigint,
+    col bigint,
+    unique key (num),
     primary key (id)
 ) Engine = InnoDB;
 
@@ -10,6 +12,14 @@ create table num_vdx_tbl
     num         bigint,
     keyspace_id varbinary(20),
     primary key (num)
+) Engine = InnoDB;
+
+create table col_vdx_tbl
+(
+    col         bigint,
+    id          bigint,
+    keyspace_id varbinary(20),
+    primary key (col, id)
 ) Engine = InnoDB;
 
 create table user_tbl

--- a/go/test/endtoend/vtgate/queries/dml/vschema.json
+++ b/go/test/endtoend/vtgate/queries/dml/vschema.json
@@ -9,7 +9,18 @@
       "params": {
         "table": "num_vdx_tbl",
         "from": "num",
-        "to": "keyspace_id"
+        "to": "keyspace_id",
+        "ignore_nulls": "true"
+      },
+      "owner": "s_tbl"
+    },
+    "col_vdx": {
+      "type": "consistent_lookup",
+      "params": {
+        "table": "col_vdx_tbl",
+        "from": "col,id",
+        "to": "keyspace_id",
+        "ignore_nulls": "true"
       },
       "owner": "s_tbl"
     },
@@ -63,6 +74,10 @@
         {
           "column": "num",
           "name": "num_vdx"
+        },
+        {
+          "columns": ["col", "id"],
+          "name": "col_vdx"
         }
       ]
     },
@@ -70,6 +85,14 @@
       "column_vindexes": [
         {
           "column": "num",
+          "name": "hash"
+        }
+      ]
+    },
+    "col_vdx_tbl": {
+      "column_vindexes": [
+        {
+          "column": "col",
           "name": "hash"
         }
       ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The test was previously inserting a duplicate value into a unique vindex column. However, due to a bug, the test was incorrectly passing.

This bug has been fixed in [PR #17974](https://github.com/vitessio/vitess/pull/17974).
To ensure the tests go 🟢 on older releases, we need to update the test setup to use the correct configuration.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
