### PR TITLE
fix: Preserve multi-column TupleExpr in tuple simplifier

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -40,7 +40,7 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	require.NoError(t, err)
 
 	deleteAll := func() {
-		tables := []string{"t1", "tbl", "unq_idx", "nonunq_idx", "tbl_enum_set", "uks.unsharded"}
+		tables := []string{"t1", "tbl", "unq_idx", "nonunq_idx", "tbl_enum_set", "uks.unsharded", "all_types"}
 		for _, table := range tables {
 			_, _ = mcmp.ExecAndIgnore("delete from " + table)
 		}
@@ -826,4 +826,14 @@ func TestTabletTypeRouting(t *testing.T) {
 	// We verify that querying the replica tablet creates an unknown table error.
 	_, err = utils.ExecAllowError(t, vtConn, "select * from ks_misc.t1")
 	require.ErrorContains(t, err, "table unknown not found")
+}
+
+// TestJoinMixedCaseExpr tests that join condition with expression from both table having in clause is handled correctly.
+func TestJoinMixedCaseExpr(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec(`insert into all_types(id, int_unsigned) values (1, 1), (2, 2), (3,3), (4,4), (10,5), (20, 6)`)
+	mcmp.Exec(`prepare prep_pk from 'SELECT t1.id from all_types t1 join all_types t2 on t1.int_unsigned = (case when t2.int_unsigned in (1, 2, 3) then 1 when t2.int_unsigned = 4 then 10 else 20 end)'`)
+	mcmp.AssertMatches(`execute prep_pk`, `[[INT64(1)] [INT64(1)] [INT64(1)]]`)
 }

--- a/go/vt/vtgate/evalengine/translate_simplify.go
+++ b/go/vt/vtgate/evalengine/translate_simplify.go
@@ -138,10 +138,21 @@ func simplifyExpr(env *ExpressionEnv, e IR) (IR, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &Literal{inner: simplified}, nil
+		return convertToIR(simplified), nil
 	}
 	if err := e.simplify(env); err != nil {
 		return nil, err
 	}
 	return e, nil
+}
+
+func convertToIR(simplified eval) IR {
+	if x, isTuple := simplified.(*evalTuple); isTuple {
+		var te TupleExpr
+		for _, t := range x.t {
+			te = append(te, convertToIR(t))
+		}
+		return te
+	}
+	return &Literal{inner: simplified}
 }

--- a/go/vt/vtgate/evalengine/translate_simplify.go
+++ b/go/vt/vtgate/evalengine/translate_simplify.go
@@ -138,7 +138,7 @@ func simplifyExpr(env *ExpressionEnv, e IR) (IR, error) {
 		if err != nil {
 			return nil, err
 		}
-		return convertToIR(simplified), nil
+		return evalToIR(simplified), nil
 	}
 	if err := e.simplify(env); err != nil {
 		return nil, err
@@ -146,11 +146,14 @@ func simplifyExpr(env *ExpressionEnv, e IR) (IR, error) {
 	return e, nil
 }
 
-func convertToIR(simplified eval) IR {
-	if x, isTuple := simplified.(*evalTuple); isTuple {
-		var te TupleExpr
-		for _, t := range x.t {
-			te = append(te, convertToIR(t))
+// evalToIR turns an internal eval result into an IR:
+//   - if it’s an evalTuple, it recurses into a TupleExpr
+//   - otherwise it wraps the single value in a Literal
+func evalToIR(simplified eval) IR {
+	if tuple, isTuple := simplified.(*evalTuple); isTuple {
+		te := make(TupleExpr, len(tuple.t))
+		for i, t := range tuple.t {
+			te[i] = evalToIR(t)
 		}
 		return te
 	}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4761,5 +4761,49 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "case statement in join condition for evaluation",
+    "query": "select 1 from user u1 join user u2 on u1.col = (case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from user u1 join user u2 on u1.col = (case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end)",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "JoinVars": {
+          "u1_col": 1
+        },
+        "TableName": "`user`_`user`",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1, u1.col from `user` as u1 where 1 != 1",
+            "Query": "select 1, u1.col from `user` as u1",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
+            "Query": "select 1 from `user` as u2 where :u1_col /* INT16 */ = case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4763,7 +4763,7 @@
     }
   },
   {
-    "comment": "case statement in join condition for evaluation",
+    "comment": "case statement in join condition for evaluation - tuple‐expr simplification in CASE",
     "query": "select 1 from user u1 join user u2 on u1.col = (case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end)",
     "plan": {
       "QueryType": "SELECT",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4766,6 +4766,7 @@
     "comment": "case statement in join condition for evaluation - tuple‐expr simplification in CASE",
     "query": "select 1 from user u1 join user u2 on u1.col = (case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end)",
     "plan": {
+      "Type": "Join",
       "QueryType": "SELECT",
       "Original": "select 1 from user u1 join user u2 on u1.col = (case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end)",
       "Instructions": {
@@ -4775,7 +4776,6 @@
         "JoinVars": {
           "u1_col": 1
         },
-        "TableName": "`user`_`user`",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4785,8 +4785,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1, u1.col from `user` as u1 where 1 != 1",
-            "Query": "select 1, u1.col from `user` as u1",
-            "Table": "`user`"
+            "Query": "select 1, u1.col from `user` as u1"
           },
           {
             "OperatorType": "Route",
@@ -4796,8 +4795,7 @@
               "Sharded": true
             },
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
-            "Query": "select 1 from `user` as u2 where :u1_col /* INT16 */ = case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end",
-            "Table": "`user`"
+            "Query": "select 1 from `user` as u2 where :u1_col /* INT16 */ = case when u2.col = 2 then 0 when u2.col in (1, 2) then 1 else 2 end"
           }
         ]
       },


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the tuple simplifier, ensuring that multi-column results remain as TupleExpr rather than being wrapped in a single Literal.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/18217

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
