### PR TITLE
Use release branches for upgrade downgrade tests

### DIFF
--- a/tools/get_next_release.sh
+++ b/tools/get_next_release.sh
@@ -26,12 +26,7 @@ if [ "$base_release_branch" != "" ]; then
   latest_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
   target_major_release=$((major_release+1))
-  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
-  target_release="v$target_release_number"
-  if [ -z "$target_release_number" ]
-  then
-    target_release="release-$target_major_release.0"
-  fi
+  target_release="release-$target_major_release.0"
   if [ "$major_release" == "$latest_major_release" ]; then
     target_release="main"
   fi

--- a/tools/get_previous_release.sh
+++ b/tools/get_previous_release.sh
@@ -29,16 +29,10 @@ fi
 if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
   target_major_release=$((major_release-1))
-  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
-  target_release="v$target_release_number"
+  target_release="release-$target_major_release.0"
 else
   target_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
-  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
-  target_release="v$target_release_number"
-  if [ -z "$target_release_number" ]
-  then
-    target_release="release-$target_major_release.0"
-  fi
+  target_release="release-$target_major_release.0"
 fi
 
 echo "$target_release"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR reworks the way we run upgrade downgrade tests. Instead of running the upgrade-downgrade tests against the previous tagged release, we run them against the release branch.

The added advantage of this approach is that if we have a broken test, we can fix the test and not need a patch release just to get upgrade downgrade tests to take that change into account. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
