### PR TITLE
test: reduce commit wait time flaky test TestReadingUnresolvedTransactions

### DIFF
--- a/go/test/endtoend/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/transaction/twopc/twopc_test.go
@@ -1065,7 +1065,7 @@ func TestReadingUnresolvedTransactions(t *testing.T) {
 			// We want to delay the commit on one of the shards to simulate slow commits on a shard.
 			twopcutil.WriteTestCommunicationFile(t, twopcutil.DebugDelayCommitShard, "80-")
 			defer twopcutil.DeleteFile(twopcutil.DebugDelayCommitShard)
-			twopcutil.WriteTestCommunicationFile(t, twopcutil.DebugDelayCommitTime, "5")
+			twopcutil.WriteTestCommunicationFile(t, twopcutil.DebugDelayCommitTime, "2")
 			defer twopcutil.DeleteFile(twopcutil.DebugDelayCommitTime)
 			// We will execute a commit in a go routine, because we know it will take some time to complete.
 			// While the commit is ongoing, we would like to check that we see the unresolved transaction.


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR addresses the flakiness in `TestReadingUnresolvedTransactions`

The test was intermittently failing with the following error:

`Error in commit: read tcp 127.0.0.1:56260->127.0.0.1:17038: use of closed network connection`

The failure occurred because VTGate resolved the commit outside of the current session received via the transaction watcher, leading to an unexpected connection closure on the current commit session.

To fix this, the commit wait time has been reduced to minimize the likelihood of transaction getting resolved via transaction resolution route.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
