### PR TITLE
Make it possible to use paths with Visitable nodes

### DIFF
--- a/go/tools/asthelpergen/integration/ast_path.go
+++ b/go/tools/asthelpergen/integration/ast_path.go
@@ -38,6 +38,7 @@ const (
 	RefOfValueSliceContainerASTElementsOffset
 	RefOfValueSliceContainerASTImplementationElements
 	RefOfOptionsl
+	VisitableInner
 )
 
 func (s ASTStep) DebugString() string {
@@ -78,6 +79,8 @@ func (s ASTStep) DebugString() string {
 		return "(*ValueSliceContainer).ASTImplementationElements"
 	case RefOfOptionsl:
 		return "(*Options).l"
+	case VisitableInner:
+		return "VisitableInner"
 	}
 	panic("unknown ASTStep")
 }
@@ -128,6 +131,8 @@ func GetNodeFromPath(node AST, path ASTPath) AST {
 			node = node.(*ValueSliceContainer).ASTElements[idx]
 		case RefOfValueSliceContainerASTImplementationElements:
 			node = node.(*ValueSliceContainer).ASTImplementationElements
+		case VisitableInner:
+			node = node.(Visitable).VisitThis()
 		default:
 			return nil
 		}

--- a/go/tools/asthelpergen/integration/ast_rewrite.go
+++ b/go/tools/asthelpergen/integration/ast_rewrite.go
@@ -721,12 +721,15 @@ func (a *application) rewriteVisitable(parent AST, node Visitable, replacer repl
 		}
 	}
 	if a.collectPaths {
-		panic("[BUG] paths are not supported on 'Visitable'")
+		a.cur.current.AddStep(uint16(VisitableInner))
 	}
 	if !a.rewriteAST(node, node.VisitThis(), func(newNode, parent AST) {
 		panic("[BUG] tried to replace 'VisitThis' on 'Visitable'")
 	}) {
 		return false
+	}
+	if a.collectPaths {
+		a.cur.current.Pop()
 	}
 	if a.post != nil {
 		a.cur.replacer = replacer

--- a/go/tools/asthelpergen/integration/integration_visit_test.go
+++ b/go/tools/asthelpergen/integration/integration_visit_test.go
@@ -190,6 +190,24 @@ func TestVisitableVisit(t *testing.T) {
 	})
 }
 
+func TestVisitablePath(t *testing.T) {
+	// Tests that Visitable containers can handle paths correctly
+	leaf := &Leaf{v: 1}
+	visitable := &testVisitable{inner: leaf}
+	refContainer := &RefContainer{ASTType: visitable}
+
+	p := map[ASTPath]AST{}
+
+	RewriteWithPaths(refContainer, func(c *Cursor) bool {
+		p[c.Path()] = c.Node()
+		return true
+	}, nil)
+
+	for path, ast := range p {
+		assert.Equal(t, GetNodeFromPath(refContainer, path), ast)
+	}
+}
+
 func TestCopyOnRewriteVisitable(t *testing.T) {
 	leaf := &Leaf{v: 1}
 	visitable := &testVisitable{inner: leaf}

--- a/go/tools/asthelpergen/paths_gen.go
+++ b/go/tools/asthelpergen/paths_gen.go
@@ -172,8 +172,11 @@ func (p *pathGen) debugString() *jen.Statement {
 		switchCases = append(switchCases, jen.Case(jen.Id(stepName+"Offset")).Block(
 			jen.Return(jen.Lit(debugStr+"Offset")),
 		))
-
 	}
+
+	switchCases = append(switchCases, jen.Case(jen.Id(visitableInner)).Block(
+		jen.Return(jen.Lit(visitableInner)),
+	))
 
 	debugStringMethod := jen.Func().Params(jen.Id("s").Id("ASTStep")).Id("DebugString").Params().String().Block(
 		jen.Switch(jen.Id("s")).Block(switchCases...),
@@ -181,6 +184,8 @@ func (p *pathGen) debugString() *jen.Statement {
 	)
 	return debugStringMethod
 }
+
+var visitableInner = visitableName + "Inner"
 
 func (p *pathGen) buildConstWithEnum() *jen.Statement {
 	// Create the const block with all step constants
@@ -203,6 +208,8 @@ func (p *pathGen) buildConstWithEnum() *jen.Statement {
 
 		addStep(stepName)
 	}
+
+	addStep(visitableInner)
 
 	constBlock := jen.Const().Defs(constDefs...)
 	return constBlock
@@ -258,6 +265,14 @@ func (p *pathGen) generateWalkCases(spi generatorSPI) []jen.Code {
 			jen.Id("node").Op("=").Add(assignNode),
 		))
 	}
+
+	/*
+		case VisitableInner:
+		node = node.(Visitable).VisitThis()
+	*/
+	cases = append(cases, jen.Case(jen.Id(visitableInner)).Block(
+		jen.Id("node").Op("=").Id("node").Assert(jen.Id("Visitable")).Dot("VisitThis").Call(),
+	))
 
 	cases = append(cases, jen.Default().Block(
 		jen.Return(jen.Nil()),

--- a/go/tools/asthelpergen/rewrite_gen.go
+++ b/go/tools/asthelpergen/rewrite_gen.go
@@ -79,9 +79,10 @@ func (r *rewriteGen) generateVisitableRewrite() {
 					),
 				),
 
-				// no path collection for Visitable
+				// path collection for Visitable
 				jen.If(jen.Id("a").Dot("collectPaths")).Block(
-					jen.Panic(jen.Lit("[BUG] paths are not supported on 'Visitable'")),
+					// 		a.cur.current.AddStep(uint16(RefOfValueSliceContainerASTImplementationElements))
+					jen.Id("a.cur.current.AddStep").Call(jen.Id("uint16(VisitableInner)")),
 				),
 
 				// rewrite internal fields
@@ -100,6 +101,12 @@ func (r *rewriteGen) generateVisitableRewrite() {
 				),
 
 				// POST
+
+				jen.If(jen.Id("a").Dot("collectPaths")).Block(
+					// 		a.cur.current.Pop()
+					jen.Id("a.cur.current.Pop").Call(),
+				),
+
 				jen.If(jen.Id("a").Dot("post").Op("!=").Nil()).Block(
 					jen.Id("a").Dot("cur").Dot("replacer").Op("=").Id("replacer"),
 					jen.Id("a").Dot("cur").Dot("parent").Op("=").Id("parent"),

--- a/go/vt/sqlparser/ast_path.go
+++ b/go/vt/sqlparser/ast_path.go
@@ -561,6 +561,7 @@ const (
 	RefOfTableAndLockTypeTable
 	RefOfRenameTablePairFromTable
 	RefOfRenameTablePairToTable
+	VisitableInner
 )
 
 func (s ASTStep) DebugString() string {
@@ -1647,6 +1648,8 @@ func (s ASTStep) DebugString() string {
 		return "(*RenameTablePair).FromTable"
 	case RefOfRenameTablePairToTable:
 		return "(*RenameTablePair).ToTable"
+	case VisitableInner:
+		return "VisitableInner"
 	}
 	panic("unknown ASTStep")
 }
@@ -2769,6 +2772,8 @@ func GetNodeFromPath(node SQLNode, path ASTPath) SQLNode {
 			node = node.(*TableName).Qualifier
 		case RefOfVindexParamKey:
 			node = node.(*VindexParam).Key
+		case VisitableInner:
+			node = node.(Visitable).VisitThis()
 		default:
 			return nil
 		}

--- a/go/vt/sqlparser/ast_rewrite.go
+++ b/go/vt/sqlparser/ast_rewrite.go
@@ -15010,12 +15010,15 @@ func (a *application) rewriteVisitable(parent SQLNode, node Visitable, replacer 
 		}
 	}
 	if a.collectPaths {
-		panic("[BUG] paths are not supported on 'Visitable'")
+		a.cur.current.AddStep(uint16(VisitableInner))
 	}
 	if !a.rewriteSQLNode(node, node.VisitThis(), func(newNode, parent SQLNode) {
 		panic("[BUG] tried to replace 'VisitThis' on 'Visitable'")
 	}) {
 		return false
+	}
+	if a.collectPaths {
+		a.cur.current.Pop()
 	}
 	if a.post != nil {
 		a.cur.replacer = replacer


### PR DESCRIPTION
## Description
Adds infrastructure to be able to keep track of paths even when using the Visitable interface.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
