### PR TITLE
`engine.Reload()`: fix file size aggregation for partitioned tables

### DIFF
--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/callerid"
@@ -1006,11 +1007,13 @@ func TestEngineReload(t *testing.T) {
 			`drop view if exists view_simple`,
 			`drop view if exists view_simple2`,
 			`drop table if exists tbl_simple`,
+			`drop table if exists tbl_nonpart`,
 			`drop table if exists tbl_part`,
 			`drop table if exists tbl_fts`,
 			`create table tbl_simple (id int primary key)`,
 			`create view view_simple as select * from tbl_simple`,
 			`create view view_simple2 as select * from tbl_simple`,
+			`create table tbl_nonpart (id INT NOT NULL, store_id INT)`,
 			`create table tbl_part (id INT NOT NULL, store_id INT) PARTITION BY HASH(store_id) PARTITIONS 4`,
 			`create table tbl_fts (id int primary key, name text, fulltext key name_fts (name))`,
 		}
@@ -1022,6 +1025,7 @@ func TestEngineReload(t *testing.T) {
 
 		expectedTables := []string{
 			"tbl_simple",
+			"tbl_nonpart",
 			"tbl_part",
 			"tbl_fts",
 			"view_simple",
@@ -1062,31 +1066,73 @@ func TestEngineReload(t *testing.T) {
 
 		expectedTables := []string{
 			"tbl_simple",
+			"tbl_nonpart",
 			"tbl_part",
 			"tbl_fts",
 			"view_simple",
 			"view_simple3",
 		}
-		err := engine.Reload(ctx)
-		require.NoError(t, err)
+		t.Run("reload without sizes", func(t *testing.T) {
+			err := engine.Reload(ctx)
+			require.NoError(t, err)
 
-		schema := engine.GetSchema()
-		require.NotEmpty(t, schema)
-		for _, expectTable := range expectedTables {
-			t.Run(expectTable, func(t *testing.T) {
-				tbl := engine.GetTable(sqlparser.NewIdentifierCS(expectTable))
-				require.NotNil(t, tbl)
+			schema := engine.GetSchema()
+			require.NotEmpty(t, schema)
+			for _, expectTable := range expectedTables {
+				t.Run(expectTable, func(t *testing.T) {
+					tbl := engine.GetTable(sqlparser.NewIdentifierCS(expectTable))
+					require.NotNil(t, tbl)
 
-				switch expectTable {
-				case "view_simple", "view_simple2", "view_simple3":
-					assert.Zero(t, tbl.FileSize)
-					assert.Zero(t, tbl.AllocatedSize)
-				default:
-					assert.Zero(t, tbl.FileSize)
-					assert.Zero(t, tbl.AllocatedSize)
-				}
-			})
-		}
+					switch expectTable {
+					case "view_simple", "view_simple2", "view_simple3":
+						assert.Zero(t, tbl.FileSize)
+						assert.Zero(t, tbl.AllocatedSize)
+					default:
+						assert.Zero(t, tbl.FileSize)
+						assert.Zero(t, tbl.AllocatedSize)
+					}
+				})
+			}
+		})
+		t.Run("reload with sizes", func(t *testing.T) {
+			err := engine.ReloadAtEx(ctx, replication.Position{}, true)
+			require.NoError(t, err)
+
+			schema := engine.GetSchema()
+			require.NotEmpty(t, schema)
+			var nonPartitionedSize uint64
+			var partitionedSize uint64
+			for _, expectTable := range expectedTables {
+				t.Run(expectTable, func(t *testing.T) {
+					tbl := engine.GetTable(sqlparser.NewIdentifierCS(expectTable))
+					require.NotNil(t, tbl)
+
+					switch expectTable {
+					case "view_simple", "view_simple2", "view_simple3":
+						assert.Zero(t, tbl.FileSize)
+						assert.Zero(t, tbl.AllocatedSize)
+					case "tbl_nonpart":
+						nonPartitionedSize = tbl.FileSize
+						assert.Positive(t, tbl.FileSize)
+						assert.Positive(t, tbl.AllocatedSize)
+					case "tbl_part":
+						partitionedSize = tbl.FileSize
+						assert.Positive(t, tbl.FileSize)
+						assert.Positive(t, tbl.AllocatedSize)
+					default:
+						assert.Positive(t, tbl.FileSize)
+						assert.Positive(t, tbl.AllocatedSize)
+					}
+				})
+			}
+			assert.Positive(t, nonPartitionedSize)
+			assert.Positive(t, partitionedSize)
+			// "tbl_part" has 4 partitions (each of which has about the same size as "tbl_nonpart")
+			// Technically partitionedSize should be 4*nonPartitionedSize, but we allow for some variance
+			assert.Greater(t, partitionedSize, nonPartitionedSize)
+			assert.Greater(t, partitionedSize, 3*nonPartitionedSize)
+			assert.Less(t, partitionedSize, 5*nonPartitionedSize)
+		})
 	})
 }
 

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -414,6 +414,50 @@ func (se *Engine) ReloadAtEx(ctx context.Context, pos replication.Position, incl
 	return nil
 }
 
+func populateInnoDBStats(ctx context.Context, conn *connpool.Conn) (map[string]*Table, error) {
+	innodbTableSizesQuery := conn.BaseShowInnodbTableSizes()
+	if innodbTableSizesQuery == "" {
+		return nil, nil
+	}
+
+	innodbResults, err := conn.Exec(ctx, innodbTableSizesQuery, maxTableCount*maxPartitionsPerTable, false)
+	if err != nil {
+		return nil, vterrors.Wrapf(err, "in Engine.reload(), reading innodb tables")
+	}
+	innodbTablesStats := make(map[string]*Table, len(innodbResults.Rows))
+	for _, row := range innodbResults.Rows {
+		innodbTableName := row[0].ToString() // In the form of encoded `schema/table`
+		fileSize, _ := row[1].ToCastUint64()
+		allocatedSize, _ := row[2].ToCastUint64()
+
+		if _, ok := innodbTablesStats[innodbTableName]; !ok {
+			innodbTablesStats[innodbTableName] = &Table{}
+		}
+		// There could be multiple appearances of the same table in the result set:
+		// A table that has FULLTEXT indexes will appear once for the table itself,
+		// with total size of row data, and once for the aggregates size of all
+		// FULLTEXT indexes. We aggregate the sizes of all appearances of the same table.
+		table := innodbTablesStats[innodbTableName]
+		table.FileSize += fileSize
+		table.AllocatedSize += allocatedSize
+
+		if originalTableName, _, found := strings.Cut(innodbTableName, "#p#"); found {
+			// innodbTableName is encoded any special characters are turned into some @0-f0-f0-f value.
+			// Therefore this "#p#" here is a clear indication that we are looking at a partitioned table.
+			// We turn `my@002ddb/tbl_part#p#p0` into `my@002ddb/tbl_part`
+			// and aggregate the total partition sizes.
+			if _, ok := innodbTablesStats[originalTableName]; !ok {
+				innodbTablesStats[originalTableName] = &Table{}
+			}
+			originalTable := innodbTablesStats[originalTableName]
+			originalTable.FileSize += fileSize
+			originalTable.AllocatedSize += allocatedSize
+		}
+	}
+	// See testing in TestEngineReload
+	return innodbTablesStats, nil
+}
+
 // reload reloads the schema. It can also be used to initialize it.
 func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 	start := time.Now()
@@ -445,51 +489,16 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 
 	var innodbTablesStats map[string]*Table
 	if includeStats {
-		if innodbTableSizesQuery := conn.Conn.BaseShowInnodbTableSizes(); innodbTableSizesQuery != "" {
-			// Since the InnoDB table size query is available to us on this MySQL version, we should use it.
-			// We therefore don't want to query for table sizes in getTableData()
-			includeStats = false
-
-			innodbResults, err := conn.Conn.Exec(ctx, innodbTableSizesQuery, maxTableCount*maxPartitionsPerTable, false)
-			if err != nil {
-				return vterrors.Wrapf(err, "in Engine.reload(), reading innodb tables")
-			}
-			innodbTablesStats = make(map[string]*Table, len(innodbResults.Rows))
-			for _, row := range innodbResults.Rows {
-				innodbTableName := row[0].ToString() // In the form of encoded `schema/table`
-				fileSize, _ := row[1].ToCastUint64()
-				allocatedSize, _ := row[2].ToCastUint64()
-
-				if _, ok := innodbTablesStats[innodbTableName]; !ok {
-					innodbTablesStats[innodbTableName] = &Table{}
-				}
-				// There could be multiple appearances of the same table in the result set:
-				// A table that has FULLTEXT indexes will appear once for the table itself,
-				// with total size of row data, and once for the aggregates size of all
-				// FULLTEXT indexes. We aggregate the sizes of all appearances of the same table.
-				table := innodbTablesStats[innodbTableName]
-				table.FileSize += fileSize
-				table.AllocatedSize += allocatedSize
-
-				if originalTableName, _, found := strings.Cut(innodbTableName, "#p#"); found {
-					// innodbTableName is encoded any special characters are turned into some @0-f0-f0-f value.
-					// Therefore this "#p#" here is a clear indication that we are looking at a partitioned table.
-					// We turn `my@002ddb/tbl_part#p#p0` into `my@002ddb/tbl_part`
-					// and aggregate the total partition sizes.
-					if _, ok := innodbTablesStats[originalTableName]; !ok {
-						innodbTablesStats[originalTableName] = &Table{}
-						originalTable := innodbTablesStats[originalTableName]
-						originalTable.FileSize += fileSize
-						originalTable.AllocatedSize += allocatedSize
-					}
-				}
-			}
-			if err := se.updateTableIndexMetrics(ctx, conn.Conn); err != nil {
-				log.Errorf("Updating index/table statistics failed, error: %v", err)
-			}
-			// See testing in TestEngineReload
+		if innodbTablesStats, err = populateInnoDBStats(ctx, conn.Conn); err != nil {
+			return err
 		}
+		// Since the InnoDB table size query is available to us on this MySQL version, we should use it.
+		// We therefore don't want to query for table sizes in getTableData()
+		includeStats = false
 
+		if err := se.updateTableIndexMetrics(ctx, conn.Conn); err != nil {
+			log.Errorf("Updating index/table statistics failed, error: %v", err)
+		}
 	}
 	tableData, err := getTableData(ctx, conn.Conn, includeStats)
 	if err != nil {


### PR DESCRIPTION

## Description

Fixes a bug where table size computation over a partitioned table only evaluates the size of the first partition, instead of the sum sizes of all partitions.

See https://github.com/vitessio/vitess/issues/18057 for details.

I refactored a block of code into its own function. But to clarify, this is the only change that was done. From:

```golang
			if _, ok := innodbTablesStats[originalTableName]; !ok {
				innodbTablesStats[originalTableName] = &Table{}
				originalTable := innodbTablesStats[originalTableName]
				originalTable.FileSize += fileSize
				originalTable.AllocatedSize += allocatedSize
			}
```

to:
```golang
			if _, ok := innodbTablesStats[originalTableName]; !ok {
				innodbTablesStats[originalTableName] = &Table{}
			}
			originalTable := innodbTablesStats[originalTableName]
			originalTable.FileSize += fileSize
			originalTable.AllocatedSize += allocatedSize
```

Added testing that validate size computation for partitioned tables.


## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/18057

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
