### PR TITLE
Fix `SHOW VITESS_SHARDS` bug that led to incomplete output

### DIFF
--- a/go/vt/srvtopo/fakesrvtopo/fakesrvtopo.go
+++ b/go/vt/srvtopo/fakesrvtopo/fakesrvtopo.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fakesrvtopo
+
+import (
+	"context"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/topo"
+)
+
+type FakeSrvTopo struct {
+	Ts                     *topo.Server
+	SrvKeyspaceNamesOutput map[string][]string
+	SrvKeyspaceNamesError  map[string]error
+	SrvKeyspaceOutput      map[string]map[string]*topodatapb.SrvKeyspace
+	SrvKeyspaceError       map[string]map[string]error
+}
+
+func (f *FakeSrvTopo) GetTopoServer() (*topo.Server, error) {
+	return f.Ts, nil
+}
+
+func (f *FakeSrvTopo) GetSrvKeyspaceNames(ctx context.Context, cell string, staleOK bool) ([]string, error) {
+	if f.SrvKeyspaceNamesError != nil && f.SrvKeyspaceNamesError[cell] != nil {
+		return nil, f.SrvKeyspaceNamesError[cell]
+	}
+	if f.SrvKeyspaceNamesOutput == nil {
+		return nil, nil
+	}
+	return f.SrvKeyspaceNamesOutput[cell], nil
+}
+
+func (f *FakeSrvTopo) GetSrvKeyspace(ctx context.Context, cell, keyspace string) (*topodatapb.SrvKeyspace, error) {
+	if f.SrvKeyspaceError != nil && f.SrvKeyspaceError[cell] != nil && f.SrvKeyspaceError[cell][keyspace] != nil {
+		return nil, f.SrvKeyspaceError[cell][keyspace]
+	}
+	if f.SrvKeyspaceOutput == nil || f.SrvKeyspaceOutput[cell] == nil {
+		return nil, nil
+	}
+	return f.SrvKeyspaceOutput[cell][keyspace], nil
+}
+
+func (f *FakeSrvTopo) WatchSrvKeyspace(ctx context.Context, cell, keyspace string, callback func(*topodatapb.SrvKeyspace, error) bool) {
+	panic("unsupported in FakeSrvTopo")
+}
+
+func (f *FakeSrvTopo) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error) bool) {
+	panic("unsupported in FakeSrvTopo")
+}

--- a/go/vt/srvtopo/resolver.go
+++ b/go/vt/srvtopo/resolver.go
@@ -106,7 +106,7 @@ func (r *Resolver) GetKeyspaceShards(ctx context.Context, keyspace string, table
 
 	partition := topoproto.SrvKeyspaceGetPartition(srvKeyspace, tabletType)
 	if partition == nil {
-		return "", nil, nil, vterrors.Errorf(vtrpcpb.Code_UNKNOWN, "No partition found for tabletType %v in keyspace %v", topoproto.TabletTypeLString(tabletType), keyspace)
+		return "", nil, nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "No partition found for tabletType %v in keyspace %v", topoproto.TabletTypeLString(tabletType), keyspace)
 	}
 	return keyspace, srvKeyspace, partition.ShardReferences, nil
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -849,10 +849,10 @@ func (e *Executor) ShowShards(ctx context.Context, filter *sqlparser.ShowFilter,
 		}
 
 		_, _, shards, err := e.resolver.resolver.GetKeyspaceShards(ctx, keyspace, destTabletType)
-		if err != nil {
-			// There might be a misconfigured keyspace or no shards in the keyspace.
-			// Skip any errors and move on.
-			continue
+		if err != nil && vterrors.Code(err) != vtrpcpb.Code_INVALID_ARGUMENT {
+			// We only ignore invalid argument errors, as they mean the keyspace
+			// doesn't have any shards for the given tablet type.
+			return nil, err
 		}
 
 		for _, shard := range shards {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -31,9 +31,6 @@ import (
 	"time"
 	"unsafe"
 
-	"vitess.io/vitess/go/vt/key"
-	"vitess.io/vitess/go/vt/srvtopo"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/safehtml/template"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +38,9 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/streamlog"
+	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/srvtopo/fakesrvtopo"
 
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
 
@@ -3064,4 +3064,311 @@ func exec(executor *Executor, session *econtext.SafeSession, sql string) (*sqlty
 
 func makeComments(text string) sqlparser.MarginComments {
 	return sqlparser.MarginComments{Trailing: text}
+}
+
+// TestExecutorShowShards tests the show shards statement on executor.
+func TestExecutorShowShards(t *testing.T) {
+	localCell := "cell1"
+	tests := []struct {
+		name           string
+		filter         *sqlparser.ShowFilter
+		destTabletType topodatapb.TabletType
+		srvTopoServer  srvtopo.Server
+		want           *sqltypes.Result
+		wantErr        string
+	}{
+		{
+			name:           "No keyspaces",
+			srvTopoServer:  &fakesrvtopo.FakeSrvTopo{},
+			filter:         nil,
+			destTabletType: topodatapb.TabletType_PRIMARY,
+			want: &sqltypes.Result{
+				Fields: buildVarCharFields("Shards"),
+				Rows:   nil,
+			},
+		}, {
+			name: "No filtering",
+			srvTopoServer: &fakesrvtopo.FakeSrvTopo{
+				SrvKeyspaceNamesOutput: map[string][]string{
+					localCell: {"ks1", "ks2"},
+				},
+				SrvKeyspaceOutput: map[string]map[string]*topodatapb.SrvKeyspace{
+					localCell: {
+						"ks1": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+						"ks2": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-40"},
+										{Name: "40-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filter:         nil,
+			destTabletType: topodatapb.TabletType_PRIMARY,
+			want: &sqltypes.Result{
+				Fields: buildVarCharFields("Shards"),
+				Rows: []sqltypes.Row{
+					buildVarCharRow("ks1/-80"),
+					buildVarCharRow("ks1/80-"),
+					buildVarCharRow("ks2/-40"),
+					buildVarCharRow("ks2/40-80"),
+					buildVarCharRow("ks2/80-"),
+				},
+			},
+		},
+		{
+			name: "Keyspace filtering",
+			srvTopoServer: &fakesrvtopo.FakeSrvTopo{
+				SrvKeyspaceNamesOutput: map[string][]string{
+					localCell: {"ks1", "ks2"},
+				},
+				SrvKeyspaceOutput: map[string]map[string]*topodatapb.SrvKeyspace{
+					localCell: {
+						"ks1": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+						"ks2": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-40"},
+										{Name: "40-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filter: &sqlparser.ShowFilter{
+				Like: "ks1%",
+			},
+			destTabletType: topodatapb.TabletType_PRIMARY,
+			want: &sqltypes.Result{
+				Fields: buildVarCharFields("Shards"),
+				Rows: []sqltypes.Row{
+					buildVarCharRow("ks1/-80"),
+					buildVarCharRow("ks1/80-"),
+				},
+			},
+		}, {
+			name: "Shard filtering",
+			srvTopoServer: &fakesrvtopo.FakeSrvTopo{
+				SrvKeyspaceNamesOutput: map[string][]string{
+					localCell: {"ks1", "ks2"},
+				},
+				SrvKeyspaceOutput: map[string]map[string]*topodatapb.SrvKeyspace{
+					localCell: {
+						"ks1": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+						"ks2": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-40"},
+										{Name: "40-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filter: &sqlparser.ShowFilter{
+				Like: "%80-",
+			},
+			destTabletType: topodatapb.TabletType_PRIMARY,
+			want: &sqltypes.Result{
+				Fields: buildVarCharFields("Shards"),
+				Rows: []sqltypes.Row{
+					buildVarCharRow("ks1/80-"),
+					buildVarCharRow("ks2/80-"),
+				},
+			},
+		},
+		{
+			name: "Keyspace and Shard filtering",
+			srvTopoServer: &fakesrvtopo.FakeSrvTopo{
+				SrvKeyspaceNamesOutput: map[string][]string{
+					localCell: {"ks1", "ks2"},
+				},
+				SrvKeyspaceOutput: map[string]map[string]*topodatapb.SrvKeyspace{
+					localCell: {
+						"ks1": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+						"ks2": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-40"},
+										{Name: "40-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filter: &sqlparser.ShowFilter{
+				Like: "ks1/80-",
+			},
+			destTabletType: topodatapb.TabletType_PRIMARY,
+			want: &sqltypes.Result{
+				Fields: buildVarCharFields("Shards"),
+				Rows: []sqltypes.Row{
+					buildVarCharRow("ks1/80-"),
+				},
+			},
+		},
+		{
+			name: "No shards because of tablet type",
+			srvTopoServer: &fakesrvtopo.FakeSrvTopo{
+				SrvKeyspaceNamesOutput: map[string][]string{
+					localCell: {"ks1", "ks2"},
+				},
+				SrvKeyspaceOutput: map[string]map[string]*topodatapb.SrvKeyspace{
+					localCell: {
+						"ks1": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+						"ks2": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-40"},
+										{Name: "40-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filter: &sqlparser.ShowFilter{
+				Like: "ks1/80-",
+			},
+			destTabletType: topodatapb.TabletType_BACKUP,
+			want: &sqltypes.Result{
+				Fields: buildVarCharFields("Shards"),
+			},
+		},
+		{
+			name: "Error getting keyspace names",
+			srvTopoServer: &fakesrvtopo.FakeSrvTopo{
+				SrvKeyspaceNamesError: map[string]error{
+					localCell: errors.New("testing error getting keyspace names"),
+				},
+			},
+			filter:         nil,
+			destTabletType: topodatapb.TabletType_PRIMARY,
+			wantErr:        "testing error getting keyspace names",
+		},
+		{
+			name: "Error getting keyspace ks1",
+			srvTopoServer: &fakesrvtopo.FakeSrvTopo{
+				SrvKeyspaceNamesOutput: map[string][]string{
+					localCell: {"ks1", "ks2"},
+				},
+				SrvKeyspaceError: map[string]map[string]error{
+					localCell: {
+						"ks1": errors.New("testing error getting keyspace ks1"),
+					},
+				},
+				SrvKeyspaceOutput: map[string]map[string]*topodatapb.SrvKeyspace{
+					localCell: {
+						"ks2": {
+							Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+								{
+									ServedType: topodatapb.TabletType_PRIMARY,
+									ShardReferences: []*topodatapb.ShardReference{
+										{Name: "-40"},
+										{Name: "40-80"},
+										{Name: "80-"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			filter:         nil,
+			destTabletType: topodatapb.TabletType_PRIMARY,
+			wantErr:        "testing error getting keyspace ks1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			e := &Executor{
+				resolver: NewResolver(srvtopo.NewResolver(tt.srvTopoServer, nil, localCell), nil, "", nil),
+			}
+			got, err := e.ShowShards(ctx, tt.filter, tt.destTabletType)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Truef(t, tt.want.Equal(got), "Results got - %v", got)
+		})
+	}
 }

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1075,9 +1075,13 @@ func TestExecutorShow(t *testing.T) {
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
-	// Make sure it still works when one of the keyspaces is in a bad state
+	// Make sure we get an error if one of the keyspaces is in a bad state
 	getSandbox(KsTestSharded).SrvKeyspaceMustFail++
 	query = "show vitess_shards"
+	_, err = executorExecSession(ctx, executor, session, query, nil)
+	require.ErrorContains(t, err, "keyspace TestExecutor fetch error")
+
+	// Running it again should pass
 	qr, err = executorExecSession(ctx, executor, session, query, nil)
 	require.NoError(t, err)
 	// Just test for first & last.
@@ -1085,7 +1089,7 @@ func TestExecutorShow(t *testing.T) {
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Shards"),
 		Rows: [][]sqltypes.Value{
-			buildVarCharRow("TestMultiCol/-20"),
+			buildVarCharRow("TestExecutor/-20"),
 			buildVarCharRow("TestXBadVSchema/e0-"),
 		},
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the issue described in https://github.com/vitessio/vitess/issues/18068. `SHOW VITESS_SHARDS` was ignoring the error from the underlying resilient query in the srvtopo server. This is incorrect and we should only ignore the error coming because of empty results. This PR fixes this problem after having introduced tests to ascertain it.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/18068

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
