### PR TITLE
`vtorc`: allow recoveries to be disabled

### DIFF
--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -16,6 +16,7 @@ vtorc \
 
 Flags:
       --allow-emergency-reparent                                    Whether VTOrc should be allowed to run emergency reparent operation when it detects a dead primary (default true)
+      --allow-recovery                                              Whether VTOrc should be allowed to run recovery actions (default true)
       --alsologtostderr                                             log to standard error as well as files
       --audit-file-location string                                  File location where the audit logs are to be stored
       --audit-purge-duration duration                               Duration for which audit logs are held before being purged. Should be in multiples of days (default 168h0m0s)

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -192,6 +192,15 @@ var (
 		},
 	)
 
+	allowRecovery = viperutil.Configure(
+		"allow-recovery",
+		viperutil.Options[bool]{
+			FlagName: "allow-recovery",
+			Default:  true,
+			Dynamic:  true,
+		},
+	)
+
 	convertTabletsWithErrantGTIDs = viperutil.Configure(
 		"change-tablets-with-errant-gtid-to-drained",
 		viperutil.Options[bool]{
@@ -234,6 +243,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Duration("topo-information-refresh-duration", topoInformationRefreshDuration.Default(), "Timer duration on which VTOrc refreshes the keyspace and vttablet records from the topology server")
 	fs.Duration("recovery-poll-duration", recoveryPollDuration.Default(), "Timer duration on which VTOrc polls its database to run a recovery")
 	fs.Bool("allow-emergency-reparent", ersEnabled.Default(), "Whether VTOrc should be allowed to run emergency reparent operation when it detects a dead primary")
+	fs.Bool("allow-recovery", allowRecovery.Default(), "Whether VTOrc should be allowed to run recovery actions")
 	fs.Bool("change-tablets-with-errant-gtid-to-drained", convertTabletsWithErrantGTIDs.Default(), "Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED")
 	fs.Bool("enable-primary-disk-stalled-recovery", enablePrimaryDiskStalledRecovery.Default(), "Whether VTOrc should detect a stalled disk on the primary and failover")
 
@@ -255,6 +265,7 @@ func registerFlags(fs *pflag.FlagSet) {
 		topoInformationRefreshDuration,
 		recoveryPollDuration,
 		ersEnabled,
+		allowRecovery,
 		convertTabletsWithErrantGTIDs,
 		enablePrimaryDiskStalledRecovery,
 	)
@@ -378,6 +389,11 @@ func ERSEnabled() bool {
 // SetERSEnabled sets the value for the ersEnabled variable. This should only be used from tests.
 func SetERSEnabled(val bool) {
 	ersEnabled.Set(val)
+}
+
+// GetAllowRecovery is a getter function.
+func GetAllowRecovery() bool {
+	return allowRecovery.Get()
 }
 
 // ConvertTabletWithErrantGTIDs reports whether VTOrc is allowed to change the tablet type of tablets with errant GTIDs to DRAINED.

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -266,6 +266,13 @@ func ContinuousDiscovery() {
 	log.Infof("continuous discovery: setting up")
 	recentDiscoveryOperationKeys = cache.New(config.GetInstancePollTime(), time.Second)
 
+	if !config.GetAllowRecovery() {
+		if err := DisableRecovery(); err != nil {
+			log.Errorf("failed to disable recoveries: %+v", err)
+			return
+		}
+	}
+
 	go handleDiscoveryRequests()
 
 	healthTick := time.Tick(config.HealthPollSeconds * time.Second)


### PR DESCRIPTION
## Description

This PR allows recoveries in VTOrc to be disabled from startup time. This is already possible to do via the HTTP API on a per-instance process, after the process has started, but there's no way to ensure it's done immediately at startup

The same `DisableRecovery()` function as the HTTP API is used to do this at startup when the new flag `--allow-recovery` is set to `false` 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
