### PR TITLE
Make the width of the pos column in vreplication.sql wider

### DIFF
--- a/go/vt/sidecardb/schema/vreplication/vreplication.sql
+++ b/go/vt/sidecardb/schema/vreplication/vreplication.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS vreplication
     `id`                    int              NOT NULL AUTO_INCREMENT,
     `workflow`              varbinary(1000)           DEFAULT NULL,
     `source`                mediumblob       NOT NULL,
-    `pos`                   varbinary(10000) NOT NULL,
+    `pos`                   mediumblob NOT NULL,
     `stop_pos`              varbinary(10000)          DEFAULT NULL,
     `max_tps`               bigint           NOT NULL,
     `max_replication_lag`   bigint           NOT NULL,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This extends the length of the _vt.vreplication pos column into a mediumblob to support environments with super long gtidsets, which can happen in Kubernetes in particular if a lot of rescheduling and binpacking has occurred. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #18185

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

My understanding is that the new dbsidecar should easily apply this transformation when needed.
