### PR TITLE
Fix split statement for create procedure to account for definers

### DIFF
--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -145,6 +145,12 @@ BEGIN
 	insert into allDefaults(id) values (128);
 	select 128 into val from dual;
 END;
+`,
+		`CREATE DEFINER=current_user() PROCEDURE with_definer(OUT val int)
+BEGIN
+	insert into allDefaults(id) values (128);
+	select 128 into val from dual;
+END;
 `}
 )
 

--- a/go/vt/sqlparser/parser_test.go
+++ b/go/vt/sqlparser/parser_test.go
@@ -137,12 +137,35 @@ func TestSplitStatementToPieces(t *testing.T) {
 		// Test that we don't split on semicolons inside create procedure calls.
 		input:     "select * from t1;create procedure p1 (in country CHAR(3), out cities INT) begin select count(*) from x where d = e; end;select * from t2",
 		lenWanted: 3,
+	}, {
+		// Create procedure with comments.
+		input:     "select * from t1; /* comment1 */ create /* comment2 */ procedure /* comment3 */ p1 (in country CHAR(3), out cities INT) begin select count(*) from x where d = e; end;select * from t2",
+		lenWanted: 3,
+	}, {
+		// Create procedure with definer current_user.
+		input:     "create DEFINER=CURRENT_USER procedure p1 (in country CHAR(3))  begin declare abc DECIMAL(14,2); DECLARE def DECIMAL(14,2); end",
+		lenWanted: 1,
+	}, {
+		// Create procedure with definer current_user().
+		input:     "create DEFINER=CURRENT_USER() procedure p1 (in country CHAR(3))  begin declare abc DECIMAL(14,2); DECLARE def DECIMAL(14,2); end",
+		lenWanted: 1,
+	}, {
+		// Create procedure with definer string.
+		input:     "create DEFINER='root' procedure p1 (in country CHAR(3))  begin declare abc DECIMAL(14,2); DECLARE def DECIMAL(14,2); end",
+		lenWanted: 1,
+	}, {
+		// Create procedure with definer string at_id.
+		input:     "create DEFINER='root'@localhost procedure p1 (in country CHAR(3))  begin declare abc DECIMAL(14,2); DECLARE def DECIMAL(14,2); end",
+		lenWanted: 1,
+	}, {
+		// Create procedure with definer id.
+		input:     "create DEFINER=`root` procedure p1 (in country CHAR(3))  begin declare abc DECIMAL(14,2); DECLARE def DECIMAL(14,2); end",
+		lenWanted: 1,
+	}, {
+		// Create procedure with definer id at_id.
+		input:     "create DEFINER=`root`@`localhost` procedure p1 (in country CHAR(3))  begin declare abc DECIMAL(14,2); DECLARE def DECIMAL(14,2); end",
+		lenWanted: 1,
 	},
-		{
-			// Create procedure with comments.
-			input:     "select * from t1; /* comment1 */ create /* comment2 */ procedure /* comment3 */ p1 (in country CHAR(3), out cities INT) begin select count(*) from x where d = e; end;select * from t2",
-			lenWanted: 3,
-		},
 	}
 
 	parser := NewTestParser()


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the bug described in https://github.com/vitessio/vitess/issues/18141. Split statements didn't account for a definer clause, which has now been fixed.

## Related Issue(s)
- Fixes https://github.com/vitessio/vitess/issues/18141
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
