### PR TITLE
Fix `Reshard Cancel` behavior

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/reshard/reshard.go
+++ b/go/cmd/vtctldclient/command/vreplication/reshard/reshard.go
@@ -57,7 +57,10 @@ func registerReshardCommands(root *cobra.Command) {
 	reshard.AddCommand(reverseTrafficCommand)
 
 	reshard.AddCommand(common.GetCompleteCommand(opts))
-	reshard.AddCommand(common.GetCancelCommand(opts))
+
+	cancel := common.GetCancelCommand(opts)
+	cancel.Flags().BoolVar(&common.CancelOptions.KeepData, "keep-data", false, "Keep the partially copied table data from the Reshard workflow in the target shards.")
+	reshard.AddCommand(cancel)
 }
 
 func init() {

--- a/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
+++ b/go/test/endtoend/vreplication/vreplication_vtctldclient_cli_test.go
@@ -127,6 +127,97 @@ func TestVtctldclientCLI(t *testing.T) {
 
 		splitShard(t, targetKeyspaceName, reshardWorkflowName, sourceShard, newShards, tablets)
 	})
+
+	t.Run("Reshard Cancel", func(t *testing.T) {
+		cell := vc.Cells["zone1"]
+		targetKeyspace := cell.Keyspaces[targetKeyspaceName]
+		sourceShard := "80-"
+		newShards := "80-c0,c0-"
+		require.NoError(t, vc.AddShards(t, []*Cell{cell}, targetKeyspace, newShards, 1, 0, 600, nil))
+		reshardWorkflowName := "reshard"
+
+		tablets := map[string]*cluster.VttabletProcess{
+			"80-c0": targetKeyspace.Shards["80-c0"].Tablets["zone1-600"].Vttablet,
+			"c0-":   targetKeyspace.Shards["c0-"].Tablets["zone1-700"].Vttablet,
+		}
+
+		sourceReplicaTab = vc.Cells["zone1"].Keyspaces[targetKeyspaceName].Shards["80-"].Tablets["zone1-301"].Vttablet
+		require.NotNil(t, sourceReplicaTab)
+		sourceTab = vc.Cells["zone1"].Keyspaces[targetKeyspaceName].Shards["80-"].Tablets["zone1-300"].Vttablet
+		require.NotNil(t, sourceTab)
+
+		targetTab1 = tablets["80-c0"]
+		require.NotNil(t, targetTab1)
+		targetTab2 = tablets["c0-"]
+		require.NotNil(t, targetTab2)
+		targetReplicaTab1 = vc.Cells["zone1"].Keyspaces[targetKeyspaceName].Shards["80-c0"].Tablets["zone1-601"].Vttablet
+		require.NotNil(t, targetReplicaTab1)
+
+		overrides := map[string]string{
+			"vreplication_copy_phase_duration":     "10h11m12s",
+			"vreplication_experimental_flags":      "7",
+			"vreplication-parallel-insert-workers": "4",
+			"vreplication_net_read_timeout":        "6000",
+			"relay_log_max_items":                  "10000",
+		}
+		createFlags := []string{"--auto-start=false", "--defer-secondary-keys=false",
+			"--on-ddl", "STOP", "--tablet-types", "primary,rdonly", "--tablet-types-in-preference-order=true",
+			"--all-cells", "--format=json",
+			"--config-overrides", mapToCSV(overrides),
+		}
+
+		rs := newReshard(vc, &reshardWorkflow{
+			workflowInfo: &workflowInfo{
+				vc:             vc,
+				workflowName:   reshardWorkflowName,
+				targetKeyspace: targetKeyspaceName,
+			},
+			sourceShards: sourceShard,
+			targetShards: newShards,
+			createFlags:  createFlags,
+		}, workflowFlavorVtctld)
+
+		rs.Create()
+
+		resp := getReshardResponse(rs)
+		require.NotNil(vc.t, resp)
+		require.NotNil(vc.t, resp.ShardStreams)
+		require.Equal(vc.t, len(resp.ShardStreams), 2)
+		keyspace := "customer"
+		for _, shard := range []string{"80-c0", "c0-"} {
+			streams := resp.ShardStreams[fmt.Sprintf("%s/%s", keyspace, shard)]
+			require.Equal(vc.t, 1, len(streams.Streams))
+			require.Equal(vc.t, binlogdatapb.VReplicationWorkflowState_Stopped.String(), streams.Streams[0].Status)
+		}
+
+		rs.Start()
+		waitForWorkflowState(t, vc, fmt.Sprintf("%s.%s", keyspace, workflowName), binlogdatapb.VReplicationWorkflowState_Running.String())
+
+		res, err := targetTab1.QueryTablet("show tables", keyspace, true)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.NotEmpty(t, res.Rows)
+
+		res, err = targetTab2.QueryTablet("show tables", keyspace, true)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.NotEmpty(t, res.Rows)
+
+		rs.Cancel()
+
+		workflowNames := workflowList(keyspace)
+		require.Empty(t, workflowNames)
+
+		res, err = targetTab1.QueryTablet("show tables", keyspace, true)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Empty(t, res.Rows)
+
+		res, err = targetTab2.QueryTablet("show tables", keyspace, true)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Empty(t, res.Rows)
+	})
 }
 
 // Tests several create flags and some complete flags and validates that some of them are set correctly for the workflow.

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1990,7 +1990,7 @@ func (s *Server) dropTargets(ctx context.Context, ts *trafficSwitcher, keepData,
 				return nil, err
 			}
 		case binlogdatapb.MigrationType_SHARDS:
-			if err := sw.dropTargetShards(ctx); err != nil {
+			if err := sw.removeTargetTables(ctx); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
## Description

This fixes two issues with the `Reshard Cancel` command.

First, it exposes the `--keep-data` flag, so that the user can manage on whether copied data should be kept or thrown away when the workflow is cancelled.

Next, it changes the `Cancel` command so that instead of dropping the shards from the topology, we keep the shards in the topology but drop the created tables instead. This way, the shards will be reset to the same state they were in before the `Reshard` operation was started.

## Related Issue(s)

Fixes: #17965 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
