### PR TITLE
Viperize tabletserver maxResultSize and warnResultSize flags

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1544,7 +1544,7 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 		cfg.TwoPCAbandonAge = 10 * time.Second
 	}
 	if flags&smallResultSize > 0 {
-		cfg.Oltp.MaxRows = 2
+		cfg.Oltp.MaxRows.Set(2)
 	}
 	if flags&enableConsolidator > 0 {
 		cfg.Consolidator = tabletenv.Enable

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -149,7 +149,6 @@ olapReadPool:
   idleTimeoutSeconds: 30m0s
   size: 200
 oltp:
-  maxRows: 10000
   queryTimeoutSeconds: 30s
   txTimeoutSeconds: 30s
 oltpReadPool:

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2034,22 +2034,22 @@ func (tsv *TabletServer) QueryPlanCacheLen() int {
 
 // SetMaxResultSize changes the max result size to the specified value.
 func (tsv *TabletServer) SetMaxResultSize(val int) {
-	tsv.qe.maxResultSize.Store(int64(val))
+	tsv.qe.maxResultSize.Set(int64(val))
 }
 
 // MaxResultSize returns the max result size.
 func (tsv *TabletServer) MaxResultSize() int {
-	return int(tsv.qe.maxResultSize.Load())
+	return int(tsv.qe.maxResultSize.Get())
 }
 
 // SetWarnResultSize changes the warn result size to the specified value.
 func (tsv *TabletServer) SetWarnResultSize(val int) {
-	tsv.qe.warnResultSize.Store(int64(val))
+	tsv.qe.warnResultSize.Set(int64(val))
 }
 
 // WarnResultSize returns the warn result size.
 func (tsv *TabletServer) WarnResultSize() int {
-	return int(tsv.qe.warnResultSize.Load())
+	return int(tsv.qe.warnResultSize.Get())
 }
 
 // SetThrottleMetricThreshold changes the throttler metric threshold

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2294,7 +2294,7 @@ func TestConfigChanges(t *testing.T) {
 	if val := tsv.MaxResultSize(); val != newSize {
 		t.Errorf("MaxResultSize: %d, want %d", val, newSize)
 	}
-	if val := int(tsv.qe.maxResultSize.Load()); val != newSize {
+	if val := int(tsv.qe.maxResultSize.Get()); val != newSize {
 		t.Errorf("tsv.qe.maxResultSize.Get: %d, want %d", val, newSize)
 	}
 
@@ -2302,7 +2302,7 @@ func TestConfigChanges(t *testing.T) {
 	if val := tsv.WarnResultSize(); val != newSize {
 		t.Errorf("WarnResultSize: %d, want %d", val, newSize)
 	}
-	if val := int(tsv.qe.warnResultSize.Load()); val != newSize {
+	if val := int(tsv.qe.warnResultSize.Get()); val != newSize {
 		t.Errorf("tsv.qe.warnResultSize.Get: %d, want %d", val, newSize)
 	}
 }


### PR DESCRIPTION

## Description

This PR introduces dynamic configuration for `--queryserver-config-max-result-size` and `--queryserver-config-warn-result-size` in the vttablet tabletserver component. The changes leverage the viperutil package to allow real-time updates to these configuration values without requiring a server restart.


## Related Issue(s)

#17687

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
