### PR TITLE
test: TestQueryTimeoutWithShardTargeting fix flaky test

### DIFF
--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -125,7 +125,7 @@ func TestQueryTimeoutWithShardTargeting(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
 			_, err := utils.ExecAllowError(t, mcmp.VtConn, query)
-			assert.ErrorContains(t, err, "context deadline exceeded")
+			// the error message can be different based on VTGate or VTTABLET or grpc error.
 			assert.ErrorContains(t, err, "(errno 1317) (sqlstate 70100)")
 		})
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the test flake in `TestQueryTimeoutWithShardTargeting`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
