### PR TITLE
Skip end-to-end test

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/dml_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/dml_test.go
@@ -78,6 +78,7 @@ func TestUniqueLookupDuplicateEntries(t *testing.T) {
 
 // TestUniqueLookupDuplicateIgnore tests the insert ignore on lookup table.
 func TestUniqueLookupDuplicateIgnore(t *testing.T) {
+	t.Skip("this is fixed in https://github.com/vitessio/vitess/pull/18151, it will be backported to 22.0")
 	mcmp, closer := start(t)
 	defer closer()
 


### PR DESCRIPTION
## Description
This test is asserting that we are doing the wrong thing. Let's skip it until we have backported the [fix](https://github.com/vitessio/vitess/pull/18151).


## Related Issue(s)
Fix on main: https://github.com/vitessio/vitess/pull/18151


## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
