### PR TITLE
Add TransactionsProcessed metric to track transactions at VTGate

### DIFF
--- a/changelog/23.0/23.0.0/summary.md
+++ b/changelog/23.0/23.0.0/summary.md
@@ -1,12 +1,15 @@
 ## Summary
 
 ### Table of Contents
+
 - **[Minor Changes](#minor-changes)**
     - **[Deletions](#deletions)**
         - [Metrics](#deleted-metrics)
-    - **[VTTablet](#minor-changes-vttablet)**
-        - [CLI Flags](#flags-vttablet)
-        - [Managed MySQL configuration defaults to caching-sha2-password](#mysql-caching-sha2-password)
+    - **[New Metrics](#new-metrics)**
+        - [VTGate](#new-vtgate-metrics)
+        - **[VTTablet](#minor-changes-vttablet)**
+            - [CLI Flags](#flags-vttablet)
+            - [Managed MySQL configuration defaults to caching-sha2-password](#mysql-caching-sha2-password)
 
 ## <a id="minor-changes"/>Minor Changes</a>
 
@@ -20,6 +23,14 @@
 | `vtgate`  |      `QueriesRouted`      |     `v22.0.0`     | [#17727](https://github.com/vitessio/vitess/pull/17727) |
 | `vtgate`  | `QueriesProcessedByTable` |     `v22.0.0`     | [#17727](https://github.com/vitessio/vitess/pull/17727) |
 | `vtgate`  |  `QueriesRoutedByTable`   |     `v22.0.0`     | [#17727](https://github.com/vitessio/vitess/pull/17727) |
+
+### <a id="new-metrics"/>New Metrics
+
+#### <a id="new-vtgate-metrics"/>VTGate
+
+|          Name           |   Dimensions    |                                     Description                                     |                           PR                            |
+|:-----------------------:|:---------------:|:-----------------------------------------------------------------------------------:|:-------------------------------------------------------:|
+| `TransactionsProcessed` | `Shard`, `Type` | Counts transactions processed at VTGate by shard distribution and transaction type. | [#18171](https://github.com/vitessio/vitess/pull/18171) |
 
 ### <a id="minor-changes-vttablet"/>VTTablet</a>
 

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -75,7 +75,7 @@ var (
 	queryExecutions        = stats.NewCountersWithMultiLabels("QueryExecutions", "Counts queries executed at VTGate by query type, plan type, and tablet type.", []string{"Query", "Plan", "Tablet"})
 	queryRoutes            = stats.NewCountersWithMultiLabels("QueryRoutes", "Counts queries routed from VTGate to VTTablet by query type, plan type, and tablet type.", []string{"Query", "Plan", "Tablet"})
 	queryExecutionsByTable = stats.NewCountersWithMultiLabels("QueryExecutionsByTable", "Counts queries executed at VTGate per table by query type and table.", []string{"Query", "Table"})
-	txProcessed            = stats.NewCountersWithMultiLabels("TransactionsProcessed", "Counts transactions processed at VTGate by shard distribution (single or multi), transaction type (read write or read only)", []string{"Shard", "Type"})
+	txProcessed            = stats.NewCountersWithMultiLabels("TransactionsProcessed", "Counts transactions processed at VTGate by shard distribution (single or cross), transaction type (read write or read only)", []string{"Shard", "Type"})
 
 	// commitMode records the timing of the commit phase of a transaction.
 	// It also tracks between different transaction mode i.e. Single, Multi and TwoPC

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -75,6 +75,7 @@ var (
 	queryExecutions        = stats.NewCountersWithMultiLabels("QueryExecutions", "Counts queries executed at VTGate by query type, plan type, and tablet type.", []string{"Query", "Plan", "Tablet"})
 	queryRoutes            = stats.NewCountersWithMultiLabels("QueryRoutes", "Counts queries routed from VTGate to VTTablet by query type, plan type, and tablet type.", []string{"Query", "Plan", "Tablet"})
 	queryExecutionsByTable = stats.NewCountersWithMultiLabels("QueryExecutionsByTable", "Counts queries executed at VTGate per table by query type and table.", []string{"Query", "Table"})
+	txProcessed            = stats.NewCountersWithMultiLabels("TransactionsProcessed", "Counts transactions processed at VTGate by shard distribution (single or multi), transaction type (read write or read only)", []string{"Shard", "Type"})
 
 	// commitMode records the timing of the commit phase of a transaction.
 	// It also tracks between different transaction mode i.e. Single, Multi and TwoPC

--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -62,6 +62,24 @@ var txAccessModeToEOTxAccessMode = map[sqlparser.TxAccessMode]querypb.ExecuteOpt
 	sqlparser.ReadOnly:               querypb.ExecuteOptions_READ_ONLY,
 }
 
+type txType int
+
+const (
+	TXReadOnly txType = iota
+	TXReadWrite
+)
+
+func (tt txType) String() string {
+	switch tt {
+	case TXReadOnly:
+		return "ReadOnly"
+	case TXReadWrite:
+		return "ReadWrite"
+	default:
+		return "Unknown"
+	}
+}
+
 type commitPhase int
 
 const (
@@ -126,10 +144,12 @@ func (txc *TxConn) Commit(ctx context.Context, session *econtext.SafeSession) er
 		return err
 	}
 
+	shardDistribution := getShardDistribution(session.ShardSessions)
+	var txnType txType
 	if twopc {
-		err = txc.commit2PC(ctx, session)
+		txnType, err = txc.commit2PC(ctx, session)
 	} else {
-		err = txc.commitNormal(ctx, session)
+		txnType, err = txc.commitNormal(ctx, session)
 	}
 
 	if err != nil {
@@ -146,7 +166,15 @@ func (txc *TxConn) Commit(ctx context.Context, session *econtext.SafeSession) er
 			_ = txc.Release(ctx, session)
 		}
 	}
+	txProcessed.Add([]string{shardDistribution, txnType.String()}, 1)
 	return nil
+}
+
+func getShardDistribution(sessions []*vtgatepb.Session_ShardSession) string {
+	if len(sessions) > 1 {
+		return "Multi"
+	}
+	return "Single"
 }
 
 func recordCommitTime(session *econtext.SafeSession, twopc bool, startTime time.Time) {
@@ -193,9 +221,13 @@ func (txc *TxConn) commitShard(ctx context.Context, s *vtgatepb.Session_ShardSes
 	return nil
 }
 
-func (txc *TxConn) commitNormal(ctx context.Context, session *econtext.SafeSession) error {
+func (txc *TxConn) commitNormal(ctx context.Context, session *econtext.SafeSession) (txType, error) {
+	txnType := TXReadOnly
 	// Retain backward compatibility on commit order for the normal session.
 	for i, shardSession := range session.ShardSessions {
+		if txnType == TXReadOnly && shardSession.RowsAffected {
+			txnType = TXReadWrite
+		}
 		if err := txc.commitShard(ctx, shardSession, session.GetLogger()); err != nil {
 			if i > 0 {
 				nShards := i
@@ -217,14 +249,14 @@ func (txc *TxConn) commitNormal(ctx context.Context, session *econtext.SafeSessi
 				})
 				warnings.Add("NonAtomicCommit", 1)
 			}
-			return err
+			return txnType, err
 		}
 	}
-	return nil
+	return txnType, nil
 }
 
 // commit2PC will not used the pinned tablets - to make sure we use the current source, we need to use the gateway's queryservice
-func (txc *TxConn) commit2PC(ctx context.Context, session *econtext.SafeSession) (err error) {
+func (txc *TxConn) commit2PC(ctx context.Context, session *econtext.SafeSession) (txnType txType, err error) {
 	// If the number of participants is one or less, then it's a normal commit.
 	if len(session.ShardSessions) <= 1 {
 		return txc.commitNormal(ctx, session)
@@ -233,8 +265,14 @@ func (txc *TxConn) commit2PC(ctx context.Context, session *econtext.SafeSession)
 	mmShard := session.ShardSessions[0]
 	rmShards := session.ShardSessions[1:]
 	dtid := dtids.New(mmShard)
+	if mmShard.RowsAffected {
+		txnType = TXReadWrite
+	}
 	participants := make([]*querypb.Target, len(rmShards))
 	for i, s := range rmShards {
+		if s.RowsAffected {
+			txnType = TXReadWrite
+		}
 		participants[i] = s.Target
 	}
 
@@ -249,12 +287,12 @@ func (txc *TxConn) commit2PC(ctx context.Context, session *econtext.SafeSession)
 
 	txPhase = Commit2pcCreateTransaction
 	if err = txc.tabletGateway.CreateTransaction(ctx, mmShard.Target, dtid, participants); err != nil {
-		return err
+		return txnType, err
 	}
 
 	if DebugTwoPc { // Test code to simulate a failure after RM prepare
 		if terr := checkTestFailure(ctx, "TRCreated_FailNow", nil); terr != nil {
-			return terr
+			return txnType, terr
 		}
 	}
 
@@ -268,24 +306,24 @@ func (txc *TxConn) commit2PC(ctx context.Context, session *econtext.SafeSession)
 		return txc.tabletGateway.Prepare(ctx, s.Target, s.TransactionId, dtid)
 	}
 	if err = txc.runSessions(ctx, rmShards, session.GetLogger(), prepareAction); err != nil {
-		return err
+		return txnType, err
 	}
 
 	if DebugTwoPc { // Test code to simulate a failure after RM prepare
 		if terr := checkTestFailure(ctx, "RMPrepared_FailNow", nil); terr != nil {
-			return terr
+			return txnType, terr
 		}
 	}
 
 	txPhase = Commit2pcStartCommit
 	startCommitState, err = txc.tabletGateway.StartCommit(ctx, mmShard.Target, mmShard.TransactionId, dtid)
 	if err != nil {
-		return err
+		return txnType, err
 	}
 
 	if DebugTwoPc { // Test code to simulate a failure after MM commit
 		if terr := checkTestFailure(ctx, "MMCommitted_FailNow", nil); terr != nil {
-			return terr
+			return txnType, terr
 		}
 	}
 
@@ -299,7 +337,7 @@ func (txc *TxConn) commit2PC(ctx context.Context, session *econtext.SafeSession)
 		return txc.tabletGateway.CommitPrepared(ctx, s.Target, dtid)
 	}
 	if err = txc.runSessions(ctx, rmShards, session.GetLogger(), prepareCommitAction); err != nil {
-		return err
+		return txnType, err
 	}
 
 	// At this point, application can continue forward.
@@ -307,7 +345,7 @@ func (txc *TxConn) commit2PC(ctx context.Context, session *econtext.SafeSession)
 	// This step is to clean up the transaction metadata.
 	txPhase = Commit2pcConclude
 	_ = txc.tabletGateway.ConcludeTransaction(ctx, mmShard.Target, dtid)
-	return nil
+	return txnType, nil
 }
 
 func (txc *TxConn) errActionAndLogWarn(

--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -62,6 +62,11 @@ var txAccessModeToEOTxAccessMode = map[sqlparser.TxAccessMode]querypb.ExecuteOpt
 	sqlparser.ReadOnly:               querypb.ExecuteOptions_READ_ONLY,
 }
 
+const (
+	SingleShardTransaction = "Single"
+	CrossShardTransaction  = "Cross"
+)
+
 type txType int
 
 const (
@@ -172,9 +177,9 @@ func (txc *TxConn) Commit(ctx context.Context, session *econtext.SafeSession) er
 
 func getShardDistribution(sessions []*vtgatepb.Session_ShardSession) string {
 	if len(sessions) > 1 {
-		return "Multi"
+		return CrossShardTransaction
 	}
-	return "Single"
+	return SingleShardTransaction
 }
 
 func recordCommitTime(session *econtext.SafeSession, twopc bool, startTime time.Time) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR introduces a new counter metric `TransactionsProcessed` to VTGate to track the number of transactions processed, categorized by:
* Shard distribution: single or cross
* Transaction type: read only or read write

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes https://github.com/vitessio/vitess/issues/17585

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
