### PR TITLE
Implement server side cursors

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -154,6 +154,12 @@ type Conn struct {
 	// PrepareData is the map to use a prepared statement.
 	PrepareData map[uint32]*PrepareData
 
+	// cursorStates represent queries which are running as a result of a
+	// COM_STMT_EXECUTE. Rows will be fetched with COM_STMT_FETCH, and
+	// possibly a query will need to be terminated as a result of what
+	// happens in the protocol, etc.
+	cursorStates map[uint32]*CursorState
+
 	// protects the bufferedWriter and bufferedReader
 	bufMu sync.Mutex
 
@@ -234,6 +240,31 @@ type PrepareData struct {
 	ParamsCount uint16
 }
 
+// CursorSate
+type CursorState struct {
+	// The goroutine which generates the results delivers |Result|s with a
+	// batch of rows one at a time on the |next| channel.  As long as the
+	// query has not delivered EOF, we will have pending rows, because we
+	// prefetch them as soon as they are exhausted. That is, if we have 10
+	// pending rows and a client fetches only 10 rows, we will block on
+	// fetching more rows before ew return the currently cached 10 rows.
+	// This allows us to detect EOF and correctly return CursorExhausted.
+	pending *sqltypes.Result
+
+	// The channel on which the running query is sending batched results.
+	next chan *sqltypes.Result
+
+	// The channel on which the running query will return its final error
+	// status, either `nil` or an error.
+	done chan error
+
+	// A control channel on which the running query is listening. If the
+	// server needs to cancel the inflight query based on what is happening
+	// in the wire protocol handling, it will send on this channel and then
+	// block on `done` being sent to.
+	quit chan error
+}
+
 // execResult is an enum signifying the result of executing a query
 type execResult byte
 
@@ -291,6 +322,7 @@ func newServerConn(conn net.Conn, listener *Listener) *Conn {
 		conn:           conn,
 		listener:       listener,
 		PrepareData:    make(map[uint32]*PrepareData),
+		cursorStates:   make(map[uint32]*CursorState),
 		keepAliveOn:    enabledKeepAlive,
 		flushDelay:     listener.flushDelay,
 		truncateErrLen: listener.truncateErrLen,
@@ -1098,6 +1130,9 @@ func (c *Conn) handleNextCommand(handler Handler) bool {
 		if ok {
 			delete(c.PrepareData, stmtID)
 		}
+		c.discardCursor(stmtID)
+	case ComStmtFetch:
+		return c.handleComStmtFetch(handler, data)
 	case ComStmtReset:
 		return c.handleComStmtReset(data)
 	case ComResetConnection:
@@ -1197,6 +1232,7 @@ func (c *Conn) handleComBinlogDumpGTID(handler Handler, data []byte) (kontinue b
 func (c *Conn) handleComResetConnection(handler Handler) {
 	// Clean up and reset the connection
 	c.recycleReadPacket()
+	c.discardAllCursors()
 	handler.ComResetConnection(c)
 	// Reset prepared statements
 	c.PrepareData = make(map[uint32]*PrepareData)
@@ -1230,8 +1266,82 @@ func (c *Conn) handleComStmtReset(data []byte) bool {
 		}
 	}
 
+	c.discardCursor(stmtID)
+
 	if err := c.writeOKPacket(&PacketOK{statusFlags: c.StatusFlags}); err != nil {
 		log.Error(fmt.Sprintf("Error writing ComStmtReset OK packet to client %v: %v", c.ConnectionID, err))
+		return false
+	}
+	return true
+}
+
+func (c *Conn) handleComStmtFetch(handler Handler, data []byte) (kontinue bool) {
+	c.startWriterBuffering()
+
+	stmtID, numRows, ok := c.parseComStmtFetch(data)
+	c.recycleReadPacket()
+	if !ok {
+		log.Error(fmt.Sprintf("Got unhandled packet from client %v, returning error: %v", c.ConnectionID, data))
+		if !c.writeErrorAndLog(sqlerror.ERUnknownComError, sqlerror.SSNetError, "error handling packet: %v", data) {
+			return false
+		}
+		return c.endWriterBuffering() == nil
+	}
+
+	// fetching from wrong statement
+	cs, ok := c.cursorStates[stmtID]
+	if !ok || cs == nil {
+		log.Error(fmt.Sprintf("Requested stmtID does not have an open cursor. Client %v, returning error: %v", c.ConnectionID, data))
+		if !c.writeErrorAndLog(sqlerror.ERUnknownComError, sqlerror.SSNetError, "error handling packet: %v", data) {
+			return false
+		}
+		return c.endWriterBuffering() == nil
+	}
+
+	// There is always a pending result set, because we prefetch it to detect EOF.
+	// When we detect EOF, we set c.cs = nil.
+
+	for cs != nil && numRows != 0 {
+		toSend := min(uint32(len(cs.pending.Rows)), numRows)
+		nextRows := cs.pending.Rows[toSend:]
+		cs.pending.Rows = cs.pending.Rows[:toSend]
+
+		if err := c.writeBinaryRows(cs.pending); err != nil {
+			log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
+			return false
+		}
+		cs.pending.Rows = nextRows
+		numRows -= toSend
+		if len(cs.pending.Rows) == 0 {
+			var ok bool
+			cs.pending, ok = <-cs.next
+			if !ok {
+				// Query has terminated. Check for an error.
+				err := <-cs.done
+				cs = nil
+				delete(c.cursorStates, stmtID)
+				if err != nil {
+					// We can't send an error in the middle of a stream.
+					// All we can do is abort the send, which will cause a 2013.
+					log.Error(fmt.Sprintf("Error in the middle of a stream to %s: %v", c, err))
+					return false
+				}
+			}
+		}
+	}
+
+	if cs == nil {
+		c.StatusFlags |= uint16(ServerStatusLastRowSent)
+	}
+	if err := c.writeEndResult(false, 0, 0, handler.WarningCount(c)); err != nil {
+		log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
+		return false
+	}
+	if cs == nil {
+		c.StatusFlags &= ^uint16(ServerStatusLastRowSent)
+	}
+	if err := c.endWriterBuffering(); err != nil {
+		log.Error(fmt.Sprintf("Conn %v: endWriterBuffering() failed: %v", c.ID(), err))
 		return false
 	}
 	return true
@@ -1275,9 +1385,18 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 			kontinue = false
 		}
 	}()
-	queryStart := time.Now()
-	stmtID, _, err := c.parseComStmtExecute(c.PrepareData, data)
+
+	// flush is called at the end of this block.
+	// To simplify error handling, we do not
+	// encapsulate it with a defer'd func()
+	c.startWriterBuffering()
+
+	stmtID, cursorType, err := c.parseComStmtExecute(c.PrepareData, data)
 	c.recycleReadPacket()
+
+	if err != nil {
+		return c.writeErrorPacketFromErrorAndLog(err)
+	}
 
 	if stmtID != uint32(0) {
 		defer func() {
@@ -1287,73 +1406,145 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 		}()
 	}
 
-	if err != nil {
-		return c.writeErrorPacketFromErrorAndLog(err)
-	}
-
-	receivedResult := false
-	// sendFinished is set if the response should just be an OK packet.
-	sendFinished := false
+	queryStart := time.Now()
 	prepare := c.PrepareData[stmtID]
-	err = handler.ComStmtExecute(c, prepare, func(qr *sqltypes.Result) error {
-		if sendFinished {
-			// Failsafe: Unreachable if server is well-behaved.
-			return io.EOF
-		}
+	if cursorType == CursorTypeNoCursor {
+		receivedResult := false
+		sendFinished := false // sendFinished is set if the response should just be an OK packet.
+		err = handler.ComStmtExecute(c, prepare, func(qr *sqltypes.Result) error {
+			if sendFinished {
+				// Failsafe: Unreachable if server is well-behaved.
+				return io.EOF
+			}
 
-		if !receivedResult {
-			receivedResult = true
+			if !receivedResult {
+				receivedResult = true
 
-			if len(qr.Fields) == 0 {
-				sendFinished = true
-				// We should not send any more packets after this.
-				ok := PacketOK{
-					affectedRows:     qr.RowsAffected,
-					lastInsertID:     qr.InsertID,
-					statusFlags:      c.StatusFlags,
-					warnings:         0,
-					info:             "",
-					sessionStateData: qr.SessionStateChanges,
+				if len(qr.Fields) == 0 {
+					sendFinished = true
+					// We should not send any more packets after this.
+					ok := PacketOK{
+						affectedRows:     qr.RowsAffected,
+						lastInsertID:     qr.InsertID,
+						statusFlags:      c.StatusFlags,
+						warnings:         0,
+						info:             "",
+						sessionStateData: qr.SessionStateChanges,
+					}
+					return c.writeOKPacket(&ok)
 				}
-				return c.writeOKPacket(&ok)
+				if err := c.writeFields(qr); err != nil {
+					return err
+				}
 			}
-			if err := c.writeFields(qr); err != nil {
-				return err
+
+			return c.writeBinaryRows(qr)
+		})
+
+		// If no field was sent, we expect an error.
+		if !receivedResult {
+			// This is just a failsafe. Should never happen.
+			if err == nil || err == io.EOF {
+				err = sqlerror.NewSQLErrorFromError(errors.New("unexpected: query ended without no results and no error"))
 			}
-		}
 
-		return c.writeBinaryRows(qr)
-	})
-
-	// If no field was sent, we expect an error.
-	if !receivedResult {
-		// This is just a failsafe. Should never happen.
-		if err == nil || err == io.EOF {
-			err = sqlerror.NewSQLErrorFromError(errors.New("unexpected: query ended without no results and no error"))
-		}
-		if !c.writeErrorPacketFromErrorAndLog(err) {
-			return false
-		}
-	} else {
-		if err != nil {
-			// We can't send an error in the middle of a stream.
-			// All we can do is abort the send, which will cause a 2013.
-			log.Error(fmt.Sprintf("Error in the middle of a stream to %s: %v", c, err))
-			return false
-		}
-
-		// Send the end packet only sendFinished is false (results were streamed).
-		// In this case the affectedRows and lastInsertID are always 0 since it
-		// was a read operation.
-		if !sendFinished {
-			if err := c.writeEndResult(false, 0, 0, handler.WarningCount(c)); err != nil {
-				log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
+			if !c.writeErrorPacketFromErrorAndLog(err) {
 				return false
 			}
+		} else {
+			if err != nil {
+				// We can't send an error in the middle of a stream.
+				// All we can do is abort the send, which will cause a 2013.
+				log.Error(fmt.Sprintf("Error in the middle of a stream to %s: %v", c, err))
+				return false
+			}
+
+			// Send the end packet only sendFinished is false (results were streamed).
+			// In this case the affectedRows and lastInsertID are always 0 since it
+			// was a read operation.
+			if !sendFinished {
+				if err := c.writeEndResult(false, 0, 0, handler.WarningCount(c)); err != nil {
+					log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
+					return false
+				}
+			}
 		}
+		return true
 	}
 
-	timings.Record(queryTimingKey, queryStart)
+	next := make(chan *sqltypes.Result)
+	done, quit := make(chan error), make(chan error)
+
+	go func() {
+		var err error
+		defer func() {
+			// pass along error, even if there's a panic
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic while running query for server-side cursor: %v", r)
+			}
+			close(next)
+			done <- err
+			close(done)
+		}()
+		err = handler.ComStmtExecute(c, prepare, func(qr *sqltypes.Result) error {
+			// block until query results are sent or receive signal to quit
+			var qerr error
+			select {
+			case next <- qr:
+			case qerr = <-quit:
+			}
+			return qerr
+		})
+	}()
+
+	// Immediately receive the very first query result to write the fields
+	qr, ok := <-next
+	if !ok {
+		<-done
+		if !c.writeErrorAndLog(sqlerror.ERUnknownError, sqlerror.SSUnknownSQLState, "error handling packet: %v", "missing result set") {
+			log.Error(fmt.Sprintf("Error writing query error to %s", c))
+			return false
+		}
+		return false
+	}
+
+	defer timings.Record(queryTimingKey, queryStart)
+
+	if len(qr.Fields) == 0 {
+		// DML or something without a result set. We do not open a cursor here.
+		<-done
+		return c.writeOKPacket(&PacketOK{
+			affectedRows: qr.RowsAffected,
+			lastInsertID: qr.InsertID,
+			statusFlags:  c.StatusFlags,
+			warnings:     0,
+		}) == nil
+	}
+
+	// Open the cursor and write the fields.
+	c.StatusFlags |= uint16(ServerStatusCursorExists)
+	if err := c.writeFieldsWithoutEOF(qr); err != nil {
+		log.Error(fmt.Sprintf("Error writing fields to %s: %v", c, err))
+		return false
+	}
+
+	// TODO: Look into whether accessing WarningCount
+	// here after passing `c` to ComStmtExecute in the
+	// goroutine above races.
+	if werr := c.writeEndResult(false, 0, 0, handler.WarningCount(c)); werr != nil {
+		log.Error(fmt.Sprintf("Error writing result to %s: %v", c, werr))
+		return false
+	}
+
+	// After writing the EOF_Packet/OK_Packet above, we
+	// have told the client the cursor is open.
+	c.StatusFlags &= ^uint16(ServerStatusCursorExists)
+	c.cursorStates[stmtID] = &CursorState{
+		next:    next,
+		done:    done,
+		quit:    quit,
+		pending: qr,
+	}
 	return true
 }
 
@@ -1627,6 +1818,28 @@ func (c *Conn) handleComQuery(handler Handler, data []byte) (kontinue bool) {
 
 	timings.Record(queryTimingKey, queryStart)
 	return true
+}
+
+// discardCursor stops the statement execute goroutine and clears the cursor state, if it exists
+func (c *Conn) discardCursor(stmtID uint32) {
+	// close cursor if open with unread results
+	cs, ok := c.cursorStates[stmtID]
+	if ok {
+		select {
+		case cs.quit <- errors.New("cancel cursor query"):
+			<-cs.done
+		case <-cs.done:
+		}
+		delete(c.cursorStates, stmtID)
+	}
+}
+
+// discardAllCursors discards all open cursors on the connection
+func (c *Conn) discardAllCursors() {
+	for stmtID := range c.cursorStates {
+		c.discardCursor(stmtID)
+	}
+	c.cursorStates = make(map[uint32]*CursorState)
 }
 
 func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -75,6 +75,7 @@ func createSocketPair(t *testing.T) (net.Listener, *Conn, *Conn) {
 	cConn := newConn(clientConn, DefaultFlushDelay, 0)
 	sConn := newConn(serverConn, DefaultFlushDelay, 0)
 	sConn.PrepareData = map[uint32]*PrepareData{}
+	sConn.cursorStates = map[uint32]*CursorState{}
 
 	return listener, sConn, cConn
 }
@@ -885,9 +886,9 @@ func TestEmptyQuery(t *testing.T) {
 			// The queries run will be an empty query; Even with the empty error, the connection should be fine
 			require.True(t, res, "we should not break the connection in case of no errors")
 			// Read the result and assert that we indeed see the error for empty query.
-			data, more, _, err := cConn.ReadQueryResult(100, true)
+			data, status, _, err := cConn.ReadQueryResult(100, true)
 			require.EqualError(t, err, "Query was empty (errno 1065) (sqlstate 42000)")
-			require.False(t, more)
+			require.False(t, (status&ServerMoreResultsExists) != 0)
 			require.Nil(t, data)
 		})
 	}
@@ -915,17 +916,17 @@ func TestMultiStatement(t *testing.T) {
 			// The queries run will be select 1; and select 2; These queries do not return any errors, so the connection should still be open
 			require.True(t, res, "we should not break the connection in case of no errors")
 			// Read the result of the query and assert that it is indeed what we want. This will contain the result of the first query.
-			data, more, _, err := cConn.ReadQueryResult(100, true)
+			data, status, _, err := cConn.ReadQueryResult(100, true)
 			require.NoError(t, err)
 			// Since we executed 2 queries, there should be more results to be read
-			require.True(t, more)
+			require.True(t, (status&ServerMoreResultsExists) != 0)
 			require.True(t, data.Equal(selectRowsResult))
 
 			// Read the results for the second query and verify the correctness
-			data, more, _, err = cConn.ReadQueryResult(100, true)
+			data, status, _, err = cConn.ReadQueryResult(100, true)
 			require.NoError(t, err)
 			// This was the final query run, so we expect that more should be false as there are no more queries.
-			require.False(t, more)
+			require.False(t, (status&ServerMoreResultsExists) != 0)
 			require.True(t, data.Equal(selectRowsResult))
 
 			// This time we run two queries fist of which will return an error
@@ -937,10 +938,10 @@ func TestMultiStatement(t *testing.T) {
 			require.True(t, res, "we should not break the connection because of execution errors")
 
 			// Read the result and assert that we indeed see the error that testRun throws.
-			data, more, _, err = cConn.ReadQueryResult(100, true)
+			data, status, _, err = cConn.ReadQueryResult(100, true)
 			require.EqualError(t, err, "cannot get column number (errno 2027) (sqlstate HY000)")
 			// In case of errors in a multi-statement, the following statements are not executed, therefore we want that more should be false
-			require.False(t, more)
+			require.False(t, (status&ServerMoreResultsExists) != 0)
 			require.Nil(t, data)
 		})
 	}

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -888,7 +888,7 @@ func TestEmptyQuery(t *testing.T) {
 			// Read the result and assert that we indeed see the error for empty query.
 			data, status, _, err := cConn.ReadQueryResult(100, true)
 			require.EqualError(t, err, "Query was empty (errno 1065) (sqlstate 42000)")
-			require.False(t, (status&ServerMoreResultsExists) != 0)
+			require.False(t, IsMoreResultsExists(status))
 			require.Nil(t, data)
 		})
 	}
@@ -919,14 +919,14 @@ func TestMultiStatement(t *testing.T) {
 			data, status, _, err := cConn.ReadQueryResult(100, true)
 			require.NoError(t, err)
 			// Since we executed 2 queries, there should be more results to be read
-			require.True(t, (status&ServerMoreResultsExists) != 0)
+			require.True(t, IsMoreResultsExists(status))
 			require.True(t, data.Equal(selectRowsResult))
 
 			// Read the results for the second query and verify the correctness
 			data, status, _, err = cConn.ReadQueryResult(100, true)
 			require.NoError(t, err)
 			// This was the final query run, so we expect that more should be false as there are no more queries.
-			require.False(t, (status&ServerMoreResultsExists) != 0)
+			require.False(t, IsMoreResultsExists(status))
 			require.True(t, data.Equal(selectRowsResult))
 
 			// This time we run two queries fist of which will return an error
@@ -941,7 +941,7 @@ func TestMultiStatement(t *testing.T) {
 			data, status, _, err = cConn.ReadQueryResult(100, true)
 			require.EqualError(t, err, "cannot get column number (errno 2027) (sqlstate HY000)")
 			// In case of errors in a multi-statement, the following statements are not executed, therefore we want that more should be false
-			require.False(t, (status&ServerMoreResultsExists) != 0)
+			require.False(t, IsMoreResultsExists(status))
 			require.Nil(t, data)
 		})
 	}

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -156,7 +156,8 @@ const (
 
 // Status flags. They are returned by the server in a few cases.
 // Originally found in include/mysql/mysql_com.h
-// See http://dev.mysql.com/doc/internals/en/status-flags.html
+// See https://dev.mysql.com/doc/dev/mysql-server/latest/mysql__com_8h.html#a1d854e841086925be1883e4d7b4e8cad
+// and https://mariadb.com/kb/en/ok_packet/#server-status-flag
 const (
 	// a transaction is active
 	ServerStatusInTrans   uint16 = 0x0001
@@ -181,6 +182,16 @@ const (
 	ServerStatusInTransReadonly uint16 = 0x2000
 	// connection state information has changed
 	ServerSessionStateChanged uint16 = 0x4000
+)
+
+// Cursor Types. They are received on COM_STMT_EXECUTE()
+// See https://dev.mysql.com/doc/dev/mysql-server/latest/mysql__com_8h.html#a3e5e9e744ff6f7b989a604fd669977da
+// and https://mariadb.com/kb/en/com_stmt_execute/#flag
+const (
+	CursorTypeNoCursor = iota
+	CursorTypeReadOnly
+	CursorTypeCursorForUpdate
+	CursorTypeScrollableCursor
 )
 
 // State Change Information

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -184,6 +184,11 @@ const (
 	ServerSessionStateChanged uint16 = 0x4000
 )
 
+// Helper for checking if SERVER_MORE_RESULTS_EXISTS is set
+func IsMoreResultsExists(status uint16) bool {
+	return status&ServerMoreResultsExists == ServerMoreResultsExists
+}
+
 // Cursor Types. They are received on COM_STMT_EXECUTE()
 // See https://dev.mysql.com/doc/dev/mysql-server/latest/mysql__com_8h.html#a3e5e9e744ff6f7b989a604fd669977da
 // and https://mariadb.com/kb/en/com_stmt_execute/#flag

--- a/go/mysql/mysql_fuzzer.go
+++ b/go/mysql/mysql_fuzzer.go
@@ -198,6 +198,7 @@ func FuzzHandleNextCommand(data []byte) int {
 		queryPacket: data,
 	}, DefaultFlushDelay, 0, false)
 	sConn.PrepareData = map[uint32]*PrepareData{}
+	sConn.cursorStates = map[uint32]*CursorState{}
 
 	handler := &fuzztestRun{}
 	_ = sConn.handleNextCommand(handler)

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -317,7 +317,7 @@ func (c *Conn) parseRow(data []byte, fields []*querypb.Field, reader func([]byte
 //	    readComQueryResponse will fail, and we'll return CRServerLost(2013).
 func (c *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (result *sqltypes.Result, err error) {
 	result, status, err := c.ExecuteFetchMulti(query, maxrows, wantfields)
-	if (status & ServerMoreResultsExists) != 0 {
+	if IsMoreResultsExists(status) {
 		// Multiple results are unexpected. Prioritize this "unexpected" error over whatever error we got from the first result.
 		err = errors.Join(ErrExecuteFetchMultipleResults, err)
 	}
@@ -337,7 +337,7 @@ func (c *Conn) ExecuteFetchMultiDrain(query string) (err error) {
 // drainMoreResults ensures to drain all query results, even if there's an error.
 // We collect all errors until we consume all results.
 func (c *Conn) drainMoreResults(status uint16, err error) error {
-	for (status & ServerMoreResultsExists) != 0 {
+	for IsMoreResultsExists(status) {
 		var moreErr error
 		_, status, _, moreErr = c.ReadQueryResult(FETCH_NO_ROWS, false)
 		if moreErr != nil {

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -403,6 +403,8 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	// Adjust the count of open connections
 	defer connCount.Add(-1)
 
+	defer c.discardAllCursors()
+
 	// First build and send the server handshake packet.
 	serverAuthPluginData, err := c.writeHandshakeV10(l.ServerVersion, l.authServer, uint8(l.charset), l.TLSConfig.Load() != nil)
 	if err != nil {

--- a/go/test/endtoend/topotest/consul/main_test.go
+++ b/go/test/endtoend/topotest/consul/main_test.go
@@ -279,11 +279,11 @@ func execute(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
 func execMulti(t *testing.T, conn *mysql.Conn, query string) []*sqltypes.Result {
 	t.Helper()
 	var res []*sqltypes.Result
-	qr, more, err := conn.ExecuteFetchMulti(query, 1000, true)
+	qr, status, err := conn.ExecuteFetchMulti(query, 1000, true)
 	res = append(res, qr)
 	require.NoError(t, err)
-	for more == true {
-		qr, more, _, err = conn.ReadQueryResult(1000, true)
+	for mysql.IsMoreResultsExists(status) {
+		qr, status, _, err = conn.ReadQueryResult(1000, true)
 		require.NoError(t, err)
 		res = append(res, qr)
 	}

--- a/go/test/endtoend/topotest/etcd2/main_test.go
+++ b/go/test/endtoend/topotest/etcd2/main_test.go
@@ -273,11 +273,11 @@ func TestNamedLocking(t *testing.T) {
 func execMulti(t *testing.T, conn *mysql.Conn, query string) []*sqltypes.Result {
 	t.Helper()
 	var res []*sqltypes.Result
-	qr, more, err := conn.ExecuteFetchMulti(query, 1000, true)
+	qr, status, err := conn.ExecuteFetchMulti(query, 1000, true)
 	res = append(res, qr)
 	require.NoError(t, err)
-	for more == true {
-		qr, more, _, err = conn.ReadQueryResult(1000, true)
+	for mysql.IsMoreResultsExists(status) {
+		qr, status, _, err = conn.ReadQueryResult(1000, true)
 		require.NoError(t, err)
 		res = append(res, qr)
 	}

--- a/go/test/endtoend/topotest/zk2/main_test.go
+++ b/go/test/endtoend/topotest/zk2/main_test.go
@@ -248,11 +248,11 @@ func TestKeyspaceLocking(t *testing.T) {
 func execMulti(t *testing.T, conn *mysql.Conn, query string) []*sqltypes.Result {
 	t.Helper()
 	var res []*sqltypes.Result
-	qr, more, err := conn.ExecuteFetchMulti(query, 1000, true)
+	qr, status, err := conn.ExecuteFetchMulti(query, 1000, true)
 	res = append(res, qr)
 	require.NoError(t, err)
-	for more == true {
-		qr, more, _, err = conn.ReadQueryResult(1000, true)
+	for mysql.IsMoreResultsExists(status) {
+		qr, status, _, err = conn.ReadQueryResult(1000, true)
 		require.NoError(t, err)
 		res = append(res, qr)
 	}

--- a/go/test/endtoend/vtgate/queries/multi_query/multi_query_test.go
+++ b/go/test/endtoend/vtgate/queries/multi_query/multi_query_test.go
@@ -170,12 +170,12 @@ func TestMultiQuery(t *testing.T) {
 // results obtained from the gRPC connection.
 func getMySqlResults(conn *mysql.Conn, sql string) ([]*sqltypes.Result, error) {
 	var results []*sqltypes.Result
-	mysqlQr, mysqlMore, mysqlErr := conn.ExecuteFetchMulti(sql, 1000, true)
+	mysqlQr, mysqlStatus, mysqlErr := conn.ExecuteFetchMulti(sql, 1000, true)
 	if mysqlQr != nil {
 		results = append(results, mysqlQr)
 	}
-	for mysqlMore {
-		mysqlQr, mysqlMore, _, mysqlErr = conn.ReadQueryResult(1000, true)
+	for mysql.IsMoreResultsExists(mysqlStatus) {
+		mysqlQr, mysqlStatus, _, mysqlErr = conn.ReadQueryResult(1000, true)
 		if mysqlQr != nil {
 			results = append(results, mysqlQr)
 		}

--- a/go/test/endtoend/vtgate/reservedconn/udv_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/udv_test.go
@@ -146,9 +146,9 @@ func TestMysqlDumpInitialLog(t *testing.T) {
 
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
-			_, more, err := conn.ExecuteFetchMulti(query, 1000, true)
+			_, status, err := conn.ExecuteFetchMulti(query, 1000, true)
 			require.NoError(t, err)
-			require.False(t, more)
+			require.False(t, mysql.IsMoreResultsExists(status))
 		})
 	}
 }

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -454,11 +454,11 @@ func TestFloatValueDefault(t *testing.T) {
 func execMulti(t *testing.T, conn *mysql.Conn, query string) []*sqltypes.Result {
 	t.Helper()
 	var res []*sqltypes.Result
-	qr, more, err := conn.ExecuteFetchMulti(query, 1000, true)
+	qr, status, err := conn.ExecuteFetchMulti(query, 1000, true)
 	res = append(res, qr)
 	require.NoError(t, err)
-	for more == true {
-		qr, more, _, err = conn.ReadQueryResult(1000, true)
+	for mysql.IsMoreResultsExists(status) {
+		qr, status, _, err = conn.ReadQueryResult(1000, true)
 		require.NoError(t, err)
 		res = append(res, qr)
 	}

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -162,14 +162,14 @@ func (dc *dbClientImpl) ExecuteFetch(query string, maxrows int) (*sqltypes.Resul
 
 func (dc *dbClientImpl) ExecuteFetchMulti(query string, maxrows int) ([]*sqltypes.Result, error) {
 	results := make([]*sqltypes.Result, 0)
-	mqr, more, err := dc.dbConn.ExecuteFetchMulti(query, maxrows, true)
+	mqr, status, err := dc.dbConn.ExecuteFetchMulti(query, maxrows, true)
 	if err != nil {
 		dc.handleError(err)
 		return nil, err
 	}
 	results = append(results, mqr)
-	for more {
-		mqr, more, _, err = dc.dbConn.ReadQueryResult(maxrows, false)
+	for mysql.IsMoreResultsExists(status) {
+		mqr, status, _, err = dc.dbConn.ReadQueryResult(maxrows, false)
 		if err != nil {
 			dc.handleError(err)
 			return nil, err

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1206,12 +1206,12 @@ func (mysqld *Mysqld) executeMysqlScript(ctx context.Context, connParams *mysql.
 	}
 	defer conn.Close()
 
-	_, more, err := conn.ExecuteFetchMulti(sql, -1, false)
+	_, status, err := conn.ExecuteFetchMulti(sql, -1, false)
 	if err != nil {
 		return err
 	}
-	for more {
-		_, more, _, err = conn.ReadQueryResult(0, false)
+	for mysql.IsMoreResultsExists(status) {
+		_, status, _, err = conn.ReadQueryResult(0, false)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -238,12 +238,12 @@ func initTimezoneData(t *testing.T, conn *mysql.Conn) {
 		t.Fatalf("failed to retrieve timezone info: %v", err)
 	}
 
-	_, more, err := conn.ExecuteFetchMulti(fmt.Sprintf("USE mysql; %s\n", string(out)), -1, false)
+	_, status, err := conn.ExecuteFetchMulti(fmt.Sprintf("USE mysql; %s\n", string(out)), -1, false)
 	if err != nil {
 		t.Fatalf("failed to insert timezone info: %v", err)
 	}
-	for more {
-		_, more, _, err = conn.ReadQueryResult(-1, false)
+	for mysql.IsMoreResultsExists(status) {
+		_, status, _, err = conn.ReadQueryResult(-1, false)
 		if err != nil {
 			t.Fatalf("failed to insert timezone info: %v", err)
 		}

--- a/go/vt/vttablet/tabletmanager/rpc_query.go
+++ b/go/vt/vttablet/tabletmanager/rpc_query.go
@@ -130,12 +130,12 @@ func (tm *TabletManager) executeMultiFetchAsDba(
 		return nil, err
 	}
 	results := make([]*querypb.QueryResult, 0, len(queries))
-	result, more, err := conn.ExecuteFetchMulti(uq, maxRows, true /*wantFields*/)
+	result, status, err := conn.ExecuteFetchMulti(uq, maxRows, true /*wantFields*/)
 	if err == nil {
 		results = append(results, sqltypes.ResultToProto3(result))
 	}
-	for more {
-		result, more, _, err = conn.ReadQueryResult(maxRows, true /*wantFields*/)
+	for (status & sqltypes.ServerMoreResultsExists) != 0 {
+		result, status, _, err = conn.ReadQueryResult(maxRows, true /*wantFields*/)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

To be able to use the [MySQL foreign data wrapper for PostgreSQL](https://github.com/EnterpriseDB/mysql_fdw), we have to support server side cursors.

(Note: While supporting PostgreSQL FDW was the triggering reason for me to implement this, this MR is not specific for that. It implements MySQL cursor support. It doesn't do anything specific for PostgreSQL compatibility.)

To that end each connection now keeps track of a list of open cursors, and implements the COM_STMT_FETCH command for retrieving data from an open cursor.

Based on the implementation in the Dolthub fork of Vitess:

- https://github.com/dolthub/vitess/pull/228
- https://github.com/dolthub/vitess/pull/232

Compared to the implementation in the Dolthub fork this commit:
- Was changed to fit with all changes made in Vitess since the Dolthub version was forked
- Remove a few superfluous formatting/whitespace changes made in there to make reviewing easier.
- Also supports multiple open cursors whereas the Dolthub fork only supports a single open cursor.

I've also moved all the changes to other code (namely, updating them to use the "status" integer instead of the old "more" boolean) into a separate commit to make it easier to review.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/18046

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

This only implements a new protocol feature and does not affect any on-disk information. No migrations should be required.
