### PR TITLE
bugfix: INSERT IGNORE not inserting rows

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/insert_test.go
@@ -516,3 +516,11 @@ func TestInsertJson(t *testing.T) {
 	utils.AssertMatches(t, mcmp.VtConn, `select * from uks.j_utbl order by id`,
 		`[[INT64(1) JSON("{}")] [INT64(2) JSON("{\"a\": 1, \"b\": 2}")] [INT64(3) JSON("{\"k\": \"a\"}")] [INT64(4) JSON("{\"date\": 1629849600, \"keywordSourceId\": 930701976723823, \"keywordSourceVersionId\": 210825230433}")]]`)
 }
+
+func TestInsertIgnoreNullAndInsertNull(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert ignore into s_tbl(id) values (1)") // the remaining columns are be set to NULL
+	mcmp.Exec("select * from s_tbl")
+}

--- a/go/test/endtoend/vtgate/queries/dml/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/insert_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/test/endtoend/utils"
@@ -522,5 +524,22 @@ func TestInsertIgnoreNullAndInsertNull(t *testing.T) {
 	defer closer()
 
 	mcmp.Exec("insert ignore into s_tbl(id) values (1)") // the remaining columns are be set to NULL
-	mcmp.Exec("select * from s_tbl")
+	mcmp.Exec("select id, num, col from s_tbl")
+	mcmp.Exec("insert ignore into s_tbl(id, num, col) values (2, 2, 2), (3, NULL, 3), (4, 4, NULL)")
+	mcmp.Exec("insert into s_tbl(id, num, col) values (5, 5, 5), (6, NULL, 6), (7, 7, NULL)")
+	mcmp.Exec("select id, num, col from s_tbl")
+	utils.AssertMatches(t, mcmp.VtConn, "select num, hex(keyspace_id) from num_vdx_tbl order by num",
+		`[[INT64(2) VARCHAR("06E7EA22CE92708F")] [INT64(4) VARCHAR("D2FD8867D50D2DFE")] [INT64(5) VARCHAR("70BB023C810CA87A")] [INT64(7) VARCHAR("FB8BAAAD918119B8")]]`)
+	utils.AssertMatches(t, mcmp.VtConn, "select col, id, hex(keyspace_id) from col_vdx_tbl order by col, id",
+		`[[INT64(2) INT64(2) VARCHAR("06E7EA22CE92708F")] [INT64(3) INT64(3) VARCHAR("4EB190C9A2FA169C")] [INT64(5) INT64(5) VARCHAR("70BB023C810CA87A")] [INT64(6) INT64(6) VARCHAR("F098480AC4C4BE71")]]`)
+
+	mcmp.Exec("insert ignore into name_tbl(id, name) values (1, 'foo'), (2, 'bar')")
+	mcmp.Exec("select id, name from name_tbl order by id")
+
+	// This should contain the one row that was inserted above
+	utils.AssertMatches(t, mcmp.VtConn, "select name, id, hex(keyspace_id) from name_vdx_tbl order by name, id",
+		`[[VARCHAR("bar") INT64(2) VARCHAR("06E7EA22CE92708F")] [VARCHAR("foo") INT64(1) VARCHAR("166B40B44ABA4BD6")]]`)
+
+	_, err := utils.ExecAllowError(t, mcmp.VtConn, "insert ignore into name_tbl(id, name) values (22, NULL)") // this should fail, since we have a vindex that does not ignore nulls
+	require.ErrorContains(t, err, "Column 'name,id' cannot be null")
 }

--- a/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
@@ -1,12 +1,17 @@
 create table s_tbl
 (
-    id  bigint,
-    num bigint,
-    col bigint,
+    id   bigint,
+    num  bigint,
+    col  bigint,
     unique key (num),
     primary key (id)
 ) Engine = InnoDB;
-
+create table name_tbl
+(
+    id   bigint,
+    name varchar(50),
+    primary key (id)
+) Engine = InnoDB;
 create table num_vdx_tbl
 (
     num         bigint,
@@ -20,6 +25,14 @@ create table col_vdx_tbl
     id          bigint,
     keyspace_id varbinary(20),
     primary key (col, id)
+) Engine = InnoDB
+;
+create table name_vdx_tbl
+(
+    name        varchar(50),
+    id          bigint,
+    keyspace_id varbinary(20),
+    primary key (name, id)
 ) Engine = InnoDB;
 
 create table user_tbl
@@ -100,7 +113,7 @@ create table lkp_mixed_idx
 
 create table j_tbl
 (
-    id  bigint,
+    id   bigint,
     jdoc json,
     primary key (id)
 ) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/queries/dml/vschema.json
+++ b/go/test/endtoend/vtgate/queries/dml/vschema.json
@@ -4,6 +4,9 @@
     "hash": {
       "type": "hash"
     },
+    "hash_varchar": {
+      "type": "unicode_loose_xxhash"
+    },
     "num_vdx": {
       "type": "consistent_lookup_unique",
       "params": {
@@ -23,6 +26,15 @@
         "ignore_nulls": "true"
       },
       "owner": "s_tbl"
+    },
+    "name_vdx": {
+      "type": "consistent_lookup",
+      "params": {
+        "table": "name_vdx_tbl",
+        "from": "name,id",
+        "to": "keyspace_id"
+      },
+      "owner": "name_tbl"
     },
     "oid_vdx": {
       "type": "consistent_lookup_unique",
@@ -76,8 +88,26 @@
           "name": "num_vdx"
         },
         {
-          "columns": ["col", "id"],
+          "columns": [
+            "col",
+            "id"
+          ],
           "name": "col_vdx"
+        }
+      ]
+    },
+    "name_tbl": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "hash"
+        },
+        {
+          "columns": [
+            "name",
+            "id"
+          ],
+          "name": "name_vdx"
         }
       ]
     },
@@ -94,6 +124,14 @@
         {
           "column": "col",
           "name": "hash"
+        }
+      ]
+    },
+    "name_vdx_tbl": {
+      "column_vindexes": [
+        {
+          "column": "name",
+          "name": "hash_varchar"
         }
       ]
     },


### PR DESCRIPTION
## Description
vtgate was failing to insert to the base table when one of the vindexes reported it had ignored a row.

## Related Issue(s)
Fixes #17979

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
