### PR TITLE
Fix subquery merging regression introduced in #11379

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -342,8 +342,8 @@ func canMergeOnFilter(ctx *plancontext.PlanningContext, a, b *Route, predicate s
 	if comparison.Operator != sqlparser.EqualOp {
 		return false
 	}
-	left := comparison.Left
-	right := comparison.Right
+	left := getColName(comparison.Left)
+	right := getColName(comparison.Right)
 
 	lVindex := findColumnVindex(ctx, a, left)
 	if lVindex == nil {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -4576,72 +4576,22 @@
     "comment": "Mergeable subquery with `MAX` aggregate and grouped by unique vindex",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id IN (5, 6) GROUP BY music.user_id)",
     "plan": {
-      "Type": "Complex",
+      "Type": "MultiShard",
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id IN (5, 6) GROUP BY music.user_id)",
       "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutIn",
-        "PulloutVars": [
-          "__sq_has_values",
-          "__sq1"
+        "OperatorType": "Route",
+        "Variant": "IN",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id from music where 1 != 1",
+        "Query": "select music.id from music where music.id in (select max(music.id) from music where music.user_id in (5, 6) group by music.user_id)",
+        "Values": [
+          "(5, 6)"
         ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Route",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select max(music.id) from music where 1 != 1 group by music.user_id",
-            "Query": "select max(music.id) from music where music.user_id in ::__vals group by music.user_id",
-            "Values": [
-              "(5, 6)"
-            ],
-            "Vindex": "user_index"
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "VindexLookup",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "Values": [
-              "::__sq1"
-            ],
-            "Vindex": "music_user_map",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "IN",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
-                "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                "Values": [
-                  "::name"
-                ],
-                "Vindex": "user_index"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "ByDestination",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select music.id from music where 1 != 1",
-                "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals"
-              }
-            ]
-          }
-        ]
+        "Vindex": "user_index"
       },
       "TablesUsed": [
         "user.music"
@@ -4736,72 +4686,22 @@
     "comment": "Mergeable subquery with `MAX` aggregate with `EqualUnique` route operator",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id = 5)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id = 5)",
       "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutIn",
-        "PulloutVars": [
-          "__sq_has_values",
-          "__sq1"
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id from music where 1 != 1",
+        "Query": "select music.id from music where music.id in (select max(music.id) from music where music.user_id = 5)",
+        "Values": [
+          "5"
         ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Route",
-            "Variant": "EqualUnique",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select max(music.id) from music where 1 != 1",
-            "Query": "select max(music.id) from music where music.user_id = 5",
-            "Values": [
-              "5"
-            ],
-            "Vindex": "user_index"
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "VindexLookup",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "Values": [
-              "::__sq1"
-            ],
-            "Vindex": "music_user_map",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "IN",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
-                "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                "Values": [
-                  "::name"
-                ],
-                "Vindex": "user_index"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "ByDestination",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select music.id from music where 1 != 1",
-                "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals"
-              }
-            ]
-          }
-        ]
+        "Vindex": "user_index"
       },
       "TablesUsed": [
         "user.music"
@@ -4812,72 +4712,22 @@
     "comment": "Mergeable subquery with `LIMIT` due to `EqualUnique` route",
     "query": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id = 5 LIMIT 10)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT MAX(music.id) FROM music WHERE music.user_id = 5 LIMIT 10)",
       "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutIn",
-        "PulloutVars": [
-          "__sq_has_values",
-          "__sq1"
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id from music where 1 != 1",
+        "Query": "select music.id from music where music.id in (select max(music.id) from music where music.user_id = 5 limit 10)",
+        "Values": [
+          "5"
         ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Route",
-            "Variant": "EqualUnique",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select max(music.id) from music where 1 != 1",
-            "Query": "select max(music.id) from music where music.user_id = 5 limit 10",
-            "Values": [
-              "5"
-            ],
-            "Vindex": "user_index"
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "VindexLookup",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "Values": [
-              "::__sq1"
-            ],
-            "Vindex": "music_user_map",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "IN",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
-                "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
-                "Values": [
-                  "::name"
-                ],
-                "Vindex": "user_index"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "ByDestination",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select music.id from music where 1 != 1",
-                "Query": "select music.id from music where :__sq_has_values and music.id in ::__vals"
-              }
-            ]
-          }
-        ]
+        "Vindex": "user_index"
       },
       "TablesUsed": [
         "user.music"


### PR DESCRIPTION
## Description
This PR restores subquery merging behavior that was unintentionally broken by #11379, undoing the regression that reintroduced suboptimal query planning previously addressed in #10966.

### Background

Given a query like:

```sql
SELECT music.id
FROM music
WHERE music.id IN (
  SELECT MAX(music.id)
  FROM music
  WHERE music.user_id IN (5, 6)
  GROUP BY music.user_id
)
```

We expect the planner to merge the subquery and send at most one query per shard based on the `music.user_id IN (5, 6)` condition. Currently, however, the planner fails to do this and ends up sending multiple queries per shard.

Curiously, wrapping the subquery in a derived table works as expected:

```sql
SELECT music.id
FROM music
WHERE music.id IN (
  SELECT * FROM (
    SELECT MAX(music.id)
    FROM music
    WHERE music.user_id IN (5, 6)
    GROUP BY music.user_id
  ) AS _inner
)
```

This PR restores the merging behavior so that both forms behave consistently and optimally.

## Related Issue(s)
Fixes #18259

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
