### PR TITLE
Tests: Run tests in OLAP mode

### DIFF
--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -148,8 +148,10 @@ jobs:
           # If there is a vschema file there, we use it, otherwise we let vt tester autogenerate it.
           if [ -f $dir/vschema.json ]; then
             vt tester --xunit --vschema "$dir"vschema.json $dir/*.test
-          else 
+            vt tester --olap --xunit --vschema "$dir"vschema.json $dir/*.test
+          else
             vt tester --sharded --xunit $dir/*.test
+            vt tester --olap --sharded --xunit $dir/*.test
           fi
           # Number the reports by changing their file names.
           mv report.xml report"$i".xml

--- a/go/test/endtoend/vtgate/plan_tests/main_test.go
+++ b/go/test/endtoend/vtgate/plan_tests/main_test.go
@@ -179,7 +179,8 @@ func verifyTestExpectations(t *testing.T, pd engine.PrimitiveDescription, test p
 	// 1. Verify that the Join primitive sees atleast 1 row on the left side.
 	engine.WalkPrimitiveDescription(pd, func(description engine.PrimitiveDescription) {
 		if description.OperatorType == "Join" {
-			assert.NotZero(t, description.Inputs[0].RowsReceived[0])
+			message := fmt.Sprintf("expected at least 1 row on the left side of the join for query: %s", test.Query)
+			assert.NotZero(t, description.Inputs[0].RowsReceived[0], message)
 		}
 	})
 

--- a/test/templates/cluster_vitess_tester.tpl
+++ b/test/templates/cluster_vitess_tester.tpl
@@ -153,8 +153,10 @@ jobs:
           # If there is a vschema file there, we use it, otherwise we let vt tester autogenerate it.
           if [ -f $dir/vschema.json ]; then
             vt tester --xunit --vschema "$dir"vschema.json $dir/*.test
-          else 
+            vt tester --olap --xunit --vschema "$dir"vschema.json $dir/*.test
+          else
             vt tester --sharded --xunit $dir/*.test
+            vt tester --olap --sharded --xunit $dir/*.test
           fi
           # Number the reports by changing their file names.
           mv report.xml report"$i".xml


### PR DESCRIPTION
## Description
It's easy to run these tests in OLAP mode. Let's do it.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
