### PR TITLE
Skip Field Query for Views During Schema Refresh to Improve Reload Time

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -42,7 +42,6 @@ import (
 	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
-	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sidecardb"
@@ -599,10 +598,6 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 		tableType := row[1].String()
 		table, err := LoadTable(conn, se.cp.DBName(), tableName, tableType, row[3].ToString(), se.env.Environment().CollationEnv())
 		if err != nil {
-			if isView := strings.Contains(tableType, tmutils.TableView); isView {
-				log.Warningf("Failed reading schema for the view: %s, error: %v", tableName, err)
-				continue
-			}
 			// Non recoverable error:
 			rec.RecordError(vterrors.Wrapf(err, "in Engine.reload(), reading table %s", tableName))
 			continue

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -37,7 +37,6 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/mysql/replication"
-	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/test/utils"
@@ -730,7 +729,8 @@ func TestOpenFailedDueToExecErr(t *testing.T) {
 	}
 }
 
-// TestOpenFailedDueToLoadTableErr tests that schema engine load should not fail instead should log the failures.
+// TestOpenFailedDueToLoadTableErr tests that schema engine load should fail for test_table and
+// No field query is expected to be executed for view i.e. test_view.
 func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	tl := syslogger.NewTestLogger()
 	defer tl.Close()
@@ -747,58 +747,11 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	// this will cause NewTable error, as it expects zero rows.
 	db.MockQueriesForTable("test_table", sqltypes.MakeTestResult(sqltypes.MakeTestFields("foo", "varchar"), ""))
 
-	// adding column query for table_view
-	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "test_view"),
-		sqltypes.MakeTestResult(sqltypes.MakeTestFields("column_name", "varchar"), ""))
-	// rejecting the impossible query
-	db.AddRejectedQuery("SELECT * FROM `fakesqldb`.`test_view` WHERE 1 != 1", sqlerror.NewSQLErrorFromError(errors.New("The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")))
-
 	AddFakeInnoDBReadRowsResult(db, 0)
 	se := newEngine(1*time.Second, 1*time.Second, 0, db, nil)
 	err := se.Open()
 	// failed load should return an error because of test_table
 	assert.ErrorContains(t, err, "Row count exceeded")
-
-	logs := tl.GetAllLogs()
-	logOutput := strings.Join(logs, ":::")
-	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the view: test_view")
-	assert.Contains(t, logOutput, "The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")
-}
-
-// TestOpenNoErrorDueToInvalidViews tests that schema engine load does not fail instead should log the failures for the views
-func TestOpenNoErrorDueToInvalidViews(t *testing.T) {
-	tl := syslogger.NewTestLogger()
-	defer tl.Close()
-	db := fakesqldb.New(t)
-	defer db.Close()
-	schematest.AddDefaultQueries(db)
-	db.AddQuery(mysql.BaseShowTables, &sqltypes.Result{
-		Fields: mysql.BaseShowTablesFields,
-		Rows: [][]sqltypes.Value{
-			mysql.BaseShowTablesWithSizesRow("foo_view", true, "VIEW"),
-			mysql.BaseShowTablesWithSizesRow("bar_view", true, "VIEW"),
-		},
-	})
-
-	// adding column query for table_view
-	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "foo_view"),
-		&sqltypes.Result{})
-	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "bar_view"),
-		sqltypes.MakeTestResult(sqltypes.MakeTestFields("column_name", "varchar"), "col1", "col2"))
-	// rejecting the impossible query
-	db.AddRejectedQuery("SELECT `col1`, `col2` FROM `fakesqldb`.`bar_view` WHERE 1 != 1", sqlerror.NewSQLError(sqlerror.ERWrongFieldWithGroup, sqlerror.SSClientError, "random error for table bar_view"))
-
-	AddFakeInnoDBReadRowsResult(db, 0)
-	se := newEngine(1*time.Second, 1*time.Second, 0, db, nil)
-	err := se.Open()
-	require.NoError(t, err)
-
-	logs := tl.GetAllLogs()
-	logOutput := strings.Join(logs, ":::")
-	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the view: foo_view")
-	assert.Contains(t, logOutput, "unable to get columns for table fakesqldb.foo_view")
-	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the view: bar_view")
-	assert.Contains(t, logOutput, "random error for table bar_view")
 }
 
 func TestExportVars(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -36,6 +36,10 @@ import (
 // LoadTable creates a Table from the schema info in the database.
 func LoadTable(conn *connpool.PooledConn, databaseName, tableName, tableType string, comment string, collationEnv *collations.Environment) (*Table, error) {
 	ta := NewTable(tableName, NoType)
+	if strings.Contains(tableType, tmutils.TableView) {
+		ta.Type = View
+		return ta, nil
+	}
 	sqlTableName := sqlparser.String(ta.Name)
 	if err := fetchColumns(ta, conn, databaseName, sqlTableName); err != nil {
 		return nil, err
@@ -49,8 +53,6 @@ func LoadTable(conn *connpool.PooledConn, databaseName, tableName, tableType str
 			return nil, err
 		}
 		ta.Type = Message
-	case strings.Contains(tableType, tmutils.TableView):
-		ta.Type = View
 	}
 	return ta, nil
 }

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -70,17 +70,8 @@ func TestLoadView(t *testing.T) {
 	want := &Table{
 		Name: sqlparser.NewIdentifierCS("test_table"),
 		Type: View,
-		Fields: []*querypb.Field{{
-			Name: "pk",
-			Type: sqltypes.Int32,
-		}, {
-			Name: "name",
-			Type: sqltypes.Int32,
-		}, {
-			Name: "addr",
-			Type: sqltypes.Int32,
-		}},
 	}
+	// empty fields
 	assert.Equal(t, want, table)
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

During schema refresh, Vitess loads field information by executing an impossible query (SELECT * FROM <table_name> WHERE 1 != 1), which is used by other components.
However, this information is irrelevant for views, as it is not consumed by any part of Vitess.

This PR skips the execution of this query for views, improving schema reload time, especially for complex views that take longer to process. By avoiding unnecessary queries, it optimizes the performance of the schema engine.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/18051

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
