### PR TITLE
Recover panic in vcopier due to closed channel

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -919,6 +919,12 @@ func (vrh *vcopierCopyTaskResultHooks) notify(ctx context.Context, result *vcopi
 //	}()
 func (vrh *vcopierCopyTaskResultHooks) sendTo(ch chan<- *vcopierCopyTaskResult) {
 	vrh.do(func(ctx context.Context, result *vcopierCopyTaskResult) {
+		defer func() {
+			// This recover prevents panics when sending to a potentially closed channel.
+			if err := recover(); err != nil {
+				log.Errorf("uncaught panic, vcopier copy task result: %v, error: %+v", result, err)
+			}
+		}()
 		select {
 		case ch <- result:
 		case <-ctx.Done():


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Prevent tablet crash by recovering panic in `vcopierCopyTaskResultHooks.sendTo`, also log the error in case there's a panic. This panic occurs if a callback added in `copyAll` tries to send a result to `resultCh` after the channel has been closed (since `copyAll` defers `close(resultCh)`). This can possibly occur if the context exceeds its deadline.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
