### PR TITLE
Take into account the tablet type not being set while checking for primary tablet mismatch recovery

### DIFF
--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -452,7 +452,7 @@ func GetReplicationAnalysis(keyspace string, shard string, hints *ReplicationAna
 			a.Analysis = PrimarySemiSyncMustNotBeSet
 			a.Description = "Primary semi-sync must not be set"
 			//
-		} else if a.IsClusterPrimary && a.CurrentTabletType != topodatapb.TabletType_PRIMARY {
+		} else if a.IsClusterPrimary && a.CurrentTabletType != topodatapb.TabletType_UNKNOWN && a.CurrentTabletType != topodatapb.TabletType_PRIMARY {
 			a.Analysis = PrimaryCurrentTypeMismatch
 			a.Description = "Primary tablet's current type is not PRIMARY"
 		} else if topo.IsReplicaType(a.TabletType) && a.ErrantGTID != "" {

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -115,6 +115,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidReplicatingReplicas: 0,
 				IsPrimary:                     1,
 				IsStalledDisk:                 1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -143,6 +144,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountSemiSyncReplicasEnabled:       2,
 				SemiSyncPrimaryClients:             0,
 				SemiSyncBlocked:                    1,
+				CurrentTabletType:                  int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -171,6 +173,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountSemiSyncReplicasEnabled:       1,
 				SemiSyncPrimaryClients:             1,
 				SemiSyncBlocked:                    1,
+				CurrentTabletType:                  int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -193,6 +196,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidReplicas:            4,
 				CountValidReplicatingReplicas: 0,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -209,10 +213,11 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
-				DurabilityPolicy: policy.DurabilityNone,
-				LastCheckValid:   0,
-				CountReplicas:    0,
-				IsPrimary:        1,
+				DurabilityPolicy:  policy.DurabilityNone,
+				LastCheckValid:    0,
+				CountReplicas:     0,
+				IsPrimary:         1,
+				CurrentTabletType: int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -229,10 +234,11 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
-				DurabilityPolicy: policy.DurabilityNone,
-				LastCheckValid:   0,
-				CountReplicas:    3,
-				IsPrimary:        1,
+				DurabilityPolicy:  policy.DurabilityNone,
+				LastCheckValid:    0,
+				CountReplicas:     3,
+				IsPrimary:         1,
+				CurrentTabletType: int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -255,6 +261,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidReplicas:            2,
 				CountValidReplicatingReplicas: 0,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -276,6 +283,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountReplicas:      4,
 				CountValidReplicas: 4,
 				IsPrimary:          0,
+				CurrentTabletType:  int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -298,6 +306,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidReplicas: 4,
 				IsPrimary:          1,
 				ReadOnly:           1,
+				CurrentTabletType:  int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -319,11 +328,36 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountReplicas:      4,
 				CountValidReplicas: 4,
 				IsPrimary:          1,
-				CurrentTabletType:  2,
+				CurrentTabletType:  int(topodatapb.TabletType_REPLICA),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
 			codeWanted:     PrimaryCurrentTypeMismatch,
+		}, {
+			name: "Unknown tablet type shouldn't run the mismatch recovery analysis",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy:              policy.DurabilityNone,
+				LastCheckValid:                1,
+				CountReplicas:                 4,
+				CountValidReplicas:            4,
+				CountValidReplicatingReplicas: 3,
+				CountValidOracleGTIDReplicas:  4,
+				CountLoggingReplicas:          2,
+				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_UNKNOWN),
+			}},
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     NoProblem,
 		}, {
 			name: "PrimarySemiSyncMustNotBeSet",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -342,6 +376,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidReplicas:     4,
 				IsPrimary:              1,
 				SemiSyncPrimaryEnabled: 1,
+				CurrentTabletType:      int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -364,6 +399,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidReplicas:     4,
 				IsPrimary:              1,
 				SemiSyncPrimaryEnabled: 0,
+				CurrentTabletType:      int(topodatapb.TabletType_PRIMARY),
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
@@ -388,6 +424,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -425,6 +462,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -465,6 +503,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -505,6 +544,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -546,6 +586,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -587,6 +628,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -631,6 +673,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
 				SemiSyncPrimaryEnabled:        1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -672,6 +715,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -754,6 +798,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
 				SemiSyncPrimaryEnabled:        1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -850,6 +895,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
@@ -891,6 +937,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 				CountValidOracleGTIDReplicas:  4,
 				CountLoggingReplicas:          2,
 				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
 			}, {
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},

--- a/go/vt/vtorc/test/recovery_analysis.go
+++ b/go/vt/vtorc/test/recovery_analysis.go
@@ -149,9 +149,6 @@ func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
 	rowMap["semi_sync_replica_enabled"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.SemiSyncReplicaEnabled), Valid: true}
 	res, _ := prototext.Marshal(info.TabletInfo)
 	currentType := info.CurrentTabletType
-	if currentType == 0 {
-		currentType = int(info.TabletInfo.Type)
-	}
 	rowMap["current_tablet_type"] = sqlutils.CellData{String: fmt.Sprintf("%v", currentType), Valid: true}
 	rowMap["tablet_info"] = sqlutils.CellData{String: string(res), Valid: true}
 	rowMap["is_disk_stalled"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsStalledDisk), Valid: true}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue described in https://github.com/vitessio/vitess/issues/18031 by augmenting the check for primary tablet mismatch to also take into account that the field can be empty and set to unknown.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes  https://github.com/vitessio/vitess/issues/18031

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
