### PR TITLE
Add TMC RPCs for updating sequences for `switchwrites`

### DIFF
--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
@@ -7635,125 +7635,16 @@ func (x *ChangeTagsResponse) GetTags() map[string]string {
 	return nil
 }
 
-type SequenceMetadata struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// The name of the sequence table.
-	BackingTableName string `protobuf:"bytes,1,opt,name=backing_table_name,json=backingTableName,proto3" json:"backing_table_name,omitempty"`
-	// The dbName in use by the keyspace where the backing table lives.
-	BackingTableDbName string `protobuf:"bytes,2,opt,name=backing_table_db_name,json=backingTableDbName,proto3" json:"backing_table_db_name,omitempty"`
-	// The name of the table using the sequence.
-	UsingTableName string `protobuf:"bytes,3,opt,name=using_table_name,json=usingTableName,proto3" json:"using_table_name,omitempty"`
-	// The dbName in use by the keyspace where the using table lives.
-	UsingTableDbName string `protobuf:"bytes,4,opt,name=using_table_db_name,json=usingTableDbName,proto3" json:"using_table_db_name,omitempty"`
-	// Escaped column name specified for sequence in table.
-	UsingColEscaped string `protobuf:"bytes,5,opt,name=using_col_escaped,json=usingColEscaped,proto3" json:"using_col_escaped,omitempty"`
-	// Escaped name of the table using the sequence.
-	UsingTableNameEscaped string `protobuf:"bytes,6,opt,name=using_table_name_escaped,json=usingTableNameEscaped,proto3" json:"using_table_name_escaped,omitempty"`
-	// Escaped db name in use by the keyspace where the using table lives.
-	UsingTableDbNameEscaped string `protobuf:"bytes,7,opt,name=using_table_db_name_escaped,json=usingTableDbNameEscaped,proto3" json:"using_table_db_name_escaped,omitempty"`
-	// Escaped name of the sequence table.
-	BackingTableNameEscaped string `protobuf:"bytes,8,opt,name=backing_table_name_escaped,json=backingTableNameEscaped,proto3" json:"backing_table_name_escaped,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
-}
-
-func (x *SequenceMetadata) Reset() {
-	*x = SequenceMetadata{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[145]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SequenceMetadata) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SequenceMetadata) ProtoMessage() {}
-
-func (x *SequenceMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[145]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SequenceMetadata.ProtoReflect.Descriptor instead.
-func (*SequenceMetadata) Descriptor() ([]byte, []int) {
-	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{145}
-}
-
-func (x *SequenceMetadata) GetBackingTableName() string {
-	if x != nil {
-		return x.BackingTableName
-	}
-	return ""
-}
-
-func (x *SequenceMetadata) GetBackingTableDbName() string {
-	if x != nil {
-		return x.BackingTableDbName
-	}
-	return ""
-}
-
-func (x *SequenceMetadata) GetUsingTableName() string {
-	if x != nil {
-		return x.UsingTableName
-	}
-	return ""
-}
-
-func (x *SequenceMetadata) GetUsingTableDbName() string {
-	if x != nil {
-		return x.UsingTableDbName
-	}
-	return ""
-}
-
-func (x *SequenceMetadata) GetUsingColEscaped() string {
-	if x != nil {
-		return x.UsingColEscaped
-	}
-	return ""
-}
-
-func (x *SequenceMetadata) GetUsingTableNameEscaped() string {
-	if x != nil {
-		return x.UsingTableNameEscaped
-	}
-	return ""
-}
-
-func (x *SequenceMetadata) GetUsingTableDbNameEscaped() string {
-	if x != nil {
-		return x.UsingTableDbNameEscaped
-	}
-	return ""
-}
-
-func (x *SequenceMetadata) GetBackingTableNameEscaped() string {
-	if x != nil {
-		return x.BackingTableNameEscaped
-	}
-	return ""
-}
-
 type UpdateSequenceTablesRequest struct {
-	state                    protoimpl.MessageState `protogen:"open.v1"`
-	Sequences                []*SequenceMetadata    `protobuf:"bytes,1,rep,name=sequences,proto3" json:"sequences,omitempty"`
-	MaxValuesBySequenceTable map[string]int64       `protobuf:"bytes,2,rep,name=max_values_by_sequence_table,json=maxValuesBySequenceTable,proto3" json:"max_values_by_sequence_table,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	state         protoimpl.MessageState                          `protogen:"open.v1"`
+	Sequences     []*UpdateSequenceTablesRequest_SequenceMetadata `protobuf:"bytes,1,rep,name=sequences,proto3" json:"sequences,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UpdateSequenceTablesRequest) Reset() {
 	*x = UpdateSequenceTablesRequest{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[146]
+	mi := &file_tabletmanagerdata_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7765,7 +7656,7 @@ func (x *UpdateSequenceTablesRequest) String() string {
 func (*UpdateSequenceTablesRequest) ProtoMessage() {}
 
 func (x *UpdateSequenceTablesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[146]
+	mi := &file_tabletmanagerdata_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7778,19 +7669,12 @@ func (x *UpdateSequenceTablesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSequenceTablesRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSequenceTablesRequest) Descriptor() ([]byte, []int) {
-	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{146}
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{145}
 }
 
-func (x *UpdateSequenceTablesRequest) GetSequences() []*SequenceMetadata {
+func (x *UpdateSequenceTablesRequest) GetSequences() []*UpdateSequenceTablesRequest_SequenceMetadata {
 	if x != nil {
 		return x.Sequences
-	}
-	return nil
-}
-
-func (x *UpdateSequenceTablesRequest) GetMaxValuesBySequenceTable() map[string]int64 {
-	if x != nil {
-		return x.MaxValuesBySequenceTable
 	}
 	return nil
 }
@@ -7803,7 +7687,7 @@ type UpdateSequenceTablesResponse struct {
 
 func (x *UpdateSequenceTablesResponse) Reset() {
 	*x = UpdateSequenceTablesResponse{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[147]
+	mi := &file_tabletmanagerdata_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7815,7 +7699,7 @@ func (x *UpdateSequenceTablesResponse) String() string {
 func (*UpdateSequenceTablesResponse) ProtoMessage() {}
 
 func (x *UpdateSequenceTablesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[147]
+	mi := &file_tabletmanagerdata_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7828,19 +7712,19 @@ func (x *UpdateSequenceTablesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSequenceTablesResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSequenceTablesResponse) Descriptor() ([]byte, []int) {
-	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{147}
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{146}
 }
 
 type GetMaxValueForSequencesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Sequences     []*SequenceMetadata    `protobuf:"bytes,1,rep,name=sequences,proto3" json:"sequences,omitempty"`
+	state         protoimpl.MessageState                             `protogen:"open.v1"`
+	Sequences     []*GetMaxValueForSequencesRequest_SequenceMetadata `protobuf:"bytes,1,rep,name=sequences,proto3" json:"sequences,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetMaxValueForSequencesRequest) Reset() {
 	*x = GetMaxValueForSequencesRequest{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[148]
+	mi := &file_tabletmanagerdata_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7852,7 +7736,7 @@ func (x *GetMaxValueForSequencesRequest) String() string {
 func (*GetMaxValueForSequencesRequest) ProtoMessage() {}
 
 func (x *GetMaxValueForSequencesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[148]
+	mi := &file_tabletmanagerdata_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7865,10 +7749,10 @@ func (x *GetMaxValueForSequencesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMaxValueForSequencesRequest.ProtoReflect.Descriptor instead.
 func (*GetMaxValueForSequencesRequest) Descriptor() ([]byte, []int) {
-	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{148}
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{147}
 }
 
-func (x *GetMaxValueForSequencesRequest) GetSequences() []*SequenceMetadata {
+func (x *GetMaxValueForSequencesRequest) GetSequences() []*GetMaxValueForSequencesRequest_SequenceMetadata {
 	if x != nil {
 		return x.Sequences
 	}
@@ -7884,7 +7768,7 @@ type GetMaxValueForSequencesResponse struct {
 
 func (x *GetMaxValueForSequencesResponse) Reset() {
 	*x = GetMaxValueForSequencesResponse{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[149]
+	mi := &file_tabletmanagerdata_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7896,7 +7780,7 @@ func (x *GetMaxValueForSequencesResponse) String() string {
 func (*GetMaxValueForSequencesResponse) ProtoMessage() {}
 
 func (x *GetMaxValueForSequencesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[149]
+	mi := &file_tabletmanagerdata_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7909,7 +7793,7 @@ func (x *GetMaxValueForSequencesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMaxValueForSequencesResponse.ProtoReflect.Descriptor instead.
 func (*GetMaxValueForSequencesResponse) Descriptor() ([]byte, []int) {
-	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{149}
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *GetMaxValueForSequencesResponse) GetMaxValuesBySequenceTable() map[string]int64 {
@@ -7941,7 +7825,7 @@ type ReadVReplicationWorkflowResponse_Stream struct {
 
 func (x *ReadVReplicationWorkflowResponse_Stream) Reset() {
 	*x = ReadVReplicationWorkflowResponse_Stream{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[155]
+	mi := &file_tabletmanagerdata_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7953,7 +7837,7 @@ func (x *ReadVReplicationWorkflowResponse_Stream) String() string {
 func (*ReadVReplicationWorkflowResponse_Stream) ProtoMessage() {}
 
 func (x *ReadVReplicationWorkflowResponse_Stream) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[155]
+	mi := &file_tabletmanagerdata_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8089,7 +7973,7 @@ type CheckThrottlerResponse_Metric struct {
 
 func (x *CheckThrottlerResponse_Metric) Reset() {
 	*x = CheckThrottlerResponse_Metric{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[158]
+	mi := &file_tabletmanagerdata_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8101,7 +7985,7 @@ func (x *CheckThrottlerResponse_Metric) String() string {
 func (*CheckThrottlerResponse_Metric) ProtoMessage() {}
 
 func (x *CheckThrottlerResponse_Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[158]
+	mi := &file_tabletmanagerdata_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8176,7 +8060,7 @@ type GetThrottlerStatusResponse_MetricResult struct {
 
 func (x *GetThrottlerStatusResponse_MetricResult) Reset() {
 	*x = GetThrottlerStatusResponse_MetricResult{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[160]
+	mi := &file_tabletmanagerdata_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8188,7 +8072,7 @@ func (x *GetThrottlerStatusResponse_MetricResult) String() string {
 func (*GetThrottlerStatusResponse_MetricResult) ProtoMessage() {}
 
 func (x *GetThrottlerStatusResponse_MetricResult) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[160]
+	mi := &file_tabletmanagerdata_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8228,7 +8112,7 @@ type GetThrottlerStatusResponse_MetricHealth struct {
 
 func (x *GetThrottlerStatusResponse_MetricHealth) Reset() {
 	*x = GetThrottlerStatusResponse_MetricHealth{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[163]
+	mi := &file_tabletmanagerdata_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8240,7 +8124,7 @@ func (x *GetThrottlerStatusResponse_MetricHealth) String() string {
 func (*GetThrottlerStatusResponse_MetricHealth) ProtoMessage() {}
 
 func (x *GetThrottlerStatusResponse_MetricHealth) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[163]
+	mi := &file_tabletmanagerdata_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8281,7 +8165,7 @@ type GetThrottlerStatusResponse_RecentApp struct {
 
 func (x *GetThrottlerStatusResponse_RecentApp) Reset() {
 	*x = GetThrottlerStatusResponse_RecentApp{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[167]
+	mi := &file_tabletmanagerdata_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8293,7 +8177,7 @@ func (x *GetThrottlerStatusResponse_RecentApp) String() string {
 func (*GetThrottlerStatusResponse_RecentApp) ProtoMessage() {}
 
 func (x *GetThrottlerStatusResponse_RecentApp) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[167]
+	mi := &file_tabletmanagerdata_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8321,6 +8205,142 @@ func (x *GetThrottlerStatusResponse_RecentApp) GetResponseCode() CheckThrottlerR
 		return x.ResponseCode
 	}
 	return CheckThrottlerResponseCode_UNDEFINED
+}
+
+type UpdateSequenceTablesRequest_SequenceMetadata struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The name of the sequence table.
+	BackingTableName string `protobuf:"bytes,1,opt,name=backing_table_name,json=backingTableName,proto3" json:"backing_table_name,omitempty"`
+	// The dbName in use by the keyspace where the backing table lives.
+	BackingTableDbName string `protobuf:"bytes,2,opt,name=backing_table_db_name,json=backingTableDbName,proto3" json:"backing_table_db_name,omitempty"`
+	// The maximum used sequence value.
+	MaxValue      int64 `protobuf:"varint,3,opt,name=max_value,json=maxValue,proto3" json:"max_value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateSequenceTablesRequest_SequenceMetadata) Reset() {
+	*x = UpdateSequenceTablesRequest_SequenceMetadata{}
+	mi := &file_tabletmanagerdata_proto_msgTypes[170]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSequenceTablesRequest_SequenceMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSequenceTablesRequest_SequenceMetadata) ProtoMessage() {}
+
+func (x *UpdateSequenceTablesRequest_SequenceMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_tabletmanagerdata_proto_msgTypes[170]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSequenceTablesRequest_SequenceMetadata.ProtoReflect.Descriptor instead.
+func (*UpdateSequenceTablesRequest_SequenceMetadata) Descriptor() ([]byte, []int) {
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{145, 0}
+}
+
+func (x *UpdateSequenceTablesRequest_SequenceMetadata) GetBackingTableName() string {
+	if x != nil {
+		return x.BackingTableName
+	}
+	return ""
+}
+
+func (x *UpdateSequenceTablesRequest_SequenceMetadata) GetBackingTableDbName() string {
+	if x != nil {
+		return x.BackingTableDbName
+	}
+	return ""
+}
+
+func (x *UpdateSequenceTablesRequest_SequenceMetadata) GetMaxValue() int64 {
+	if x != nil {
+		return x.MaxValue
+	}
+	return 0
+}
+
+type GetMaxValueForSequencesRequest_SequenceMetadata struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The name of the sequence table. This will be used for mapping max value
+	// with table in the response.
+	BackingTableName string `protobuf:"bytes,1,opt,name=backing_table_name,json=backingTableName,proto3" json:"backing_table_name,omitempty"`
+	// Escaped column name specified for sequence in table.
+	UsingColEscaped string `protobuf:"bytes,2,opt,name=using_col_escaped,json=usingColEscaped,proto3" json:"using_col_escaped,omitempty"`
+	// Escaped name of the table using the sequence.
+	UsingTableNameEscaped string `protobuf:"bytes,3,opt,name=using_table_name_escaped,json=usingTableNameEscaped,proto3" json:"using_table_name_escaped,omitempty"`
+	// Escaped db name in use by the keyspace where the using table lives.
+	UsingTableDbNameEscaped string `protobuf:"bytes,4,opt,name=using_table_db_name_escaped,json=usingTableDbNameEscaped,proto3" json:"using_table_db_name_escaped,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *GetMaxValueForSequencesRequest_SequenceMetadata) Reset() {
+	*x = GetMaxValueForSequencesRequest_SequenceMetadata{}
+	mi := &file_tabletmanagerdata_proto_msgTypes[171]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMaxValueForSequencesRequest_SequenceMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMaxValueForSequencesRequest_SequenceMetadata) ProtoMessage() {}
+
+func (x *GetMaxValueForSequencesRequest_SequenceMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_tabletmanagerdata_proto_msgTypes[171]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMaxValueForSequencesRequest_SequenceMetadata.ProtoReflect.Descriptor instead.
+func (*GetMaxValueForSequencesRequest_SequenceMetadata) Descriptor() ([]byte, []int) {
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{147, 0}
+}
+
+func (x *GetMaxValueForSequencesRequest_SequenceMetadata) GetBackingTableName() string {
+	if x != nil {
+		return x.BackingTableName
+	}
+	return ""
+}
+
+func (x *GetMaxValueForSequencesRequest_SequenceMetadata) GetUsingColEscaped() string {
+	if x != nil {
+		return x.UsingColEscaped
+	}
+	return ""
+}
+
+func (x *GetMaxValueForSequencesRequest_SequenceMetadata) GetUsingTableNameEscaped() string {
+	if x != nil {
+		return x.UsingTableNameEscaped
+	}
+	return ""
+}
+
+func (x *GetMaxValueForSequencesRequest_SequenceMetadata) GetUsingTableDbNameEscaped() string {
+	if x != nil {
+		return x.UsingTableDbNameEscaped
+	}
+	return ""
 }
 
 var File_tabletmanagerdata_proto protoreflect.FileDescriptor
@@ -9492,94 +9512,81 @@ var file_tabletmanagerdata_proto_rawDesc = string([]byte{
 	0x0a, 0x09, 0x54, 0x61, 0x67, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b,
 	0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a,
 	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61,
-	0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0xac, 0x03, 0x0a, 0x10, 0x53, 0x65, 0x71, 0x75,
-	0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12, 0x2c, 0x0a, 0x12,
-	0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61,
-	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e,
-	0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x31, 0x0a, 0x15, 0x62, 0x61,
-	0x63, 0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e,
-	0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x62, 0x61, 0x63, 0x6b, 0x69,
-	0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x62, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x28, 0x0a,
-	0x10, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61, 0x6d,
-	0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61,
-	0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x2d, 0x0a, 0x13, 0x75, 0x73, 0x69, 0x6e, 0x67,
-	0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x04,
-	0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65,
-	0x44, 0x62, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x2a, 0x0a, 0x11, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f,
-	0x63, 0x6f, 0x6c, 0x5f, 0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28,
-	0x09, 0x52, 0x0f, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6c, 0x45, 0x73, 0x63, 0x61, 0x70,
-	0x65, 0x64, 0x12, 0x37, 0x0a, 0x18, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c,
-	0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x06,
-	0x20, 0x01, 0x28, 0x09, 0x52, 0x15, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65,
-	0x4e, 0x61, 0x6d, 0x65, 0x45, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x12, 0x3c, 0x0a, 0x1b, 0x75,
-	0x73, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e, 0x61,
-	0x6d, 0x65, 0x5f, 0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09,
-	0x52, 0x17, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x62, 0x4e, 0x61,
-	0x6d, 0x65, 0x45, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x12, 0x3b, 0x0a, 0x1a, 0x62, 0x61, 0x63,
-	0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x5f,
-	0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x17, 0x62,
-	0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x45,
-	0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x22, 0xbc, 0x02, 0x0a, 0x1b, 0x55, 0x70, 0x64, 0x61, 0x74,
-	0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52,
-	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x41, 0x0a, 0x09, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e,
-	0x63, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x74, 0x61, 0x62, 0x6c,
-	0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x53, 0x65,
-	0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52, 0x09,
-	0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x12, 0x8c, 0x01, 0x0a, 0x1c, 0x6d, 0x61,
-	0x78, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x5f, 0x62, 0x79, 0x5f, 0x73, 0x65, 0x71, 0x75,
-	0x65, 0x6e, 0x63, 0x65, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b,
-	0x32, 0x4c, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72,
-	0x64, 0x61, 0x74, 0x61, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x65, 0x71, 0x75, 0x65,
-	0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
-	0x2e, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75,
-	0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x18,
-	0x6d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65,
-	0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x1a, 0x4b, 0x0a, 0x1d, 0x4d, 0x61, 0x78, 0x56,
-	0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54,
-	0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79,
-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76,
-	0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75,
-	0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0x1e, 0x0a, 0x1c, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53,
-	0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x73,
-	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x63, 0x0a, 0x1e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56,
+	0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0x8f, 0x02, 0x0a, 0x1b, 0x55, 0x70, 0x64, 0x61,
+	0x74, 0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73,
+	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x5d, 0x0a, 0x09, 0x73, 0x65, 0x71, 0x75, 0x65,
+	0x6e, 0x63, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x3f, 0x2e, 0x74, 0x61, 0x62,
+	0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x55,
+	0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62,
+	0x6c, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x2e, 0x53, 0x65, 0x71, 0x75, 0x65,
+	0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52, 0x09, 0x73, 0x65, 0x71,
+	0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x1a, 0x90, 0x01, 0x0a, 0x10, 0x53, 0x65, 0x71, 0x75, 0x65,
+	0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12, 0x2c, 0x0a, 0x12, 0x62,
+	0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61, 0x6d,
+	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67,
+	0x54, 0x61, 0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x31, 0x0a, 0x15, 0x62, 0x61, 0x63,
+	0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e, 0x61,
+	0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e,
+	0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x62, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1b, 0x0a, 0x09,
+	0x6d, 0x61, 0x78, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x52,
+	0x08, 0x6d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22, 0x1e, 0x0a, 0x1c, 0x55, 0x70, 0x64,
+	0x61, 0x74, 0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65,
+	0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0xe8, 0x02, 0x0a, 0x1e, 0x47, 0x65,
+	0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71, 0x75,
+	0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x60, 0x0a, 0x09,
+	0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x42, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64,
+	0x61, 0x74, 0x61, 0x2e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x46,
+	0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x2e, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64,
+	0x61, 0x74, 0x61, 0x52, 0x09, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x1a, 0xe3,
+	0x01, 0x0a, 0x10, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64,
+	0x61, 0x74, 0x61, 0x12, 0x2c, 0x0a, 0x12, 0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74,
+	0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x10, 0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d,
+	0x65, 0x12, 0x2a, 0x0a, 0x11, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6c, 0x5f, 0x65,
+	0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x75, 0x73,
+	0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6c, 0x45, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x12, 0x37, 0x0a,
+	0x18, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61, 0x6d,
+	0x65, 0x5f, 0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x15, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x45,
+	0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x12, 0x3c, 0x0a, 0x1b, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f,
+	0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x65, 0x73,
+	0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x17, 0x75, 0x73, 0x69,
+	0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x62, 0x4e, 0x61, 0x6d, 0x65, 0x45, 0x73, 0x63,
+	0x61, 0x70, 0x65, 0x64, 0x22, 0x81, 0x02, 0x0a, 0x1f, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56,
 	0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73,
-	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x41, 0x0a, 0x09, 0x73, 0x65, 0x71, 0x75, 0x65,
-	0x6e, 0x63, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x74, 0x61, 0x62,
-	0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x53,
-	0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52,
-	0x09, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x22, 0x81, 0x02, 0x0a, 0x1f, 0x47,
-	0x65, 0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71,
-	0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x90,
-	0x01, 0x0a, 0x1c, 0x6d, 0x61, 0x78, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x5f, 0x62, 0x79,
-	0x5f, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x18,
-	0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x50, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61,
-	0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78,
-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65,
-	0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c,
-	0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62,
-	0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x18, 0x6d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75,
-	0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c,
-	0x65, 0x1a, 0x4b, 0x0a, 0x1d, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79,
-	0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74,
-	0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
-	0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
-	0x01, 0x28, 0x03, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x2a, 0x3e,
-	0x0a, 0x19, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f,
-	0x6e, 0x50, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x07, 0x0a, 0x03, 0x41,
-	0x4e, 0x59, 0x10, 0x00, 0x12, 0x0b, 0x0a, 0x07, 0x49, 0x4e, 0x4f, 0x52, 0x44, 0x45, 0x52, 0x10,
-	0x01, 0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x03, 0x2a, 0x83,
-	0x01, 0x0a, 0x1a, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x54, 0x68, 0x72, 0x6f, 0x74, 0x74, 0x6c, 0x65,
-	0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x12, 0x0d, 0x0a,
-	0x09, 0x55, 0x4e, 0x44, 0x45, 0x46, 0x49, 0x4e, 0x45, 0x44, 0x10, 0x00, 0x12, 0x06, 0x0a, 0x02,
-	0x4f, 0x4b, 0x10, 0x01, 0x12, 0x16, 0x0a, 0x12, 0x54, 0x48, 0x52, 0x45, 0x53, 0x48, 0x4f, 0x4c,
-	0x44, 0x5f, 0x45, 0x58, 0x43, 0x45, 0x45, 0x44, 0x45, 0x44, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a,
-	0x41, 0x50, 0x50, 0x5f, 0x44, 0x45, 0x4e, 0x49, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e,
-	0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x5f, 0x4d, 0x45, 0x54, 0x52, 0x49, 0x43, 0x10, 0x04,
-	0x12, 0x12, 0x0a, 0x0e, 0x49, 0x4e, 0x54, 0x45, 0x52, 0x4e, 0x41, 0x4c, 0x5f, 0x45, 0x52, 0x52,
-	0x4f, 0x52, 0x10, 0x05, 0x42, 0x30, 0x5a, 0x2e, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2e, 0x69,
-	0x6f, 0x2f, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2f, 0x67, 0x6f, 0x2f, 0x76, 0x74, 0x2f, 0x70,
-	0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67,
-	0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x90, 0x01, 0x0a, 0x1c, 0x6d, 0x61, 0x78,
+	0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x5f, 0x62, 0x79, 0x5f, 0x73, 0x65, 0x71, 0x75, 0x65,
+	0x6e, 0x63, 0x65, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x50, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64,
+	0x61, 0x74, 0x61, 0x2e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x46,
+	0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x2e, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53,
+	0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72,
+	0x79, 0x52, 0x18, 0x6d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65,
+	0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x1a, 0x4b, 0x0a, 0x1d, 0x4d,
+	0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e,
+	0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03,
+	0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14,
+	0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x76,
+	0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x2a, 0x3e, 0x0a, 0x19, 0x54, 0x61, 0x62, 0x6c,
+	0x65, 0x74, 0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x50, 0x72, 0x65, 0x66, 0x65,
+	0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x07, 0x0a, 0x03, 0x41, 0x4e, 0x59, 0x10, 0x00, 0x12, 0x0b,
+	0x0a, 0x07, 0x49, 0x4e, 0x4f, 0x52, 0x44, 0x45, 0x52, 0x10, 0x01, 0x12, 0x0b, 0x0a, 0x07, 0x55,
+	0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x03, 0x2a, 0x83, 0x01, 0x0a, 0x1a, 0x43, 0x68, 0x65,
+	0x63, 0x6b, 0x54, 0x68, 0x72, 0x6f, 0x74, 0x74, 0x6c, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x12, 0x0d, 0x0a, 0x09, 0x55, 0x4e, 0x44, 0x45, 0x46,
+	0x49, 0x4e, 0x45, 0x44, 0x10, 0x00, 0x12, 0x06, 0x0a, 0x02, 0x4f, 0x4b, 0x10, 0x01, 0x12, 0x16,
+	0x0a, 0x12, 0x54, 0x48, 0x52, 0x45, 0x53, 0x48, 0x4f, 0x4c, 0x44, 0x5f, 0x45, 0x58, 0x43, 0x45,
+	0x45, 0x44, 0x45, 0x44, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a, 0x41, 0x50, 0x50, 0x5f, 0x44, 0x45,
+	0x4e, 0x49, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57,
+	0x4e, 0x5f, 0x4d, 0x45, 0x54, 0x52, 0x49, 0x43, 0x10, 0x04, 0x12, 0x12, 0x0a, 0x0e, 0x49, 0x4e,
+	0x54, 0x45, 0x52, 0x4e, 0x41, 0x4c, 0x5f, 0x45, 0x52, 0x52, 0x4f, 0x52, 0x10, 0x05, 0x42, 0x30,
+	0x5a, 0x2e, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2e, 0x69, 0x6f, 0x2f, 0x76, 0x69, 0x74, 0x65,
+	0x73, 0x73, 0x2f, 0x67, 0x6f, 0x2f, 0x76, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74,
+	0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 })
 
 var (
@@ -9744,45 +9751,45 @@ var file_tabletmanagerdata_proto_goTypes = []any{
 	(*GetThrottlerStatusResponse)(nil),              // 144: tabletmanagerdata.GetThrottlerStatusResponse
 	(*ChangeTagsRequest)(nil),                       // 145: tabletmanagerdata.ChangeTagsRequest
 	(*ChangeTagsResponse)(nil),                      // 146: tabletmanagerdata.ChangeTagsResponse
-	(*SequenceMetadata)(nil),                        // 147: tabletmanagerdata.SequenceMetadata
-	(*UpdateSequenceTablesRequest)(nil),             // 148: tabletmanagerdata.UpdateSequenceTablesRequest
-	(*UpdateSequenceTablesResponse)(nil),            // 149: tabletmanagerdata.UpdateSequenceTablesResponse
-	(*GetMaxValueForSequencesRequest)(nil),          // 150: tabletmanagerdata.GetMaxValueForSequencesRequest
-	(*GetMaxValueForSequencesResponse)(nil),         // 151: tabletmanagerdata.GetMaxValueForSequencesResponse
-	nil,                                             // 152: tabletmanagerdata.UserPermission.PrivilegesEntry
-	nil,                                             // 153: tabletmanagerdata.DbPermission.PrivilegesEntry
-	nil,                                             // 154: tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
-	nil,                                             // 155: tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
-	nil,                                             // 156: tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
-	(*ReadVReplicationWorkflowResponse_Stream)(nil), // 157: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
-	nil,                                   // 158: tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
-	nil,                                   // 159: tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
-	(*CheckThrottlerResponse_Metric)(nil), // 160: tabletmanagerdata.CheckThrottlerResponse.Metric
-	nil,                                   // 161: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
-	(*GetThrottlerStatusResponse_MetricResult)(nil), // 162: tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
-	nil, // 163: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
-	nil, // 164: tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
-	(*GetThrottlerStatusResponse_MetricHealth)(nil), // 165: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
-	nil, // 166: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
-	nil, // 167: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
-	nil, // 168: tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
-	(*GetThrottlerStatusResponse_RecentApp)(nil), // 169: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
-	nil,                                      // 170: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
-	nil,                                      // 171: tabletmanagerdata.ChangeTagsRequest.TagsEntry
-	nil,                                      // 172: tabletmanagerdata.ChangeTagsResponse.TagsEntry
-	nil,                                      // 173: tabletmanagerdata.UpdateSequenceTablesRequest.MaxValuesBySequenceTableEntry
-	nil,                                      // 174: tabletmanagerdata.GetMaxValueForSequencesResponse.MaxValuesBySequenceTableEntry
-	(*query.Field)(nil),                      // 175: query.Field
-	(topodata.TabletType)(0),                 // 176: topodata.TabletType
-	(*vtrpc.CallerID)(nil),                   // 177: vtrpc.CallerID
-	(*query.QueryResult)(nil),                // 178: query.QueryResult
-	(*query.TransactionMetadata)(nil),        // 179: query.TransactionMetadata
-	(*mysqlctl.HostMetricsResponse)(nil),     // 180: mysqlctl.HostMetricsResponse
-	(*replicationdata.Status)(nil),           // 181: replicationdata.Status
-	(*replicationdata.PrimaryStatus)(nil),    // 182: replicationdata.PrimaryStatus
-	(*topodata.TabletAlias)(nil),             // 183: topodata.TabletAlias
-	(*replicationdata.FullStatus)(nil),       // 184: replicationdata.FullStatus
-	(replicationdata.StopReplicationMode)(0), // 185: replicationdata.StopReplicationMode
+	(*UpdateSequenceTablesRequest)(nil),             // 147: tabletmanagerdata.UpdateSequenceTablesRequest
+	(*UpdateSequenceTablesResponse)(nil),            // 148: tabletmanagerdata.UpdateSequenceTablesResponse
+	(*GetMaxValueForSequencesRequest)(nil),          // 149: tabletmanagerdata.GetMaxValueForSequencesRequest
+	(*GetMaxValueForSequencesResponse)(nil),         // 150: tabletmanagerdata.GetMaxValueForSequencesResponse
+	nil,                                             // 151: tabletmanagerdata.UserPermission.PrivilegesEntry
+	nil,                                             // 152: tabletmanagerdata.DbPermission.PrivilegesEntry
+	nil,                                             // 153: tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
+	nil,                                             // 154: tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
+	nil,                                             // 155: tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
+	(*ReadVReplicationWorkflowResponse_Stream)(nil), // 156: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
+	nil,                                   // 157: tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
+	nil,                                   // 158: tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
+	(*CheckThrottlerResponse_Metric)(nil), // 159: tabletmanagerdata.CheckThrottlerResponse.Metric
+	nil,                                   // 160: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
+	(*GetThrottlerStatusResponse_MetricResult)(nil), // 161: tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
+	nil, // 162: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
+	nil, // 163: tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
+	(*GetThrottlerStatusResponse_MetricHealth)(nil), // 164: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
+	nil, // 165: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
+	nil, // 166: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
+	nil, // 167: tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
+	(*GetThrottlerStatusResponse_RecentApp)(nil), // 168: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
+	nil, // 169: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
+	nil, // 170: tabletmanagerdata.ChangeTagsRequest.TagsEntry
+	nil, // 171: tabletmanagerdata.ChangeTagsResponse.TagsEntry
+	(*UpdateSequenceTablesRequest_SequenceMetadata)(nil),    // 172: tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata
+	(*GetMaxValueForSequencesRequest_SequenceMetadata)(nil), // 173: tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata
+	nil,                                           // 174: tabletmanagerdata.GetMaxValueForSequencesResponse.MaxValuesBySequenceTableEntry
+	(*query.Field)(nil),                           // 175: query.Field
+	(topodata.TabletType)(0),                      // 176: topodata.TabletType
+	(*vtrpc.CallerID)(nil),                        // 177: vtrpc.CallerID
+	(*query.QueryResult)(nil),                     // 178: query.QueryResult
+	(*query.TransactionMetadata)(nil),             // 179: query.TransactionMetadata
+	(*mysqlctl.HostMetricsResponse)(nil),          // 180: mysqlctl.HostMetricsResponse
+	(*replicationdata.Status)(nil),                // 181: replicationdata.Status
+	(*replicationdata.PrimaryStatus)(nil),         // 182: replicationdata.PrimaryStatus
+	(*topodata.TabletAlias)(nil),                  // 183: topodata.TabletAlias
+	(*replicationdata.FullStatus)(nil),            // 184: replicationdata.FullStatus
+	(replicationdata.StopReplicationMode)(0),      // 185: replicationdata.StopReplicationMode
 	(*replicationdata.StopReplicationStatus)(nil), // 186: replicationdata.StopReplicationStatus
 	(*vttime.Duration)(nil),                       // 187: vttime.Duration
 	(*logutil.Event)(nil),                         // 188: logutil.Event
@@ -9799,14 +9806,14 @@ var file_tabletmanagerdata_proto_depIdxs = []int32{
 	2,   // 1: tabletmanagerdata.SchemaDefinition.table_definitions:type_name -> tabletmanagerdata.TableDefinition
 	3,   // 2: tabletmanagerdata.SchemaChangeResult.before_schema:type_name -> tabletmanagerdata.SchemaDefinition
 	3,   // 3: tabletmanagerdata.SchemaChangeResult.after_schema:type_name -> tabletmanagerdata.SchemaDefinition
-	152, // 4: tabletmanagerdata.UserPermission.privileges:type_name -> tabletmanagerdata.UserPermission.PrivilegesEntry
-	153, // 5: tabletmanagerdata.DbPermission.privileges:type_name -> tabletmanagerdata.DbPermission.PrivilegesEntry
+	151, // 4: tabletmanagerdata.UserPermission.privileges:type_name -> tabletmanagerdata.UserPermission.PrivilegesEntry
+	152, // 5: tabletmanagerdata.DbPermission.privileges:type_name -> tabletmanagerdata.DbPermission.PrivilegesEntry
 	5,   // 6: tabletmanagerdata.Permissions.user_permissions:type_name -> tabletmanagerdata.UserPermission
 	6,   // 7: tabletmanagerdata.Permissions.db_permissions:type_name -> tabletmanagerdata.DbPermission
-	154, // 8: tabletmanagerdata.ExecuteHookRequest.extra_env:type_name -> tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
+	153, // 8: tabletmanagerdata.ExecuteHookRequest.extra_env:type_name -> tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
 	3,   // 9: tabletmanagerdata.GetSchemaResponse.schema_definition:type_name -> tabletmanagerdata.SchemaDefinition
 	7,   // 10: tabletmanagerdata.GetPermissionsResponse.permissions:type_name -> tabletmanagerdata.Permissions
-	155, // 11: tabletmanagerdata.GetGlobalStatusVarsResponse.status_values:type_name -> tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
+	154, // 11: tabletmanagerdata.GetGlobalStatusVarsResponse.status_values:type_name -> tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
 	176, // 12: tabletmanagerdata.ChangeTypeRequest.tablet_type:type_name -> topodata.TabletType
 	4,   // 13: tabletmanagerdata.PreflightSchemaResponse.change_results:type_name -> tabletmanagerdata.SchemaChangeResult
 	3,   // 14: tabletmanagerdata.ApplySchemaRequest.before_schema:type_name -> tabletmanagerdata.SchemaDefinition
@@ -9844,7 +9851,7 @@ var file_tabletmanagerdata_proto_depIdxs = []int32{
 	191, // 46: tabletmanagerdata.CreateVReplicationWorkflowRequest.workflow_type:type_name -> binlogdata.VReplicationWorkflowType
 	192, // 47: tabletmanagerdata.CreateVReplicationWorkflowRequest.workflow_sub_type:type_name -> binlogdata.VReplicationWorkflowSubType
 	178, // 48: tabletmanagerdata.CreateVReplicationWorkflowResponse.result:type_name -> query.QueryResult
-	156, // 49: tabletmanagerdata.DeleteTableDataRequest.table_filters:type_name -> tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
+	155, // 49: tabletmanagerdata.DeleteTableDataRequest.table_filters:type_name -> tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
 	178, // 50: tabletmanagerdata.DeleteVReplicationWorkflowResponse.result:type_name -> query.QueryResult
 	193, // 51: tabletmanagerdata.ReadVReplicationWorkflowsRequest.include_states:type_name -> binlogdata.VReplicationWorkflowState
 	193, // 52: tabletmanagerdata.ReadVReplicationWorkflowsRequest.exclude_states:type_name -> binlogdata.VReplicationWorkflowState
@@ -9853,8 +9860,8 @@ var file_tabletmanagerdata_proto_depIdxs = []int32{
 	0,   // 55: tabletmanagerdata.ReadVReplicationWorkflowResponse.tablet_selection_preference:type_name -> tabletmanagerdata.TabletSelectionPreference
 	191, // 56: tabletmanagerdata.ReadVReplicationWorkflowResponse.workflow_type:type_name -> binlogdata.VReplicationWorkflowType
 	192, // 57: tabletmanagerdata.ReadVReplicationWorkflowResponse.workflow_sub_type:type_name -> binlogdata.VReplicationWorkflowSubType
-	157, // 58: tabletmanagerdata.ReadVReplicationWorkflowResponse.streams:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
-	158, // 59: tabletmanagerdata.ReadVReplicationWorkflowResponse.config_overrides:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
+	156, // 58: tabletmanagerdata.ReadVReplicationWorkflowResponse.streams:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
+	157, // 59: tabletmanagerdata.ReadVReplicationWorkflowResponse.config_overrides:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
 	133, // 60: tabletmanagerdata.VDiffRequest.options:type_name -> tabletmanagerdata.VDiffOptions
 	178, // 61: tabletmanagerdata.VDiffResponse.output:type_name -> query.QueryResult
 	130, // 62: tabletmanagerdata.VDiffOptions.picker_options:type_name -> tabletmanagerdata.VDiffPickerOptions
@@ -9866,44 +9873,43 @@ var file_tabletmanagerdata_proto_depIdxs = []int32{
 	0,   // 68: tabletmanagerdata.UpdateVReplicationWorkflowRequest.tablet_selection_preference:type_name -> tabletmanagerdata.TabletSelectionPreference
 	194, // 69: tabletmanagerdata.UpdateVReplicationWorkflowRequest.on_ddl:type_name -> binlogdata.OnDDLAction
 	193, // 70: tabletmanagerdata.UpdateVReplicationWorkflowRequest.state:type_name -> binlogdata.VReplicationWorkflowState
-	159, // 71: tabletmanagerdata.UpdateVReplicationWorkflowRequest.config_overrides:type_name -> tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
+	158, // 71: tabletmanagerdata.UpdateVReplicationWorkflowRequest.config_overrides:type_name -> tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
 	178, // 72: tabletmanagerdata.UpdateVReplicationWorkflowResponse.result:type_name -> query.QueryResult
 	193, // 73: tabletmanagerdata.UpdateVReplicationWorkflowsRequest.state:type_name -> binlogdata.VReplicationWorkflowState
 	178, // 74: tabletmanagerdata.UpdateVReplicationWorkflowsResponse.result:type_name -> query.QueryResult
-	161, // 75: tabletmanagerdata.CheckThrottlerResponse.metrics:type_name -> tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
+	160, // 75: tabletmanagerdata.CheckThrottlerResponse.metrics:type_name -> tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
 	1,   // 76: tabletmanagerdata.CheckThrottlerResponse.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
-	163, // 77: tabletmanagerdata.GetThrottlerStatusResponse.aggregated_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
-	164, // 78: tabletmanagerdata.GetThrottlerStatusResponse.metric_thresholds:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
-	166, // 79: tabletmanagerdata.GetThrottlerStatusResponse.metrics_health:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
-	167, // 80: tabletmanagerdata.GetThrottlerStatusResponse.throttled_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
-	168, // 81: tabletmanagerdata.GetThrottlerStatusResponse.app_checked_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
-	170, // 82: tabletmanagerdata.GetThrottlerStatusResponse.recent_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
-	171, // 83: tabletmanagerdata.ChangeTagsRequest.tags:type_name -> tabletmanagerdata.ChangeTagsRequest.TagsEntry
-	172, // 84: tabletmanagerdata.ChangeTagsResponse.tags:type_name -> tabletmanagerdata.ChangeTagsResponse.TagsEntry
-	147, // 85: tabletmanagerdata.UpdateSequenceTablesRequest.sequences:type_name -> tabletmanagerdata.SequenceMetadata
-	173, // 86: tabletmanagerdata.UpdateSequenceTablesRequest.max_values_by_sequence_table:type_name -> tabletmanagerdata.UpdateSequenceTablesRequest.MaxValuesBySequenceTableEntry
-	147, // 87: tabletmanagerdata.GetMaxValueForSequencesRequest.sequences:type_name -> tabletmanagerdata.SequenceMetadata
-	174, // 88: tabletmanagerdata.GetMaxValueForSequencesResponse.max_values_by_sequence_table:type_name -> tabletmanagerdata.GetMaxValueForSequencesResponse.MaxValuesBySequenceTableEntry
-	190, // 89: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.bls:type_name -> binlogdata.BinlogSource
-	189, // 90: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_updated:type_name -> vttime.Time
-	189, // 91: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.transaction_timestamp:type_name -> vttime.Time
-	193, // 92: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.state:type_name -> binlogdata.VReplicationWorkflowState
-	189, // 93: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_heartbeat:type_name -> vttime.Time
-	189, // 94: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_throttled:type_name -> vttime.Time
-	1,   // 95: tabletmanagerdata.CheckThrottlerResponse.Metric.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
-	160, // 96: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry.value:type_name -> tabletmanagerdata.CheckThrottlerResponse.Metric
-	162, // 97: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
-	189, // 98: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth.last_healthy_at:type_name -> vttime.Time
-	165, // 99: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
-	195, // 100: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry.value:type_name -> topodata.ThrottledAppRule
-	189, // 101: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.checked_at:type_name -> vttime.Time
-	1,   // 102: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
-	169, // 103: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
-	104, // [104:104] is the sub-list for method output_type
-	104, // [104:104] is the sub-list for method input_type
-	104, // [104:104] is the sub-list for extension type_name
-	104, // [104:104] is the sub-list for extension extendee
-	0,   // [0:104] is the sub-list for field type_name
+	162, // 77: tabletmanagerdata.GetThrottlerStatusResponse.aggregated_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
+	163, // 78: tabletmanagerdata.GetThrottlerStatusResponse.metric_thresholds:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
+	165, // 79: tabletmanagerdata.GetThrottlerStatusResponse.metrics_health:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
+	166, // 80: tabletmanagerdata.GetThrottlerStatusResponse.throttled_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
+	167, // 81: tabletmanagerdata.GetThrottlerStatusResponse.app_checked_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
+	169, // 82: tabletmanagerdata.GetThrottlerStatusResponse.recent_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
+	170, // 83: tabletmanagerdata.ChangeTagsRequest.tags:type_name -> tabletmanagerdata.ChangeTagsRequest.TagsEntry
+	171, // 84: tabletmanagerdata.ChangeTagsResponse.tags:type_name -> tabletmanagerdata.ChangeTagsResponse.TagsEntry
+	172, // 85: tabletmanagerdata.UpdateSequenceTablesRequest.sequences:type_name -> tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata
+	173, // 86: tabletmanagerdata.GetMaxValueForSequencesRequest.sequences:type_name -> tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata
+	174, // 87: tabletmanagerdata.GetMaxValueForSequencesResponse.max_values_by_sequence_table:type_name -> tabletmanagerdata.GetMaxValueForSequencesResponse.MaxValuesBySequenceTableEntry
+	190, // 88: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.bls:type_name -> binlogdata.BinlogSource
+	189, // 89: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_updated:type_name -> vttime.Time
+	189, // 90: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.transaction_timestamp:type_name -> vttime.Time
+	193, // 91: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.state:type_name -> binlogdata.VReplicationWorkflowState
+	189, // 92: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_heartbeat:type_name -> vttime.Time
+	189, // 93: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_throttled:type_name -> vttime.Time
+	1,   // 94: tabletmanagerdata.CheckThrottlerResponse.Metric.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
+	159, // 95: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry.value:type_name -> tabletmanagerdata.CheckThrottlerResponse.Metric
+	161, // 96: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
+	189, // 97: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth.last_healthy_at:type_name -> vttime.Time
+	164, // 98: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
+	195, // 99: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry.value:type_name -> topodata.ThrottledAppRule
+	189, // 100: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.checked_at:type_name -> vttime.Time
+	1,   // 101: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
+	168, // 102: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
+	103, // [103:103] is the sub-list for method output_type
+	103, // [103:103] is the sub-list for method input_type
+	103, // [103:103] is the sub-list for extension type_name
+	103, // [103:103] is the sub-list for extension extendee
+	0,   // [0:103] is the sub-list for field type_name
 }
 
 func init() { file_tabletmanagerdata_proto_init() }

--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
@@ -7760,8 +7760,9 @@ func (x *GetMaxValueForSequencesRequest) GetSequences() []*GetMaxValueForSequenc
 }
 
 type GetMaxValueForSequencesResponse struct {
-	state                    protoimpl.MessageState `protogen:"open.v1"`
-	MaxValuesBySequenceTable map[string]int64       `protobuf:"bytes,1,rep,name=max_values_by_sequence_table,json=maxValuesBySequenceTable,proto3" json:"max_values_by_sequence_table,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Max used sequence value mapped with the backing sequence table.
+	MaxValuesBySequenceTable map[string]int64 `protobuf:"bytes,1,rep,name=max_values_by_sequence_table,json=maxValuesBySequenceTable,proto3" json:"max_values_by_sequence_table,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }

--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
@@ -7635,6 +7635,290 @@ func (x *ChangeTagsResponse) GetTags() map[string]string {
 	return nil
 }
 
+type SequenceMetadata struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The name of the sequence table.
+	BackingTableName string `protobuf:"bytes,1,opt,name=backing_table_name,json=backingTableName,proto3" json:"backing_table_name,omitempty"`
+	// The dbName in use by the keyspace where the backing table lives.
+	BackingTableDbName string `protobuf:"bytes,2,opt,name=backing_table_db_name,json=backingTableDbName,proto3" json:"backing_table_db_name,omitempty"`
+	// The name of the table using the sequence.
+	UsingTableName string `protobuf:"bytes,3,opt,name=using_table_name,json=usingTableName,proto3" json:"using_table_name,omitempty"`
+	// The dbName in use by the keyspace where the using table lives.
+	UsingTableDbName string `protobuf:"bytes,4,opt,name=using_table_db_name,json=usingTableDbName,proto3" json:"using_table_db_name,omitempty"`
+	// Escaped column name specified for sequence in table.
+	UsingColEscaped string `protobuf:"bytes,5,opt,name=using_col_escaped,json=usingColEscaped,proto3" json:"using_col_escaped,omitempty"`
+	// Escaped name of the table using the sequence.
+	UsingTableNameEscaped string `protobuf:"bytes,6,opt,name=using_table_name_escaped,json=usingTableNameEscaped,proto3" json:"using_table_name_escaped,omitempty"`
+	// Escaped db name in use by the keyspace where the using table lives.
+	UsingTableDbNameEscaped string `protobuf:"bytes,7,opt,name=using_table_db_name_escaped,json=usingTableDbNameEscaped,proto3" json:"using_table_db_name_escaped,omitempty"`
+	// Escaped name of the sequence table.
+	BackingTableNameEscaped string `protobuf:"bytes,8,opt,name=backing_table_name_escaped,json=backingTableNameEscaped,proto3" json:"backing_table_name_escaped,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *SequenceMetadata) Reset() {
+	*x = SequenceMetadata{}
+	mi := &file_tabletmanagerdata_proto_msgTypes[145]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SequenceMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SequenceMetadata) ProtoMessage() {}
+
+func (x *SequenceMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_tabletmanagerdata_proto_msgTypes[145]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SequenceMetadata.ProtoReflect.Descriptor instead.
+func (*SequenceMetadata) Descriptor() ([]byte, []int) {
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{145}
+}
+
+func (x *SequenceMetadata) GetBackingTableName() string {
+	if x != nil {
+		return x.BackingTableName
+	}
+	return ""
+}
+
+func (x *SequenceMetadata) GetBackingTableDbName() string {
+	if x != nil {
+		return x.BackingTableDbName
+	}
+	return ""
+}
+
+func (x *SequenceMetadata) GetUsingTableName() string {
+	if x != nil {
+		return x.UsingTableName
+	}
+	return ""
+}
+
+func (x *SequenceMetadata) GetUsingTableDbName() string {
+	if x != nil {
+		return x.UsingTableDbName
+	}
+	return ""
+}
+
+func (x *SequenceMetadata) GetUsingColEscaped() string {
+	if x != nil {
+		return x.UsingColEscaped
+	}
+	return ""
+}
+
+func (x *SequenceMetadata) GetUsingTableNameEscaped() string {
+	if x != nil {
+		return x.UsingTableNameEscaped
+	}
+	return ""
+}
+
+func (x *SequenceMetadata) GetUsingTableDbNameEscaped() string {
+	if x != nil {
+		return x.UsingTableDbNameEscaped
+	}
+	return ""
+}
+
+func (x *SequenceMetadata) GetBackingTableNameEscaped() string {
+	if x != nil {
+		return x.BackingTableNameEscaped
+	}
+	return ""
+}
+
+type UpdateSequenceTablesRequest struct {
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	Sequences                []*SequenceMetadata    `protobuf:"bytes,1,rep,name=sequences,proto3" json:"sequences,omitempty"`
+	MaxValuesBySequenceTable map[string]int64       `protobuf:"bytes,2,rep,name=max_values_by_sequence_table,json=maxValuesBySequenceTable,proto3" json:"max_values_by_sequence_table,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *UpdateSequenceTablesRequest) Reset() {
+	*x = UpdateSequenceTablesRequest{}
+	mi := &file_tabletmanagerdata_proto_msgTypes[146]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSequenceTablesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSequenceTablesRequest) ProtoMessage() {}
+
+func (x *UpdateSequenceTablesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tabletmanagerdata_proto_msgTypes[146]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSequenceTablesRequest.ProtoReflect.Descriptor instead.
+func (*UpdateSequenceTablesRequest) Descriptor() ([]byte, []int) {
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{146}
+}
+
+func (x *UpdateSequenceTablesRequest) GetSequences() []*SequenceMetadata {
+	if x != nil {
+		return x.Sequences
+	}
+	return nil
+}
+
+func (x *UpdateSequenceTablesRequest) GetMaxValuesBySequenceTable() map[string]int64 {
+	if x != nil {
+		return x.MaxValuesBySequenceTable
+	}
+	return nil
+}
+
+type UpdateSequenceTablesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateSequenceTablesResponse) Reset() {
+	*x = UpdateSequenceTablesResponse{}
+	mi := &file_tabletmanagerdata_proto_msgTypes[147]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSequenceTablesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSequenceTablesResponse) ProtoMessage() {}
+
+func (x *UpdateSequenceTablesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tabletmanagerdata_proto_msgTypes[147]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSequenceTablesResponse.ProtoReflect.Descriptor instead.
+func (*UpdateSequenceTablesResponse) Descriptor() ([]byte, []int) {
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{147}
+}
+
+type GetMaxValueForSequencesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sequences     []*SequenceMetadata    `protobuf:"bytes,1,rep,name=sequences,proto3" json:"sequences,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMaxValueForSequencesRequest) Reset() {
+	*x = GetMaxValueForSequencesRequest{}
+	mi := &file_tabletmanagerdata_proto_msgTypes[148]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMaxValueForSequencesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMaxValueForSequencesRequest) ProtoMessage() {}
+
+func (x *GetMaxValueForSequencesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tabletmanagerdata_proto_msgTypes[148]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMaxValueForSequencesRequest.ProtoReflect.Descriptor instead.
+func (*GetMaxValueForSequencesRequest) Descriptor() ([]byte, []int) {
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{148}
+}
+
+func (x *GetMaxValueForSequencesRequest) GetSequences() []*SequenceMetadata {
+	if x != nil {
+		return x.Sequences
+	}
+	return nil
+}
+
+type GetMaxValueForSequencesResponse struct {
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	MaxValuesBySequenceTable map[string]int64       `protobuf:"bytes,1,rep,name=max_values_by_sequence_table,json=maxValuesBySequenceTable,proto3" json:"max_values_by_sequence_table,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *GetMaxValueForSequencesResponse) Reset() {
+	*x = GetMaxValueForSequencesResponse{}
+	mi := &file_tabletmanagerdata_proto_msgTypes[149]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMaxValueForSequencesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMaxValueForSequencesResponse) ProtoMessage() {}
+
+func (x *GetMaxValueForSequencesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tabletmanagerdata_proto_msgTypes[149]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMaxValueForSequencesResponse.ProtoReflect.Descriptor instead.
+func (*GetMaxValueForSequencesResponse) Descriptor() ([]byte, []int) {
+	return file_tabletmanagerdata_proto_rawDescGZIP(), []int{149}
+}
+
+func (x *GetMaxValueForSequencesResponse) GetMaxValuesBySequenceTable() map[string]int64 {
+	if x != nil {
+		return x.MaxValuesBySequenceTable
+	}
+	return nil
+}
+
 type ReadVReplicationWorkflowResponse_Stream struct {
 	state                protoimpl.MessageState               `protogen:"open.v1"`
 	Id                   int32                                `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -7657,7 +7941,7 @@ type ReadVReplicationWorkflowResponse_Stream struct {
 
 func (x *ReadVReplicationWorkflowResponse_Stream) Reset() {
 	*x = ReadVReplicationWorkflowResponse_Stream{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[150]
+	mi := &file_tabletmanagerdata_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7669,7 +7953,7 @@ func (x *ReadVReplicationWorkflowResponse_Stream) String() string {
 func (*ReadVReplicationWorkflowResponse_Stream) ProtoMessage() {}
 
 func (x *ReadVReplicationWorkflowResponse_Stream) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[150]
+	mi := &file_tabletmanagerdata_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7805,7 +8089,7 @@ type CheckThrottlerResponse_Metric struct {
 
 func (x *CheckThrottlerResponse_Metric) Reset() {
 	*x = CheckThrottlerResponse_Metric{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[153]
+	mi := &file_tabletmanagerdata_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7817,7 +8101,7 @@ func (x *CheckThrottlerResponse_Metric) String() string {
 func (*CheckThrottlerResponse_Metric) ProtoMessage() {}
 
 func (x *CheckThrottlerResponse_Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[153]
+	mi := &file_tabletmanagerdata_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7892,7 +8176,7 @@ type GetThrottlerStatusResponse_MetricResult struct {
 
 func (x *GetThrottlerStatusResponse_MetricResult) Reset() {
 	*x = GetThrottlerStatusResponse_MetricResult{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[155]
+	mi := &file_tabletmanagerdata_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7904,7 +8188,7 @@ func (x *GetThrottlerStatusResponse_MetricResult) String() string {
 func (*GetThrottlerStatusResponse_MetricResult) ProtoMessage() {}
 
 func (x *GetThrottlerStatusResponse_MetricResult) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[155]
+	mi := &file_tabletmanagerdata_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7944,7 +8228,7 @@ type GetThrottlerStatusResponse_MetricHealth struct {
 
 func (x *GetThrottlerStatusResponse_MetricHealth) Reset() {
 	*x = GetThrottlerStatusResponse_MetricHealth{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[158]
+	mi := &file_tabletmanagerdata_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7956,7 +8240,7 @@ func (x *GetThrottlerStatusResponse_MetricHealth) String() string {
 func (*GetThrottlerStatusResponse_MetricHealth) ProtoMessage() {}
 
 func (x *GetThrottlerStatusResponse_MetricHealth) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[158]
+	mi := &file_tabletmanagerdata_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7997,7 +8281,7 @@ type GetThrottlerStatusResponse_RecentApp struct {
 
 func (x *GetThrottlerStatusResponse_RecentApp) Reset() {
 	*x = GetThrottlerStatusResponse_RecentApp{}
-	mi := &file_tabletmanagerdata_proto_msgTypes[162]
+	mi := &file_tabletmanagerdata_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8009,7 +8293,7 @@ func (x *GetThrottlerStatusResponse_RecentApp) String() string {
 func (*GetThrottlerStatusResponse_RecentApp) ProtoMessage() {}
 
 func (x *GetThrottlerStatusResponse_RecentApp) ProtoReflect() protoreflect.Message {
-	mi := &file_tabletmanagerdata_proto_msgTypes[162]
+	mi := &file_tabletmanagerdata_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9208,23 +9492,94 @@ var file_tabletmanagerdata_proto_rawDesc = string([]byte{
 	0x0a, 0x09, 0x54, 0x61, 0x67, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b,
 	0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a,
 	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61,
-	0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x2a, 0x3e, 0x0a, 0x19, 0x54, 0x61, 0x62, 0x6c, 0x65,
-	0x74, 0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x50, 0x72, 0x65, 0x66, 0x65, 0x72,
-	0x65, 0x6e, 0x63, 0x65, 0x12, 0x07, 0x0a, 0x03, 0x41, 0x4e, 0x59, 0x10, 0x00, 0x12, 0x0b, 0x0a,
-	0x07, 0x49, 0x4e, 0x4f, 0x52, 0x44, 0x45, 0x52, 0x10, 0x01, 0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e,
-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x03, 0x2a, 0x83, 0x01, 0x0a, 0x1a, 0x43, 0x68, 0x65, 0x63,
-	0x6b, 0x54, 0x68, 0x72, 0x6f, 0x74, 0x74, 0x6c, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
-	0x73, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x12, 0x0d, 0x0a, 0x09, 0x55, 0x4e, 0x44, 0x45, 0x46, 0x49,
-	0x4e, 0x45, 0x44, 0x10, 0x00, 0x12, 0x06, 0x0a, 0x02, 0x4f, 0x4b, 0x10, 0x01, 0x12, 0x16, 0x0a,
-	0x12, 0x54, 0x48, 0x52, 0x45, 0x53, 0x48, 0x4f, 0x4c, 0x44, 0x5f, 0x45, 0x58, 0x43, 0x45, 0x45,
-	0x44, 0x45, 0x44, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a, 0x41, 0x50, 0x50, 0x5f, 0x44, 0x45, 0x4e,
-	0x49, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e,
-	0x5f, 0x4d, 0x45, 0x54, 0x52, 0x49, 0x43, 0x10, 0x04, 0x12, 0x12, 0x0a, 0x0e, 0x49, 0x4e, 0x54,
-	0x45, 0x52, 0x4e, 0x41, 0x4c, 0x5f, 0x45, 0x52, 0x52, 0x4f, 0x52, 0x10, 0x05, 0x42, 0x30, 0x5a,
-	0x2e, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2e, 0x69, 0x6f, 0x2f, 0x76, 0x69, 0x74, 0x65, 0x73,
-	0x73, 0x2f, 0x67, 0x6f, 0x2f, 0x76, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74, 0x61,
-	0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x62,
-	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0xac, 0x03, 0x0a, 0x10, 0x53, 0x65, 0x71, 0x75,
+	0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12, 0x2c, 0x0a, 0x12,
+	0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61,
+	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x62, 0x61, 0x63, 0x6b, 0x69, 0x6e,
+	0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x31, 0x0a, 0x15, 0x62, 0x61,
+	0x63, 0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e,
+	0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x62, 0x61, 0x63, 0x6b, 0x69,
+	0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x62, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x28, 0x0a,
+	0x10, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61, 0x6d,
+	0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61,
+	0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x2d, 0x0a, 0x13, 0x75, 0x73, 0x69, 0x6e, 0x67,
+	0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x04,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65,
+	0x44, 0x62, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x2a, 0x0a, 0x11, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f,
+	0x63, 0x6f, 0x6c, 0x5f, 0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x0f, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6c, 0x45, 0x73, 0x63, 0x61, 0x70,
+	0x65, 0x64, 0x12, 0x37, 0x0a, 0x18, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c,
+	0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x06,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x15, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65,
+	0x4e, 0x61, 0x6d, 0x65, 0x45, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x12, 0x3c, 0x0a, 0x1b, 0x75,
+	0x73, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x64, 0x62, 0x5f, 0x6e, 0x61,
+	0x6d, 0x65, 0x5f, 0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x17, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x62, 0x4e, 0x61,
+	0x6d, 0x65, 0x45, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x12, 0x3b, 0x0a, 0x1a, 0x62, 0x61, 0x63,
+	0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x5f,
+	0x65, 0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x17, 0x62,
+	0x61, 0x63, 0x6b, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x45,
+	0x73, 0x63, 0x61, 0x70, 0x65, 0x64, 0x22, 0xbc, 0x02, 0x0a, 0x1b, 0x55, 0x70, 0x64, 0x61, 0x74,
+	0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52,
+	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x41, 0x0a, 0x09, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e,
+	0x63, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x74, 0x61, 0x62, 0x6c,
+	0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x53, 0x65,
+	0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52, 0x09,
+	0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x12, 0x8c, 0x01, 0x0a, 0x1c, 0x6d, 0x61,
+	0x78, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x5f, 0x62, 0x79, 0x5f, 0x73, 0x65, 0x71, 0x75,
+	0x65, 0x6e, 0x63, 0x65, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b,
+	0x32, 0x4c, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72,
+	0x64, 0x61, 0x74, 0x61, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x65, 0x71, 0x75, 0x65,
+	0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x2e, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75,
+	0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x18,
+	0x6d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65,
+	0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x1a, 0x4b, 0x0a, 0x1d, 0x4d, 0x61, 0x78, 0x56,
+	0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54,
+	0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76,
+	0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75,
+	0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0x1e, 0x0a, 0x1c, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53,
+	0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x73,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x63, 0x0a, 0x1e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56,
+	0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73,
+	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x41, 0x0a, 0x09, 0x73, 0x65, 0x71, 0x75, 0x65,
+	0x6e, 0x63, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x74, 0x61, 0x62,
+	0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x53,
+	0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52,
+	0x09, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x22, 0x81, 0x02, 0x0a, 0x1f, 0x47,
+	0x65, 0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71,
+	0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x90,
+	0x01, 0x0a, 0x1c, 0x6d, 0x61, 0x78, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x5f, 0x62, 0x79,
+	0x5f, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x18,
+	0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x50, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61,
+	0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78,
+	0x56, 0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65,
+	0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c,
+	0x75, 0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62,
+	0x6c, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x18, 0x6d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75,
+	0x65, 0x73, 0x42, 0x79, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c,
+	0x65, 0x1a, 0x4b, 0x0a, 0x1d, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x79,
+	0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x45, 0x6e, 0x74,
+	0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x03, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x2a, 0x3e,
+	0x0a, 0x19, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f,
+	0x6e, 0x50, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x07, 0x0a, 0x03, 0x41,
+	0x4e, 0x59, 0x10, 0x00, 0x12, 0x0b, 0x0a, 0x07, 0x49, 0x4e, 0x4f, 0x52, 0x44, 0x45, 0x52, 0x10,
+	0x01, 0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x03, 0x2a, 0x83,
+	0x01, 0x0a, 0x1a, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x54, 0x68, 0x72, 0x6f, 0x74, 0x74, 0x6c, 0x65,
+	0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x12, 0x0d, 0x0a,
+	0x09, 0x55, 0x4e, 0x44, 0x45, 0x46, 0x49, 0x4e, 0x45, 0x44, 0x10, 0x00, 0x12, 0x06, 0x0a, 0x02,
+	0x4f, 0x4b, 0x10, 0x01, 0x12, 0x16, 0x0a, 0x12, 0x54, 0x48, 0x52, 0x45, 0x53, 0x48, 0x4f, 0x4c,
+	0x44, 0x5f, 0x45, 0x58, 0x43, 0x45, 0x45, 0x44, 0x45, 0x44, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a,
+	0x41, 0x50, 0x50, 0x5f, 0x44, 0x45, 0x4e, 0x49, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e,
+	0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x5f, 0x4d, 0x45, 0x54, 0x52, 0x49, 0x43, 0x10, 0x04,
+	0x12, 0x12, 0x0a, 0x0e, 0x49, 0x4e, 0x54, 0x45, 0x52, 0x4e, 0x41, 0x4c, 0x5f, 0x45, 0x52, 0x52,
+	0x4f, 0x52, 0x10, 0x05, 0x42, 0x30, 0x5a, 0x2e, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2e, 0x69,
+	0x6f, 0x2f, 0x76, 0x69, 0x74, 0x65, 0x73, 0x73, 0x2f, 0x67, 0x6f, 0x2f, 0x76, 0x74, 0x2f, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67,
+	0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 })
 
 var (
@@ -9240,7 +9595,7 @@ func file_tabletmanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_tabletmanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_tabletmanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 166)
+var file_tabletmanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 173)
 var file_tabletmanagerdata_proto_goTypes = []any{
 	(TabletSelectionPreference)(0),                  // 0: tabletmanagerdata.TabletSelectionPreference
 	(CheckThrottlerResponseCode)(0),                 // 1: tabletmanagerdata.CheckThrottlerResponseCode
@@ -9389,155 +9744,166 @@ var file_tabletmanagerdata_proto_goTypes = []any{
 	(*GetThrottlerStatusResponse)(nil),              // 144: tabletmanagerdata.GetThrottlerStatusResponse
 	(*ChangeTagsRequest)(nil),                       // 145: tabletmanagerdata.ChangeTagsRequest
 	(*ChangeTagsResponse)(nil),                      // 146: tabletmanagerdata.ChangeTagsResponse
-	nil,                                             // 147: tabletmanagerdata.UserPermission.PrivilegesEntry
-	nil,                                             // 148: tabletmanagerdata.DbPermission.PrivilegesEntry
-	nil,                                             // 149: tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
-	nil,                                             // 150: tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
-	nil,                                             // 151: tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
-	(*ReadVReplicationWorkflowResponse_Stream)(nil), // 152: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
-	nil,                                   // 153: tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
-	nil,                                   // 154: tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
-	(*CheckThrottlerResponse_Metric)(nil), // 155: tabletmanagerdata.CheckThrottlerResponse.Metric
-	nil,                                   // 156: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
-	(*GetThrottlerStatusResponse_MetricResult)(nil), // 157: tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
-	nil, // 158: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
-	nil, // 159: tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
-	(*GetThrottlerStatusResponse_MetricHealth)(nil), // 160: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
-	nil, // 161: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
-	nil, // 162: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
-	nil, // 163: tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
-	(*GetThrottlerStatusResponse_RecentApp)(nil), // 164: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
-	nil,                                      // 165: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
-	nil,                                      // 166: tabletmanagerdata.ChangeTagsRequest.TagsEntry
-	nil,                                      // 167: tabletmanagerdata.ChangeTagsResponse.TagsEntry
-	(*query.Field)(nil),                      // 168: query.Field
-	(topodata.TabletType)(0),                 // 169: topodata.TabletType
-	(*vtrpc.CallerID)(nil),                   // 170: vtrpc.CallerID
-	(*query.QueryResult)(nil),                // 171: query.QueryResult
-	(*query.TransactionMetadata)(nil),        // 172: query.TransactionMetadata
-	(*mysqlctl.HostMetricsResponse)(nil),     // 173: mysqlctl.HostMetricsResponse
-	(*replicationdata.Status)(nil),           // 174: replicationdata.Status
-	(*replicationdata.PrimaryStatus)(nil),    // 175: replicationdata.PrimaryStatus
-	(*topodata.TabletAlias)(nil),             // 176: topodata.TabletAlias
-	(*replicationdata.FullStatus)(nil),       // 177: replicationdata.FullStatus
-	(replicationdata.StopReplicationMode)(0), // 178: replicationdata.StopReplicationMode
-	(*replicationdata.StopReplicationStatus)(nil), // 179: replicationdata.StopReplicationStatus
-	(*vttime.Duration)(nil),                       // 180: vttime.Duration
-	(*logutil.Event)(nil),                         // 181: logutil.Event
-	(*vttime.Time)(nil),                           // 182: vttime.Time
-	(*binlogdata.BinlogSource)(nil),               // 183: binlogdata.BinlogSource
-	(binlogdata.VReplicationWorkflowType)(0),      // 184: binlogdata.VReplicationWorkflowType
-	(binlogdata.VReplicationWorkflowSubType)(0),   // 185: binlogdata.VReplicationWorkflowSubType
-	(binlogdata.VReplicationWorkflowState)(0),     // 186: binlogdata.VReplicationWorkflowState
-	(binlogdata.OnDDLAction)(0),                   // 187: binlogdata.OnDDLAction
-	(*topodata.ThrottledAppRule)(nil),             // 188: topodata.ThrottledAppRule
+	(*SequenceMetadata)(nil),                        // 147: tabletmanagerdata.SequenceMetadata
+	(*UpdateSequenceTablesRequest)(nil),             // 148: tabletmanagerdata.UpdateSequenceTablesRequest
+	(*UpdateSequenceTablesResponse)(nil),            // 149: tabletmanagerdata.UpdateSequenceTablesResponse
+	(*GetMaxValueForSequencesRequest)(nil),          // 150: tabletmanagerdata.GetMaxValueForSequencesRequest
+	(*GetMaxValueForSequencesResponse)(nil),         // 151: tabletmanagerdata.GetMaxValueForSequencesResponse
+	nil,                                             // 152: tabletmanagerdata.UserPermission.PrivilegesEntry
+	nil,                                             // 153: tabletmanagerdata.DbPermission.PrivilegesEntry
+	nil,                                             // 154: tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
+	nil,                                             // 155: tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
+	nil,                                             // 156: tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
+	(*ReadVReplicationWorkflowResponse_Stream)(nil), // 157: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
+	nil,                                   // 158: tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
+	nil,                                   // 159: tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
+	(*CheckThrottlerResponse_Metric)(nil), // 160: tabletmanagerdata.CheckThrottlerResponse.Metric
+	nil,                                   // 161: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
+	(*GetThrottlerStatusResponse_MetricResult)(nil), // 162: tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
+	nil, // 163: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
+	nil, // 164: tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
+	(*GetThrottlerStatusResponse_MetricHealth)(nil), // 165: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
+	nil, // 166: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
+	nil, // 167: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
+	nil, // 168: tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
+	(*GetThrottlerStatusResponse_RecentApp)(nil), // 169: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
+	nil,                                      // 170: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
+	nil,                                      // 171: tabletmanagerdata.ChangeTagsRequest.TagsEntry
+	nil,                                      // 172: tabletmanagerdata.ChangeTagsResponse.TagsEntry
+	nil,                                      // 173: tabletmanagerdata.UpdateSequenceTablesRequest.MaxValuesBySequenceTableEntry
+	nil,                                      // 174: tabletmanagerdata.GetMaxValueForSequencesResponse.MaxValuesBySequenceTableEntry
+	(*query.Field)(nil),                      // 175: query.Field
+	(topodata.TabletType)(0),                 // 176: topodata.TabletType
+	(*vtrpc.CallerID)(nil),                   // 177: vtrpc.CallerID
+	(*query.QueryResult)(nil),                // 178: query.QueryResult
+	(*query.TransactionMetadata)(nil),        // 179: query.TransactionMetadata
+	(*mysqlctl.HostMetricsResponse)(nil),     // 180: mysqlctl.HostMetricsResponse
+	(*replicationdata.Status)(nil),           // 181: replicationdata.Status
+	(*replicationdata.PrimaryStatus)(nil),    // 182: replicationdata.PrimaryStatus
+	(*topodata.TabletAlias)(nil),             // 183: topodata.TabletAlias
+	(*replicationdata.FullStatus)(nil),       // 184: replicationdata.FullStatus
+	(replicationdata.StopReplicationMode)(0), // 185: replicationdata.StopReplicationMode
+	(*replicationdata.StopReplicationStatus)(nil), // 186: replicationdata.StopReplicationStatus
+	(*vttime.Duration)(nil),                       // 187: vttime.Duration
+	(*logutil.Event)(nil),                         // 188: logutil.Event
+	(*vttime.Time)(nil),                           // 189: vttime.Time
+	(*binlogdata.BinlogSource)(nil),               // 190: binlogdata.BinlogSource
+	(binlogdata.VReplicationWorkflowType)(0),      // 191: binlogdata.VReplicationWorkflowType
+	(binlogdata.VReplicationWorkflowSubType)(0),   // 192: binlogdata.VReplicationWorkflowSubType
+	(binlogdata.VReplicationWorkflowState)(0),     // 193: binlogdata.VReplicationWorkflowState
+	(binlogdata.OnDDLAction)(0),                   // 194: binlogdata.OnDDLAction
+	(*topodata.ThrottledAppRule)(nil),             // 195: topodata.ThrottledAppRule
 }
 var file_tabletmanagerdata_proto_depIdxs = []int32{
-	168, // 0: tabletmanagerdata.TableDefinition.fields:type_name -> query.Field
+	175, // 0: tabletmanagerdata.TableDefinition.fields:type_name -> query.Field
 	2,   // 1: tabletmanagerdata.SchemaDefinition.table_definitions:type_name -> tabletmanagerdata.TableDefinition
 	3,   // 2: tabletmanagerdata.SchemaChangeResult.before_schema:type_name -> tabletmanagerdata.SchemaDefinition
 	3,   // 3: tabletmanagerdata.SchemaChangeResult.after_schema:type_name -> tabletmanagerdata.SchemaDefinition
-	147, // 4: tabletmanagerdata.UserPermission.privileges:type_name -> tabletmanagerdata.UserPermission.PrivilegesEntry
-	148, // 5: tabletmanagerdata.DbPermission.privileges:type_name -> tabletmanagerdata.DbPermission.PrivilegesEntry
+	152, // 4: tabletmanagerdata.UserPermission.privileges:type_name -> tabletmanagerdata.UserPermission.PrivilegesEntry
+	153, // 5: tabletmanagerdata.DbPermission.privileges:type_name -> tabletmanagerdata.DbPermission.PrivilegesEntry
 	5,   // 6: tabletmanagerdata.Permissions.user_permissions:type_name -> tabletmanagerdata.UserPermission
 	6,   // 7: tabletmanagerdata.Permissions.db_permissions:type_name -> tabletmanagerdata.DbPermission
-	149, // 8: tabletmanagerdata.ExecuteHookRequest.extra_env:type_name -> tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
+	154, // 8: tabletmanagerdata.ExecuteHookRequest.extra_env:type_name -> tabletmanagerdata.ExecuteHookRequest.ExtraEnvEntry
 	3,   // 9: tabletmanagerdata.GetSchemaResponse.schema_definition:type_name -> tabletmanagerdata.SchemaDefinition
 	7,   // 10: tabletmanagerdata.GetPermissionsResponse.permissions:type_name -> tabletmanagerdata.Permissions
-	150, // 11: tabletmanagerdata.GetGlobalStatusVarsResponse.status_values:type_name -> tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
-	169, // 12: tabletmanagerdata.ChangeTypeRequest.tablet_type:type_name -> topodata.TabletType
+	155, // 11: tabletmanagerdata.GetGlobalStatusVarsResponse.status_values:type_name -> tabletmanagerdata.GetGlobalStatusVarsResponse.StatusValuesEntry
+	176, // 12: tabletmanagerdata.ChangeTypeRequest.tablet_type:type_name -> topodata.TabletType
 	4,   // 13: tabletmanagerdata.PreflightSchemaResponse.change_results:type_name -> tabletmanagerdata.SchemaChangeResult
 	3,   // 14: tabletmanagerdata.ApplySchemaRequest.before_schema:type_name -> tabletmanagerdata.SchemaDefinition
 	3,   // 15: tabletmanagerdata.ApplySchemaRequest.after_schema:type_name -> tabletmanagerdata.SchemaDefinition
 	3,   // 16: tabletmanagerdata.ApplySchemaResponse.before_schema:type_name -> tabletmanagerdata.SchemaDefinition
 	3,   // 17: tabletmanagerdata.ApplySchemaResponse.after_schema:type_name -> tabletmanagerdata.SchemaDefinition
-	170, // 18: tabletmanagerdata.ExecuteQueryRequest.caller_id:type_name -> vtrpc.CallerID
-	171, // 19: tabletmanagerdata.ExecuteQueryResponse.result:type_name -> query.QueryResult
-	171, // 20: tabletmanagerdata.ExecuteFetchAsDbaResponse.result:type_name -> query.QueryResult
-	171, // 21: tabletmanagerdata.ExecuteMultiFetchAsDbaResponse.results:type_name -> query.QueryResult
-	171, // 22: tabletmanagerdata.ExecuteFetchAsAllPrivsResponse.result:type_name -> query.QueryResult
-	171, // 23: tabletmanagerdata.ExecuteFetchAsAppResponse.result:type_name -> query.QueryResult
-	172, // 24: tabletmanagerdata.GetUnresolvedTransactionsResponse.transactions:type_name -> query.TransactionMetadata
-	172, // 25: tabletmanagerdata.ReadTransactionResponse.transaction:type_name -> query.TransactionMetadata
-	173, // 26: tabletmanagerdata.MysqlHostMetricsResponse.HostMetrics:type_name -> mysqlctl.HostMetricsResponse
-	174, // 27: tabletmanagerdata.ReplicationStatusResponse.status:type_name -> replicationdata.Status
-	175, // 28: tabletmanagerdata.PrimaryStatusResponse.status:type_name -> replicationdata.PrimaryStatus
-	171, // 29: tabletmanagerdata.VReplicationExecResponse.result:type_name -> query.QueryResult
-	176, // 30: tabletmanagerdata.PopulateReparentJournalRequest.primary_alias:type_name -> topodata.TabletAlias
-	176, // 31: tabletmanagerdata.InitReplicaRequest.parent:type_name -> topodata.TabletAlias
-	175, // 32: tabletmanagerdata.DemotePrimaryResponse.primary_status:type_name -> replicationdata.PrimaryStatus
-	177, // 33: tabletmanagerdata.FullStatusResponse.status:type_name -> replicationdata.FullStatus
-	176, // 34: tabletmanagerdata.SetReplicationSourceRequest.parent:type_name -> topodata.TabletAlias
-	176, // 35: tabletmanagerdata.ReplicaWasRestartedRequest.parent:type_name -> topodata.TabletAlias
-	178, // 36: tabletmanagerdata.StopReplicationAndGetStatusRequest.stop_replication_mode:type_name -> replicationdata.StopReplicationMode
-	179, // 37: tabletmanagerdata.StopReplicationAndGetStatusResponse.status:type_name -> replicationdata.StopReplicationStatus
-	180, // 38: tabletmanagerdata.BackupRequest.mysql_shutdown_timeout:type_name -> vttime.Duration
-	181, // 39: tabletmanagerdata.BackupResponse.event:type_name -> logutil.Event
-	182, // 40: tabletmanagerdata.RestoreFromBackupRequest.backup_time:type_name -> vttime.Time
-	182, // 41: tabletmanagerdata.RestoreFromBackupRequest.restore_to_timestamp:type_name -> vttime.Time
-	181, // 42: tabletmanagerdata.RestoreFromBackupResponse.event:type_name -> logutil.Event
-	183, // 43: tabletmanagerdata.CreateVReplicationWorkflowRequest.binlog_source:type_name -> binlogdata.BinlogSource
-	169, // 44: tabletmanagerdata.CreateVReplicationWorkflowRequest.tablet_types:type_name -> topodata.TabletType
+	177, // 18: tabletmanagerdata.ExecuteQueryRequest.caller_id:type_name -> vtrpc.CallerID
+	178, // 19: tabletmanagerdata.ExecuteQueryResponse.result:type_name -> query.QueryResult
+	178, // 20: tabletmanagerdata.ExecuteFetchAsDbaResponse.result:type_name -> query.QueryResult
+	178, // 21: tabletmanagerdata.ExecuteMultiFetchAsDbaResponse.results:type_name -> query.QueryResult
+	178, // 22: tabletmanagerdata.ExecuteFetchAsAllPrivsResponse.result:type_name -> query.QueryResult
+	178, // 23: tabletmanagerdata.ExecuteFetchAsAppResponse.result:type_name -> query.QueryResult
+	179, // 24: tabletmanagerdata.GetUnresolvedTransactionsResponse.transactions:type_name -> query.TransactionMetadata
+	179, // 25: tabletmanagerdata.ReadTransactionResponse.transaction:type_name -> query.TransactionMetadata
+	180, // 26: tabletmanagerdata.MysqlHostMetricsResponse.HostMetrics:type_name -> mysqlctl.HostMetricsResponse
+	181, // 27: tabletmanagerdata.ReplicationStatusResponse.status:type_name -> replicationdata.Status
+	182, // 28: tabletmanagerdata.PrimaryStatusResponse.status:type_name -> replicationdata.PrimaryStatus
+	178, // 29: tabletmanagerdata.VReplicationExecResponse.result:type_name -> query.QueryResult
+	183, // 30: tabletmanagerdata.PopulateReparentJournalRequest.primary_alias:type_name -> topodata.TabletAlias
+	183, // 31: tabletmanagerdata.InitReplicaRequest.parent:type_name -> topodata.TabletAlias
+	182, // 32: tabletmanagerdata.DemotePrimaryResponse.primary_status:type_name -> replicationdata.PrimaryStatus
+	184, // 33: tabletmanagerdata.FullStatusResponse.status:type_name -> replicationdata.FullStatus
+	183, // 34: tabletmanagerdata.SetReplicationSourceRequest.parent:type_name -> topodata.TabletAlias
+	183, // 35: tabletmanagerdata.ReplicaWasRestartedRequest.parent:type_name -> topodata.TabletAlias
+	185, // 36: tabletmanagerdata.StopReplicationAndGetStatusRequest.stop_replication_mode:type_name -> replicationdata.StopReplicationMode
+	186, // 37: tabletmanagerdata.StopReplicationAndGetStatusResponse.status:type_name -> replicationdata.StopReplicationStatus
+	187, // 38: tabletmanagerdata.BackupRequest.mysql_shutdown_timeout:type_name -> vttime.Duration
+	188, // 39: tabletmanagerdata.BackupResponse.event:type_name -> logutil.Event
+	189, // 40: tabletmanagerdata.RestoreFromBackupRequest.backup_time:type_name -> vttime.Time
+	189, // 41: tabletmanagerdata.RestoreFromBackupRequest.restore_to_timestamp:type_name -> vttime.Time
+	188, // 42: tabletmanagerdata.RestoreFromBackupResponse.event:type_name -> logutil.Event
+	190, // 43: tabletmanagerdata.CreateVReplicationWorkflowRequest.binlog_source:type_name -> binlogdata.BinlogSource
+	176, // 44: tabletmanagerdata.CreateVReplicationWorkflowRequest.tablet_types:type_name -> topodata.TabletType
 	0,   // 45: tabletmanagerdata.CreateVReplicationWorkflowRequest.tablet_selection_preference:type_name -> tabletmanagerdata.TabletSelectionPreference
-	184, // 46: tabletmanagerdata.CreateVReplicationWorkflowRequest.workflow_type:type_name -> binlogdata.VReplicationWorkflowType
-	185, // 47: tabletmanagerdata.CreateVReplicationWorkflowRequest.workflow_sub_type:type_name -> binlogdata.VReplicationWorkflowSubType
-	171, // 48: tabletmanagerdata.CreateVReplicationWorkflowResponse.result:type_name -> query.QueryResult
-	151, // 49: tabletmanagerdata.DeleteTableDataRequest.table_filters:type_name -> tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
-	171, // 50: tabletmanagerdata.DeleteVReplicationWorkflowResponse.result:type_name -> query.QueryResult
-	186, // 51: tabletmanagerdata.ReadVReplicationWorkflowsRequest.include_states:type_name -> binlogdata.VReplicationWorkflowState
-	186, // 52: tabletmanagerdata.ReadVReplicationWorkflowsRequest.exclude_states:type_name -> binlogdata.VReplicationWorkflowState
+	191, // 46: tabletmanagerdata.CreateVReplicationWorkflowRequest.workflow_type:type_name -> binlogdata.VReplicationWorkflowType
+	192, // 47: tabletmanagerdata.CreateVReplicationWorkflowRequest.workflow_sub_type:type_name -> binlogdata.VReplicationWorkflowSubType
+	178, // 48: tabletmanagerdata.CreateVReplicationWorkflowResponse.result:type_name -> query.QueryResult
+	156, // 49: tabletmanagerdata.DeleteTableDataRequest.table_filters:type_name -> tabletmanagerdata.DeleteTableDataRequest.TableFiltersEntry
+	178, // 50: tabletmanagerdata.DeleteVReplicationWorkflowResponse.result:type_name -> query.QueryResult
+	193, // 51: tabletmanagerdata.ReadVReplicationWorkflowsRequest.include_states:type_name -> binlogdata.VReplicationWorkflowState
+	193, // 52: tabletmanagerdata.ReadVReplicationWorkflowsRequest.exclude_states:type_name -> binlogdata.VReplicationWorkflowState
 	125, // 53: tabletmanagerdata.ReadVReplicationWorkflowsResponse.workflows:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse
-	169, // 54: tabletmanagerdata.ReadVReplicationWorkflowResponse.tablet_types:type_name -> topodata.TabletType
+	176, // 54: tabletmanagerdata.ReadVReplicationWorkflowResponse.tablet_types:type_name -> topodata.TabletType
 	0,   // 55: tabletmanagerdata.ReadVReplicationWorkflowResponse.tablet_selection_preference:type_name -> tabletmanagerdata.TabletSelectionPreference
-	184, // 56: tabletmanagerdata.ReadVReplicationWorkflowResponse.workflow_type:type_name -> binlogdata.VReplicationWorkflowType
-	185, // 57: tabletmanagerdata.ReadVReplicationWorkflowResponse.workflow_sub_type:type_name -> binlogdata.VReplicationWorkflowSubType
-	152, // 58: tabletmanagerdata.ReadVReplicationWorkflowResponse.streams:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
-	153, // 59: tabletmanagerdata.ReadVReplicationWorkflowResponse.config_overrides:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
+	191, // 56: tabletmanagerdata.ReadVReplicationWorkflowResponse.workflow_type:type_name -> binlogdata.VReplicationWorkflowType
+	192, // 57: tabletmanagerdata.ReadVReplicationWorkflowResponse.workflow_sub_type:type_name -> binlogdata.VReplicationWorkflowSubType
+	157, // 58: tabletmanagerdata.ReadVReplicationWorkflowResponse.streams:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream
+	158, // 59: tabletmanagerdata.ReadVReplicationWorkflowResponse.config_overrides:type_name -> tabletmanagerdata.ReadVReplicationWorkflowResponse.ConfigOverridesEntry
 	133, // 60: tabletmanagerdata.VDiffRequest.options:type_name -> tabletmanagerdata.VDiffOptions
-	171, // 61: tabletmanagerdata.VDiffResponse.output:type_name -> query.QueryResult
+	178, // 61: tabletmanagerdata.VDiffResponse.output:type_name -> query.QueryResult
 	130, // 62: tabletmanagerdata.VDiffOptions.picker_options:type_name -> tabletmanagerdata.VDiffPickerOptions
 	132, // 63: tabletmanagerdata.VDiffOptions.core_options:type_name -> tabletmanagerdata.VDiffCoreOptions
 	131, // 64: tabletmanagerdata.VDiffOptions.report_options:type_name -> tabletmanagerdata.VDiffReportOptions
-	171, // 65: tabletmanagerdata.VDiffTableLastPK.target:type_name -> query.QueryResult
-	171, // 66: tabletmanagerdata.VDiffTableLastPK.source:type_name -> query.QueryResult
-	169, // 67: tabletmanagerdata.UpdateVReplicationWorkflowRequest.tablet_types:type_name -> topodata.TabletType
+	178, // 65: tabletmanagerdata.VDiffTableLastPK.target:type_name -> query.QueryResult
+	178, // 66: tabletmanagerdata.VDiffTableLastPK.source:type_name -> query.QueryResult
+	176, // 67: tabletmanagerdata.UpdateVReplicationWorkflowRequest.tablet_types:type_name -> topodata.TabletType
 	0,   // 68: tabletmanagerdata.UpdateVReplicationWorkflowRequest.tablet_selection_preference:type_name -> tabletmanagerdata.TabletSelectionPreference
-	187, // 69: tabletmanagerdata.UpdateVReplicationWorkflowRequest.on_ddl:type_name -> binlogdata.OnDDLAction
-	186, // 70: tabletmanagerdata.UpdateVReplicationWorkflowRequest.state:type_name -> binlogdata.VReplicationWorkflowState
-	154, // 71: tabletmanagerdata.UpdateVReplicationWorkflowRequest.config_overrides:type_name -> tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
-	171, // 72: tabletmanagerdata.UpdateVReplicationWorkflowResponse.result:type_name -> query.QueryResult
-	186, // 73: tabletmanagerdata.UpdateVReplicationWorkflowsRequest.state:type_name -> binlogdata.VReplicationWorkflowState
-	171, // 74: tabletmanagerdata.UpdateVReplicationWorkflowsResponse.result:type_name -> query.QueryResult
-	156, // 75: tabletmanagerdata.CheckThrottlerResponse.metrics:type_name -> tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
+	194, // 69: tabletmanagerdata.UpdateVReplicationWorkflowRequest.on_ddl:type_name -> binlogdata.OnDDLAction
+	193, // 70: tabletmanagerdata.UpdateVReplicationWorkflowRequest.state:type_name -> binlogdata.VReplicationWorkflowState
+	159, // 71: tabletmanagerdata.UpdateVReplicationWorkflowRequest.config_overrides:type_name -> tabletmanagerdata.UpdateVReplicationWorkflowRequest.ConfigOverridesEntry
+	178, // 72: tabletmanagerdata.UpdateVReplicationWorkflowResponse.result:type_name -> query.QueryResult
+	193, // 73: tabletmanagerdata.UpdateVReplicationWorkflowsRequest.state:type_name -> binlogdata.VReplicationWorkflowState
+	178, // 74: tabletmanagerdata.UpdateVReplicationWorkflowsResponse.result:type_name -> query.QueryResult
+	161, // 75: tabletmanagerdata.CheckThrottlerResponse.metrics:type_name -> tabletmanagerdata.CheckThrottlerResponse.MetricsEntry
 	1,   // 76: tabletmanagerdata.CheckThrottlerResponse.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
-	158, // 77: tabletmanagerdata.GetThrottlerStatusResponse.aggregated_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
-	159, // 78: tabletmanagerdata.GetThrottlerStatusResponse.metric_thresholds:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
-	161, // 79: tabletmanagerdata.GetThrottlerStatusResponse.metrics_health:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
-	162, // 80: tabletmanagerdata.GetThrottlerStatusResponse.throttled_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
-	163, // 81: tabletmanagerdata.GetThrottlerStatusResponse.app_checked_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
-	165, // 82: tabletmanagerdata.GetThrottlerStatusResponse.recent_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
-	166, // 83: tabletmanagerdata.ChangeTagsRequest.tags:type_name -> tabletmanagerdata.ChangeTagsRequest.TagsEntry
-	167, // 84: tabletmanagerdata.ChangeTagsResponse.tags:type_name -> tabletmanagerdata.ChangeTagsResponse.TagsEntry
-	183, // 85: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.bls:type_name -> binlogdata.BinlogSource
-	182, // 86: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_updated:type_name -> vttime.Time
-	182, // 87: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.transaction_timestamp:type_name -> vttime.Time
-	186, // 88: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.state:type_name -> binlogdata.VReplicationWorkflowState
-	182, // 89: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_heartbeat:type_name -> vttime.Time
-	182, // 90: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_throttled:type_name -> vttime.Time
-	1,   // 91: tabletmanagerdata.CheckThrottlerResponse.Metric.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
-	155, // 92: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry.value:type_name -> tabletmanagerdata.CheckThrottlerResponse.Metric
-	157, // 93: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
-	182, // 94: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth.last_healthy_at:type_name -> vttime.Time
-	160, // 95: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
-	188, // 96: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry.value:type_name -> topodata.ThrottledAppRule
-	182, // 97: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.checked_at:type_name -> vttime.Time
-	1,   // 98: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
-	164, // 99: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
-	100, // [100:100] is the sub-list for method output_type
-	100, // [100:100] is the sub-list for method input_type
-	100, // [100:100] is the sub-list for extension type_name
-	100, // [100:100] is the sub-list for extension extendee
-	0,   // [0:100] is the sub-list for field type_name
+	163, // 77: tabletmanagerdata.GetThrottlerStatusResponse.aggregated_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry
+	164, // 78: tabletmanagerdata.GetThrottlerStatusResponse.metric_thresholds:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricThresholdsEntry
+	166, // 79: tabletmanagerdata.GetThrottlerStatusResponse.metrics_health:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry
+	167, // 80: tabletmanagerdata.GetThrottlerStatusResponse.throttled_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry
+	168, // 81: tabletmanagerdata.GetThrottlerStatusResponse.app_checked_metrics:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.AppCheckedMetricsEntry
+	170, // 82: tabletmanagerdata.GetThrottlerStatusResponse.recent_apps:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry
+	171, // 83: tabletmanagerdata.ChangeTagsRequest.tags:type_name -> tabletmanagerdata.ChangeTagsRequest.TagsEntry
+	172, // 84: tabletmanagerdata.ChangeTagsResponse.tags:type_name -> tabletmanagerdata.ChangeTagsResponse.TagsEntry
+	147, // 85: tabletmanagerdata.UpdateSequenceTablesRequest.sequences:type_name -> tabletmanagerdata.SequenceMetadata
+	173, // 86: tabletmanagerdata.UpdateSequenceTablesRequest.max_values_by_sequence_table:type_name -> tabletmanagerdata.UpdateSequenceTablesRequest.MaxValuesBySequenceTableEntry
+	147, // 87: tabletmanagerdata.GetMaxValueForSequencesRequest.sequences:type_name -> tabletmanagerdata.SequenceMetadata
+	174, // 88: tabletmanagerdata.GetMaxValueForSequencesResponse.max_values_by_sequence_table:type_name -> tabletmanagerdata.GetMaxValueForSequencesResponse.MaxValuesBySequenceTableEntry
+	190, // 89: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.bls:type_name -> binlogdata.BinlogSource
+	189, // 90: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_updated:type_name -> vttime.Time
+	189, // 91: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.transaction_timestamp:type_name -> vttime.Time
+	193, // 92: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.state:type_name -> binlogdata.VReplicationWorkflowState
+	189, // 93: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_heartbeat:type_name -> vttime.Time
+	189, // 94: tabletmanagerdata.ReadVReplicationWorkflowResponse.Stream.time_throttled:type_name -> vttime.Time
+	1,   // 95: tabletmanagerdata.CheckThrottlerResponse.Metric.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
+	160, // 96: tabletmanagerdata.CheckThrottlerResponse.MetricsEntry.value:type_name -> tabletmanagerdata.CheckThrottlerResponse.Metric
+	162, // 97: tabletmanagerdata.GetThrottlerStatusResponse.AggregatedMetricsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricResult
+	189, // 98: tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth.last_healthy_at:type_name -> vttime.Time
+	165, // 99: tabletmanagerdata.GetThrottlerStatusResponse.MetricsHealthEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.MetricHealth
+	195, // 100: tabletmanagerdata.GetThrottlerStatusResponse.ThrottledAppsEntry.value:type_name -> topodata.ThrottledAppRule
+	189, // 101: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.checked_at:type_name -> vttime.Time
+	1,   // 102: tabletmanagerdata.GetThrottlerStatusResponse.RecentApp.response_code:type_name -> tabletmanagerdata.CheckThrottlerResponseCode
+	169, // 103: tabletmanagerdata.GetThrottlerStatusResponse.RecentAppsEntry.value:type_name -> tabletmanagerdata.GetThrottlerStatusResponse.RecentApp
+	104, // [104:104] is the sub-list for method output_type
+	104, // [104:104] is the sub-list for method input_type
+	104, // [104:104] is the sub-list for extension type_name
+	104, // [104:104] is the sub-list for extension extendee
+	0,   // [0:104] is the sub-list for field type_name
 }
 
 func init() { file_tabletmanagerdata_proto_init() }
@@ -9556,7 +9922,7 @@ func file_tabletmanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tabletmanagerdata_proto_rawDesc), len(file_tabletmanagerdata_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   166,
+			NumMessages:   173,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata_vtproto.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata_vtproto.pb.go
@@ -3024,19 +3024,14 @@ func (m *ChangeTagsResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (m *SequenceMetadata) CloneVT() *SequenceMetadata {
+func (m *UpdateSequenceTablesRequest_SequenceMetadata) CloneVT() *UpdateSequenceTablesRequest_SequenceMetadata {
 	if m == nil {
-		return (*SequenceMetadata)(nil)
+		return (*UpdateSequenceTablesRequest_SequenceMetadata)(nil)
 	}
-	r := new(SequenceMetadata)
+	r := new(UpdateSequenceTablesRequest_SequenceMetadata)
 	r.BackingTableName = m.BackingTableName
 	r.BackingTableDbName = m.BackingTableDbName
-	r.UsingTableName = m.UsingTableName
-	r.UsingTableDbName = m.UsingTableDbName
-	r.UsingColEscaped = m.UsingColEscaped
-	r.UsingTableNameEscaped = m.UsingTableNameEscaped
-	r.UsingTableDbNameEscaped = m.UsingTableDbNameEscaped
-	r.BackingTableNameEscaped = m.BackingTableNameEscaped
+	r.MaxValue = m.MaxValue
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -3044,7 +3039,7 @@ func (m *SequenceMetadata) CloneVT() *SequenceMetadata {
 	return r
 }
 
-func (m *SequenceMetadata) CloneMessageVT() proto.Message {
+func (m *UpdateSequenceTablesRequest_SequenceMetadata) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -3054,18 +3049,11 @@ func (m *UpdateSequenceTablesRequest) CloneVT() *UpdateSequenceTablesRequest {
 	}
 	r := new(UpdateSequenceTablesRequest)
 	if rhs := m.Sequences; rhs != nil {
-		tmpContainer := make([]*SequenceMetadata, len(rhs))
+		tmpContainer := make([]*UpdateSequenceTablesRequest_SequenceMetadata, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.Sequences = tmpContainer
-	}
-	if rhs := m.MaxValuesBySequenceTable; rhs != nil {
-		tmpContainer := make(map[string]int64, len(rhs))
-		for k, v := range rhs {
-			tmpContainer[k] = v
-		}
-		r.MaxValuesBySequenceTable = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -3094,13 +3082,33 @@ func (m *UpdateSequenceTablesResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *GetMaxValueForSequencesRequest_SequenceMetadata) CloneVT() *GetMaxValueForSequencesRequest_SequenceMetadata {
+	if m == nil {
+		return (*GetMaxValueForSequencesRequest_SequenceMetadata)(nil)
+	}
+	r := new(GetMaxValueForSequencesRequest_SequenceMetadata)
+	r.BackingTableName = m.BackingTableName
+	r.UsingColEscaped = m.UsingColEscaped
+	r.UsingTableNameEscaped = m.UsingTableNameEscaped
+	r.UsingTableDbNameEscaped = m.UsingTableDbNameEscaped
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetMaxValueForSequencesRequest_SequenceMetadata) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *GetMaxValueForSequencesRequest) CloneVT() *GetMaxValueForSequencesRequest {
 	if m == nil {
 		return (*GetMaxValueForSequencesRequest)(nil)
 	}
 	r := new(GetMaxValueForSequencesRequest)
 	if rhs := m.Sequences; rhs != nil {
-		tmpContainer := make([]*SequenceMetadata, len(rhs))
+		tmpContainer := make([]*GetMaxValueForSequencesRequest_SequenceMetadata, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
@@ -10720,7 +10728,7 @@ func (m *ChangeTagsResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *SequenceMetadata) MarshalVT() (dAtA []byte, err error) {
+func (m *UpdateSequenceTablesRequest_SequenceMetadata) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -10733,12 +10741,12 @@ func (m *SequenceMetadata) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *SequenceMetadata) MarshalToVT(dAtA []byte) (int, error) {
+func (m *UpdateSequenceTablesRequest_SequenceMetadata) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *SequenceMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *UpdateSequenceTablesRequest_SequenceMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -10750,47 +10758,10 @@ func (m *SequenceMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.BackingTableNameEscaped) > 0 {
-		i -= len(m.BackingTableNameEscaped)
-		copy(dAtA[i:], m.BackingTableNameEscaped)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BackingTableNameEscaped)))
+	if m.MaxValue != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MaxValue))
 		i--
-		dAtA[i] = 0x42
-	}
-	if len(m.UsingTableDbNameEscaped) > 0 {
-		i -= len(m.UsingTableDbNameEscaped)
-		copy(dAtA[i:], m.UsingTableDbNameEscaped)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableDbNameEscaped)))
-		i--
-		dAtA[i] = 0x3a
-	}
-	if len(m.UsingTableNameEscaped) > 0 {
-		i -= len(m.UsingTableNameEscaped)
-		copy(dAtA[i:], m.UsingTableNameEscaped)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableNameEscaped)))
-		i--
-		dAtA[i] = 0x32
-	}
-	if len(m.UsingColEscaped) > 0 {
-		i -= len(m.UsingColEscaped)
-		copy(dAtA[i:], m.UsingColEscaped)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingColEscaped)))
-		i--
-		dAtA[i] = 0x2a
-	}
-	if len(m.UsingTableDbName) > 0 {
-		i -= len(m.UsingTableDbName)
-		copy(dAtA[i:], m.UsingTableDbName)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableDbName)))
-		i--
-		dAtA[i] = 0x22
-	}
-	if len(m.UsingTableName) > 0 {
-		i -= len(m.UsingTableName)
-		copy(dAtA[i:], m.UsingTableName)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableName)))
-		i--
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x18
 	}
 	if len(m.BackingTableDbName) > 0 {
 		i -= len(m.BackingTableDbName)
@@ -10839,23 +10810,6 @@ func (m *UpdateSequenceTablesRequest) MarshalToSizedBufferVT(dAtA []byte) (int, 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.MaxValuesBySequenceTable) > 0 {
-		for k := range m.MaxValuesBySequenceTable {
-			v := m.MaxValuesBySequenceTable[k]
-			baseI := i
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
-			i--
-			dAtA[i] = 0x10
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
-			i--
-			dAtA[i] = 0x12
-		}
-	}
 	if len(m.Sequences) > 0 {
 		for iNdEx := len(m.Sequences) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := m.Sequences[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
@@ -10900,6 +10854,67 @@ func (m *UpdateSequenceTablesResponse) MarshalToSizedBufferVT(dAtA []byte) (int,
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetMaxValueForSequencesRequest_SequenceMetadata) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetMaxValueForSequencesRequest_SequenceMetadata) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetMaxValueForSequencesRequest_SequenceMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.UsingTableDbNameEscaped) > 0 {
+		i -= len(m.UsingTableDbNameEscaped)
+		copy(dAtA[i:], m.UsingTableDbNameEscaped)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableDbNameEscaped)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.UsingTableNameEscaped) > 0 {
+		i -= len(m.UsingTableNameEscaped)
+		copy(dAtA[i:], m.UsingTableNameEscaped)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableNameEscaped)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.UsingColEscaped) > 0 {
+		i -= len(m.UsingColEscaped)
+		copy(dAtA[i:], m.UsingColEscaped)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingColEscaped)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.BackingTableName) > 0 {
+		i -= len(m.BackingTableName)
+		copy(dAtA[i:], m.BackingTableName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BackingTableName)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -13741,7 +13756,7 @@ func (m *ChangeTagsResponse) SizeVT() (n int) {
 	return n
 }
 
-func (m *SequenceMetadata) SizeVT() (n int) {
+func (m *UpdateSequenceTablesRequest_SequenceMetadata) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -13755,29 +13770,8 @@ func (m *SequenceMetadata) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	l = len(m.UsingTableName)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	l = len(m.UsingTableDbName)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	l = len(m.UsingColEscaped)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	l = len(m.UsingTableNameEscaped)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	l = len(m.UsingTableDbNameEscaped)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	l = len(m.BackingTableNameEscaped)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	if m.MaxValue != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.MaxValue))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -13795,14 +13789,6 @@ func (m *UpdateSequenceTablesRequest) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
-	if len(m.MaxValuesBySequenceTable) > 0 {
-		for k, v := range m.MaxValuesBySequenceTable {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + protohelpers.SizeOfVarint(uint64(v))
-			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
-		}
-	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -13813,6 +13799,32 @@ func (m *UpdateSequenceTablesResponse) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetMaxValueForSequencesRequest_SequenceMetadata) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.BackingTableName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingColEscaped)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingTableNameEscaped)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingTableDbNameEscaped)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -31568,7 +31580,7 @@ func (m *ChangeTagsResponse) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *SequenceMetadata) UnmarshalVT(dAtA []byte) error {
+func (m *UpdateSequenceTablesRequest_SequenceMetadata) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -31591,10 +31603,10 @@ func (m *SequenceMetadata) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SequenceMetadata: wiretype end group for non-group")
+			return fmt.Errorf("proto: UpdateSequenceTablesRequest_SequenceMetadata: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SequenceMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: UpdateSequenceTablesRequest_SequenceMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -31662,10 +31674,10 @@ func (m *SequenceMetadata) UnmarshalVT(dAtA []byte) error {
 			m.BackingTableDbName = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableName", wireType)
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxValue", wireType)
 			}
-			var stringLen uint64
+			m.MaxValue = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -31675,184 +31687,11 @@ func (m *SequenceMetadata) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				m.MaxValue |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.UsingTableName = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 4:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableDbName", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.UsingTableDbName = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 5:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field UsingColEscaped", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.UsingColEscaped = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 6:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableNameEscaped", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.UsingTableNameEscaped = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 7:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableDbNameEscaped", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.UsingTableDbNameEscaped = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 8:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field BackingTableNameEscaped", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.BackingTableNameEscaped = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -31933,123 +31772,10 @@ func (m *UpdateSequenceTablesRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Sequences = append(m.Sequences, &SequenceMetadata{})
+			m.Sequences = append(m.Sequences, &UpdateSequenceTablesRequest_SequenceMetadata{})
 			if err := m.Sequences[len(m.Sequences)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MaxValuesBySequenceTable", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.MaxValuesBySequenceTable == nil {
-				m.MaxValuesBySequenceTable = make(map[string]int64)
-			}
-			var mapkey string
-			var mapvalue int64
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return protohelpers.ErrInvalidLength
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return protohelpers.ErrInvalidLength
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						mapvalue |= int64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if (skippy < 0) || (iNdEx+skippy) < 0 {
-						return protohelpers.ErrInvalidLength
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.MaxValuesBySequenceTable[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -32102,6 +31828,185 @@ func (m *UpdateSequenceTablesResponse) UnmarshalVT(dAtA []byte) error {
 			return fmt.Errorf("proto: UpdateSequenceTablesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetMaxValueForSequencesRequest_SequenceMetadata) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetMaxValueForSequencesRequest_SequenceMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetMaxValueForSequencesRequest_SequenceMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BackingTableName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BackingTableName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingColEscaped", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingColEscaped = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableNameEscaped", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingTableNameEscaped = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableDbNameEscaped", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingTableDbNameEscaped = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -32182,7 +32087,7 @@ func (m *GetMaxValueForSequencesRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Sequences = append(m.Sequences, &SequenceMetadata{})
+			m.Sequences = append(m.Sequences, &GetMaxValueForSequencesRequest_SequenceMetadata{})
 			if err := m.Sequences[len(m.Sequences)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata_vtproto.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata_vtproto.pb.go
@@ -3024,6 +3024,122 @@ func (m *ChangeTagsResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *SequenceMetadata) CloneVT() *SequenceMetadata {
+	if m == nil {
+		return (*SequenceMetadata)(nil)
+	}
+	r := new(SequenceMetadata)
+	r.BackingTableName = m.BackingTableName
+	r.BackingTableDbName = m.BackingTableDbName
+	r.UsingTableName = m.UsingTableName
+	r.UsingTableDbName = m.UsingTableDbName
+	r.UsingColEscaped = m.UsingColEscaped
+	r.UsingTableNameEscaped = m.UsingTableNameEscaped
+	r.UsingTableDbNameEscaped = m.UsingTableDbNameEscaped
+	r.BackingTableNameEscaped = m.BackingTableNameEscaped
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *SequenceMetadata) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *UpdateSequenceTablesRequest) CloneVT() *UpdateSequenceTablesRequest {
+	if m == nil {
+		return (*UpdateSequenceTablesRequest)(nil)
+	}
+	r := new(UpdateSequenceTablesRequest)
+	if rhs := m.Sequences; rhs != nil {
+		tmpContainer := make([]*SequenceMetadata, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Sequences = tmpContainer
+	}
+	if rhs := m.MaxValuesBySequenceTable; rhs != nil {
+		tmpContainer := make(map[string]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MaxValuesBySequenceTable = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *UpdateSequenceTablesRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *UpdateSequenceTablesResponse) CloneVT() *UpdateSequenceTablesResponse {
+	if m == nil {
+		return (*UpdateSequenceTablesResponse)(nil)
+	}
+	r := new(UpdateSequenceTablesResponse)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *UpdateSequenceTablesResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *GetMaxValueForSequencesRequest) CloneVT() *GetMaxValueForSequencesRequest {
+	if m == nil {
+		return (*GetMaxValueForSequencesRequest)(nil)
+	}
+	r := new(GetMaxValueForSequencesRequest)
+	if rhs := m.Sequences; rhs != nil {
+		tmpContainer := make([]*SequenceMetadata, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Sequences = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetMaxValueForSequencesRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *GetMaxValueForSequencesResponse) CloneVT() *GetMaxValueForSequencesResponse {
+	if m == nil {
+		return (*GetMaxValueForSequencesResponse)(nil)
+	}
+	r := new(GetMaxValueForSequencesResponse)
+	if rhs := m.MaxValuesBySequenceTable; rhs != nil {
+		tmpContainer := make(map[string]int64, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MaxValuesBySequenceTable = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetMaxValueForSequencesResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *TableDefinition) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -10604,6 +10720,285 @@ func (m *ChangeTagsResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *SequenceMetadata) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SequenceMetadata) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SequenceMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.BackingTableNameEscaped) > 0 {
+		i -= len(m.BackingTableNameEscaped)
+		copy(dAtA[i:], m.BackingTableNameEscaped)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BackingTableNameEscaped)))
+		i--
+		dAtA[i] = 0x42
+	}
+	if len(m.UsingTableDbNameEscaped) > 0 {
+		i -= len(m.UsingTableDbNameEscaped)
+		copy(dAtA[i:], m.UsingTableDbNameEscaped)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableDbNameEscaped)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.UsingTableNameEscaped) > 0 {
+		i -= len(m.UsingTableNameEscaped)
+		copy(dAtA[i:], m.UsingTableNameEscaped)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableNameEscaped)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.UsingColEscaped) > 0 {
+		i -= len(m.UsingColEscaped)
+		copy(dAtA[i:], m.UsingColEscaped)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingColEscaped)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.UsingTableDbName) > 0 {
+		i -= len(m.UsingTableDbName)
+		copy(dAtA[i:], m.UsingTableDbName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableDbName)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.UsingTableName) > 0 {
+		i -= len(m.UsingTableName)
+		copy(dAtA[i:], m.UsingTableName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UsingTableName)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.BackingTableDbName) > 0 {
+		i -= len(m.BackingTableDbName)
+		copy(dAtA[i:], m.BackingTableDbName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BackingTableDbName)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.BackingTableName) > 0 {
+		i -= len(m.BackingTableName)
+		copy(dAtA[i:], m.BackingTableName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BackingTableName)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UpdateSequenceTablesRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UpdateSequenceTablesRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *UpdateSequenceTablesRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MaxValuesBySequenceTable) > 0 {
+		for k := range m.MaxValuesBySequenceTable {
+			v := m.MaxValuesBySequenceTable[k]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Sequences) > 0 {
+		for iNdEx := len(m.Sequences) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Sequences[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UpdateSequenceTablesResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UpdateSequenceTablesResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *UpdateSequenceTablesResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetMaxValueForSequencesRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetMaxValueForSequencesRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetMaxValueForSequencesRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Sequences) > 0 {
+		for iNdEx := len(m.Sequences) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Sequences[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetMaxValueForSequencesResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetMaxValueForSequencesResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetMaxValueForSequencesResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MaxValuesBySequenceTable) > 0 {
+		for k := range m.MaxValuesBySequenceTable {
+			v := m.MaxValuesBySequenceTable[k]
+			baseI := i
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *TableDefinition) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -13339,6 +13734,116 @@ func (m *ChangeTagsResponse) SizeVT() (n int) {
 			_ = k
 			_ = v
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SequenceMetadata) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.BackingTableName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.BackingTableDbName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingTableName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingTableDbName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingColEscaped)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingTableNameEscaped)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.UsingTableDbNameEscaped)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.BackingTableNameEscaped)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *UpdateSequenceTablesRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Sequences) > 0 {
+		for _, e := range m.Sequences {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.MaxValuesBySequenceTable) > 0 {
+		for k, v := range m.MaxValuesBySequenceTable {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + protohelpers.SizeOfVarint(uint64(v))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *UpdateSequenceTablesResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetMaxValueForSequencesRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Sequences) > 0 {
+		for _, e := range m.Sequences {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetMaxValueForSequencesResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.MaxValuesBySequenceTable) > 0 {
+		for k, v := range m.MaxValuesBySequenceTable {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + protohelpers.SizeOfVarint(uint64(v))
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
 	}
@@ -31040,6 +31545,811 @@ func (m *ChangeTagsResponse) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Tags[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SequenceMetadata) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SequenceMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SequenceMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BackingTableName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BackingTableName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BackingTableDbName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BackingTableDbName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingTableName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableDbName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingTableDbName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingColEscaped", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingColEscaped = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableNameEscaped", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingTableNameEscaped = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UsingTableDbNameEscaped", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UsingTableDbNameEscaped = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BackingTableNameEscaped", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BackingTableNameEscaped = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *UpdateSequenceTablesRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UpdateSequenceTablesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UpdateSequenceTablesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sequences", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sequences = append(m.Sequences, &SequenceMetadata{})
+			if err := m.Sequences[len(m.Sequences)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxValuesBySequenceTable", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MaxValuesBySequenceTable == nil {
+				m.MaxValuesBySequenceTable = make(map[string]int64)
+			}
+			var mapkey string
+			var mapvalue int64
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapvalue |= int64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.MaxValuesBySequenceTable[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *UpdateSequenceTablesResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UpdateSequenceTablesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UpdateSequenceTablesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetMaxValueForSequencesRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetMaxValueForSequencesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetMaxValueForSequencesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sequences", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sequences = append(m.Sequences, &SequenceMetadata{})
+			if err := m.Sequences[len(m.Sequences)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetMaxValueForSequencesResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetMaxValueForSequencesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetMaxValueForSequencesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxValuesBySequenceTable", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MaxValuesBySequenceTable == nil {
+				m.MaxValuesBySequenceTable = make(map[string]int64)
+			}
+			var mapkey string
+			var mapvalue int64
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapvalue |= int64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.MaxValuesBySequenceTable[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go/vt/proto/tabletmanagerservice/tabletmanagerservice.pb.go
+++ b/go/vt/proto/tabletmanagerservice/tabletmanagerservice.pb.go
@@ -46,7 +46,7 @@ var file_tabletmanagerservice_proto_rawDesc = string([]byte{
 	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x14, 0x74, 0x61,
 	0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x73, 0x65, 0x72, 0x76, 0x69,
 	0x63, 0x65, 0x1a, 0x17, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65,
-	0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x32, 0x9a, 0x3b, 0x0a, 0x0d,
+	0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x32, 0x9a, 0x3d, 0x0a, 0x0d,
 	0x54, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x4d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x12, 0x49, 0x0a,
 	0x04, 0x50, 0x69, 0x6e, 0x67, 0x12, 0x1e, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61,
 	0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x50, 0x69, 0x6e, 0x67, 0x52, 0x65,
@@ -387,6 +387,22 @@ var file_tabletmanagerservice_proto_rawDesc = string([]byte{
 	0x73, 0x74, 0x1a, 0x31, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67,
 	0x65, 0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x56, 0x52, 0x65, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74,
 	0x69, 0x6f, 0x6e, 0x57, 0x61, 0x69, 0x74, 0x46, 0x6f, 0x72, 0x50, 0x6f, 0x73, 0x52, 0x65, 0x73,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x79, 0x0a, 0x14, 0x55, 0x70, 0x64, 0x61, 0x74,
+	0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x12,
+	0x2e, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64,
+	0x61, 0x74, 0x61, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e,
+	0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a,
+	0x2f, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64,
+	0x61, 0x74, 0x61, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e,
+	0x63, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x22, 0x00, 0x12, 0x82, 0x01, 0x0a, 0x17, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c,
+	0x75, 0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x12, 0x31,
+	0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x64, 0x61,
+	0x74, 0x61, 0x2e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x46, 0x6f,
+	0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x1a, 0x32, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65,
+	0x72, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x47, 0x65, 0x74, 0x4d, 0x61, 0x78, 0x56, 0x61, 0x6c, 0x75,
+	0x65, 0x46, 0x6f, 0x72, 0x53, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73,
 	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x4c, 0x0a, 0x05, 0x56, 0x44, 0x69, 0x66, 0x66,
 	0x12, 0x1f, 0x2e, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x74, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72,
 	0x64, 0x61, 0x74, 0x61, 0x2e, 0x56, 0x44, 0x69, 0x66, 0x66, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
@@ -576,92 +592,96 @@ var file_tabletmanagerservice_proto_goTypes = []any{
 	(*tabletmanagerdata.ValidateVReplicationPermissionsRequest)(nil),  // 45: tabletmanagerdata.ValidateVReplicationPermissionsRequest
 	(*tabletmanagerdata.VReplicationExecRequest)(nil),                 // 46: tabletmanagerdata.VReplicationExecRequest
 	(*tabletmanagerdata.VReplicationWaitForPosRequest)(nil),           // 47: tabletmanagerdata.VReplicationWaitForPosRequest
-	(*tabletmanagerdata.VDiffRequest)(nil),                            // 48: tabletmanagerdata.VDiffRequest
-	(*tabletmanagerdata.ResetReplicationRequest)(nil),                 // 49: tabletmanagerdata.ResetReplicationRequest
-	(*tabletmanagerdata.InitPrimaryRequest)(nil),                      // 50: tabletmanagerdata.InitPrimaryRequest
-	(*tabletmanagerdata.PopulateReparentJournalRequest)(nil),          // 51: tabletmanagerdata.PopulateReparentJournalRequest
-	(*tabletmanagerdata.ReadReparentJournalInfoRequest)(nil),          // 52: tabletmanagerdata.ReadReparentJournalInfoRequest
-	(*tabletmanagerdata.InitReplicaRequest)(nil),                      // 53: tabletmanagerdata.InitReplicaRequest
-	(*tabletmanagerdata.DemotePrimaryRequest)(nil),                    // 54: tabletmanagerdata.DemotePrimaryRequest
-	(*tabletmanagerdata.UndoDemotePrimaryRequest)(nil),                // 55: tabletmanagerdata.UndoDemotePrimaryRequest
-	(*tabletmanagerdata.ReplicaWasPromotedRequest)(nil),               // 56: tabletmanagerdata.ReplicaWasPromotedRequest
-	(*tabletmanagerdata.ResetReplicationParametersRequest)(nil),       // 57: tabletmanagerdata.ResetReplicationParametersRequest
-	(*tabletmanagerdata.FullStatusRequest)(nil),                       // 58: tabletmanagerdata.FullStatusRequest
-	(*tabletmanagerdata.SetReplicationSourceRequest)(nil),             // 59: tabletmanagerdata.SetReplicationSourceRequest
-	(*tabletmanagerdata.ReplicaWasRestartedRequest)(nil),              // 60: tabletmanagerdata.ReplicaWasRestartedRequest
-	(*tabletmanagerdata.StopReplicationAndGetStatusRequest)(nil),      // 61: tabletmanagerdata.StopReplicationAndGetStatusRequest
-	(*tabletmanagerdata.PromoteReplicaRequest)(nil),                   // 62: tabletmanagerdata.PromoteReplicaRequest
-	(*tabletmanagerdata.BackupRequest)(nil),                           // 63: tabletmanagerdata.BackupRequest
-	(*tabletmanagerdata.RestoreFromBackupRequest)(nil),                // 64: tabletmanagerdata.RestoreFromBackupRequest
-	(*tabletmanagerdata.CheckThrottlerRequest)(nil),                   // 65: tabletmanagerdata.CheckThrottlerRequest
-	(*tabletmanagerdata.GetThrottlerStatusRequest)(nil),               // 66: tabletmanagerdata.GetThrottlerStatusRequest
-	(*tabletmanagerdata.PingResponse)(nil),                            // 67: tabletmanagerdata.PingResponse
-	(*tabletmanagerdata.SleepResponse)(nil),                           // 68: tabletmanagerdata.SleepResponse
-	(*tabletmanagerdata.ExecuteHookResponse)(nil),                     // 69: tabletmanagerdata.ExecuteHookResponse
-	(*tabletmanagerdata.GetSchemaResponse)(nil),                       // 70: tabletmanagerdata.GetSchemaResponse
-	(*tabletmanagerdata.GetPermissionsResponse)(nil),                  // 71: tabletmanagerdata.GetPermissionsResponse
-	(*tabletmanagerdata.GetGlobalStatusVarsResponse)(nil),             // 72: tabletmanagerdata.GetGlobalStatusVarsResponse
-	(*tabletmanagerdata.SetReadOnlyResponse)(nil),                     // 73: tabletmanagerdata.SetReadOnlyResponse
-	(*tabletmanagerdata.SetReadWriteResponse)(nil),                    // 74: tabletmanagerdata.SetReadWriteResponse
-	(*tabletmanagerdata.ChangeTagsResponse)(nil),                      // 75: tabletmanagerdata.ChangeTagsResponse
-	(*tabletmanagerdata.ChangeTypeResponse)(nil),                      // 76: tabletmanagerdata.ChangeTypeResponse
-	(*tabletmanagerdata.RefreshStateResponse)(nil),                    // 77: tabletmanagerdata.RefreshStateResponse
-	(*tabletmanagerdata.RunHealthCheckResponse)(nil),                  // 78: tabletmanagerdata.RunHealthCheckResponse
-	(*tabletmanagerdata.ReloadSchemaResponse)(nil),                    // 79: tabletmanagerdata.ReloadSchemaResponse
-	(*tabletmanagerdata.PreflightSchemaResponse)(nil),                 // 80: tabletmanagerdata.PreflightSchemaResponse
-	(*tabletmanagerdata.ApplySchemaResponse)(nil),                     // 81: tabletmanagerdata.ApplySchemaResponse
-	(*tabletmanagerdata.ResetSequencesResponse)(nil),                  // 82: tabletmanagerdata.ResetSequencesResponse
-	(*tabletmanagerdata.LockTablesResponse)(nil),                      // 83: tabletmanagerdata.LockTablesResponse
-	(*tabletmanagerdata.UnlockTablesResponse)(nil),                    // 84: tabletmanagerdata.UnlockTablesResponse
-	(*tabletmanagerdata.ExecuteQueryResponse)(nil),                    // 85: tabletmanagerdata.ExecuteQueryResponse
-	(*tabletmanagerdata.ExecuteFetchAsDbaResponse)(nil),               // 86: tabletmanagerdata.ExecuteFetchAsDbaResponse
-	(*tabletmanagerdata.ExecuteMultiFetchAsDbaResponse)(nil),          // 87: tabletmanagerdata.ExecuteMultiFetchAsDbaResponse
-	(*tabletmanagerdata.ExecuteFetchAsAllPrivsResponse)(nil),          // 88: tabletmanagerdata.ExecuteFetchAsAllPrivsResponse
-	(*tabletmanagerdata.ExecuteFetchAsAppResponse)(nil),               // 89: tabletmanagerdata.ExecuteFetchAsAppResponse
-	(*tabletmanagerdata.GetUnresolvedTransactionsResponse)(nil),       // 90: tabletmanagerdata.GetUnresolvedTransactionsResponse
-	(*tabletmanagerdata.ReadTransactionResponse)(nil),                 // 91: tabletmanagerdata.ReadTransactionResponse
-	(*tabletmanagerdata.GetTransactionInfoResponse)(nil),              // 92: tabletmanagerdata.GetTransactionInfoResponse
-	(*tabletmanagerdata.ConcludeTransactionResponse)(nil),             // 93: tabletmanagerdata.ConcludeTransactionResponse
-	(*tabletmanagerdata.MysqlHostMetricsResponse)(nil),                // 94: tabletmanagerdata.MysqlHostMetricsResponse
-	(*tabletmanagerdata.ReplicationStatusResponse)(nil),               // 95: tabletmanagerdata.ReplicationStatusResponse
-	(*tabletmanagerdata.PrimaryStatusResponse)(nil),                   // 96: tabletmanagerdata.PrimaryStatusResponse
-	(*tabletmanagerdata.PrimaryPositionResponse)(nil),                 // 97: tabletmanagerdata.PrimaryPositionResponse
-	(*tabletmanagerdata.WaitForPositionResponse)(nil),                 // 98: tabletmanagerdata.WaitForPositionResponse
-	(*tabletmanagerdata.StopReplicationResponse)(nil),                 // 99: tabletmanagerdata.StopReplicationResponse
-	(*tabletmanagerdata.StopReplicationMinimumResponse)(nil),          // 100: tabletmanagerdata.StopReplicationMinimumResponse
-	(*tabletmanagerdata.StartReplicationResponse)(nil),                // 101: tabletmanagerdata.StartReplicationResponse
-	(*tabletmanagerdata.StartReplicationUntilAfterResponse)(nil),      // 102: tabletmanagerdata.StartReplicationUntilAfterResponse
-	(*tabletmanagerdata.GetReplicasResponse)(nil),                     // 103: tabletmanagerdata.GetReplicasResponse
-	(*tabletmanagerdata.CreateVReplicationWorkflowResponse)(nil),      // 104: tabletmanagerdata.CreateVReplicationWorkflowResponse
-	(*tabletmanagerdata.DeleteTableDataResponse)(nil),                 // 105: tabletmanagerdata.DeleteTableDataResponse
-	(*tabletmanagerdata.DeleteVReplicationWorkflowResponse)(nil),      // 106: tabletmanagerdata.DeleteVReplicationWorkflowResponse
-	(*tabletmanagerdata.HasVReplicationWorkflowsResponse)(nil),        // 107: tabletmanagerdata.HasVReplicationWorkflowsResponse
-	(*tabletmanagerdata.ReadVReplicationWorkflowResponse)(nil),        // 108: tabletmanagerdata.ReadVReplicationWorkflowResponse
-	(*tabletmanagerdata.ReadVReplicationWorkflowsResponse)(nil),       // 109: tabletmanagerdata.ReadVReplicationWorkflowsResponse
-	(*tabletmanagerdata.UpdateVReplicationWorkflowResponse)(nil),      // 110: tabletmanagerdata.UpdateVReplicationWorkflowResponse
-	(*tabletmanagerdata.UpdateVReplicationWorkflowsResponse)(nil),     // 111: tabletmanagerdata.UpdateVReplicationWorkflowsResponse
-	(*tabletmanagerdata.ValidateVReplicationPermissionsResponse)(nil), // 112: tabletmanagerdata.ValidateVReplicationPermissionsResponse
-	(*tabletmanagerdata.VReplicationExecResponse)(nil),                // 113: tabletmanagerdata.VReplicationExecResponse
-	(*tabletmanagerdata.VReplicationWaitForPosResponse)(nil),          // 114: tabletmanagerdata.VReplicationWaitForPosResponse
-	(*tabletmanagerdata.VDiffResponse)(nil),                           // 115: tabletmanagerdata.VDiffResponse
-	(*tabletmanagerdata.ResetReplicationResponse)(nil),                // 116: tabletmanagerdata.ResetReplicationResponse
-	(*tabletmanagerdata.InitPrimaryResponse)(nil),                     // 117: tabletmanagerdata.InitPrimaryResponse
-	(*tabletmanagerdata.PopulateReparentJournalResponse)(nil),         // 118: tabletmanagerdata.PopulateReparentJournalResponse
-	(*tabletmanagerdata.ReadReparentJournalInfoResponse)(nil),         // 119: tabletmanagerdata.ReadReparentJournalInfoResponse
-	(*tabletmanagerdata.InitReplicaResponse)(nil),                     // 120: tabletmanagerdata.InitReplicaResponse
-	(*tabletmanagerdata.DemotePrimaryResponse)(nil),                   // 121: tabletmanagerdata.DemotePrimaryResponse
-	(*tabletmanagerdata.UndoDemotePrimaryResponse)(nil),               // 122: tabletmanagerdata.UndoDemotePrimaryResponse
-	(*tabletmanagerdata.ReplicaWasPromotedResponse)(nil),              // 123: tabletmanagerdata.ReplicaWasPromotedResponse
-	(*tabletmanagerdata.ResetReplicationParametersResponse)(nil),      // 124: tabletmanagerdata.ResetReplicationParametersResponse
-	(*tabletmanagerdata.FullStatusResponse)(nil),                      // 125: tabletmanagerdata.FullStatusResponse
-	(*tabletmanagerdata.SetReplicationSourceResponse)(nil),            // 126: tabletmanagerdata.SetReplicationSourceResponse
-	(*tabletmanagerdata.ReplicaWasRestartedResponse)(nil),             // 127: tabletmanagerdata.ReplicaWasRestartedResponse
-	(*tabletmanagerdata.StopReplicationAndGetStatusResponse)(nil),     // 128: tabletmanagerdata.StopReplicationAndGetStatusResponse
-	(*tabletmanagerdata.PromoteReplicaResponse)(nil),                  // 129: tabletmanagerdata.PromoteReplicaResponse
-	(*tabletmanagerdata.BackupResponse)(nil),                          // 130: tabletmanagerdata.BackupResponse
-	(*tabletmanagerdata.RestoreFromBackupResponse)(nil),               // 131: tabletmanagerdata.RestoreFromBackupResponse
-	(*tabletmanagerdata.CheckThrottlerResponse)(nil),                  // 132: tabletmanagerdata.CheckThrottlerResponse
-	(*tabletmanagerdata.GetThrottlerStatusResponse)(nil),              // 133: tabletmanagerdata.GetThrottlerStatusResponse
+	(*tabletmanagerdata.UpdateSequenceTablesRequest)(nil),             // 48: tabletmanagerdata.UpdateSequenceTablesRequest
+	(*tabletmanagerdata.GetMaxValueForSequencesRequest)(nil),          // 49: tabletmanagerdata.GetMaxValueForSequencesRequest
+	(*tabletmanagerdata.VDiffRequest)(nil),                            // 50: tabletmanagerdata.VDiffRequest
+	(*tabletmanagerdata.ResetReplicationRequest)(nil),                 // 51: tabletmanagerdata.ResetReplicationRequest
+	(*tabletmanagerdata.InitPrimaryRequest)(nil),                      // 52: tabletmanagerdata.InitPrimaryRequest
+	(*tabletmanagerdata.PopulateReparentJournalRequest)(nil),          // 53: tabletmanagerdata.PopulateReparentJournalRequest
+	(*tabletmanagerdata.ReadReparentJournalInfoRequest)(nil),          // 54: tabletmanagerdata.ReadReparentJournalInfoRequest
+	(*tabletmanagerdata.InitReplicaRequest)(nil),                      // 55: tabletmanagerdata.InitReplicaRequest
+	(*tabletmanagerdata.DemotePrimaryRequest)(nil),                    // 56: tabletmanagerdata.DemotePrimaryRequest
+	(*tabletmanagerdata.UndoDemotePrimaryRequest)(nil),                // 57: tabletmanagerdata.UndoDemotePrimaryRequest
+	(*tabletmanagerdata.ReplicaWasPromotedRequest)(nil),               // 58: tabletmanagerdata.ReplicaWasPromotedRequest
+	(*tabletmanagerdata.ResetReplicationParametersRequest)(nil),       // 59: tabletmanagerdata.ResetReplicationParametersRequest
+	(*tabletmanagerdata.FullStatusRequest)(nil),                       // 60: tabletmanagerdata.FullStatusRequest
+	(*tabletmanagerdata.SetReplicationSourceRequest)(nil),             // 61: tabletmanagerdata.SetReplicationSourceRequest
+	(*tabletmanagerdata.ReplicaWasRestartedRequest)(nil),              // 62: tabletmanagerdata.ReplicaWasRestartedRequest
+	(*tabletmanagerdata.StopReplicationAndGetStatusRequest)(nil),      // 63: tabletmanagerdata.StopReplicationAndGetStatusRequest
+	(*tabletmanagerdata.PromoteReplicaRequest)(nil),                   // 64: tabletmanagerdata.PromoteReplicaRequest
+	(*tabletmanagerdata.BackupRequest)(nil),                           // 65: tabletmanagerdata.BackupRequest
+	(*tabletmanagerdata.RestoreFromBackupRequest)(nil),                // 66: tabletmanagerdata.RestoreFromBackupRequest
+	(*tabletmanagerdata.CheckThrottlerRequest)(nil),                   // 67: tabletmanagerdata.CheckThrottlerRequest
+	(*tabletmanagerdata.GetThrottlerStatusRequest)(nil),               // 68: tabletmanagerdata.GetThrottlerStatusRequest
+	(*tabletmanagerdata.PingResponse)(nil),                            // 69: tabletmanagerdata.PingResponse
+	(*tabletmanagerdata.SleepResponse)(nil),                           // 70: tabletmanagerdata.SleepResponse
+	(*tabletmanagerdata.ExecuteHookResponse)(nil),                     // 71: tabletmanagerdata.ExecuteHookResponse
+	(*tabletmanagerdata.GetSchemaResponse)(nil),                       // 72: tabletmanagerdata.GetSchemaResponse
+	(*tabletmanagerdata.GetPermissionsResponse)(nil),                  // 73: tabletmanagerdata.GetPermissionsResponse
+	(*tabletmanagerdata.GetGlobalStatusVarsResponse)(nil),             // 74: tabletmanagerdata.GetGlobalStatusVarsResponse
+	(*tabletmanagerdata.SetReadOnlyResponse)(nil),                     // 75: tabletmanagerdata.SetReadOnlyResponse
+	(*tabletmanagerdata.SetReadWriteResponse)(nil),                    // 76: tabletmanagerdata.SetReadWriteResponse
+	(*tabletmanagerdata.ChangeTagsResponse)(nil),                      // 77: tabletmanagerdata.ChangeTagsResponse
+	(*tabletmanagerdata.ChangeTypeResponse)(nil),                      // 78: tabletmanagerdata.ChangeTypeResponse
+	(*tabletmanagerdata.RefreshStateResponse)(nil),                    // 79: tabletmanagerdata.RefreshStateResponse
+	(*tabletmanagerdata.RunHealthCheckResponse)(nil),                  // 80: tabletmanagerdata.RunHealthCheckResponse
+	(*tabletmanagerdata.ReloadSchemaResponse)(nil),                    // 81: tabletmanagerdata.ReloadSchemaResponse
+	(*tabletmanagerdata.PreflightSchemaResponse)(nil),                 // 82: tabletmanagerdata.PreflightSchemaResponse
+	(*tabletmanagerdata.ApplySchemaResponse)(nil),                     // 83: tabletmanagerdata.ApplySchemaResponse
+	(*tabletmanagerdata.ResetSequencesResponse)(nil),                  // 84: tabletmanagerdata.ResetSequencesResponse
+	(*tabletmanagerdata.LockTablesResponse)(nil),                      // 85: tabletmanagerdata.LockTablesResponse
+	(*tabletmanagerdata.UnlockTablesResponse)(nil),                    // 86: tabletmanagerdata.UnlockTablesResponse
+	(*tabletmanagerdata.ExecuteQueryResponse)(nil),                    // 87: tabletmanagerdata.ExecuteQueryResponse
+	(*tabletmanagerdata.ExecuteFetchAsDbaResponse)(nil),               // 88: tabletmanagerdata.ExecuteFetchAsDbaResponse
+	(*tabletmanagerdata.ExecuteMultiFetchAsDbaResponse)(nil),          // 89: tabletmanagerdata.ExecuteMultiFetchAsDbaResponse
+	(*tabletmanagerdata.ExecuteFetchAsAllPrivsResponse)(nil),          // 90: tabletmanagerdata.ExecuteFetchAsAllPrivsResponse
+	(*tabletmanagerdata.ExecuteFetchAsAppResponse)(nil),               // 91: tabletmanagerdata.ExecuteFetchAsAppResponse
+	(*tabletmanagerdata.GetUnresolvedTransactionsResponse)(nil),       // 92: tabletmanagerdata.GetUnresolvedTransactionsResponse
+	(*tabletmanagerdata.ReadTransactionResponse)(nil),                 // 93: tabletmanagerdata.ReadTransactionResponse
+	(*tabletmanagerdata.GetTransactionInfoResponse)(nil),              // 94: tabletmanagerdata.GetTransactionInfoResponse
+	(*tabletmanagerdata.ConcludeTransactionResponse)(nil),             // 95: tabletmanagerdata.ConcludeTransactionResponse
+	(*tabletmanagerdata.MysqlHostMetricsResponse)(nil),                // 96: tabletmanagerdata.MysqlHostMetricsResponse
+	(*tabletmanagerdata.ReplicationStatusResponse)(nil),               // 97: tabletmanagerdata.ReplicationStatusResponse
+	(*tabletmanagerdata.PrimaryStatusResponse)(nil),                   // 98: tabletmanagerdata.PrimaryStatusResponse
+	(*tabletmanagerdata.PrimaryPositionResponse)(nil),                 // 99: tabletmanagerdata.PrimaryPositionResponse
+	(*tabletmanagerdata.WaitForPositionResponse)(nil),                 // 100: tabletmanagerdata.WaitForPositionResponse
+	(*tabletmanagerdata.StopReplicationResponse)(nil),                 // 101: tabletmanagerdata.StopReplicationResponse
+	(*tabletmanagerdata.StopReplicationMinimumResponse)(nil),          // 102: tabletmanagerdata.StopReplicationMinimumResponse
+	(*tabletmanagerdata.StartReplicationResponse)(nil),                // 103: tabletmanagerdata.StartReplicationResponse
+	(*tabletmanagerdata.StartReplicationUntilAfterResponse)(nil),      // 104: tabletmanagerdata.StartReplicationUntilAfterResponse
+	(*tabletmanagerdata.GetReplicasResponse)(nil),                     // 105: tabletmanagerdata.GetReplicasResponse
+	(*tabletmanagerdata.CreateVReplicationWorkflowResponse)(nil),      // 106: tabletmanagerdata.CreateVReplicationWorkflowResponse
+	(*tabletmanagerdata.DeleteTableDataResponse)(nil),                 // 107: tabletmanagerdata.DeleteTableDataResponse
+	(*tabletmanagerdata.DeleteVReplicationWorkflowResponse)(nil),      // 108: tabletmanagerdata.DeleteVReplicationWorkflowResponse
+	(*tabletmanagerdata.HasVReplicationWorkflowsResponse)(nil),        // 109: tabletmanagerdata.HasVReplicationWorkflowsResponse
+	(*tabletmanagerdata.ReadVReplicationWorkflowResponse)(nil),        // 110: tabletmanagerdata.ReadVReplicationWorkflowResponse
+	(*tabletmanagerdata.ReadVReplicationWorkflowsResponse)(nil),       // 111: tabletmanagerdata.ReadVReplicationWorkflowsResponse
+	(*tabletmanagerdata.UpdateVReplicationWorkflowResponse)(nil),      // 112: tabletmanagerdata.UpdateVReplicationWorkflowResponse
+	(*tabletmanagerdata.UpdateVReplicationWorkflowsResponse)(nil),     // 113: tabletmanagerdata.UpdateVReplicationWorkflowsResponse
+	(*tabletmanagerdata.ValidateVReplicationPermissionsResponse)(nil), // 114: tabletmanagerdata.ValidateVReplicationPermissionsResponse
+	(*tabletmanagerdata.VReplicationExecResponse)(nil),                // 115: tabletmanagerdata.VReplicationExecResponse
+	(*tabletmanagerdata.VReplicationWaitForPosResponse)(nil),          // 116: tabletmanagerdata.VReplicationWaitForPosResponse
+	(*tabletmanagerdata.UpdateSequenceTablesResponse)(nil),            // 117: tabletmanagerdata.UpdateSequenceTablesResponse
+	(*tabletmanagerdata.GetMaxValueForSequencesResponse)(nil),         // 118: tabletmanagerdata.GetMaxValueForSequencesResponse
+	(*tabletmanagerdata.VDiffResponse)(nil),                           // 119: tabletmanagerdata.VDiffResponse
+	(*tabletmanagerdata.ResetReplicationResponse)(nil),                // 120: tabletmanagerdata.ResetReplicationResponse
+	(*tabletmanagerdata.InitPrimaryResponse)(nil),                     // 121: tabletmanagerdata.InitPrimaryResponse
+	(*tabletmanagerdata.PopulateReparentJournalResponse)(nil),         // 122: tabletmanagerdata.PopulateReparentJournalResponse
+	(*tabletmanagerdata.ReadReparentJournalInfoResponse)(nil),         // 123: tabletmanagerdata.ReadReparentJournalInfoResponse
+	(*tabletmanagerdata.InitReplicaResponse)(nil),                     // 124: tabletmanagerdata.InitReplicaResponse
+	(*tabletmanagerdata.DemotePrimaryResponse)(nil),                   // 125: tabletmanagerdata.DemotePrimaryResponse
+	(*tabletmanagerdata.UndoDemotePrimaryResponse)(nil),               // 126: tabletmanagerdata.UndoDemotePrimaryResponse
+	(*tabletmanagerdata.ReplicaWasPromotedResponse)(nil),              // 127: tabletmanagerdata.ReplicaWasPromotedResponse
+	(*tabletmanagerdata.ResetReplicationParametersResponse)(nil),      // 128: tabletmanagerdata.ResetReplicationParametersResponse
+	(*tabletmanagerdata.FullStatusResponse)(nil),                      // 129: tabletmanagerdata.FullStatusResponse
+	(*tabletmanagerdata.SetReplicationSourceResponse)(nil),            // 130: tabletmanagerdata.SetReplicationSourceResponse
+	(*tabletmanagerdata.ReplicaWasRestartedResponse)(nil),             // 131: tabletmanagerdata.ReplicaWasRestartedResponse
+	(*tabletmanagerdata.StopReplicationAndGetStatusResponse)(nil),     // 132: tabletmanagerdata.StopReplicationAndGetStatusResponse
+	(*tabletmanagerdata.PromoteReplicaResponse)(nil),                  // 133: tabletmanagerdata.PromoteReplicaResponse
+	(*tabletmanagerdata.BackupResponse)(nil),                          // 134: tabletmanagerdata.BackupResponse
+	(*tabletmanagerdata.RestoreFromBackupResponse)(nil),               // 135: tabletmanagerdata.RestoreFromBackupResponse
+	(*tabletmanagerdata.CheckThrottlerResponse)(nil),                  // 136: tabletmanagerdata.CheckThrottlerResponse
+	(*tabletmanagerdata.GetThrottlerStatusResponse)(nil),              // 137: tabletmanagerdata.GetThrottlerStatusResponse
 }
 var file_tabletmanagerservice_proto_depIdxs = []int32{
 	0,   // 0: tabletmanagerservice.TabletManager.Ping:input_type -> tabletmanagerdata.PingRequest
@@ -712,94 +732,98 @@ var file_tabletmanagerservice_proto_depIdxs = []int32{
 	45,  // 45: tabletmanagerservice.TabletManager.ValidateVReplicationPermissions:input_type -> tabletmanagerdata.ValidateVReplicationPermissionsRequest
 	46,  // 46: tabletmanagerservice.TabletManager.VReplicationExec:input_type -> tabletmanagerdata.VReplicationExecRequest
 	47,  // 47: tabletmanagerservice.TabletManager.VReplicationWaitForPos:input_type -> tabletmanagerdata.VReplicationWaitForPosRequest
-	48,  // 48: tabletmanagerservice.TabletManager.VDiff:input_type -> tabletmanagerdata.VDiffRequest
-	49,  // 49: tabletmanagerservice.TabletManager.ResetReplication:input_type -> tabletmanagerdata.ResetReplicationRequest
-	50,  // 50: tabletmanagerservice.TabletManager.InitPrimary:input_type -> tabletmanagerdata.InitPrimaryRequest
-	51,  // 51: tabletmanagerservice.TabletManager.PopulateReparentJournal:input_type -> tabletmanagerdata.PopulateReparentJournalRequest
-	52,  // 52: tabletmanagerservice.TabletManager.ReadReparentJournalInfo:input_type -> tabletmanagerdata.ReadReparentJournalInfoRequest
-	53,  // 53: tabletmanagerservice.TabletManager.InitReplica:input_type -> tabletmanagerdata.InitReplicaRequest
-	54,  // 54: tabletmanagerservice.TabletManager.DemotePrimary:input_type -> tabletmanagerdata.DemotePrimaryRequest
-	55,  // 55: tabletmanagerservice.TabletManager.UndoDemotePrimary:input_type -> tabletmanagerdata.UndoDemotePrimaryRequest
-	56,  // 56: tabletmanagerservice.TabletManager.ReplicaWasPromoted:input_type -> tabletmanagerdata.ReplicaWasPromotedRequest
-	57,  // 57: tabletmanagerservice.TabletManager.ResetReplicationParameters:input_type -> tabletmanagerdata.ResetReplicationParametersRequest
-	58,  // 58: tabletmanagerservice.TabletManager.FullStatus:input_type -> tabletmanagerdata.FullStatusRequest
-	59,  // 59: tabletmanagerservice.TabletManager.SetReplicationSource:input_type -> tabletmanagerdata.SetReplicationSourceRequest
-	60,  // 60: tabletmanagerservice.TabletManager.ReplicaWasRestarted:input_type -> tabletmanagerdata.ReplicaWasRestartedRequest
-	61,  // 61: tabletmanagerservice.TabletManager.StopReplicationAndGetStatus:input_type -> tabletmanagerdata.StopReplicationAndGetStatusRequest
-	62,  // 62: tabletmanagerservice.TabletManager.PromoteReplica:input_type -> tabletmanagerdata.PromoteReplicaRequest
-	63,  // 63: tabletmanagerservice.TabletManager.Backup:input_type -> tabletmanagerdata.BackupRequest
-	64,  // 64: tabletmanagerservice.TabletManager.RestoreFromBackup:input_type -> tabletmanagerdata.RestoreFromBackupRequest
-	65,  // 65: tabletmanagerservice.TabletManager.CheckThrottler:input_type -> tabletmanagerdata.CheckThrottlerRequest
-	66,  // 66: tabletmanagerservice.TabletManager.GetThrottlerStatus:input_type -> tabletmanagerdata.GetThrottlerStatusRequest
-	67,  // 67: tabletmanagerservice.TabletManager.Ping:output_type -> tabletmanagerdata.PingResponse
-	68,  // 68: tabletmanagerservice.TabletManager.Sleep:output_type -> tabletmanagerdata.SleepResponse
-	69,  // 69: tabletmanagerservice.TabletManager.ExecuteHook:output_type -> tabletmanagerdata.ExecuteHookResponse
-	70,  // 70: tabletmanagerservice.TabletManager.GetSchema:output_type -> tabletmanagerdata.GetSchemaResponse
-	71,  // 71: tabletmanagerservice.TabletManager.GetPermissions:output_type -> tabletmanagerdata.GetPermissionsResponse
-	72,  // 72: tabletmanagerservice.TabletManager.GetGlobalStatusVars:output_type -> tabletmanagerdata.GetGlobalStatusVarsResponse
-	73,  // 73: tabletmanagerservice.TabletManager.SetReadOnly:output_type -> tabletmanagerdata.SetReadOnlyResponse
-	74,  // 74: tabletmanagerservice.TabletManager.SetReadWrite:output_type -> tabletmanagerdata.SetReadWriteResponse
-	75,  // 75: tabletmanagerservice.TabletManager.ChangeTags:output_type -> tabletmanagerdata.ChangeTagsResponse
-	76,  // 76: tabletmanagerservice.TabletManager.ChangeType:output_type -> tabletmanagerdata.ChangeTypeResponse
-	77,  // 77: tabletmanagerservice.TabletManager.RefreshState:output_type -> tabletmanagerdata.RefreshStateResponse
-	78,  // 78: tabletmanagerservice.TabletManager.RunHealthCheck:output_type -> tabletmanagerdata.RunHealthCheckResponse
-	79,  // 79: tabletmanagerservice.TabletManager.ReloadSchema:output_type -> tabletmanagerdata.ReloadSchemaResponse
-	80,  // 80: tabletmanagerservice.TabletManager.PreflightSchema:output_type -> tabletmanagerdata.PreflightSchemaResponse
-	81,  // 81: tabletmanagerservice.TabletManager.ApplySchema:output_type -> tabletmanagerdata.ApplySchemaResponse
-	82,  // 82: tabletmanagerservice.TabletManager.ResetSequences:output_type -> tabletmanagerdata.ResetSequencesResponse
-	83,  // 83: tabletmanagerservice.TabletManager.LockTables:output_type -> tabletmanagerdata.LockTablesResponse
-	84,  // 84: tabletmanagerservice.TabletManager.UnlockTables:output_type -> tabletmanagerdata.UnlockTablesResponse
-	85,  // 85: tabletmanagerservice.TabletManager.ExecuteQuery:output_type -> tabletmanagerdata.ExecuteQueryResponse
-	86,  // 86: tabletmanagerservice.TabletManager.ExecuteFetchAsDba:output_type -> tabletmanagerdata.ExecuteFetchAsDbaResponse
-	87,  // 87: tabletmanagerservice.TabletManager.ExecuteMultiFetchAsDba:output_type -> tabletmanagerdata.ExecuteMultiFetchAsDbaResponse
-	88,  // 88: tabletmanagerservice.TabletManager.ExecuteFetchAsAllPrivs:output_type -> tabletmanagerdata.ExecuteFetchAsAllPrivsResponse
-	89,  // 89: tabletmanagerservice.TabletManager.ExecuteFetchAsApp:output_type -> tabletmanagerdata.ExecuteFetchAsAppResponse
-	90,  // 90: tabletmanagerservice.TabletManager.GetUnresolvedTransactions:output_type -> tabletmanagerdata.GetUnresolvedTransactionsResponse
-	91,  // 91: tabletmanagerservice.TabletManager.ReadTransaction:output_type -> tabletmanagerdata.ReadTransactionResponse
-	92,  // 92: tabletmanagerservice.TabletManager.GetTransactionInfo:output_type -> tabletmanagerdata.GetTransactionInfoResponse
-	93,  // 93: tabletmanagerservice.TabletManager.ConcludeTransaction:output_type -> tabletmanagerdata.ConcludeTransactionResponse
-	94,  // 94: tabletmanagerservice.TabletManager.MysqlHostMetrics:output_type -> tabletmanagerdata.MysqlHostMetricsResponse
-	95,  // 95: tabletmanagerservice.TabletManager.ReplicationStatus:output_type -> tabletmanagerdata.ReplicationStatusResponse
-	96,  // 96: tabletmanagerservice.TabletManager.PrimaryStatus:output_type -> tabletmanagerdata.PrimaryStatusResponse
-	97,  // 97: tabletmanagerservice.TabletManager.PrimaryPosition:output_type -> tabletmanagerdata.PrimaryPositionResponse
-	98,  // 98: tabletmanagerservice.TabletManager.WaitForPosition:output_type -> tabletmanagerdata.WaitForPositionResponse
-	99,  // 99: tabletmanagerservice.TabletManager.StopReplication:output_type -> tabletmanagerdata.StopReplicationResponse
-	100, // 100: tabletmanagerservice.TabletManager.StopReplicationMinimum:output_type -> tabletmanagerdata.StopReplicationMinimumResponse
-	101, // 101: tabletmanagerservice.TabletManager.StartReplication:output_type -> tabletmanagerdata.StartReplicationResponse
-	102, // 102: tabletmanagerservice.TabletManager.StartReplicationUntilAfter:output_type -> tabletmanagerdata.StartReplicationUntilAfterResponse
-	103, // 103: tabletmanagerservice.TabletManager.GetReplicas:output_type -> tabletmanagerdata.GetReplicasResponse
-	104, // 104: tabletmanagerservice.TabletManager.CreateVReplicationWorkflow:output_type -> tabletmanagerdata.CreateVReplicationWorkflowResponse
-	105, // 105: tabletmanagerservice.TabletManager.DeleteTableData:output_type -> tabletmanagerdata.DeleteTableDataResponse
-	106, // 106: tabletmanagerservice.TabletManager.DeleteVReplicationWorkflow:output_type -> tabletmanagerdata.DeleteVReplicationWorkflowResponse
-	107, // 107: tabletmanagerservice.TabletManager.HasVReplicationWorkflows:output_type -> tabletmanagerdata.HasVReplicationWorkflowsResponse
-	108, // 108: tabletmanagerservice.TabletManager.ReadVReplicationWorkflow:output_type -> tabletmanagerdata.ReadVReplicationWorkflowResponse
-	109, // 109: tabletmanagerservice.TabletManager.ReadVReplicationWorkflows:output_type -> tabletmanagerdata.ReadVReplicationWorkflowsResponse
-	110, // 110: tabletmanagerservice.TabletManager.UpdateVReplicationWorkflow:output_type -> tabletmanagerdata.UpdateVReplicationWorkflowResponse
-	111, // 111: tabletmanagerservice.TabletManager.UpdateVReplicationWorkflows:output_type -> tabletmanagerdata.UpdateVReplicationWorkflowsResponse
-	112, // 112: tabletmanagerservice.TabletManager.ValidateVReplicationPermissions:output_type -> tabletmanagerdata.ValidateVReplicationPermissionsResponse
-	113, // 113: tabletmanagerservice.TabletManager.VReplicationExec:output_type -> tabletmanagerdata.VReplicationExecResponse
-	114, // 114: tabletmanagerservice.TabletManager.VReplicationWaitForPos:output_type -> tabletmanagerdata.VReplicationWaitForPosResponse
-	115, // 115: tabletmanagerservice.TabletManager.VDiff:output_type -> tabletmanagerdata.VDiffResponse
-	116, // 116: tabletmanagerservice.TabletManager.ResetReplication:output_type -> tabletmanagerdata.ResetReplicationResponse
-	117, // 117: tabletmanagerservice.TabletManager.InitPrimary:output_type -> tabletmanagerdata.InitPrimaryResponse
-	118, // 118: tabletmanagerservice.TabletManager.PopulateReparentJournal:output_type -> tabletmanagerdata.PopulateReparentJournalResponse
-	119, // 119: tabletmanagerservice.TabletManager.ReadReparentJournalInfo:output_type -> tabletmanagerdata.ReadReparentJournalInfoResponse
-	120, // 120: tabletmanagerservice.TabletManager.InitReplica:output_type -> tabletmanagerdata.InitReplicaResponse
-	121, // 121: tabletmanagerservice.TabletManager.DemotePrimary:output_type -> tabletmanagerdata.DemotePrimaryResponse
-	122, // 122: tabletmanagerservice.TabletManager.UndoDemotePrimary:output_type -> tabletmanagerdata.UndoDemotePrimaryResponse
-	123, // 123: tabletmanagerservice.TabletManager.ReplicaWasPromoted:output_type -> tabletmanagerdata.ReplicaWasPromotedResponse
-	124, // 124: tabletmanagerservice.TabletManager.ResetReplicationParameters:output_type -> tabletmanagerdata.ResetReplicationParametersResponse
-	125, // 125: tabletmanagerservice.TabletManager.FullStatus:output_type -> tabletmanagerdata.FullStatusResponse
-	126, // 126: tabletmanagerservice.TabletManager.SetReplicationSource:output_type -> tabletmanagerdata.SetReplicationSourceResponse
-	127, // 127: tabletmanagerservice.TabletManager.ReplicaWasRestarted:output_type -> tabletmanagerdata.ReplicaWasRestartedResponse
-	128, // 128: tabletmanagerservice.TabletManager.StopReplicationAndGetStatus:output_type -> tabletmanagerdata.StopReplicationAndGetStatusResponse
-	129, // 129: tabletmanagerservice.TabletManager.PromoteReplica:output_type -> tabletmanagerdata.PromoteReplicaResponse
-	130, // 130: tabletmanagerservice.TabletManager.Backup:output_type -> tabletmanagerdata.BackupResponse
-	131, // 131: tabletmanagerservice.TabletManager.RestoreFromBackup:output_type -> tabletmanagerdata.RestoreFromBackupResponse
-	132, // 132: tabletmanagerservice.TabletManager.CheckThrottler:output_type -> tabletmanagerdata.CheckThrottlerResponse
-	133, // 133: tabletmanagerservice.TabletManager.GetThrottlerStatus:output_type -> tabletmanagerdata.GetThrottlerStatusResponse
-	67,  // [67:134] is the sub-list for method output_type
-	0,   // [0:67] is the sub-list for method input_type
+	48,  // 48: tabletmanagerservice.TabletManager.UpdateSequenceTables:input_type -> tabletmanagerdata.UpdateSequenceTablesRequest
+	49,  // 49: tabletmanagerservice.TabletManager.GetMaxValueForSequences:input_type -> tabletmanagerdata.GetMaxValueForSequencesRequest
+	50,  // 50: tabletmanagerservice.TabletManager.VDiff:input_type -> tabletmanagerdata.VDiffRequest
+	51,  // 51: tabletmanagerservice.TabletManager.ResetReplication:input_type -> tabletmanagerdata.ResetReplicationRequest
+	52,  // 52: tabletmanagerservice.TabletManager.InitPrimary:input_type -> tabletmanagerdata.InitPrimaryRequest
+	53,  // 53: tabletmanagerservice.TabletManager.PopulateReparentJournal:input_type -> tabletmanagerdata.PopulateReparentJournalRequest
+	54,  // 54: tabletmanagerservice.TabletManager.ReadReparentJournalInfo:input_type -> tabletmanagerdata.ReadReparentJournalInfoRequest
+	55,  // 55: tabletmanagerservice.TabletManager.InitReplica:input_type -> tabletmanagerdata.InitReplicaRequest
+	56,  // 56: tabletmanagerservice.TabletManager.DemotePrimary:input_type -> tabletmanagerdata.DemotePrimaryRequest
+	57,  // 57: tabletmanagerservice.TabletManager.UndoDemotePrimary:input_type -> tabletmanagerdata.UndoDemotePrimaryRequest
+	58,  // 58: tabletmanagerservice.TabletManager.ReplicaWasPromoted:input_type -> tabletmanagerdata.ReplicaWasPromotedRequest
+	59,  // 59: tabletmanagerservice.TabletManager.ResetReplicationParameters:input_type -> tabletmanagerdata.ResetReplicationParametersRequest
+	60,  // 60: tabletmanagerservice.TabletManager.FullStatus:input_type -> tabletmanagerdata.FullStatusRequest
+	61,  // 61: tabletmanagerservice.TabletManager.SetReplicationSource:input_type -> tabletmanagerdata.SetReplicationSourceRequest
+	62,  // 62: tabletmanagerservice.TabletManager.ReplicaWasRestarted:input_type -> tabletmanagerdata.ReplicaWasRestartedRequest
+	63,  // 63: tabletmanagerservice.TabletManager.StopReplicationAndGetStatus:input_type -> tabletmanagerdata.StopReplicationAndGetStatusRequest
+	64,  // 64: tabletmanagerservice.TabletManager.PromoteReplica:input_type -> tabletmanagerdata.PromoteReplicaRequest
+	65,  // 65: tabletmanagerservice.TabletManager.Backup:input_type -> tabletmanagerdata.BackupRequest
+	66,  // 66: tabletmanagerservice.TabletManager.RestoreFromBackup:input_type -> tabletmanagerdata.RestoreFromBackupRequest
+	67,  // 67: tabletmanagerservice.TabletManager.CheckThrottler:input_type -> tabletmanagerdata.CheckThrottlerRequest
+	68,  // 68: tabletmanagerservice.TabletManager.GetThrottlerStatus:input_type -> tabletmanagerdata.GetThrottlerStatusRequest
+	69,  // 69: tabletmanagerservice.TabletManager.Ping:output_type -> tabletmanagerdata.PingResponse
+	70,  // 70: tabletmanagerservice.TabletManager.Sleep:output_type -> tabletmanagerdata.SleepResponse
+	71,  // 71: tabletmanagerservice.TabletManager.ExecuteHook:output_type -> tabletmanagerdata.ExecuteHookResponse
+	72,  // 72: tabletmanagerservice.TabletManager.GetSchema:output_type -> tabletmanagerdata.GetSchemaResponse
+	73,  // 73: tabletmanagerservice.TabletManager.GetPermissions:output_type -> tabletmanagerdata.GetPermissionsResponse
+	74,  // 74: tabletmanagerservice.TabletManager.GetGlobalStatusVars:output_type -> tabletmanagerdata.GetGlobalStatusVarsResponse
+	75,  // 75: tabletmanagerservice.TabletManager.SetReadOnly:output_type -> tabletmanagerdata.SetReadOnlyResponse
+	76,  // 76: tabletmanagerservice.TabletManager.SetReadWrite:output_type -> tabletmanagerdata.SetReadWriteResponse
+	77,  // 77: tabletmanagerservice.TabletManager.ChangeTags:output_type -> tabletmanagerdata.ChangeTagsResponse
+	78,  // 78: tabletmanagerservice.TabletManager.ChangeType:output_type -> tabletmanagerdata.ChangeTypeResponse
+	79,  // 79: tabletmanagerservice.TabletManager.RefreshState:output_type -> tabletmanagerdata.RefreshStateResponse
+	80,  // 80: tabletmanagerservice.TabletManager.RunHealthCheck:output_type -> tabletmanagerdata.RunHealthCheckResponse
+	81,  // 81: tabletmanagerservice.TabletManager.ReloadSchema:output_type -> tabletmanagerdata.ReloadSchemaResponse
+	82,  // 82: tabletmanagerservice.TabletManager.PreflightSchema:output_type -> tabletmanagerdata.PreflightSchemaResponse
+	83,  // 83: tabletmanagerservice.TabletManager.ApplySchema:output_type -> tabletmanagerdata.ApplySchemaResponse
+	84,  // 84: tabletmanagerservice.TabletManager.ResetSequences:output_type -> tabletmanagerdata.ResetSequencesResponse
+	85,  // 85: tabletmanagerservice.TabletManager.LockTables:output_type -> tabletmanagerdata.LockTablesResponse
+	86,  // 86: tabletmanagerservice.TabletManager.UnlockTables:output_type -> tabletmanagerdata.UnlockTablesResponse
+	87,  // 87: tabletmanagerservice.TabletManager.ExecuteQuery:output_type -> tabletmanagerdata.ExecuteQueryResponse
+	88,  // 88: tabletmanagerservice.TabletManager.ExecuteFetchAsDba:output_type -> tabletmanagerdata.ExecuteFetchAsDbaResponse
+	89,  // 89: tabletmanagerservice.TabletManager.ExecuteMultiFetchAsDba:output_type -> tabletmanagerdata.ExecuteMultiFetchAsDbaResponse
+	90,  // 90: tabletmanagerservice.TabletManager.ExecuteFetchAsAllPrivs:output_type -> tabletmanagerdata.ExecuteFetchAsAllPrivsResponse
+	91,  // 91: tabletmanagerservice.TabletManager.ExecuteFetchAsApp:output_type -> tabletmanagerdata.ExecuteFetchAsAppResponse
+	92,  // 92: tabletmanagerservice.TabletManager.GetUnresolvedTransactions:output_type -> tabletmanagerdata.GetUnresolvedTransactionsResponse
+	93,  // 93: tabletmanagerservice.TabletManager.ReadTransaction:output_type -> tabletmanagerdata.ReadTransactionResponse
+	94,  // 94: tabletmanagerservice.TabletManager.GetTransactionInfo:output_type -> tabletmanagerdata.GetTransactionInfoResponse
+	95,  // 95: tabletmanagerservice.TabletManager.ConcludeTransaction:output_type -> tabletmanagerdata.ConcludeTransactionResponse
+	96,  // 96: tabletmanagerservice.TabletManager.MysqlHostMetrics:output_type -> tabletmanagerdata.MysqlHostMetricsResponse
+	97,  // 97: tabletmanagerservice.TabletManager.ReplicationStatus:output_type -> tabletmanagerdata.ReplicationStatusResponse
+	98,  // 98: tabletmanagerservice.TabletManager.PrimaryStatus:output_type -> tabletmanagerdata.PrimaryStatusResponse
+	99,  // 99: tabletmanagerservice.TabletManager.PrimaryPosition:output_type -> tabletmanagerdata.PrimaryPositionResponse
+	100, // 100: tabletmanagerservice.TabletManager.WaitForPosition:output_type -> tabletmanagerdata.WaitForPositionResponse
+	101, // 101: tabletmanagerservice.TabletManager.StopReplication:output_type -> tabletmanagerdata.StopReplicationResponse
+	102, // 102: tabletmanagerservice.TabletManager.StopReplicationMinimum:output_type -> tabletmanagerdata.StopReplicationMinimumResponse
+	103, // 103: tabletmanagerservice.TabletManager.StartReplication:output_type -> tabletmanagerdata.StartReplicationResponse
+	104, // 104: tabletmanagerservice.TabletManager.StartReplicationUntilAfter:output_type -> tabletmanagerdata.StartReplicationUntilAfterResponse
+	105, // 105: tabletmanagerservice.TabletManager.GetReplicas:output_type -> tabletmanagerdata.GetReplicasResponse
+	106, // 106: tabletmanagerservice.TabletManager.CreateVReplicationWorkflow:output_type -> tabletmanagerdata.CreateVReplicationWorkflowResponse
+	107, // 107: tabletmanagerservice.TabletManager.DeleteTableData:output_type -> tabletmanagerdata.DeleteTableDataResponse
+	108, // 108: tabletmanagerservice.TabletManager.DeleteVReplicationWorkflow:output_type -> tabletmanagerdata.DeleteVReplicationWorkflowResponse
+	109, // 109: tabletmanagerservice.TabletManager.HasVReplicationWorkflows:output_type -> tabletmanagerdata.HasVReplicationWorkflowsResponse
+	110, // 110: tabletmanagerservice.TabletManager.ReadVReplicationWorkflow:output_type -> tabletmanagerdata.ReadVReplicationWorkflowResponse
+	111, // 111: tabletmanagerservice.TabletManager.ReadVReplicationWorkflows:output_type -> tabletmanagerdata.ReadVReplicationWorkflowsResponse
+	112, // 112: tabletmanagerservice.TabletManager.UpdateVReplicationWorkflow:output_type -> tabletmanagerdata.UpdateVReplicationWorkflowResponse
+	113, // 113: tabletmanagerservice.TabletManager.UpdateVReplicationWorkflows:output_type -> tabletmanagerdata.UpdateVReplicationWorkflowsResponse
+	114, // 114: tabletmanagerservice.TabletManager.ValidateVReplicationPermissions:output_type -> tabletmanagerdata.ValidateVReplicationPermissionsResponse
+	115, // 115: tabletmanagerservice.TabletManager.VReplicationExec:output_type -> tabletmanagerdata.VReplicationExecResponse
+	116, // 116: tabletmanagerservice.TabletManager.VReplicationWaitForPos:output_type -> tabletmanagerdata.VReplicationWaitForPosResponse
+	117, // 117: tabletmanagerservice.TabletManager.UpdateSequenceTables:output_type -> tabletmanagerdata.UpdateSequenceTablesResponse
+	118, // 118: tabletmanagerservice.TabletManager.GetMaxValueForSequences:output_type -> tabletmanagerdata.GetMaxValueForSequencesResponse
+	119, // 119: tabletmanagerservice.TabletManager.VDiff:output_type -> tabletmanagerdata.VDiffResponse
+	120, // 120: tabletmanagerservice.TabletManager.ResetReplication:output_type -> tabletmanagerdata.ResetReplicationResponse
+	121, // 121: tabletmanagerservice.TabletManager.InitPrimary:output_type -> tabletmanagerdata.InitPrimaryResponse
+	122, // 122: tabletmanagerservice.TabletManager.PopulateReparentJournal:output_type -> tabletmanagerdata.PopulateReparentJournalResponse
+	123, // 123: tabletmanagerservice.TabletManager.ReadReparentJournalInfo:output_type -> tabletmanagerdata.ReadReparentJournalInfoResponse
+	124, // 124: tabletmanagerservice.TabletManager.InitReplica:output_type -> tabletmanagerdata.InitReplicaResponse
+	125, // 125: tabletmanagerservice.TabletManager.DemotePrimary:output_type -> tabletmanagerdata.DemotePrimaryResponse
+	126, // 126: tabletmanagerservice.TabletManager.UndoDemotePrimary:output_type -> tabletmanagerdata.UndoDemotePrimaryResponse
+	127, // 127: tabletmanagerservice.TabletManager.ReplicaWasPromoted:output_type -> tabletmanagerdata.ReplicaWasPromotedResponse
+	128, // 128: tabletmanagerservice.TabletManager.ResetReplicationParameters:output_type -> tabletmanagerdata.ResetReplicationParametersResponse
+	129, // 129: tabletmanagerservice.TabletManager.FullStatus:output_type -> tabletmanagerdata.FullStatusResponse
+	130, // 130: tabletmanagerservice.TabletManager.SetReplicationSource:output_type -> tabletmanagerdata.SetReplicationSourceResponse
+	131, // 131: tabletmanagerservice.TabletManager.ReplicaWasRestarted:output_type -> tabletmanagerdata.ReplicaWasRestartedResponse
+	132, // 132: tabletmanagerservice.TabletManager.StopReplicationAndGetStatus:output_type -> tabletmanagerdata.StopReplicationAndGetStatusResponse
+	133, // 133: tabletmanagerservice.TabletManager.PromoteReplica:output_type -> tabletmanagerdata.PromoteReplicaResponse
+	134, // 134: tabletmanagerservice.TabletManager.Backup:output_type -> tabletmanagerdata.BackupResponse
+	135, // 135: tabletmanagerservice.TabletManager.RestoreFromBackup:output_type -> tabletmanagerdata.RestoreFromBackupResponse
+	136, // 136: tabletmanagerservice.TabletManager.CheckThrottler:output_type -> tabletmanagerdata.CheckThrottlerResponse
+	137, // 137: tabletmanagerservice.TabletManager.GetThrottlerStatus:output_type -> tabletmanagerdata.GetThrottlerStatusResponse
+	69,  // [69:138] is the sub-list for method output_type
+	0,   // [0:69] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/go/vt/proto/tabletmanagerservice/tabletmanagerservice_grpc.pb.go
+++ b/go/vt/proto/tabletmanagerservice/tabletmanagerservice_grpc.pb.go
@@ -92,6 +92,8 @@ type TabletManagerClient interface {
 	ValidateVReplicationPermissions(ctx context.Context, in *tabletmanagerdata.ValidateVReplicationPermissionsRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ValidateVReplicationPermissionsResponse, error)
 	VReplicationExec(ctx context.Context, in *tabletmanagerdata.VReplicationExecRequest, opts ...grpc.CallOption) (*tabletmanagerdata.VReplicationExecResponse, error)
 	VReplicationWaitForPos(ctx context.Context, in *tabletmanagerdata.VReplicationWaitForPosRequest, opts ...grpc.CallOption) (*tabletmanagerdata.VReplicationWaitForPosResponse, error)
+	UpdateSequenceTables(ctx context.Context, in *tabletmanagerdata.UpdateSequenceTablesRequest, opts ...grpc.CallOption) (*tabletmanagerdata.UpdateSequenceTablesResponse, error)
+	GetMaxValueForSequences(ctx context.Context, in *tabletmanagerdata.GetMaxValueForSequencesRequest, opts ...grpc.CallOption) (*tabletmanagerdata.GetMaxValueForSequencesResponse, error)
 	// VDiff API
 	VDiff(ctx context.Context, in *tabletmanagerdata.VDiffRequest, opts ...grpc.CallOption) (*tabletmanagerdata.VDiffResponse, error)
 	// ResetReplication makes the target not replicating
@@ -573,6 +575,24 @@ func (c *tabletManagerClient) VReplicationWaitForPos(ctx context.Context, in *ta
 	return out, nil
 }
 
+func (c *tabletManagerClient) UpdateSequenceTables(ctx context.Context, in *tabletmanagerdata.UpdateSequenceTablesRequest, opts ...grpc.CallOption) (*tabletmanagerdata.UpdateSequenceTablesResponse, error) {
+	out := new(tabletmanagerdata.UpdateSequenceTablesResponse)
+	err := c.cc.Invoke(ctx, "/tabletmanagerservice.TabletManager/UpdateSequenceTables", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tabletManagerClient) GetMaxValueForSequences(ctx context.Context, in *tabletmanagerdata.GetMaxValueForSequencesRequest, opts ...grpc.CallOption) (*tabletmanagerdata.GetMaxValueForSequencesResponse, error) {
+	out := new(tabletmanagerdata.GetMaxValueForSequencesResponse)
+	err := c.cc.Invoke(ctx, "/tabletmanagerservice.TabletManager/GetMaxValueForSequences", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *tabletManagerClient) VDiff(ctx context.Context, in *tabletmanagerdata.VDiffRequest, opts ...grpc.CallOption) (*tabletmanagerdata.VDiffResponse, error) {
 	out := new(tabletmanagerdata.VDiffResponse)
 	err := c.cc.Invoke(ctx, "/tabletmanagerservice.TabletManager/VDiff", in, out, opts...)
@@ -863,6 +883,8 @@ type TabletManagerServer interface {
 	ValidateVReplicationPermissions(context.Context, *tabletmanagerdata.ValidateVReplicationPermissionsRequest) (*tabletmanagerdata.ValidateVReplicationPermissionsResponse, error)
 	VReplicationExec(context.Context, *tabletmanagerdata.VReplicationExecRequest) (*tabletmanagerdata.VReplicationExecResponse, error)
 	VReplicationWaitForPos(context.Context, *tabletmanagerdata.VReplicationWaitForPosRequest) (*tabletmanagerdata.VReplicationWaitForPosResponse, error)
+	UpdateSequenceTables(context.Context, *tabletmanagerdata.UpdateSequenceTablesRequest) (*tabletmanagerdata.UpdateSequenceTablesResponse, error)
+	GetMaxValueForSequences(context.Context, *tabletmanagerdata.GetMaxValueForSequencesRequest) (*tabletmanagerdata.GetMaxValueForSequencesResponse, error)
 	// VDiff API
 	VDiff(context.Context, *tabletmanagerdata.VDiffRequest) (*tabletmanagerdata.VDiffResponse, error)
 	// ResetReplication makes the target not replicating
@@ -1052,6 +1074,12 @@ func (UnimplementedTabletManagerServer) VReplicationExec(context.Context, *table
 }
 func (UnimplementedTabletManagerServer) VReplicationWaitForPos(context.Context, *tabletmanagerdata.VReplicationWaitForPosRequest) (*tabletmanagerdata.VReplicationWaitForPosResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method VReplicationWaitForPos not implemented")
+}
+func (UnimplementedTabletManagerServer) UpdateSequenceTables(context.Context, *tabletmanagerdata.UpdateSequenceTablesRequest) (*tabletmanagerdata.UpdateSequenceTablesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateSequenceTables not implemented")
+}
+func (UnimplementedTabletManagerServer) GetMaxValueForSequences(context.Context, *tabletmanagerdata.GetMaxValueForSequencesRequest) (*tabletmanagerdata.GetMaxValueForSequencesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMaxValueForSequences not implemented")
 }
 func (UnimplementedTabletManagerServer) VDiff(context.Context, *tabletmanagerdata.VDiffRequest) (*tabletmanagerdata.VDiffResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method VDiff not implemented")
@@ -1987,6 +2015,42 @@ func _TabletManager_VReplicationWaitForPos_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TabletManager_UpdateSequenceTables_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(tabletmanagerdata.UpdateSequenceTablesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TabletManagerServer).UpdateSequenceTables(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tabletmanagerservice.TabletManager/UpdateSequenceTables",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TabletManagerServer).UpdateSequenceTables(ctx, req.(*tabletmanagerdata.UpdateSequenceTablesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TabletManager_GetMaxValueForSequences_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(tabletmanagerdata.GetMaxValueForSequencesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TabletManagerServer).GetMaxValueForSequences(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tabletmanagerservice.TabletManager/GetMaxValueForSequences",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TabletManagerServer).GetMaxValueForSequences(ctx, req.(*tabletmanagerdata.GetMaxValueForSequencesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _TabletManager_VDiff_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(tabletmanagerdata.VDiffRequest)
 	if err := dec(in); err != nil {
@@ -2533,6 +2597,14 @@ var TabletManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "VReplicationWaitForPos",
 			Handler:    _TabletManager_VReplicationWaitForPos_Handler,
+		},
+		{
+			MethodName: "UpdateSequenceTables",
+			Handler:    _TabletManager_UpdateSequenceTables_Handler,
+		},
+		{
+			MethodName: "GetMaxValueForSequences",
+			Handler:    _TabletManager_GetMaxValueForSequences_Handler,
 		},
 		{
 			MethodName: "VDiff",

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -992,6 +992,14 @@ func (itmc *internalTabletManagerClient) UpdateVReplicationWorkflows(context.Con
 	return nil, fmt.Errorf("not implemented in vtcombo")
 }
 
+func (itmc *internalTabletManagerClient) UpdateSequenceTables(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error) {
+	return nil, fmt.Errorf("not implemented in vtcombo")
+}
+
+func (itmc *internalTabletManagerClient) GetMaxValueForSequences(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error) {
+	return nil, fmt.Errorf("not implemented in vtcombo")
+}
+
 func (itmc *internalTabletManagerClient) ResetReplication(context.Context, *topodatapb.Tablet) error {
 	return fmt.Errorf("not implemented in vtcombo")
 }

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -839,6 +839,16 @@ func (tmc *testTMClient) ReloadSchema(ctx context.Context, tablet *topodatapb.Ta
 	return nil
 }
 
+func (tmc *testTMClient) UpdateSequenceTables(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error) {
+	return &tabletmanagerdatapb.UpdateSequenceTablesResponse{}, nil
+}
+
+func (tmc *testTMClient) GetMaxValueForSequences(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error) {
+	return &tabletmanagerdatapb.GetMaxValueForSequencesResponse{
+		MaxValuesBySequenceTable: map[string]int64{},
+	}, nil
+}
+
 //
 // Utility / helper functions.
 //

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workflow
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -270,6 +271,8 @@ type testTMClient struct {
 	mu                                 sync.Mutex
 	vrQueries                          map[int][]*queryResult
 	createVReplicationWorkflowRequests map[uint32]*createVReplicationWorkflowRequestResponse
+	getMaxValueForSequencesRequests    map[uint32]*getMaxValueForSequencesRequestResponse
+	updateSequenceTablesRequests       map[uint32]*tabletmanagerdatapb.UpdateSequenceTablesRequest
 	readVReplicationWorkflowRequests   map[uint32]*readVReplicationWorkflowRequestResponse
 	updateVReplicationWorklowsRequests map[uint32]*tabletmanagerdatapb.UpdateVReplicationWorkflowsRequest
 	updateVReplicationWorklowRequests  map[uint32]*updateVReplicationWorkflowRequestResponse
@@ -296,6 +299,8 @@ func newTestTMClient(env *testEnv) *testTMClient {
 		schema:                             make(map[string]*tabletmanagerdatapb.SchemaDefinition),
 		vrQueries:                          make(map[int][]*queryResult),
 		createVReplicationWorkflowRequests: make(map[uint32]*createVReplicationWorkflowRequestResponse),
+		getMaxValueForSequencesRequests:    make(map[uint32]*getMaxValueForSequencesRequestResponse),
+		updateSequenceTablesRequests:       make(map[uint32]*tabletmanagerdatapb.UpdateSequenceTablesRequest),
 		readVReplicationWorkflowRequests:   make(map[uint32]*readVReplicationWorkflowRequestResponse),
 		updateVReplicationWorklowsRequests: make(map[uint32]*tabletmanagerdatapb.UpdateVReplicationWorkflowsRequest),
 		updateVReplicationWorklowRequests:  make(map[uint32]*updateVReplicationWorkflowRequestResponse),
@@ -423,6 +428,20 @@ func (tmc *testTMClient) GetSchema(ctx context.Context, tablet *topodatapb.Table
 		}
 	}
 	return schemaDefn, nil
+}
+
+func (tmc *testTMClient) expectUpdateSequenceTablesRequest(tabletID uint32, req *tabletmanagerdatapb.UpdateSequenceTablesRequest) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
+
+	tmc.updateSequenceTablesRequests[tabletID] = req
+}
+
+func (tmc *testTMClient) expectGetMaxValueForSequencesRequest(tabletID uint32, reqres *getMaxValueForSequencesRequestResponse) {
+	tmc.mu.Lock()
+	defer tmc.mu.Unlock()
+
+	tmc.getMaxValueForSequencesRequests[tabletID] = reqres
 }
 
 func (tmc *testTMClient) expectVRQuery(tabletID int, query string, result *sqltypes.Result) {
@@ -595,6 +614,12 @@ type applySchemaRequestResponse struct {
 type updateVReplicationWorkflowRequestResponse struct {
 	req *tabletmanagerdatapb.UpdateVReplicationWorkflowRequest
 	res *tabletmanagerdatapb.UpdateVReplicationWorkflowResponse
+	err error
+}
+
+type getMaxValueForSequencesRequestResponse struct {
+	req *tabletmanagerdatapb.GetMaxValueForSequencesRequest
+	res *tabletmanagerdatapb.GetMaxValueForSequencesResponse
 	err error
 }
 
@@ -840,13 +865,43 @@ func (tmc *testTMClient) ReloadSchema(ctx context.Context, tablet *topodatapb.Ta
 }
 
 func (tmc *testTMClient) UpdateSequenceTables(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error) {
+	expect := tmc.updateSequenceTablesRequests[tablet.Alias.Uid]
+	if expect == nil {
+		return nil, nil
+	}
+	slices.SortFunc(expect.Sequences, func(x, y *tabletmanagerdatapb.UpdateSequenceTablesRequest_SequenceMetadata) int {
+		return cmp.Compare(x.BackingTableName, y.BackingTableName)
+	})
+	slices.SortFunc(req.Sequences, func(x, y *tabletmanagerdatapb.UpdateSequenceTablesRequest_SequenceMetadata) int {
+		return cmp.Compare(x.BackingTableName, y.BackingTableName)
+	})
+	if !proto.Equal(expect, req) {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected UpdateSequenceTables request on tablet %s: got %+v, want %+v",
+			topoproto.TabletAliasString(tablet.Alias), req, expect)
+	}
+	delete(tmc.updateSequenceTablesRequests, tablet.Alias.Uid)
 	return &tabletmanagerdatapb.UpdateSequenceTablesResponse{}, nil
 }
 
 func (tmc *testTMClient) GetMaxValueForSequences(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error) {
-	return &tabletmanagerdatapb.GetMaxValueForSequencesResponse{
-		MaxValuesBySequenceTable: map[string]int64{},
-	}, nil
+	expect := tmc.getMaxValueForSequencesRequests[tablet.Alias.Uid]
+	if expect == nil {
+		return &tabletmanagerdatapb.GetMaxValueForSequencesResponse{
+			MaxValuesBySequenceTable: map[string]int64{},
+		}, nil
+	}
+	slices.SortFunc(expect.req.Sequences, func(x, y *tabletmanagerdatapb.GetMaxValueForSequencesRequest_SequenceMetadata) int {
+		return cmp.Compare(x.BackingTableName, y.BackingTableName)
+	})
+	slices.SortFunc(req.Sequences, func(x, y *tabletmanagerdatapb.GetMaxValueForSequencesRequest_SequenceMetadata) int {
+		return cmp.Compare(x.BackingTableName, y.BackingTableName)
+	})
+	if !proto.Equal(expect.req, req) {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected GetMaxValueForSequences request on tablet %s: got %+v, want %+v",
+			topoproto.TabletAliasString(tablet.Alias), req, expect.req)
+	}
+	delete(tmc.getMaxValueForSequencesRequests, tablet.Alias.Uid)
+	return expect.res, expect.err
 }
 
 //

--- a/go/vt/vtctl/workflow/sequences.go
+++ b/go/vt/vtctl/workflow/sequences.go
@@ -42,10 +42,8 @@ import (
 )
 
 const (
-	sqlInitSequenceTable     = "insert into %a.%a (id, next_id, cache) values (0, %d, 1000) on duplicate key update next_id = if(next_id < %d, %d, next_id)"
 	sqlCreateSequenceTable   = "create table if not exists %a (id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence'"
 	sqlGetCurrentSequenceVal = "select next_id from %a.%a where id = 0"
-	sqlGetMaxSequenceVal     = "select max(%a) as maxval from %a.%a"
 )
 
 // sequenceMetadata contains all of the relevant metadata for a sequence that

--- a/go/vt/vtctl/workflow/sequences.go
+++ b/go/vt/vtctl/workflow/sequences.go
@@ -25,10 +25,8 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
-	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
@@ -115,40 +113,32 @@ func (sm *sequenceMetadata) escapeValues() error {
 }
 
 func (ts *trafficSwitcher) getMaxSequenceValues(ctx context.Context, sequences map[string]*sequenceMetadata) (map[string]int64, error) {
-	maxValues := make(map[string]int64, len(sequences))
-	mu := sync.Mutex{}
-	initGroup, gctx := errgroup.WithContext(ctx)
-	for _, sm := range sequences {
-		initGroup.Go(func() error {
-			maxId, err := ts.getMaxSequenceValue(gctx, sm)
-			if err != nil {
-				return err
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			maxValues[sm.backingTableName] = maxId
-			return nil
+	var sequencesMetadata []*tabletmanagerdatapb.SequenceMetadata
+	for _, seq := range sequences {
+		if err := seq.escapeValues(); err != nil {
+			return nil, err
+		}
+		sequencesMetadata = append(sequencesMetadata, &tabletmanagerdatapb.SequenceMetadata{
+			BackingTableName:        seq.backingTableName,
+			BackingTableDbName:      seq.backingTableDBName,
+			UsingTableName:          seq.usingTableName,
+			UsingTableDbName:        seq.usingTableDBName,
+			UsingColEscaped:         seq.usingCol,
+			UsingTableNameEscaped:   seq.usingTable,
+			UsingTableDbNameEscaped: seq.usingTableDBName,
 		})
 	}
-	errs := initGroup.Wait()
-	if errs != nil {
-		return nil, errs
-	}
-	return maxValues, nil
-}
 
-func (ts *trafficSwitcher) getMaxSequenceValue(ctx context.Context, seq *sequenceMetadata) (int64, error) {
-	var maxSequenceValue int64
 	var mu sync.Mutex
-	setMaxSequenceValue := func(id int64) {
+	maxValuesByBackingTable := make(map[string]int64, len(sequences))
+	setMaxSequenceValue := func(maxValues map[string]int64) {
 		mu.Lock()
 		defer mu.Unlock()
-		if id > maxSequenceValue {
-			maxSequenceValue = id
+		for _, sm := range sequences {
+			if maxValuesByBackingTable[sm.backingTableName] < maxValues[sm.backingTableName] {
+				maxValuesByBackingTable[sm.backingTableName] = maxValues[sm.backingTableName]
+			}
 		}
-	}
-	if err := seq.escapeValues(); err != nil {
-		return 0, err
 	}
 	errs := ts.ForAllTargets(func(target *MigrationTarget) error {
 		primary := target.GetPrimary()
@@ -156,34 +146,18 @@ func (ts *trafficSwitcher) getMaxSequenceValue(ctx context.Context, seq *sequenc
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no primary tablet found for target shard %s/%s",
 				ts.targetKeyspace, target.GetShard().ShardName())
 		}
-
-		query := sqlparser.BuildParsedQuery(sqlGetMaxSequenceVal,
-			seq.usingCol,
-			seq.usingDB,
-			seq.usingTable,
-		)
-		qr, terr := ts.ws.tmc.ExecuteFetchAsApp(ctx, primary.Tablet, true, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
-			Query:   []byte(query.Query),
-			MaxRows: 1,
+		resp, terr := ts.ws.tmc.GetMaxValueForSequences(ctx, primary.Tablet, &tabletmanagerdatapb.GetMaxValueForSequencesRequest{
+			Sequences: sequencesMetadata,
 		})
-		if terr != nil || len(qr.Rows) != 1 {
+		if terr != nil {
 			return vterrors.Errorf(vtrpcpb.Code_INTERNAL,
-				"failed to get the max used sequence value for target table %s.%s on tablet %s in order to initialize the backing sequence table: %v",
-				ts.targetKeyspace, seq.usingTableName, topoproto.TabletAliasString(primary.Alias), terr)
+				"failed to get the max used sequence values on tablet %s in order to initialize the backing sequence table: %v",
+				topoproto.TabletAliasString(primary.Alias), terr)
 		}
-		rawVal := sqltypes.Proto3ToResult(qr).Rows[0][0]
-		maxID := int64(0)
-		if !rawVal.IsNull() { // If it's NULL then there are no rows and 0 remains the max
-			maxID, terr = rawVal.ToInt64()
-			if terr != nil {
-				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the max used sequence value for target table %s.%s on tablet %s in order to initialize the backing sequence table: %v",
-					ts.targetKeyspace, seq.usingTableName, topoproto.TabletAliasString(primary.Alias), terr)
-			}
-		}
-		setMaxSequenceValue(maxID)
+		setMaxSequenceValue(resp.MaxValuesBySequenceTable)
 		return nil
 	})
-	return maxSequenceValue, errs
+	return maxValuesByBackingTable, errs
 }
 
 func (ts *trafficSwitcher) getCurrentSequenceValues(ctx context.Context, sequences map[string]*sequenceMetadata) (map[string]int64, error) {
@@ -250,70 +224,47 @@ func (ts *trafficSwitcher) getCurrentSequenceValue(ctx context.Context, seq *seq
 	return currentVal, nil
 }
 
-func (ts *trafficSwitcher) updateSequenceValue(ctx context.Context, seq *sequenceMetadata, currentMaxValue int64) error {
-	if err := seq.escapeValues(); err != nil {
-		return err
-	}
-	nextVal := currentMaxValue + 1
-	log.Infof("Updating sequence %s.%s to %d", seq.backingTableDBName, seq.backingTableName, nextVal)
-
-	// Now we need to update the sequence table, if needed, in order to
-	// ensure that the next value it provides is > the current max.
-	sequenceShard, ierr := ts.TopoServer().GetOnlyShard(ctx, seq.backingTableKeyspace)
-	if ierr != nil || sequenceShard == nil || sequenceShard.PrimaryAlias == nil {
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the primary tablet for keyspace %s: %v",
-			seq.backingTableKeyspace, ierr)
-	}
-	sequenceTablet, ierr := ts.TopoServer().GetTablet(ctx, sequenceShard.PrimaryAlias)
-	if ierr != nil || sequenceTablet == nil {
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the primary tablet for keyspace %s: %v",
-			seq.backingTableKeyspace, ierr)
-	}
-	if sequenceTablet.DbNameOverride != "" {
-		seq.backingTableDBName = sequenceTablet.DbNameOverride
-	}
-	initQuery := sqlparser.BuildParsedQuery(sqlInitSequenceTable,
-		seq.backingTableDBName,
-		seq.backingTableName,
-		nextVal,
-		nextVal,
-		nextVal,
-	)
-
-	const maxTries = 2
-	var err error
-
-	for i := 0; i < maxTries; i++ {
-		// Attempt to initialize the sequence.
-		_, err = ts.ws.tmc.ExecuteFetchAsApp(ctx, sequenceTablet.Tablet, true, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
-			Query:   []byte(initQuery.Query),
-			MaxRows: 1,
+func (ts *trafficSwitcher) updateSequenceValues(ctx context.Context, sequences []*sequenceMetadata, maxValues map[string]int64) error {
+	sequencesByShard := map[string][]*tabletmanagerdatapb.SequenceMetadata{}
+	for _, seq := range sequences {
+		if err := seq.escapeValues(); err != nil {
+			return err
+		}
+		sequenceShard, ierr := ts.TopoServer().GetOnlyShard(ctx, seq.backingTableKeyspace)
+		if ierr != nil || sequenceShard == nil || sequenceShard.PrimaryAlias == nil {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the primary tablet for keyspace %s: %v",
+				seq.backingTableKeyspace, ierr)
+		}
+		tabletAliasStr := topoproto.TabletAliasString(sequenceShard.PrimaryAlias)
+		sequencesByShard[tabletAliasStr] = append(sequencesByShard[tabletAliasStr], &tabletmanagerdatapb.SequenceMetadata{
+			BackingTableName:        seq.backingTableName,
+			BackingTableDbName:      seq.backingTableDBName,
+			UsingTableName:          seq.usingTableName,
+			UsingTableDbName:        seq.usingTableDBName,
+			UsingColEscaped:         seq.usingCol,
+			UsingTableNameEscaped:   seq.usingTable,
+			UsingTableDbNameEscaped: seq.usingTableDBName,
 		})
-		if err == nil {
-			return nil
-		}
-
-		// If the table doesn't exist, try creating it.
-		sqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError)
-		if !ok || (sqlErr.Num != sqlerror.ERNoSuchTable && sqlErr.Num != sqlerror.ERBadTable) {
-			return vterrors.Errorf(
-				vtrpcpb.Code_INTERNAL,
-				"failed to initialize the backing sequence table %s.%s: %v",
-				seq.backingTableDBName, seq.backingTableName, err,
-			)
-		}
-
-		if err := ts.createSequenceTable(ctx, seq.backingTable, sequenceTablet); err != nil {
-			return vterrors.Errorf(vtrpcpb.Code_INTERNAL,
-				"failed to create the backing sequence table %s in the global-keyspace %s: %v",
-				seq.backingTable, sequenceShard.Keyspace(), err)
-		}
-		// Table has been created, so we fall through and try again on the next loop iteration.
 	}
-
-	return vterrors.Errorf(
-		vtrpcpb.Code_INTERNAL, "failed to initialize the backing sequence table %s.%s after retries. Last error: %v",
-		seq.backingTableDBName, seq.backingTableName, err)
+	for tabletAliasStr, sequencesMetadata := range sequencesByShard {
+		tabletAlias, err := topoproto.ParseTabletAlias(tabletAliasStr)
+		if err != nil {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the parse tablet alias %s: %v", tabletAlias, err)
+		}
+		sequenceTablet, ierr := ts.TopoServer().GetTablet(ctx, tabletAlias)
+		if ierr != nil || sequenceTablet == nil {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the primary tablet for keyspace %s: %v",
+				sequenceTablet.Keyspace, ierr)
+		}
+		_, err = ts.TabletManagerClient().UpdateSequenceTables(ctx, sequenceTablet.Tablet, &tabletmanagerdatapb.UpdateSequenceTablesRequest{
+			Sequences:                sequencesMetadata,
+			MaxValuesBySequenceTable: maxValues,
+		})
+		if err != nil {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to initialize the backing sequence tables on tablet %s: %v", tabletAliasStr, err)
+		}
+	}
+	return nil
 }
 
 // initializeTargetSequences initializes the backing sequence tables
@@ -334,14 +285,9 @@ func (ts *trafficSwitcher) initializeTargetSequences(ctx context.Context, sequen
 	if err != nil {
 		return err
 	}
-	for _, sm := range sequencesByBackingTable {
-		maxValue := maxValues[sm.backingTableName]
-		if maxValue == 0 {
-			continue
-		}
-		if err := ts.updateSequenceValue(ctx, sm, maxValue); err != nil {
-			return err
-		}
+	sequences := maps.Values(sequencesByBackingTable)
+	if err := ts.updateSequenceValues(ctx, sequences, maxValues); err != nil {
+		return err
 	}
 	return nil
 }

--- a/go/vt/vttablet/faketmclient/fake_client.go
+++ b/go/vt/vttablet/faketmclient/fake_client.go
@@ -338,6 +338,16 @@ func (client *FakeTabletManagerClient) VReplicationWaitForPos(ctx context.Contex
 	return nil
 }
 
+// UpdateSequenceTables is part of the tmclient.TabletManagerClient interface.
+func (itmc *FakeTabletManagerClient) UpdateSequenceTables(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error) {
+	return nil, nil
+}
+
+// GetMaxValueForSequences is part of the tmclient.TabletManagerClient interface.
+func (itmc *FakeTabletManagerClient) GetMaxValueForSequences(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error) {
+	return nil, nil
+}
+
 //
 // Reparenting related functions
 //

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -1060,6 +1060,24 @@ func (client *Client) UpdateVReplicationWorkflows(ctx context.Context, tablet *t
 	return response, nil
 }
 
+func (client *Client) GetMaxValueForSequences(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error) {
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	return c.GetMaxValueForSequences(ctx, request)
+}
+
+func (client *Client) UpdateSequenceTables(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error) {
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	return c.UpdateSequenceTables(ctx, request)
+}
+
 // VDiff is part of the tmclient.TabletManagerClient interface.
 func (client *Client) VDiff(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.VDiffRequest) (*tabletmanagerdatapb.VDiffResponse, error) {
 	log.Infof("VDiff for tablet %s, request %+v", tablet.Alias.String(), req)

--- a/go/vt/vttablet/grpctmserver/server.go
+++ b/go/vt/vttablet/grpctmserver/server.go
@@ -535,6 +535,20 @@ func (s *server) VDiff(ctx context.Context, request *tabletmanagerdatapb.VDiffRe
 	return response, err
 }
 
+func (s *server) UpdateSequenceTables(ctx context.Context, request *tabletmanagerdatapb.UpdateSequenceTablesRequest) (response *tabletmanagerdatapb.UpdateSequenceTablesResponse, err error) {
+	defer s.tm.HandleRPCPanic(ctx, "UpdateSequenceTables", request, response, true /*verbose*/, &err)
+	ctx = callinfo.GRPCCallInfo(ctx)
+	response, err = s.tm.UpdateSequenceTables(ctx, request)
+	return response, err
+}
+
+func (s *server) GetMaxValueForSequences(ctx context.Context, request *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (response *tabletmanagerdatapb.GetMaxValueForSequencesResponse, err error) {
+	defer s.tm.HandleRPCPanic(ctx, "GetMaxValueForSequences", request, response, true /*verbose*/, &err)
+	ctx = callinfo.GRPCCallInfo(ctx)
+	response, err = s.tm.GetMaxValueForSequences(ctx, request)
+	return response, err
+}
+
 //
 // Reparenting related functions
 //

--- a/go/vt/vttablet/tabletmanager/rpc_agent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_agent.go
@@ -128,6 +128,8 @@ type RPCTM interface {
 	VReplicationWaitForPos(ctx context.Context, id int32, pos string) error
 	UpdateVReplicationWorkflow(ctx context.Context, req *tabletmanagerdatapb.UpdateVReplicationWorkflowRequest) (*tabletmanagerdatapb.UpdateVReplicationWorkflowResponse, error)
 	UpdateVReplicationWorkflows(ctx context.Context, req *tabletmanagerdatapb.UpdateVReplicationWorkflowsRequest) (*tabletmanagerdatapb.UpdateVReplicationWorkflowsResponse, error)
+	UpdateSequenceTables(ctx context.Context, request *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error)
+	GetMaxValueForSequences(ctx context.Context, request *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error)
 
 	// VDiff API
 	VDiff(ctx context.Context, req *tabletmanagerdatapb.VDiffRequest) (*tabletmanagerdatapb.VDiffResponse, error)

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -711,7 +711,7 @@ func (tm *TabletManager) UpdateVReplicationWorkflows(ctx context.Context, req *t
 	}, nil
 }
 
-func (tm *TabletManager) GetMaxValueForSequences(ctx context.Context, req *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (map[string]int64, error) {
+func (tm *TabletManager) GetMaxValueForSequences(ctx context.Context, req *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error) {
 	maxValues := make(map[string]int64, len(req.Sequences))
 	mu := sync.Mutex{}
 	initGroup, gctx := errgroup.WithContext(ctx)
@@ -731,7 +731,9 @@ func (tm *TabletManager) GetMaxValueForSequences(ctx context.Context, req *table
 	if errs != nil {
 		return nil, errs
 	}
-	return maxValues, nil
+	return &tabletmanagerdatapb.GetMaxValueForSequencesResponse{
+		MaxValuesBySequenceTable: maxValues,
+	}, nil
 }
 
 func (tm *TabletManager) getMaxSequenceValue(ctx context.Context, sm *tabletmanagerdatapb.GetMaxValueForSequencesRequest_SequenceMetadata) (int64, error) {
@@ -759,13 +761,13 @@ func (tm *TabletManager) getMaxSequenceValue(ctx context.Context, sm *tabletmana
 	return maxID, nil
 }
 
-func (tm *TabletManager) UpdateSequenceTables(ctx context.Context, req *tabletmanagerdatapb.UpdateSequenceTablesRequest) error {
+func (tm *TabletManager) UpdateSequenceTables(ctx context.Context, req *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error) {
 	for _, sm := range req.Sequences {
 		if err := tm.updateSequenceValue(ctx, sm); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return &tabletmanagerdatapb.UpdateSequenceTablesResponse{}, nil
 }
 
 func (tm *TabletManager) updateSequenceValue(ctx context.Context, seq *tabletmanagerdatapb.UpdateSequenceTablesRequest_SequenceMetadata) error {

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -21,24 +21,30 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/exp/maps"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/cmd/vtctldclient/command/vreplication/movetables"
 	"vitess.io/vitess/go/constants/sidecar"
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/protoutil"
+	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	"vitess.io/vitess/go/vt/proto/vttime"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl/workflow"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -87,6 +93,9 @@ where u.user = %a
   )
 limit 1
 `
+	sqlGetMaxSequenceVal   = "select max(%a) as maxval from %a.%a"
+	sqlInitSequenceTable   = "insert into %a.%a (id, next_id, cache) values (0, %d, 1000) on duplicate key update next_id = if(next_id < %d, %d, next_id)"
+	sqlCreateSequenceTable = "create table if not exists %a (id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence'"
 )
 
 var (
@@ -700,6 +709,133 @@ func (tm *TabletManager) UpdateVReplicationWorkflows(ctx context.Context, req *t
 			RowsAffected: res.RowsAffected,
 		},
 	}, nil
+}
+
+func (tm *TabletManager) GetMaxValueForSequences(ctx context.Context, req *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (map[string]int64, error) {
+	maxValues := make(map[string]int64, len(req.Sequences))
+	mu := sync.Mutex{}
+	initGroup, gctx := errgroup.WithContext(ctx)
+	for _, sm := range req.Sequences {
+		initGroup.Go(func() error {
+			maxId, err := tm.getMaxSequenceValue(gctx, sm)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			maxValues[sm.BackingTableName] = maxId
+			return nil
+		})
+	}
+	errs := initGroup.Wait()
+	if errs != nil {
+		return nil, errs
+	}
+	return maxValues, nil
+}
+
+func (tm *TabletManager) getMaxSequenceValue(ctx context.Context, seq *tabletmanagerdatapb.SequenceMetadata) (int64, error) {
+	query := sqlparser.BuildParsedQuery(sqlGetMaxSequenceVal,
+		seq.UsingColEscaped,
+		seq.UsingTableDbNameEscaped,
+		seq.UsingTableNameEscaped,
+	)
+	qr, err := tm.ExecuteFetchAsApp(ctx, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
+		Query:   []byte(query.Query),
+		MaxRows: 1,
+	})
+	if err != nil || len(qr.Rows) != 1 {
+		return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+			"failed to get the max used sequence value for target table %s in order to initialize the backing sequence table: %v", seq.UsingTableName, err)
+	}
+	rawVal := sqltypes.Proto3ToResult(qr).Rows[0][0]
+	maxID := int64(0)
+	if !rawVal.IsNull() { // If it's NULL then there are no rows and 0 remains the max
+		maxID, err = rawVal.ToInt64()
+		if err != nil {
+			return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to get the max used sequence value for target table %s in order to initialize the backing sequence table: %v", seq.UsingTableName, err)
+		}
+	}
+	return maxID, nil
+}
+
+func (tm *TabletManager) UpdateSequenceTables(ctx context.Context, req *tabletmanagerdatapb.UpdateSequenceTablesRequest) error {
+	for _, sm := range req.Sequences {
+		maxValue := req.MaxValuesBySequenceTable[sm.BackingTableName]
+		if maxValue == 0 {
+			continue
+		}
+		if err := tm.updateSequenceValue(ctx, sm, maxValue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tm *TabletManager) updateSequenceValue(ctx context.Context, seq *tabletmanagerdatapb.SequenceMetadata, currentMaxValue int64) error {
+	nextVal := currentMaxValue + 1
+	if tm.Tablet().DbNameOverride != "" {
+		seq.BackingTableDbName = tm.Tablet().DbNameOverride
+	}
+	log.Infof("Updating sequence %s.%s to %d", seq.BackingTableDbName, seq.BackingTableName, nextVal)
+	initQuery := sqlparser.BuildParsedQuery(sqlInitSequenceTable,
+		seq.BackingTableDbName,
+		seq.BackingTableName,
+		nextVal,
+		nextVal,
+		nextVal,
+	)
+	const maxTries = 2
+	var err error
+
+	for i := 0; i < maxTries; i++ {
+		// Attempt to initialize the sequence.
+		_, err = tm.ExecuteFetchAsApp(ctx, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
+			Query:   []byte(initQuery.Query),
+			MaxRows: 1,
+		})
+		if err == nil {
+			return nil
+		}
+
+		// If the table doesn't exist, try creating it.
+		sqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError)
+		if !ok || (sqlErr.Num != sqlerror.ERNoSuchTable && sqlErr.Num != sqlerror.ERBadTable) {
+			return vterrors.Errorf(
+				vtrpcpb.Code_INTERNAL,
+				"failed to initialize the backing sequence table %s.%s: %v",
+				seq.BackingTableDbName, seq.BackingTableName, err,
+			)
+		}
+
+		if err := tm.createSequenceTable(ctx, seq.BackingTableNameEscaped); err != nil {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+				"failed to create the backing sequence table %s in the global-keyspace %s: %v",
+				seq.BackingTableNameEscaped, tm.Tablet().Keyspace, err)
+		}
+		// Table has been created, so we fall through and try again on the next loop iteration.
+	}
+
+	return vterrors.Errorf(
+		vtrpcpb.Code_INTERNAL, "failed to initialize the backing sequence table %s.%s after retries. Last error: %v",
+		seq.BackingTableDbName, seq.BackingTableNameEscaped, err)
+}
+
+func (tm *TabletManager) createSequenceTable(ctx context.Context, tableName string) error {
+	escapedTableName, err := sqlescape.EnsureEscaped(tableName)
+	if err != nil {
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid table name %s: %v",
+			tableName, err)
+	}
+	stmt := sqlparser.BuildParsedQuery(sqlCreateSequenceTable, escapedTableName)
+	_, err = tm.ApplySchema(ctx, &tmutils.SchemaChange{
+		SQL:                     stmt.Query,
+		Force:                   false,
+		AllowReplication:        true,
+		SQLMode:                 vreplication.SQLMode,
+		DisableForeignKeyChecks: true,
+	})
+	return err
 }
 
 // ValidateVReplicationPermissions validates that the --db_filtered_user has

--- a/go/vt/vttablet/tmclient/rpc_client_api.go
+++ b/go/vt/vttablet/tmclient/rpc_client_api.go
@@ -219,6 +219,8 @@ type TabletManagerClient interface {
 	VReplicationExec(ctx context.Context, tablet *topodatapb.Tablet, query string) (*querypb.QueryResult, error)
 	VReplicationWaitForPos(ctx context.Context, tablet *topodatapb.Tablet, id int32, pos string) error
 	VDiff(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.VDiffRequest) (*tabletmanagerdatapb.VDiffResponse, error)
+	UpdateSequenceTables(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error)
+	GetMaxValueForSequences(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error)
 
 	//
 	// Reparenting related functions

--- a/go/vt/vttablet/tmrpctest/test_tm_rpc.go
+++ b/go/vt/vttablet/tmrpctest/test_tm_rpc.go
@@ -96,6 +96,16 @@ func (fra *fakeRPCTM) UpdateVReplicationWorkflows(ctx context.Context, req *tabl
 	panic("implement me")
 }
 
+func (fra *fakeRPCTM) UpdateSequenceTables(ctx context.Context, req *tabletmanagerdatapb.UpdateSequenceTablesRequest) (*tabletmanagerdatapb.UpdateSequenceTablesResponse, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (fra *fakeRPCTM) GetMaxValueForSequences(ctx context.Context, req *tabletmanagerdatapb.GetMaxValueForSequencesRequest) (*tabletmanagerdatapb.GetMaxValueForSequencesResponse, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (fra *fakeRPCTM) ResetSequences(ctx context.Context, tables []string) error {
 	// TODO implement me
 	panic("implement me")

--- a/proto/tabletmanagerdata.proto
+++ b/proto/tabletmanagerdata.proto
@@ -989,5 +989,6 @@ message GetMaxValueForSequencesRequest {
 }
 
 message GetMaxValueForSequencesResponse {
+  // Max used sequence value mapped with the backing sequence table.
   map<string, int64> max_values_by_sequence_table = 1;
 }

--- a/proto/tabletmanagerdata.proto
+++ b/proto/tabletmanagerdata.proto
@@ -958,34 +958,33 @@ message ChangeTagsResponse {
   map<string, string> tags = 1;
 }
 
-message SequenceMetadata {
-  // The name of the sequence table.
-  string backing_table_name = 1;
-  // The dbName in use by the keyspace where the backing table lives.
-  string backing_table_db_name = 2;
-  // The name of the table using the sequence.
-  string using_table_name = 3;
-  // The dbName in use by the keyspace where the using table lives.
-  string using_table_db_name = 4;
-  // Escaped column name specified for sequence in table.
-  string using_col_escaped = 5;
-  // Escaped name of the table using the sequence.
-  string using_table_name_escaped = 6;
-  // Escaped db name in use by the keyspace where the using table lives.
-  string using_table_db_name_escaped = 7;
-  // Escaped name of the sequence table.
-  string backing_table_name_escaped = 8;
-}
-
 message UpdateSequenceTablesRequest {
+  message SequenceMetadata {
+    // The name of the sequence table.
+    string backing_table_name = 1;
+    // The dbName in use by the keyspace where the backing table lives.
+    string backing_table_db_name = 2;
+    // The maximum used sequence value.
+    int64 max_value = 3;
+  }
   repeated SequenceMetadata sequences = 1;
-  map<string, int64> max_values_by_sequence_table = 2;
 }
 
 message UpdateSequenceTablesResponse {
 }
 
 message GetMaxValueForSequencesRequest {
+  message SequenceMetadata {
+    // The name of the sequence table. This will be used for mapping max value
+    // with table in the response.
+    string backing_table_name = 1;
+    // Escaped column name specified for sequence in table.
+    string using_col_escaped = 2;
+    // Escaped name of the table using the sequence.
+    string using_table_name_escaped = 3;
+    // Escaped db name in use by the keyspace where the using table lives.
+    string using_table_db_name_escaped = 4;
+  }
   repeated SequenceMetadata sequences = 1;
 }
 

--- a/proto/tabletmanagerdata.proto
+++ b/proto/tabletmanagerdata.proto
@@ -957,3 +957,38 @@ message ChangeTagsRequest {
 message ChangeTagsResponse {
   map<string, string> tags = 1;
 }
+
+message SequenceMetadata {
+  // The name of the sequence table.
+  string backing_table_name = 1;
+  // The dbName in use by the keyspace where the backing table lives.
+  string backing_table_db_name = 2;
+  // The name of the table using the sequence.
+  string using_table_name = 3;
+  // The dbName in use by the keyspace where the using table lives.
+  string using_table_db_name = 4;
+  // Escaped column name specified for sequence in table.
+  string using_col_escaped = 5;
+  // Escaped name of the table using the sequence.
+  string using_table_name_escaped = 6;
+  // Escaped db name in use by the keyspace where the using table lives.
+  string using_table_db_name_escaped = 7;
+  // Escaped name of the sequence table.
+  string backing_table_name_escaped = 8;
+}
+
+message UpdateSequenceTablesRequest {
+  repeated SequenceMetadata sequences = 1;
+  map<string, int64> max_values_by_sequence_table = 2;
+}
+
+message UpdateSequenceTablesResponse {
+}
+
+message GetMaxValueForSequencesRequest {
+  repeated SequenceMetadata sequences = 1;
+}
+
+message GetMaxValueForSequencesResponse {
+  map<string, int64> max_values_by_sequence_table = 1;
+}

--- a/proto/tabletmanagerservice.proto
+++ b/proto/tabletmanagerservice.proto
@@ -148,6 +148,8 @@ service TabletManager {
   rpc ValidateVReplicationPermissions(tabletmanagerdata.ValidateVReplicationPermissionsRequest) returns(tabletmanagerdata.ValidateVReplicationPermissionsResponse) {};
   rpc VReplicationExec(tabletmanagerdata.VReplicationExecRequest) returns(tabletmanagerdata.VReplicationExecResponse) {};
   rpc VReplicationWaitForPos(tabletmanagerdata.VReplicationWaitForPosRequest) returns(tabletmanagerdata.VReplicationWaitForPosResponse) {};
+  rpc UpdateSequenceTables(tabletmanagerdata.UpdateSequenceTablesRequest) returns(tabletmanagerdata.UpdateSequenceTablesResponse) {};
+  rpc GetMaxValueForSequences(tabletmanagerdata.GetMaxValueForSequencesRequest) returns(tabletmanagerdata.GetMaxValueForSequencesResponse) {};
 
   // VDiff API
   rpc VDiff(tabletmanagerdata.VDiffRequest) returns(tabletmanagerdata.VDiffResponse) {};

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -36330,153 +36330,11 @@ export namespace tabletmanagerdata {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
-    /** Properties of a SequenceMetadata. */
-    interface ISequenceMetadata {
-
-        /** SequenceMetadata backing_table_name */
-        backing_table_name?: (string|null);
-
-        /** SequenceMetadata backing_table_db_name */
-        backing_table_db_name?: (string|null);
-
-        /** SequenceMetadata using_table_name */
-        using_table_name?: (string|null);
-
-        /** SequenceMetadata using_table_db_name */
-        using_table_db_name?: (string|null);
-
-        /** SequenceMetadata using_col_escaped */
-        using_col_escaped?: (string|null);
-
-        /** SequenceMetadata using_table_name_escaped */
-        using_table_name_escaped?: (string|null);
-
-        /** SequenceMetadata using_table_db_name_escaped */
-        using_table_db_name_escaped?: (string|null);
-
-        /** SequenceMetadata backing_table_name_escaped */
-        backing_table_name_escaped?: (string|null);
-    }
-
-    /** Represents a SequenceMetadata. */
-    class SequenceMetadata implements ISequenceMetadata {
-
-        /**
-         * Constructs a new SequenceMetadata.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: tabletmanagerdata.ISequenceMetadata);
-
-        /** SequenceMetadata backing_table_name. */
-        public backing_table_name: string;
-
-        /** SequenceMetadata backing_table_db_name. */
-        public backing_table_db_name: string;
-
-        /** SequenceMetadata using_table_name. */
-        public using_table_name: string;
-
-        /** SequenceMetadata using_table_db_name. */
-        public using_table_db_name: string;
-
-        /** SequenceMetadata using_col_escaped. */
-        public using_col_escaped: string;
-
-        /** SequenceMetadata using_table_name_escaped. */
-        public using_table_name_escaped: string;
-
-        /** SequenceMetadata using_table_db_name_escaped. */
-        public using_table_db_name_escaped: string;
-
-        /** SequenceMetadata backing_table_name_escaped. */
-        public backing_table_name_escaped: string;
-
-        /**
-         * Creates a new SequenceMetadata instance using the specified properties.
-         * @param [properties] Properties to set
-         * @returns SequenceMetadata instance
-         */
-        public static create(properties?: tabletmanagerdata.ISequenceMetadata): tabletmanagerdata.SequenceMetadata;
-
-        /**
-         * Encodes the specified SequenceMetadata message. Does not implicitly {@link tabletmanagerdata.SequenceMetadata.verify|verify} messages.
-         * @param message SequenceMetadata message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: tabletmanagerdata.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified SequenceMetadata message, length delimited. Does not implicitly {@link tabletmanagerdata.SequenceMetadata.verify|verify} messages.
-         * @param message SequenceMetadata message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: tabletmanagerdata.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a SequenceMetadata message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns SequenceMetadata
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.SequenceMetadata;
-
-        /**
-         * Decodes a SequenceMetadata message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns SequenceMetadata
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.SequenceMetadata;
-
-        /**
-         * Verifies a SequenceMetadata message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a SequenceMetadata message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns SequenceMetadata
-         */
-        public static fromObject(object: { [k: string]: any }): tabletmanagerdata.SequenceMetadata;
-
-        /**
-         * Creates a plain object from a SequenceMetadata message. Also converts values to other types if specified.
-         * @param message SequenceMetadata
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: tabletmanagerdata.SequenceMetadata, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this SequenceMetadata to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-
-        /**
-         * Gets the default type url for SequenceMetadata
-         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-         * @returns The default type url
-         */
-        public static getTypeUrl(typeUrlPrefix?: string): string;
-    }
-
     /** Properties of an UpdateSequenceTablesRequest. */
     interface IUpdateSequenceTablesRequest {
 
         /** UpdateSequenceTablesRequest sequences */
-        sequences?: (tabletmanagerdata.ISequenceMetadata[]|null);
-
-        /** UpdateSequenceTablesRequest max_values_by_sequence_table */
-        max_values_by_sequence_table?: ({ [k: string]: (number|Long) }|null);
+        sequences?: (tabletmanagerdata.UpdateSequenceTablesRequest.ISequenceMetadata[]|null);
     }
 
     /** Represents an UpdateSequenceTablesRequest. */
@@ -36489,10 +36347,7 @@ export namespace tabletmanagerdata {
         constructor(properties?: tabletmanagerdata.IUpdateSequenceTablesRequest);
 
         /** UpdateSequenceTablesRequest sequences. */
-        public sequences: tabletmanagerdata.ISequenceMetadata[];
-
-        /** UpdateSequenceTablesRequest max_values_by_sequence_table. */
-        public max_values_by_sequence_table: { [k: string]: (number|Long) };
+        public sequences: tabletmanagerdata.UpdateSequenceTablesRequest.ISequenceMetadata[];
 
         /**
          * Creates a new UpdateSequenceTablesRequest instance using the specified properties.
@@ -36570,6 +36425,118 @@ export namespace tabletmanagerdata {
          * @returns The default type url
          */
         public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    namespace UpdateSequenceTablesRequest {
+
+        /** Properties of a SequenceMetadata. */
+        interface ISequenceMetadata {
+
+            /** SequenceMetadata backing_table_name */
+            backing_table_name?: (string|null);
+
+            /** SequenceMetadata backing_table_db_name */
+            backing_table_db_name?: (string|null);
+
+            /** SequenceMetadata max_value */
+            max_value?: (number|Long|null);
+        }
+
+        /** Represents a SequenceMetadata. */
+        class SequenceMetadata implements ISequenceMetadata {
+
+            /**
+             * Constructs a new SequenceMetadata.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: tabletmanagerdata.UpdateSequenceTablesRequest.ISequenceMetadata);
+
+            /** SequenceMetadata backing_table_name. */
+            public backing_table_name: string;
+
+            /** SequenceMetadata backing_table_db_name. */
+            public backing_table_db_name: string;
+
+            /** SequenceMetadata max_value. */
+            public max_value: (number|Long);
+
+            /**
+             * Creates a new SequenceMetadata instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns SequenceMetadata instance
+             */
+            public static create(properties?: tabletmanagerdata.UpdateSequenceTablesRequest.ISequenceMetadata): tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata;
+
+            /**
+             * Encodes the specified SequenceMetadata message. Does not implicitly {@link tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata.verify|verify} messages.
+             * @param message SequenceMetadata message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: tabletmanagerdata.UpdateSequenceTablesRequest.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified SequenceMetadata message, length delimited. Does not implicitly {@link tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata.verify|verify} messages.
+             * @param message SequenceMetadata message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: tabletmanagerdata.UpdateSequenceTablesRequest.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a SequenceMetadata message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns SequenceMetadata
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata;
+
+            /**
+             * Decodes a SequenceMetadata message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns SequenceMetadata
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata;
+
+            /**
+             * Verifies a SequenceMetadata message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a SequenceMetadata message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns SequenceMetadata
+             */
+            public static fromObject(object: { [k: string]: any }): tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata;
+
+            /**
+             * Creates a plain object from a SequenceMetadata message. Also converts values to other types if specified.
+             * @param message SequenceMetadata
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: tabletmanagerdata.UpdateSequenceTablesRequest.SequenceMetadata, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this SequenceMetadata to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+
+            /**
+             * Gets the default type url for SequenceMetadata
+             * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+             * @returns The default type url
+             */
+            public static getTypeUrl(typeUrlPrefix?: string): string;
+        }
     }
 
     /** Properties of an UpdateSequenceTablesResponse. */
@@ -36667,7 +36634,7 @@ export namespace tabletmanagerdata {
     interface IGetMaxValueForSequencesRequest {
 
         /** GetMaxValueForSequencesRequest sequences */
-        sequences?: (tabletmanagerdata.ISequenceMetadata[]|null);
+        sequences?: (tabletmanagerdata.GetMaxValueForSequencesRequest.ISequenceMetadata[]|null);
     }
 
     /** Represents a GetMaxValueForSequencesRequest. */
@@ -36680,7 +36647,7 @@ export namespace tabletmanagerdata {
         constructor(properties?: tabletmanagerdata.IGetMaxValueForSequencesRequest);
 
         /** GetMaxValueForSequencesRequest sequences. */
-        public sequences: tabletmanagerdata.ISequenceMetadata[];
+        public sequences: tabletmanagerdata.GetMaxValueForSequencesRequest.ISequenceMetadata[];
 
         /**
          * Creates a new GetMaxValueForSequencesRequest instance using the specified properties.
@@ -36758,6 +36725,124 @@ export namespace tabletmanagerdata {
          * @returns The default type url
          */
         public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    namespace GetMaxValueForSequencesRequest {
+
+        /** Properties of a SequenceMetadata. */
+        interface ISequenceMetadata {
+
+            /** SequenceMetadata backing_table_name */
+            backing_table_name?: (string|null);
+
+            /** SequenceMetadata using_col_escaped */
+            using_col_escaped?: (string|null);
+
+            /** SequenceMetadata using_table_name_escaped */
+            using_table_name_escaped?: (string|null);
+
+            /** SequenceMetadata using_table_db_name_escaped */
+            using_table_db_name_escaped?: (string|null);
+        }
+
+        /** Represents a SequenceMetadata. */
+        class SequenceMetadata implements ISequenceMetadata {
+
+            /**
+             * Constructs a new SequenceMetadata.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: tabletmanagerdata.GetMaxValueForSequencesRequest.ISequenceMetadata);
+
+            /** SequenceMetadata backing_table_name. */
+            public backing_table_name: string;
+
+            /** SequenceMetadata using_col_escaped. */
+            public using_col_escaped: string;
+
+            /** SequenceMetadata using_table_name_escaped. */
+            public using_table_name_escaped: string;
+
+            /** SequenceMetadata using_table_db_name_escaped. */
+            public using_table_db_name_escaped: string;
+
+            /**
+             * Creates a new SequenceMetadata instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns SequenceMetadata instance
+             */
+            public static create(properties?: tabletmanagerdata.GetMaxValueForSequencesRequest.ISequenceMetadata): tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata;
+
+            /**
+             * Encodes the specified SequenceMetadata message. Does not implicitly {@link tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata.verify|verify} messages.
+             * @param message SequenceMetadata message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: tabletmanagerdata.GetMaxValueForSequencesRequest.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified SequenceMetadata message, length delimited. Does not implicitly {@link tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata.verify|verify} messages.
+             * @param message SequenceMetadata message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: tabletmanagerdata.GetMaxValueForSequencesRequest.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a SequenceMetadata message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns SequenceMetadata
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata;
+
+            /**
+             * Decodes a SequenceMetadata message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns SequenceMetadata
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata;
+
+            /**
+             * Verifies a SequenceMetadata message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a SequenceMetadata message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns SequenceMetadata
+             */
+            public static fromObject(object: { [k: string]: any }): tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata;
+
+            /**
+             * Creates a plain object from a SequenceMetadata message. Also converts values to other types if specified.
+             * @param message SequenceMetadata
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: tabletmanagerdata.GetMaxValueForSequencesRequest.SequenceMetadata, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this SequenceMetadata to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+
+            /**
+             * Gets the default type url for SequenceMetadata
+             * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+             * @returns The default type url
+             */
+            public static getTypeUrl(typeUrlPrefix?: string): string;
+        }
     }
 
     /** Properties of a GetMaxValueForSequencesResponse. */

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -36329,6 +36329,533 @@ export namespace tabletmanagerdata {
          */
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
+
+    /** Properties of a SequenceMetadata. */
+    interface ISequenceMetadata {
+
+        /** SequenceMetadata backing_table_name */
+        backing_table_name?: (string|null);
+
+        /** SequenceMetadata backing_table_db_name */
+        backing_table_db_name?: (string|null);
+
+        /** SequenceMetadata using_table_name */
+        using_table_name?: (string|null);
+
+        /** SequenceMetadata using_table_db_name */
+        using_table_db_name?: (string|null);
+
+        /** SequenceMetadata using_col_escaped */
+        using_col_escaped?: (string|null);
+
+        /** SequenceMetadata using_table_name_escaped */
+        using_table_name_escaped?: (string|null);
+
+        /** SequenceMetadata using_table_db_name_escaped */
+        using_table_db_name_escaped?: (string|null);
+
+        /** SequenceMetadata backing_table_name_escaped */
+        backing_table_name_escaped?: (string|null);
+    }
+
+    /** Represents a SequenceMetadata. */
+    class SequenceMetadata implements ISequenceMetadata {
+
+        /**
+         * Constructs a new SequenceMetadata.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: tabletmanagerdata.ISequenceMetadata);
+
+        /** SequenceMetadata backing_table_name. */
+        public backing_table_name: string;
+
+        /** SequenceMetadata backing_table_db_name. */
+        public backing_table_db_name: string;
+
+        /** SequenceMetadata using_table_name. */
+        public using_table_name: string;
+
+        /** SequenceMetadata using_table_db_name. */
+        public using_table_db_name: string;
+
+        /** SequenceMetadata using_col_escaped. */
+        public using_col_escaped: string;
+
+        /** SequenceMetadata using_table_name_escaped. */
+        public using_table_name_escaped: string;
+
+        /** SequenceMetadata using_table_db_name_escaped. */
+        public using_table_db_name_escaped: string;
+
+        /** SequenceMetadata backing_table_name_escaped. */
+        public backing_table_name_escaped: string;
+
+        /**
+         * Creates a new SequenceMetadata instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns SequenceMetadata instance
+         */
+        public static create(properties?: tabletmanagerdata.ISequenceMetadata): tabletmanagerdata.SequenceMetadata;
+
+        /**
+         * Encodes the specified SequenceMetadata message. Does not implicitly {@link tabletmanagerdata.SequenceMetadata.verify|verify} messages.
+         * @param message SequenceMetadata message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: tabletmanagerdata.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified SequenceMetadata message, length delimited. Does not implicitly {@link tabletmanagerdata.SequenceMetadata.verify|verify} messages.
+         * @param message SequenceMetadata message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: tabletmanagerdata.ISequenceMetadata, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a SequenceMetadata message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns SequenceMetadata
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.SequenceMetadata;
+
+        /**
+         * Decodes a SequenceMetadata message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns SequenceMetadata
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.SequenceMetadata;
+
+        /**
+         * Verifies a SequenceMetadata message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a SequenceMetadata message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns SequenceMetadata
+         */
+        public static fromObject(object: { [k: string]: any }): tabletmanagerdata.SequenceMetadata;
+
+        /**
+         * Creates a plain object from a SequenceMetadata message. Also converts values to other types if specified.
+         * @param message SequenceMetadata
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: tabletmanagerdata.SequenceMetadata, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this SequenceMetadata to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for SequenceMetadata
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of an UpdateSequenceTablesRequest. */
+    interface IUpdateSequenceTablesRequest {
+
+        /** UpdateSequenceTablesRequest sequences */
+        sequences?: (tabletmanagerdata.ISequenceMetadata[]|null);
+
+        /** UpdateSequenceTablesRequest max_values_by_sequence_table */
+        max_values_by_sequence_table?: ({ [k: string]: (number|Long) }|null);
+    }
+
+    /** Represents an UpdateSequenceTablesRequest. */
+    class UpdateSequenceTablesRequest implements IUpdateSequenceTablesRequest {
+
+        /**
+         * Constructs a new UpdateSequenceTablesRequest.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: tabletmanagerdata.IUpdateSequenceTablesRequest);
+
+        /** UpdateSequenceTablesRequest sequences. */
+        public sequences: tabletmanagerdata.ISequenceMetadata[];
+
+        /** UpdateSequenceTablesRequest max_values_by_sequence_table. */
+        public max_values_by_sequence_table: { [k: string]: (number|Long) };
+
+        /**
+         * Creates a new UpdateSequenceTablesRequest instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns UpdateSequenceTablesRequest instance
+         */
+        public static create(properties?: tabletmanagerdata.IUpdateSequenceTablesRequest): tabletmanagerdata.UpdateSequenceTablesRequest;
+
+        /**
+         * Encodes the specified UpdateSequenceTablesRequest message. Does not implicitly {@link tabletmanagerdata.UpdateSequenceTablesRequest.verify|verify} messages.
+         * @param message UpdateSequenceTablesRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: tabletmanagerdata.IUpdateSequenceTablesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified UpdateSequenceTablesRequest message, length delimited. Does not implicitly {@link tabletmanagerdata.UpdateSequenceTablesRequest.verify|verify} messages.
+         * @param message UpdateSequenceTablesRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: tabletmanagerdata.IUpdateSequenceTablesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes an UpdateSequenceTablesRequest message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns UpdateSequenceTablesRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.UpdateSequenceTablesRequest;
+
+        /**
+         * Decodes an UpdateSequenceTablesRequest message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns UpdateSequenceTablesRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.UpdateSequenceTablesRequest;
+
+        /**
+         * Verifies an UpdateSequenceTablesRequest message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates an UpdateSequenceTablesRequest message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns UpdateSequenceTablesRequest
+         */
+        public static fromObject(object: { [k: string]: any }): tabletmanagerdata.UpdateSequenceTablesRequest;
+
+        /**
+         * Creates a plain object from an UpdateSequenceTablesRequest message. Also converts values to other types if specified.
+         * @param message UpdateSequenceTablesRequest
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: tabletmanagerdata.UpdateSequenceTablesRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this UpdateSequenceTablesRequest to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for UpdateSequenceTablesRequest
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of an UpdateSequenceTablesResponse. */
+    interface IUpdateSequenceTablesResponse {
+    }
+
+    /** Represents an UpdateSequenceTablesResponse. */
+    class UpdateSequenceTablesResponse implements IUpdateSequenceTablesResponse {
+
+        /**
+         * Constructs a new UpdateSequenceTablesResponse.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: tabletmanagerdata.IUpdateSequenceTablesResponse);
+
+        /**
+         * Creates a new UpdateSequenceTablesResponse instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns UpdateSequenceTablesResponse instance
+         */
+        public static create(properties?: tabletmanagerdata.IUpdateSequenceTablesResponse): tabletmanagerdata.UpdateSequenceTablesResponse;
+
+        /**
+         * Encodes the specified UpdateSequenceTablesResponse message. Does not implicitly {@link tabletmanagerdata.UpdateSequenceTablesResponse.verify|verify} messages.
+         * @param message UpdateSequenceTablesResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: tabletmanagerdata.IUpdateSequenceTablesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified UpdateSequenceTablesResponse message, length delimited. Does not implicitly {@link tabletmanagerdata.UpdateSequenceTablesResponse.verify|verify} messages.
+         * @param message UpdateSequenceTablesResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: tabletmanagerdata.IUpdateSequenceTablesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes an UpdateSequenceTablesResponse message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns UpdateSequenceTablesResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.UpdateSequenceTablesResponse;
+
+        /**
+         * Decodes an UpdateSequenceTablesResponse message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns UpdateSequenceTablesResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.UpdateSequenceTablesResponse;
+
+        /**
+         * Verifies an UpdateSequenceTablesResponse message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates an UpdateSequenceTablesResponse message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns UpdateSequenceTablesResponse
+         */
+        public static fromObject(object: { [k: string]: any }): tabletmanagerdata.UpdateSequenceTablesResponse;
+
+        /**
+         * Creates a plain object from an UpdateSequenceTablesResponse message. Also converts values to other types if specified.
+         * @param message UpdateSequenceTablesResponse
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: tabletmanagerdata.UpdateSequenceTablesResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this UpdateSequenceTablesResponse to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for UpdateSequenceTablesResponse
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a GetMaxValueForSequencesRequest. */
+    interface IGetMaxValueForSequencesRequest {
+
+        /** GetMaxValueForSequencesRequest sequences */
+        sequences?: (tabletmanagerdata.ISequenceMetadata[]|null);
+    }
+
+    /** Represents a GetMaxValueForSequencesRequest. */
+    class GetMaxValueForSequencesRequest implements IGetMaxValueForSequencesRequest {
+
+        /**
+         * Constructs a new GetMaxValueForSequencesRequest.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: tabletmanagerdata.IGetMaxValueForSequencesRequest);
+
+        /** GetMaxValueForSequencesRequest sequences. */
+        public sequences: tabletmanagerdata.ISequenceMetadata[];
+
+        /**
+         * Creates a new GetMaxValueForSequencesRequest instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GetMaxValueForSequencesRequest instance
+         */
+        public static create(properties?: tabletmanagerdata.IGetMaxValueForSequencesRequest): tabletmanagerdata.GetMaxValueForSequencesRequest;
+
+        /**
+         * Encodes the specified GetMaxValueForSequencesRequest message. Does not implicitly {@link tabletmanagerdata.GetMaxValueForSequencesRequest.verify|verify} messages.
+         * @param message GetMaxValueForSequencesRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: tabletmanagerdata.IGetMaxValueForSequencesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GetMaxValueForSequencesRequest message, length delimited. Does not implicitly {@link tabletmanagerdata.GetMaxValueForSequencesRequest.verify|verify} messages.
+         * @param message GetMaxValueForSequencesRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: tabletmanagerdata.IGetMaxValueForSequencesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GetMaxValueForSequencesRequest message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GetMaxValueForSequencesRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.GetMaxValueForSequencesRequest;
+
+        /**
+         * Decodes a GetMaxValueForSequencesRequest message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GetMaxValueForSequencesRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.GetMaxValueForSequencesRequest;
+
+        /**
+         * Verifies a GetMaxValueForSequencesRequest message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GetMaxValueForSequencesRequest message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GetMaxValueForSequencesRequest
+         */
+        public static fromObject(object: { [k: string]: any }): tabletmanagerdata.GetMaxValueForSequencesRequest;
+
+        /**
+         * Creates a plain object from a GetMaxValueForSequencesRequest message. Also converts values to other types if specified.
+         * @param message GetMaxValueForSequencesRequest
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: tabletmanagerdata.GetMaxValueForSequencesRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GetMaxValueForSequencesRequest to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for GetMaxValueForSequencesRequest
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a GetMaxValueForSequencesResponse. */
+    interface IGetMaxValueForSequencesResponse {
+
+        /** GetMaxValueForSequencesResponse max_values_by_sequence_table */
+        max_values_by_sequence_table?: ({ [k: string]: (number|Long) }|null);
+    }
+
+    /** Represents a GetMaxValueForSequencesResponse. */
+    class GetMaxValueForSequencesResponse implements IGetMaxValueForSequencesResponse {
+
+        /**
+         * Constructs a new GetMaxValueForSequencesResponse.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: tabletmanagerdata.IGetMaxValueForSequencesResponse);
+
+        /** GetMaxValueForSequencesResponse max_values_by_sequence_table. */
+        public max_values_by_sequence_table: { [k: string]: (number|Long) };
+
+        /**
+         * Creates a new GetMaxValueForSequencesResponse instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GetMaxValueForSequencesResponse instance
+         */
+        public static create(properties?: tabletmanagerdata.IGetMaxValueForSequencesResponse): tabletmanagerdata.GetMaxValueForSequencesResponse;
+
+        /**
+         * Encodes the specified GetMaxValueForSequencesResponse message. Does not implicitly {@link tabletmanagerdata.GetMaxValueForSequencesResponse.verify|verify} messages.
+         * @param message GetMaxValueForSequencesResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: tabletmanagerdata.IGetMaxValueForSequencesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GetMaxValueForSequencesResponse message, length delimited. Does not implicitly {@link tabletmanagerdata.GetMaxValueForSequencesResponse.verify|verify} messages.
+         * @param message GetMaxValueForSequencesResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: tabletmanagerdata.IGetMaxValueForSequencesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GetMaxValueForSequencesResponse message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GetMaxValueForSequencesResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): tabletmanagerdata.GetMaxValueForSequencesResponse;
+
+        /**
+         * Decodes a GetMaxValueForSequencesResponse message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GetMaxValueForSequencesResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): tabletmanagerdata.GetMaxValueForSequencesResponse;
+
+        /**
+         * Verifies a GetMaxValueForSequencesResponse message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GetMaxValueForSequencesResponse message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GetMaxValueForSequencesResponse
+         */
+        public static fromObject(object: { [k: string]: any }): tabletmanagerdata.GetMaxValueForSequencesResponse;
+
+        /**
+         * Creates a plain object from a GetMaxValueForSequencesResponse message. Also converts values to other types if specified.
+         * @param message GetMaxValueForSequencesResponse
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: tabletmanagerdata.GetMaxValueForSequencesResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GetMaxValueForSequencesResponse to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for GetMaxValueForSequencesResponse
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
 }
 
 /** Namespace binlogdata. */


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds 2 TMC RPCs:
- `GetMaxValueForSequences` : Gets the max used sequence value mapped with the provided backing sequence tables.
- `UpdateSequenceTables`: Updates all the sequence tables listed in the request, with the max value provided in the sequence metadata.

Instead of separate RPC calls for each table per shard, these 2 RPCs allow it to reduce to just 1 RPC call (all tables at once) per shard for fetching and updating max sequence value each.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #17871
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
