### PR TITLE
[release-16.0 Direct PR] VDiff: Fix logic for reconciling extra rows Part 2

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"testing"
 
+	_flag "vitess.io/vitess/go/internal/flag"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -171,6 +173,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	_flag.ParseFlagsForTest()
 	exitCode := func() int {
 		var err error
 		tstenv, err = testenv.Init()

--- a/go/vt/vttablet/tabletmanager/vdiff/report.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/report.go
@@ -48,6 +48,11 @@ type DiffReport struct {
 	MismatchedRowsDiffs  []*DiffMismatch `json:"MismatchedRowsSample,omitempty"`
 }
 
+func (dr *DiffReport) String() string {
+	return fmt.Sprintf("DiffReport:: Table: %s, ProcessedRows: %d, MatchingRows: %d, MismatchedRows: %d, ExtraRowsSource: %d, ExtraRowsTarget: %d",
+		dr.TableName, dr.ProcessedRows, dr.MatchingRows, dr.MismatchedRows, dr.ExtraRowsSource, dr.ExtraRowsTarget)
+}
+
 type ProgressReport struct {
 	Percentage float64
 	ETA        string `json:"ETA,omitempty"` // a formatted date

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -35,6 +35,8 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
+// TestReconcileExtraRows tests reconcileExtraRows() by providing different types of source and target slices and validating
+// that the matching rows are correctly identified and removed.
 func TestReconcileExtraRows(t *testing.T) {
 	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()
@@ -72,6 +74,7 @@ func TestReconcileExtraRows(t *testing.T) {
 		wantMatchingCount   int64
 		wantMismatchedCount int64
 	}
+
 	testCases := []testCase{
 		{
 			name: "no extra rows, same order",
@@ -103,15 +106,15 @@ func TestReconcileExtraRows(t *testing.T) {
 			name: "extra rows, same count of extras on both",
 			extraDiffsSource: []*RowDiff{
 				{Row: map[string]string{"1": "c1"}},
-				{Row: map[string]string{"2": "c2"}},
 				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"2": "c2"}},
 				{Row: map[string]string{"3b": "c3b"}},
 			},
 			extraDiffsTarget: []*RowDiff{
 				{Row: map[string]string{"2": "c2"}},
 				{Row: map[string]string{"4a": "c4a"}},
-				{Row: map[string]string{"1": "c1"}},
 				{Row: map[string]string{"4b": "c4b"}},
+				{Row: map[string]string{"1": "c1"}},
 			},
 			wantExtraSource: []*RowDiff{
 				{Row: map[string]string{"3a": "c3a"}},

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -35,6 +35,174 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
+func TestReconcileExtraRows(t *testing.T) {
+	vdenv := newTestVDiffEnv(t)
+	defer vdenv.close()
+	UUID := uuid.New()
+	controllerQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		vdiffTestCols,
+		vdiffTestColTypes,
+	),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
+	)
+
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
+	require.NoError(t, err)
+	wd, err := newWorkflowDiffer(ct, vdiffenv.opts)
+	require.NoError(t, err)
+
+	dr := &DiffReport{
+		TableName:            "t1",
+		ExtraRowsSourceDiffs: []*RowDiff{},
+		ExtraRowsTargetDiffs: []*RowDiff{},
+		MismatchedRowsDiffs:  nil,
+	}
+
+	type testCase struct {
+		name             string
+		maxExtras        int64
+		extraDiffsSource []*RowDiff
+		extraDiffsTarget []*RowDiff
+
+		wantExtraSource []*RowDiff
+		wantExtraTarget []*RowDiff
+
+		wantProcessedCount  int64
+		wantMatchingCount   int64
+		wantMismatchedCount int64
+	}
+	testCases := []testCase{
+		{
+			name: "no extra rows, same order",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+			},
+			wantExtraSource: []*RowDiff{},
+			wantExtraTarget: []*RowDiff{},
+		},
+		{
+			name: "no extra rows, different order",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"1": "c1"}},
+			},
+			wantExtraSource: []*RowDiff{},
+			wantExtraTarget: []*RowDiff{},
+		},
+		{
+			name: "extra rows, same count of extras on both",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"4b": "c4b"}},
+			},
+			wantExtraSource: []*RowDiff{
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			wantExtraTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"4b": "c4b"}},
+			},
+		},
+		{
+			name: "extra rows, less extras on target",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"1": "c1"}},
+			},
+			wantExtraSource: []*RowDiff{
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			wantExtraTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+			},
+		},
+		{
+			name: "extra rows, no matching rows",
+			extraDiffsSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			extraDiffsTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"5": "c5"}},
+				{Row: map[string]string{"6": "c6"}},
+			},
+			wantExtraSource: []*RowDiff{
+				{Row: map[string]string{"1": "c1"}},
+				{Row: map[string]string{"2": "c2"}},
+				{Row: map[string]string{"3a": "c3a"}},
+				{Row: map[string]string{"3b": "c3b"}},
+			},
+			wantExtraTarget: []*RowDiff{
+				{Row: map[string]string{"4a": "c4a"}},
+				{Row: map[string]string{"5": "c5"}},
+				{Row: map[string]string{"6": "c6"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			maxExtras := int64(10)
+			if tc.maxExtras != 0 {
+				maxExtras = tc.maxExtras
+			}
+
+			dr.ExtraRowsSourceDiffs = tc.extraDiffsSource
+			dr.ExtraRowsTargetDiffs = tc.extraDiffsTarget
+			dr.ExtraRowsSource = int64(len(tc.extraDiffsSource))
+			dr.ExtraRowsTarget = int64(len(tc.extraDiffsTarget))
+			origExtraRowsSource := dr.ExtraRowsSource
+
+			dr.MatchingRows = 0
+			dr.MismatchedRows = dr.ExtraRowsSource
+			dr.ProcessedRows = 0
+
+			wd.reconcileExtraRows(dr, maxExtras)
+
+			// check counts
+			require.Equal(t, dr.MatchingRows, origExtraRowsSource-dr.ExtraRowsSource)
+			require.Equal(t, dr.ProcessedRows, dr.MatchingRows)
+			require.Equal(t, dr.MismatchedRows, origExtraRowsSource-dr.MatchingRows)
+			require.Equal(t, dr.ExtraRowsSource, int64(len(tc.wantExtraSource)))
+			require.Equal(t, dr.ExtraRowsTarget, int64(len(tc.wantExtraTarget)))
+
+			// check actual extra rows
+			require.EqualValues(t, dr.ExtraRowsSourceDiffs, tc.wantExtraSource)
+			require.EqualValues(t, dr.ExtraRowsTargetDiffs, tc.wantExtraTarget)
+		})
+	}
+}
+
 func TestBuildPlanSuccess(t *testing.T) {
 	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()


### PR DESCRIPTION

## Description

Additional checks on top of https://github.com/vitessio/vitess/pull/17930 to break out of reconcile logic if we have processed all extra rows.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
