### PR TITLE
VTAdmin: Show Hostname Alongside Tablet ID on tablet selection drop-downs

### DIFF
--- a/web/vtadmin/src/components/routes/shard/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/shard/Advanced.tsx
@@ -394,9 +394,13 @@ const Advanced: React.FC = () => {
                                             <Select
                                                 onChange={(t) => setTablet(t as vtadmin.Tablet)}
                                                 label="Tablet"
-                                                renderItem={(t: vtadmin.Tablet) =>
-                                                    `${formatAlias(t.tablet?.alias)} (${formatDisplayType(t)})`
-                                                }
+                                                renderItem={(t: vtadmin.Tablet) => (
+                                                    <div className="flex items-center">
+                                                        <span>{formatAlias(t.tablet?.alias)}</span>
+                                                        <span className="text-gray-500 text-sm mx-2">{t.tablet?.hostname || 'Unknown'}</span>
+                                                        <span>({formatDisplayType(t)})</span>
+                                                    </div>
+                                                )}
                                                 items={tabletsInCluster}
                                                 selectedItem={tablet}
                                                 placeholder="Tablet"
@@ -478,9 +482,13 @@ const Advanced: React.FC = () => {
                                                 onChange={(t) => setPlannedReparentTablet(t as vtadmin.Tablet)}
                                                 label="Tablet"
                                                 items={tabletsInCluster}
-                                                renderItem={(t: vtadmin.Tablet) =>
-                                                    `${formatAlias(t.tablet?.alias)} (${formatDisplayType(t)})`
-                                                }
+                                                renderItem={(t: vtadmin.Tablet) => (
+                                                    <div className="flex items-center">
+                                                        <span>{formatAlias(t.tablet?.alias)}</span>
+                                                        <span className="text-gray-500 text-sm mx-2">{t.tablet?.hostname || 'Unknown'}</span>
+                                                        <span>({formatDisplayType(t)})</span>
+                                                    </div>
+                                                )}
                                                 selectedItem={plannedReparentTablet}
                                                 placeholder="Tablet"
                                                 description="This tablet will be the new primary for this shard."
@@ -512,9 +520,13 @@ const Advanced: React.FC = () => {
                                                 onChange={(t) => setEmergencyReparentTablet(t as vtadmin.Tablet)}
                                                 label="Tablet"
                                                 items={tabletsInCluster}
-                                                renderItem={(t: vtadmin.Tablet) =>
-                                                    `${formatAlias(t.tablet?.alias)} (${formatDisplayType(t)})`
-                                                }
+                                                renderItem={(t: vtadmin.Tablet) => (
+                                                    <div className="flex items-center">
+                                                        <span>{formatAlias(t.tablet?.alias)}</span>
+                                                        <span className="text-gray-500 text-sm mx-2">{t.tablet?.hostname || 'Unknown'}</span>
+                                                        <span>({formatDisplayType(t)})</span>
+                                                    </div>
+                                                )}
                                                 selectedItem={emergencyReparentTablet}
                                                 placeholder="Tablet"
                                                 description="This tablet will be the new primary for this shard."

--- a/web/vtadmin/src/components/routes/shard/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/shard/Advanced.tsx
@@ -397,7 +397,9 @@ const Advanced: React.FC = () => {
                                                 renderItem={(t: vtadmin.Tablet) => (
                                                     <div className="flex items-center">
                                                         <span>{formatAlias(t.tablet?.alias)}</span>
-                                                        <span className="text-gray-500 text-sm mx-2">{t.tablet?.hostname || 'Unknown'}</span>
+                                                        <span className="text-gray-500 text-sm mx-2">
+                                                            {t.tablet?.hostname || 'Unknown'}
+                                                        </span>
                                                         <span>({formatDisplayType(t)})</span>
                                                     </div>
                                                 )}
@@ -485,7 +487,9 @@ const Advanced: React.FC = () => {
                                                 renderItem={(t: vtadmin.Tablet) => (
                                                     <div className="flex items-center">
                                                         <span>{formatAlias(t.tablet?.alias)}</span>
-                                                        <span className="text-gray-500 text-sm mx-2">{t.tablet?.hostname || 'Unknown'}</span>
+                                                        <span className="text-gray-500 text-sm mx-2">
+                                                            {t.tablet?.hostname || 'Unknown'}
+                                                        </span>
                                                         <span>({formatDisplayType(t)})</span>
                                                     </div>
                                                 )}
@@ -523,7 +527,9 @@ const Advanced: React.FC = () => {
                                                 renderItem={(t: vtadmin.Tablet) => (
                                                     <div className="flex items-center">
                                                         <span>{formatAlias(t.tablet?.alias)}</span>
-                                                        <span className="text-gray-500 text-sm mx-2">{t.tablet?.hostname || 'Unknown'}</span>
+                                                        <span className="text-gray-500 text-sm mx-2">
+                                                            {t.tablet?.hostname || 'Unknown'}
+                                                        </span>
                                                         <span>({formatDisplayType(t)})</span>
                                                     </div>
                                                 )}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Added hostname alongside tablet Id on VTAdmin tablet selection drop-downs

- using a different text style for the hostname to improve readability
- displaying 'Unknown' when the hostname is missing 

![Screenshot 2025-03-18 at 8 13 00 PM](https://github.com/user-attachments/assets/fa0662db-2824-4390-8a6d-3533d90e91cd)

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Fixes #17954 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
