### PR TITLE
Fix evalengine crashes on unexpected types

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -775,6 +775,32 @@ func TestCompilerSingle(t *testing.T) {
 			// exercise the path to push sets onto the stack.
 			result: `FLOAT64(1)`,
 		},
+		{
+			expression: `GREATEST(NULL, '2023-10-24')`,
+			result:     `NULL`,
+		},
+		{
+			expression: `GREATEST(NULL, 1)`,
+			result:     `NULL`,
+		},
+		{
+			expression: `GREATEST(NULL, 1.0)`,
+			result:     `NULL`,
+		},
+		{
+			expression: `GREATEST(NULL, 1.0e0)`,
+			result:     `NULL`,
+		},
+		{
+			expression: `GREATEST(column0, 1.0e0)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte("foo"))},
+			// Enum and set are treated as strings in this case.
+			result: `VARCHAR("foo")`,
+		},
+		{
+			expression: `GREATEST(JSON_OBJECT(), JSON_ARRAY())`,
+			result:     `VARCHAR("{}")`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -1156,7 +1156,7 @@ func StrcmpComparison(yield Query) {
 
 func MultiComparisons(yield Query) {
 	var numbers = []string{
-		`0`, `-1`, `1`, `0.0`, `1.0`, `-1.0`, `1.0E0`, `-1.0E0`, `0.0E0`,
+		`NULL`, `0`, `-1`, `1`, `0.0`, `1.0`, `-1.0`, `1.0E0`, `-1.0E0`, `0.0E0`,
 		strconv.FormatUint(math.MaxUint64, 10),
 		strconv.FormatUint(math.MaxInt64, 10),
 		strconv.FormatInt(math.MinInt64, 10),


### PR DESCRIPTION
This fixes a number of issues identified in the evalengine. We don't properly check for NULLs when necessary and also don't handle all the types here properly, such as JSON, ENUM and SET.

Marked also for back porting as this fixes a panic issue.

## Related Issue(s)

Fixes #18253 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
