### PR TITLE
Add release-22.0 to the golang upgrade workflow

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-21.0, release-20.0 ]
+        branch: [ main, release-22.0, release-21.0, release-20.0 ]
     name: Update Golang Version
     runs-on: ubuntu-24.04
     steps:
@@ -37,9 +37,9 @@ jobs:
           old_go_version=$(go run ./go/tools/go-upgrade/go-upgrade.go get go-version)
           echo "old-go-version=${old_go_version}" >> $GITHUB_OUTPUT
 
-          if [ "${{ matrix.branch }}" == "main" ]; then
+          if [[ "${{ matrix.branch }}" == "main" ]]; then
             go run ./go/tools/go-upgrade/go-upgrade.go upgrade --main --allow-major-upgrade
-          elif [ "${{ matrix.branch }}" == "release-21.0" ]; then
+          elif [[ ("${{ matrix.branch }}" == "release-21.0") || ("${{ matrix.branch }}" == "release-22.0") ]]; then
             go run ./go/tools/go-upgrade/go-upgrade.go upgrade
           else
             go run ./go/tools/go-upgrade/go-upgrade.go upgrade --workflow-update=false


### PR DESCRIPTION
## Description

This is a follow up of the v22 code freeze, adding the new branch to the list of go-upgradeable branches.

Part of https://github.com/vitessio/vitess/issues/18023.