### PR TITLE
Allow the use of db credentials when verifying unmanaged tablets config

### DIFF
--- a/go/vt/dbconfigs/credentials.go
+++ b/go/vt/dbconfigs/credentials.go
@@ -133,6 +133,12 @@ func GetCredentialsServer() CredentialsServer {
 	return cs
 }
 
+// SetDbCredentialsFilePath sets the value of the `--db-credentials-file` flag.
+// This should be used only for testing.
+func SetDbCredentialsFilePath(path string) {
+	dbCredentialsFile = path
+}
+
 // FileCredentialsServer is a simple implementation of CredentialsServer using
 // a json file. Protected by mu.
 type FileCredentialsServer struct {

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -929,7 +929,12 @@ func (c *TabletConfig) verifyUnmanagedTabletConfig() error {
 		return errors.New("database app user not specified")
 	}
 	if c.DB.App.Password == "" {
-		return errors.New("database app user password not specified")
+		_, pass, err := dbconfigs.GetCredentialsServer().GetUserAndPassword(c.DB.App.User)
+		if err == nil && pass != "" {
+			c.DB.App.Password = pass
+		} else {
+			return errors.New("database app user password not specified")
+		}
 	}
 	// Replication fixes should be disabled for Unmanaged tablets.
 	mysqlctl.DisableActiveReparents = true

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -494,4 +494,12 @@ func TestVerifyUnmanagedTabletConfig(t *testing.T) {
 	config.DB.App.Password = "testPassword"
 	err = config.verifyUnmanagedTabletConfig()
 	assert.Nil(t, err)
+
+	dbconfigs.SetDbCredentialsFilePath("./data/db_credentials.json")
+	defer dbconfigs.SetDbCredentialsFilePath("")
+	config.DB.App.Password = ""
+
+	err = config.verifyUnmanagedTabletConfig()
+	assert.Nil(t, err)
+	assert.Equal(t, "testPassword", config.DB.App.Password)
 }

--- a/go/vt/vttablet/tabletserver/tabletenv/data/db_credentials.json
+++ b/go/vt/vttablet/tabletserver/tabletenv/data/db_credentials.json
@@ -1,0 +1,3 @@
+{
+  "testUser": ["testPassword"]
+}


### PR DESCRIPTION
## Description

In https://github.com/planetscale/vitess-operator/pull/671 we are starting to use the `--unmanaged` vttablet flag introduced in https://github.com/vitessio/vitess/pull/14871. CI is showing an interesting failure where vttablet expects a password and user to be set via flags. The operator does set the user ([code](https://github.com/planetscale/vitess-operator/blob/08006336ff267678914cb2fac001fc5962f42f47/pkg/operator/vttablet/datastore.go#L115)); but the password is instead stored in a K8S `Secret` object, and is passed down to vttablet via the `--db-credentials-file` flag.

However, with the current implementation, vttablet does not take into account the password stored in `--db-credentials-file` when verifying the unmanaged tablet settings and fail early since we have not set the `--db_app_password` flag.

This PR fixes this issue by making vttablet look at the credentials file before failing the unmanaged verification.
