### PR TITLE
Add `topoproto.IsTabletWithinKeyRanges(...)` helper

### DIFF
--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -310,8 +310,8 @@ func IsTabletWithinKeyRanges(tablet *topodatapb.Tablet, keyRanges []*topodatapb.
 
 // IsTabletWithinKeyRangesString returns true if the provided tablet is within a provided string of
 // shard ranges. An error is returned if the shard range spec string cannot be parsed.
-func IsTabletWithinKeyRangesString(tablet *topodatapb.Tablet, keyRangesSpec string) (bool, error) {
-	keyRanges, err := key.ParseShardingSpec(keyRangesSpec)
+func IsTabletWithinKeyRangesString(tablet *topodatapb.Tablet, keyRangesString string) (bool, error) {
+	keyRanges, err := key.ParseShardingSpec(keyRangesString)
 	if err != nil {
 		return false, err
 	}

--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -297,7 +297,7 @@ func IsServingType(tabletType topodatapb.TabletType) bool {
 	}
 }
 
-// IsTabletWithinKeyRanges returns true if the provided tablet is within a slice of key.KeyRange.
+// IsTabletWithinKeyRanges returns true if the provided tablet is within a slice of *topodatapb.KeyRange.
 func IsTabletWithinKeyRanges(tablet *topodatapb.Tablet, keyRanges []*topodatapb.KeyRange) bool {
 	tabletKeyRange := tablet.GetKeyRange()
 	for _, keyRange := range keyRanges {
@@ -309,7 +309,7 @@ func IsTabletWithinKeyRanges(tablet *topodatapb.Tablet, keyRanges []*topodatapb.
 }
 
 // IsTabletWithinKeyRangesString returns true if the provided tablet is within a provided string of
-// shard ranges. An error is returned if the shard range spec string cannot be parsed.
+// one or more shard ranges. An error is returned if the shard range spec string cannot be parsed.
 func IsTabletWithinKeyRangesString(tablet *topodatapb.Tablet, keyRangesString string) (bool, error) {
 	keyRanges, err := key.ParseShardingSpec(keyRangesString)
 	if err != nil {

--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -299,11 +299,21 @@ func IsServingType(tabletType topodatapb.TabletType) bool {
 
 // IsTabletWithinKeyRanges returns true if the provided tablet is within a slice of key.KeyRange.
 func IsTabletWithinKeyRanges(tablet *topodatapb.Tablet, keyRanges []*topodatapb.KeyRange) bool {
-       tabletKeyRange := tablet.GetKeyRange()
-       for _, keyRange := range keyRanges {
-               if key.KeyRangeContainsKeyRange(keyRange, tabletKeyRange) {
-                       return true
-               }
-       }
-       return false
+	tabletKeyRange := tablet.GetKeyRange()
+	for _, keyRange := range keyRanges {
+		if key.KeyRangeContainsKeyRange(keyRange, tabletKeyRange) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTabletWithinKeyRangesString returns true if the provided tablet is within a provided string of
+// shard ranges. An error is returned if the shard range spec string cannot be parsed.
+func IsTabletWithinKeyRangesString(tablet *topodatapb.Tablet, keyRangesSpec string) (bool, error) {
+	keyRanges, err := key.ParseShardingSpec(keyRangesSpec)
+	if err != nil {
+		return false, err
+	}
+	return IsTabletWithinKeyRanges(tablet, keyRanges), nil
 }

--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -30,6 +30,7 @@ import (
 
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/sets"
+	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -294,4 +295,15 @@ func IsServingType(tabletType topodatapb.TabletType) bool {
 	default:
 		return false
 	}
+}
+
+// IsTabletWithinKeyRanges returns true if the provided tablet is within a slice of key.KeyRange.
+func IsTabletWithinKeyRanges(tablet *topodatapb.Tablet, keyRanges []*topodatapb.KeyRange) bool {
+       tabletKeyRange := tablet.GetKeyRange()
+       for _, keyRange := range keyRanges {
+               if key.KeyRangeContainsKeyRange(keyRange, tabletKeyRange) {
+                       return true
+               }
+       }
+       return false
 }

--- a/go/vt/topo/topoproto/tablet_test.go
+++ b/go/vt/topo/topoproto/tablet_test.go
@@ -132,7 +132,7 @@ func TestIsTabletsInList(t *testing.T) {
 	}
 }
 
-func TestIsTabletWithinKeyRanges(t *testing.T) {
+func TestIsTabletWithinKeyRangesString(t *testing.T) {
 	tablet := &topodatapb.Tablet{
 		Keyspace: "ks",
 		KeyRange: key.NewKeyRange([]byte{0x00}, []byte{0x40}),
@@ -140,17 +140,20 @@ func TestIsTabletWithinKeyRanges(t *testing.T) {
 
 	{
 		// match
-		keyRanges := []*topodatapb.KeyRange{
-			key.NewKeyRange([]byte{0x00}, []byte{0x80}),
-		}
-		require.True(t, IsTabletWithinKeyRanges(tablet, keyRanges))
+		found, err := IsTabletWithinKeyRangesString(tablet, "-40")
+		require.NoError(t, err)
+		require.True(t, found)
 	}
 	{
 		// no match
-		keyRanges := []*topodatapb.KeyRange{
-			key.NewKeyRange([]byte{0x80}, []byte{0x90}),
-		}
-		require.False(t, IsTabletWithinKeyRanges(tablet, keyRanges))
-
+		found, err := IsTabletWithinKeyRangesString(tablet, "80-")
+		require.NoError(t, err)
+		require.False(t, found)
+	}
+	{
+		// bad shard spec
+		found, err := IsTabletWithinKeyRangesString(tablet, "!!!won'tparse!!!")
+		require.Error(t, err)
+		require.False(t, found)
 	}
 }

--- a/go/vt/topo/topoproto/tablet_test.go
+++ b/go/vt/topo/topoproto/tablet_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
@@ -127,5 +129,28 @@ func TestIsTabletsInList(t *testing.T) {
 			out := IsTabletInList(testcase.tablet, testcase.allTablets)
 			assert.Equal(t, testcase.isInList, out)
 		})
+	}
+}
+
+func TestIsTabletWithinKeyRanges(t *testing.T) {
+	tablet := &topodatapb.Tablet{
+		Keyspace: "ks",
+		KeyRange: key.NewKeyRange([]byte{0x00}, []byte{0x40}),
+	}
+
+	{
+		// match
+		keyRanges := []*topodatapb.KeyRange{
+			key.NewKeyRange([]byte{0x00}, []byte{0x80}),
+		}
+		require.True(t, IsTabletWithinKeyRanges(tablet, keyRanges))
+	}
+	{
+		// no match
+		keyRanges := []*topodatapb.KeyRange{
+			key.NewKeyRange([]byte{0x80}, []byte{0x90}),
+		}
+		require.False(t, IsTabletWithinKeyRanges(tablet, keyRanges))
+
 	}
 }

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -152,15 +152,8 @@ func shouldWatchTablet(tablet *topodatapb.Tablet) bool {
 	if !ok {
 		return false
 	}
-	// Get the tablet's key range, and check if
-	// it is part of the shard ranges we are watching.
-	kr := tablet.GetKeyRange()
-	for _, shardRange := range shardRanges {
-		if key.KeyRangeContainsKeyRange(shardRange, kr) {
-			return true
-		}
-	}
-	return false
+	// Check if tablet is part of the shard ranges we are watching.
+	return topoproto.IsTabletWithinKeyRanges(tablet, shardRanges)
 }
 
 // OpenTabletDiscovery opens the vitess topo if enables and returns a ticker


### PR DESCRIPTION
## Description

To [compliment the new/v22 key-range awareness in VTOrc's `--clusters_to_watch` flag](https://github.com/vitessio/vitess/pull/17604), this PR adds to `go/vt/topo/topoproto` the helpers:
1. `IsTabletWithinKeyRanges(...) bool`
2. `IsTabletWithinKeyRangesString(...) (bool, error)`

This is useful for external automation to validate that a VTOrc using a range-based `--clusters_to_watch` value will monitor a given `*topodatapb.Tablet`, mimic'ing the logic [of the `shouldWatchTablet(...)` func](https://github.com/vitessio/vitess/blob/main/go/vt/vtorc/logic/tablet_discovery.go#L144) of `go/vt/vtorc/logic/tablet_discovery.go`

The real-world use case of this is automation to "find" the VTOrc of a given tablet and/or validate a tablet is being watched by someone

## Related Issue(s)

https://github.com/vitessio/vitess/issues/17330

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
