### PR TITLE
Change test compatibility

### DIFF
--- a/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
+++ b/go/test/endtoend/vtgate/queries/vexplain/vexplain_test.go
@@ -75,7 +75,7 @@ func TestVtGateVExplain(t *testing.T) {
 		"vexplain queries/all will actually run queries")
 
 	binaryPrefix := ""
-	if utils.BinaryIsAtLeastAtVersion(22, "vtgate") {
+	if utils.BinaryIsAtLeastAtVersion(23, "vtgate") {
 		binaryPrefix = "_binary"
 	}
 


### PR DESCRIPTION
Because of https://github.com/vitessio/vitess/pull/18200 we need to change the test compatibility here for when that lands.

## Related Issue(s)

Part of https://github.com/vitessio/vitess/issues/18143 as well.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
