### PR TITLE
vtadmin: display transaction participant list as comma separated

### DIFF
--- a/web/vtadmin/src/components/routes/Transactions.tsx
+++ b/web/vtadmin/src/components/routes/Transactions.tsx
@@ -100,18 +100,21 @@ export const Transactions = () => {
                         <div>{formatTransactionState(row)}</div>
                     </DataCell>
                     <DataCell>
-                        {row.participants?.map((participant) => {
-                            const shard = `${participant.keyspace}/${participant.shard}`;
-                            return (
-                                <ShardLink
-                                    clusterID={params.clusterID}
-                                    keyspace={participant.keyspace}
-                                    shard={participant.shard}
-                                >
-                                    {shard}
-                                </ShardLink>
-                            );
-                        })}
+                        {row.participants
+                            ?.map((participant) => {
+                                const shard = `${participant.keyspace}/${participant.shard}`;
+                                return (
+                                    <ShardLink
+                                        clusterID={params.clusterID}
+                                        keyspace={participant.keyspace}
+                                        shard={participant.shard}
+                                        key={shard}
+                                    >
+                                        {shard}
+                                    </ShardLink>
+                                );
+                            })
+                            .reduce((prev, curr) => [prev, ', ', curr])}
                     </DataCell>
                     <DataCell>
                         <div className="font-sans whitespace-nowrap">{formatDateTime(row.time_created)}</div>


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This is a UI fix to show distributed transaction participants as comma separated list

![Screenshot 2025-03-19 at 10 41 35 AM](https://github.com/user-attachments/assets/254dfd50-48b0-42ba-b031-4db15f34cce9)



## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/pull/17142
- https://github.com/vitessio/vitess/issues/16245

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
