### PR TITLE
Add Deferred Optimization Execution Metric

### DIFF
--- a/go/test/vschemawrapper/vschema_wrapper.go
+++ b/go/test/vschemawrapper/vschema_wrapper.go
@@ -69,7 +69,7 @@ func NewVschemaWrapper(
 		Collation:         env.CollationEnv().DefaultConnectionCharset(),
 		DefaultTabletType: topodatapb.TabletType_PRIMARY,
 		SetVarEnabled:     true,
-	})
+	}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -33,6 +33,10 @@ import (
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -42,11 +46,6 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/logstats"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
-
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
-	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
 func (vte *VTExplain) initVtgateExecutor(ctx context.Context, ts *topo.Server, vSchemaStr, ksShardMapStr string, opts *Options, srvTopoCounts *stats.CountersWithSingleLabel) error {
@@ -75,6 +74,7 @@ func (vte *VTExplain) initVtgateExecutor(ctx context.Context, ts *topo.Server, v
 	queryLogBufferSize := 10
 	plans := theine.NewStore[vtgate.PlanCacheKey, *engine.Plan](4*1024*1024, false)
 	eConfig := vtgate.ExecutorConfig{
+		Name:         "TestExecutor",
 		Normalize:    opts.Normalize,
 		StreamSize:   streamSize,
 		AllowScatter: true,

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -61,6 +61,10 @@ type noopVCursor struct {
 	inTx bool
 }
 
+func (t *noopVCursor) GetExecutionMetrics() *Metrics {
+	panic("implement me")
+}
+
 func (t *noopVCursor) SetExecQueryTimeout(timeout *int) {
 	panic("implement me")
 }
@@ -467,6 +471,12 @@ type loggingVCursor struct {
 	onExecuteMultiShardFn  func(context.Context, Primitive, []*srvtopo.ResolvedShard, []*querypb.BoundQuery, bool, bool)
 	onStreamExecuteMultiFn func(context.Context, Primitive, string, []*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, bool, bool, func(*sqltypes.Result) error)
 	onRecordMirrorStatsFn  func(time.Duration, time.Duration, error)
+
+	metrics *Metrics
+}
+
+func (f *loggingVCursor) GetExecutionMetrics() *Metrics {
+	return f.metrics
 }
 
 func (f *loggingVCursor) HasCreatedTempTable() {

--- a/go/vt/vtgate/engine/metrics.go
+++ b/go/vt/vtgate/engine/metrics.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"sync"
+
+	"vitess.io/vitess/go/stats"
+)
+
+type Metrics struct {
+	optimizedQueryExec *stats.CountersWithSingleLabel
+}
+
+// TODO (fix it): This is a temporary solution to avoid multiple registry of metric counter in test.
+var defaultMetric = &Metrics{}
+var once sync.Once
+
+func InitializeMetrics() *Metrics {
+	once.Do(func() {
+		defaultMetric.optimizedQueryExec = stats.NewCountersWithSingleLabel("OptimizedQueryExecutions", "Counts optimized queries executed at VTGate by plan type.", "Plan")
+	})
+	return defaultMetric
+}

--- a/go/vt/vtgate/engine/metrics.go
+++ b/go/vt/vtgate/engine/metrics.go
@@ -27,6 +27,6 @@ type Metrics struct {
 
 func InitMetrics(exporter *servenv.Exporter) *Metrics {
 	return &Metrics{
-		optimizedQueryExec: exporter.NewCountersWithSingleLabel("OptimizedQueryExec", "Number of optimized query execution", "Operation"),
+		optimizedQueryExec: exporter.NewCountersWithSingleLabel("OptimizedQueryExecutions", "Counts optimized queries executed at VTGate by plan type.", "Plan"),
 	}
 }

--- a/go/vt/vtgate/engine/metrics.go
+++ b/go/vt/vtgate/engine/metrics.go
@@ -17,22 +17,16 @@ limitations under the License.
 package engine
 
 import (
-	"sync"
-
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 type Metrics struct {
 	optimizedQueryExec *stats.CountersWithSingleLabel
 }
 
-// TODO (fix it): This is a temporary solution to avoid multiple registry of metric counter in test.
-var defaultMetric = &Metrics{}
-var once sync.Once
-
-func InitializeMetrics() *Metrics {
-	once.Do(func() {
-		defaultMetric.optimizedQueryExec = stats.NewCountersWithSingleLabel("OptimizedQueryExecutions", "Counts optimized queries executed at VTGate by plan type.", "Plan")
-	})
-	return defaultMetric
+func InitMetrics(exporter *servenv.Exporter) *Metrics {
+	return &Metrics{
+		optimizedQueryExec: exporter.NewCountersWithSingleLabel("OptimizedQueryExec", "Number of optimized query execution", "Operation"),
+	}
 }

--- a/go/vt/vtgate/engine/plan_switcher_test.go
+++ b/go/vt/vtgate/engine/plan_switcher_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 // TestPlanSwitcherMetrics tests that the PlanSwitcher increments the correct metric
@@ -30,7 +32,7 @@ func TestPlanSwitcherMetrics(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{
-		metrics: InitializeMetrics(),
+		metrics: InitMetrics(servenv.NewExporter("PlanTest", "")),
 	}
 	initial := vc.metrics.optimizedQueryExec.Counts()
 	_, err := p.TryExecute(context.Background(), vc, nil, false)

--- a/go/vt/vtgate/engine/plan_switcher_test.go
+++ b/go/vt/vtgate/engine/plan_switcher_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlanSwitcherMetrics tests that the PlanSwitcher increments the correct metric
+func TestPlanSwitcherMetrics(t *testing.T) {
+	p := &PlanSwitcher{
+		Optimized: &TransactionStatus{},
+	}
+
+	vc := &loggingVCursor{
+		metrics: InitializeMetrics(),
+	}
+	initial := vc.metrics.optimizedQueryExec.Counts()
+	_, err := p.TryExecute(context.Background(), vc, nil, false)
+	require.NoError(t, err)
+	after := vc.metrics.optimizedQueryExec.Counts()
+	require.EqualValues(t, 1, after["MultiShard"]-initial["MultiShard"])
+}

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -149,6 +149,8 @@ type (
 		RecordMirrorStats(time.Duration, time.Duration, error)
 
 		SetLastInsertID(uint64)
+
+		GetExecutionMetrics() *Metrics
 	}
 
 	// SessionActions gives primitives ability to interact with the session state

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -128,7 +128,7 @@ type (
 		resolver    *Resolver
 		scatterConn *ScatterConn
 		txConn      *TxConn
-		metrics     *Metrics
+		metrics     econtext.Metrics
 
 		mu           sync.Mutex
 		vschema      *vindexes.VSchema
@@ -1172,7 +1172,7 @@ func (e *Executor) fetchOrCreatePlan(
 }
 
 func (e *Executor) newVCursor(safeSession *econtext.SafeSession, comments sqlparser.MarginComments, logStats *logstats.LogStats) (*econtext.VCursorImpl, error) {
-	return econtext.NewVCursorImpl(safeSession, comments, e, logStats, e.vm, e.VSchema(), e.resolver.resolver, e.serv, nullResultsObserver{}, e.vConfig, nil)
+	return econtext.NewVCursorImpl(safeSession, comments, e, logStats, e.vm, e.VSchema(), e.resolver.resolver, e.serv, nullResultsObserver{}, e.vConfig, e.metrics)
 }
 
 func (e *Executor) tryOptimizedPlan(
@@ -1812,4 +1812,8 @@ func fkMode(foreignkey string) vschemapb.Keyspace_ForeignKeyMode {
 
 	}
 	return vschemapb.Keyspace_unspecified
+}
+
+func (m *Metrics) GetExecutionMetrics() *engine.Metrics {
+	return m.engineMetrics
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -111,6 +111,7 @@ func init() {
 // the abilities of the underlying vttablets.
 type (
 	ExecutorConfig struct {
+		Name       string
 		Normalize  bool
 		StreamSize int
 		// AllowScatter will fail planning if set to false and a plan contains any scatter queries
@@ -120,7 +121,8 @@ type (
 	}
 
 	Executor struct {
-		config ExecutorConfig
+		config   ExecutorConfig
+		exporter *servenv.Exporter
 
 		env         *vtenv.Environment
 		serv        srvtopo.Server
@@ -185,6 +187,7 @@ func NewExecutor(
 ) *Executor {
 	e := &Executor{
 		config:      eConfig,
+		exporter:    servenv.NewExporter(eConfig.Name, ""),
 		env:         env,
 		serv:        serv,
 		cell:        cell,
@@ -200,7 +203,7 @@ func NewExecutor(
 	// setting the vcursor config.
 	e.initVConfig(warnOnShardedOnly, pv)
 	e.metrics = &Metrics{
-		engineMetrics: engine.InitializeMetrics(),
+		engineMetrics: engine.InitMetrics(e.exporter),
 	}
 
 	// we subscribe to update from the VSchemaManager

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
-
 	"vitess.io/vitess/go/cache/theine"
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/sqltypes"
@@ -45,6 +43,7 @@ import (
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
 	"vitess.io/vitess/go/vt/vtgate/logstats"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 	"vitess.io/vitess/go/vt/vttablet/sandboxconn"
@@ -245,6 +244,7 @@ func createCustomExecutor(t testing.TB, vschema string, mysqlVersion string) (ex
 
 func createExecutorConfig() ExecutorConfig {
 	return ExecutorConfig{
+		Name:         "TestExecutor",
 		StreamSize:   10,
 		AllowScatter: true,
 	}
@@ -252,6 +252,7 @@ func createExecutorConfig() ExecutorConfig {
 
 func createExecutorConfigWithNormalizer() ExecutorConfig {
 	return ExecutorConfig{
+		Name:         "TestExecutor",
 		StreamSize:   10,
 		AllowScatter: true,
 		Normalize:    true,

--- a/go/vt/vtgate/executor_plan_test.go
+++ b/go/vt/vtgate/executor_plan_test.go
@@ -119,9 +119,7 @@ func TestDeferredOptimization(t *testing.T) {
 
 	resolver := newTestResolver(ctx, nil, nil, "")
 	executor := Executor{
-		config: ExecutorConfig{
-			AllowScatter: true,
-		},
+		config:      createExecutorConfig(),
 		env:         env,
 		resolver:    resolver,
 		vschema:     vindexes.BuildVSchema(result, parser),

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -28,8 +28,6 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
 
-	"vitess.io/vitess/go/vt/sysvars"
-
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/mysql/config"
 	"vitess.io/vitess/go/mysql/sqlerror"
@@ -47,6 +45,7 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/sysvars"
 	"vitess.io/vitess/go/vt/topo"
 	topoprotopb "vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools"
@@ -145,6 +144,10 @@ type (
 		) ([]*srvtopo.ResolvedShard, [][][]sqltypes.Value, error)
 	}
 
+	Metrics interface {
+		GetExecutionMetrics() *engine.Metrics
+	}
+
 	// VCursorImpl implements the VCursor functionality used by dependent
 	// packages to call back into VTGate.
 	VCursorImpl struct {
@@ -158,6 +161,7 @@ type (
 		resolver       Resolver
 		topoServer     *topo.Server
 		logStats       *logstats.LogStats
+		metrics        Metrics
 
 		// fkChecksState stores the state of foreign key checks variable.
 		// This state is meant to be the final fk checks state after consulting the
@@ -201,6 +205,7 @@ func NewVCursorImpl(
 	serv srvtopo.Server,
 	observer ResultsObserver,
 	cfg VCursorConfig,
+	metrics Metrics,
 ) (*VCursorImpl, error) {
 	keyspace, tabletType, destination, err := ParseDestinationTarget(safeSession.TargetString, cfg.DefaultTabletType, vschema)
 	if err != nil {
@@ -226,12 +231,13 @@ func NewVCursorImpl(
 		marginComments: marginComments,
 		executor:       executor,
 		logStats:       logStats,
-		resolver:       resolver,
-		vschema:        vschema,
-		vm:             vm,
-		topoServer:     ts,
+		metrics:        metrics,
 
-		observer: observer,
+		resolver:   resolver,
+		vschema:    vschema,
+		vm:         vm,
+		topoServer: ts,
+		observer:   observer,
 	}, nil
 }
 
@@ -262,16 +268,18 @@ func (vc *VCursorImpl) CloneForMirroring(ctx context.Context) engine.VCursor {
 	clonedCtx := callerid.NewContext(ctx, callerId, immediateCallerId)
 
 	v := &VCursorImpl{
-		config:              vc.config,
-		SafeSession:         NewAutocommitSession(vc.SafeSession.Session),
-		keyspace:            vc.keyspace,
-		tabletType:          vc.tabletType,
-		destination:         vc.destination,
-		marginComments:      vc.marginComments,
-		executor:            vc.executor,
-		resolver:            vc.resolver,
-		topoServer:          vc.topoServer,
-		logStats:            &logstats.LogStats{Ctx: clonedCtx},
+		config:         vc.config,
+		SafeSession:    NewAutocommitSession(vc.SafeSession.Session),
+		keyspace:       vc.keyspace,
+		tabletType:     vc.tabletType,
+		destination:    vc.destination,
+		marginComments: vc.marginComments,
+		executor:       vc.executor,
+		resolver:       vc.resolver,
+		topoServer:     vc.topoServer,
+		logStats:       &logstats.LogStats{Ctx: clonedCtx},
+		metrics:        vc.metrics,
+
 		ignoreMaxMemoryRows: vc.ignoreMaxMemoryRows,
 		vschema:             vc.vschema,
 		vm:                  vc.vm,
@@ -303,6 +311,7 @@ func (vc *VCursorImpl) CloneForReplicaWarming(ctx context.Context) engine.VCurso
 		resolver:       vc.resolver,
 		topoServer:     vc.topoServer,
 		logStats:       &logstats.LogStats{Ctx: clonedCtx},
+		metrics:        vc.metrics,
 
 		ignoreMaxMemoryRows: vc.ignoreMaxMemoryRows,
 		vschema:             vc.vschema,
@@ -328,12 +337,19 @@ func (vc *VCursorImpl) cloneWithAutocommitSession() *VCursorImpl {
 		marginComments: vc.marginComments,
 		executor:       vc.executor,
 		logStats:       vc.logStats,
-		resolver:       vc.resolver,
-		vschema:        vc.vschema,
-		vm:             vc.vm,
-		topoServer:     vc.topoServer,
-		observer:       vc.observer,
+		metrics:        vc.metrics,
+
+		resolver:   vc.resolver,
+		vschema:    vc.vschema,
+		vm:         vc.vm,
+		topoServer: vc.topoServer,
+		observer:   vc.observer,
 	}
+}
+
+// GetExecutionMetrics provides the execution metrics object.
+func (vc *VCursorImpl) GetExecutionMetrics() *engine.Metrics {
+	return vc.metrics.GetExecutionMetrics()
 }
 
 // HasSystemVariables returns whether the session has set system variables or not

--- a/go/vt/vtgate/executorcontext/vcursor_impl_test.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl_test.go
@@ -174,7 +174,7 @@ func TestDestinationKeyspace(t *testing.T) {
 				&fakeVSchemaOperator{vschema: tc.vschema}, tc.vschema, nil, nil,
 				fakeObserver{}, VCursorConfig{
 					DefaultTabletType: topodatapb.TabletType_PRIMARY,
-				})
+				}, nil)
 			impl.vschema = tc.vschema
 			dest, keyspace, tabletType, err := impl.TargetDestination(tc.qualifier)
 			if tc.expectedError == "" {
@@ -232,7 +232,7 @@ func TestSetTarget(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d#%s", i, tc.targetString), func(t *testing.T) {
 			cfg := VCursorConfig{DefaultTabletType: topodatapb.TabletType_PRIMARY}
-			vc, _ := NewVCursorImpl(NewSafeSession(&vtgatepb.Session{InTransaction: true}), sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: tc.vschema}, tc.vschema, nil, nil, fakeObserver{}, cfg)
+			vc, _ := NewVCursorImpl(NewSafeSession(&vtgatepb.Session{InTransaction: true}), sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: tc.vschema}, tc.vschema, nil, nil, fakeObserver{}, cfg, nil)
 			vc.vschema = tc.vschema
 			err := vc.SetTarget(tc.targetString)
 			if tc.expectedError == "" {
@@ -257,7 +257,7 @@ func TestFirstSortedKeyspace(t *testing.T) {
 		},
 	}
 
-	vc, err := NewVCursorImpl(NewSafeSession(nil), sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: vschemaWith2KS}, vschemaWith2KS, srvtopo.NewResolver(&FakeTopoServer{}, nil, ""), nil, fakeObserver{}, VCursorConfig{})
+	vc, err := NewVCursorImpl(NewSafeSession(nil), sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: vschemaWith2KS}, vschemaWith2KS, srvtopo.NewResolver(&FakeTopoServer{}, nil, ""), nil, fakeObserver{}, VCursorConfig{}, nil)
 	require.NoError(t, err)
 	ks, err := vc.FirstSortedKeyspace()
 	require.NoError(t, err)
@@ -271,7 +271,7 @@ func TestSetExecQueryTimeout(t *testing.T) {
 	vc, err := NewVCursorImpl(safeSession, sqlparser.MarginComments{}, nil, nil, nil, &vindexes.VSchema{}, nil, nil, fakeObserver{}, VCursorConfig{
 		// flag timeout
 		QueryTimeout: 20,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	vc.SetExecQueryTimeout(nil)
@@ -312,7 +312,7 @@ func TestSetExecQueryTimeout(t *testing.T) {
 func TestRecordMirrorStats(t *testing.T) {
 	safeSession := NewSafeSession(nil)
 	logStats := logstats.NewLogStats(context.Background(), t.Name(), "select 1", "", nil, streamlog.NewQueryLogConfigForTest())
-	vc, err := NewVCursorImpl(safeSession, sqlparser.MarginComments{}, nil, logStats, nil, &vindexes.VSchema{}, nil, nil, fakeObserver{}, VCursorConfig{})
+	vc, err := NewVCursorImpl(safeSession, sqlparser.MarginComments{}, nil, logStats, nil, &vindexes.VSchema{}, nil, nil, fakeObserver{}, VCursorConfig{}, nil)
 	require.NoError(t, err)
 
 	require.Zero(t, logStats.MirrorSourceExecuteTime)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR introduces a new metric to track the execution of Deferred Optimization in Vitess. Deferred Optimization enhances query planning by generating a more efficient plan during the first execution of a prepared statement.
The new metric helps monitor how often queries leverage this feature, providing insights into its impact.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- https://github.com/vitessio/vitess/pull/17992
- https://github.com/vitessio/vitess/issues/17840

## Checklist

-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
