### PR TITLE
`vttablet`: allow `--init_tablet_type DRAINED`

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -252,9 +252,9 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32, d
 		return nil, err
 	}
 	switch tabletType {
-	case topodatapb.TabletType_SPARE, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY:
+	case topodatapb.TabletType_SPARE, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY, topodatapb.TabletType_DRAINED:
 	default:
-		return nil, fmt.Errorf("invalid init_tablet_type %v; can only be REPLICA, RDONLY or SPARE", tabletType)
+		return nil, fmt.Errorf("invalid init_tablet_type %v; can only be REPLICA, RDONLY, SPARE or DRAINED", tabletType)
 	}
 
 	buildTags, err := getBuildTags(servenv.AppVersion.ToStringMap(), skipBuildInfoTags)


### PR DESCRIPTION
## Description

This PR allows `vttablet` to start-up as `DRAINED`, via the existing `--init_tablet_type` flag

Today only `REPLICA`, `RDONLY` and `SPARE` are accepted, however none of these types allow a tablet to be started that is ignored by both VTOrc and VTGate. See issue for more context: https://github.com/vitessio/vitess/issues/18178

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/18178

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
