### PR TITLE
Switch to using the default caching sha2 password

### DIFF
--- a/changelog/23.0/23.0.0/summary.md
+++ b/changelog/23.0/23.0.0/summary.md
@@ -4,6 +4,7 @@
 - **[Minor Changes](#minor-changes)**
     - **[VTTablet](#minor-changes-vttablet)**
         - [CLI Flags](#flags-vttablet)
+        - [Managed MySQL configuration defaults to caching-sha2-password](#mysql-caching-sha2-password)
 
 ## <a id="minor-changes"/>Minor Changes</a>
 
@@ -12,3 +13,15 @@
 #### <a id="flags-vttablet"/>CLI Flags</a>
 
 - `skip-user-metrics` flag if enabled, replaces the username label with "UserLabelDisabled" to prevent metric explosion in environments with many unique users.
+
+#### <a id="mysql-caching-sha2-password"/>Managed MySQL configuration defaults to caching-sha2-password</a>
+
+The default authentication plugin for MySQL 8.0.26 and later is now `caching_sha2_password` instead of `mysql_native_password`. This change is made because `mysql_native_password` is deprecated and removed in future MySQL versions. `mysql_native_password` is still enabled for backwards compatibility.
+
+This change specifically affects the replication user. If you have a user configured with an explicit password, it is recommended to make sure to upgrade this user after upgrading to v23 with a statement like the following:
+
+```sql
+ALTER USER 'vt_repl'@'%' IDENTIFIED WITH caching_sha2_password BY 'your-existing-password';
+```
+
+In future Vitess versions, the `mysql_native_password` authentication plugin will be disabled for managed MySQL instances.

--- a/config/mycnf/mysql8026.cnf
+++ b/config/mycnf/mysql8026.cnf
@@ -16,9 +16,6 @@ binlog_expire_logs_seconds = 259200
 # disable mysqlx
 mysqlx = 0
 
-# 8.0 changes the default auth-plugin to caching_sha2_password
-default_authentication_plugin = mysql_native_password
-
 # Semi-sync replication is required for automated unplanned failover
 # (when the primary goes away). Here we just load the plugin so it's
 # available if desired, but it's disabled at startup.

--- a/config/mycnf/mysql84.cnf
+++ b/config/mycnf/mysql84.cnf
@@ -16,10 +16,9 @@ binlog_expire_logs_seconds = 259200
 # disable mysqlx
 mysqlx = 0
 
-# 8.4 changes the default auth-plugin to caching_sha2_password and
-# disables mysql_native_password by default.
+# 8.4 disables mysql_native_password by default, but we keep it
+# enabled for compatibility while upgrading Vitess and / or MySQL.
 mysql_native_password = ON
-authentication_policy = 'mysql_native_password'
 
 # Semi-sync replication is required for automated unplanned failover
 # (when the primary goes away). Here we just load the plugin so it's


### PR DESCRIPTION
After #18033 added forward compatibility in the upcoming v22, we can make it the default in v23. 

## Related Issue(s)

Part of #17966

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required