### PR TITLE
[Direct PR] (v16) VDiff: add support for tables with no primary keys

### DIFF
--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -49,6 +49,7 @@ create table ` + "`Lead-1`(`Lead`" + ` binary(16), name varbinary(16), date1 dat
 create table _vt_PURGE_4f9194b43b2011eb8a0104ed332e05c2_20221210194431(id int, val varbinary(128), primary key(id), key(val));
 create table db_order_test (c_uuid varchar(64) not null default '', created_at datetime not null, dstuff varchar(128), dtstuff text, dbstuff blob, cstuff char(32), primary key (c_uuid,created_at), key (dstuff)) CHARSET=utf8mb4;
 create table datze (id int, dt1 datetime not null default current_timestamp, dt2 datetime not null, ts1 timestamp default current_timestamp, primary key (id), key (dt1));
+create table customer_nopk(id int, name varchar(128)) CHARSET=utf8;
 `
 
 	// These should always be ignored in vreplication
@@ -81,7 +82,8 @@ create table datze (id int, dt1 datetime not null default current_timestamp, dt2
 	"Lead": {},
 	"Lead-1": {},
 	"db_order_test": {},
-	"datze": {}
+	"datze": {},
+	"customer_nopk": {}
   }
 }
 `
@@ -150,6 +152,14 @@ create table datze (id int, dt1 datetime not null default current_timestamp, dt2
       ]
     },
     "datze": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "reverse_bits"
+        }
+      ]
+    },
+	"customer_nopk": {
       "column_vindexes": [
         {
           "column": "id",

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -33,3 +33,20 @@ insert into datze(id, dt2, ts1) values (4, '2022-03-27 03:00:00', current_timest
 insert into datze(id, dt2, ts1) values (5, '2022-03-27 03:15:00', current_timestamp);
 insert into datze(id, dt2, ts1) values (6, current_timestamp, current_timestamp);
 
+insert into customer_nopk(id, name) values(1, 'abc');
+insert into customer_nopk(id, name) values(2, 'def');
+insert into customer_nopk(id, name) values(3, 'ghi');
+insert into customer_nopk(id, name) values(4, 'jkl');
+insert into customer_nopk(id, name) values(5, 'mno');
+insert into customer_nopk(id, name) values(6, 'pqr');
+insert into customer_nopk(id, name) values(7, 'stu');
+insert into customer_nopk(id, name) values(8, 'vwx');
+insert into customer_nopk(id, name) values(9, 'yz');
+insert into customer_nopk(id, name) values(10, 'abc');
+insert into customer_nopk(id, name) values(11, 'def');
+insert into customer_nopk(id, name) values(12, 'ghi');
+insert into customer_nopk(id, name) values(13, 'jkl');
+insert into customer_nopk(id, name) values(14, 'mno');
+insert into customer_nopk(id, name) values(15, 'pqr');
+
+

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -62,7 +62,7 @@ var testCases = []*testCase{
 		sourceShards:      "0",
 		targetShards:      "-80,80-",
 		tabletBaseID:      200,
-		tables:            "customer,Lead,Lead-1",
+		tables:            "customer,customer_nopk,Lead,Lead-1",
 		autoRetryError:    true,
 		retryInsert:       `insert into customer(cid, name, typ) values(91234, 'Testy McTester', 'soho')`,
 		resume:            true,
@@ -187,7 +187,8 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, tks *Keyspace, 
 		updateTableStats(t, tab, tc.tables) // need to do this in order to test progress reports
 	}
 
-	vdiff(t, tc.targetKs, tc.workflow, allCellNames, true, true, nil)
+	// vdiff v1 fails for tables without pks. Since it is not supported anymore, let's just not test with v1.
+	vdiff(t, tc.targetKs, tc.workflow, allCellNames, false, true, nil)
 
 	if tc.autoRetryError {
 		testAutoRetryError(t, tc, allCellNames)

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -98,7 +98,7 @@ func waitForVDiff2ToComplete(t *testing.T, ksWorkflow, cells, uuid string, compl
 				if !completedAtMin.IsZero() {
 					ca := info.CompletedAt
 					completedAt, _ := time.Parse(vdiff2.TimestampFormat, ca)
-					if !completedAt.After(completedAtMin) {
+					if completedAt.Before(completedAtMin) {
 						continue
 					}
 				}

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -433,6 +433,7 @@ func (td *tableDiffer) setupRowSorters() {
 	for shard, source := range td.wd.ct.sources {
 		sources[shard] = source.shardStreamer
 	}
+	log.Infof("Setting up row sorters for %d sources, with pk %+v, for workflow %s", len(sources), td.tablePlan.comparePKs, td.wd.ct.workflow)
 	td.sourcePrimitive = newMergeSorter(sources, td.tablePlan.comparePKs)
 
 	// create a merge sorter for the target


### PR DESCRIPTION
## Description

Tables with no PKs were not supported in v16. This PR adds support for users who want to migrate to new MySQL versions, for example, to eventually migrate to newer Vitess versions.

It essentially treats all columns as part of the primary key.

## Related Issue(s)


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
