### PR TITLE
Throttler: keep watching topo even on error

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -380,7 +380,7 @@ func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspa
 		if !topo.IsErrType(err, topo.Interrupted) && !errors.Is(err, context.Canceled) {
 			log.Errorf("WatchSrvKeyspaceCallback error: %v", err)
 		}
-		return false
+		return true
 	}
 	throttlerConfig := throttler.normalizeThrottlerConfig(srvks.ThrottlerConfig)
 


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/18209
Ensure the tablet throttler keeps a watch on `SrvKeyspace` even if the watch returns an error. This is done by always returning `true`. See details in linked issue; TL;DR this function removes the listener when it returns `false`:

https://github.com/vitessio/vitess/blob/68242a621b5c2a92ee19b92fb2cbcffd797e6ef9/go/vt/srvtopo/watch.go#L164-L171

Testing: I was able to validate before/after behavior with local `endtoend` testing, but one that requires long sleep & long timeouts. Not sure how to do the same without these sleeps and without modifying `go/vt` code specifically for this test. I propose we can satisfy with just making this change as it is straightforward

## backport

This fixes a bug that causes the throttler to not read `SevKeyspace` changes until it re-`Open()`s, which normally only happens when the tablet type changes. This should be backported to supported versions.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/18209

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
