### PR TITLE
Fix flakiness in checking for drained tablets in Vtorc test

### DIFF
--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -1221,7 +1221,9 @@ func WaitForDrainedTabletInVTOrc(t *testing.T, vtorcInstance *cluster.VTOrcProce
 				continue
 			}
 			found := strings.Count(res, fmt.Sprintf(`"tablet_type": "%d"`, topodatapb.TabletType_DRAINED))
-			if found == count {
+			// There are two tables that store the tablet type, the database_instance and vitess_tablet table.
+			// Both of them should agree in the stable state.
+			if found == count*2 {
 				return
 			}
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
After the changes in https://github.com/vitessio/vitess/pull/17870, there are 2 tables that store the tablet type, and that affects the function checking for drained tablets count, making that test flaky. This PR fixes the check post those changes.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
