### PR TITLE
Bugfix: Missing data when running vtgate outer joins

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -671,6 +671,21 @@ func TestStraightJoin(t *testing.T) {
 	require.Contains(t, fmt.Sprintf("%v", res.Rows), "t1_tbl")
 }
 
+func TestFailingOuterJoinInOLAP(t *testing.T) {
+	// This query was returning different results in MySQL and Vitess
+	mcmp, closer := start(t)
+	defer closer()
+
+	// Insert data into the 2 tables
+	mcmp.Exec("insert into t1(id1, id2) values (1,2), (5, 42)")
+	mcmp.Exec("insert into tbl(id, unq_col, nonunq_col) values (1,2,3), (2,5,3)")
+
+	utils.Exec(t, mcmp.VtConn, "set workload = olap")
+
+	// This query was
+	mcmp.Exec("select t1.id1 from t1 left join tbl on t1.id2 = tbl.nonunq_col")
+}
+
 func TestColumnAliases(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -166,7 +166,10 @@ func (jn *Join) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars 
 					nil,
 					jn.Cols,
 				)}
-				return callback(result)
+
+				if err := callback(result); err != nil {
+					return err
+				}
 			}
 		}
 		// This needs to be locking since it's not safe to just use


### PR DESCRIPTION
## Description
While working on other, unrelated issues, we noticed that outer joins where sometimes returning too few rows when run in OLAP.

This fix makes sure we return the same rows as MySQL.

## Related Issue(s)
Fixes #18041
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
