### PR TITLE
Fix golang-ci lint file to allow a version without preceding `v`

### DIFF
--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -48,7 +48,7 @@ if ! command -v golangci-lint >/dev/null 2>&1; then
   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$REQUIRED_VERSION
 else
   VERSION_OUTPUT=$(golangci-lint --version)
-  INSTALLED_VERSION=$(echo "$VERSION_OUTPUT" | sed -n 's/^golangci-lint has version v\([0-9.]*\).*/\1/p')
+  INSTALLED_VERSION=$(echo "$VERSION_OUTPUT" | sed -E -n 's/^golangci-lint has version v?([0-9.]+) .*/\1/p')
   if ! version_greater_or_equal "$INSTALLED_VERSION" "${REQUIRED_VERSION#v}"; then
     echo "golangci-lint version $INSTALLED_VERSION found, but $REQUIRED_VERSION or newer is required."
     echo "Installing version $REQUIRED_VERSION..."


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The output for golang-ci-lint can be of 2 variants - 
```
golangci-lint has version 2.0.2 built with go1.24.1 from 2b224c2c on 2025-03-25T21:36:18Z
```
and 
```
golangci-lint has version v2.0.2 built with go1.24.1 from 2b224c2c on 2025-03-25T21:36:18Z
```

The script for golang-ci lint doesn't allow for the first variant. This PR fixes that by making the `v` optional.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
