### PR TITLE
VStream: Add flag to support copying only specific tables

### DIFF
--- a/go/test/endtoend/vreplication/vstream_test.go
+++ b/go/test/endtoend/vreplication/vstream_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/log"
@@ -36,6 +37,153 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
+
+func TestVStreamWithTablesToSkipCopyFlag(t *testing.T) {
+	vc = NewVitessCluster(t, nil)
+	defer vc.TearDown()
+
+	require.NotNil(t, vc)
+	defaultReplicas = 2
+	defaultRdonly = 0
+
+	defaultCell := vc.Cells[vc.CellNames[0]]
+	vc.AddKeyspace(t, []*Cell{defaultCell}, "product", "0", initialProductVSchema, initialProductSchema, defaultReplicas, defaultRdonly, 100, nil)
+	verifyClusterHealth(t, vc)
+
+	ctx := context.Background()
+	vstreamConn, err := vtgateconn.Dial(ctx, fmt.Sprintf("%s:%d", vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateGrpcPort))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer vstreamConn.Close()
+	vgtid := &binlogdatapb.VGtid{
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "product",
+			Shard:    "0",
+			Gtid:     "",
+		}}}
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{
+			{
+				Match:  "customer",
+				Filter: "select * from customer",
+			}, {
+				Match:  "product",
+				Filter: "select * from product",
+			}, {
+				Match:  "merchant",
+				Filter: "select * from merchant",
+			},
+		},
+	}
+	flags := &vtgatepb.VStreamFlags{
+		TablesToSkipCopy: []string{"customer", "merchant"},
+	}
+	id := 0
+	vtgateConn := vc.GetVTGateConn(t)
+	defer vtgateConn.Close()
+
+	// To test the copy phase, let's insert 10 rows intitally in each table
+	// present in the filter before running the VStream.
+	for range 10 {
+		id++
+		execVtgateQuery(t, vtgateConn, "product", fmt.Sprintf("insert into customer (cid, name) values (%d, 'customer%d')", id+100, id))
+		execVtgateQuery(t, vtgateConn, "product", fmt.Sprintf("insert into product (pid, description) values (%d, 'description%d')", id+100, id))
+		execVtgateQuery(t, vtgateConn, "product", fmt.Sprintf("insert into merchant (mname, category) values ('mname%d', 'category%d')", id+100, id))
+	}
+
+	// Stream events from the VStream API
+	reader, err := vstreamConn.VStream(ctx, topodatapb.TabletType_PRIMARY, vgtid, filter, flags)
+	require.NoError(t, err)
+	var numRowEvents int64
+
+	copyPhaseCompleted := atomic.Bool{}
+	copyPhaseCompleted.Store(false)
+
+	done := atomic.Bool{}
+	done.Store(false)
+
+	// Start reading events from the VStream.
+	go func() {
+		for {
+			evs, err := reader.Recv()
+			switch err {
+			case nil:
+				for _, ev := range evs {
+					if ev.Type == binlogdatapb.VEventType_ROW {
+						numRowEvents++
+					}
+					if ev.Type == binlogdatapb.VEventType_COPY_COMPLETED {
+						copyPhaseCompleted.Store(true)
+					}
+				}
+			case io.EOF:
+				log.Infof("Stream Ended")
+			default:
+				log.Infof("%s:: remote error: %v", time.Now(), err)
+			}
+
+			if done.Load() {
+				return
+			}
+		}
+	}()
+
+	// Wait for copy phase to complete.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	for {
+		<-ticker.C
+		if copyPhaseCompleted.Load() {
+			break
+		}
+	}
+
+	stopInserting := atomic.Bool{}
+	stopInserting.Store(false)
+	var insertMu sync.Mutex
+	go func() {
+		for {
+			if stopInserting.Load() {
+				return
+			}
+			insertMu.Lock()
+			id++
+			execVtgateQuery(t, vtgateConn, "product", fmt.Sprintf("insert into customer (cid, name) values (%d, 'customer%d')", id+100, id))
+			execVtgateQuery(t, vtgateConn, "product", fmt.Sprintf("insert into product (pid, description) values (%d, 'description%d')", id+100, id))
+			execVtgateQuery(t, vtgateConn, "product", fmt.Sprintf("insert into merchant (mname, category) values ('mname%d', 'category%d')", id+100, id))
+			insertMu.Unlock()
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	stopInserting.Store(true)
+	time.Sleep(10 * time.Second) // Give the vstream plenty of time to catchup
+	done.Store(true)
+
+	qr1 := execVtgateQuery(t, vtgateConn, "product", "select count(*) from customer")
+	qr2 := execVtgateQuery(t, vtgateConn, "product", "select count(*) from product")
+	qr3 := execVtgateQuery(t, vtgateConn, "product", "select count(*) from merchant")
+	require.NotNil(t, qr1)
+	require.NotNil(t, qr2)
+	require.NotNil(t, qr3)
+
+	// Total number of rows.
+	insertedRows1, err := qr1.Rows[0][0].ToCastInt64()
+	require.NoError(t, err)
+	require.NotZero(t, insertedRows1)
+	insertedRows2, err := qr2.Rows[0][0].ToCastInt64()
+	require.NoError(t, err)
+	require.NotZero(t, insertedRows2)
+	insertedRows3, err := qr3.Rows[0][0].ToCastInt64()
+	require.NoError(t, err)
+	require.NotZero(t, insertedRows3)
+
+	// Since we don't expect customer and merchant table to be part of copy
+	// phase, we can subtract 10 * 2 from the total rows found in the 3 tables.
+	wantTotalRows := insertedRows1 + insertedRows2 + insertedRows3 - 10*2
+	assert.Equal(t, wantTotalRows, numRowEvents)
+}
 
 // Validates that we have a working VStream API
 // If Failover is enabled:

--- a/go/vt/proto/binlogdata/binlogdata.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata.pb.go
@@ -2152,10 +2152,11 @@ type VStreamOptions struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	InternalTables  []string               `protobuf:"bytes,1,rep,name=internal_tables,json=internalTables,proto3" json:"internal_tables,omitempty"`
 	ConfigOverrides map[string]string      `protobuf:"bytes,2,rep,name=config_overrides,json=configOverrides,proto3" json:"config_overrides,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Skip copy phase for these tables.
-	TablesToSkipCopy []string `protobuf:"bytes,3,rep,name=tables_to_skip_copy,json=tablesToSkipCopy,proto3" json:"tables_to_skip_copy,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Copy only these tables, skip the rest in the filter.
+	// If not provided, the default behaviour is to copy all tables.
+	TablesToCopy  []string `protobuf:"bytes,3,rep,name=tables_to_copy,json=tablesToCopy,proto3" json:"tables_to_copy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VStreamOptions) Reset() {
@@ -2202,9 +2203,9 @@ func (x *VStreamOptions) GetConfigOverrides() map[string]string {
 	return nil
 }
 
-func (x *VStreamOptions) GetTablesToSkipCopy() []string {
+func (x *VStreamOptions) GetTablesToCopy() []string {
 	if x != nil {
-		return x.TablesToSkipCopy
+		return x.TablesToCopy
 	}
 	return nil
 }
@@ -3205,11 +3206,11 @@ const file_binlogdata_proto_rawDesc = "" +
 	"\vp_k_columns\x18\x03 \x03(\x03R\tpKColumns\x12#\n" +
 	"\x0ep_k_index_name\x18\x04 \x01(\tR\vpKIndexName\"A\n" +
 	"\rMinimalSchema\x120\n" +
-	"\x06tables\x18\x01 \x03(\v2\x18.binlogdata.MinimalTableR\x06tables\"\x88\x02\n" +
+	"\x06tables\x18\x01 \x03(\v2\x18.binlogdata.MinimalTableR\x06tables\"\xff\x01\n" +
 	"\x0eVStreamOptions\x12'\n" +
 	"\x0finternal_tables\x18\x01 \x03(\tR\x0einternalTables\x12Z\n" +
-	"\x10config_overrides\x18\x02 \x03(\v2/.binlogdata.VStreamOptions.ConfigOverridesEntryR\x0fconfigOverrides\x12-\n" +
-	"\x13tables_to_skip_copy\x18\x03 \x03(\tR\x10tablesToSkipCopy\x1aB\n" +
+	"\x10config_overrides\x18\x02 \x03(\v2/.binlogdata.VStreamOptions.ConfigOverridesEntryR\x0fconfigOverrides\x12$\n" +
+	"\x0etables_to_copy\x18\x03 \x03(\tR\ftablesToCopy\x1aB\n" +
 	"\x14ConfigOverridesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfd\x02\n" +

--- a/go/vt/proto/binlogdata/binlogdata.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata.pb.go
@@ -2152,8 +2152,10 @@ type VStreamOptions struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	InternalTables  []string               `protobuf:"bytes,1,rep,name=internal_tables,json=internalTables,proto3" json:"internal_tables,omitempty"`
 	ConfigOverrides map[string]string      `protobuf:"bytes,2,rep,name=config_overrides,json=configOverrides,proto3" json:"config_overrides,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Skip copy phase for these tables.
+	TablesToSkipCopy []string `protobuf:"bytes,3,rep,name=tables_to_skip_copy,json=tablesToSkipCopy,proto3" json:"tables_to_skip_copy,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *VStreamOptions) Reset() {
@@ -2196,6 +2198,13 @@ func (x *VStreamOptions) GetInternalTables() []string {
 func (x *VStreamOptions) GetConfigOverrides() map[string]string {
 	if x != nil {
 		return x.ConfigOverrides
+	}
+	return nil
+}
+
+func (x *VStreamOptions) GetTablesToSkipCopy() []string {
+	if x != nil {
+		return x.TablesToSkipCopy
 	}
 	return nil
 }
@@ -3196,10 +3205,11 @@ const file_binlogdata_proto_rawDesc = "" +
 	"\vp_k_columns\x18\x03 \x03(\x03R\tpKColumns\x12#\n" +
 	"\x0ep_k_index_name\x18\x04 \x01(\tR\vpKIndexName\"A\n" +
 	"\rMinimalSchema\x120\n" +
-	"\x06tables\x18\x01 \x03(\v2\x18.binlogdata.MinimalTableR\x06tables\"\xd9\x01\n" +
+	"\x06tables\x18\x01 \x03(\v2\x18.binlogdata.MinimalTableR\x06tables\"\x88\x02\n" +
 	"\x0eVStreamOptions\x12'\n" +
 	"\x0finternal_tables\x18\x01 \x03(\tR\x0einternalTables\x12Z\n" +
-	"\x10config_overrides\x18\x02 \x03(\v2/.binlogdata.VStreamOptions.ConfigOverridesEntryR\x0fconfigOverrides\x1aB\n" +
+	"\x10config_overrides\x18\x02 \x03(\v2/.binlogdata.VStreamOptions.ConfigOverridesEntryR\x0fconfigOverrides\x12-\n" +
+	"\x13tables_to_skip_copy\x18\x03 \x03(\tR\x10tablesToSkipCopy\x1aB\n" +
 	"\x14ConfigOverridesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfd\x02\n" +

--- a/go/vt/proto/binlogdata/binlogdata_vtproto.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata_vtproto.pb.go
@@ -593,10 +593,10 @@ func (m *VStreamOptions) CloneVT() *VStreamOptions {
 		}
 		r.ConfigOverrides = tmpContainer
 	}
-	if rhs := m.TablesToSkipCopy; rhs != nil {
+	if rhs := m.TablesToCopy; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
-		r.TablesToSkipCopy = tmpContainer
+		r.TablesToCopy = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -2462,11 +2462,11 @@ func (m *VStreamOptions) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.TablesToSkipCopy) > 0 {
-		for iNdEx := len(m.TablesToSkipCopy) - 1; iNdEx >= 0; iNdEx-- {
-			i -= len(m.TablesToSkipCopy[iNdEx])
-			copy(dAtA[i:], m.TablesToSkipCopy[iNdEx])
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TablesToSkipCopy[iNdEx])))
+	if len(m.TablesToCopy) > 0 {
+		for iNdEx := len(m.TablesToCopy) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.TablesToCopy[iNdEx])
+			copy(dAtA[i:], m.TablesToCopy[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TablesToCopy[iNdEx])))
 			i--
 			dAtA[i] = 0x1a
 		}
@@ -3976,8 +3976,8 @@ func (m *VStreamOptions) SizeVT() (n int) {
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
 	}
-	if len(m.TablesToSkipCopy) > 0 {
-		for _, s := range m.TablesToSkipCopy {
+	if len(m.TablesToCopy) > 0 {
+		for _, s := range m.TablesToCopy {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
@@ -8787,7 +8787,7 @@ func (m *VStreamOptions) UnmarshalVT(dAtA []byte) error {
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field TablesToSkipCopy", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field TablesToCopy", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -8815,7 +8815,7 @@ func (m *VStreamOptions) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.TablesToSkipCopy = append(m.TablesToSkipCopy, string(dAtA[iNdEx:postIndex]))
+			m.TablesToCopy = append(m.TablesToCopy, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go/vt/proto/binlogdata/binlogdata_vtproto.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata_vtproto.pb.go
@@ -593,6 +593,11 @@ func (m *VStreamOptions) CloneVT() *VStreamOptions {
 		}
 		r.ConfigOverrides = tmpContainer
 	}
+	if rhs := m.TablesToSkipCopy; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.TablesToSkipCopy = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -2457,6 +2462,15 @@ func (m *VStreamOptions) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.TablesToSkipCopy) > 0 {
+		for iNdEx := len(m.TablesToSkipCopy) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.TablesToSkipCopy[iNdEx])
+			copy(dAtA[i:], m.TablesToSkipCopy[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TablesToSkipCopy[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.ConfigOverrides) > 0 {
 		for k := range m.ConfigOverrides {
 			v := m.ConfigOverrides[k]
@@ -3960,6 +3974,12 @@ func (m *VStreamOptions) SizeVT() (n int) {
 			_ = v
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.TablesToSkipCopy) > 0 {
+		for _, s := range m.TablesToSkipCopy {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
 	n += len(m.unknownFields)
@@ -8764,6 +8784,38 @@ func (m *VStreamOptions) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.ConfigOverrides[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TablesToSkipCopy", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TablesToSkipCopy = append(m.TablesToSkipCopy, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go/vt/proto/vtgate/vtgate.pb.go
+++ b/go/vt/proto/vtgate/vtgate.pb.go
@@ -1338,10 +1338,11 @@ type VStreamFlags struct {
 	StreamKeyspaceHeartbeats bool `protobuf:"varint,7,opt,name=stream_keyspace_heartbeats,json=streamKeyspaceHeartbeats,proto3" json:"stream_keyspace_heartbeats,omitempty"`
 	// Include reshard journal events in the stream.
 	IncludeReshardJournalEvents bool `protobuf:"varint,8,opt,name=include_reshard_journal_events,json=includeReshardJournalEvents,proto3" json:"include_reshard_journal_events,omitempty"`
-	// Skip copy phase for these tables.
-	TablesToSkipCopy []string `protobuf:"bytes,9,rep,name=tables_to_skip_copy,json=tablesToSkipCopy,proto3" json:"tables_to_skip_copy,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Copy only these tables, skip the rest in the filter.
+	// If not provided, the default behaviour is to copy all tables.
+	TablesToCopy  []string `protobuf:"bytes,9,rep,name=tables_to_copy,json=tablesToCopy,proto3" json:"tables_to_copy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VStreamFlags) Reset() {
@@ -1430,9 +1431,9 @@ func (x *VStreamFlags) GetIncludeReshardJournalEvents() bool {
 	return false
 }
 
-func (x *VStreamFlags) GetTablesToSkipCopy() []string {
+func (x *VStreamFlags) GetTablesToCopy() []string {
 	if x != nil {
-		return x.TablesToSkipCopy
+		return x.TablesToCopy
 	}
 	return nil
 }
@@ -2003,7 +2004,7 @@ const file_vtgate_proto_rawDesc = "" +
 	"\x19ResolveTransactionRequest\x12,\n" +
 	"\tcaller_id\x18\x01 \x01(\v2\x0f.vtrpc.CallerIDR\bcallerId\x12\x12\n" +
 	"\x04dtid\x18\x02 \x01(\tR\x04dtid\"\x1c\n" +
-	"\x1aResolveTransactionResponse\"\x9e\x03\n" +
+	"\x1aResolveTransactionResponse\"\x95\x03\n" +
 	"\fVStreamFlags\x12#\n" +
 	"\rminimize_skew\x18\x01 \x01(\bR\fminimizeSkew\x12-\n" +
 	"\x12heartbeat_interval\x18\x02 \x01(\rR\x11heartbeatInterval\x12&\n" +
@@ -2012,8 +2013,8 @@ const file_vtgate_proto_rawDesc = "" +
 	"\x0fcell_preference\x18\x05 \x01(\tR\x0ecellPreference\x12!\n" +
 	"\ftablet_order\x18\x06 \x01(\tR\vtabletOrder\x12<\n" +
 	"\x1astream_keyspace_heartbeats\x18\a \x01(\bR\x18streamKeyspaceHeartbeats\x12C\n" +
-	"\x1einclude_reshard_journal_events\x18\b \x01(\bR\x1bincludeReshardJournalEvents\x12-\n" +
-	"\x13tables_to_skip_copy\x18\t \x03(\tR\x10tablesToSkipCopy\"\xf6\x01\n" +
+	"\x1einclude_reshard_journal_events\x18\b \x01(\bR\x1bincludeReshardJournalEvents\x12$\n" +
+	"\x0etables_to_copy\x18\t \x03(\tR\ftablesToCopy\"\xf6\x01\n" +
 	"\x0eVStreamRequest\x12,\n" +
 	"\tcaller_id\x18\x01 \x01(\v2\x0f.vtrpc.CallerIDR\bcallerId\x125\n" +
 	"\vtablet_type\x18\x02 \x01(\x0e2\x14.topodata.TabletTypeR\n" +

--- a/go/vt/proto/vtgate/vtgate.pb.go
+++ b/go/vt/proto/vtgate/vtgate.pb.go
@@ -1338,8 +1338,10 @@ type VStreamFlags struct {
 	StreamKeyspaceHeartbeats bool `protobuf:"varint,7,opt,name=stream_keyspace_heartbeats,json=streamKeyspaceHeartbeats,proto3" json:"stream_keyspace_heartbeats,omitempty"`
 	// Include reshard journal events in the stream.
 	IncludeReshardJournalEvents bool `protobuf:"varint,8,opt,name=include_reshard_journal_events,json=includeReshardJournalEvents,proto3" json:"include_reshard_journal_events,omitempty"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	// Skip copy phase for these tables.
+	TablesToSkipCopy []string `protobuf:"bytes,9,rep,name=tables_to_skip_copy,json=tablesToSkipCopy,proto3" json:"tables_to_skip_copy,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *VStreamFlags) Reset() {
@@ -1426,6 +1428,13 @@ func (x *VStreamFlags) GetIncludeReshardJournalEvents() bool {
 		return x.IncludeReshardJournalEvents
 	}
 	return false
+}
+
+func (x *VStreamFlags) GetTablesToSkipCopy() []string {
+	if x != nil {
+		return x.TablesToSkipCopy
+	}
+	return nil
 }
 
 // VStreamRequest is the payload for VStream.
@@ -1994,7 +2003,7 @@ const file_vtgate_proto_rawDesc = "" +
 	"\x19ResolveTransactionRequest\x12,\n" +
 	"\tcaller_id\x18\x01 \x01(\v2\x0f.vtrpc.CallerIDR\bcallerId\x12\x12\n" +
 	"\x04dtid\x18\x02 \x01(\tR\x04dtid\"\x1c\n" +
-	"\x1aResolveTransactionResponse\"\xef\x02\n" +
+	"\x1aResolveTransactionResponse\"\x9e\x03\n" +
 	"\fVStreamFlags\x12#\n" +
 	"\rminimize_skew\x18\x01 \x01(\bR\fminimizeSkew\x12-\n" +
 	"\x12heartbeat_interval\x18\x02 \x01(\rR\x11heartbeatInterval\x12&\n" +
@@ -2003,7 +2012,8 @@ const file_vtgate_proto_rawDesc = "" +
 	"\x0fcell_preference\x18\x05 \x01(\tR\x0ecellPreference\x12!\n" +
 	"\ftablet_order\x18\x06 \x01(\tR\vtabletOrder\x12<\n" +
 	"\x1astream_keyspace_heartbeats\x18\a \x01(\bR\x18streamKeyspaceHeartbeats\x12C\n" +
-	"\x1einclude_reshard_journal_events\x18\b \x01(\bR\x1bincludeReshardJournalEvents\"\xf6\x01\n" +
+	"\x1einclude_reshard_journal_events\x18\b \x01(\bR\x1bincludeReshardJournalEvents\x12-\n" +
+	"\x13tables_to_skip_copy\x18\t \x03(\tR\x10tablesToSkipCopy\"\xf6\x01\n" +
 	"\x0eVStreamRequest\x12,\n" +
 	"\tcaller_id\x18\x01 \x01(\v2\x0f.vtrpc.CallerIDR\bcallerId\x125\n" +
 	"\vtablet_type\x18\x02 \x01(\x0e2\x14.topodata.TabletTypeR\n" +

--- a/go/vt/proto/vtgate/vtgate_vtproto.pb.go
+++ b/go/vt/proto/vtgate/vtgate_vtproto.pb.go
@@ -435,6 +435,11 @@ func (m *VStreamFlags) CloneVT() *VStreamFlags {
 	r.TabletOrder = m.TabletOrder
 	r.StreamKeyspaceHeartbeats = m.StreamKeyspaceHeartbeats
 	r.IncludeReshardJournalEvents = m.IncludeReshardJournalEvents
+	if rhs := m.TablesToSkipCopy; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.TablesToSkipCopy = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1841,6 +1846,15 @@ func (m *VStreamFlags) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.TablesToSkipCopy) > 0 {
+		for iNdEx := len(m.TablesToSkipCopy) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.TablesToSkipCopy[iNdEx])
+			copy(dAtA[i:], m.TablesToSkipCopy[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TablesToSkipCopy[iNdEx])))
+			i--
+			dAtA[i] = 0x4a
+		}
+	}
 	if m.IncludeReshardJournalEvents {
 		i--
 		if m.IncludeReshardJournalEvents {
@@ -2759,6 +2773,12 @@ func (m *VStreamFlags) SizeVT() (n int) {
 	}
 	if m.IncludeReshardJournalEvents {
 		n += 2
+	}
+	if len(m.TablesToSkipCopy) > 0 {
+		for _, s := range m.TablesToSkipCopy {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6432,6 +6452,38 @@ func (m *VStreamFlags) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.IncludeReshardJournalEvents = bool(v != 0)
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TablesToSkipCopy", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TablesToSkipCopy = append(m.TablesToSkipCopy, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/go/vt/proto/vtgate/vtgate_vtproto.pb.go
+++ b/go/vt/proto/vtgate/vtgate_vtproto.pb.go
@@ -435,10 +435,10 @@ func (m *VStreamFlags) CloneVT() *VStreamFlags {
 	r.TabletOrder = m.TabletOrder
 	r.StreamKeyspaceHeartbeats = m.StreamKeyspaceHeartbeats
 	r.IncludeReshardJournalEvents = m.IncludeReshardJournalEvents
-	if rhs := m.TablesToSkipCopy; rhs != nil {
+	if rhs := m.TablesToCopy; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
-		r.TablesToSkipCopy = tmpContainer
+		r.TablesToCopy = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -1846,11 +1846,11 @@ func (m *VStreamFlags) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.TablesToSkipCopy) > 0 {
-		for iNdEx := len(m.TablesToSkipCopy) - 1; iNdEx >= 0; iNdEx-- {
-			i -= len(m.TablesToSkipCopy[iNdEx])
-			copy(dAtA[i:], m.TablesToSkipCopy[iNdEx])
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TablesToSkipCopy[iNdEx])))
+	if len(m.TablesToCopy) > 0 {
+		for iNdEx := len(m.TablesToCopy) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.TablesToCopy[iNdEx])
+			copy(dAtA[i:], m.TablesToCopy[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TablesToCopy[iNdEx])))
 			i--
 			dAtA[i] = 0x4a
 		}
@@ -2774,8 +2774,8 @@ func (m *VStreamFlags) SizeVT() (n int) {
 	if m.IncludeReshardJournalEvents {
 		n += 2
 	}
-	if len(m.TablesToSkipCopy) > 0 {
-		for _, s := range m.TablesToSkipCopy {
+	if len(m.TablesToCopy) > 0 {
+		for _, s := range m.TablesToCopy {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
@@ -6454,7 +6454,7 @@ func (m *VStreamFlags) UnmarshalVT(dAtA []byte) error {
 			m.IncludeReshardJournalEvents = bool(v != 0)
 		case 9:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field TablesToSkipCopy", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field TablesToCopy", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -6482,7 +6482,7 @@ func (m *VStreamFlags) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.TablesToSkipCopy = append(m.TablesToSkipCopy, string(dAtA[iNdEx:postIndex]))
+			m.TablesToCopy = append(m.TablesToCopy, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -642,6 +642,14 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 			}
 		}
 
+		if options != nil {
+			options.TablesToSkipCopy = vs.flags.TablesToSkipCopy
+		} else {
+			options = &binlogdatapb.VStreamOptions{
+				TablesToSkipCopy: vs.flags.TablesToSkipCopy,
+			}
+		}
+
 		// Safe to access sgtid.Gtid here (because it can't change until streaming begins).
 		req := &binlogdatapb.VStreamRequest{
 			Target:       target,

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -643,10 +643,10 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 		}
 
 		if options != nil {
-			options.TablesToSkipCopy = vs.flags.GetTablesToSkipCopy()
+			options.TablesToCopy = vs.flags.GetTablesToCopy()
 		} else {
 			options = &binlogdatapb.VStreamOptions{
-				TablesToSkipCopy: vs.flags.GetTablesToSkipCopy(),
+				TablesToCopy: vs.flags.GetTablesToCopy(),
 			}
 		}
 

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -643,10 +643,10 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 		}
 
 		if options != nil {
-			options.TablesToSkipCopy = vs.flags.TablesToSkipCopy
+			options.TablesToSkipCopy = vs.flags.GetTablesToSkipCopy()
 		} else {
 			options = &binlogdatapb.VStreamOptions{
-				TablesToSkipCopy: vs.flags.TablesToSkipCopy,
+				TablesToSkipCopy: vs.flags.GetTablesToSkipCopy(),
 			}
 		}
 

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -166,14 +166,20 @@ func (uvs *uvstreamer) buildTablePlan() error {
 	}
 
 	// Set of tables to skip during the copy phase.
-	TablesToSkipCopySet := sets.New(uvs.options.TablesToSkipCopy...)
+	var TablesToSkipCopySet sets.Set[string]
+	if uvs.options != nil && len(uvs.options.TablesToSkipCopy) > 0 {
+		TablesToSkipCopySet = sets.New(uvs.options.TablesToSkipCopy...)
+	}
 
 	for tableName := range tables {
 		rule, err := matchTable(tableName, uvs.filter, tables)
 		if err != nil {
 			return err
 		}
-		if rule == nil || TablesToSkipCopySet.Has(tableName) {
+		if rule == nil {
+			continue
+		}
+		if TablesToSkipCopySet != nil && TablesToSkipCopySet.Has(tableName) {
 			continue
 		}
 		plan := &tablePlan{

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -166,20 +166,14 @@ func (uvs *uvstreamer) buildTablePlan() error {
 	}
 
 	// Set of tables to skip during the copy phase.
-	var TablesToSkipCopySet sets.Set[string]
-	if uvs.options != nil && len(uvs.options.TablesToSkipCopy) > 0 {
-		TablesToSkipCopySet = sets.New(uvs.options.TablesToSkipCopy...)
-	}
+	TablesToSkipCopySet := sets.New(uvs.options.GetTablesToSkipCopy()...)
 
 	for tableName := range tables {
 		rule, err := matchTable(tableName, uvs.filter, tables)
 		if err != nil {
 			return err
 		}
-		if rule == nil {
-			continue
-		}
-		if TablesToSkipCopySet != nil && TablesToSkipCopySet.Has(tableName) {
+		if rule == nil || TablesToSkipCopySet.Has(tableName) {
 			continue
 		}
 		plan := &tablePlan{

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -416,8 +416,11 @@ func (uvs *uvstreamer) currentPosition() (replication.Position, error) {
 // 2. TablePKs nil, startPos empty => full table copy of tables matching filter
 // 3. TablePKs not nil, startPos empty => table copy (for pks > lastPK)
 // 4. TablePKs not nil, startPos set => run catchup from startPos, then table copy  (for pks > lastPK)
+//
+// If TablesToCopy option is not nil, copy only the tables listed in TablesToCopy.
+// For other tables not in TablesToCopy, if startPos is set, perform catchup starting from startPos.
 func (uvs *uvstreamer) init() error {
-	if uvs.startPos == "" /* full copy */ || len(uvs.inTablePKs) > 0 /* resume copy */ {
+	if uvs.startPos == "" /* full copy */ || len(uvs.inTablePKs) > 0 /* resume copy */ || len(uvs.options.GetTablesToCopy()) > 0 /* copy specific tables */ {
 		if err := uvs.buildTablePlan(); err != nil {
 			return err
 		}

--- a/proto/binlogdata.proto
+++ b/proto/binlogdata.proto
@@ -497,6 +497,8 @@ message MinimalSchema {
 message VStreamOptions {
   repeated string internal_tables = 1;
   map<string, string> config_overrides = 2;
+  // Skip copy phase for these tables.
+  repeated string tables_to_skip_copy = 3;
 }
 
 // VStreamRequest is the payload for VStreamer

--- a/proto/binlogdata.proto
+++ b/proto/binlogdata.proto
@@ -497,8 +497,9 @@ message MinimalSchema {
 message VStreamOptions {
   repeated string internal_tables = 1;
   map<string, string> config_overrides = 2;
-  // Skip copy phase for these tables.
-  repeated string tables_to_skip_copy = 3;
+  // Copy only these tables, skip the rest in the filter.
+  // If not provided, the default behaviour is to copy all tables.
+  repeated string tables_to_copy = 3;
 }
 
 // VStreamRequest is the payload for VStreamer

--- a/proto/vtgate.proto
+++ b/proto/vtgate.proto
@@ -368,8 +368,9 @@ message VStreamFlags {
   bool stream_keyspace_heartbeats = 7;
   // Include reshard journal events in the stream.
   bool include_reshard_journal_events = 8;
-  // Skip copy phase for these tables.
-  repeated string tables_to_skip_copy = 9;
+  // Copy only these tables, skip the rest in the filter.
+  // If not provided, the default behaviour is to copy all tables.
+  repeated string tables_to_copy = 9;
 }
 
 // VStreamRequest is the payload for VStream.

--- a/proto/vtgate.proto
+++ b/proto/vtgate.proto
@@ -368,6 +368,8 @@ message VStreamFlags {
   bool stream_keyspace_heartbeats = 7;
   // Include reshard journal events in the stream.
   bool include_reshard_journal_events = 8;
+  // Skip copy phase for these tables.
+  repeated string tables_to_skip_copy = 9;
 }
 
 // VStreamRequest is the payload for VStream.

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -39631,6 +39631,9 @@ export namespace binlogdata {
 
         /** VStreamOptions config_overrides */
         config_overrides?: ({ [k: string]: string }|null);
+
+        /** VStreamOptions tables_to_skip_copy */
+        tables_to_skip_copy?: (string[]|null);
     }
 
     /** Represents a VStreamOptions. */
@@ -39647,6 +39650,9 @@ export namespace binlogdata {
 
         /** VStreamOptions config_overrides. */
         public config_overrides: { [k: string]: string };
+
+        /** VStreamOptions tables_to_skip_copy. */
+        public tables_to_skip_copy: string[];
 
         /**
          * Creates a new VStreamOptions instance using the specified properties.

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -39632,8 +39632,8 @@ export namespace binlogdata {
         /** VStreamOptions config_overrides */
         config_overrides?: ({ [k: string]: string }|null);
 
-        /** VStreamOptions tables_to_skip_copy */
-        tables_to_skip_copy?: (string[]|null);
+        /** VStreamOptions tables_to_copy */
+        tables_to_copy?: (string[]|null);
     }
 
     /** Represents a VStreamOptions. */
@@ -39651,8 +39651,8 @@ export namespace binlogdata {
         /** VStreamOptions config_overrides. */
         public config_overrides: { [k: string]: string };
 
-        /** VStreamOptions tables_to_skip_copy. */
-        public tables_to_skip_copy: string[];
+        /** VStreamOptions tables_to_copy. */
+        public tables_to_copy: string[];
 
         /**
          * Creates a new VStreamOptions instance using the specified properties.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR adds an optional `TablesToCopy` option/flag in `VStreamOptions`/`VStreamFlag` to add support for copying only specific tables in copy phase. We just add only mentioned tables to the `tablePlan` (which is used to specify the tables to be copied) in `uvstreamer`. If no tables are specified or `TablesToCopy` flag is `nil`, we follow the default behaviour of copying all tables.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #18160
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
