### PR TITLE
Add deployment strategy to vtgate in `operator.yaml`

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -1430,6 +1430,24 @@ spec:
                       type: object
                     sidecarContainers:
                       x-kubernetes-preserve-unknown-fields: true
+                    strategy:
+                      properties:
+                        rollingUpdate:
+                          properties:
+                            maxSurge:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          type: string
+                      type: object
                     terminationGracePeriodSeconds:
                       format: int64
                       type: integer
@@ -2811,6 +2829,24 @@ spec:
                             type: object
                           sidecarContainers:
                             x-kubernetes-preserve-unknown-fields: true
+                          strategy:
+                            properties:
+                              rollingUpdate:
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                type: string
+                            type: object
                           terminationGracePeriodSeconds:
                             format: int64
                             type: integer


### PR DESCRIPTION
## Description

This PR is a follow-up of https://github.com/planetscale/vitess-operator/pull/676, where I am porting the changes made to the default operator.yaml file we provide.

The orignal PR allows end-users to define a rolling update strategy for the vtgate deployment.